### PR TITLE
Add TRS refresh timestamp to teachers table

### DIFF
--- a/app/services/teachers/refresh_trs_attributes.rb
+++ b/app/services/teachers/refresh_trs_attributes.rb
@@ -19,7 +19,8 @@ module Teachers
           trs_induction_status: trs_teacher.induction_status,
           trs_qts_status_description: trs_teacher.qts_status_description,
           trs_initial_teacher_training_provider_name: trs_teacher.initial_teacher_training_provider_name,
-          trs_initial_teacher_training_end_date: trs_teacher.initial_teacher_training_end_date
+          trs_initial_teacher_training_end_date: trs_teacher.initial_teacher_training_end_date,
+          trs_data_last_refreshed_at: Time.zone.now
         )
 
         new_name = Teachers::Name.new(teacher).full_name

--- a/db/migrate/20250115130749_add_last_refreshed_timestamp_to_teachers.rb
+++ b/db/migrate/20250115130749_add_last_refreshed_timestamp_to_teachers.rb
@@ -1,0 +1,5 @@
+class AddLastRefreshedTimestampToTeachers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :teachers, :trs_data_last_refreshed_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_15_105233) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_15_130749) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -508,6 +508,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_15_105233) do
     t.string "trs_induction_status", limit: 16
     t.string "trs_initial_teacher_training_provider_name"
     t.date "trs_initial_teacher_training_end_date"
+    t.datetime "trs_data_last_refreshed_at", precision: nil
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["search"], name: "index_teachers_on_search", using: :gin
     t.index ["trn"], name: "index_teachers_on_trn", unique: true

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -7,18 +7,21 @@ describe Teachers::RefreshTRSAttributes do
     let(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Kermit", trs_last_name: "Van Bouten") }
 
     it 'updates the relevant TRS attributes' do
-      Teachers::RefreshTRSAttributes.new(teacher).refresh!
+      freeze_time do
+        Teachers::RefreshTRSAttributes.new(teacher).refresh!
 
-      teacher.reload
+        teacher.reload
 
-      # these values are returned by the fake API client
-      expect(teacher.trs_first_name).to eql('Kirk')
-      expect(teacher.trs_last_name).to eql('Van Houten')
-      expect(teacher.trs_induction_status).to eql('Pass')
-      expect(teacher.trs_qts_awarded_on).to eql(3.years.ago.to_date)
-      expect(teacher.trs_qts_status_description).to eql('Passed')
-      expect(teacher.trs_initial_teacher_training_provider_name).to eql('Example Provider Ltd.')
-      expect(teacher.trs_initial_teacher_training_end_date).to eql(Date.new(2021, 4, 5))
+        # these values are returned by the fake API client
+        expect(teacher.trs_first_name).to eql('Kirk')
+        expect(teacher.trs_last_name).to eql('Van Houten')
+        expect(teacher.trs_induction_status).to eql('Pass')
+        expect(teacher.trs_qts_awarded_on).to eql(3.years.ago.to_date)
+        expect(teacher.trs_qts_status_description).to eql('Passed')
+        expect(teacher.trs_initial_teacher_training_provider_name).to eql('Example Provider Ltd.')
+        expect(teacher.trs_initial_teacher_training_end_date).to eql(Date.new(2021, 4, 5))
+        expect(teacher.trs_data_last_refreshed_at).to eql(Time.zone.now)
+      end
     end
 
     it 'adds a teacher_name_updated_by_trs event' do


### PR DESCRIPTION
It'll be useful to know when the teacher record was last synced with TRS and we might even use it to ensure we don't leave any records too long between sync.