### PR TITLE
When registering an ECT only create a new Teacher record if it does exist

### DIFF
--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -22,7 +22,8 @@ module Schools
   private
 
     def create_teacher!
-      @teacher = ::Teacher.create!(trs_first_name:, trs_last_name:, trn:, corrected_name:)
+      @teacher = ::Teacher.where(trn:)
+                          .first_or_create!(trs_first_name:, trs_last_name:, trn:, corrected_name:)
     end
 
     def start_at_school!

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -21,7 +21,13 @@ describe Schools::RegisterECT do
     let(:teacher) { Teacher.first }
     let(:ect_at_school_period) { ECTAtSchoolPeriod.first }
 
-    it 'creates a new Teacher record' do
+    it 'does not create a new Teacher record if a Teacher with the same TRN already exists' do
+      FactoryBot.create(:teacher, trn:, trs_first_name: 'Bob', trs_last_name: 'Smith', corrected_name: 'Bob Smithy-Smith')
+
+      expect { service.register_teacher! }.not_to change(Teacher, :count)
+    end
+
+    it 'creates a new Teacher record if it does not exist' do
       expect { service.register_teacher! }.to change(Teacher, :count).from(0).to(1)
       expect(teacher.trs_first_name).to eq(trs_first_name)
       expect(teacher.trs_last_name).to eq(trs_last_name)


### PR DESCRIPTION
### Ticket 
https://github.com/DFE-Digital/register-ects-project-board/issues/689

### Context
Currently, if the when the same ECT is registered more than once a 'TRN already exists' validation error is raised. This should not happen

### Changes
When registering an ECT only create a new Teacher record if it does exist

