### PR TITLE
Replacing placeholder content on confirmation screen

### DIFF
--- a/app/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb
@@ -4,13 +4,13 @@
 %>
 
 
-<%= govuk_panel(title_text: "You’ve successfully claimed #{PendingInductionSubmissions::Name.new(@pending_induction_submission).full_name}'s induction") %>
+<%= govuk_panel(title_text: "You’ve successfully claimed #{PendingInductionSubmissions::Name.new(@pending_induction_submission).full_name}’s induction") %>
 
 <p>
   You’ve successfully claimed <%= PendingInductionSubmissions::Name.new(@pending_induction_submission).full_name %> with <%= @appropriate_body.name %>. This means that they cannot be claimed by another appropriate body.
 </p>
 
-<h2 class="govuk-heading-m">What happens next</h2> 
+<h2 class="govuk-heading-m">What happens next</h2>
 
 <p>
   Use this service to report of any changes in John Smith's induction. For example, if:

--- a/app/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb
@@ -4,14 +4,25 @@
 %>
 
 
-<%=
-  govuk_panel(
-    title_text: "Success",
-    text: sanitize("#{@pending_induction_submission.trs_first_name} #{@pending_induction_submission.trs_last_name} has been registered with #{@appropriate_body&.name}")
-  )
-%>
+<%= govuk_panel(title_text: "You’ve successfully claimed #{PendingInductionSubmissions::Name.new(@pending_induction_submission).full_name}'s induction") %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_link_to("Register another ECT", new_ab_claim_an_ect_find_path, secondary: true) %>
-  <%= govuk_button_link_to("Return to the homepage", ab_teachers_path, secondary: true) %>
-</div>
+<p>
+  You’ve successfully claimed <%= PendingInductionSubmissions::Name.new(@pending_induction_submission).full_name %> with <%= @appropriate_body.name %>. This means that they cannot be claimed by another appropriate body.
+</p>
+
+<h2 class="govuk-heading-m">What happens next</h2> 
+
+<p>
+  Use this service to report of any changes in John Smith's induction. For example, if:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>they change appropriate body</li>
+  <li>they need an extension</li>
+  <li>their induction programme changes or ends</li>
+</ul>
+
+<ul class="govuk-list">
+  <li><%= govuk_link_to("Claim another ECT", new_ab_claim_an_ect_find_path, no_visited_state: true) %></li>
+  <li><%= govuk_link_to("Back to homepage", ab_teachers_path, no_visited_state: true) %></li>
+</ul>

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
       it 'finds the right PendingInductionSubmission record and renders the page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/")
 
-        expected_content = "#{pending_induction_submission.trs_first_name} #{pending_induction_submission.trs_last_name} has been registered with #{appropriate_body.name}"
+        expected_content = "You’ve successfully claimed #{pending_induction_submission.trs_first_name} #{pending_induction_submission.trs_last_name}’s induction"
 
         expect(response.body).to include(expected_content)
         expect(response).to be_successful

--- a/spec/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe "appropriate_bodies/claim_an_ect/register_ect/show.html.erb" do
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_first_name: 'Crispin', trs_last_name: 'Bonham-Carter') }
 
   it "sets the page title to '<name> is registered'" do
+    assign(:appropriate_body, pending_induction_submission.appropriate_body)
     assign(:pending_induction_submission, pending_induction_submission)
 
     render
@@ -11,11 +12,12 @@ RSpec.describe "appropriate_bodies/claim_an_ect/register_ect/show.html.erb" do
   end
 
   it 'has links to register another ECT and to return to the homepage' do
+    assign(:appropriate_body, pending_induction_submission.appropriate_body)
     assign(:pending_induction_submission, pending_induction_submission)
 
     render
 
-    expect(rendered).to have_link('Return to the homepage', href: '/appropriate-body/teachers')
-    expect(rendered).to have_link('Register another ECT', href: '/appropriate-body/claim-an-ect/find-ect/new')
+    expect(rendered).to have_link('Back to homepage', href: '/appropriate-body/teachers')
+    expect(rendered).to have_link('Claim another ECT', href: '/appropriate-body/claim-an-ect/find-ect/new')
   end
 end


### PR DESCRIPTION
Updating and replacing confirmation screen content and also updating grey buttons to links as per 'Success (teacher claimed)' page - heuristic improvements
[#732](https://github.com/DFE-Digital/register-ects-project-board/issues/732)

| Before | After |
|  ------ | ------ |
|<img width="1002" alt="Screenshot 2025-01-16 at 17 15 43" src="https://github.com/user-attachments/assets/63530a73-9419-4053-89d7-a26d965d3234" /> |<img width="684" alt="Screenshot 2025-01-16 at 17 08 04" src="https://github.com/user-attachments/assets/33b68b9e-e11d-43b0-bc81-2b6fbd3ea000" /> |


