### PR TITLE
Improve the `finished_on` validation when closing induction periods

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
@@ -3,16 +3,16 @@ module AppropriateBodies
     class RecordFailedOutcomeController < AppropriateBodiesController
       def new
         @teacher = find_teacher
-
         @pending_induction_submission = PendingInductionSubmission.new
       end
 
       def create
         @teacher = find_teacher
-        @pending_induction_submission = PendingInductionSubmission.new(
+        @pending_induction_submission = PendingInductionSubmissions::Build.closing_induction_period(
+          ::Teachers::InductionPeriod.new(@teacher).active_induction_period,
           **pending_induction_submission_params,
           **pending_induction_submission_attributes
-        )
+        ).pending_induction_submission
 
         record_outcome = AppropriateBodies::RecordOutcome.new(
           appropriate_body: @appropriate_body,

--- a/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
@@ -9,10 +9,12 @@ module AppropriateBodies
 
       def create
         @teacher = find_teacher
-        @pending_induction_submission = PendingInductionSubmission.new(
+        @pending_induction_submission = PendingInductionSubmissions::Build.closing_induction_period(
+          ::Teachers::InductionPeriod.new(@teacher).active_induction_period,
           **pending_induction_submission_params,
           **pending_induction_submission_attributes
-        )
+        ).pending_induction_submission
+
         record_outcome = AppropriateBodies::RecordOutcome.new(
           appropriate_body: @appropriate_body,
           pending_induction_submission: @pending_induction_submission,

--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -9,10 +9,11 @@ module AppropriateBodies
 
       def create
         @teacher = find_teacher
-        @pending_induction_submission = PendingInductionSubmission.new(
+        @pending_induction_submission = PendingInductionSubmissions::Build.closing_induction_period(
+          ::Teachers::InductionPeriod.new(@teacher).active_induction_period,
           **pending_induction_submission_params,
           **pending_induction_submission_attributes
-        )
+        ).pending_induction_submission
 
         release_ect = AppropriateBodies::ReleaseECT.new(
           appropriate_body: @appropriate_body,

--- a/app/services/pending_induction_submissions/build.rb
+++ b/app/services/pending_induction_submissions/build.rb
@@ -1,0 +1,18 @@
+module PendingInductionSubmissions
+  class Build
+    attr_reader :pending_induction_submission
+
+    def initialize(...)
+      @pending_induction_submission = PendingInductionSubmission.new(...)
+    end
+
+    # build a PendingInductionSubmission with the started_on date of the inductoin period
+    # it'll be closing populated so we can compare it to the finish date when applying
+    # validation
+    def self.closing_induction_period(induction_period, **attributes)
+      started_on = induction_period.started_on
+
+      new(started_on:, **attributes)
+    end
+  end
+end

--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -1,0 +1,19 @@
+<%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+<%=
+  f.govuk_date_field :finished_on,
+    legend: {
+      text: "Enter the date #{Teachers::Name.new(@teacher).full_name} moved from #{@appropriate_body.name}"
+    }
+%>
+
+<%=
+  f.govuk_number_field :number_of_terms,
+    width: 4,
+    label: {
+      size: 'm',
+      text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?",
+    },
+    hint: { text: "Enter partial terms of induction as a decimal number. For example, one term and a half should be given as 1.5 terms." }
+%>
+

--- a/app/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb
@@ -1,23 +1,6 @@
 <% page_data(title: "Record failed outcome for #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_record_failed_outcome_path(@teacher), method: 'post') do |f| %>
-  <%= content_for(:error_summary) { f.govuk_error_summary } %>
-
-  <%=
-    f.govuk_date_field :finished_on,
-      legend: {
-        text: "When did #{Teachers::Name.new(@teacher).full_name} finish their induction with you?"
-      }
-  %>
-
-  <%=
-    f.govuk_number_field :number_of_terms,
-      width: 4,
-      label: {
-        size: 'm',
-        text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?"
-      }
-  %>
-
+  <%= render partial: 'appropriate_bodies/teachers/outcome_form', locals: { f: f } %>
   <%= f.govuk_submit "Record failing outcome for #{Teachers::Name.new(@teacher).full_name}" %>
 <% end %>

--- a/app/views/appropriate_bodies/teachers/record_passed_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_passed_outcome/new.html.erb
@@ -1,23 +1,6 @@
 <% page_data(title: "Record passed outcome for #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_record_passed_outcome_path(@teacher), method: 'post') do |f| %>
-  <%= content_for(:error_summary) { f.govuk_error_summary } %>
-
-  <%=
-    f.govuk_date_field :finished_on,
-      legend: {
-        text: "When did #{Teachers::Name.new(@teacher).full_name} finish their induction with you?"
-      }
-  %>
-
-  <%=
-    f.govuk_number_field :number_of_terms,
-      width: 4,
-      label: {
-        size: 'm',
-        text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?"
-      }
-  %>
-
+  <%= render partial: 'appropriate_bodies/teachers/outcome_form', locals: { f: f } %>
   <%= f.govuk_submit "Record passing outcome for #{Teachers::Name.new(@teacher).full_name}" %>
 <% end %>

--- a/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/new.html.erb
@@ -5,24 +5,6 @@
 ) %>
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_release_ect_path(@teacher), method: 'post') do |f| %>
-  <%= content_for(:error_summary) { f.govuk_error_summary } %>
-
-  <%=
-    f.govuk_date_field :finished_on,
-      legend: {
-        text: "Enter the date #{Teachers::Name.new(@teacher).full_name} moved from #{@appropriate_body.name}"
-      }
-  %>
-
-  <%=
-    f.govuk_number_field :number_of_terms,
-      width: 4,
-      label: {
-        size: 'm',
-        text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?",
-      },
-      hint: { text: "Enter partial terms of induction as a decimal number. For example, one term and a half should be given as 1.5 terms." }
-  %>
-
+  <%= render partial: 'appropriate_bodies/teachers/outcome_form', locals: { f: f } %>
   <%= f.govuk_submit %>
 <% end %>

--- a/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
 
         before do
           allow(AppropriateBodies::RecordOutcome).to receive(:new).and_return(fake_record_outcome)
+          allow(PendingInductionSubmissions::Build).to receive(:closing_induction_period).and_call_original
         end
 
         it 'creates a new pending induction submission' do
@@ -76,6 +77,15 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
               params: valid_params
             )
           }.to change(PendingInductionSubmission, :count).by(1)
+        end
+
+        it 'uses PendingInductionSubmissions::Build to instantiate the PendingInductionSubmission' do
+          post(
+            "/appropriate-body/teachers/#{teacher.trn}/record-passed-outcome",
+            params: valid_params
+          )
+
+          expect(PendingInductionSubmissions::Build).to have_received(:closing_induction_period).once
         end
 
         it 'calls the record outcome service and redirects' do
@@ -96,7 +106,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
         end
       end
 
-      context 'with invalid params' do
+      context 'with missing params' do
         let(:invalid_params) do
           {
             pending_induction_submission: {
@@ -113,8 +123,28 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
             params: invalid_params
           )
 
-          expect(response).to be_successful
-          expect(response.body).to include('Record passed outcome')
+          expect(response.body).to include('There is a problem')
+        end
+      end
+
+      context 'when finished_on is before started_on' do
+        let(:invalid_params) do
+          {
+            pending_induction_submission: {
+              finished_on: induction_period.started_on - 1.month,
+              number_of_terms: 5,
+              outcome: 'pass'
+            }
+          }
+        end
+
+        it 'includes finish date must be later than start date' do
+          post(
+            "/appropriate-body/teachers/#{teacher.trn}/record-passed-outcome",
+            params: invalid_params
+          )
+
+          expect(response.body).to include('The finish date must be later than the start date')
         end
       end
     end

--- a/spec/services/pending_induction_submissions/build_spec.rb
+++ b/spec/services/pending_induction_submissions/build_spec.rb
@@ -1,0 +1,17 @@
+describe PendingInductionSubmissions::Name do
+  let(:started_on) { 2.months.ago.to_date }
+  let(:finished_on) { 2.weeks.ago.to_date }
+  let(:induction_period) { FactoryBot.create(:induction_period, started_on:) }
+  subject { PendingInductionSubmissions::Build.new(finished_on:) }
+
+  it { is_expected.to respond_to(:pending_induction_submission) }
+
+  describe '.closing_induction_period' do
+    it "sets the started_on date for the pending induction submission to the induction period's start date" do
+      pending_induction_period = PendingInductionSubmissions::Build.closing_induction_period(induction_period, finished_on:).pending_induction_submission
+
+      expect(pending_induction_period.started_on).to eql(started_on)
+      expect(pending_induction_period.finished_on).to eql(finished_on)
+    end
+  end
+end


### PR DESCRIPTION
When we're closing an induction period we populate a `PendingInductionSubmission` record and use it to close the `InductionPeriod`. We do this because soon we'll add bulk editing (via CSV uploads/API) and this allows us to do everything in a consistent manner.

We always want to ensure the `finished_on` date is later than the `started_on` date, so this change adds a `PendingInductionSubmissions::Build` class that lets use use the `InductionPeriod` (which will soon be closed) to initalize the `PendingInductionSubmissions,` so we can compare the two dates.

Also add some specs covering this as it bucks the trend a little 🤏🏽 