### PR TITLE
Updated existing content and added help text decimal places for terms

### DIFF
--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -14,7 +14,7 @@
       size: 'm',
       text: "How many terms of induction did they spend with you?"
     },
-    hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5." }) do
+    hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
 %>
   <p class="govuk-body">You’ll need to consider:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -3,17 +3,23 @@
 <%=
   f.govuk_date_field :finished_on,
     legend: {
-      text: "Enter the date #{Teachers::Name.new(@teacher).full_name} moved from #{@appropriate_body.name}"
+      text: "When did they move from #{@appropriate_body.name}?"
     }
 %>
 
 <%=
-  f.govuk_number_field :number_of_terms,
+  f.govuk_number_field(:number_of_terms,
     width: 4,
     label: {
       size: 'm',
-      text: "How many terms of induction did #{Teachers::Name.new(@teacher).full_name} spend with you?",
+      text: "How many terms of induction did they spend with you?"
     },
-    hint: { text: "Enter partial terms of induction as a decimal number. For example, one term and a half should be given as 1.5 terms." }
+    hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5." }) do
 %>
-
+  <p class="govuk-body">You’ll need to consider:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the amount of induction time they’ve completed so far</li>
+    <li>their full-time equivalent (FTE) working patterns and any long periods of absence</li>
+    <li>if they have sufficient time in their current post which can count towards their induction</li>
+  </ul>
+<% end %>

--- a/app/views/appropriate_bodies/teachers/extensions/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/extensions/new.html.erb
@@ -1,6 +1,6 @@
 <%
   page_data(
-    title: "Add an Extension to an ECT's induction",
+    title: "How many terms do you want to extend #{Teachers::Name.new(@teacher).full_name}’s induction by?",
     caption: Teachers::Name.new(@teacher).full_name,
     caption_size: 'm',
     backlink_href: ab_teacher_path(@teacher)
@@ -10,11 +10,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <p class="govuk-body">
-      Before recording an extension, a final assessment must have been completed by the ECT's School Induction Tutor or Headteacher, which provides a recommendation on the ECT's performance against the Teaching Standards. As an Appropriate Body, you must have made a final decision on whether to extend the induction on the basis of this recommendation.
+      You can only extend their induction if it has been assessed by a school induction tutor or headteacher.
     </p>
 
+    <p class="govuk-body">You do not need to extend for things like:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>extended sick leave</li>
+        <li>maternity or paternity leave</li>
+        <li>statutory adoption leave</li>
+        <li>shared parental leave</li>
+        <li>parental bereavement leave</li>
+      <li>unpaid carer’s leave</li>
+    </ul>
+
     <p class="govuk-body">
-      You do not need to record an extension when an induction needs to be extended due to a period of extended absence (an "automatic extension")
+      <%= Teachers::Name.new(@teacher).full_name %> can appeal an extension to their induction. You must tell them about their right to appeal and the appeal process.
     </p>
 
     <%= form_with(
@@ -26,17 +37,10 @@
 
       <%= f.govuk_number_field(
         :number_of_terms,
-        label: { text: "How many additional terms of induction do you need to add to #{Teachers::Name.new(@teacher).full_name}'s induction?", size: "m" },
         width: 5,
-        min: 0.1,
-        max: 12.0,
-        step: 0.1,
-        hint: { text: "You can record the number of terms using up to one decimal place" }
+        label: { text: 'Enter number of terms', size: 'm' },
+        hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5." }
       ) %>
-
-      <p class="govuk-body">
-        An ECT may appeal an extension to their induction. You must advise the ECT of their right to appeal and provide them with information about who to appeal to, and the time limit for doing so. More information can be found here
-      </p>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/appropriate_bodies/teachers/extensions/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/extensions/new.html.erb
@@ -39,7 +39,7 @@
         :number_of_terms,
         width: 5,
         label: { text: 'Enter number of terms', size: 'm' },
-        hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5." }
+        hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }
       ) %>
 
       <%= f.govuk_submit "Continue" %>

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -46,8 +46,7 @@ private
   end
 
   def and_i_enter_a_terms_value_of(number)
-    teacher_name = Teachers::Name.new(teacher).full_name
-    label = "How many terms of induction did #{teacher_name} spend with you?"
+    label = "How many terms of induction did they spend with you?"
 
     page.get_by_label(label).fill(number.to_s)
   end

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -46,8 +46,7 @@ private
   end
 
   def and_i_enter_a_terms_value_of(number)
-    teacher_name = Teachers::Name.new(teacher).full_name
-    label = "How many terms of induction did #{teacher_name} spend with you?"
+    label = "How many terms of induction did they spend with you?"
 
     page.get_by_label(label).fill(number.to_s)
   end

--- a/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Appropriate Body teacher extensions new", type: :request do
       get("/appropriate-body/teachers/#{teacher.trn}/extensions/new")
 
       expect(response).to be_successful
-      expect(response.body).to include('Add an Extension to an ECT&#39;s induction')
+      expect(response.body).to include('Enter number of terms')
     end
   end
 


### PR DESCRIPTION
Induction period closure changed on all 3 pages: pass induction, fail induction and release.

Before and after screenshots: 

| Before | After |
|  ------ | ------ |
|<img width="668" alt="Screenshot 2025-01-17 at 14 18 49" src="https://github.com/user-attachments/assets/8aedb7d5-b2c3-4c54-9221-f84a9ffb596e" /> |<img width="694" alt="Screenshot 2025-01-17 at 16 29 10" src="https://github.com/user-attachments/assets/5104c1f2-36b6-4e51-a420-aa6c8057dd5f" />|


| Before | After |
|  ------ | ------ |
| <img width="652" alt="Screenshot 2025-01-17 at 16 30 24" src="https://github.com/user-attachments/assets/03d9a90e-8e8b-4568-80bd-4de938ff8022" /> |<img width="680" alt="Screenshot 2025-01-17 at 16 29 47" src="https://github.com/user-attachments/assets/dd970f34-63f9-4713-82fd-d5f10ff8f14a" />|

Fixes DFE-Digital/register-ects-project-board#1149