### PR TITLE
Make teacher search work on word prefixes

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -25,7 +25,12 @@ class Teacher < ApplicationRecord
             teacher_reference_number: true
 
   # Scopes
-  scope :search, ->(query_string) { where("teachers.search @@ websearch_to_tsquery('unaccented', ?)", query_string) }
+  scope :search, lambda { |query_string|
+    where(
+      "teachers.search @@ to_tsquery('unaccented', ?)",
+      FullTextSearch::Query.new(query_string).search_by_all_prefixes
+    )
+  }
 
   def to_param
     trn

--- a/lib/full_text_search/query.rb
+++ b/lib/full_text_search/query.rb
@@ -1,0 +1,19 @@
+module FullTextSearch
+  class Query
+    def initialize(string)
+      @string = string
+    end
+
+    # splits a string and adds the suffix ':*', which allows
+    # us to search for partial words, so 'Jo' would match 'John'
+    # and 'Joey'
+    #
+    # the segments are joined with '&' so 'Jo Sm' would return
+    # 'John Smith' but not 'Joan Jones'
+    #
+    # https://www.postgresql.org/docs/current/datatype-textsearch.html#DATATYPE-TSQUERY
+    def search_by_all_prefixes
+      @string.split.map { |w| w + ":*" }.join(" & ")
+    end
+  end
+end

--- a/spec/lib/full_text_search/query_spec.rb
+++ b/spec/lib/full_text_search/query_spec.rb
@@ -1,0 +1,21 @@
+describe FullTextSearch::Query do
+  subject { FullTextSearch::Query.new(string).search_by_all_prefixes }
+
+  context 'when the string has no words' do
+    let(:string) { '' }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'when the string has one word (Cletus)' do
+    let(:string) { 'Cletus' }
+
+    it { is_expected.to eql('Cletus:*') }
+  end
+
+  context 'when the string has many words (Cletus Van Damme)' do
+    let(:string) { 'Cletus Van Damme' }
+
+    it { is_expected.to eql('Cletus:* & Van:* & Damme:*') }
+  end
+end


### PR DESCRIPTION
Now search terms will receive a wildcard suffix that means results will be returned if all of the provided words match a teacher's name fields.

This means we can find John Smith by searching for:

* John Smith
* john smith
* jo sm
* jo
* sm