### PR TITLE
Switch reset button to link

### DIFF
--- a/app/views/appropriate_bodies/teachers/index.html.erb
+++ b/app/views/appropriate_bodies/teachers/index.html.erb
@@ -20,7 +20,7 @@
 
       <div class="govuk-button-group">
         <%= f.govuk_submit("Search") %>
-        <button type="reset" class="govuk-button govuk-button--secondary">Reset</button>
+        <%= govuk_link_to("Reset", ab_teachers_path, secondary: true) %>
       </div>
     <% end %>
   </div>

--- a/spec/views/appropriate_bodies/teachers/index.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/index.html.erb_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe "appropriate_bodies/teachers/index.html.erb" do
+  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:teachers) { Teacher.all }
+
+  before do
+    assign(:appropriate_body, appropriate_body)
+    assign(:teachers, Teacher.all)
+
+    render
+  end
+
+  describe 'heading and title' do
+    it 'sets the page title and heading to the appropriate body name' do
+      expect(view.content_for(:page_header)).to have_css('h1', text: appropriate_body.name)
+    end
+
+    it 'sets the page title and heading to the appropriate body name' do
+      expect(view.content_for(:page_title)).to start_with(appropriate_body.name)
+    end
+  end
+
+  describe 'form' do
+    it "includes a form with a 'Search' submission button" do
+      expect(rendered).to have_css('form button', text: 'Search')
+    end
+
+    it "includes a form with a 'Reset' link" do
+      expect(rendered).to have_css("form a", text: 'Reset')
+      expect(rendered).to have_link('Reset', href: ab_teachers_path)
+    end
+  end
+end


### PR DESCRIPTION
The reset button was just doing the [default HTML reset behaviour](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/reset) but it's a bit unintuitive. This changes it to a link back to the teachers index page, which is effectively a reset as the GET params are lost.

I also changed the styling from button to link, because that's what it is.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/29138ca6-2df9-443e-b8ef-135f5c390071) |![image](https://github.com/user-attachments/assets/eb7e4692-dd03-4c6a-9e5b-befba1bb5361) |
