### PR TITLE
Hide the edit link for AB past induction periods

### DIFF
--- a/app/components/teachers/past_induction_periods_component.html.erb
+++ b/app/components/teachers/past_induction_periods_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m">Past induction periods</h2>
 
-<ul class="govuk-list">
+<ul id="past-induction-periods" class="govuk-list">
   <% past_periods.each do |period| %>
     <li>
       <%=

--- a/app/components/teachers/past_induction_periods_component.rb
+++ b/app/components/teachers/past_induction_periods_component.rb
@@ -1,10 +1,11 @@
 module Teachers
   class PastInductionPeriodsComponent < ViewComponent::Base
-    attr_reader :teacher, :induction
+    attr_reader :teacher, :induction, :enable_edit
 
-    def initialize(teacher:)
+    def initialize(teacher:, enable_edit: false)
       @teacher = teacher
       @induction = Teachers::Induction.new(teacher)
+      @enable_edit = enable_edit
     end
 
     def render?
@@ -18,7 +19,7 @@ module Teachers
     end
 
     def can_edit?(period)
-      period.outcome.blank?
+      enable_edit && period.outcome.blank?
     end
 
     def edit_link(period)

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -10,7 +10,7 @@
 
 <%= render(Teachers::InductionSummaryComponent.new(teacher: @teacher)) %>
 <%= render(Teachers::CurrentInductionPeriodComponent.new(teacher: @teacher, enable_edit: true)) %>
-<%= render(Teachers::PastInductionPeriodsComponent.new(teacher: @teacher)) %>
+<%= render(Teachers::PastInductionPeriodsComponent.new(teacher: @teacher, enable_edit: true)) %>
 
 <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") if @teacher.has_migration_failures? %>
 

--- a/spec/views/appropriate_bodies/teachers/show.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/show.html.erb_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'appropriate_bodies/teachers/show.html.erb' do
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  before do
+    FactoryBot.create(:induction_period, teacher:, appropriate_body:, started_on: 24.months.ago, finished_on: 12.months.ago)
+    FactoryBot.create(:induction_period, teacher:, appropriate_body:, started_on: 11.months.ago, finished_on: 3.months.ago)
+
+    assign(:teacher, teacher)
+    assign(:appropriate_body, appropriate_body)
+  end
+
+  it 'shows a list of past induction periods' do
+    render
+
+    expect(rendered).to have_css('ul#past-induction-periods li', count: 2)
+  end
+
+  it "the past induction periods don't have edit links" do
+    render
+
+    past_induction_period_list = rendered.html.at('ul#past-induction-periods')
+
+    expect(past_induction_period_list).not_to have_link('Edit')
+  end
+end


### PR DESCRIPTION
This was added for admins and incorrectly shown on the AB side too. Now it can be configured with the enable_edit argument which defaults to false.

| Before | After |
| ----- | ------ |
| ![Screenshot From 2025-01-19 17-03-06](https://github.com/user-attachments/assets/16f00e27-9a68-49f7-a497-ca8a3c5e3d7a) | ![Screenshot From 2025-01-19 17-03-21](https://github.com/user-attachments/assets/12bc57aa-c8d9-44ce-8dc3-0867f27e03d5) 