### PR TITLE
Add a presence check to number_of_terms

### DIFF
--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -40,6 +40,7 @@ class PendingInductionSubmission < ApplicationRecord
             on: %i[release_ect record_outcome]
 
   validates :number_of_terms,
+            presence: { message: "Enter a number of terms" },
             inclusion: { in: 0..16,
                          message: "Terms must be between 0 and 16" },
             on: %i[release_ect record_outcome]

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -57,6 +57,7 @@ describe PendingInductionSubmission do
     end
 
     describe "number_of_terms" do
+      it { is_expected.to validate_presence_of(:number_of_terms).with_message('Enter a number of terms').on(%i[release_ect record_outcome]) }
       it { is_expected.to validate_inclusion_of(:number_of_terms).in_range(0..16).with_message("Terms must be between 0 and 16").on(%i[release_ect record_outcome]) }
     end
 


### PR DESCRIPTION
While this is alredy covered by the inclusion check the validation message isn't great when the input is blank.

| Before | After |
| ------ | ------ |
| ![Screenshot From 2025-01-19 17-29-39](https://github.com/user-attachments/assets/7e4ceded-d618-4461-9371-b2621a4a5603) | ![Screenshot From 2025-01-19 17-29-50](https://github.com/user-attachments/assets/69db0d1d-437d-4366-aec9-b0f1babdb028) |