### PR TITLE
Prevent induction start dates that are too early

### DIFF
--- a/app/models/concerns/common_induction_period_validation.rb
+++ b/app/models/concerns/common_induction_period_validation.rb
@@ -28,4 +28,11 @@ module CommonInductionPeriodValidation
 
     errors.add(:finished_on, "End date cannot be in the future")
   end
+
+  def ensure_start_date_after_qts_date(qts_award_date)
+    return if started_on.blank? || qts_award_date.blank?
+    return if started_on >= qts_award_date
+
+    errors.add(:started_on, "Start date cannot be before QTS award date (#{qts_award_date.to_fs(:govuk)})")
+  end
 end

--- a/app/models/concerns/common_induction_period_validation.rb
+++ b/app/models/concerns/common_induction_period_validation.rb
@@ -1,0 +1,13 @@
+module CommonInductionPeriodValidation
+  extend ActiveSupport::Concern
+
+  included do
+    validate :started_on_from_september_2021_onwards, if: -> { started_on.present? }
+  end
+
+  def started_on_from_september_2021_onwards
+    return if started_on >= Date.new(2021, 9, 1)
+
+    errors.add(:started_on, "Enter a start date after 1 September 2021")
+  end
+end

--- a/app/models/concerns/common_induction_period_validation.rb
+++ b/app/models/concerns/common_induction_period_validation.rb
@@ -2,6 +2,9 @@ module CommonInductionPeriodValidation
   extend ActiveSupport::Concern
 
   included do
+    validates :appropriate_body_id,
+              presence: { message: "Select an appropriate body" }
+
     validate :started_on_from_september_2021_onwards, if: -> { started_on.present? }
   end
 

--- a/app/models/concerns/common_induction_period_validation.rb
+++ b/app/models/concerns/common_induction_period_validation.rb
@@ -6,11 +6,26 @@ module CommonInductionPeriodValidation
               presence: { message: "Select an appropriate body" }
 
     validate :started_on_from_september_2021_onwards, if: -> { started_on.present? }
+
+    validate :started_on_not_in_future, if: -> { started_on.present? }
+    validate :finished_on_not_in_future, if: -> { finished_on.present? }
   end
 
   def started_on_from_september_2021_onwards
     return if started_on >= Date.new(2021, 9, 1)
 
     errors.add(:started_on, "Enter a start date after 1 September 2021")
+  end
+
+  def started_on_not_in_future
+    return if started_on <= Date.current
+
+    errors.add(:started_on, "Start date cannot be in the future")
+  end
+
+  def finished_on_not_in_future
+    return if finished_on <= Date.current
+
+    errors.add(:finished_on, "End date cannot be in the future")
   end
 end

--- a/app/models/concerns/shared_induction_period_validation.rb
+++ b/app/models/concerns/shared_induction_period_validation.rb
@@ -1,4 +1,4 @@
-module CommonInductionPeriodValidation
+module SharedInductionPeriodValidation
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -21,6 +21,7 @@ class InductionPeriod < ApplicationRecord
             inclusion: { in: %w[fip cip diy],
                          message: "Choose an induction programme" }
 
+  validate :started_on_from_september_2021_onwards, if: -> { started_on.present? }
   validate :started_on_not_in_future, if: -> { started_on.present? }
   validate :finished_on_not_in_future, if: -> { finished_on.present? }
   validate :start_date_after_qts_date
@@ -32,6 +33,12 @@ class InductionPeriod < ApplicationRecord
   scope :siblings_of, ->(instance) { for_teacher(instance.teacher).excluding(instance) }
 
 private
+
+  def started_on_from_september_2021_onwards
+    return if started_on >= Date.new(2021, 9, 1)
+
+    errors.add(:started_on, "Enter a start date after 1 September 2021")
+  end
 
   def started_on_not_in_future
     return if started_on <= Date.current

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -1,5 +1,6 @@
 class InductionPeriod < ApplicationRecord
   include Interval
+  include CommonInductionPeriodValidation
 
   # Associations
   belongs_to :appropriate_body
@@ -21,7 +22,6 @@ class InductionPeriod < ApplicationRecord
             inclusion: { in: %w[fip cip diy],
                          message: "Choose an induction programme" }
 
-  validate :started_on_from_september_2021_onwards, if: -> { started_on.present? }
   validate :started_on_not_in_future, if: -> { started_on.present? }
   validate :finished_on_not_in_future, if: -> { finished_on.present? }
   validate :start_date_after_qts_date
@@ -33,12 +33,6 @@ class InductionPeriod < ApplicationRecord
   scope :siblings_of, ->(instance) { for_teacher(instance.teacher).excluding(instance) }
 
 private
-
-  def started_on_from_september_2021_onwards
-    return if started_on >= Date.new(2021, 9, 1)
-
-    errors.add(:started_on, "Enter a start date after 1 September 2021")
-  end
 
   def started_on_not_in_future
     return if started_on <= Date.current

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -19,8 +19,6 @@ class InductionPeriod < ApplicationRecord
             inclusion: { in: %w[fip cip diy],
                          message: "Choose an induction programme" }
 
-  validate :started_on_not_in_future, if: -> { started_on.present? }
-  validate :finished_on_not_in_future, if: -> { finished_on.present? }
   validate :start_date_after_qts_date
   validate :teacher_distinct_period, if: -> { valid_date_order? }
 
@@ -30,18 +28,6 @@ class InductionPeriod < ApplicationRecord
   scope :siblings_of, ->(instance) { for_teacher(instance.teacher).excluding(instance) }
 
 private
-
-  def started_on_not_in_future
-    return if started_on <= Date.current
-
-    errors.add(:started_on, "Start date cannot be in the future")
-  end
-
-  def finished_on_not_in_future
-    return if finished_on <= Date.current
-
-    errors.add(:finished_on, "End date cannot be in the future")
-  end
 
   def start_date_after_qts_date
     return if started_on.blank? || teacher.trs_qts_awarded_on.blank?

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -1,6 +1,6 @@
 class InductionPeriod < ApplicationRecord
   include Interval
-  include CommonInductionPeriodValidation
+  include SharedInductionPeriodValidation
 
   # Associations
   belongs_to :appropriate_body

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -12,8 +12,10 @@ class InductionPeriod < ApplicationRecord
             presence: true
 
   validates :number_of_terms,
-            presence: { message: "Enter a number of terms",
-                        if: -> { finished_on.present? } }
+            inclusion: { in: 0..16,
+                         message: "Terms must be between 0 and 16" },
+            presence: { message: "Enter a number of terms" },
+            if: -> { finished_on.present? }
 
   validates :induction_programme,
             inclusion: { in: %w[fip cip diy],

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -29,13 +29,6 @@ class InductionPeriod < ApplicationRecord
 
 private
 
-  def start_date_after_qts_date
-    return if started_on.blank? || teacher.trs_qts_awarded_on.blank?
-    return if started_on >= teacher.trs_qts_awarded_on
-
-    errors.add(:started_on, "Start date cannot be before QTS award date (#{teacher.trs_qts_awarded_on.to_fs(:govuk)})")
-  end
-
   def valid_date_order?
     return true if started_on.blank? || finished_on.blank?
 
@@ -46,5 +39,11 @@ private
     overlapping_siblings = InductionPeriod.siblings_of(self).overlapping_with(self).exists?
 
     errors.add(:base, "Induction periods cannot overlap") if overlapping_siblings
+  end
+
+  def start_date_after_qts_date
+    return if teacher.blank?
+
+    ensure_start_date_after_qts_date(teacher.trs_qts_awarded_on)
   end
 end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -11,9 +11,6 @@ class InductionPeriod < ApplicationRecord
   validates :started_on,
             presence: true
 
-  validates :appropriate_body_id,
-            presence: true
-
   validates :number_of_terms,
             presence: { message: "Enter a number of terms",
                         if: -> { finished_on.present? } }

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -66,18 +66,13 @@ class PendingInductionSubmission < ApplicationRecord
             presence: { message: "QTS has not been awarded" },
             on: :register_ect
 
-  validate :trs_qts_awarded_on_before_started_on, on: :register_ect
+  validate :start_date_after_qts_date, on: :register_ect
 
 private
 
-  def trs_qts_awarded_on_before_started_on
-    return unless started_on && trs_qts_awarded_on
+  def start_date_after_qts_date
+    return if trs_qts_awarded_on.blank?
 
-    if trs_qts_awarded_on > started_on
-      errors.add(
-        :started_on,
-        "Induction start date cannot be earlier than QTS award date (#{trs_qts_awarded_on.to_fs(:govuk)})"
-      )
-    end
+    ensure_start_date_after_qts_date(trs_qts_awarded_on)
   end
 end

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -66,8 +66,6 @@ class PendingInductionSubmission < ApplicationRecord
             presence: { message: "QTS has not been awarded" },
             on: :register_ect
 
-  validate :started_on_not_in_future, if: -> { started_on.present? }
-  validate :finished_on_not_in_future, if: -> { finished_on.present? }
   validate :trs_qts_awarded_on_before_started_on, on: :register_ect
 
 private
@@ -81,17 +79,5 @@ private
         "Induction start date cannot be earlier than QTS award date (#{trs_qts_awarded_on.to_fs(:govuk)})"
       )
     end
-  end
-
-  def started_on_not_in_future
-    return if started_on <= Date.current
-
-    errors.add(:started_on, "Start date cannot be in the future")
-  end
-
-  def finished_on_not_in_future
-    return if finished_on <= Date.current
-
-    errors.add(:finished_on, "End date cannot be in the future")
   end
 end

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -5,7 +5,7 @@
 # eventually write to the actual database before deleting the record here.
 class PendingInductionSubmission < ApplicationRecord
   include Interval
-  include CommonInductionPeriodValidation
+  include SharedInductionPeriodValidation
 
   attribute :confirmed
 

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -5,6 +5,7 @@
 # eventually write to the actual database before deleting the record here.
 class PendingInductionSubmission < ApplicationRecord
   include Interval
+  include CommonInductionPeriodValidation
 
   attribute :confirmed
 

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -15,9 +15,6 @@ class PendingInductionSubmission < ApplicationRecord
   belongs_to :appropriate_body
 
   # Validations
-  validates :appropriate_body_id,
-            presence: { message: "Select an appropriate body" }
-
   validates :trn,
             presence: { message: "Enter a TRN" },
             format: { with: Teacher::TRN_FORMAT, message: "TRN must be 7 numeric digits" },

--- a/spec/components/teachers/past_induction_periods_component_spec.rb
+++ b/spec/components/teachers/past_induction_periods_component_spec.rb
@@ -52,15 +52,15 @@ RSpec.describe Teachers::PastInductionPeriodsComponent, type: :component do
       let!(:older_period) do
         FactoryBot.create(:induction_period,
                           teacher:,
-                          started_on: 4.years.ago,
-                          finished_on: 3.years.ago)
+                          started_on: 3.years.ago,
+                          finished_on: 2.years.ago)
       end
 
       it "displays all past periods in chronological order" do
         render_inline(component)
         dates = page.all(".govuk-summary-list__value").map(&:text)
-        expect(dates).to include(4.years.ago.to_date.to_fs(:govuk))
         expect(dates).to include(3.years.ago.to_date.to_fs(:govuk))
+        expect(dates).to include(2.years.ago.to_date.to_fs(:govuk))
       end
     end
   end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -39,6 +39,21 @@ describe InductionPeriod do
 
     it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy]).with_message("Choose an induction programme") }
 
+    describe '#started_on_from_september_2021_onwards' do
+      context 'when started_on before September 2021' do
+        subject { FactoryBot.build(:induction_period, started_on:) }
+        let(:started_on) { Date.new(2021, 8, 31) }
+        before { subject.valid? }
+
+        it 'has a suitable error message' do
+          expect(subject.errors.messages[:started_on]).to include("Enter a start date after 1 September 2021")
+        end
+      end
+
+      it { is_expected.not_to allow_values(Date.new(2021, 8, 31)).for(:started_on) }
+      it { is_expected.to allow_values(Date.new(2021, 9, 1), Date.new(2021, 9, 2)).for(:started_on) }
+    end
+
     describe "started_on_not_in_future" do
       let(:induction_period) { FactoryBot.create(:induction_period, finished_on: nil) }
 

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -11,7 +11,7 @@ describe InductionPeriod do
   describe "validations" do
     subject { FactoryBot.build(:induction_period) }
 
-    it { is_expected.to validate_presence_of(:appropriate_body_id) }
+    it { is_expected.to validate_presence_of(:appropriate_body_id).with_message("Select an appropriate body") }
 
     describe 'overlapping periods' do
       let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -1,4 +1,7 @@
 describe InductionPeriod do
+  it { is_expected.to be_a_kind_of(Interval) }
+  it { is_expected.to be_a_kind_of(CommonInductionPeriodValidation) }
+
   describe "associations" do
     it { is_expected.to belong_to(:appropriate_body) }
     it { is_expected.to belong_to(:teacher) }

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -1,6 +1,6 @@
 describe InductionPeriod do
   it { is_expected.to be_a_kind_of(Interval) }
-  it { is_expected.to be_a_kind_of(CommonInductionPeriodValidation) }
+  it { is_expected.to be_a_kind_of(SharedInductionPeriodValidation) }
 
   describe "associations" do
     it { is_expected.to belong_to(:appropriate_body) }

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -7,6 +7,8 @@ describe PendingInductionSubmission do
   end
 
   describe "validation" do
+    it { is_expected.to validate_presence_of(:appropriate_body_id).with_message("Select an appropriate body") }
+
     describe "trn" do
       it { is_expected.to validate_presence_of(:trn).on(:find_ect).with_message("Enter a TRN") }
 

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -1,5 +1,6 @@
 describe PendingInductionSubmission do
   it { is_expected.to be_a_kind_of(Interval) }
+  it { is_expected.to be_a_kind_of(CommonInductionPeriodValidation) }
 
   describe "associations" do
     it { is_expected.to belong_to(:appropriate_body) }
@@ -41,6 +42,21 @@ describe PendingInductionSubmission do
         ["111/1111", "AAAA/BBB", "1234/12345"].each do |id|
           it { is_expected.not_to allow_value(id).for(:establishment_id).on(:find_ect).with_message("Enter an establishment ID in the format 1234/567") }
         end
+      end
+
+      describe '#started_on_from_september_2021_onwards' do
+        context 'when started_on before September 2021' do
+          subject { FactoryBot.build(:pending_induction_submission, started_on:) }
+          let(:started_on) { Date.new(2021, 8, 31) }
+          before { subject.valid? }
+
+          it 'has a suitable error message' do
+            expect(subject.errors.messages[:started_on]).to include("Enter a start date after 1 September 2021")
+          end
+        end
+
+        it { is_expected.not_to allow_values(Date.new(2021, 8, 31)).for(:started_on) }
+        it { is_expected.to allow_values(Date.new(2021, 9, 1), Date.new(2021, 9, 2)).for(:started_on) }
       end
     end
 

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -149,7 +149,7 @@ describe PendingInductionSubmission do
       end
     end
 
-    describe "trs_qts_awarded_on_before_started_on" do
+    describe "start_date_after_qts_date" do
       let(:pending_induction_submission) { FactoryBot.build(:pending_induction_submission, started_on:, trs_qts_awarded_on: Date.new(2023, 5, 1)) }
 
       context "when trs_qts_awarded_on is before started_on" do
@@ -168,7 +168,7 @@ describe PendingInductionSubmission do
         it "is invalid" do
           pending_induction_submission.valid?(:register_ect)
 
-          expect(pending_induction_submission.errors[:started_on]).to include("Induction start date cannot be earlier than QTS award date (1 May 2023)")
+          expect(pending_induction_submission.errors[:started_on]).to include("Start date cannot be before QTS award date (1 May 2023)")
         end
       end
     end

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -1,6 +1,6 @@
 describe PendingInductionSubmission do
   it { is_expected.to be_a_kind_of(Interval) }
-  it { is_expected.to be_a_kind_of(CommonInductionPeriodValidation) }
+  it { is_expected.to be_a_kind_of(SharedInductionPeriodValidation) }
 
   describe "associations" do
     it { is_expected.to belong_to(:appropriate_body) }

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
       it "fails because invalid" do
         expect(subject.register(pending_induction_submission_params)).to be_falsey
         expect(subject.pending_induction_submission.errors[:started_on]).to include(
-          "Induction start date cannot be earlier than QTS award date (3 May 2023)"
+          "Start date cannot be before QTS award date (3 May 2023)"
         )
       end
     end


### PR DESCRIPTION
I chose 1 September 2021 as the cutoff. Seems sensible but happy to change if there's a cause to be creating them before then.

![image](https://github.com/user-attachments/assets/939738d6-676e-4b28-b995-a37e70f7ff87)
