### PR TITLE
Register ECT/Mentors - Create TeacherEmail table to store emails

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -11,6 +11,10 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :events
 
   # Validations
+  validates :email,
+            notify_email: true,
+            allow_nil: true
+
   validates :started_on,
             presence: true
 

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -9,6 +9,10 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_many :events
 
   # Validations
+  validates :email,
+            notify_email: true,
+            allow_nil: true
+
   validates :started_on,
             presence: true
 

--- a/db/migrate/20250123161607_add_email_to_mentor_at_school_periods.rb
+++ b/db/migrate/20250123161607_add_email_to_mentor_at_school_periods.rb
@@ -1,0 +1,5 @@
+class AddEmailToMentorAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :mentor_at_school_periods, :email, :string
+  end
+end

--- a/db/migrate/20250123161652_add_email_to_ect_at_school_periods.rb
+++ b/db/migrate/20250123161652_add_email_to_ect_at_school_periods.rb
@@ -1,0 +1,5 @@
+class AddEmailToECTAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ect_at_school_periods, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_20_140655) do
-# These are extensions that must be enabled in order to support this database
+ActiveRecord::Schema[8.0].define(version: 2025_01_23_161652) do
+  # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
   enable_extension "unaccent"
@@ -148,6 +148,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_20_140655) do
     t.uuid "legacy_start_id"
     t.uuid "legacy_end_id"
     t.enum "working_pattern", enum_type: "working_pattern"
+    t.string "email"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
@@ -277,6 +278,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_20_140655) do
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.uuid "legacy_start_id"
     t.uuid "legacy_end_id"
+    t.string "email"
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -219,6 +219,7 @@ print_seed_info("Emma Thompson (mentor)", indent: 2, colour: MENTOR_COLOUR)
 emma_thompson_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
   teacher: emma_thompson,
   school: abbey_grove_school,
+  email: 'emma.thompson@matilda.com',
   started_on: 3.years.ago
 ).tap { |sp| describe_mentor_at_school_period(sp) }
 
@@ -248,6 +249,7 @@ print_seed_info("Kate Winslet (ECT)", indent: 2, colour: ECT_COLOUR)
 kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   teacher: kate_winslet,
   school: ackley_bridge,
+  email: 'kate.winslet@titanic.com',
   started_on: 1.year.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -269,6 +271,7 @@ print_seed_info("Hugh Laurie (mentor)", indent: 2, colour: MENTOR_COLOUR)
 hugh_laurie_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
   teacher: hugh_laurie,
   school: abbey_grove_school,
+  email: 'hugh.laurie@house.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_mentor_at_school_period(sp) }
 
@@ -288,6 +291,7 @@ print_seed_info("Alan Rickman (ECT)", indent: 2, colour: ECT_COLOUR)
 alan_rickman_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   teacher: alan_rickman,
   school: ackley_bridge,
+  email: 'alan.rickman@diehard.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -325,6 +329,7 @@ print_seed_info("Hugh Grant (ECT)", indent: 2, colour: ECT_COLOUR)
 hugh_grant_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
   teacher: hugh_grant,
   school: abbey_grove_school,
+  email: 'hugh.grant@wonka.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -359,6 +364,7 @@ print_seed_info("Jamie Parsons (ECT)", indent: 2, colour: ECT_COLOUR)
 jamie_parsons_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
   teacher: jamie_parsons,
   school: abbey_grove_school,
+  email: 'jamie.parsons@aol.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -438,6 +444,7 @@ InductionPeriod.create!(
 imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
   teacher: imogen_stubbs,
   school: mallory_towers,
+  email: 'imogen.stubbs@eriktheviking.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -465,6 +472,7 @@ InductionPeriod.create!(
 gemma_jones_at_malory_towers = ECTAtSchoolPeriod.create!(
   teacher: gemma_jones,
   school: mallory_towers,
+  email: 'gemma.jones@rocketman.com',
   started_on: 21.months.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -484,6 +492,7 @@ print_seed_info("André Roussimoff (ECT)", indent: 2, colour: ECT_COLOUR)
 andre_roussimoff_mentoring_at_ackley_bridge = MentorAtSchoolPeriod.create!(
   teacher: andre_roussimoff,
   school: ackley_bridge,
+  email: 'andre.giant@wwf.com',
   started_on: 1.year.ago
 ).tap { |sp| describe_mentor_at_school_period(sp) }
 
@@ -498,6 +507,7 @@ print_seed_info("Anthony Hopkins (ECT)", indent: 2, colour: ECT_COLOUR)
 anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
   teacher: anthony_hopkins,
   school: brookfield_school,
+  email: 'anthony.hopkins@favabeans.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -512,6 +522,7 @@ print_seed_info("John Withers (mentor)", indent: 2, colour: MENTOR_COLOUR)
 john_withers_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
   teacher: john_withers,
   school: abbey_grove_school,
+  email: 'john.withers@amusementpark.com',
   started_on: 2.years.ago
 ).tap { |sp| describe_mentor_at_school_period(sp) }
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -15,6 +15,12 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to validate_presence_of(:school_id) }
     it { is_expected.to validate_presence_of(:teacher_id) }
 
+    context "email" do
+      it { is_expected.to allow_value(nil).for(:email) }
+      it { is_expected.to allow_value("test@example.com").for(:email) }
+      it { is_expected.not_to allow_value("invalid_email").for(:email) }
+    end
+
     context "teacher distinct period" do
       context "when the period has not finished yet" do
         context "when the teacher has a sibling ect_at_school_period starting later" do

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -14,6 +14,12 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to validate_presence_of(:school_id) }
     it { is_expected.to validate_presence_of(:teacher_id) }
 
+    context "email" do
+      it { is_expected.to allow_value(nil).for(:email) }
+      it { is_expected.to allow_value("test@example.com").for(:email) }
+      it { is_expected.not_to allow_value("invalid_email").for(:email) }
+    end
+
     context "teacher school distinct period" do
       context "when the period has not finished yet" do
         context "when the teacher has a school sibling mentor_at_school_period starting later" do


### PR DESCRIPTION
### Ticket
https://github.com/DFE-Digital/register-ects-project-board/issues/1091 

### Note 
This 1 of 2 possible solutions up for discussion. [Please also see the other proposed solution](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/60).

### Changes
- Create TeacherEmail table to store `teacher_id` and `email`. The `ect_at_school_period` and `mentor_at_school_period` tables now reference this new table. 
- This allows us to ensure that the combination of `teacher_id` and `email` is unique, as well as ensuring that `emails` by themselves are unique (so that other Mentors and ECTs cannot take an existing address)
- Validate at both the model and db layers

### Validation summary ( `teacher_emails` table)

Feature | Allowed?
-- | --
Duplicate email for same teacher | No
Teacher can have more than one email | Yes
Duplicate email across all teachers | No
Blank (nil) emails | Yes
