### PR TITLE
Remove id from migration failure message

### DIFF
--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -32,7 +32,7 @@ module Migrators
       teacher = ::Teacher.find_by(legacy_ect_id: participant_profile.id)
 
       if teacher.nil?
-        failure_manager.record_failure(participant_profile, "Cannot find Teacher for ParticipantProfile::ECT with id #{participant_profile.id}")
+        failure_manager.record_failure(participant_profile, "Cannot find Teacher for ECT in mentorship period")
         return false
       end
 


### PR DESCRIPTION
Remove the `id` of the missing ECT from the failure message in order to keep the message more generic so that we can group failure types more easily.