### PR TITLE
Show the TRS induction status from teacher record

### DIFF
--- a/app/components/teachers/induction_summary_component.rb
+++ b/app/components/teachers/induction_summary_component.rb
@@ -1,10 +1,11 @@
 module Teachers
   class InductionSummaryComponent < ViewComponent::Base
-    attr_reader :teacher, :induction
+    attr_reader :teacher, :induction, :induction_periods
 
     def initialize(teacher:)
       @teacher = teacher
       @induction = Teachers::Induction.new(teacher)
+      @induction_periods = teacher.induction_periods
     end
 
     def render?
@@ -22,11 +23,15 @@ module Teachers
     end
 
     def status_tag
-      helpers.govuk_tag(text: "placeholder", colour: %w[grey green red purple orange yellow].sample)
+      helpers.govuk_tag(**Teachers::InductionStatus.new(teacher:, induction_periods:, trs_induction_status:).status_tag_kwargs)
     end
 
     def extension_view_link
       helpers.govuk_link_to("View", helpers.ab_teacher_extensions_path(teacher), no_visited_state: true)
+    end
+
+    def trs_induction_status
+      teacher.trs_induction_status
     end
   end
 end

--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -25,7 +25,7 @@ module AppropriateBodyHelper
     ]
   end
 
-  def summary_card_for_teacher(teacher)
+  def summary_card_for_teacher(teacher:)
     induction_start_date = Teachers::InductionPeriod.new(teacher).induction_start_date&.to_fs(:govuk)
 
     govuk_summary_card(title: Teachers::Name.new(teacher).full_name) do |card|
@@ -40,13 +40,14 @@ module AppropriateBodyHelper
           },
           {
             key: { text: "Status" },
-            # FIXME: this is a placeholder as we cannot display a real status yet
-            value: { text: govuk_tag(text: "placeholder", colour: %w[grey green red purple orange yellow].sample) },
+            value: { text: govuk_tag(**Teachers::InductionStatus.new(teacher:).status_tag_kwargs) },
           },
         ]
       )
     end
   end
+
+private
 
   def pending_induction_submission_full_name(pending_induction_submission)
     PendingInductionSubmissions::Name.new(pending_induction_submission).full_name

--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -40,7 +40,15 @@ module AppropriateBodyHelper
           },
           {
             key: { text: "Status" },
-            value: { text: govuk_tag(**Teachers::InductionStatus.new(teacher:).status_tag_kwargs) },
+            value: {
+              text: govuk_tag(
+                **Teachers::InductionStatus.new(
+                  teacher:,
+                  induction_periods: teacher.induction_periods,
+                  trs_induction_status: teacher.trs_induction_status
+                ).status_tag_kwargs
+              ),
+            },
           },
         ]
       )

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -13,6 +13,10 @@ module Interval
     scope :containing_period, ->(period) { where("range @> daterange(?, ?)", period.started_on, period.finished_on) }
   end
 
+  def ongoing?
+    finished_on.nil?
+  end
+
   def finish!(finished_on = Date.current)
     update!(finished_on:)
   end

--- a/app/services/teachers/induction_status.rb
+++ b/app/services/teachers/induction_status.rb
@@ -1,0 +1,79 @@
+class Teachers::InductionStatus
+  class MissingTeacherAndTRSInductionStatus < StandardError; end
+
+  attr_reader :teacher, :induction_periods, :trs_induction_status
+
+  def initialize(teacher: nil, induction_periods: [], trs_induction_status: nil)
+    @teacher = teacher
+    @induction_periods = induction_periods
+    @trs_induction_status = trs_induction_status || teacher&.trs_induction_status
+  end
+
+  def status_tag_kwargs
+    case induction_info
+    in { teacher_present: true, has_an_open_induction_period: true }
+      in_progress
+    in { teacher_present: true, has_an_open_induction_period: false, has_an_induction_outcome: false }
+      paused
+    in { teacher_present: true, has_an_open_induction_period: false, induction_outcome: 'pass' }
+      passed
+    in { teacher_present: true, has_an_open_induction_period: false, induction_outcome: 'fail' }
+      failed
+    in { teacher_present: false, trs_induction_status: 'RequiredToComplete' }
+      required_to_complete
+    in { teacher_present: false, trs_induction_status: 'Exempt' }
+      exempt
+    in { teacher_present: false, trs_induction_status: 'InProgress' }
+      in_progress
+    in { teacher_present: false, trs_induction_status: 'Failed' }
+      failed
+    in { teacher_present: false, trs_induction_status: 'Passed' }
+      passed
+    in { teacher_present: false, trs_induction_status: 'FailedInWales' }
+      failed_in_wales
+    in { teacher_present: false, trs_induction_status: 'None' }
+      none
+    else
+      unknown
+    end
+  end
+
+  def induction_status = status_tag_kwargs.fetch(:text)
+  def induction_status_colour = status_tag_kwargs.fetch(:colour)
+
+private
+
+  def induction_info
+    {
+      has_an_open_induction_period: has_any_open_induction_periods?,
+      has_an_induction_outcome: has_an_induction_outcome?,
+      teacher_present: teacher.present?,
+      induction_outcome:,
+      trs_induction_status:,
+    }
+  end
+
+  def has_any_open_induction_periods?
+    induction_periods.any?(&:ongoing?)
+  end
+
+  def has_an_induction_outcome?
+    induction_periods.any? { |ip| ip.outcome.present? }
+  end
+
+  def induction_outcome
+    return unless (period_with_outcome = induction_periods.find { |ip| ip.outcome.present? })
+
+    period_with_outcome.outcome
+  end
+
+  def exempt = { text: 'Exempt', colour: 'green' }
+  def failed = { text: 'Failed', colour: 'red' }
+  def failed_in_wales = { text: 'Failed in Wales', colour: 'red' }
+  def in_progress = { text: 'In progress', colour: 'blue' }
+  def none = { text: 'None', colour: 'grey' }
+  def passed = { text: 'Passed', colour: 'green' }
+  def paused = { text: 'Induction paused', colour: 'pink' }
+  def required_to_complete = { text: 'Required to complete', colour: 'yellow' }
+  def unknown = { text: 'Unknown', colour: 'grey' }
+end

--- a/app/services/teachers/induction_status.rb
+++ b/app/services/teachers/induction_status.rb
@@ -1,9 +1,7 @@
 class Teachers::InductionStatus
-  class MissingTeacherAndTRSInductionStatus < StandardError; end
-
   attr_reader :teacher, :induction_periods, :trs_induction_status
 
-  def initialize(teacher: nil, induction_periods: [], trs_induction_status: nil)
+  def initialize(teacher:, induction_periods:, trs_induction_status:)
     @teacher = teacher
     @induction_periods = induction_periods
     @trs_induction_status = trs_induction_status || teacher&.trs_induction_status
@@ -54,15 +52,15 @@ private
   end
 
   def has_any_open_induction_periods?
-    induction_periods.any?(&:ongoing?)
+    induction_periods&.any?(&:ongoing?)
   end
 
   def has_an_induction_outcome?
-    induction_periods.any? { |ip| ip.outcome.present? }
+    induction_periods&.any? { |ip| ip.outcome.present? }
   end
 
   def induction_outcome
-    return unless (period_with_outcome = induction_periods.find { |ip| ip.outcome.present? })
+    return unless (period_with_outcome = induction_periods&.find { |ip| ip.outcome.present? })
 
     period_with_outcome.outcome
   end

--- a/app/views/admin/teachers/index.html.erb
+++ b/app/views/admin/teachers/index.html.erb
@@ -37,8 +37,15 @@
               },
               {
                 key: { text: "Status" },
-                # FIXME: this is a placeholder as we cannot display a real status yet
-                value: { text: govuk_tag(text: "placeholder", colour: %w[grey green red purple orange yellow].sample) },
+                value: {
+                  text: govuk_tag(
+                    **Teachers::InductionStatus.new(
+                      teacher:,
+                      induction_periods: teacher.induction_periods,
+                      trs_induction_status: teacher.trs_induction_status
+                    ).status_tag_kwargs
+                  )
+                },
               },
             ]
           )

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -72,7 +72,13 @@
 
     sl.with_row do |r|
       r.with_key(text: "Induction status")
-      r.with_value(text: govuk_tag(**Teachers::InductionStatus.new(trs_induction_status: @pending_induction_submission.trs_induction_status).status_tag_kwargs))
+      r.with_value(text: govuk_tag(
+        **Teachers::InductionStatus.new(
+          teacher: @teacher,
+          induction_periods: @teacher&.induction_periods,
+          trs_induction_status: @pending_induction_submission.trs_induction_status
+        ).status_tag_kwargs
+      ))
     end if @pending_induction_submission.trs_induction_status.present?
   end
 %>

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -72,7 +72,7 @@
 
     sl.with_row do |r|
       r.with_key(text: "Induction status")
-      r.with_value(text: @pending_induction_submission.trs_induction_status)
+      r.with_value(text: govuk_tag(**Teachers::InductionStatus.new(trs_induction_status: @pending_induction_submission.trs_induction_status).status_tag_kwargs))
     end if @pending_induction_submission.trs_induction_status.present?
   end
 %>

--- a/app/views/appropriate_bodies/teachers/index.html.erb
+++ b/app/views/appropriate_bodies/teachers/index.html.erb
@@ -27,7 +27,7 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% @teachers.all.each do |teacher| %>
-      <%= summary_card_for_teacher(teacher) %>
+      <%= summary_card_for_teacher(teacher:) %>
     <% end %>
   </div>
 </div>

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -13,6 +13,14 @@ FactoryBot.define do
       number_of_terms { nil }
     end
 
+    trait :pass do
+      outcome { :pass }
+    end
+
+    trait :fail do
+      outcome { :fail }
+    end
+
     trait(:cip) { induction_programme { "cip" } }
     trait(:diy) { induction_programme { "diy" } }
   end

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
     let(:teacher) { FactoryBot.create(:teacher) }
 
     it "builds a summary card for a teacher" do
-      expect(summary_card_for_teacher(teacher)).to include(
+      expect(summary_card_for_teacher(teacher:)).to include(
         CGI.escapeHTML(teacher.trs_first_name),
         CGI.escapeHTML(teacher.trs_last_name)
       )
@@ -36,7 +36,7 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
       end
 
       it "displays the most recent induction start date" do
-        expect(summary_card_for_teacher(teacher)).to include(expected_date)
+        expect(summary_card_for_teacher(teacher:)).to include(expected_date)
       end
     end
   end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -91,6 +91,20 @@ describe Interval do
       end
     end
   end
+
+  describe '#ongoing?' do
+    context 'when finished_on is nil' do
+      subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: nil) }
+
+      it { is_expected.to be_ongoing }
+    end
+
+    context 'when finished_on is present' do
+      subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: 1.day.ago) }
+
+      it { is_expected.not_to be_ongoing }
+    end
+  end
 end
 
 class DummyMentor < ApplicationRecord

--- a/spec/services/teachers/induction_status_spec.rb
+++ b/spec/services/teachers/induction_status_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe Teachers::InductionStatus do
+  subject { Teachers::InductionStatus.new(teacher:, induction_periods:, trs_induction_status:) }
+
+  context 'when the teacher record exists in our database' do
+    let(:trs_induction_status) { nil }
+
+    context 'when the ECT has an open induction period' do
+      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:induction_periods) do
+        [
+          FactoryBot.create(:induction_period),
+          FactoryBot.create(:induction_period, :active)
+        ]
+      end
+
+      it "has a status of 'In progress'" do
+        expect(subject.induction_status).to eql('In progress')
+      end
+    end
+
+    context 'when the ECT has no open induction period' do
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      context 'when there is no induction outcome' do
+        let(:induction_periods) { FactoryBot.create_list(:induction_period, 2) }
+
+        it "has a status of 'Paused'" do
+          expect(subject.induction_status).to eql('Induction paused')
+        end
+      end
+
+      context 'when there is a :pass outcome' do
+        let(:induction_periods) do
+          [
+            FactoryBot.create(:induction_period),
+            FactoryBot.create(:induction_period, :pass)
+          ]
+        end
+
+        it "has a status of 'Passed'" do
+          expect(subject.induction_status).to eql('Passed')
+        end
+      end
+
+      context 'when there is a :fail outcome' do
+        let(:induction_periods) do
+          [
+            FactoryBot.create(:induction_period),
+            FactoryBot.create(:induction_period, :fail)
+          ]
+        end
+
+        it "has a status of 'Failed'" do
+          expect(subject.induction_status).to eql('Failed')
+        end
+      end
+    end
+  end
+
+  context 'when the teacher record does not exist in our database' do
+    let(:teacher) { nil }
+    let(:induction_periods) { [] }
+
+    context 'when there is no induction outcome' do
+      {
+        "Exempt" => "Exempt",
+        "RequiredToComplete" => "Required to complete",
+        "InProgress" => "In progress",
+        "Failed" => "Failed",
+        "Passed" => "Passed",
+        "FailedInWales" => "Failed in Wales",
+        "None" => "None",
+      }.each do |trs_induction_status, our_description|
+        context "when the trs_induction_status is #{trs_induction_status}" do
+          let(:our_description) { our_description }
+          let(:trs_induction_status) { trs_induction_status }
+
+          it "has a status of '#{our_description}'" do
+            expect(subject.induction_status).to eql(our_description)
+          end
+        end
+      end
+    end
+  end
+
+  context 'when no conditions are matched' do
+    let(:teacher) { nil }
+    let(:induction_periods) { [] }
+    let(:trs_induction_status) { 'SomethingEntirelyDifferent' }
+
+    it "has a status of 'Unknown'" do
+      expect(subject.induction_status).to eql('Unknown')
+    end
+  end
+end


### PR DESCRIPTION
This change makes the status retrieved from TRS visible in the appropriate body UI.

The statuses on our test records aren't very exciting but here the top record with 'None' is pulled from TRS using the service written in #23.

![Screenshot From 2025-01-21 10-27-39](https://github.com/user-attachments/assets/43a11b3c-e5f3-49c5-adde-12294b586812)

I made up the colours, feedback on them welcome. The values in the PR map to [these tag variants](https://design-system.service.gov.uk/components/tag/#additional-colours).


Fixes #1026