### PR TITLE
Add spec covering pending induction submission status

### DIFF
--- a/app/services/teachers/induction_status.rb
+++ b/app/services/teachers/induction_status.rb
@@ -4,7 +4,7 @@ class Teachers::InductionStatus
   def initialize(teacher:, induction_periods:, trs_induction_status:)
     @teacher = teacher
     @induction_periods = induction_periods
-    @trs_induction_status = trs_induction_status || teacher&.trs_induction_status
+    @trs_induction_status = trs_induction_status
   end
 
   def status_tag_kwargs

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe "appropriate_bodies/claim_an_ect/check_ect/edit.html.erb" do
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: '/appropriate-body/claim-an-ect/find-ect/new')
   end
 
+  describe 'induction status' do
+    let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_induction_status: 'FailedInWales') }
+
+    it 'displays the status tag that corresponds to the TRS induction status on the pending induction submission' do
+      assign(:pending_induction_submission, pending_induction_submission)
+
+      render
+
+      expect(rendered).to have_css('strong.govuk-tag', text: 'Failed in Wales')
+    end
+  end
+
   describe 'induction periods' do
     let(:teacher) { FactoryBot.create(:teacher) }
     let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }


### PR DESCRIPTION
Add spec covering the use of the TRS induction status on the check ECT page.

This should really have been included in #53.
