### PR TITLE
Restrict the registration of ECTs who are prohibited from teaching

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -25,6 +25,8 @@ class TestGuidanceComponent < ViewComponent::Base
         ["3002578", "10/09/1977", "CB196295D", ""],
         ["3002577", "02/12/2000", "BT524135A", ""],
         ["3002576", "04/03/1999", "GE377928A", ""],
+        ["2632412", "16/02/1984", "", "Prohibited from teaching"],
+        ["2908239", "12/08/1978", "", "Prohibited from teaching"],
       ]
     end
 

--- a/app/views/schools/register_ect_wizard/cannot_register_ect.html.erb
+++ b/app/views/schools/register_ect_wizard/cannot_register_ect.html.erb
@@ -1,0 +1,5 @@
+<% page_data(title: "You cannot register #{@ect.full_name}", error: false) %>
+
+<p class="govuk-body">Our records show that <%= @ect.full_name %> cannot be registered for training or mentoring.</p>
+
+<p class="govuk-body"><%= govuk_link_to("Back to ECTs", schools_ects_home_path) %></p>

--- a/app/wizards/schools/register_ect_wizard/cannot_register_ect_step.rb
+++ b/app/wizards/schools/register_ect_wizard/cannot_register_ect_step.rb
@@ -1,0 +1,6 @@
+module Schools
+  module RegisterECTWizard
+    class CannotRegisterECTStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/register_ect_wizard/find_ect_step.rb
+++ b/app/wizards/schools/register_ect_wizard/find_ect_step.rb
@@ -18,6 +18,7 @@ module Schools
         return :already_active_at_school if ect.active_at_school?(school:)
         return :induction_completed if ect.induction_completed?
         return :induction_exempt if ect.induction_exempt?
+        return :cannot_register_ect if trs_teacher.prohibited_from_teaching?
 
         :review_ect_details
       end

--- a/app/wizards/schools/register_ect_wizard/wizard.rb
+++ b/app/wizards/schools/register_ect_wizard/wizard.rb
@@ -10,6 +10,7 @@ module Schools
           {
             already_active_at_school: AlreadyActiveAtSchoolStep,
             state_school_appropriate_body: StateSchoolAppropriateBodyStep,
+            cannot_register_ect: CannotRegisterECTStep,
             check_answers: CheckAnswersStep,
             confirmation: ConfirmationStep,
             email_address: EmailAddressStep,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
 
       get "trn-not-found", action: :new
       get "not-found", action: :new
+      get "cannot-register-ect", action: :new
 
       get "already_active_at_school", action: :new
       get "induction-completed", action: :new

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -72,6 +72,10 @@ module TRS
       true
     end
 
+    def prohibited_from_teaching?
+      @alerts&.any? { |alert| alert.dig('alertType', 'alertCategory', 'alertCategoryId') == PROHIBITED_FROM_TEACHING_CATEGORY_ID }
+    end
+
   private
 
     def induction_status_completed?
@@ -89,10 +93,6 @@ module TRS
 
     def qts_awarded?
       @qts_awarded_on.present?
-    end
-
-    def prohibited_from_teaching?
-      @alerts&.any? { |alert| alert.dig('alertType', 'alertCategory', 'alertCategoryId') == PROHIBITED_FROM_TEACHING_CATEGORY_ID }
     end
   end
 end

--- a/spec/lib/trs/teacher_spec.rb
+++ b/spec/lib/trs/teacher_spec.rb
@@ -156,4 +156,46 @@ RSpec.describe TRS::Teacher do
       end
     end
   end
+
+  describe '#prohibited_from_teaching?' do
+    context 'when teacher has a prohibition alert' do
+      let(:data) do
+        {
+          'alerts' => [
+            {
+              'alertType' => { 'alertCategory' => { 'alertCategoryId' => 'b2b19019-b165-47a3-8745-3297ff152581' } },
+            }
+          ]
+        }
+      end
+
+      it 'returns true' do
+        expect(subject.prohibited_from_teaching?).to be true
+      end
+    end
+
+    context 'when teacher has no alerts' do
+      let(:data) { { 'alerts' => [] } }
+
+      it 'returns false' do
+        expect(subject.prohibited_from_teaching?).to be false
+      end
+    end
+
+    context "when teacher has different type of alert" do
+      let(:data) do
+        {
+          'alerts' => [
+            {
+              'alertType' => { 'alertCategory' => { 'alertCategoryId' => 'different_category' } },
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(subject.prohibited_from_teaching?).to be false
+      end
+    end
+  end
 end

--- a/spec/views/schools/register_ect_wizard/cannot_register_ect.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/cannot_register_ect.html.erb_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "schools/register_ect_wizard/cannot_register_ect" do
+  let(:ect) { double('ECT', full_name: 'John Doe') }
+  let(:title) { "You cannot register #{ect.full_name}" }
+
+  before do
+    assign(:ect, ect)
+    render
+  end
+
+  it "sets the page title to 'You cannot register John Doe'" do
+    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  end
+
+  it "displays the cannot register ECT message" do
+    expect(rendered).to have_content("Our records show that John Doe cannot be registered for training or mentoring.")
+  end
+
+  it "includes a link back to ECTs" do
+    expect(rendered).to have_link("Back to ECTs", href: schools_ects_home_path)
+  end
+end

--- a/spec/wizards/schools/register_ect/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect/find_ect_step_spec.rb
@@ -41,6 +41,37 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     subject { wizard.current_step }
 
+    context 'when the teacher is prohibited from teaching' do
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      before do
+        fake_client = TRS::FakeAPIClient.new
+
+        allow(fake_client).to receive(:find_teacher).and_return(
+          TRS::Teacher.new(
+            'trn' => '1234568',
+            'firstName' => 'Kirk',
+            'lastName' => 'Van Houten',
+            'dateOfBirth' => '1977-02-03',
+            'alerts' => [
+              {
+                'alertType' => {
+                  'alertCategory' => {
+                    'alertCategoryId' => TRS::Teacher::PROHIBITED_FROM_TEACHING_CATEGORY_ID
+                  }
+                }
+              }
+            ]
+          )
+        )
+        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        subject.save!
+      end
+
+      it 'returns :cannot_register_ect' do
+        expect(subject.next_step).to eq(:cannot_register_ect)
+      end
+    end
+
     context 'when the ect is not found in TRS' do
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))


### PR DESCRIPTION
This PR prevents ECTs who are prohibited from teaching from being registered in the service.

We don't anticipate schools attempting to register ECTs who are prohibited from teaching. However, we implemented this functionality as an added safeguard.

Since this involves sensitive safeguarding information, we display a more generic page stating that the ECT cannot be registered.

Changes
- Added new wizard step `CannotRegisterECTStep` to handle prohibited teacher cases
- Added view to display appropriate message when registration is prevented
- Added two TRS teachers with prohibited alerts to facilitate testing in non-prod envs