### PR TITLE
Allow any value zero or over for number of terms

### DIFF
--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -25,7 +25,6 @@ class InductionPeriod < ApplicationRecord
   validate :finished_on_not_in_future, if: -> { finished_on.present? }
   validate :start_date_after_qts_date
   validate :teacher_distinct_period, if: -> { valid_date_order? }
-  validate :number_of_terms_for_ongoing_induction_period
 
   # Scopes
   scope :for_teacher, ->(teacher) { where(teacher:) }
@@ -63,13 +62,5 @@ private
     overlapping_siblings = InductionPeriod.siblings_of(self).overlapping_with(self).exists?
 
     errors.add(:base, "Induction periods cannot overlap") if overlapping_siblings
-  end
-
-  def number_of_terms_for_ongoing_induction_period
-    return if finished_on.blank?
-    return if number_of_terms.blank?
-    return if number_of_terms.zero? || number_of_terms >= 1
-
-    errors.add(:number_of_terms, "Partial terms can only be recorded after completing a full term of induction. If the early career teacher has done less than one full term of induction they cannot record partial terms and the number inputted should be 0.")
   end
 end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -156,21 +156,6 @@ describe InductionPeriod do
           expect(subject).to be_valid
         end
       end
-
-      context "when number_of_terms is between 0 and 1" do
-        before { subject.number_of_terms = 0.5 }
-
-        it "is invalid" do
-          expect(subject).not_to be_valid
-        end
-
-        it "adds the correct error message" do
-          subject.valid?
-          expect(subject.errors[:number_of_terms]).to include(
-            "Partial terms can only be recorded after completing a full term of induction. If the early career teacher has done less than one full term of induction they cannot record partial terms and the number inputted should be 0."
-          )
-        end
-      end
     end
   end
 


### PR DESCRIPTION
We previously had an extra rule that prevents number_of_terms from being between 0 and 1 because of feedback from within DfE, but we want to relax that because there are circumstances where shorter values need to be recorded.