### PR TITLE
Fix bug where induction period not saved

### DIFF
--- a/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
@@ -45,7 +45,7 @@ module AppropriateBodies
 
         teacher.save!
 
-        if new_name != old_name
+        if old_name && new_name != old_name
           Events::Record.teacher_name_changed_in_trs!(author:, old_name:, new_name:, teacher:, appropriate_body:)
         end
 

--- a/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
@@ -17,13 +17,13 @@ module AppropriateBodies
         # if teacher.persisted? && teacher.induction_periods.present?
         #   raise AppropriateBodies::Errors::TeacherAlreadyClaimedError, "Teacher already claimed"
         # end
-
         ActiveRecord::Base.transaction do
           steps = [
             update_teacher,
+            create_induction_period,
             send_begin_induction_notification_to_trs,
             pending_induction_submission.save(context: :register_ect),
-            create_induction_period && record_induction_period_event
+            record_induction_period_event
           ]
 
           steps.all? or raise ActiveRecord::Rollback

--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -63,6 +63,8 @@ module AppropriateBodies
         outcome:,
         number_of_terms: pending_induction_submission.number_of_terms
       )
+
+      active_induction_period.valid?
     end
 
     def send_fail_induction_notification_to_trs

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -62,7 +62,9 @@ module Events
     end
 
     def record_event!
-      RecordEventJob.perform_later(**attributes)
+      # FIXME: This job is causing serialization errors when launched within a failing transaction block.
+      # We have not yet identified the root cause of this issue therefore we're going to run the job inline for now.
+      RecordEventJob.perform_now(**attributes)
     end
 
     # Appropriate body events

--- a/app/services/teachers/name.rb
+++ b/app/services/teachers/name.rb
@@ -13,6 +13,7 @@ class Teachers::Name
 
   def full_name_in_trs
     return if teacher.blank?
+    return if teacher.trs_first_name.blank? && teacher.trs_last_name.blank?
 
     %(#{teacher.trs_first_name} #{teacher.trs_last_name})
   end

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -96,6 +96,24 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
       end
     end
 
+    context "when pending_induction_submission isn't valid" do
+      let(:pending_induction_submission_params) do
+        {
+          induction_programme: "fip",
+          started_on: Date.new(2000, 5, 2),
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Doe",
+          trs_qts_awarded_on:
+        }
+      end
+
+      it "can perform jobs without erroring" do
+        subject.register(pending_induction_submission_params)
+        perform_enqueued_jobs
+      end
+    end
+
     context 'when registering an existing teacher' do
       context "when the teacher has no induction period" do
         let!(:existing_teacher) { FactoryBot.create(:teacher, trn: "1234567") }

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -6,7 +6,7 @@ describe Events::Record do
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
   let(:author_params) { { author_id: author.id, author_name: author.name, author_email: author.email, author_type: :dfe_staff_user } }
 
-  before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+  before { allow(RecordEventJob).to receive(:perform_now).and_return(true) }
 
   describe '#initialize' do
     let(:heading) { 'Something happened' }
@@ -56,11 +56,11 @@ describe Events::Record do
 
       event_attributes = { **author.event_author_params, **attributes.except(:author) }
 
-      allow(RecordEventJob).to receive(:perform_later).with(**event_attributes).and_return(true)
+      allow(RecordEventJob).to receive(:perform_now).with(**event_attributes).and_return(true)
 
       event_record.record_event!
 
-      expect(RecordEventJob).to have_received(:perform_later).with(**event_attributes)
+      expect(RecordEventJob).to have_received(:perform_now).with(**event_attributes)
     end
   end
 
@@ -69,7 +69,7 @@ describe Events::Record do
       freeze_time do
         Events::Record.record_appropriate_body_claims_teacher_event!(author:, teacher:, appropriate_body:, induction_period:)
 
-        expect(RecordEventJob).to have_received(:perform_later).with(
+        expect(RecordEventJob).to have_received(:perform_now).with(
           induction_period:,
           teacher:,
           appropriate_body:,
@@ -87,7 +87,7 @@ describe Events::Record do
       freeze_time do
         Events::Record.record_appropriate_body_passes_teacher_event(author:, teacher:, appropriate_body:, induction_period:)
 
-        expect(RecordEventJob).to have_received(:perform_later).with(
+        expect(RecordEventJob).to have_received(:perform_now).with(
           induction_period:,
           teacher:,
           appropriate_body:,
@@ -105,7 +105,7 @@ describe Events::Record do
       freeze_time do
         Events::Record.record_appropriate_body_fails_teacher_event(author:, teacher:, appropriate_body:, induction_period:)
 
-        expect(RecordEventJob).to have_received(:perform_later).with(
+        expect(RecordEventJob).to have_received(:perform_now).with(
           induction_period:,
           teacher:,
           appropriate_body:,

--- a/spec/services/teachers/extensions/update_extension_spec.rb
+++ b/spec/services/teachers/extensions/update_extension_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Teachers::Extensions::UpdateExtension do
       let(:service) { described_class.new(extension, invalid_params) }
 
       it "does not update the extension" do
-        # expect { service.update_extension }.to(not_change { extension.reload.attributes })
         expect { service.update_extension }.not_to(change { extension.reload.attributes })
       end
 


### PR DESCRIPTION
This happens becuase we were checking for the truthiness of each success step but calling `.create` on a invalid model returns the unsaved record which is truthy.


Now we call `#persisted?` at the end of the method and only call record_induction_period_event if the induction period was saved.

Additionally, the event job errored when deserialising non-persisted models that were rolled back if a transaction errored.

ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1157
