### PR TITLE
Group migration failures

### DIFF
--- a/app/controllers/migration/failures_controller.rb
+++ b/app/controllers/migration/failures_controller.rb
@@ -2,29 +2,37 @@ class Migration::FailuresController < ::AdminController
   layout "full"
 
   def index
-    @failures = grouped_failures
+    @teacher_failures = teacher_grouped_failures
+    @failures = generic_grouped_failures
   end
 
 private
 
-  def grouped_failures
+  def teacher_grouped_failures
+    failures = TeacherMigrationFailure.all
+    failure_group.new(:teacher, failures.count, failures.group(:message).count.sort.to_h)
+  end
+
+  def generic_grouped_failures
     migrator_models.map do |model|
-      {
-        model:,
-        failures: MigrationFailure.joins(:data_migration).where(data_migration: { model: }).group(:failure_message).count
-      }
+      failures = migration_failures_for_model(model:)
+      failure_group.new(model, failures.count, failures.group(:failure_message).count.sort.to_h)
     end
   end
 
-  def migrator_names
-    @migrator_names ||= migrator_models.map(&:humanize)
+  def failure_group
+    @failure_group ||= Data.define(:model, :failure_count, :failures)
+  end
+
+  def migration_failures_for_model(model:)
+    MigrationFailure.joins(:data_migration).where(data_migration: { model: })
   end
 
   def migrator_models
-    @migrator_models ||= migrators.map { |m| m.model }.sort
+    @migrator_models ||= migrators.map(&:model)
   end
 
   def migrators
-    Migrators::Base.migrators
+    Migrators::Base.migrators_in_dependency_order
   end
 end

--- a/app/controllers/migration/teacher_failures_controller.rb
+++ b/app/controllers/migration/teacher_failures_controller.rb
@@ -1,0 +1,21 @@
+class Migration::TeacherFailuresController < ::AdminController
+  layout "full"
+
+  def index
+    @pagy, teachers = pagy(
+      find_matching_failures(params[:err]).order(:trs_last_name, :trs_first_name, :id)
+    )
+    @teachers = Admin::TeacherPresenter.wrap(teachers)
+  end
+
+private
+
+  def find_matching_failures(failure_message)
+    scope = ::Teacher.joins(:teacher_migration_failures)
+    if failure_message.present?
+      tmf = TeacherMigrationFailure.arel_table
+      scope = scope.where(tmf[:message].matches("%#{failure_message}%"))
+    end
+    scope
+  end
+end

--- a/app/controllers/migration/teachers_controller.rb
+++ b/app/controllers/migration/teachers_controller.rb
@@ -3,7 +3,7 @@ class Migration::TeachersController < ::AdminController
 
   def index
     @pagy, teachers = pagy(
-      Teachers::Search.new(query_string: params[:q]).search.order(:last_name, :first_name, :id)
+      Teachers::Search.new(query_string: params[:q]).search.order(:trs_last_name, :trs_first_name, :id)
     )
     @teachers = Admin::TeacherPresenter.wrap(teachers)
   end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -59,9 +59,7 @@ module MigrationHelper
     return unless failure_count.positive?
 
     model = data_migrations.sample.model
-    govuk_link_to failures_migration_migrations_path(model) do
-      %(Failures<span: class="govuk-visually-hidden"> for #{model.humanize}</span>).html_safe
-    end
+    govuk_link_to "Failures", migration_failures_path(model: model)
   end
 
   def data_migration_download_failures_report_link(data_migrations)

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -59,7 +59,7 @@ module MigrationHelper
     return unless failure_count.positive?
 
     model = data_migrations.sample.model
-    govuk_link_to "Failures", migration_failures_path(model: model)
+    govuk_link_to "Failures", migration_failures_path(model:)
   end
 
   def data_migration_download_failures_report_link(data_migrations)

--- a/app/views/migration/failures/index.html.erb
+++ b/app/views/migration/failures/index.html.erb
@@ -1,12 +1,46 @@
 <% page_data(title: "Migration failures", backlink_href: migration_migrations_path) %>
 
+<% if @teacher_failures.failure_count.positive? %>
+  <h3 class="govuk-heading-m">Teacher related failures (<%= @teacher_failures.failure_count %> items in <%= @teacher_failures.failures.count %> groups)</h3>
+  <%= govuk_table(html_attributes: { class: "govuk-!-font-size-14" }) do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Error")
+        row.with_cell(text: "Count")
+      end
+    end
+    table.with_body do |body|
+      @teacher_failures.failures.each do |err, count|
+        body.with_row do |row|
+          row.with_cell(text: err)
+          row.with_cell do
+            govuk_link_to(count.to_s, migration_teacher_failures_path(err: err))
+          end
+        end
+      end
+    end
+  end %>
+<% end %>
+
 <% @failures.each do |failure_group| %>
-  <%= govuk_summary_list(card: { title: failure_group[:model].to_s.humanize }) do |summary_list| %>
-    <% failure_group[:failures].each do |err, count| %>
-      <%= summary_list.with_row do |row|
-        row.with_key(text: err)
-        row.with_value(text: count)
-      end %>
-    <% end %>
+  <% if failure_group.failure_count.positive? %>
+  <h3 class="govuk-heading-m"><%= failure_group.model.to_s.humanize %> un-linked failures (<%= failure_group.failure_count %> items in <%= failure_group.failures.count %> groups)</h3>
+    <%= govuk_table(html_attributes: { class: "govuk-!-font-size-14" }) do |table|
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: "Error")
+          row.with_cell(text: "Count")
+        end
+      end
+      table.with_body do |body|
+        failure_group.failures.each do |err, count|
+          body.with_row do |row|
+            row.with_cell(text: err)
+            row.with_cell(text: count)
+          end
+        end
+      end
+    end
+    %>
   <% end %> 
 <% end %>

--- a/app/views/migration/failures/index.html.erb
+++ b/app/views/migration/failures/index.html.erb
@@ -1,32 +1,12 @@
-<% page_data(title: "Migration failures for #{@model}", backlink_href: migration_migrations_path) %>
+<% page_data(title: "Migration failures", backlink_href: migration_migrations_path) %>
 
-<p class="govuk-body"><strong><%= @pagy.count %></strong> failed records</p>
-
-<% if @model.in? %w[teacher mentorship_period] %>
-  <%= govuk_table do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(text: "Teacher")
-        row.with_cell(text: "Failure")
-      end
-    end
-
-    table.with_body do |body|
-      @migration_failures.each_with_index do |failure, index|
-        parent_link = govuk_link_to(Teachers::Name.new(failure.parent).full_name,
-                                    migration_teacher_path(failure.parent)) unless failure.parent.blank?
-
-        body.with_row(html_attributes: { class: "govuk-!-font-size-16" }) do |row|
-          if parent_link
-            row.with_cell { parent_link }
-            row.with_cell(text: failure.failure_type)
-          else
-            row.with_cell { govuk_tag(text: "Failed to create teacher", colour:  "red") }
-            row.with_cell(text: failure_item_json_code(failure.item))
-          end
-        end
-      end
-    end
-  end %>
+<% @failures.each do |failure_group| %>
+  <%= govuk_summary_list(card: { title: failure_group[:model].to_s.humanize }) do |summary_list| %>
+    <% failure_group[:failures].each do |err, count| %>
+      <%= summary_list.with_row do |row|
+        row.with_key(text: err)
+        row.with_value(text: count)
+      end %>
+    <% end %>
+  <% end %> 
 <% end %>
-<%= govuk_pagination pagy: @pagy %>

--- a/app/views/migration/teacher_failures/index.html.erb
+++ b/app/views/migration/teacher_failures/index.html.erb
@@ -1,0 +1,48 @@
+<% page_data(title: "Teachers with failures") %>
+
+<%= form_with method: :get do |f| %>
+  <%=
+    f.govuk_text_field(
+      "err",
+      value: params[:err],
+      label: { text: "Search for teachers with failures", size: "s" },
+      hint: { text: "Migration failure message" },
+    )
+  %>
+
+  <%= f.govuk_submit "Search" %>
+<% end %>
+
+<p class="govuk-body"><strong><%= @pagy.count %></strong> teachers with this failure found</p>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Name")
+        row.with_cell(text: "Role")
+        row.with_cell(text: "TRN")
+        row.with_cell { govuk_visually_hidden("Has migration errors") }
+      end
+    end
+
+    table.with_body do |body|
+      @teachers.each_with_index do |teacher, index|
+        body.with_row do |row|
+          row.with_cell do
+            govuk_link_to Teachers::Name.new(teacher).full_name, migration_teacher_path(teacher, page: @pagy.page)
+          end
+          row.with_cell(text: Teachers::Role.new(teacher:))
+          row.with_cell(text: teacher.trn)
+          if teacher.has_migration_failures?
+            row.with_cell { govuk_tag(text: "Error", colour: "red") }
+          else
+            row.with_cell(text: "")
+          end
+        end
+      end
+    end
+  end
+%>
+
+<%= govuk_pagination pagy: @pagy %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       end
     end
     resources :failures, only: %i[index]
+    resources :teacher_failures, path: "teacher-failures", only: %i[index]
     resources :teachers, only: %i[index show]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,11 +84,12 @@ Rails.application.routes.draw do
   namespace :migration do
     resources :migrations, only: %i[index create], path: "/" do
       collection do
-        get ":model/failures", to: "failures#index", as: :failures
+        # get ":model/failures", to: "failures#index", as: :failures
         get "download_report/:model", action: :download_report, as: :download_report
         post "reset", action: :reset, as: :reset
       end
     end
+    resources :failures, only: %i[index]
     resources :teachers, only: %i[index show]
   end
 


### PR DESCRIPTION
We want to be able group similar migration failures so that we can get a view on the numbers of each and be able to start working on the groups and fixing the data.

This PR adds a view of the groupings
![image](https://github.com/user-attachments/assets/8c6d0ce9-dea1-4681-92b8-09e00bf8c349)

and also provides a view of Teacher records searchable by "migration error"

![image](https://github.com/user-attachments/assets/fe56ece0-8c7c-4c31-b7a5-ea329eb133f9)
