### PR TITLE
Restrict the registration of mentors who are prohibited from teaching

### DIFF
--- a/app/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb
+++ b/app/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb
@@ -1,0 +1,5 @@
+<% page_data(title: "You cannot register #{@mentor.full_name}", error: false) %>
+
+<p class="govuk-body">Our records show that <%= @mentor.full_name %> cannot be registered as a mentor.</p>
+
+<p class="govuk-body"><%= govuk_link_to("Back to ECTs", schools_ects_home_path) %></p>

--- a/app/wizards/schools/register_mentor_wizard/cannot_register_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/cannot_register_mentor_step.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Schools
+  module RegisterMentorWizard
+    class CannotRegisterMentorStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
@@ -14,6 +14,7 @@ module Schools
         return :trn_not_found unless mentor.in_trs?
         return :national_insurance_number unless mentor.matches_trs_dob?
         return :already_active_at_school if mentor.active_at_school?
+        return :cannot_register_mentor if trs_teacher.prohibited_from_teaching?
 
         :review_mentor_details
       end

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -7,6 +7,7 @@ module Schools
         [
           {
             already_active_at_school: AlreadyActiveAtSchoolStep,
+            cannot_register_mentor: CannotRegisterMentorStep,
             check_answers: CheckAnswersStep,
             confirmation: ConfirmationStep,
             email_address: EmailAddressStep,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,7 @@ Rails.application.routes.draw do
       get "no-trn", action: :new
       get "trn-not-found", action: :new
       get "not-found", action: :new
+      get "cannot-register-mentor", action: :new
 
       get "already-active-at-school", action: :new
       post "already-active-at-school", action: :create

--- a/spec/features/schools/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe 'Registering a mentor' do
+  include_context 'fake trs api client that finds teacher prohibited from teaching'
+
+  scenario 'School attempts to register a prohibited teacher as a mentor' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_there_is_an_active_mentor_registered_at_the_school
+    and_i_sign_in_as_that_school_user
+    then_i_am_on_the_schools_landing_page
+
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_who_will_mentor_page
+
+    when_i_select_register_a_new_mentor
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_details_of_a_prohibited_teacher
+    then_i_should_be_taken_to_the_cannot_register_mentor_page
+
+    when_i_click_back_to_ects
+    then_i_should_be_taken_to_the_school_ects_page
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_there_is_an_active_mentor_registered_at_the_school
+    teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    @mentor_name = Teachers::Name.new(teacher).full_name
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def then_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_in_the_who_will_mentor_page
+    expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
+    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+  end
+
+  def when_i_select_register_a_new_mentor
+    page.get_by_role(:radio, name: "Register a new mentor").check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_submit_details_of_a_prohibited_teacher
+    page.get_by_label('trn').fill('9876543')
+    page.get_by_label('day').fill('3')
+    page.get_by_label('month').fill('2')
+    page.get_by_label('year').fill('1977')
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_cannot_register_mentor_page
+    path = '/school/register-mentor/cannot-register-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_back_to_ects
+    page.get_by_role('link', name: 'Back to ECTs').click
+  end
+
+  def then_i_should_be_taken_to_the_school_ects_page
+    path = '/schools/home/ects'
+    expect(page.url).to end_with(path)
+  end
+end

--- a/spec/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "schools/register_mentor_wizard/cannot_register_mentor" do
+  let(:mentor) { double('Mentor', full_name: 'Jane Smith') }
+  let(:title) { "You cannot register #{mentor.full_name}" }
+
+  before do
+    assign(:mentor, mentor)
+    render
+  end
+
+  it "sets the page title to 'You cannot register Jane Smith'" do
+    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  end
+
+  it "displays the cannot register mentor message" do
+    expect(rendered).to have_content("Our records show that Jane Smith cannot be registered as a mentor.")
+  end
+
+  it "includes a link back to ECTs" do
+    expect(rendered).to have_link("Back to ECTs", href: schools_ects_home_path)
+  end
+end 

--- a/spec/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb_spec.rb
@@ -18,4 +18,4 @@ RSpec.describe "schools/register_mentor_wizard/cannot_register_mentor" do
   it "includes a link back to ECTs" do
     expect(rendered).to have_link("Back to ECTs", href: schools_ects_home_path)
   end
-end 
+end


### PR DESCRIPTION
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/972

This PR prevents mentors who are prohibited from teaching from being registered in the service.

We don't anticipate schools attempting to register mentors who are prohibited from teaching. However, we implemented this functionality as an added safeguard.

Since this involves sensitive safeguarding information, we display a more generic page stating that the mentor cannot be registered.