### PR TITLE
Remove migration from github workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [staging, migration, sandbox]
+        environment: [staging, sandbox]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
To prevent issues with testing, fixing data and running migrations I've removed the `migration` environment from the default deploy workflow.
Ideally we should add a separate workflow to deploy to migration in a subsequent PR.