### PR TITLE
[893]: fix syntax on GitHub workflow

### DIFF
--- a/.github/workflows/restore-snapshot-db-from-azure-storage.yml
+++ b/.github/workflows/restore-snapshot-db-from-azure-storage.yml
@@ -90,7 +90,7 @@ jobs:
             echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
 
       - name: Backup ${{ env.DEPLOY_ENV }} postgres
-        uses: .github/actions/restore-snapshot-database-from-azure-storage
+        uses: ./.github/actions/restore-snapshot-database-from-azure-storage
         with:
           storage-account: ${{ env.STORAGE_ACCOUNT_NAME }}
           app-name: ${{ env.SERVICE_NAME }}-${{ env.DEPLOY_ENV }}-web


### PR DESCRIPTION
The valid syntax to call an action from a workflow needs to start by `./.github/...` instead of `.github/...`