### PR TITLE
Update the roadmap for our team

### DIFF
--- a/documentation/site/content/product/objectives.md
+++ b/documentation/site/content/product/objectives.md
@@ -1,0 +1,17 @@
+---
+title: Our team's objectives
+---
+All of these items of work are related to our objectives as a team. Our objectives are structured to enable us to meet the Teaching CPD vision of services serving their core purposes and being flexible enough to adapt to future change and opportunities.
+
+Our objectives are centered around how we can make it easierfor schools, lead providers and appropriate bodies to support and train ECTs and mentors.
+
+1. Reduce workload for schools when registering early career teachers and their mentors for training 🏫
+2. Improve data quality and the flexibility of the services by changing the data model and migrating data cleanly to Register early career teachers 👾
+3. Better meet lead provider needs by showing the right data over the Lead provider API, improving documentation and updating validation rules ☁️
+4. Improve understanding of financial information internally and make sure payments are calculated correctly 💰
+5. Ensure the successful development of the Register early career teacher services by planning for dependencies, risks and communications 🗒️
+6. Minimise time and money spent on support tasks by creating improved joint support and finance tooling 🦸
+7. Improve how data on ECF is reported and create performance metrics for the new Register early career teachers services 📊
+8. Reduce confusion for users by helping them understand how the Register early career teacher services are structured, the service's purposes and their own responsibilities ✏️
+9. Build services that are safe, protect privacy and are tested and documented well 🔨
+10. Save time for appropriate bodies to submit induction data for early career teachers and check relevant training information in 1 place ⏲️

--- a/documentation/site/content/product/objectives.md
+++ b/documentation/site/content/product/objectives.md
@@ -3,7 +3,7 @@ title: Our team's objectives
 ---
 All of these items of work are related to our objectives as a team. Our objectives are structured to enable us to meet the Teaching CPD vision of services serving their core purposes and being flexible enough to adapt to future change and opportunities.
 
-Our objectives are centered around how we can make it easierfor schools, lead providers and appropriate bodies to support and train ECTs and mentors.
+Our objectives are centred around how we can make it easier for schools, lead providers and appropriate bodies to support and train ECTs and mentors.
 
 1. Reduce workload for schools when registering early career teachers and their mentors for training 🏫
 2. Improve data quality and the flexibility of the services by changing the data model and migrating data cleanly to Register early career teachers 👾
@@ -14,4 +14,4 @@ Our objectives are centered around how we can make it easierfor schools, lead pr
 7. Improve how data on ECF is reported and create performance metrics for the new Register early career teachers services 📊
 8. Reduce confusion for users by helping them understand how the Register early career teacher services are structured, the service's purposes and their own responsibilities ✏️
 9. Build services that are safe, protect privacy and are tested and documented well 🔨
-10. Save time for appropriate bodies to submit induction data for early career teachers and check relevant training information in 1 place ⏲️
+10. Make it easier for appropriate bodies to submit induction data for early career teachers and check relevant training information in 1 place ⏲️

--- a/documentation/site/content/product/roadmap/introduction.md
+++ b/documentation/site/content/product/roadmap/introduction.md
@@ -21,7 +21,7 @@ So far, we have:
 * built a way for schools to register ECTs and mentors to save school's time and improve data accuracy
 * set up DfE Sign in for appropriate bodies, so we can improve how all users access the service
 * improved how mentors are assigned to ECTs, so we can reduce having to chase schools to tell us mentor information
-* built a service for appropriate bodies to pass or fail inductions individually, so we can start to consolidate services and reduce workload for all users
+* built a service for appropriate bodies to record data about inductions individually, so we can start to consolidate services and reduce workload for all users
 * set up how we want to migrate data from ECF1 to the new Register early career teachers service
 * designed how ECTs and mentors are registered when they are moving schools
 													

--- a/documentation/site/content/product/roadmap/introduction.md
+++ b/documentation/site/content/product/roadmap/introduction.md
@@ -14,7 +14,7 @@ All of these items of work are related [to our objectives as a team.](/product/o
 Our objectives are centered around how we can make it easier for schools, lead providers and appropriate bodies to support or train ECTs and mentors.
 
 
-## What we've already done
+## What we've done
 
 So far, we have:
 

--- a/documentation/site/content/product/roadmap/introduction.md
+++ b/documentation/site/content/product/roadmap/introduction.md
@@ -5,26 +5,26 @@ It sets out what we're working on now, what will come next, and what we might pu
 
 By sending this out publicly, we hope to:
 
-* give direction and vision to our team
+* give direction to our team
 * be transparent about what we're working on and why
-* prioritise what we need to work on and when
 * gather more feedback about the work we're aiming to do
 
-## Our objectives
-All of these items of work are related to our objectives as a team. Our objectives are structured to enable us to meet the Teaching CPD vision of services serving their core purposes and being flexible enough to adapt to future change and opportunities.
+All of these items of work are related [to our objectives as a team.](/product/objectives) 
 
-1. Reduce workload for schools when registering early career teachers and their mentors for training 🏫
-2. Improve data quality and the flexibility of the services by changing the data model and migrating data cleanly to Register early career teachers 👾
-3. Better meet lead provider needs by showing the right data over the Lead provider API, improving documentation and updating validation rules ☁️
-4. Improve understanding of financial information internally and make sure payments are calculated correctly 💰
-5. Ensure the successful development of the Register early career teacher services by planning for dependencies, risks and communications 🗒️
-6. Minimise time and money spent on support tasks by creating improved joint support and finance tooling 🦸
-7. Improve how data on ECF is reported and create performance metrics for the new Register early career teachers services 📊
-8. Reduce confusion for users by helping them understand how the Register early career teacher services are structured, the service's purposes and their own responsibilities ✏️
-9. Build services that are safe, protect privacy and are tested and documented well 🔨
-10. Save time for appropriate bodies to submit induction data for early career teachers and check relevant training information in 1 place ⏲️
-															
+Our objectives are centered around how we can make it easier for schools, lead providers and appropriate bodies to support or train ECTs and mentors.
 
+
+## What we've already done
+
+So far, we have:
+
+* built a way for schools to register ECTs and mentors to save school's time and improve data accuracy
+* set up DfE Sign in for appropriate bodies, so we can improve how all users access the service
+* improved how mentors are assigned to ECTs, so we can reduce having to chase schools to tell us mentor information
+* built a service for appropriate bodies to pass or fail inductions individually, so we can start to consolidate services and reduce workload for all users
+* set up how we want to migrate data from ECF1 to the new Register early career teachers service
+* designed how ECTs and mentors are registered when they are moving schools
+													
 # The roadmap
 
 

--- a/documentation/site/content/product/roadmap/later.md
+++ b/documentation/site/content/product/roadmap/later.md
@@ -1,6 +1,8 @@
 ## Later 🔮
 
-* improving the data we send over the lead provider API, so lead providers can submit the data they need and have it validated correctly, saving them time and improving our data quality
 * improving the API documentation, so lead provider users can see the guidance applicable to them and understand it easily
 * calculating financial information, so that we can pay lead providers the correct amounts for training
 * enabling appropriate bodies to check training data for early career teachers, in the same service where they submit induction data, so we can save them time and improve data accuracy
+* consider if we need to gather the school induction tutor for schools so we can reduce confusion for schools whilst making sure lead providers have the information they need
+* working out how to notify school of changes that have happened in training or where they need to act in the service
+

--- a/documentation/site/content/product/roadmap/later.md
+++ b/documentation/site/content/product/roadmap/later.md
@@ -1,8 +1,8 @@
 ## Later 🔮
-
-* improving the API documentation, so lead provider users can see the guidance applicable to them and understand it easily
-* calculating financial information, so that we can pay lead providers the correct amounts for training
-* enabling appropriate bodies to check training data for early career teachers, in the same service where they submit induction data, so we can save them time and improve data accuracy
+We will:
+* improve the API documentation, so lead provider users can see the guidance applicable to them and understand it easily
+* calculate financial information, so that we can pay lead providers the correct amounts for training
+* enable appropriate bodies to check training data for early career teachers, in the same service where they submit induction data, so we can save them time and improve data accuracy
 * consider if we need to gather the school induction tutor for schools so we can reduce confusion for schools whilst making sure lead providers have the information they need
-* working out how to notify school of changes that have happened in training or where they need to act in the service
+* work out how to notify school of changes that have happened in training or where they need to act in the service, so data is kept updated for training and funding to take place quickly
 

--- a/documentation/site/content/product/roadmap/next.md
+++ b/documentation/site/content/product/roadmap/next.md
@@ -1,7 +1,9 @@
 ## Next ➡️
 
-* considering how to indicate when early career teachers have left for other reasons, so we can reduce confusion for schools and lead providers
+We will:
+
+* consider how to indicate when early career teachers have left for other reasons, so we can reduce confusion for schools and lead providers
 * start work on the API for lead providers, so we can send them information from schools and pay them for providing training
 * improve how the API works, so lead providers can submit the data they need and have it validated correctly, saving them time and improving our data quality
-* building a check using this API to make sure the migrated data is correct
-* building a way for appropriate bodies to efficiently record inductions in bulk and reduce their workload
+* build a check using this API to make sure the migrated data is correct
+* build a way for appropriate bodies to efficiently record inductions in bulk to reduce their workload

--- a/documentation/site/content/product/roadmap/next.md
+++ b/documentation/site/content/product/roadmap/next.md
@@ -7,3 +7,5 @@ We will:
 * improve how the API works, so lead providers can submit the data they need and have it validated correctly, saving them time and improving our data quality
 * build a check using this API to make sure the migrated data is correct
 * build a way for appropriate bodies to efficiently record inductions in bulk to reduce their workload
+* work out how we might integrate with the third party services which appropriate bodies use to manage inductions, so we can make it easier to record inductions
+* improve the record inductions service with appropriate bodies to better meet their needs in peak periods

--- a/documentation/site/content/product/roadmap/next.md
+++ b/documentation/site/content/product/roadmap/next.md
@@ -1,7 +1,7 @@
 ## Next ➡️
 
-* improving how early career teachers are transferred between different schools, so that all users have the information they need and can make changes easily
 * considering how to indicate when early career teachers have left for other reasons, so we can reduce confusion for schools and lead providers
-* start building support tooling to help with registration, so that our support users have the autonomy they need to quickly and simply aid schools
-* building a service for appropriate bodies to submit induction data, so that we can maintain induction processes and consolidate our data 
-* getting ready for the changes in policy for 2025, so that our digital services are up to date and can maintain registration of ECTs
+* start work on the API for lead providers, so we can send them information from schools and pay them for providing training
+* improve how the API works, so lead providers can submit the data they need and have it validated correctly, saving them time and improving our data quality
+* building a check using this API to make sure the migrated data is correct
+* building a way for appropriate bodies to efficiently record inductions in bulk and reduce their workload

--- a/documentation/site/content/product/roadmap/now.md
+++ b/documentation/site/content/product/roadmap/now.md
@@ -1,7 +1,7 @@
 ## Now 🏃
 
-* exploring using DfE sign in for school users and allowing multiple accounts, so we can improve their access to the service 
-* improving how an early career teacher or mentor is registered, so we save schools time and improve data accuracy
-* improving how records for ECTs and mentors are viewed, so we can remind them of essential actions they need to take and can make changes to records easily
-* designing a prototype and setting up the infrastructure for a service where appropriate bodies can submit induction data, so we improve the accuracy of our data and can later consolidate registration for schools
-* setting up processes for how we will migrate data from the legacy service to our new service, so that we can migrate data from ECF1 to ECF2 efficiently and cleanly. ECF1 is the current set of services for managing training and induction for early career teachers. ECF 2 is the future service that will replace and improve upon ECF1.
+* improving how early career teachers are transferred between different schools, so that all users have the information they need and can make changes easily
+* setting up how records for early career teachers and mentors are viewed, so school users can understand what's happening and make changes when needed
+* cleaning up the data we've set up processes to migrate, starting with induction records
+* releasing the new service for appropriate bodies to record inductions, so we can improve data quality and consolidate training and induction information
+* working on our support console, so it can support all of our users internally and externally

--- a/documentation/site/content/product/roadmap/now.md
+++ b/documentation/site/content/product/roadmap/now.md
@@ -1,5 +1,6 @@
 ## Now 🏃
 
+We are:
 * improving how early career teachers are transferred between different schools, so that all users have the information they need and can make changes easily
 * setting up how records for early career teachers and mentors are viewed, so school users can understand what's happening and make changes when needed
 * cleaning up the data we've set up processes to migrate, starting with induction records


### PR DESCRIPTION
In this PR I am trying to:
- Separate our team objectives to a different page, to reduce clutter on our roadmap
- Add what we've done so far in rebuilding the ECF1 services
- Update what we're doing now, next and later