### PR TITLE
[893] - fix backup-file name to restore from Azure Storage

### DIFF
--- a/.github/actions/backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/backup-and-restore-snapshot-database/action.yml
@@ -1,5 +1,5 @@
-name: Backup DB
-description: Backup production DB and restore to snapshot DB
+name: Backup production and restore snapshot DB
+description: Dump production DB and straight restore to snapshot DB keeping no copy in Azure Storage
 
 inputs:
   environment:

--- a/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
+++ b/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
@@ -1,4 +1,4 @@
-name: Nightly backup production database, upload it to Azure Storage and restore the snapshot database from it
+name: Nightly copy production main db into snapshot db keeping backup in Azure Storage
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly_copy_production_db_straight_into_snapshot_db.yml
+++ b/.github/workflows/nightly_copy_production_db_straight_into_snapshot_db.yml
@@ -1,4 +1,5 @@
-name: Restore Snapshot DB from production DB
+name: Nightly copy production main db into snapshot db keeping no backup in Azure Storage
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/restore-snapshot-db-from-azure-storage.yml
+++ b/.github/workflows/restore-snapshot-db-from-azure-storage.yml
@@ -100,5 +100,5 @@ jobs:
           resource-group: ${{ env.RESOURCE_GROUP_NAME }}
           cluster: ${{ env.CLUSTER }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          backup-file: ${{ env.BACKUP_FILE }}.sql
+          backup-file: ${{ env.BACKUP_FILE }}.sql.gz
           slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
The `backup-db` workflow stores compressed db dump files in Azure Storage.
Therefore, the restore workflow needs to append `.gz` at the end of the `backup-file` name.
Also, renaming some related workflows for clarity.
