### PR TITLE
Adding a manual workflow for deploying to an environment

### DIFF
--- a/.github/workflows/deploy_migration.yml
+++ b/.github/workflows/deploy_migration.yml
@@ -1,0 +1,58 @@
+name: "Manual deploy image"
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        default: migration
+        type: environment
+        options:
+          - migration
+          - production
+          - sandbox
+          - staging
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    outputs:
+      docker-image-tag: ${{ steps.build-docker-image.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/register-early-career-teachers-public
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
+
+  deploy:
+    name: Deploy to environment
+    needs: [docker]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          environment: ${{ inputs.environment }}
+          docker-image-tag: ${{ needs.docker.outputs.docker-image-tag }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          commit-sha: ${{ github.sha }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -1,8 +1,13 @@
-name: "Manual deploy image"
+name: "Manually deploy imn environment"
 
 on:
   workflow_dispatch:
     inputs:
+      branch-name:
+        description: Branch to deploy
+        required: true
+        default: main
+        type: string
       environment:
         description: Deployment environment
         required: true
@@ -15,7 +20,7 @@ on:
           - staging
 
 permissions:
-  contents: read
+  id-token: write
   packages: write
   pull-requests: write
   security-events: write
@@ -29,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch-name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: DFE-Digital/github-actions/build-docker-image@master
@@ -46,6 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch-name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: ./.github/actions/deploy-environment-to-aks

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -1,4 +1,4 @@
-name: "Manually deploy imn environment"
+name: "Manually deploy an environment"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The migration environment is no longer in the normal deploy workflow to prevent issues with deployments being triggered by merges during migration or while fixing/reviewing data.
In addition, the introduction of DfE Analytics will prevent manual deployments to envs as terraform apply in the console now requires gcloud logins and not all developers will have gcloud accounts or access.

This PR adds a workflow that enables deploying to an environment manually (this is virtually identical to a workflow added to ECFv1).