### PR TITLE
Prefix FactoryBot methods with `FactoryBot`.

### DIFF
--- a/spec/wizards/schools/register_ect/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect/find_ect_step_spec.rb
@@ -42,7 +42,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     subject { wizard.current_step }
 
     context 'when the teacher is prohibited from teaching' do
-      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
       before do
         fake_client = TRS::FakeAPIClient.new
 

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -41,7 +41,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     subject { wizard.current_step }
 
     context 'when the mentor is prohibited from teaching' do
-      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
       before do
         fake_client = TRS::FakeAPIClient.new
 


### PR DESCRIPTION
This makes it clearer for people unfamiliar with the codebase that create and build are from FactoryBot.
