### PR TITLE
[893] - match ubuntu versions for backing up and restoring databases

### DIFF
--- a/.github/workflows/nightly-backup-of-production-db.yml
+++ b/.github/workflows/nightly-backup-of-production-db.yml
@@ -5,7 +5,8 @@ on:
     - cron: "15 0 * * *" # 00:15 UTC
 
 jobs:
-  backup-and-store:
+  backup-production-and-store-in-azure-storage:
+    runs-on: ubuntu-latest
     uses: ./.github/workflows/backup-db.yml
     with:
       environment: production

--- a/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
+++ b/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
@@ -6,13 +6,13 @@ on:
     - cron: "15 4 * * *" # 04:15 UTC
 
 jobs:
-  backup-and-store:
+  backup-production-and-store-in-azure-storage:
     uses: ./.github/workflows/backup-db.yml
     with:
       environment: production
       backup-file: backup-production.sql
 
-  restore-from-storage:
+  restore-from-azure-storage:
     uses: ./.github/workflows/restore-snapshot-db-from-azure-storage.yml
     with:
       environment: production

--- a/.github/workflows/nightly_copy_production_db_straight_into_snapshot_db.yml
+++ b/.github/workflows/nightly_copy_production_db_straight_into_snapshot_db.yml
@@ -16,8 +16,8 @@ on:
     - cron: "15 4 * * *" # 04:15 UTC
 
 jobs:
-  backup-and-restore-production:
-    runs-on: ubuntu-20.04
+  backup-production-and-restore-snapshot:
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment || 'production' }}
     steps:


### PR DESCRIPTION
Run db workflows on `ubuntu-latest` to prevent issues with different versions when dumping and restoring a database.