### PR TITLE
[1059] - block school user from adding an ect as their own mentor

### DIFF
--- a/app/forms/schools/assign_mentor_form.rb
+++ b/app/forms/schools/assign_mentor_form.rb
@@ -30,7 +30,7 @@ module Schools
     end
 
     def mentorship_authorized
-      errors.add(:mentor_id, "This teacher cannot be mentoring this ECT") if eligible_mentors.exclude?(mentor)
+      errors.add(:mentor_id, "It needs to be a different mentor for this ECT") if eligible_mentors.exclude?(mentor)
     end
 
     def persisted?

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -39,6 +39,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
     current_mentorship&.mentor
   end
 
+  delegate :trn, to: :teacher
+
 private
 
   def teacher_distinct_period

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -21,8 +21,15 @@ module Schools
 
   private
 
+    def already_registered_as_an_ect?
+      ::Teacher.find_by_trn(trn)&.ect_at_school_periods&.exists?
+    end
+
     def create_teacher!
-      @teacher = ::Teacher.create!(trs_first_name:, trs_last_name:, trn:, corrected_name:)
+      raise ActiveRecord::RecordInvalid if already_registered_as_an_ect?
+
+      @teacher = ::Teacher.create_with(trs_first_name:, trs_last_name:, corrected_name:)
+                          .find_or_create_by!(trn:)
     end
 
     def start_at_school!

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -12,7 +12,7 @@ module Schools
       @working_pattern = working_pattern
     end
 
-    def register_teacher!
+    def register!
       ActiveRecord::Base.transaction do
         create_teacher!
         start_at_school!

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -20,8 +20,15 @@ module Schools
 
   private
 
+    def already_registered_as_a_mentor?
+      ::Teacher.find_by_trn(trn)&.mentor_at_school_periods&.exists?
+    end
+
     def create_teacher!
-      @teacher = ::Teacher.create!(trs_first_name:, trs_last_name:, corrected_name:, trn:)
+      raise ActiveRecord::RecordInvalid if already_registered_as_a_mentor?
+
+      @teacher = ::Teacher.create_with(trs_first_name:, trs_last_name:, corrected_name:)
+                          .find_or_create_by!(trn:)
     end
 
     def school

--- a/app/views/schools/mentorships/new.html.erb
+++ b/app/views/schools/mentorships/new.html.erb
@@ -1,4 +1,6 @@
-<% page_data(title: "Who will mentor #{@ect_name}?", header: false, error: @mentor_form.errors.present?) %>
+<% page_data(title: "Who will mentor #{@ect_name}?",
+             header: false,
+             error: @mentor_form.errors.present?) %>
 
 <%=
   # TODO: consolidate into #page_data :backlink_href if possible

--- a/app/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb
+++ b/app/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb
@@ -1,0 +1,10 @@
+---
+title: You cannot assign an ECT as their own mentor
+backlink_href: <%= schools_register_mentor_wizard_find_mentor_path %>
+---
+
+You have entered the same details for the mentor as the ECT you are assigning them to.
+
+You must assign someone else as the ECT's mentor.
+
+<%= govuk_button_link_to('Assign a different mentor', schools_register_mentor_wizard_find_mentor_path) %>

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -52,7 +52,7 @@ module Schools
                                  school:,
                                  started_on: Date.parse(start_date),
                                  working_pattern:)
-                               .register_teacher!
+                            .register!
       end
 
       def active_at_school?(school:)

--- a/app/wizards/schools/register_mentor_wizard/cannot_mentor_themself_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/cannot_mentor_themself_step.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Schools
+  module RegisterMentorWizard
+    class CannotMentorThemselfStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
@@ -12,6 +12,7 @@ module Schools
 
       def next_step
         return :trn_not_found unless mentor.in_trs?
+        return :cannot_mentor_themself if mentor.trn == ect.trn
         return :national_insurance_number unless mentor.matches_trs_dob?
         return :already_active_at_school if mentor.active_at_school?
         return :cannot_register_mentor if trs_teacher.prohibited_from_teaching?
@@ -22,7 +23,7 @@ module Schools
     private
 
       def persist
-        mentor.update(trn:,
+        mentor.update(trn: formatted_trn,
                       date_of_birth: date_of_birth.values.join("-"),
                       trs_date_of_birth: trs_teacher.date_of_birth,
                       trs_first_name: trs_teacher.first_name,
@@ -30,7 +31,11 @@ module Schools
       end
 
       def trs_teacher
-        @trs_teacher ||= fetch_trs_teacher(trn:)
+        @trs_teacher ||= fetch_trs_teacher(trn: formatted_trn)
+      end
+
+      def formatted_trn
+        @formatted_trn ||= Validation::TeacherReferenceNumber.new(trn).formatted_trn
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -7,6 +7,7 @@ module Schools
         [
           {
             already_active_at_school: AlreadyActiveAtSchoolStep,
+            cannot_mentor_themself: CannotMentorThemselfStep,
             cannot_register_mentor: CannotRegisterMentorStep,
             check_answers: CheckAnswersStep,
             confirmation: ConfirmationStep,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,9 @@ Rails.application.routes.draw do
       get "find-mentor", action: :new
       post "find-mentor", action: :create
 
+      get "cannot-mentor-themself", action: :new
+      post "cannot-mentor-themself", action: :create
+
       get "national-insurance-number", action: :new
       post "national-insurance-number", action: :create
 

--- a/spec/features/schools/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe 'Registering a mentor' do
+  include_context 'fake trs api client'
+
+  scenario 'An ECT becoming mentor cannot mentor themself' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_trn_of_the_ect
+    then_i_should_be_taken_to_the_cannot_mentor_themself_page
+
+    when_i_click_on_assign_a_different_mentor
+    then_i_should_be_taken_to_the_find_mentor_page
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_submit_the_trn_of_the_ect
+    page.get_by_label('trn').fill(@ect.trn)
+    page.get_by_label('day').fill('1')
+    page.get_by_label('month').fill('2')
+    page.get_by_label('year').fill('1980')
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_cannot_mentor_themself_page
+    expect(page.url).to end_with('/school/register-mentor/cannot-mentor-themself')
+  end
+
+  def when_i_click_on_assign_a_different_mentor
+    page.get_by_role('link', name: 'Assign a different mentor').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -90,6 +90,48 @@ describe MentorshipPeriod do
         end
       end
     end
+
+    context '#not_self_mentoring' do
+      context 'when mentor and mentee are the same teacher' do
+        let!(:teacher) { ect_at_school_period.teacher }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+
+        subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+
+        it 'add a base error' do
+          subject.valid?
+
+          expect(subject.errors.messages[:base]).to include('A mentee cannot mentor themself')
+        end
+      end
+
+      context 'when mentor and mentee are different teachers' do
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+
+        subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+
+        it 'do not add an error' do
+          subject.valid?
+
+          expect(subject.errors.messages[:base]).not_to include('A mentee cannot mentor themself')
+        end
+      end
+
+      context 'when mentor or mentee are not set yet' do
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+
+        subject { FactoryBot.build(:mentorship_period, mentor: mentor_at_school_period) }
+
+        it 'do not add an error' do
+          subject.valid?
+
+          expect(subject.errors.messages[:base]).not_to include('A mentee cannot mentor themself')
+        end
+      end
+    end
   end
 
   describe "scopes" do

--- a/spec/services/schools/assign_mentor_form_spec.rb
+++ b/spec/services/schools/assign_mentor_form_spec.rb
@@ -33,7 +33,7 @@ describe Schools::AssignMentorForm, type: :model do
     end
 
     describe "mentorship authorised" do
-      context "when the school has no eligible mentors for the ect" do
+      context "when the mentor is not eligible for the ect" do
         let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
         let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school: ect.school, teacher: ect.teacher) }
 
@@ -44,7 +44,7 @@ describe Schools::AssignMentorForm, type: :model do
         end
 
         it "adds a base error" do
-          expect(subject.errors.messages[:mentor_id]).to include("This teacher cannot be mentoring this ECT")
+          expect(subject.errors.messages[:mentor_id]).to include("It needs to be a different mentor for this ECT")
         end
       end
     end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -17,8 +17,7 @@ describe Schools::RegisterECT do
                         working_pattern:)
   end
 
-  describe '#register_teacher!' do
-    let(:teacher) { Teacher.first }
+  describe '#register!' do
     let(:ect_at_school_period) { ECTAtSchoolPeriod.first }
 
     it 'creates a new Teacher record' do
@@ -30,8 +29,8 @@ describe Schools::RegisterECT do
     end
 
     it 'creates an associated ECTATSchoolPeriod record' do
-      expect { service.register_teacher! }.to change(ECTAtSchoolPeriod, :count).from(0).to(1)
-      expect(ect_at_school_period.teacher_id).to eq(teacher.id)
+      expect { service.register! }.to change(ECTAtSchoolPeriod, :count).from(0).to(1)
+      expect(ect_at_school_period.teacher_id).to eq(Teacher.first.id)
       expect(ect_at_school_period.started_on).to eq(started_on)
       expect(ect_at_school_period.working_pattern).to eq(working_pattern)
     end

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -16,20 +16,40 @@ describe Schools::RegisterMentor do
   end
 
   describe '#call' do
-    let(:teacher) { Teacher.first }
     let(:mentor_at_school_period) { MentorAtSchoolPeriod.first }
 
-    it 'creates a new Teacher record' do
-      expect { service.register! }.to change(Teacher, :count).from(0).to(1)
-      expect(teacher.trs_first_name).to eq(trs_first_name)
-      expect(teacher.trs_last_name).to eq(trs_last_name)
-      expect(teacher.corrected_name).to eq(corrected_name)
-      expect(teacher.trn).to eq(trn)
+    context "when a Teacher record with the same trn don't exist" do
+      let(:teacher) { Teacher.first }
+
+      it 'creates a new Teacher record' do
+        expect { service.register! }.to change(Teacher, :count).from(0).to(1)
+        expect(teacher.trs_first_name).to eq(trs_first_name)
+        expect(teacher.trs_last_name).to eq(trs_last_name)
+        expect(teacher.corrected_name).to eq(corrected_name)
+        expect(teacher.trn).to eq(trn)
+      end
+    end
+
+    context "when a Teacher record with the same trn exists but has no mentor records" do
+      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+
+      it "doesn't create a new Teacher record" do
+        expect { service.register! }.to_not change(Teacher, :count)
+      end
+    end
+
+    context "when a Teacher record with the same trn exists and has mentor records" do
+      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let!(:mentor) { FactoryBot.create(:mentor_at_school_period, teacher:) }
+
+      it "raise an exception" do
+        expect { service.register! }.to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
 
     it 'creates an associated MentorATSchoolPeriod record' do
       expect { service.register! }.to change(MentorAtSchoolPeriod, :count).from(0).to(1)
-      expect(mentor_at_school_period.teacher_id).to eq(teacher.id)
+      expect(mentor_at_school_period.teacher_id).to eq(Teacher.first.id)
       expect(mentor_at_school_period.started_on).to eq(started_on)
     end
 

--- a/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe "schools/register_mentor_wizard/already_active_at_school.md.erb" do
+  let(:assign_mentor_path) { wizard.current_step_path }
+  let(:ect_name) { Faker::Name.name }
+  let(:store) { double(trs_first_name: "John", trs_last_name: "Waters", corrected_name: "Jim Waters") }
+  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :already_active_at_school, store:) }
+  let(:mentor) { wizard.mentor }
+  let(:title) { "This mentor has already been registered" }
+
+  before do
+    assign(:wizard, wizard)
+    assign(:mentor, mentor)
+    assign(:ect_name, ect_name)
+    render
+  end
+
+  it "sets the page title to 'This mentor has already been registered'" do
+    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  end
+
+  it 'includes no back button' do
+    expect(view.content_for(:backlink_or_breadcrumb)).to be_blank
+  end
+
+  it 'includes a button to assign the existing mentor to the ECT' do
+    expect(rendered).to have_button("Assign #{mentor.full_name} to mentor #{ect_name}")
+    expect(rendered).to have_selector("form[action='#{assign_mentor_path}']")
+  end
+
+  it "includes a link back to ECTs" do
+    expect(rendered).to have_link("Back to ECTs", href: schools_ects_home_path)
+  end
+end

--- a/spec/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "schools/register_mentor_wizard/cannot_mentor_themself.md.erb" do
+  let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
+  let(:title) { 'You cannot assign an ECT as their own mentor' }
+
+  before do
+    render
+  end
+
+  it "sets the page title to 'You cannot assign an ECT as their own mentor'" do
+    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  end
+
+  it 'includes a back button that links to find-mentor page of the journey' do
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: back_path)
+  end
+
+  it 'includes a button to assign a different mentor to the ECT' do
+    expect(rendered).to have_link('Assign a different mentor', href: back_path)
+  end
+end

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -26,7 +26,8 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
   end
 
   describe '#next_step' do
-    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, step_params:) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, step_params:, ect_id: ect.id) }
     let(:step_params) do
       ActionController::Parameters.new(
         "find_mentor" => {
@@ -40,37 +41,6 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     subject { wizard.current_step }
 
-    context 'when the mentor is prohibited from teaching' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      before do
-        fake_client = TRS::FakeAPIClient.new
-
-        allow(fake_client).to receive(:find_teacher).and_return(
-          TRS::Teacher.new(
-            'trn' => '1234568',
-            'firstName' => 'Jane',
-            'lastName' => 'Smith',
-            'dateOfBirth' => '1977-02-03',
-            'alerts' => [
-              {
-                'alertType' => {
-                  'alertCategory' => {
-                    'alertCategoryId' => TRS::Teacher::PROHIBITED_FROM_TEACHING_CATEGORY_ID
-                  }
-                }
-              }
-            ]
-          )
-        )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
-        subject.save!
-      end
-
-      it 'returns :cannot_register_mentor' do
-        expect(subject.next_step).to eq(:cannot_register_mentor)
-      end
-    end
-
     context 'when the mentor is not found in TRS' do
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))
@@ -79,6 +49,20 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
       it 'returns :trn_not_found' do
         expect(subject.next_step).to eq(:trn_not_found)
+      end
+    end
+
+    context 'when the mentor trn matches that of the ECT' do
+      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher:) }
+
+      before do
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        subject.save!
+      end
+
+      it 'returns :cannot_mentor_themself' do
+        expect(subject.next_step).to eq(:cannot_mentor_themself)
       end
     end
 
@@ -116,6 +100,37 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
       it 'returns :already_active_at_school' do
         expect(subject.next_step).to eq(:already_active_at_school)
+      end
+    end
+
+    context 'when the mentor is prohibited from teaching' do
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      before do
+        fake_client = TRS::FakeAPIClient.new
+
+        allow(fake_client).to receive(:find_teacher).and_return(
+          TRS::Teacher.new(
+            'trn' => '1234568',
+            'firstName' => 'Jane',
+            'lastName' => 'Smith',
+            'dateOfBirth' => '1977-02-03',
+            'alerts' => [
+              {
+                'alertType' => {
+                  'alertCategory' => {
+                    'alertCategoryId' => TRS::Teacher::PROHIBITED_FROM_TEACHING_CATEGORY_ID
+                  }
+                }
+              }
+            ]
+          )
+        )
+        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        subject.save!
+      end
+
+      it 'returns :cannot_register_mentor' do
+        expect(subject.next_step).to eq(:cannot_register_mentor)
       end
     end
 


### PR DESCRIPTION
[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/1059)

This story blocks school users from adding an ECT as the ECT's own mentor as this is against the policy intent. This is most likely to happen in error if a user enters the ECT's TRN instead of the mentor's TRN - this new page will block the journey in this case.

This PR:
- adds a new step to display an error page when the user enters the TRN of the ECT to mentor in FindMentorStep.
- allow registering a teacher a second time as a mentor if it was already an ECT or viceverse. Otherwise, raise an exception
- prevents ECTs from auto-assigning themselves as mentors if they are already registered as mentors.

Better review commit by commit.

Video: 
https://github.com/user-attachments/assets/3874d17c-b156-4e3a-a96f-69aafe2b09ef



