### PR TITLE
Configure rack attack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY . .
 # Precompile assets
 RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used \
     GOVUK_NOTIFY_API_KEY=TestKey \
+    REDIS_CACHE_URL=redis://127.0.0.1:6379 \
     bundle exec rails assets:precompile
 
 # Cleanup to save space in the production image

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "jsbundling-rails"
 gem "pg", "~> 1.5"
 gem "propshaft"
 gem "puma", ">= 5.0"
+gem "rack-attack"
+gem "redis"
 gem "tzinfo-data", platforms: %i[windows jruby]
 
 gem "govuk-components"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required
@@ -456,6 +458,10 @@ GEM
     rdoc (6.11.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.23.2)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -640,7 +646,9 @@ DEPENDENCIES
   playwright-ruby-client
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.0.1)
+  redis
   rotp
   rspec
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL") }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,6 +5,7 @@ class Rack::Attack
     /otp-sign-in/verify
     /sign-in
     /auth
+    /healthcheck
   ].freeze
 
   def self.protected_path?(request)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,24 @@
+class Rack::Attack
+  PROTECTED_ROUTES = %w[
+    /otp-sign-in
+    /otp-sign-in/code
+    /otp-sign-in/verify
+    /sign-in
+    /auth
+  ].freeze
+
+  def self.protected_path?(request)
+    PROTECTED_ROUTES.any? { |route| request.path.start_with?(route) }
+  end
+
+  throttle("protected routes (OTP)", limit: 5, period: 20.seconds) do |request|
+    request.ip if protected_path?(request)
+  end
+end
+
+ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, request_id, payload|
+  ip = payload.fetch(:request).ip
+  path = payload.fetch(:request).fullpath
+
+  Rails.logger.warn("[rack-attack] Throttled request #{request_id} from #{ip} to '#{path}'")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,8 @@ Rails.application.routes.draw do
   resources :cities, only: %i[index create show]
 
   # omniauth sign-in
-  get 'auth/:provider/callback', to: 'sessions#create'
+  get '/auth/:provider/callback', to: 'sessions#create'
+  post '/auth/:provider/callback', to: 'sessions#create'
   get '/sign-in', to: 'sessions#new'
   get '/sign-out', to: 'sessions#destroy'
 
@@ -30,8 +31,6 @@ Rails.application.routes.draw do
   constraints -> { Rails.application.config.enable_personas } do
     resources 'personas', only: %i[index]
   end
-
-  post 'auth/:provider/callback', to: 'sessions#create'
 
   get '/admin', to: redirect('admin/teachers')
 

--- a/config/terraform/application/application.tf
+++ b/config/terraform/application/application.tf
@@ -24,6 +24,7 @@ module "application_configuration" {
   secret_variables = {
     DATABASE_URL        = module.postgres.url
     BLAZER_DATABASE_URL = var.environment == "production" ? module.infrastructure_secrets.map[local.snapshot_db_kv_secret_name] : module.postgres.url
+    REDIS_CACHE_URL     = module.redis-cache.url
   }
 }
 

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "Rack::Attack" do
+  include ActiveSupport::Testing::TimeHelpers
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+  before do
+    allow(Rack::Attack.cache).to receive(:store) { memory_store }
+    Rack::Attack.reset!
+    Rack::Attack.enabled = true
+  end
+
+  after do
+    Rack::Attack.enabled = false
+  end
+
+  ['/otp-sign-in', '/otp-sign-in/code', '/sign-in', '/otp-sign-in/code'].each do |protected_route|
+    it "allows 5 requests in quick succession #{protected_route}" do
+      5.times do
+        get(protected_route)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it 'blocks the 6th' do
+      5.times { get(protected_route) }
+      get(protected_route)
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it 'allows more requests after 20 seconds' do
+      5.times { get(protected_route) }
+      travel(20.seconds)
+      get(protected_route)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  xit 'POST /otp-sign-in'
+  xit 'POST /otp-sign-in/verify'
+end


### PR DESCRIPTION
Add and configure `rack-attack` to protect against abusive requests.

For this to work in production we need to enable the Redis cache. It's already provisioned and present for the production-like environments.


## Testing locally with [siege](https://openbenchmarking.org/test/pts/apache-siege&eval=26ae0a03bb5a412022a81331100103a2e4882950)

To test locally you need to enable the cache in dev.

```
bundle exec rails dev:cache
```

Then create a siege file, e.g. in `~/protected-paths`:

```
HOST=http://localhost:3000
$(HOST)/sign-in
$(HOST)/otp-sign-in
```

Now we can run it with `siege ~/protected-paths`. Hopefully things are quickly throttled, like this:


![Screenshot From 2025-01-30 15-10-17](https://github.com/user-attachments/assets/6e9e8b87-093a-4c53-a503-fdb870ff64eb)

