### PR TITLE
Add `unknown` and `pre_september_2021` induction programmes

### DIFF
--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -23,7 +23,7 @@ class InductionPeriod < ApplicationRecord
             }
 
   validates :induction_programme,
-            inclusion: { in: %w[fip cip diy],
+            inclusion: { in: %w[fip cip diy unknown pre_september_2021],
                          message: "Choose an induction programme" }
 
   validate :start_date_after_qts_date

--- a/db/migrate/20250130172854_add_unknown_and_pre_september_2021_induction_programmes.rb
+++ b/db/migrate/20250130172854_add_unknown_and_pre_september_2021_induction_programmes.rb
@@ -1,0 +1,12 @@
+class AddUnknownAndPreSeptember2021InductionProgrammes < ActiveRecord::Migration[8.0]
+  def change
+    # these two new types are here to support records imported from DQT
+    # some are after September 2021 and have no induction programme; they're not
+    # really 'valid' but we need to record them
+    add_enum_value :induction_programme, 'unknown'
+    # any that started before september 2021 and have no induction programme
+    # are valid, because the ECF induction programmes didn't exist when they
+    # were openend - again they don't need fixing but should be recorded
+    add_enum_value :induction_programme, 'pre_september_2021'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_135949) do
   create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
   create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
   create_enum "induction_outcomes", ["fail", "pass"]
-  create_enum "induction_programme", ["cip", "fip", "diy"]
+  create_enum "induction_programme", ["cip", "fip", "diy", "unknown", "pre_september_2021"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
   create_table "academic_years", primary_key: "year", id: :serial, force: :cascade do |t|

--- a/lib/appropriate_bodies/importers/induction_period_importer.rb
+++ b/lib/appropriate_bodies/importers/induction_period_importer.rb
@@ -47,7 +47,7 @@ module AppropriateBodies::Importers
         {
           "Full Induction Programme" => "fip",
           "Core Induction Programme" => "cip",
-          "School-based Induction Programme" => "diy" # FIXME: check this! - perhaps school-funded fip?
+          "School-based Induction Programme" => "diy"
         }.fetch(induction_programme, "unknown")
       end
     end

--- a/lib/appropriate_bodies/importers/induction_period_importer.rb
+++ b/lib/appropriate_bodies/importers/induction_period_importer.rb
@@ -4,6 +4,7 @@ module AppropriateBodies::Importers
   class InductionPeriodImporter
     IMPORT_ERROR_LOG = 'tmp/induction_period_import.log'.freeze
     LOGFILE = Rails.root.join("log/induction_period_import.log").freeze
+    ECF_CUTOFF = Date.new(2021, 9, 1).freeze
 
     attr_accessor :csv, :data
 
@@ -41,11 +42,13 @@ module AppropriateBodies::Importers
     private
 
       def convert_induction_programme
+        return "pre_september_2021" if started_on < ECF_CUTOFF
+
         {
           "Full Induction Programme" => "fip",
           "Core Induction Programme" => "cip",
           "School-based Induction Programme" => "diy" # FIXME: check this! - perhaps school-funded fip?
-        }.fetch(induction_programme, "fip")
+        }.fetch(induction_programme, "unknown")
       end
     end
 

--- a/spec/lib/appropriate_bodies/importers/induction_period_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/induction_period_importer_spec.rb
@@ -3,6 +3,7 @@ describe AppropriateBodies::Importers::InductionPeriodImporter do
   let!(:ab_2) { FactoryBot.create(:appropriate_body, legacy_id: '1ddf3e82-c1ae-e311-b8ed-005056822391') }
   let!(:ab_3) { FactoryBot.create(:appropriate_body, legacy_id: 'ef1c5e56-a8e6-41e2-a47d-c75a098cd61f') }
   let!(:ab_4) { FactoryBot.create(:appropriate_body, legacy_id: '67fc4692-2b90-4a80-8131-795eb93bc496') }
+  let!(:ab_5) { FactoryBot.create(:appropriate_body, legacy_id: 'f4837bce-28ae-46d0-aae7-d49f1d8f62e3') }
 
   let!(:ect_1) { FactoryBot.create(:teacher, trn: '2600071') }
   let!(:ect_2) { FactoryBot.create(:teacher, trn: '1666461') }
@@ -12,9 +13,10 @@ describe AppropriateBodies::Importers::InductionPeriodImporter do
     <<~CSV
       appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
       #{ab_1.legacy_id},01/01/2012 00:00:00,10/31/2012 00:00:00,Core Induction Programme,3,2600071
-      #{ab_2.legacy_id},09/02/2019 00:00:00,11/13/2020 00:00:00,School-based Induction Programme,3,1666461
-      #{ab_3.legacy_id},02/01/2012 00:00:00,10/31/2012 00:00:00,Full Induction Programme,3,2600049
-      #{ab_4.legacy_id},02/01/2012 00:00:00,10/31/2012 00:00:00,,3,2600049
+      #{ab_2.legacy_id},12/12/2021 00:00:00,10/31/2022 00:00:00,Core Induction Programme,3,2600071
+      #{ab_3.legacy_id},09/02/2022 00:00:00,11/13/2023 00:00:00,School-based Induction Programme,3,1666461
+      #{ab_4.legacy_id},02/01/2023 00:00:00,10/31/2014 00:00:00,Full Induction Programme,3,2600049
+      #{ab_5.legacy_id},02/01/2024 00:00:00,10/31/2015 00:00:00,,3,2600049
     CSV
   end
 
@@ -26,16 +28,17 @@ describe AppropriateBodies::Importers::InductionPeriodImporter do
   end
 
   it 'converts all rows' do
-    expect(subject.rows.size).to eql(4)
+    expect(subject.rows.size).to eql(5)
   end
 
   describe 'mapping induction programmes' do
     it 'converts names to codes properly' do
       mappings = {
-        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_1.legacy_id } => 'cip',
-        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_2.legacy_id } => 'diy',
-        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_3.legacy_id } => 'fip',
-        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_4.legacy_id } => 'fip' # defaults when missing
+        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_1.legacy_id } => 'pre_september_2021',
+        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_2.legacy_id } => 'cip',
+        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_3.legacy_id } => 'diy',
+        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_4.legacy_id } => 'fip',
+        subject.rows.find { |r| r.legacy_appropriate_body_id == ab_5.legacy_id } => 'unknown'
       }
       mappings.each do |row, expected_induction_programme|
         expect(row.to_hash.fetch(:induction_programme)).to eql(expected_induction_programme)

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -40,7 +40,7 @@ describe InductionPeriod do
       end
     end
 
-    it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy]).with_message("Choose an induction programme") }
+    it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy unknown pre_september_2021]).with_message("Choose an induction programme") }
 
     describe '#started_on_from_september_2021_onwards' do
       context 'when started_on before September 2021' do


### PR DESCRIPTION
ECF started in September 2021 so any induction periods that started before then shouldn't have an ECF programme type; they will be assigned `pre_september_2021`.

Any induction period that starts on or after 1 Septmeber 2021 should have an induction type, but some in DQT don't so we're setting them as `unknown`.

Refs #65
