### PR TITLE
ECT claiming fixes

### DIFF
--- a/app/controllers/appropriate_bodies/claim_an_ect/check_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/check_ect_controller.rb
@@ -2,6 +2,7 @@ module AppropriateBodies
   module ClaimAnECT
     class CheckECTController < AppropriateBodiesController
       def edit
+        @current_appropriate_body = current_user.appropriate_body
         @pending_induction_submission = find_pending_induction_submission
         @teacher = Teacher.find_by(trn: @pending_induction_submission.trn)
       end

--- a/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
@@ -38,7 +38,9 @@ module AppropriateBodies
 
         render(:new)
       rescue AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB => e
-        redirect_to(ab_teacher_path(find_ect.pending_induction_submission.trn), notice: e.message)
+        teacher_id = Teacher.find_by!(trn: find_ect.pending_induction_submission.trn).id
+
+        redirect_to(ab_teacher_path(teacher_id), notice: e.message)
       end
 
     private

--- a/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
@@ -10,13 +10,13 @@ module AppropriateBodies
 
       def create
         find_ect = AppropriateBodies::ClaimAnECT::FindECT
-          .new(
-            appropriate_body: @appropriate_body,
-            pending_induction_submission: PendingInductionSubmission.new(
-              **pending_induction_submission_params,
-              **pending_induction_submission_attributes
-            )
+        .new(
+          appropriate_body: @appropriate_body,
+          pending_induction_submission: PendingInductionSubmission.new(
+            **pending_induction_submission_params,
+            **pending_induction_submission_attributes
           )
+        )
         @pending_induction_submission = find_ect.pending_induction_submission
 
         if find_ect.import_from_trs!
@@ -38,9 +38,7 @@ module AppropriateBodies
 
         render(:new)
       rescue AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB => e
-        teacher_id = Teacher.find_by!(trn: find_ect.pending_induction_submission.trn).id
-
-        redirect_to(ab_teacher_path(teacher_id), notice: e.message)
+        redirect_to(ab_teacher_path(find_ect.pending_induction_submission.trn), notice: e.message)
       end
 
     private

--- a/app/helpers/induction_helper.rb
+++ b/app/helpers/induction_helper.rb
@@ -1,0 +1,7 @@
+module InductionHelper
+  def claiming_body?(teacher, body)
+    return true if teacher.nil?
+
+    Teachers::Induction.new(teacher).with_appropriate_body?(body)
+  end
+end

--- a/app/services/teachers/induction.rb
+++ b/app/services/teachers/induction.rb
@@ -25,5 +25,9 @@ module Teachers
     def has_extensions?
       teacher.induction_extensions.any?
     end
+
+    def with_appropriate_body?(appropriate_body)
+      current_induction_period&.appropriate_body == appropriate_body
+    end
   end
 end

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -5,11 +5,18 @@
   backlink_href: new_ab_claim_an_ect_find_path)
 %>
 
-<% unless induction_status_from(teacher: @teacher, pending_induction_submission: @pending_induction_submission).completed? %>
-  <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_check_path(@pending_induction_submission, method: 'patch')) do |f| %>
-    <%= f.govuk_submit("Claim induction") %>
+<% unless claiming_body?(@teacher, @current_appropriate_body) %>
+  <div class="govuk-inset-text">
+    You cannot register <%= pending_induction_submission_full_name(@pending_induction_submission) %>. 
+    Our records show that <%= pending_induction_submission_full_name(@pending_induction_submission) %> is completing their induction with another appropriate body.
+  </div>
+<% else %> 
+  <% unless induction_status_from(teacher: @teacher, pending_induction_submission: @pending_induction_submission).completed? %>
+    <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_check_path(@pending_induction_submission, method: 'patch')) do |f| %>
+      <%= f.govuk_submit("Claim induction") %>
+    <% end %>
   <% end %>
-<% end %>
+<% end %> 
 
 <h2 class="govuk-heading-m">Personal details</h2>
 

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -6,10 +6,10 @@
 %>
 
 <% unless claiming_body?(@teacher, @current_appropriate_body) %>
-  <div class="govuk-inset-text">
+  <%= govuk_inset_text do %>
     You cannot register <%= pending_induction_submission_full_name(@pending_induction_submission) %>. 
     Our records show that <%= pending_induction_submission_full_name(@pending_induction_submission) %> is completing their induction with another appropriate body.
-  </div>
+  <% end %>
 <% else %> 
   <% unless induction_status_from(teacher: @teacher, pending_induction_submission: @pending_induction_submission).completed? %>
     <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_check_path(@pending_induction_submission, method: 'patch')) do |f| %>

--- a/app/views/schools/register_ect_wizard/review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/review_ect_details.html.erb
@@ -43,7 +43,7 @@ end %>
   <%= f.govuk_submit "Confirm and continue" %>
 <% end %>
 
-<div class="govuk-inset-text">
+<%= govuk_inset_text do %>
   If this is not the person you intended to register as an ECT, go back
   and <%= govuk_link_to("check details", schools_register_ect_wizard_find_ect_path) %>.
-</div>
+<% end %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_details.html.erb
@@ -44,7 +44,7 @@ end %>
   <%= f.govuk_submit "Confirm and continue" %>
 <% end %>
 
-<div class="govuk-inset-text">
+<%= govuk_inset_text do %>
   If this is not the person you intended to register as a mentor, go back
   and <%= govuk_link_to("check details", schools_register_mentor_wizard_find_mentor_path) %>.
-</div>
+<% end %>

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -3,6 +3,28 @@ RSpec.describe 'Claiming an ECT' do
 
   before { sign_in_as_appropriate_body_user(appropriate_body:) }
 
+  describe "when the ECT is already claimed by another appropriate body" do
+    include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+
+    before do
+      other_body = FactoryBot.create(:appropriate_body)
+      teacher = FactoryBot.create(:teacher, trn: '1234567')
+      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_body)
+    end
+
+    scenario 'Button is hidden when induction is completed' do
+      given_i_am_on_the_claim_an_ect_find_page
+      when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
+      and_i_submit_the_form
+
+      now_i_should_be_on_the_claim_an_ect_check_page
+      then_i_should_not_see_the_claim_button
+
+      expect(page.get_by_text('You cannot register Kirk Van Houten')).to be_visible
+      expect(page.get_by_text('Our records show that Kirk Van Houten is completing their induction with another appropriate body.')).to be_visible
+    end
+  end
+
   describe "when the ECT has not passed the induction" do
     include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
 

--- a/spec/helpers/induction_helper_spec.rb
+++ b/spec/helpers/induction_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe InductionHelper, type: :helper do
+  describe '#claiming_body?' do
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+    let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+    it 'returns true when the current induction is with the claiming body' do
+      expect(helper.claiming_body?(teacher, induction_period.appropriate_body)).to be true
+    end
+
+    it 'returns false when the current induction is with another body' do
+      expect(helper.claiming_body?(teacher, other_appropriate_body)).to be false
+    end
+  end
+end

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -89,4 +89,17 @@ RSpec.describe Teachers::Induction do
       expect(service.has_extensions?).to be false
     end
   end
+
+  describe "#with_appropriate_body?" do
+    let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+
+    it "returns true when the current induction is with the body" do
+      expect(service.with_appropriate_body?(induction_period.appropriate_body)).to be true
+    end
+
+    it "returns false when the current induction is with another body" do
+      expect(service.with_appropriate_body?(other_appropriate_body)).to be false
+    end
+  end
 end

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -1,57 +1,76 @@
-RSpec.describe "appropriate_bodies/claim_an_ect/check_ect/edit.html.erb" do
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_first_name: 'Anna', trs_last_name: 'Chancellor') }
+RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+  let(:pending_induction_submission) do
+    FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_first_name: 'Anna', trs_last_name: 'Chancellor')
+  end
+
+  let(:teacher) do
+    FactoryBot.create(:teacher,
+                      trs_first_name: pending_induction_submission.trs_first_name,
+                      trs_last_name: pending_induction_submission.trs_last_name,
+                      trn: pending_induction_submission.trn)
+  end
+
+  before do
+    assign(:teacher, teacher)
+    assign(:pending_induction_submission, pending_induction_submission)
+  end
 
   it "sets the page title to 'Check details for <name>'" do
-    assign(:pending_induction_submission, pending_induction_submission)
-
     render
-
     expected_title = "Check details for Anna Chancellor"
     expect(sanitize(view.content_for(:page_title))).to eql(sanitize(expected_title))
   end
 
   it 'includes a back button that links to the AB homepage' do
-    assign(:pending_induction_submission, pending_induction_submission)
-
     render
-
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: '/appropriate-body/claim-an-ect/find-ect/new')
   end
 
+  describe 'claim induction CTA' do
+    context 'when the ECT is not yet claimed by an appropriate body' do
+      it 'renders the claim button' do
+        render
+        expect(rendered).to have_button('Claim induction')
+      end
+    end
+
+    context 'when the ECT has an ongoing induction period with another appropriate body' do
+      let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+
+      before { assign(:current_appropriate_body, appropriate_body) }
+
+      it 'replaces the claim button with explanatory text' do
+        render
+        expect(rendered).to have_text('You cannot register Anna Chancellor')
+        expect(rendered).to have_text('completing their induction with another appropriate body')
+        expect(rendered).to_not have_button('Claim induction')
+      end
+    end
+  end
+
   describe 'induction status' do
+    let(:teacher) { nil }
     let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_induction_status: 'FailedInWales') }
 
     it 'displays the status tag that corresponds to the TRS induction status on the pending induction submission' do
-      assign(:pending_induction_submission, pending_induction_submission)
-
       render
-
       expect(rendered).to have_css('strong.govuk-tag', text: 'Failed in Wales')
     end
   end
 
   describe 'induction periods' do
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
-
     context 'when the ECT has past induction periods' do
       let!(:current_induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
 
       it 'shows the current induction period' do
-        assign(:teacher, teacher)
-        assign(:pending_induction_submission, pending_induction_submission)
-
         render
-
         expect(rendered).to have_css('.govuk-summary-card__title', text: current_induction_period.appropriate_body.name)
       end
 
       it 'has no release link' do
-        assign(:teacher, teacher)
-        assign(:pending_induction_submission, pending_induction_submission)
-
         render
-
         expect(rendered).not_to have_link('Release')
       end
     end
@@ -60,11 +79,7 @@ RSpec.describe "appropriate_bodies/claim_an_ect/check_ect/edit.html.erb" do
       let!(:past_induction_period) { FactoryBot.create(:induction_period, teacher:) }
 
       it 'shows a list of past induction periods' do
-        assign(:teacher, teacher)
-        assign(:pending_induction_submission, pending_induction_submission)
-
         render
-
         expect(rendered).to have_css('ul.govuk-list > li .govuk-summary-card__title', text: past_induction_period.appropriate_body.name)
       end
     end


### PR DESCRIPTION
- replace "Claim induction" CTA when ECT is already claimed by another body
- fix redirect when claiming an already claimed ECT

# Testing

Try ECT `3002582`  