### PR TITLE
[893] - keep only the last 7 days of backups in Azure Storage

### DIFF
--- a/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
@@ -137,7 +137,7 @@ runs:
       env:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Snapshot Database restore succeeded
-        SLACK_MESSAGE: ${{ inputs.app-name }} - snapshot restore job succeeded
+        SLACK_MESSAGE: ${{ inputs.app-name }} - snapshot restore job from ${{ inputs.storage-account }} / database-backup / ${{ inputs.backup-file }} succeeded!
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLACK_COLOR: success
         SLACK_FOOTER: Sent from restore-snapshot-database-from-azure-storage action
@@ -148,7 +148,7 @@ runs:
       env:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Snapshot Database restore failure
-        SLACK_MESSAGE: ${{ inputs.app-name }} snapshot restore job failed
+        SLACK_MESSAGE: ${{ inputs.app-name }} snapshot restore job from ${{ inputs.storage-account }} / database-backup / ${{ inputs.backup-file }} failed!
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLACK_COLOR: failure
         SLACK_FOOTER: Sent from restore-snapshot-database-from-azure-storage action

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -123,7 +123,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_USERNAME: CI Deployment
-          SLACK_TITLE: ${{ env.DEPLOY_ENV }} database dump stored in Azure Storage (${{ env.STORAGE_ACCOUNT_NAME }}) - Success
+          SLACK_TITLE: ${{ env.DEPLOY_ENV }} database dump stored in Azure Storage (${{ env.STORAGE_ACCOUNT_NAME }} / database-backup / ${{ env.BACKUP_FILE }}.sql) - Success
           SLACK_MESSAGE: ${{ env.APP_NAME }} - ${{ env.DEPLOY_ENV }} database backup job succeeded
           SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
           SLACK_COLOR: success

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -11,9 +11,6 @@ on:
         options:
           - staging
           - production
-      azure-credentials:
-        description: Azure credentials
-        required: false
       backup-file:
         description: |
           Backup file name (without extension). Default is cpdec2_[env]_adhoc_YYYY-MM-DD. Set it explicitly when backing up a point-in-time (PTR) server. (Optional)
@@ -35,10 +32,6 @@ on:
         required: true
         default: staging
         type: string
-      azure-credentials:
-        description: Azure Credentials
-        type: string
-        required: false
       backup-file:
         description: |
           Backup file name (without extension). Default is cpdec2_[env]_adhoc_YYYY-MM-DD. Set it explicitly when backing up a point-in-time (PTR) server. (Optional)

--- a/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
+++ b/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
@@ -6,17 +6,31 @@ on:
     - cron: "15 4 * * *" # 04:15 UTC
 
 jobs:
+  generate-day_of_week:
+    runs-on: ubuntu-latest
+    outputs:
+      today_day: ${{ steps.get-day.outputs.today_day }}
+    steps:
+      - name: Get today's day of the week
+        id: get-day
+        run: echo "today_day=$(date +'%A')" >> $GITHUB_OUTPUT
+
   backup-production-and-store-in-azure-storage:
     uses: ./.github/workflows/backup-db.yml
+    needs: generate-day_of_week
     with:
       environment: production
+      backup-file: cpdec2_production_adhoc_${{ needs.generate-day_of_week.outputs.today_day }}
     secrets:
       azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
   restore-snapshot-from-azure-storage:
-    needs: backup-production-and-store-in-azure-storage
+    needs:
+      - generate-day_of_week
+      - backup-production-and-store-in-azure-storage
     uses: ./.github/workflows/restore-snapshot-db-from-azure-storage.yml
     with:
       environment: production
+      backup-file: cpdec2_production_adhoc_${{ needs.generate-day_of_week.outputs.today_day }}
     secrets:
       azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
- Nightly production db backups will create dump files named `cpdec2_pd_adhoc_day_of_week`. 
  This way every week the new backups will be overwriting those from the previous one keeping so only the last 7 days copies in Azure Storage.

- Display full path to the backup file in Azure Storage on Slack notifications.
