### PR TITLE
Unset `number_of_terms` when induction periods aren't finished

### DIFF
--- a/lib/appropriate_bodies/importers/importer.rb
+++ b/lib/appropriate_bodies/importers/importer.rb
@@ -64,8 +64,6 @@ module AppropriateBodies::Importers
       puts "Induction extensions inserted: #{InductionExtension.count}"
 
       # TODO: insert events
-
-      binding.debugger
     end
     # rubocop:enable Rails/Output
   end

--- a/lib/appropriate_bodies/importers/induction_period_importer.rb
+++ b/lib/appropriate_bodies/importers/induction_period_importer.rb
@@ -32,7 +32,7 @@ module AppropriateBodies::Importers
 
       # used for comparisons in tests
       def to_hash
-        { appropriate_body_id:, started_on:, finished_on:, induction_programme: convert_induction_programme, number_of_terms: fixed_number_of_terms }
+        { appropriate_body_id:, started_on:, finished_on: fixed_finished_on, induction_programme: convert_induction_programme, number_of_terms: fixed_number_of_terms }
       end
 
       def to_record
@@ -43,6 +43,10 @@ module AppropriateBodies::Importers
 
       def fixed_number_of_terms
         (finished_on.present?) ? number_of_terms : nil
+      end
+
+      def fixed_finished_on
+        finished_on == started_on ? finished_on + 1 : finished_on
       end
 
       def convert_induction_programme
@@ -85,7 +89,7 @@ module AppropriateBodies::Importers
       rows
         .reject { |ip| ip.started_on.nil? }
         .reject { |ip| ip.started_on == Date.new(1, 1, 1) }
-        .reject { |ip| ip.finished_on && ip.started_on >= ip.finished_on }
+        .reject { |ip| ip.finished_on && ip.started_on > ip.finished_on }
         .group_by(&:trn)
         .select { |_trn, periods| periods.any? { |p| p.finished_on.nil? } }
         .transform_values { |periods| periods.sort_by { |p| [p.started_on, p.length, p.appropriate_body_id] } }

--- a/lib/appropriate_bodies/importers/induction_period_importer.rb
+++ b/lib/appropriate_bodies/importers/induction_period_importer.rb
@@ -32,14 +32,18 @@ module AppropriateBodies::Importers
 
       # used for comparisons in tests
       def to_hash
-        { appropriate_body_id:, started_on:, finished_on:, induction_programme: convert_induction_programme, number_of_terms: }
+        { appropriate_body_id:, started_on:, finished_on:, induction_programme: convert_induction_programme, number_of_terms: fixed_number_of_terms }
       end
 
       def to_record
-        { appropriate_body_id:, started_on:, finished_on:, induction_programme: convert_induction_programme, number_of_terms:, teacher_id: }
+        { **to_hash, teacher_id: }
       end
 
     private
+
+      def fixed_number_of_terms
+        (finished_on.present?) ? number_of_terms : nil
+      end
 
       def convert_induction_programme
         return "pre_september_2021" if started_on < ECF_CUTOFF

--- a/spec/lib/appropriate_bodies/importers/induction_period_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/induction_period_importer_spec.rb
@@ -46,6 +46,23 @@ describe AppropriateBodies::Importers::InductionPeriodImporter do
     end
   end
 
+  describe 'number of terms' do
+    context 'when number_of_terms is present and finished_on is blank' do
+      let(:sample_csv_data) do
+        <<~CSV
+          appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+          025e61e7-ec32-eb11-a813-000d3a228dfc,01/01/2012 00:00:00,,,3,2600071
+        CSV
+      end
+
+      it 'sets the number_of_terms to nil' do
+        row_data = subject.periods_as_hashes_by_trn['2600071'].first
+        expect(row_data.fetch(:started_on)).to eql(Date.new(2012, 1, 1))
+        expect(row_data.fetch(:number_of_terms)).to be_nil
+      end
+    end
+  end
+
   describe 'rebuilding periods' do
     context 'when an ECT has no open induction periods' do
       let(:sample_csv_data) do

--- a/spec/lib/appropriate_bodies/importers/induction_period_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/induction_period_importer_spec.rb
@@ -63,6 +63,24 @@ describe AppropriateBodies::Importers::InductionPeriodImporter do
     end
   end
 
+  describe 'finished_on' do
+    context 'when started_on and finished_on are the same day' do
+      let(:sample_csv_data) do
+        <<~CSV
+          appropriate_body_id,started_on,finished_on,induction_programme_choice,number_of_terms,trn
+          025e61e7-ec32-eb11-a813-000d3a228dfc,01/01/2012 00:00:00,01/01/2012 00:00:00,,3,2600071
+          025e61e7-ec32-eb11-a813-000d3a228dfc,01/01/2021 00:00:00,,,3,2600071
+        CSV
+      end
+
+      it 'bumps the finish date by one day' do
+        row_data = subject.periods_as_hashes_by_trn['2600071'].first
+        expect(row_data.fetch(:started_on)).to eql(Date.new(2012, 1, 1))
+        expect(row_data.fetch(:finished_on)).to eql(Date.new(2012, 1, 2))
+      end
+    end
+  end
+
   describe 'rebuilding periods' do
     context 'when an ECT has no open induction periods' do
       let(:sample_csv_data) do


### PR DESCRIPTION
There should never be a `number_of_terms` present on an ongoing induction period.
