### PR TITLE
Bugfix: Allow data from TRS API to be persisted

### DIFF
--- a/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
@@ -29,7 +29,7 @@ module AppropriateBodies
     private
 
       def update_params
-        params.require(:pending_induction_submission).permit(:started_on, :induction_programme)
+        params.require(:pending_induction_submission).permit(:started_on, :induction_programme, :trs_induction_status)
       end
 
       def find_pending_induction_submission

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -74,6 +74,13 @@ class PendingInductionSubmission < ApplicationRecord
 
   validate :start_date_after_qts_date, on: :register_ect
 
+  validates :trs_induction_status,
+            inclusion: {
+              in: %w[None RequiredToComplete Exempt InProgress Passed Failed FailedInWales],
+              message: "TRS Induction Status is not known",
+            },
+            on: :register_ect
+
 private
 
   def start_date_after_qts_date

--- a/db/migrate/20250131171406_increase_induction_status_limit.rb
+++ b/db/migrate/20250131171406_increase_induction_status_limit.rb
@@ -1,0 +1,9 @@
+class IncreaseInductionStatusLimit < ActiveRecord::Migration[8.0]
+  def up
+    change_column :pending_induction_submissions, :trs_induction_status, :string, limit: 18
+  end
+
+  def down
+    change_column :pending_induction_submissions, :trs_induction_status, :string, limit: 16
+  end
+end

--- a/db/migrate/20250131171406_increase_induction_status_limit.rb
+++ b/db/migrate/20250131171406_increase_induction_status_limit.rb
@@ -1,9 +1,0 @@
-class IncreaseInductionStatusLimit < ActiveRecord::Migration[8.0]
-  def up
-    change_column :pending_induction_submissions, :trs_induction_status, :string, limit: 18
-  end
-
-  def down
-    change_column :pending_induction_submissions, :trs_induction_status, :string, limit: 16
-  end
-end

--- a/db/migrate/20250131171406_remove_induction_status_limit.rb
+++ b/db/migrate/20250131171406_remove_induction_status_limit.rb
@@ -1,0 +1,9 @@
+class RemoveInductionStatusLimit < ActiveRecord::Migration[8.0]
+  def up
+    change_column :pending_induction_submissions, :trs_induction_status, :string, limit: nil
+  end
+
+  def down
+    change_column :pending_induction_submissions, :trs_induction_status, :string, limit: 16
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_23_161652) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_31_171406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -322,7 +322,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_161652) do
     t.string "trs_first_name", limit: 80
     t.string "trs_last_name", limit: 80
     t.date "date_of_birth"
-    t.string "trs_induction_status", limit: 16
+    t.string "trs_induction_status", limit: 18
     t.enum "induction_programme", enum_type: "induction_programme"
     t.date "started_on"
     t.date "finished_on"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -322,7 +322,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_31_171406) do
     t.string "trs_first_name", limit: 80
     t.string "trs_last_name", limit: 80
     t.date "date_of_birth"
-    t.string "trs_induction_status", limit: 18
+    t.string "trs_induction_status"
     t.enum "induction_programme", enum_type: "induction_programme"
     t.date "started_on"
     t.date "finished_on"

--- a/spec/factories/pending_induction_submission_factory.rb
+++ b/spec/factories/pending_induction_submission_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     date_of_birth { Faker::Date.between(from: 80.years.ago, to: 20.years.ago) }
     trs_first_name { Faker::Name.first_name }
     trs_last_name { Faker::Name.last_name }
+    trs_induction_status { "None" }
     started_on { 1.year.ago }
     trs_qts_awarded_on { 2.years.ago }
 

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -25,6 +25,13 @@ describe PendingInductionSubmission do
       end
     end
 
+    describe "trs_induction_status" do
+      let(:statuses) { %w[None RequiredToComplete Exempt InProgress Passed Failed FailedInWales] }
+
+      it { is_expected.to validate_presence_of(:trs_induction_status).on(:register_ect).with_message("TRS Induction Status is not known") }
+      it { is_expected.to allow_values(*statuses).for(:trs_induction_status) }
+    end
+
     describe "date_of_birth" do
       it { is_expected.to validate_presence_of(:date_of_birth).with_message("Enter a date of birth").on(:find_ect) }
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
       context 'when the submission is valid' do
         let(:registration_params) do
           {
+            trs_induction_status: 'None',
             induction_programme: 'fip',
             'started_on(3)' => '4',
             'started_on(2)' => '6',

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
         trn: "1234567",
         trs_first_name: "John",
         trs_last_name: "Doe",
+        trs_induction_status: "None",
         trs_qts_awarded_on:
       }
     end


### PR DESCRIPTION
Character limit prevented ECTs with a status of "RequiredToComplete" from being processed.

- ~Increase size of `PendingInductionSubmission` `trs_induction_status` character limit from `16` to `18`.~
- Remove `PendingInductionSubmission` `trs_induction_status` character limit.
- Add validation when registering.