### PR TITLE
[897] - setup blazer in production

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -2,5 +2,78 @@
 
 data_sources:
   main:
-    url: <%= ENV["DATABASE_URL"] %>
+    url: <%= ENV["BLAZER_DATABASE_URL"] %>
+
+# statement timeout, in seconds
+# none by default
+# timeout: 15
+
+# caching settings
+# can greatly improve speed
+# off by default
+# cache:
+#   mode: slow # or all
+#   expires_in: 60 # min
+#   slow_threshold: 15 # sec, only used in slow mode
+
+# wrap queries in a transaction for safety
+# not necessary if you use a read-only user
+# true by default
+# use_transaction: false
+
+smart_variables:
+# zone_id: "SELECT id, name FROM zones ORDER BY name ASC"
+# period: ["day", "week", "month"]
+# status: {0: "Active", 1: "Archived"}
+
+linked_columns:
+# user_id: "/admin/users/{value}"
+
+smart_columns:
+# user_id: "SELECT id, name FROM users WHERE id IN {value}"
+
+# create audits
+# audit: true
+
+# change the time zone
+# time_zone: "Pacific Time (US & Canada)"
+
+# class name of the user model
+user_class: Sessions::Users::DfEUser
+
+# method name for the current user
+user_method: current_user
+
+# method name for the display name
+# user_name: name
+
+# custom before_action to use for auth
 before_action_method: require_admin
+
+# email to send checks from
+# from_email: blazer@example.org
+
+# webhook for Slack
+# slack_webhook_url: <%= ENV["BLAZER_SLACK_WEBHOOK_URL"] %>
+
+check_schedules:
+# - "1 day"
+# - "1 hour"
+# - "5 minutes"
+
+# enable anomaly detection
+# note: with trend, time series are sent to https://trendapi.org
+# anomaly_checks: prophet / trend / anomaly_detection
+
+# enable forecasting
+# note: with trend, time series are sent to https://trendapi.org
+# forecasting: prophet / trend
+
+# enable map
+# mapbox_access_token: <%= ENV["MAPBOX_ACCESS_TOKEN"] %>
+
+# enable uploads
+# uploads:
+#   url: <%= ENV["BLAZER_UPLOADS_URL"] %>
+#   schema: uploads
+#   data_source: main

--- a/config/terraform/application/application.tf
+++ b/config/terraform/application/application.tf
@@ -1,3 +1,7 @@
+locals {
+  snapshot_db_kv_secret_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg-snapshot-database-url"
+}
+
 module "application_configuration" {
   source = "./vendor/modules/aks//aks/application_configuration"
 
@@ -18,7 +22,8 @@ module "application_configuration" {
     }
   )
   secret_variables = {
-    DATABASE_URL = module.postgres.url
+    DATABASE_URL        = module.postgres.url
+    BLAZER_DATABASE_URL = var.environment == "production" ? module.infrastructure_secrets.map[local.snapshot_db_kv_secret_name] : module.postgres.url
   }
 }
 

--- a/config/terraform/application/config/production.yml
+++ b/config/terraform/application/config/production.yml
@@ -1,6 +1,7 @@
 ---
 ENABLE_SENTRY: true
 ENABLE_PERSONAS: false
+ENABLE_BLAZER: true
 DFE_SIGN_IN_API_AUDIENCE: signin.education.gov.uk
 DFE_SIGN_IN_API_BASE_URL: 'https://api.signin.education.gov.uk'
 DFE_SIGN_IN_CLIENT_ID: RegisterECTs


### PR DESCRIPTION
This PR sets up `BLAZER_DATABASE_URL` for all the environments:
- pointing to the snapshot database in production
- pointing to the main database otherwise