### PR TITLE
Make the health check more informative

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,0 +1,21 @@
+class HealthCheckController < ApplicationController
+  skip_before_action :authenticate
+
+  def show = render(json:)
+
+private
+
+  def json
+    { commit_sha:, database: }.to_json
+  end
+
+  def commit_sha
+    ENV.fetch('COMMIT_SHA', 'UNKNOWN')
+  end
+
+  def database
+    'connected' if ActiveRecord::Base.connection.execute('select 1 as ok').tuple(0)['ok'] == 1
+  rescue PG::ConnectionBad
+    'not connected'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get '/accessibility', to: 'pages#accessibility'
   get '/privacy', to: 'pages#privacy'
 
-  get "healthcheck" => "rails/health#show", as: :rails_health_check
+  get "healthcheck" => "health_check#show", as: :rails_health_check
 
   scope via: :all do
     get '/404', to: 'errors#not_found'

--- a/spec/requests/health_check_controller_spec.rb
+++ b/spec/requests/health_check_controller_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe "Health check" do
+  describe "GET /healthcheck" do
+    it 'returns some JSON describing the application health' do
+      get "/healthcheck"
+
+      expect(JSON.parse(response.body)).to eql(
+        {
+          'commit_sha' => 'UNKNOWN',
+          'database' => 'connected',
+        }
+      )
+    end
+
+    context 'when the commit SHA is known' do
+      before do
+        allow(ENV).to receive(:fetch).with('COMMIT_SHA', 'UNKNOWN').and_return('abc123def')
+      end
+
+      it 'returns the commit sha' do
+        get "/healthcheck"
+
+        expect(JSON.parse(response.body).fetch('commit_sha')).to eql('abc123def')
+      end
+    end
+
+    context 'when the database is not connected' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(PG::ConnectionBad)
+      end
+
+      it 'returns not connected' do
+        get "/healthcheck"
+
+        expect(JSON.parse(response.body).fetch('database')).to eql('not connected')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Being able to use the health check to determine the overall state of the app is useful. For example, app won't function without the database, so we should ensure it's working.
