### PR TITLE
fix bug: some args are not been passed correctly to to github actions

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -50,7 +50,7 @@ runs:
         TF_VAR_statuscake_api_token: ${{ inputs.statuscake-api-token }}
         DOCKER_IMAGE_TAG: ${{ inputs.docker-image-tag }}
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
-        COMMIT_SHA: ${{ inputs.current-commit-sha }}
+        COMMIT_SHA: ${{ inputs.commit-sha }}
 
     - uses: Azure/login@v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
 
   deploy-production:
     name: Deploy production
-    needs: [deploy-nonprod]
+    needs: [docker, deploy-nonprod]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     environment:


### PR DESCRIPTION
 - deploy-env-to-aks:  rename arg `inputs.current-commit-sha` to its right name `inputs.commit-sha`
 - deploy: `deploy-production` needs to depend on `docker` step. Otherwise, its output (`needs.docker.outputs.docker-image-tag`) is not accessible