### PR TITLE
Replace 'Do it yourself' with 'School-based induction programme'

### DIFF
--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -3,13 +3,10 @@ module AppropriateBodyHelper
   InductionOutcomeChoice = Struct.new(:identifier, :name)
 
   def induction_programme_choices
-    # FIXME: the names here are currently the ones we use internally, they
-    #        should be switched with something more appropriate for external
-    #        users
     [
       InductionProgrammeChoice.new(identifier: 'fip', name: 'Full induction programme'),
       InductionProgrammeChoice.new(identifier: 'cip', name: 'Core induction programme'),
-      InductionProgrammeChoice.new(identifier: 'diy', name: 'Do it yourself')
+      InductionProgrammeChoice.new(identifier: 'diy', name: 'School-based induction programme')
     ]
   end
 

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
     it "has keys for the old (pre-2025) induction choices" do
       expect(induction_programme_choices.map(&:identifier)).to eql(%w[fip cip diy])
     end
+
+    it "has names for the old (pre-2025) induction choices" do
+      expect(induction_programme_choices.map(&:name)).to eql([
+        'Full induction programme',
+        'Core induction programme',
+        'School-based induction programme'
+      ])
+    end
   end
 
   describe "#summary_card_for_teacher" do


### PR DESCRIPTION
DIY is an internal term, we should use terms the users will understand in the UI. This was brought up earlier this morning in a UR session.
