### PR TITLE
Schedule future deletions of pending induction submissions 

### DIFF
--- a/app/jobs/fail_ect_induction_job.rb
+++ b/app/jobs/fail_ect_induction_job.rb
@@ -3,7 +3,7 @@ class FailECTInductionJob < ApplicationJob
     ActiveRecord::Base.transaction do
       api_client.fail_induction!(trn:, completion_date:)
 
-      PendingInductionSubmission.find(pending_induction_submission_id).destroy!
+      PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
     end
   end
 

--- a/app/jobs/pass_ect_induction_job.rb
+++ b/app/jobs/pass_ect_induction_job.rb
@@ -3,7 +3,7 @@ class PassECTInductionJob < ApplicationJob
     ActiveRecord::Base.transaction do
       api_client.pass_induction!(trn:, completion_date:)
 
-      PendingInductionSubmission.find(pending_induction_submission_id).destroy!
+      PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
     end
   end
 

--- a/app/services/appropriate_bodies/release_ect.rb
+++ b/app/services/appropriate_bodies/release_ect.rb
@@ -17,7 +17,7 @@ module AppropriateBodies
           number_of_terms: pending_induction_submission.number_of_terms
         )
 
-        pending_induction_submission.destroy!
+        pending_induction_submission.update(delete_at: 24.hours.from_now)
         record_event!
       end
     end

--- a/db/migrate/20250205135949_add_delete_at_timestamp_to_pending_induction_submissions.rb
+++ b/db/migrate/20250205135949_add_delete_at_timestamp_to_pending_induction_submissions.rb
@@ -1,0 +1,5 @@
+class AddDeleteAtTimestampToPendingInductionSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :pending_induction_submissions, :delete_at, :timestamp, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_31_171406) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_05_135949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -339,6 +339,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_31_171406) do
     t.string "trs_initial_teacher_training_provider_name"
     t.enum "outcome", enum_type: "induction_outcomes"
     t.date "trs_qts_awarded_on"
+    t.datetime "delete_at", precision: nil
     t.index ["appropriate_body_id"], name: "index_pending_induction_submissions_on_appropriate_body_id"
   end
 

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Releasing an ECT' do
 
     then_i_should_be_on_the_success_page
     and_the_release_ect_service_should_have_been_called
-    and_the_pending_induction_submission_should_have_been_deleted
+    and_the_pending_induction_submission_delete_at_timestamp_is_set
   end
 
 private
@@ -79,8 +79,8 @@ private
     expect(page.locator('.govuk-panel')).to have_text(/#{teacher_name} has been released/)
   end
 
-  def and_the_pending_induction_submission_should_have_been_deleted
-    expect(PendingInductionSubmission.find_by(trn: teacher.trn, appropriate_body:)).to be_nil
+  def and_the_pending_induction_submission_delete_at_timestamp_is_set
+    expect(PendingInductionSubmission.find_by(trn: teacher.trn, appropriate_body:).delete_at).to be_within(1.second).of(24.hours.from_now)
   end
 
   def and_the_release_ect_service_should_have_been_called

--- a/spec/jobs/fail_ect_induction_job_spec.rb
+++ b/spec/jobs/fail_ect_induction_job_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe FailECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
   let(:completion_date) { "2024-01-13" }
-  let!(:pending_induction_submission_id) { FactoryBot.create(:pending_induction_submission).id }
+  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
 
   before do
@@ -27,10 +28,18 @@ RSpec.describe FailECTInductionJob, type: :job do
         )
       end
 
-      it "destroys the pending induction submission" do
-        expect {
-          described_class.perform_now(trn:, completion_date:, pending_induction_submission_id:)
-        }.to change { PendingInductionSubmission.count }.by(-1)
+      it "it sets the delete_at timestamp to 24 hours in the future" do
+        freeze_time do
+          described_class.perform_now(
+            trn:,
+            completion_date:,
+            pending_induction_submission_id:
+          )
+
+          pending_induction_submission.reload
+
+          expect(pending_induction_submission.delete_at).to eql(24.hours.from_now)
+        end
       end
     end
   end

--- a/spec/services/appropriate_bodies/release_ect_spec.rb
+++ b/spec/services/appropriate_bodies/release_ect_spec.rb
@@ -74,9 +74,12 @@ describe AppropriateBodies::ReleaseECT do
       expect(Event.last.event_type).to eq("appropriate_body_releases_teacher")
     end
 
-    it 'destroys the pending_induction_submission' do
-      subject.release!
-      expect(PendingInductionSubmission.where(id: pending_induction_submission.id)).to be_empty
+    it 'sets the pending_induction_submission delete_at timestamp to 24h in the future' do
+      freeze_time do
+        subject.release!
+        pending_induction_submission.reload
+        expect(pending_induction_submission.delete_at).to eql(24.hours.from_now)
+      end
     end
 
     context "when an ECT has no ongoing induction periods" do


### PR DESCRIPTION
We encounter a few bugs where the Pending Induction Submission is deleted too quickly and we can't see it on the confirmation screen. This change, instead of deleting it, adds a `delete_at` timestamp.

We can add a scheduled job which deletes any pending induction submission records with a `delete_at` in the past. This will follow in a subsequent PR.

## Changes

- **Add delete_at timestamp to pending induction submission**
- **Schedule pending induction deletion on pass/fail**
- **Schedule pending induction deletion on release**
