### PR TITLE
Add DfE Sign-in config for sandbox

### DIFF
--- a/config/terraform/application/config/sandbox.yml
+++ b/config/terraform/application/config/sandbox.yml
@@ -4,3 +4,8 @@ ENVIRONMENT_PHASE_BANNER_TAG: Sandbox 🏖️
 ENVIRONMENT_PHASE_BANNER_CONTENT: This is the sandbox environment.
 ENABLE_SENTRY: true
 ENABLE_PERSONAS: false
+DFE_SIGN_IN_API_AUDIENCE: signin.education.gov.uk
+DFE_SIGN_IN_API_BASE_URL: 'https://dev-api.signin.education.gov.uk'
+DFE_SIGN_IN_CLIENT_ID: RegisterECTs
+DFE_SIGN_IN_ISSUER: 'https://dev-oidc.signin.education.gov.uk'
+DFE_SIGN_IN_REDIRECT_URI: 'https://sandbox.register-early-career-teachers.education.gov.uk/auth/dfe/callback'


### PR DESCRIPTION
We'll be using the same setup as development and connecting to DfE Sign-in's `dev` env.
