### PR TITLE
Fix weird email rendering issue

### DIFF
--- a/app/mailers/otp_mailer.rb
+++ b/app/mailers/otp_mailer.rb
@@ -4,6 +4,6 @@ class OTPMailer < ApplicationMailer
     @recipient_name = params.fetch(:recipient_name)
     @code = params.fetch(:code)
 
-    view_mail(NOTIFY_TEMPLATE_ID, to:, subject: "Sign in to ECF2 with this one time password")
+    view_mail(NOTIFY_TEMPLATE_ID, to:, subject: "Sign in to Register ECTs with this one time password")
   end
 end

--- a/app/mailers/otp_mailer.rb
+++ b/app/mailers/otp_mailer.rb
@@ -4,6 +4,6 @@ class OTPMailer < ApplicationMailer
     @recipient_name = params.fetch(:recipient_name)
     @code = params.fetch(:code)
 
-    view_mail(NOTIFY_TEMPLATE_ID, to:, subject: "Sign-in to ECF2 with this one time password")
+    view_mail(NOTIFY_TEMPLATE_ID, to:, subject: "Sign in to ECF2 with this one time password")
   end
 end

--- a/app/views/otp_mailer/otp_code_email.text.erb
+++ b/app/views/otp_mailer/otp_code_email.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @recipient_name %>
 
-# Use this code to sign in to [ECF 2](otp_sign_in_code_url)
+Use this code to sign in to [Register early career teachers](otp_sign_in_code_url):
 
 ^ <%= @code %>
 

--- a/app/views/otp_mailer/otp_code_email.text.erb
+++ b/app/views/otp_mailer/otp_code_email.text.erb
@@ -4,4 +4,4 @@ Dear <%= @recipient_name %>
 
 ^ <%= @code %>
 
-This code expires in 10 minutes
+The code expires in 10 minutes.

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module RegisterEarlyCareerTeachers
     config.active_record.belongs_to_required_by_default = false
     config.generators.system_tests = nil
     config.action_mailer.deliver_later_queue_name = "mailers"
+    config.action_mailer.preview_paths << Rails.root.join('spec/mailers/previews')
     config.generators.system_tests = nil
 
     config.generators do |g|

--- a/spec/mailers/otp_mailer_spec.rb
+++ b/spec/mailers/otp_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OTPMailer, type: :mailer do
     let(:mail) { OTPMailer.with(recipient_email:, recipient_name:, code:).otp_code_email }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Sign in to ECF2 with this one time password")
+      expect(mail.subject).to eq("Sign in to Register ECTs with this one time password")
       expect(mail.to).to eq([recipient_email])
     end
 

--- a/spec/mailers/otp_mailer_spec.rb
+++ b/spec/mailers/otp_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OTPMailer, type: :mailer do
     let(:mail) { OTPMailer.with(recipient_email:, recipient_name:, code:).otp_code_email }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Sign-in to ECF2 with this one time password")
+      expect(mail.subject).to eq("Sign in to ECF2 with this one time password")
       expect(mail.to).to eq([recipient_email])
     end
 


### PR DESCRIPTION
This fixes DFE-Digital/register-ects-project-board#1205

The cause appears to be Notify not wanting to render links in level one headings.

| Before | After |
|------|-------|
|![Screenshot From 2025-02-06 13-13-28](https://github.com/user-attachments/assets/d4562041-955e-4f2d-8cdc-99dccf0b5426)|![Screenshot From 2025-02-06 13-21-50](https://github.com/user-attachments/assets/b3029252-97e1-47f2-bd3f-89724c703a84) |

## Changes

- **Add spec/mailers/previews to config**
- **Minor rewordings**
- **Take the link out of the header**
