### PR TITLE
Add personal info to filtered params config

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,11 +6,22 @@
 Rails.application.config.filter_parameters += %i[
   _key
   certificate
+  commit
   crypt
+  email
+  email_address
+  first_name
+  last_name
+  name
   otp
   passw
+  q
   salt
   secret
   ssn
   token
+  trn
+  trs_email_address
+  trs_first_name
+  trs_last_name
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -31,6 +31,6 @@ Rails.application.config.filter_parameters += %i[
   trs_email_address
   trs_first_name
   trs_last_name
-trs_date_of_birth
-trs_national_insurance_number
+  trs_date_of_birth
+  trs_national_insurance_number
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,15 +5,22 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
   _key
+  author_email
+  author_name
   certificate
   commit
+  corrected_name
   crypt
+  date_of_birth
   email
+  emails
   email_address
   first_name
   last_name
   name
+  national_insurance_number
   otp
+  otp_secret
   passw
   q
   salt

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -31,4 +31,6 @@ Rails.application.config.filter_parameters += %i[
   trs_email_address
   trs_first_name
   trs_last_name
+trs_date_of_birth
+trs_national_insurance_number
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,14 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += %i[passw secret token _key crypt salt certificate otp ssn]
+Rails.application.config.filter_parameters += %i[
+  _key
+  certificate
+  crypt
+  otp
+  passw
+  salt
+  secret
+  ssn
+  token
+]


### PR DESCRIPTION
@shaheislamdfe [pointed out we weren't filtering email addresses out of logs](https://kibana-uk1.logit.io/s/b2876053-0173-44fc-983d-99567292ba31/app/discover#/doc/filebeat-*/filebeat-2025.02.06?id=RsOc25QBZOOvpK1CzFoX).

This change adds fields containing personal information to Rails' list of `filter_parameters`.

## Changes

- **Reformat and sort the filter param list**
- **Filter params that might contain personal data**

## Testing

Checking the logs with this enabled we can see:

```
Parameters: {"authenticity_token"=>"[FILTERED]", "email"=>"[FILTERED]", "name"=>"[FILTERED]", "appropriate_body_id"=>"5", "school_urn"=>"", "dfe_staff"=>"false", "commit"=>"[FILTERED]", "provider"=>"persona"}

Started GET "/appropriate-body/teachers?q=[FILTERED]" for 127.0.0.1 at 2025-02-07 15:12:20 +0000

Processing by OTPSessionsController#create as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]", "sessions_otp_sign_in_form"=>"[FILTERED]"}
```

## Review notes

Did I miss any personal fields?