### PR TITLE
[1158] - make the start button in ab home page link to DfE Sign In page

### DIFF
--- a/app/views/appropriate_bodies/landing/show.md.erb
+++ b/app/views/appropriate_bodies/landing/show.md.erb
@@ -4,10 +4,14 @@ title: Record inductions as an appropriate body
 
 Use this service if you’re an appropriate body supporting the induction of early career teachers (ECTs).
 
-You’ll need to give details about: 
+You’ll need to give details about:
 
 * who you’re supporting, or no longer supporting
 * the induction history and progress of your ECTs
 * whether an ECT has passed or failed, or had their induction extended
 
-<%= govuk_start_button(text: "Start now", href: ab_teachers_path) %>
+<% if Rails.application.config.dfe_sign_in_enabled && !Rails.application.config.enable_personas %>
+  <%= govuk_start_button(text: "Start now", href: '/auth/dfe_sign_in', as_button: true) %>
+<% else %>
+  <%= govuk_start_button(text: "Start now", href: sign_in_path) %>
+<% end %>


### PR DESCRIPTION
Make the start button in ab home page link to DfE Sign In page

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/1158)

![image](https://github.com/user-attachments/assets/2eb8c1d4-49fe-4d08-8872-9f9b534e5052)

Only testable in [Sandbox](https://sandbox.register-early-career-teachers.education.gov.uk/appropriate-body) or [Production](https://www.register-early-career-teachers.education.gov.uk/appropriate-body)