### PR TITLE
fix id param is not trn

### DIFF
--- a/app/controllers/migration/teachers_controller.rb
+++ b/app/controllers/migration/teachers_controller.rb
@@ -62,6 +62,6 @@ private
   end
 
   def teacher
-    @teacher ||= Admin::TeacherPresenter.new(Teacher.find_by(trn: params[:id]))
+    @teacher ||= Admin::TeacherPresenter.new(Teacher.find(params[:id]))
   end
 end

--- a/app/presenters/admin/teacher_presenter.rb
+++ b/app/presenters/admin/teacher_presenter.rb
@@ -20,10 +20,6 @@ module Admin
       teacher.mentor_at_school_periods.any?
     end
 
-    # def trn
-    #   teacher.trn
-    # end
-
     def latest_school_period_as_an_ect
       latest = school_periods_as_an_ect.first
       SchoolPeriodPresenter.new(latest) if latest.present?


### PR DESCRIPTION
Fix a bug in the `Migration::TeachersController` which was still expecting the `params[:id]` to be the `trn` and this is no longer the case.