### PR TITLE
Enable dfe analytics on sandbox

### DIFF
--- a/config/terraform/application/config/sandbox.yml
+++ b/config/terraform/application/config/sandbox.yml
@@ -10,4 +10,4 @@ DFE_SIGN_IN_CLIENT_ID: RegisterECTs
 DFE_SIGN_IN_ISSUER: 'https://dev-oidc.signin.education.gov.uk'
 DFE_SIGN_IN_REDIRECT_URI: 'https://sandbox.register-early-career-teachers.education.gov.uk/auth/dfe/callback'
 SERVICE_URL: 'https://sandbox.register-early-career-teachers.education.gov.uk/'
-DFE_ANALYTICS_ENABLED: false
+DFE_ANALYTICS_ENABLED: true


### PR DESCRIPTION
This PR updates the terraform config which was introduced by [#158](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/158), to enable the dfe analytics on sandbox.