### PR TITLE
Force SSL in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
 
   # Log to STDOUT by default


### PR DESCRIPTION
This should ensure cookies are set with `secure: true`.



![image](https://github.com/user-attachments/assets/267cd474-51a8-4bc6-a2c9-65f5465bafed)
