### PR TITLE
Enable dfe analytics on production

### DIFF
--- a/config/terraform/application/config/production.yml
+++ b/config/terraform/application/config/production.yml
@@ -8,6 +8,6 @@ DFE_SIGN_IN_CLIENT_ID: RegisterECTs
 DFE_SIGN_IN_ISSUER: 'https://oidc.signin.education.gov.uk'
 DFE_SIGN_IN_REDIRECT_URI: 'https://www.register-early-career-teachers.education.gov.uk/auth/dfe/callback'
 SERVICE_URL: 'https://www.register-early-career-teachers.education.gov.uk'
-DFE_ANALYTICS_ENABLED: false
+DFE_ANALYTICS_ENABLED: true
 TRS_API_BASE_URL: 'https://teacher-qualifications-api.education.gov.uk'
 TRS_API_VERSION: '20250203'


### PR DESCRIPTION
This PR updates the terraform config, introduced by https://github.com/DFE-Digital/register-early-career-teachers-public/pull/158, to enable the dfe analytics on production.