### PR TITLE
Try and fix migration deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Register early career teachers has two repositories, [an internal](https://githu
 We write tickets and organise our sprints on the internal repository. The public one is where we write and update code. This helps minimise the risk of accidentally posting sensitive information in a ticket, but still allows for our code to be public and transparent.
 
 We still aim to work as openly as possible and will respond to any issues or pull requests raised against the public repository.
+
+(test)

--- a/README.md
+++ b/README.md
@@ -25,5 +25,3 @@ Register early career teachers has two repositories, [an internal](https://githu
 We write tickets and organise our sprints on the internal repository. The public one is where we write and update code. This helps minimise the risk of accidentally posting sensitive information in a ticket, but still allows for our code to be public and transparent.
 
 We still aim to work as openly as possible and will respond to any issues or pull requests raised against the public repository.
-
-(test)

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -104,5 +104,5 @@ DfE::Analytics.configure do |config|
   # it wont be used by the application. Eg: proc { |x| x.to_s =~ /Namespace::/ } will exclude all
   # models namespaced with Namespace
   #
-  # config.excluded_models_proc = proc { |_model| false }
+  config.excluded_models_proc = proc { |model| model.module_parent == Migration }
 end


### PR DESCRIPTION
Manually deploying to migration is failing.
It appears to be related to analytics and the `Migration::` models built for connecting to ECTv1 tables.

DfE Analytics has a config option to exclude models so attempting to see if we can exclude the entire `Migration::` namespace of models to remedy the issue.