### PR TITLE
Use a new dataset for DfE Analytics to prevent collisions with ECF1

### DIFF
--- a/config/terraform/application/gcp_wif.tf
+++ b/config/terraform/application/gcp_wif.tf
@@ -10,5 +10,5 @@ module "dfe_analytics" {
   namespace             = var.namespace
   service_short         = var.service_short
   environment           = var.environment
-  gcp_dataset           = "ecf_events_${var.config}"
+  gcp_dataset           = "ecf2_events_${var.config}"
 }


### PR DESCRIPTION
The initial plan was to append events to the existing ECF1 dataset. However, both ECF1 and ECF2 share common table names, which makes it difficult to distinguish the origin of the events between the two services.

This PR updates the Terraform configuration to use a dedicated BigQuery dataset for ECF2, ensuring a clear separation of data between the two services.

Related PRs: #122 and #158