### PR TITLE
TRS API adjustments

### DIFF
--- a/app/jobs/fail_ect_induction_job.rb
+++ b/app/jobs/fail_ect_induction_job.rb
@@ -1,7 +1,7 @@
 class FailECTInductionJob < ApplicationJob
-  def perform(trn:, completion_date:, pending_induction_submission_id:)
+  def perform(trn:, completed_date:, pending_induction_submission_id:)
     ActiveRecord::Base.transaction do
-      api_client.fail_induction!(trn:, completion_date:)
+      api_client.fail_induction!(trn:, completed_date:)
 
       PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
     end

--- a/app/jobs/pass_ect_induction_job.rb
+++ b/app/jobs/pass_ect_induction_job.rb
@@ -1,7 +1,7 @@
 class PassECTInductionJob < ApplicationJob
-  def perform(trn:, completion_date:, pending_induction_submission_id:)
+  def perform(trn:, completed_date:, pending_induction_submission_id:)
     ActiveRecord::Base.transaction do
-      api_client.pass_induction!(trn:, completion_date:)
+      api_client.pass_induction!(trn:, completed_date:)
 
       PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
     end

--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -70,7 +70,7 @@ module AppropriateBodies
     def send_fail_induction_notification_to_trs
       FailECTInductionJob.perform_later(
         trn: pending_induction_submission.trn,
-        completion_date: pending_induction_submission.finished_on.to_s,
+        completed_date: pending_induction_submission.finished_on.to_s,
         pending_induction_submission_id: pending_induction_submission.id
       )
     end
@@ -78,7 +78,7 @@ module AppropriateBodies
     def send_pass_induction_notification_to_trs
       PassECTInductionJob.perform_later(
         trn: pending_induction_submission.trn,
-        completion_date: pending_induction_submission.finished_on.to_s,
+        completed_date: pending_induction_submission.finished_on.to_s,
         pending_induction_submission_id: pending_induction_submission.id
       )
     end

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -67,8 +67,8 @@ module TRS
         #        we want to keep hold of?
         true
       else
-        Rails.logger.warn("Error: #{response.status}")
-        Rails.logger.warn("Response: #{response.body}")
+        Rails.logger.error("Error: #{response.status}")
+        Rails.logger.error("Response: #{response.body}")
 
         false
       end

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -40,23 +40,22 @@ module TRS
       update_induction_status(trn:, status: 'InProgress', start_date:, modified_at:)
     end
 
-    def pass_induction!(trn:, completion_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Pass', completion_date:, modified_at:)
+    def pass_induction!(trn:, completed_date:, modified_at: Time.zone.now)
+      update_induction_status(trn:, status: 'Pass', completed_date:, modified_at:)
     end
 
-    def fail_induction!(trn:, completion_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Fail', completion_date:, modified_at:)
+    def fail_induction!(trn:, completed_date:, modified_at: Time.zone.now)
+      update_induction_status(trn:, status: 'Fail', completed_date:, modified_at:)
     end
 
   private
 
-    def update_induction_status(trn:, status:, modified_at:, start_date: nil, completion_date: nil)
+    def update_induction_status(trn:, status:, modified_at:, start_date: nil, completed_date: nil)
       payload = { 'inductionStatus' => status,
                   'startDate' => start_date,
-                  'completionDate' => completion_date,
+                  'completedDate' => completed_date,
                   'modifiedOn' => modified_at }.compact.to_json
 
-      # FIXME: verify this is the right endpoint
       response = @connection.put(persons_path(trn, suffix: 'cpd-induction'), payload)
 
       Rails.logger.debug("calling TRS API: #{response}")

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -57,7 +57,7 @@ module TRS
                   'modifiedOn' => modified_at }.compact.to_json
 
       # FIXME: verify this is the right endpoint
-      response = @connection.put(persons_path(trn, suffix: 'induction'), payload)
+      response = @connection.put(persons_path(trn, suffix: 'cpd-induction'), payload)
 
       Rails.logger.debug("calling TRS API: #{response}")
 

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -51,7 +51,7 @@ module TRS
   private
 
     def update_induction_status(trn:, status:, modified_at:, start_date: nil, completed_date: nil)
-      payload = { 'inductionStatus' => status,
+      payload = { 'status' => status,
                   'startDate' => start_date,
                   'completedDate' => completed_date,
                   'modifiedOn' => modified_at }.compact.to_json

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -53,14 +53,6 @@ module TRS
       }
     end
 
-    def begin_induction!(start_date)
-      api_client.begin_induction!(trn:, start_date:)
-    end
-
-    def complete_induction!(completion_date:, status:)
-      api_client.complete_induction!(trn:, completion_date:, status:)
-    end
-
     def check_eligibility!
       raise TRS::Errors::QTSNotAwarded unless qts_awarded?
       raise TRS::Errors::ProhibitedFromTeaching if prohibited_from_teaching?

--- a/spec/jobs/fail_ect_induction_job_spec.rb
+++ b/spec/jobs/fail_ect_induction_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FailECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
-  let(:completion_date) { "2024-01-13" }
+  let(:completed_date) { "2024-01-13" }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
@@ -14,16 +14,16 @@ RSpec.describe FailECTInductionJob, type: :job do
     context "when the API call is successful" do
       before do
         allow(api_client).to receive(:fail_induction!)
-          .with(trn:, completion_date:)
+          .with(trn:, completed_date:)
       end
 
       it "calls the API client with correct parameters" do
         expect(api_client).to receive(:fail_induction!)
-          .with(trn:, completion_date:)
+          .with(trn:, completed_date:)
 
         described_class.perform_now(
           trn:,
-          completion_date:,
+          completed_date:,
           pending_induction_submission_id:
         )
       end
@@ -32,7 +32,7 @@ RSpec.describe FailECTInductionJob, type: :job do
         freeze_time do
           described_class.perform_now(
             trn:,
-            completion_date:,
+            completed_date:,
             pending_induction_submission_id:
           )
 

--- a/spec/jobs/pass_ect_induction_job_spec.rb
+++ b/spec/jobs/pass_ect_induction_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PassECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
-  let(:completion_date) { "2024-01-13" }
+  let(:completed_date) { "2024-01-13" }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
@@ -14,16 +14,16 @@ RSpec.describe PassECTInductionJob, type: :job do
     context "when the API call is successful" do
       before do
         allow(api_client).to receive(:pass_induction!)
-          .with(trn:, completion_date:)
+          .with(trn:, completed_date:)
       end
 
       it "calls the API client with correct parameters" do
         expect(api_client).to receive(:pass_induction!)
-          .with(trn:, completion_date:)
+          .with(trn:, completed_date:)
 
         described_class.perform_now(
           trn:,
-          completion_date:,
+          completed_date:,
           pending_induction_submission_id:
         )
       end
@@ -32,7 +32,7 @@ RSpec.describe PassECTInductionJob, type: :job do
         freeze_time do
           described_class.perform_now(
             trn:,
-            completion_date:,
+            completed_date:,
             pending_induction_submission_id:
           )
 

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -107,12 +107,12 @@ RSpec.describe TRS::APIClient do
   describe '#pass_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000234' }
-    let(:completion_date) { '2024-02-02' }
+    let(:completed_date) { '2024-02-02' }
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
         'inductionStatus' => 'Pass',
-        'completionDate' => completion_date,
+        'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json
     end
@@ -123,7 +123,7 @@ RSpec.describe TRS::APIClient do
 
     it "puts to the induction endpoint with the 'pass' parameters" do
       travel_to(modified_at) do
-        client.pass_induction!(trn:, completion_date:)
+        client.pass_induction!(trn:, completed_date:)
       end
 
       expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
@@ -133,12 +133,12 @@ RSpec.describe TRS::APIClient do
   describe '#fail_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000345' }
-    let(:completion_date) { '2024-03-03' }
+    let(:completed_date) { '2024-03-03' }
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
         'inductionStatus' => 'Fail',
-        'completionDate' => completion_date,
+        'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json
     end
@@ -149,7 +149,7 @@ RSpec.describe TRS::APIClient do
 
     it "puts to the induction endpoint with the 'fail' parameters" do
       travel_to(modified_at) do
-        client.fail_induction!(trn:, completion_date:)
+        client.fail_induction!(trn:, completed_date:)
       end
       expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
     end

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe TRS::APIClient do
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
-        'inductionStatus' => 'InProgress',
+        'status' => 'InProgress',
         'startDate' => start_date,
         'modifiedOn' => modified_at
       }.to_json
@@ -111,7 +111,7 @@ RSpec.describe TRS::APIClient do
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
-        'inductionStatus' => 'Pass',
+        'status' => 'Pass',
         'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json
@@ -137,7 +137,7 @@ RSpec.describe TRS::APIClient do
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
-        'inductionStatus' => 'Fail',
+        'status' => 'Fail',
         'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TRS::APIClient do
     end
 
     before do
-      allow(connection).to receive(:put).with("v3/persons/#{trn}/induction", expected_payload).and_return(response)
+      allow(connection).to receive(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).and_return(response)
     end
 
     it "puts to the induction endpoint with the 'begin' parameters" do
@@ -100,7 +100,7 @@ RSpec.describe TRS::APIClient do
         client.begin_induction!(trn:, start_date:)
       end
 
-      expect(connection).to have_received(:put).with("v3/persons/#{trn}/induction", expected_payload).once
+      expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
     end
   end
 
@@ -118,7 +118,7 @@ RSpec.describe TRS::APIClient do
     end
 
     before do
-      allow(connection).to receive(:put).with("v3/persons/#{trn}/induction", expected_payload).and_return(response)
+      allow(connection).to receive(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).and_return(response)
     end
 
     it "puts to the induction endpoint with the 'pass' parameters" do
@@ -126,7 +126,7 @@ RSpec.describe TRS::APIClient do
         client.pass_induction!(trn:, completion_date:)
       end
 
-      expect(connection).to have_received(:put).with("v3/persons/#{trn}/induction", expected_payload).once
+      expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
     end
   end
 
@@ -144,14 +144,14 @@ RSpec.describe TRS::APIClient do
     end
 
     before do
-      allow(connection).to receive(:put).with("v3/persons/#{trn}/induction", expected_payload).and_return(response)
+      allow(connection).to receive(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).and_return(response)
     end
 
     it "puts to the induction endpoint with the 'fail' parameters" do
       travel_to(modified_at) do
         client.fail_induction!(trn:, completion_date:)
       end
-      expect(connection).to have_received(:put).with("v3/persons/#{trn}/induction", expected_payload).once
+      expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
     end
   end
 end

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
           service.pass!
         }.to have_enqueued_job(PassECTInductionJob).with(
           trn: pending_induction_submission.trn,
-          completion_date: pending_induction_submission.finished_on.to_s,
+          completed_date: pending_induction_submission.finished_on.to_s,
           pending_induction_submission_id: pending_induction_submission.id
         )
       end
@@ -107,7 +107,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
           service.fail!
         }.to have_enqueued_job(FailECTInductionJob).with(
           trn: pending_induction_submission.trn,
-          completion_date: pending_induction_submission.finished_on.to_s,
+          completed_date: pending_induction_submission.finished_on.to_s,
           pending_induction_submission_id: pending_induction_submission.id
         )
       end


### PR DESCRIPTION
We were developing against an early version of the TRS API and the dust hadn't quite settled. Some assumptions we made weren't quite right and this PR attempts to address them.

The main changes are:

* the induction endpoint is `/v3/persons/{trn}/cpd-induction` not `/v3/persons/{trn}/cpd-induction`
* completion date is set with `completedDate` not `completionDate`
* status date is set with `status` not `inductionStatus`
