### PR TITLE
Make the record failing outcome button red

### DIFF
--- a/app/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb
@@ -2,5 +2,5 @@
 
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_record_failed_outcome_path(@teacher), method: 'post') do |f| %>
   <%= render partial: 'appropriate_bodies/teachers/outcome_form', locals: { f: f } %>
-  <%= f.govuk_submit "Record failing outcome for #{Teachers::Name.new(@teacher).full_name}" %>
+  <%= f.govuk_submit "Record failing outcome for #{Teachers::Name.new(@teacher).full_name}", warning: true %>
 <% end %>

--- a/spec/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe "appropriate_bodies/teachers/record_failed_outcome/new.html.erb" do
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:pending_induction_submission) { PendingInductionSubmission.new }
+
+  before do
+    assign(:appropriate_body, appropriate_body)
+    assign(:pending_induction_submission, pending_induction_submission)
+    assign(:teacher, teacher)
+
+    render
+  end
+
+  it 'renders a form with the expected fields' do
+    expect(rendered).to have_css('form')
+  end
+
+  it 'has a date field for the leaving date' do
+    expect(rendered).to have_css('legend', text: "When did they move from #{appropriate_body.name}?")
+    expect(rendered).to have_css('form label', text: 'Day')
+    expect(rendered).to have_css('form label', text: 'Month')
+    expect(rendered).to have_css('form label', text: 'Year')
+  end
+
+  it 'has a date field for the extension length' do
+    expect(rendered).to have_css('label', text: 'How many terms of induction did they spend with you?')
+  end
+
+  it 'has a warning submit button' do
+    expect(rendered).to have_css('button.govuk-button--warning')
+  end
+end

--- a/spec/views/appropriate_bodies/teachers/record_passed_outcome/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_passed_outcome/new.html.erb_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe "appropriate_bodies/teachers/record_passed_outcome/new.html.erb" do
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:pending_induction_submission) { PendingInductionSubmission.new }
+
+  before do
+    assign(:appropriate_body, appropriate_body)
+    assign(:pending_induction_submission, pending_induction_submission)
+    assign(:teacher, teacher)
+
+    render
+  end
+
+  it 'renders a form with the expected fields' do
+    expect(rendered).to have_css('form')
+  end
+
+  it 'has a date field for the leaving date' do
+    expect(rendered).to have_css('legend', text: "When did they move from #{appropriate_body.name}?")
+    expect(rendered).to have_css('form label', text: 'Day')
+    expect(rendered).to have_css('form label', text: 'Month')
+    expect(rendered).to have_css('form label', text: 'Year')
+  end
+
+  it 'has a date field for the extension length' do
+    expect(rendered).to have_css('label', text: 'How many terms of induction did they spend with you?')
+  end
+
+  it 'has a warning submit button' do
+    expect(rendered).to have_css('button.govuk-button')
+  end
+end


### PR DESCRIPTION
| Before | After |
| ------ | ------- |
| ![Screenshot From 2025-02-12 09-52-19](https://github.com/user-attachments/assets/3d7ce1f5-71d8-4781-873f-5c3949b77201) | ![Screenshot From 2025-02-12 09-52-27](https://github.com/user-attachments/assets/a082fc9d-f933-4330-84d8-359de22814f7) |

Also, I added some view specs covering these pages.

- **Make the fail button red**
- **Add view specs for the pass/fail induction pages**
