### PR TITLE
Removed duplication on find ect page

### DIFF
--- a/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
@@ -4,10 +4,6 @@
   backlink_href: ab_teachers_path)
 %>
 
-<div class="govuk-body">
-  Find your ECT by entering their teacher reference number (TRN) and date of birth.
-</div>
-
 <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_find_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 


### PR DESCRIPTION
Cleaned up content and removed duplication / extra acronyms 

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="672" alt="Screenshot 2025-02-12 at 11 08 13" src="https://github.com/user-attachments/assets/933294cf-94f1-4b26-bca8-f225cbd8915f" /> | <img width="630" alt="Screenshot 2025-02-12 at 11 08 21" src="https://github.com/user-attachments/assets/a873274f-a4e9-4648-8577-5329e5ec09fd" /> |

Bug ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1233



