### PR TITLE
Add ecf2 big query tables

### DIFF
--- a/config/terraform/application/gcp_wif.tf
+++ b/config/terraform/application/gcp_wif.tf
@@ -8,7 +8,10 @@ module "dfe_analytics" {
   azure_resource_prefix = var.azure_resource_prefix
   cluster               = var.cluster
   namespace             = var.namespace
-  service_short         = var.service_short
+  service_short         = "ecf2"
   environment           = var.environment
-  gcp_dataset           = "ecf2_events_${var.config}"
+  gcp_keyring           = "ecf-key-ring"
+  gcp_key               = "ecf-key"
+  gcp_taxonomy_id       = 6302091323314055162
+  gcp_policy_tag_id     = 301313311867345339
 }


### PR DESCRIPTION
## Description
ECF2 requires new tables for populating events into big query.

## How to review
New table will be created for review apps to which the events would be published.

## After Merge
New tables for staging, sandbox, production environments.