### PR TITLE
Add terms label

### DIFF
--- a/app/controllers/appropriate_bodies/teachers/extensions_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/extensions_controller.rb
@@ -45,7 +45,7 @@ module AppropriateBodies
     private
 
       def find_teacher
-        AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+        AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
       end
 
       def extension_params

--- a/app/controllers/appropriate_bodies/teachers/initial_teacher_training_records_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/initial_teacher_training_records_controller.rb
@@ -76,7 +76,7 @@ module AppropriateBodies
     private
 
       def find_teacher
-        AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+        AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
@@ -2,12 +2,12 @@ module AppropriateBodies
   module Teachers
     class RecordFailedOutcomeController < AppropriateBodiesController
       def new
-        @teacher = find_teacher
+        @teacher = find_current_teacher
         @pending_induction_submission = PendingInductionSubmission.new
       end
 
       def create
-        @teacher = find_teacher
+        @teacher = find_current_teacher
         @pending_induction_submission = PendingInductionSubmissions::Build.closing_induction_period(
           ::Teachers::InductionPeriod.new(@teacher).active_induction_period,
           **pending_induction_submission_params,
@@ -23,10 +23,7 @@ module AppropriateBodies
 
         PendingInductionSubmission.transaction do
           if @pending_induction_submission.save(context: :record_outcome) && record_outcome.fail!
-            redirect_to(
-              ab_teacher_record_failed_outcome_path(@teacher),
-              flash: { teacher_name: ::Teachers::Name.new(@teacher).full_name }
-            )
+            redirect_to(ab_teacher_record_failed_outcome_path(@teacher))
           else
             render :new
           end
@@ -34,7 +31,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher_name = flash['teacher_name']
+        @teacher = find_former_teacher
       end
 
     private
@@ -47,8 +44,12 @@ module AppropriateBodies
         { appropriate_body_id: @appropriate_body.id, trn: @teacher.trn, outcome: "fail" }
       end
 
-      def find_teacher
+      def find_current_teacher
         AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+      end
+
+      def find_former_teacher
+        AppropriateBodies::ECTs.new(@appropriate_body).former.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_failed_outcome_controller.rb
@@ -48,7 +48,7 @@ module AppropriateBodies
       end
 
       def find_teacher
-        AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+        AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
@@ -2,13 +2,13 @@ module AppropriateBodies
   module Teachers
     class RecordPassedOutcomeController < AppropriateBodiesController
       def new
-        @teacher = find_teacher
+        @teacher = find_current_teacher
 
         @pending_induction_submission = PendingInductionSubmission.new
       end
 
       def create
-        @teacher = find_teacher
+        @teacher = find_current_teacher
         @pending_induction_submission = PendingInductionSubmissions::Build.closing_induction_period(
           ::Teachers::InductionPeriod.new(@teacher).active_induction_period,
           **pending_induction_submission_params,
@@ -26,7 +26,6 @@ module AppropriateBodies
           if @pending_induction_submission.save(context: :record_outcome) && record_outcome.pass!
             redirect_to(
               ab_teacher_record_passed_outcome_path(@teacher),
-              flash: { teacher_name: ::Teachers::Name.new(@teacher).full_name }
             )
           else
             render :new
@@ -35,7 +34,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher_name = flash['teacher_name']
+        @teacher = find_former_teacher
       end
 
     private
@@ -48,8 +47,12 @@ module AppropriateBodies
         { appropriate_body_id: @appropriate_body.id, trn: @teacher.trn, outcome: "pass" }
       end
 
-      def find_teacher
+      def find_current_teacher
         AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+      end
+
+      def find_former_teacher
+        AppropriateBodies::ECTs.new(@appropriate_body).former.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_passed_outcome_controller.rb
@@ -49,7 +49,7 @@ module AppropriateBodies
       end
 
       def find_teacher
-        AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+        AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -2,13 +2,13 @@ module AppropriateBodies
   module Teachers
     class ReleaseECTController < AppropriateBodiesController
       def new
-        @teacher = find_teacher
+        @teacher = find_current_teacher
 
         @pending_induction_submission = PendingInductionSubmission.new
       end
 
       def create
-        @teacher = find_teacher
+        @teacher = find_current_teacher
         @pending_induction_submission = PendingInductionSubmissions::Build.closing_induction_period(
           ::Teachers::InductionPeriod.new(@teacher).active_induction_period,
           **pending_induction_submission_params,
@@ -23,10 +23,7 @@ module AppropriateBodies
 
         PendingInductionSubmission.transaction do
           if @pending_induction_submission.save(context: :release_ect) && release_ect.release!
-            redirect_to(
-              ab_teacher_release_ect_path(@teacher),
-              flash: { teacher_name: ::Teachers::Name.new(@teacher).full_name }
-            )
+            redirect_to(ab_teacher_release_ect_path(@teacher))
           else
             render :new
           end
@@ -37,7 +34,7 @@ module AppropriateBodies
       end
 
       def show
-        @teacher_name = flash['teacher_name']
+        @teacher = find_former_teacher
       end
 
     private
@@ -50,8 +47,12 @@ module AppropriateBodies
         { appropriate_body_id: @appropriate_body.id, trn: @teacher.trn }
       end
 
-      def find_teacher
+      def find_current_teacher
         AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+      end
+
+      def find_former_teacher
+        AppropriateBodies::ECTs.new(@appropriate_body).former.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/release_ect_controller.rb
@@ -51,7 +51,7 @@ module AppropriateBodies
       end
 
       def find_teacher
-        AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
+        AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:teacher_id])
       end
     end
   end

--- a/app/controllers/appropriate_bodies/teachers_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers_controller.rb
@@ -12,7 +12,7 @@ module AppropriateBodies
     end
 
     def show
-      @teacher = AppropriateBodies::CurrentTeachers.new(@appropriate_body).current.find_by!(id: params[:id])
+      @teacher = AppropriateBodies::ECTs.new(@appropriate_body).current.find_by!(id: params[:id])
     end
   end
 end

--- a/app/services/appropriate_bodies/ects.rb
+++ b/app/services/appropriate_bodies/ects.rb
@@ -1,5 +1,5 @@
 module AppropriateBodies
-  class CurrentTeachers
+  class ECTs
     attr_reader :appropriate_body
 
     def initialize(appropriate_body)

--- a/app/services/appropriate_bodies/ects.rb
+++ b/app/services/appropriate_bodies/ects.rb
@@ -7,10 +7,19 @@ module AppropriateBodies
     end
 
     def current
+      all.merge(InductionPeriod.ongoing)
+    end
+
+    def former
+      all.merge(InductionPeriod.finished)
+    end
+
+  private
+
+    def all
       Teacher
         .joins(:induction_periods)
         .merge(InductionPeriod.for_appropriate_body(appropriate_body))
-        .merge(InductionPeriod.ongoing)
     end
   end
 end

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -28,7 +28,7 @@ module Teachers
       @scope = if appropriate_body.nil?
                  Teacher.none
                else
-                 AppropriateBodies::CurrentTeachers.new(appropriate_body).current
+                 AppropriateBodies::ECTs.new(appropriate_body).current
                end
     end
 

--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -12,8 +12,8 @@
     width: 4,
     label: {
       size: 'm',
-      text: "How many terms of induction did they spend with you?"
-    },
+      text: "How many terms of induction did they spend with you?",
+    }, suffix_text: 'terms',
     hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
 %>
   <p class="govuk-body">You’ll need to consider:</p>

--- a/app/views/appropriate_bodies/teachers/extensions/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/extensions/new.html.erb
@@ -38,7 +38,7 @@
       <%= f.govuk_number_field(
         :number_of_terms,
         width: 5,
-        label: { text: 'Enter number of terms', size: 'm' },
+        label: { text: 'Enter number of terms', size: 'm' }, suffix_text: 'terms',
         hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }
       ) %>
 

--- a/app/views/appropriate_bodies/teachers/record_failed_outcome/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_failed_outcome/show.html.erb
@@ -1,6 +1,11 @@
+<% page_data(
+  title: "You have recorded a failing outcome for #{Teachers::Name.new(@teacher).full_name}",
+  header: false)
+%>
+
 <%= govuk_panel(
   title_text: "Success",
-  text: "You have recorded a failing outcome for #{@teacher_name}"
+  text: "You have recorded a failing outcome for #{Teachers::Name.new(@teacher).full_name}"
 ) %>
 
 <%= govuk_button_link_to("Return to the homepage", ab_teachers_path, secondary: true) %>

--- a/app/views/appropriate_bodies/teachers/record_passed_outcome/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_passed_outcome/show.html.erb
@@ -1,6 +1,11 @@
+<% page_data(
+  title: "You have recorded a pass outcome for #{Teachers::Name.new(@teacher).full_name}",
+  header: false)
+%>
+
 <%= govuk_panel(
   title_text: "Success",
-  text: "You have recorded a pass outcome for #{@teacher_name}"
+  text: "You have recorded a pass outcome for #{Teachers::Name.new(@teacher).full_name}"
 ) %>
 
 <%= govuk_button_link_to("Return to the homepage", ab_teachers_path, secondary: true) %>

--- a/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
@@ -1,18 +1,18 @@
 <% page_data(
-  title: "#{@teacher_name} has been released",
+  title: "#{Teachers::Name.new(@teacher).full_name} has been released",
   header: false)
 %>
 
 <%=
-  govuk_panel(title_text: "You've successfully released #{@teacher_name}")
+  govuk_panel(title_text: "You've successfully released #{Teachers::Name.new(@teacher).full_name}")
 %>
 
 <h2 class="govuk-heading-m">What happens next</h2>
 
 <p>
-  Another appropriate body can now claim #{@teacher_name}'s induction.
+  Another appropriate body can now claim <%= Teachers::Name.new(@teacher).full_name %>'s induction.
 </p>
 
 <p class="govuk-body">
-<%= govuk_link_to("Back to homepage", ab_teachers_path, no_visited_state: true) %>
+  <%= govuk_link_to("Back to homepage", ab_teachers_path, no_visited_state: true) %>
 </p>

--- a/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
+++ b/app/views/appropriate_bodies/teachers/release_ect/show.html.erb
@@ -4,7 +4,15 @@
 %>
 
 <%=
-  govuk_panel(title_text: "Success", text: "#{@teacher_name} has been released")
+  govuk_panel(title_text: "You've successfully released #{@teacher_name}")
 %>
 
-<%= govuk_button_link_to("Return to the homepage", ab_teachers_path, secondary: true) %>
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p>
+  Another appropriate body can now claim #{@teacher_name}'s induction.
+</p>
+
+<p class="govuk-body">
+<%= govuk_link_to("Back to homepage", ab_teachers_path, no_visited_state: true) %>
+</p>

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -76,7 +76,7 @@ private
 
     teacher_name = ::Teachers::Name.new(teacher).full_name
 
-    expect(page.locator('.govuk-panel')).to have_text(/#{teacher_name} has been released/)
+    expect(page.locator('.govuk-panel')).to have_text(/You've successfully released #{teacher_name}/)
   end
 
   def and_the_pending_induction_submission_delete_at_timestamp_is_set

--- a/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
@@ -151,6 +151,16 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
   end
 
   describe 'GET /appropriate-body/teachers/:id/record-failed-outcome' do
+    let!(:induction_period) do
+      FactoryBot.create(
+        :induction_period,
+        :fail,
+        teacher:,
+        appropriate_body:,
+        induction_programme: 'fip'
+      )
+    end
+
     context 'when not signed in' do
       it 'redirects to the signin page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")

--- a/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
@@ -151,6 +151,16 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
   end
 
   describe 'GET /appropriate-body/teachers/:teacher_id/record-passed-outcome' do
+    let!(:induction_period) do
+      FactoryBot.create(
+        :induction_period,
+        :pass,
+        teacher:,
+        appropriate_body:,
+        induction_programme: 'fip'
+      )
+    end
+
     context 'when not signed in' do
       it 'redirects to the signin page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")

--- a/spec/services/appropriate_bodies/ects_spec.rb
+++ b/spec/services/appropriate_bodies/ects_spec.rb
@@ -12,4 +12,16 @@ describe AppropriateBodies::ECTs do
       expect(subject.current.to_sql).to include(%("induction_periods"."finished_on" IS NULL))
     end
   end
+
+  describe "#former" do
+    subject { AppropriateBodies::ECTs.new(appropriate_body) }
+
+    it 'only returns records belonging to the current appropriate body' do
+      expect(subject.former.to_sql).to include(%(induction_periods"."appropriate_body_id" = #{appropriate_body.id}))
+    end
+
+    it 'only returns ongoing induction periods' do
+      expect(subject.former.to_sql).to include(%("induction_periods"."finished_on" IS NOT NULL))
+    end
+  end
 end

--- a/spec/services/appropriate_bodies/ects_spec.rb
+++ b/spec/services/appropriate_bodies/ects_spec.rb
@@ -1,8 +1,8 @@
-describe AppropriateBodies::CurrentTeachers do
+describe AppropriateBodies::ECTs do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   describe "#current" do
-    subject { AppropriateBodies::CurrentTeachers.new(appropriate_body) }
+    subject { AppropriateBodies::ECTs.new(appropriate_body) }
 
     it 'only returns records belonging to the current appropriate body' do
       expect(subject.current.to_sql).to include(%(induction_periods"."appropriate_body_id" = #{appropriate_body.id}))


### PR DESCRIPTION
Added suffix text to term labels on both the release page: https://staging.register-early-career-teachers.education.gov.uk/appropriate-body/teachers/311/release/new and the extensions page: https://staging.register-early-career-teachers.education.gov.uk/appropriate-body/teachers/311/extensions/new 

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="675" alt="Screenshot 2025-02-12 at 14 17 30" src="https://github.com/user-attachments/assets/ea846bc3-8766-4e82-a281-30b9992fb7e2" /> |  |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="750" alt="Screenshot 2025-02-12 at 14 41 06" src="https://github.com/user-attachments/assets/a45ad15e-8cd3-4f83-8c63-6743cd4bba3e" /> |  |



