### PR TITLE
FTE terms suffix added to relevant pages

### DIFF
--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -13,7 +13,7 @@
     label: {
       size: 'm',
       text: "How many terms of induction did they spend with you?"
-    },
+    }, suffix_text: 'FTE terms',
     hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
 %>
   <p class="govuk-body">You’ll need to consider:</p>

--- a/app/views/appropriate_bodies/teachers/extensions/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/extensions/new.html.erb
@@ -38,7 +38,7 @@
       <%= f.govuk_number_field(
         :number_of_terms,
         width: 5,
-        label: { text: 'Enter number of terms', size: 'm' },
+        label: { text: 'Enter number of terms', size: 'm' }, suffix_text: 'FTE terms',
         hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }
       ) %>
 


### PR DESCRIPTION
Added suffix text to term labels on both the release page: https://staging.register-early-career-teachers.education.gov.uk/appropriate-body/teachers/311/release/new and the extensions page: https://staging.register-early-career-teachers.education.gov.uk/appropriate-body/teachers/311/extensions/new

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="641" alt="Screenshot 2025-02-12 at 15 49 48" src="https://github.com/user-attachments/assets/da59ba9a-ba7a-4d8c-9dde-ccb126a03e93" /> | <img width="645" alt="Screenshot 2025-02-12 at 15 49 55" src="https://github.com/user-attachments/assets/d16027f3-772d-41bd-ac19-86d145f86845" /> |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="703" alt="Screenshot 2025-02-12 at 15 51 14" src="https://github.com/user-attachments/assets/78dc90af-6916-4934-8d2f-5be5747514d7" /> | <img width="676" alt="Screenshot 2025-02-12 at 15 51 28" src="https://github.com/user-attachments/assets/b66c899a-e52c-4474-8169-757f46501dfb" /> |

Bug ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1226


