### PR TITLE
Add a workflow to enable reseed of Staging DB

### DIFF
--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -1,0 +1,26 @@
+name: "Manually deploy an environment"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  packages: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  reseed:
+    name: Reseed the database
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/reseed-db
+        id: reseed
+        with:
+          environment: staging
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -1,26 +1,24 @@
-name: "Manually deploy an environment"
+name: Reseed the staging database
 
 on:
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  packages: write
-  pull-requests: write
-  security-events: write
-
 jobs:
-  reseed:
-    name: Reseed the database
+  reseed-staging:
+    name: Reseed the staging database
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+     - name: Checkout
+       uses: actions/checkout@v4
+       with:
+         token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/actions/reseed-db
-        id: reseed
-        with:
-          environment: staging
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Reseed Staging
+      run: |
+        make ci development get-cluster-credentials
+        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed:replant" 

--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -3,6 +3,9 @@ name: Reseed the staging database
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   reseed-staging:
     name: Reseed the staging database


### PR DESCRIPTION
As we have a limited number of test DQT candidate data, we want to be able to reseed the `staging` environment database to enable further/new rounds of testing to take place.

This PR adds a workflow that can be invoked to reseed the DB.