### PR TITLE
Send start date to TRS when completing inductions

### DIFF
--- a/app/jobs/fail_ect_induction_job.rb
+++ b/app/jobs/fail_ect_induction_job.rb
@@ -1,7 +1,7 @@
 class FailECTInductionJob < ApplicationJob
-  def perform(trn:, completed_date:, pending_induction_submission_id:)
+  def perform(trn:, start_date:, completed_date:, pending_induction_submission_id:)
     ActiveRecord::Base.transaction do
-      api_client.fail_induction!(trn:, completed_date:)
+      api_client.fail_induction!(trn:, start_date:, completed_date:)
 
       PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
     end

--- a/app/jobs/pass_ect_induction_job.rb
+++ b/app/jobs/pass_ect_induction_job.rb
@@ -1,7 +1,7 @@
 class PassECTInductionJob < ApplicationJob
-  def perform(trn:, completed_date:, pending_induction_submission_id:)
+  def perform(trn:, start_date:, completed_date:, pending_induction_submission_id:)
     ActiveRecord::Base.transaction do
-      api_client.pass_induction!(trn:, completed_date:)
+      api_client.pass_induction!(trn:, start_date:, completed_date:)
 
       PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
     end

--- a/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
@@ -70,7 +70,7 @@ module AppropriateBodies
       def send_begin_induction_notification_to_trs
         BeginECTInductionJob.perform_later(
           trn: pending_induction_submission.trn,
-          start_date: pending_induction_submission.started_on.to_s,
+          start_date: pending_induction_submission.started_on,
           pending_induction_submission_id: pending_induction_submission.id
         )
       end

--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -71,7 +71,7 @@ module AppropriateBodies
       FailECTInductionJob.perform_later(
         trn: pending_induction_submission.trn,
         start_date: induction_start_date,
-        completed_date: pending_induction_submission.finished_on.to_s,
+        completed_date: pending_induction_submission.finished_on,
         pending_induction_submission_id: pending_induction_submission.id
       )
     end
@@ -80,13 +80,13 @@ module AppropriateBodies
       PassECTInductionJob.perform_later(
         trn: pending_induction_submission.trn,
         start_date: induction_start_date,
-        completed_date: pending_induction_submission.finished_on.to_s,
+        completed_date: pending_induction_submission.finished_on,
         pending_induction_submission_id: pending_induction_submission.id
       )
     end
 
     def induction_start_date
-      ::Teachers::Induction.new(teacher).induction_start_date.to_s
+      ::Teachers::Induction.new(teacher).induction_start_date
     end
   end
 end

--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -70,6 +70,7 @@ module AppropriateBodies
     def send_fail_induction_notification_to_trs
       FailECTInductionJob.perform_later(
         trn: pending_induction_submission.trn,
+        start_date: induction_start_date,
         completed_date: pending_induction_submission.finished_on.to_s,
         pending_induction_submission_id: pending_induction_submission.id
       )
@@ -78,9 +79,14 @@ module AppropriateBodies
     def send_pass_induction_notification_to_trs
       PassECTInductionJob.perform_later(
         trn: pending_induction_submission.trn,
+        start_date: induction_start_date,
         completed_date: pending_induction_submission.finished_on.to_s,
         pending_induction_submission_id: pending_induction_submission.id
       )
+    end
+
+    def induction_start_date
+      ::Teachers::Induction.new(teacher).induction_start_date.to_s
     end
   end
 end

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -40,17 +40,17 @@ module TRS
       update_induction_status(trn:, status: 'InProgress', start_date:, modified_at:)
     end
 
-    def pass_induction!(trn:, completed_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Passed', completed_date:, modified_at:)
+    def pass_induction!(trn:, start_date:, completed_date:, modified_at: Time.zone.now)
+      update_induction_status(trn:, status: 'Passed', start_date:, completed_date:, modified_at:)
     end
 
-    def fail_induction!(trn:, completed_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Failed', completed_date:, modified_at:)
+    def fail_induction!(trn:, start_date:, completed_date:, modified_at: Time.zone.now)
+      update_induction_status(trn:, status: 'Failed', start_date:, completed_date:, modified_at:)
     end
 
   private
 
-    def update_induction_status(trn:, status:, modified_at:, start_date: nil, completed_date: nil)
+    def update_induction_status(trn:, status:, modified_at:, start_date:, completed_date: nil)
       payload = { 'status' => status,
                   'startDate' => start_date,
                   'completedDate' => completed_date,

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -41,11 +41,11 @@ module TRS
     end
 
     def pass_induction!(trn:, completed_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Pass', completed_date:, modified_at:)
+      update_induction_status(trn:, status: 'Passed', completed_date:, modified_at:)
     end
 
     def fail_induction!(trn:, completed_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Fail', completed_date:, modified_at:)
+      update_induction_status(trn:, status: 'Failed', completed_date:, modified_at:)
     end
 
   private

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -37,15 +37,32 @@ module TRS
     end
 
     def begin_induction!(trn:, start_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'InProgress', start_date:, modified_at:)
+      update_induction_status(
+        trn:,
+        status: 'InProgress',
+        start_date: start_date.iso8601,
+        modified_at: modified_at.iso8601(3)
+      )
     end
 
     def pass_induction!(trn:, start_date:, completed_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Passed', start_date:, completed_date:, modified_at:)
+      update_induction_status(
+        trn:,
+        status: 'Passed',
+        start_date: start_date.iso8601,
+        completed_date: completed_date.iso8601,
+        modified_at: modified_at.iso8601(3)
+      )
     end
 
     def fail_induction!(trn:, start_date:, completed_date:, modified_at: Time.zone.now)
-      update_induction_status(trn:, status: 'Failed', start_date:, completed_date:, modified_at:)
+      update_induction_status(
+        trn:,
+        status: 'Failed',
+        start_date: start_date.iso8601,
+        completed_date: completed_date.iso8601,
+        modified_at: modified_at.iso8601(3)
+      )
     end
 
   private

--- a/spec/jobs/fail_ect_induction_job_spec.rb
+++ b/spec/jobs/fail_ect_induction_job_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe FailECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
+  let(:start_date) { "2023-11-13" }
   let(:completed_date) { "2024-01-13" }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
@@ -14,15 +15,16 @@ RSpec.describe FailECTInductionJob, type: :job do
     context "when the API call is successful" do
       before do
         allow(api_client).to receive(:fail_induction!)
-          .with(trn:, completed_date:)
+          .with(trn:, start_date:, completed_date:)
       end
 
       it "calls the API client with correct parameters" do
         expect(api_client).to receive(:fail_induction!)
-          .with(trn:, completed_date:)
+          .with(trn:, start_date:, completed_date:)
 
         described_class.perform_now(
           trn:,
+          start_date:,
           completed_date:,
           pending_induction_submission_id:
         )
@@ -32,6 +34,7 @@ RSpec.describe FailECTInductionJob, type: :job do
         freeze_time do
           described_class.perform_now(
             trn:,
+            start_date:,
             completed_date:,
             pending_induction_submission_id:
           )

--- a/spec/jobs/pass_ect_induction_job_spec.rb
+++ b/spec/jobs/pass_ect_induction_job_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe PassECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
+  let(:start_date) { "2023-11-13" }
   let(:completed_date) { "2024-01-13" }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
@@ -14,15 +15,16 @@ RSpec.describe PassECTInductionJob, type: :job do
     context "when the API call is successful" do
       before do
         allow(api_client).to receive(:pass_induction!)
-          .with(trn:, completed_date:)
+          .with(trn:, start_date:, completed_date:)
       end
 
       it "calls the API client with correct parameters" do
         expect(api_client).to receive(:pass_induction!)
-          .with(trn:, completed_date:)
+          .with(trn:, start_date:, completed_date:)
 
         described_class.perform_now(
           trn:,
+          start_date:,
           completed_date:,
           pending_induction_submission_id:
         )
@@ -32,6 +34,7 @@ RSpec.describe PassECTInductionJob, type: :job do
         freeze_time do
           described_class.perform_now(
             trn:,
+            start_date:,
             completed_date:,
             pending_induction_submission_id:
           )

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe TRS::APIClient do
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
-        'status' => 'Pass',
+        'status' => 'Passed',
         'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json
@@ -137,7 +137,7 @@ RSpec.describe TRS::APIClient do
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
-        'status' => 'Fail',
+        'status' => 'Failed',
         'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -81,40 +81,38 @@ RSpec.describe TRS::APIClient do
   describe '#begin_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000123' }
-    let(:start_date) { '2024-01-01' }
-    let(:modified_at) { "2022-05-03T03:00:00.000Z" }
+    let(:start_date) { Date.new(2024, 1, 1) }
+    let(:modified_at) { 3.years.ago }
     let(:expected_payload) do
       {
         'status' => 'InProgress',
-        'startDate' => start_date,
-        'modifiedOn' => modified_at
+        'startDate' => start_date.iso8601,
+        'modifiedOn' => modified_at.iso8601(3)
       }.to_json
-    end
-
-    before do
-      allow(connection).to receive(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).and_return(response)
     end
 
     it "puts to the induction endpoint with the 'begin' parameters" do
       travel_to(modified_at) do
-        client.begin_induction!(trn:, start_date:)
-      end
+        allow(connection).to receive(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).and_return(response)
 
-      expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
+        client.begin_induction!(trn:, start_date:, modified_at:)
+
+        expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
+      end
     end
   end
 
   describe '#pass_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000234' }
-    let(:start_date) { '2024-01-01' }
-    let(:completed_date) { '2024-02-02' }
+    let(:start_date) { Date.new(2024, 1, 1) }
+    let(:completed_date) { Date.new(2024, 2, 2) }
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
         'status' => 'Passed',
-        'startDate' => start_date,
-        'completedDate' => completed_date,
+        'startDate' => start_date.iso8601,
+        'completedDate' => completed_date.iso8601,
         'modifiedOn' => modified_at
       }.to_json
     end
@@ -135,14 +133,14 @@ RSpec.describe TRS::APIClient do
   describe '#fail_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000345' }
-    let(:start_date) { '2024-01-01' }
-    let(:completed_date) { '2024-03-03' }
+    let(:start_date) { Date.new(2024, 1, 1) }
+    let(:completed_date) { Date.new(2024, 3, 3) }
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
         'status' => 'Failed',
-        'startDate' => start_date,
-        'completedDate' => completed_date,
+        'startDate' => start_date.iso8601,
+        'completedDate' => completed_date.iso8601,
         'modifiedOn' => modified_at
       }.to_json
     end

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -107,11 +107,13 @@ RSpec.describe TRS::APIClient do
   describe '#pass_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000234' }
+    let(:start_date) { '2024-01-01' }
     let(:completed_date) { '2024-02-02' }
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
         'status' => 'Passed',
+        'startDate' => start_date,
         'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json
@@ -123,7 +125,7 @@ RSpec.describe TRS::APIClient do
 
     it "puts to the induction endpoint with the 'pass' parameters" do
       travel_to(modified_at) do
-        client.pass_induction!(trn:, completed_date:)
+        client.pass_induction!(trn:, start_date:, completed_date:)
       end
 
       expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
@@ -133,11 +135,13 @@ RSpec.describe TRS::APIClient do
   describe '#fail_induction!' do
     let(:response) { instance_double(Faraday::Response, success?: true) }
     let(:trn) { '0000345' }
+    let(:start_date) { '2024-01-01' }
     let(:completed_date) { '2024-03-03' }
     let(:modified_at) { "2022-05-03T03:00:00.000Z" }
     let(:expected_payload) do
       {
         'status' => 'Failed',
+        'startDate' => start_date,
         'completedDate' => completed_date,
         'modifiedOn' => modified_at
       }.to_json
@@ -149,7 +153,7 @@ RSpec.describe TRS::APIClient do
 
     it "puts to the induction endpoint with the 'fail' parameters" do
       travel_to(modified_at) do
-        client.fail_induction!(trn:, completed_date:)
+        client.fail_induction!(trn:, start_date:, completed_date:)
       end
       expect(connection).to have_received(:put).with("v3/persons/#{trn}/cpd-induction", expected_payload).once
     end

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
         expect {
           subject.register(pending_induction_submission_params)
         }.to have_enqueued_job(BeginECTInductionJob)
-          .with(hash_including(trn: "1234567", start_date: "2023-05-02"))
+          .with(hash_including(trn: "1234567", start_date: Date.new(2023, 5, 2)))
       end
 
       it "records an appropriate_body_claims_teacher event" do

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe AppropriateBodies::RecordOutcome do
           service.pass!
         }.to have_enqueued_job(PassECTInductionJob).with(
           trn: pending_induction_submission.trn,
-          start_date: induction_start_date.to_s,
-          completed_date: pending_induction_submission.finished_on.to_s,
+          start_date: induction_start_date,
+          completed_date: pending_induction_submission.finished_on,
           pending_induction_submission_id: pending_induction_submission.id
         )
       end
@@ -118,8 +118,8 @@ RSpec.describe AppropriateBodies::RecordOutcome do
           service.fail!
         }.to have_enqueued_job(FailECTInductionJob).with(
           trn: pending_induction_submission.trn,
-          start_date: induction_start_date.to_s,
-          completed_date: pending_induction_submission.finished_on.to_s,
+          start_date: induction_start_date,
+          completed_date: pending_induction_submission.finished_on,
           pending_induction_submission_id: pending_induction_submission.id
         )
       end

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe AppropriateBodies::RecordOutcome do
   end
 
   describe "#pass!" do
+    let(:induction_start_date) { Date.new(2024, 1, 1) }
+    let(:fake_teacher_induction) { double(Teachers::Induction, induction_start_date:) }
+
+    before { allow(Teachers::Induction).to receive(:new).with(anything).and_return(fake_teacher_induction) }
+
     context "when happy path" do
       it "updates the induction period with pass outcome" do
         service.pass!
@@ -55,6 +60,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
           service.pass!
         }.to have_enqueued_job(PassECTInductionJob).with(
           trn: pending_induction_submission.trn,
+          start_date: induction_start_date.to_s,
           completed_date: pending_induction_submission.finished_on.to_s,
           pending_induction_submission_id: pending_induction_submission.id
         )
@@ -91,6 +97,11 @@ RSpec.describe AppropriateBodies::RecordOutcome do
   end
 
   describe "#fail!" do
+    let(:induction_start_date) { Date.new(2024, 1, 1) }
+    let(:fake_teacher_induction) { double(Teachers::Induction, induction_start_date:) }
+
+    before { allow(Teachers::Induction).to receive(:new).with(anything).and_return(fake_teacher_induction) }
+
     context "when successful" do
       it "updates the induction period with fail outcome" do
         service.fail!
@@ -107,6 +118,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
           service.fail!
         }.to have_enqueued_job(FailECTInductionJob).with(
           trn: pending_induction_submission.trn,
+          start_date: induction_start_date.to_s,
           completed_date: pending_induction_submission.finished_on.to_s,
           pending_induction_submission_id: pending_induction_submission.id
         )


### PR DESCRIPTION
This PR contains a few small changes, I suggest reviewing commit-by commit.

- **Fix the TRS induction status names**
- **Add start_date param to API client pass/fail**
- **Ensure we send start date when completing inductions**
- **Make the API client take dates instead of strings**
