### PR TITLE
Add azure login to reseed workflow

### DIFF
--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -17,6 +17,10 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: Azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
     - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
       with:
         azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
Staging reseed workflow fails because it requires an azure login