### PR TITLE
Add DfE Sign-in AB mappings

### DIFF
--- a/db/migrate/20250213115105_allow_null_dfe_sign_in_organisation_ids.rb
+++ b/db/migrate/20250213115105_allow_null_dfe_sign_in_organisation_ids.rb
@@ -1,0 +1,9 @@
+class AllowNullDfESignInOrganisationIds < ActiveRecord::Migration[8.0]
+  def up
+    change_column :appropriate_bodies, :dfe_sign_in_organisation_id, :uuid, null: true
+  end
+
+  def down
+    change_column :appropriate_bodies, :dfe_sign_in_organisation_id, :uuid, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_08_225854) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_13_115105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -38,7 +38,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_08_225854) do
     t.datetime "updated_at", null: false
     t.integer "local_authority_code"
     t.integer "establishment_number"
-    t.uuid "dfe_sign_in_organisation_id", null: false
+    t.uuid "dfe_sign_in_organisation_id"
     t.uuid "legacy_id"
     t.index ["dfe_sign_in_organisation_id"], name: "index_appropriate_bodies_on_dfe_sign_in_organisation_id", unique: true
     t.index ["name"], name: "index_appropriate_bodies_on_name", unique: true

--- a/lib/appropriate_bodies/importers/appropriate_body_importer.rb
+++ b/lib/appropriate_bodies/importers/appropriate_body_importer.rb
@@ -82,11 +82,11 @@ module AppropriateBodies::Importers
       # with with the establishment number to form the establishment ID (aka the 'DfE number')
       # e.g., 123/1234
       params = case local_authority_code
-               when %r{\A[1-9]\d{2}\z}
+               when %r{\A\d{3}\z}
                  {
                    local_authority_code:
                  }
-               when %r{\A[1-9]\d{3}\z}
+               when %r{\A\d{4}\z}
                  {
                    establishment_number: local_authority_code
                  }

--- a/lib/appropriate_bodies/importers/appropriate_body_importer.rb
+++ b/lib/appropriate_bodies/importers/appropriate_body_importer.rb
@@ -6,7 +6,7 @@ module AppropriateBodies::Importers
 
     Row = Struct.new(:legacy_id, :name, :dfe_sign_in_organisation_id, :local_authority_code, :establishment_number) do
       def to_h
-        { name:, legacy_id:, establishment_number:, local_authority_code:, dfe_sign_in_organisation_id: SecureRandom.uuid } # FIXME: fix dfe_sign_in_organisation_id
+        { name:, legacy_id:, establishment_number:, local_authority_code:, dfe_sign_in_organisation_id: }
       end
     end
 
@@ -37,11 +37,7 @@ module AppropriateBodies::Importers
 
       {
         name: select_name(row).strip,
-
-        # FIXME: we'll probably have to supply these ourselves
-        #        and they're not in the sample data, so just
-        #        random values for now
-        dfe_sign_in_organisation_id: SecureRandom.uuid,
+        dfe_sign_in_organisation_id: select_dfe_sign_in_organsation_id(row),
         legacy_id: row['id'],
 
         **extract_local_authority_code_and_establishment_number(row)
@@ -53,6 +49,12 @@ module AppropriateBodies::Importers
         mappings_by_legacy_id[row['id']].fetch('appropriate_body_name')
       else
         row['name']
+      end
+    end
+
+    def select_dfe_sign_in_organsation_id(row)
+      if mappings_by_legacy_id.key?(row['id'])
+        mappings_by_legacy_id[row['id']].fetch('dfe_sign_in_organisation_id')
       end
     end
 

--- a/lib/appropriate_bodies/importers/importer.rb
+++ b/lib/appropriate_bodies/importers/importer.rb
@@ -1,13 +1,13 @@
 module AppropriateBodies::Importers
   class Importer
-    def initialize(appropriate_body_csv, teachers_csv, induction_period_csv)
+    def initialize(appropriate_body_csv, teachers_csv, induction_period_csv, dfe_sign_in_mapping_csv)
       @induction_periods_grouped_by_trn = InductionPeriodImporter.new(induction_period_csv).periods_by_trn
 
       @active_teachers = @induction_periods_grouped_by_trn.keys
       @teacher_importer_rows = TeacherImporter.new(teachers_csv, @active_teachers).rows
 
       @active_abs = @induction_periods_grouped_by_trn.flat_map { |_trn, ips| ips.map(&:legacy_appropriate_body_id) }.uniq
-      @ab_importer_rows = AppropriateBodyImporter.new(appropriate_body_csv, @active_abs).rows
+      @ab_importer_rows = AppropriateBodyImporter.new(appropriate_body_csv, @active_abs, dfe_sign_in_mapping_csv).rows
     end
 
     def import!

--- a/lib/appropriate_bodies/importers/teacher_importer.rb
+++ b/lib/appropriate_bodies/importers/teacher_importer.rb
@@ -26,10 +26,10 @@ module AppropriateBodies::Importers
       end
     end
 
-    def initialize(filename, wanted_trns)
+    def initialize(filename, wanted_trns, csv: nil)
       sorted_wanted_trns = wanted_trns.sort
 
-      file = File.readlines(filename)
+      file = csv || File.readlines(filename)
       file.delete_at(0)
       sorted_lines = file.sort
 
@@ -94,7 +94,7 @@ module AppropriateBodies::Importers
                         end
 
       # FIXME: don't bother recording anything that rounds to 0
-      converted_value.round
+      converted_value.round(1)
     end
   end
 end

--- a/lib/appropriate_bodies/importers/teacher_importer.rb
+++ b/lib/appropriate_bodies/importers/teacher_importer.rb
@@ -38,13 +38,15 @@ module AppropriateBodies::Importers
       seek = sorted_wanted_trns.shift
 
       sorted_lines.each do |line|
-        next unless line.start_with?(seek)
+        if line.strip.end_with?('InProgress')
+          wanted_lines << line
+        elsif line.start_with?(seek)
+          wanted_lines << line
 
-        wanted_lines << line
+          break if sorted_wanted_trns.empty?
 
-        break if sorted_wanted_trns.empty?
-
-        seek = sorted_wanted_trns.shift
+          seek = sorted_wanted_trns.shift
+        end
       end
 
       @csv = CSV.parse(wanted_lines.join, headers: %w[trn first_name last_name extension_length extension_length_unit induction_status])

--- a/spec/lib/appropriate_bodies/importers/appropriate_body_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/appropriate_body_importer_spec.rb
@@ -1,0 +1,162 @@
+describe AppropriateBodies::Importers::AppropriateBodyImporter do
+  let!(:ab_1) { FactoryBot.create(:appropriate_body, legacy_id: '025e61e7-ec32-eb11-a813-000d3a228dfc') }
+  let!(:ab_2) { FactoryBot.create(:appropriate_body, legacy_id: '1ddf3e82-c1ae-e311-b8ed-005056822391') }
+
+  let(:wanted_legacy_ids) { [ab_1.legacy_id, ab_2.legacy_id] }
+
+  let(:sample_appropriate_body_data) do
+    <<~CSV
+      id,name,dfe_sign_in_organisation_id,local_authority_code,establishment_number
+      #{ab_1.legacy_id},Testington Primary School,1234568,123/4567,
+      #{ab_2.legacy_id},Sampleville Primary School,23456789,987/6543,
+    CSV
+  end
+
+  let(:sample_appropriate_body_csv) { CSV.parse(sample_appropriate_body_data, headers: true) }
+
+  let(:sample_mapping_data) do
+    <<~CSV
+      appropriate_body_name,lead_school_name,dfe_sign_in_organisation_id,dqt_id
+      Test TSH,Test Lead School,203606a4-4199-46a9-84e4-56fbc5da2a36,6ae042bb-c7ae-e311-b8ed-005056822391
+    CSV
+  end
+
+  let(:sample_mapping_csv) { CSV.parse(sample_mapping_data, headers: true) }
+
+  subject { AppropriateBodies::Importers::AppropriateBodyImporter.new(nil, wanted_legacy_ids, nil, csv: sample_appropriate_body_csv, dfe_sign_in_mapping_csv: sample_mapping_csv) }
+
+  it 'converts the csv row to Row objects when initialized' do
+    expect(subject.rows).to all(be_a(AppropriateBodies::Importers::AppropriateBodyImporter::Row))
+  end
+
+  describe 'setting the local authority code and establishment number' do
+    context 'when the format is DDD' do
+      let(:sample_appropriate_body_data) do
+        <<~CSV
+          id,name,dfe_sign_in_organisation_id,local_authority_code,establishment_number
+          #{ab_1.legacy_id},Chesterton Primary School,1234568,123
+        CSV
+      end
+
+      it 'sets the local4 authority code to 123' do
+        expect(subject.rows[0].local_authority_code).to eql(123)
+      end
+    end
+
+    context 'when the format is DDDD' do
+      let(:sample_appropriate_body_data) do
+        <<~CSV
+          id,name,dfe_sign_in_organisation_id,local_authority_code,establishment_number
+          #{ab_1.legacy_id},Chesterton Primary School,1234568,1234
+        CSV
+      end
+
+      it 'sets the establishment number to 1234' do
+        expect(subject.rows[0].establishment_number).to eql(1234)
+      end
+    end
+
+    context 'when the appropriate body legacy_id is in the list of wanted_legacy_ids' do
+      it 'parses and builds the rows' do
+        expect(subject.rows.map(&:legacy_id)).to match_array(wanted_legacy_ids)
+      end
+    end
+
+    context 'when the appropriate body legacy_id is not in the list of wanted_legacy_ids' do
+      let(:wanted_legacy_ids) { [ab_1.legacy_id] }
+
+      it 'omits the unwanted rows' do
+        parsed_legacy_ids = subject.rows.map(&:legacy_id)
+
+        expect(parsed_legacy_ids).to include(ab_1.legacy_id)
+        expect(parsed_legacy_ids).not_to include(ab_2.legacy_id)
+      end
+    end
+
+    context 'when the format is DDDD/DDD' do
+      let(:sample_appropriate_body_data) do
+        <<~CSV
+          id,name,dfe_sign_in_organisation_id,local_authority_code,establishment_number
+          #{ab_1.legacy_id},Chesterton Primary School,1234568,567/1234
+        CSV
+      end
+
+      it 'sets the establishment number to 1234' do
+        expect(subject.rows[0].establishment_number).to eql(1234)
+      end
+
+      it 'sets the local authority code to 567' do
+        expect(subject.rows[0].local_authority_code).to eql(567)
+      end
+    end
+
+    context 'when the format is DDDDDDD' do
+      let(:sample_appropriate_body_data) do
+        <<~CSV
+          id,name,dfe_sign_in_organisation_id,local_authority_code,establishment_number
+          #{ab_1.legacy_id},Chesterton Primary School,1234568,5671234
+        CSV
+      end
+
+      it 'sets the establishment number to 1234' do
+        expect(subject.rows[0].establishment_number).to eql(1234)
+      end
+
+      it 'sets the local authority code to 567' do
+        expect(subject.rows[0].local_authority_code).to eql(567)
+      end
+    end
+  end
+
+  describe 'setting the name' do
+    context 'when there is no mapping in place' do
+      it 'sets the appropriate body name to the name field from the appropriate bodies csv' do
+        expect(subject.rows.map(&:name)).to match_array(['Testington Primary School', 'Sampleville Primary School'])
+      end
+    end
+
+    context 'when there is a mapping in place' do
+      let(:sample_mapping_data) do
+        <<~CSV
+          appropriate_body_name,lead_school_name,dfe_sign_in_organisation_id,dqt_id
+          Test TSH,Test Lead School,203606a4-4199-46a9-84e4-56fbc5da2a36,#{ab_1.legacy_id}
+        CSV
+      end
+
+      it 'sets the appropriate body name to the appropriate body name field from the mapping bodies csv' do
+        expect(subject.rows.map(&:name)).to match_array(['Test TSH', 'Sampleville Primary School'])
+      end
+    end
+  end
+
+  describe 'setting the DfE Sign-in ID' do
+    context 'when there is no mapping in place' do
+      it 'sets the DfE Sign-in ID to nil' do
+        expect(subject.rows.map(&:dfe_sign_in_organisation_id)).to all(be_nil)
+      end
+    end
+
+    context 'when there is a mapping in place' do
+      let(:dfe_sign_in_organisation_id) { SecureRandom.uuid }
+
+      let(:sample_mapping_data) do
+        <<~CSV
+          appropriate_body_name,lead_school_name,dfe_sign_in_organisation_id,dqt_id
+          Test TSH,Test Lead School,#{dfe_sign_in_organisation_id},#{ab_1.legacy_id}
+        CSV
+      end
+
+      it 'sets the DfE Sign-in ID to the value from the mappings CSV' do
+        ab_1_row = subject.rows.find { |r| r.legacy_id == ab_1.legacy_id }
+
+        expect(ab_1_row.dfe_sign_in_organisation_id).to eql(dfe_sign_in_organisation_id)
+      end
+
+      it 'is nil when there is no mapping' do
+        ab_2_row = subject.rows.find { |r| r.legacy_id == ab_2.legacy_id }
+
+        expect(ab_2_row.dfe_sign_in_organisation_id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/appropriate_bodies/importers/teacher_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_importer_spec.rb
@@ -1,0 +1,52 @@
+describe AppropriateBodies::Importers::TeacherImporter do
+  let(:sample_data) do
+    <<~CSV
+      trn,first_name,last_name,extension_length,extension_length_unit,induction_status
+      1234567,Faye,Tozer,,,RequiredToComplete
+      2345678,Lisa,Scott-Lee,,,InProgress
+      3456789,Lee,Latchford-Evans,,,InProgress
+    CSV
+  end
+
+  let(:wanted_trns) { %w[1234567 2345678] }
+
+  subject { AppropriateBodies::Importers::TeacherImporter.new(nil, wanted_trns, csv: sample_data.lines) }
+
+  it 'converts the wanted rows into AppropriateBodies::Importers::TeacherImporter::Row objects' do
+    expect(subject.rows.map(&:trn)).to include(*wanted_trns)
+  end
+
+  it 'skips rows that are not wanted' do
+    expect(subject.rows.map(&:trn)).not_to include('3456789')
+  end
+
+  describe 'extension lengths' do
+    let(:sample_data) do
+      <<~CSV
+        trn,first_name,last_name,extension_length,extension_length_unit,induction_status
+        1234567,Faye,Tozer,9,Years,RequiredToComplete
+        2345678,Lisa,Scott-Lee,14,Months,InProgress
+        3456789,Lee,Latchford-Evans,20,Weeks,InProgress
+        4567890,Ian,Watkins,200,Days,InProgress
+      CSV
+    end
+
+    let(:wanted_trns) { %w[1234567 2345678 3456789 4567890] }
+
+    it 'converts 9 years to be 27.0 terms' do
+      expect(subject.rows.find { |r| r.trn == '1234567' }.extension_terms).to eql(27.0)
+    end
+
+    it 'converts 14 months to be 4.7 terms' do
+      expect(subject.rows.find { |r| r.trn == '2345678' }.extension_terms).to eql(4.7)
+    end
+
+    it 'converts 20 weeks to be 1.5 terms' do
+      expect(subject.rows.find { |r| r.trn == '3456789' }.extension_terms).to eql(1.5)
+    end
+
+    it 'converts 200 days to be 3.1' do
+      expect(subject.rows.find { |r| r.trn == '4567890' }.extension_terms).to eql(3.1)
+    end
+  end
+end

--- a/spec/lib/appropriate_bodies/importers/teacher_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_importer_spec.rb
@@ -5,6 +5,7 @@ describe AppropriateBodies::Importers::TeacherImporter do
       1234567,Faye,Tozer,,,RequiredToComplete
       2345678,Lisa,Scott-Lee,,,InProgress
       3456789,Lee,Latchford-Evans,,,InProgress
+      4567890,Ian,Watkins,,,Exempt
     CSV
   end
 
@@ -12,12 +13,16 @@ describe AppropriateBodies::Importers::TeacherImporter do
 
   subject { AppropriateBodies::Importers::TeacherImporter.new(nil, wanted_trns, csv: sample_data.lines) }
 
-  it 'converts the wanted rows into AppropriateBodies::Importers::TeacherImporter::Row objects' do
+  it 'includes rows that have a wanted TRN' do
     expect(subject.rows.map(&:trn)).to include(*wanted_trns)
   end
 
-  it 'skips rows that are not wanted' do
-    expect(subject.rows.map(&:trn)).not_to include('3456789')
+  it 'includes rows that do not have a wanted TRN but have a status of InProgress' do
+    expect(subject.rows.map(&:trn)).to include('3456789')
+  end
+
+  it 'skips rows that are not wanted and have a status other than InProgress' do
+    expect(subject.rows.map(&:trn)).not_to include('4567890')
   end
 
   describe 'extension lengths' do


### PR DESCRIPTION
This PR adds the following things to the AB data importer:

* it allows  the `dfe_sign_in_organisation_id` to be `null` and only sets it if there's a corresponding value in the mapping table
* it sets the name of the appropriate body to the value from the mapping table if present, otherwise falls back to the DQT value

It also adds specs for the AB importer.