### PR TITLE
Added content to explain max number of terms

### DIFF
--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -15,7 +15,7 @@
       text: "How many terms of induction did they spend with you?"
     },
     suffix_text: 'FTE terms',
-    hint: { text: "Enter induction terms between 0 to 16. You can use up to one decimal place if the term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
+    hint: { text: "Enter induction terms between 0 and 16. You can use up to one decimal place if the term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
 %>
   <p class="govuk-body">You’ll need to consider:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -13,8 +13,9 @@
     label: {
       size: 'm',
       text: "How many terms of induction did they spend with you?"
-    }, suffix_text: 'FTE terms',
-    hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
+    },
+    suffix_text: 'FTE terms',
+    hint: { text: "Enter induction terms between 0 to 16. You can use up to one decimal place if the term is not a whole number. For example, for 2 and a half terms enter 2.5" }) do
 %>
   <p class="govuk-body">You’ll need to consider:</p>
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Added content to explain the max terms a user is able to enter. Added this content to all the relevant pages that have this behaviour / logic. Content added on:

- Release 
- Pass 
- Fail

New help text reviewed by Rob T.

Bug ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1228 

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="710" alt="Screenshot 2025-02-13 at 13 25 27" src="https://github.com/user-attachments/assets/f27f59f5-ae40-4031-956f-7a60856dbce0" /> | <img width="624" alt="Screenshot 2025-02-14 at 17 25 51" src="https://github.com/user-attachments/assets/a01ffc50-eeab-458a-b435-78e0be57205a" /> |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="651" alt="Screenshot 2025-02-13 at 13 28 29" src="https://github.com/user-attachments/assets/c3146993-0ff8-4697-b112-b56c74a1e586" /> | <img width="600" alt="Screenshot 2025-02-14 at 17 27 08" src="https://github.com/user-attachments/assets/12833ebd-3312-4f51-9ea7-1e61b289ac29" /> |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="649" alt="Screenshot 2025-02-13 at 13 29 16" src="https://github.com/user-attachments/assets/b22165a1-dc39-4fc5-91f0-fe583ac29b10" /> | <img width="588" alt="Screenshot 2025-02-14 at 17 26 42" src="https://github.com/user-attachments/assets/5a91fbb8-23f7-4786-bc1a-99b84b0ccbfa" /> |