### PR TITLE
Change induction period overlap validation to target the offending date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .envrc
 .idea
 .vscode
+.rdbgrc*
 
 bin/konduit.sh
 

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -33,9 +33,21 @@ private
   end
 
   def teacher_distinct_period
-    overlapping_siblings = InductionPeriod.siblings_of(self).overlapping_with(self).exists?
+    return unless overlap?
 
-    errors.add(:base, "Induction periods cannot overlap") if overlapping_siblings
+    if siblings.any? { |s| s.range.include?(started_on) }
+      errors.add(:started_on, "Start date cannot overlap another induction period")
+    elsif siblings.any? { |s| s.range.include?(finished_on) }
+      errors.add(:finished_on, "End date cannot overlap another induction period")
+    end
+  end
+
+  def siblings
+    InductionPeriod.siblings_of(self)
+  end
+
+  def overlap?
+    siblings.overlapping_with(self).exists?
   end
 
   def start_date_after_qts_date

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -33,7 +33,7 @@ private
   end
 
   def teacher_distinct_period
-    return unless overlap?
+    return unless overlaps_with_siblings?
 
     if siblings.any? { |s| s.range.include?(started_on) }
       errors.add(:started_on, "Start date cannot overlap another induction period")
@@ -46,7 +46,7 @@ private
     InductionPeriod.siblings_of(self)
   end
 
-  def overlap?
+  def overlaps_with_siblings?
     siblings.overlapping_with(self).exists?
   end
 

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Admin::InductionPeriodsController do
               induction_period: { started_on: 7.months.ago }
             }
             expect(response).to be_unprocessable
-            expect(sanitize(response.body)).to include("Induction periods cannot overlap")
+            expect(sanitize(response.body)).to include("Start date cannot overlap another induction period")
           end
         end
 

--- a/spec/services/admin/update_induction_period_service_spec.rb
+++ b/spec/services/admin/update_induction_period_service_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Admin::UpdateInductionPeriodService do
           it "raises an error" do
             expect { service.update_induction! }.to raise_error(
               ActiveRecord::RecordInvalid,
-              "Validation failed: Induction periods cannot overlap"
+              "Validation failed: Started on Start date cannot overlap another induction period"
             )
           end
         end
@@ -108,7 +108,7 @@ RSpec.describe Admin::UpdateInductionPeriodService do
           it "raises an error" do
             expect { service.update_induction! }.to raise_error(
               ActiveRecord::RecordInvalid,
-              "Validation failed: Induction periods cannot overlap"
+              "Validation failed: Finished on End date cannot overlap another induction period"
             )
           end
         end


### PR DESCRIPTION
This is done in a way that can be rolled out to other period types.