### PR TITLE
Only send begin notification to TRS on first induction period

### DIFF
--- a/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/register_ect.rb
@@ -69,6 +69,8 @@ module AppropriateBodies
       end
 
       def send_begin_induction_notification_to_trs
+        return true if @teacher.induction_periods.any?
+
         BeginECTInductionJob.perform_later(
           trn: pending_induction_submission.trn,
           start_date: pending_induction_submission.started_on,


### PR DESCRIPTION
We only want to send updates to TRS when someone starts an induction. We eventually should do this by checking the induction status but we can use the presence of an induction period to indicate whether it's beginnning the induction or not.

Fixes DFE-Digital/register-ects-project-board#1160
