### PR TITLE
[2241] Make BQ dataset creation optional

### DIFF
--- a/config/terraform/application/application.tf
+++ b/config/terraform/application/application.tf
@@ -15,22 +15,22 @@ module "application_configuration" {
   # Delete for non rails apps
   is_rails_application = true
 
-  config_variables = merge(local.environment_variables,
+  config_variables = merge(
+    local.environment_variables,
+    local.bigquery_variables,
     {
-      ENVIRONMENT_NAME               = var.environment
-      PGSSLMODE                      = local.postgres_ssl_mode
-      BIGQUERY_PROJECT_ID            = module.dfe_analytics.bigquery_project_id
-      BIGQUERY_TABLE_NAME            = module.dfe_analytics.bigquery_table_name
-      BIGQUERY_DFE_ANALYTICS_DATASET = module.dfe_analytics.bigquery_dataset
-
+      ENVIRONMENT_NAME = var.environment
+      PGSSLMODE        = local.postgres_ssl_mode
     }
   )
-  secret_variables = {
-    DATABASE_URL             = module.postgres.url
-    BLAZER_DATABASE_URL      = var.environment == "production" ? module.infrastructure_secrets.map[local.snapshot_db_kv_secret_name] : module.postgres.url
-    REDIS_CACHE_URL          = module.redis-cache.url
-    GOOGLE_CLOUD_CREDENTIALS = module.dfe_analytics.google_cloud_credentials
-  }
+  secret_variables = merge(
+    local.bigquery_secrets,
+    {
+      DATABASE_URL        = module.postgres.url
+      BLAZER_DATABASE_URL = var.environment == "production" ? module.infrastructure_secrets.map[local.snapshot_db_kv_secret_name] : module.postgres.url
+      REDIS_CACHE_URL     = module.redis-cache.url
+    }
+  )
 }
 
 module "web_application" {

--- a/config/terraform/application/config/review.tfvars.json
+++ b/config/terraform/application/config/review.tfvars.json
@@ -4,5 +4,6 @@
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl": false,
     "enable_logit": true,
-    "gcp_table_deletion_protection": false
+    "gcp_table_deletion_protection": false,
+    "create_bigquery_dataset": false
 }

--- a/config/terraform/application/gcp_wif.tf
+++ b/config/terraform/application/gcp_wif.tf
@@ -4,6 +4,7 @@ provider "google" {
 
 module "dfe_analytics" {
   source = "./vendor/modules/aks//aks/dfe_analytics"
+  count  = var.create_bigquery_dataset ? 1 : 0
 
   azure_resource_prefix = var.azure_resource_prefix
   cluster               = var.cluster

--- a/config/terraform/application/variables.tf
+++ b/config/terraform/application/variables.tf
@@ -108,9 +108,22 @@ variable "gcp_table_deletion_protection" {
   type    = bool
   default = null
 }
+variable "create_bigquery_dataset" {
+  default     = true
+  description = "Create bigquery dataset and events table"
+}
 
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 
   environment_variables = yamldecode(file("${path.module}/config/${var.config}.yml"))
+
+  bigquery_variables = var.create_bigquery_dataset ? {
+    BIGQUERY_PROJECT_ID            = module.dfe_analytics[0].bigquery_project_id
+    BIGQUERY_TABLE_NAME            = module.dfe_analytics[0].bigquery_table_name
+    BIGQUERY_DFE_ANALYTICS_DATASET = module.dfe_analytics[0].bigquery_dataset
+  } : {}
+  bigquery_secrets = var.create_bigquery_dataset ? {
+    GOOGLE_CLOUD_CREDENTIALS = module.dfe_analytics[0].google_cloud_credentials
+  } : {}
 }


### PR DESCRIPTION
## Description
It is rarely required for review apps and creating many datasets confuses the analytics team
Make it optional using variable `create_bigquery_dataset`

## How to review
- Create review app from main
- Run terraform plan from branch, but set create_bigquery_dataset to true
- Run the tfmv.sh script to rename the resources
- Set create_bigquery_dataset to false
- The dataset should be deleted

## Before merging
- Stop merges
- rename terraform resources using the tfmv.sh script
- remove the TEMP commit