### PR TITLE
Add missing environment options to some workflows

### DIFF
--- a/.github/workflows/restore-app-main-db.yml
+++ b/.github/workflows/restore-app-main-db.yml
@@ -10,6 +10,8 @@ on:
         type: choice
         options:
         - development
+        - sandbox
+        - staging
         - test
         - production
       confirm-production:

--- a/config/global_config/sandbox.sh
+++ b/config/global_config/sandbox.sh
@@ -1,4 +1,5 @@
 CONFIG=sandbox
+ENVIRONMENT=sandbox
 CONFIG_SHORT=sb
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
 AZURE_RESOURCE_PREFIX=s189p01


### PR DESCRIPTION
- add `sandbox` and `staging` options to the `restore-app-main-db` GitHub workflow
- add missing envar to sandbox global config script.