### PR TITLE
Add appeal content to fail induction page

### DIFF
--- a/app/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb
@@ -1,5 +1,7 @@
 <% page_data(title: "Record failed outcome for #{Teachers::Name.new(@teacher).full_name}", error: @pending_induction_submission.errors.any?) %>
-
+<p class="govuk-body">
+  <%= Teachers::Name.new(@teacher).full_name %> can appeal this outcome. You must tell them about their right to appeal and the appeal process.
+</p>
 <%= form_with(model: @pending_induction_submission, url: ab_teacher_record_failed_outcome_path(@teacher), method: 'post') do |f| %>
   <%= render partial: 'appropriate_bodies/teachers/outcome_form', locals: { f: f } %>
   <%= f.govuk_submit "Record failing outcome for #{Teachers::Name.new(@teacher).full_name}", warning: true %>


### PR DESCRIPTION
Bug ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1234 

Added ECT appeal content and left existing content as it is because we have the red CTA now which indicates a fail quite obviously. 

Content does need cleaning up / refining post MVP but for now, it's good to go.

 Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="605" alt="Screenshot 2025-02-14 at 15 11 07" src="https://github.com/user-attachments/assets/00de984f-06fe-46e3-9948-968c92489092" /> | <img width="634" alt="Screenshot 2025-02-14 at 15 07 25" src="https://github.com/user-attachments/assets/4eeac822-81dd-4ac2-9692-f2527530229b" /> |