### PR TITLE
Improve teacher filtering on import

### DIFF
--- a/spec/lib/appropriate_bodies/importers/teacher_importer_spec.rb
+++ b/spec/lib/appropriate_bodies/importers/teacher_importer_spec.rb
@@ -17,8 +17,8 @@ describe AppropriateBodies::Importers::TeacherImporter do
     expect(subject.rows.map(&:trn)).to include(*wanted_trns)
   end
 
-  it 'includes rows that do not have a wanted TRN but have a status of InProgress' do
-    expect(subject.rows.map(&:trn)).to include('3456789')
+  it 'does not include with a status of InProgress that do not have a wanted TRN' do
+    expect(subject.rows.map(&:trn)).not_to include('3456789')
   end
 
   it 'skips rows that are not wanted and have a status other than InProgress' do


### PR DESCRIPTION
Previously we brought in all teachers who had statuses of `InProgress` and `RequiredToComplete`, which left us with lots of teacher records that had no induction periods.

Now we're more selective and bring in teachers who have a status of `InProress` and `RequiredToComplete` and have at least one induction period. As a result the import is significantly faster.
