### PR TITLE
Add trs name fields and corrected_name to the blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -2,12 +2,9 @@
 shared:
   :teachers:
   - id
-  - corrected_name
   - created_at
   - updated_at
   - trn
-  - trs_first_name
-  - trs_last_name
   - legacy_id
   - legacy_ect_id
   - legacy_mentor_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -195,6 +195,10 @@
   - delivery_partner_id
   - created_at
   - updated_at
+  :teachers:
+  - corrected_name
+  - trs_first_name
+  - trs_last_name
   :pending_induction_submissions:
   - id
   - appropriate_body_id


### PR DESCRIPTION
Blocklist unused teacher fields that are not used by analytics and should not be included in BigQuery event tables:
- corrected_name
- trs_first_name
- trs_last_name