### PR TITLE
Change landing page content to holding page for go live

### DIFF
--- a/app/views/appropriate_bodies/landing/show.md.erb
+++ b/app/views/appropriate_bodies/landing/show.md.erb
@@ -1,17 +1,5 @@
 ---
-title: Record inductions as an appropriate body
+title: Sorry, the service is unavailable
 ---
 
-Use this service if you’re an appropriate body supporting the induction of early career teachers (ECTs).
-
-You’ll need to give details about:
-
-* who you’re supporting, or no longer supporting
-* the induction history and progress of your ECTs
-* whether an ECT has passed or failed, or had their induction extended
-
-<% if Rails.application.config.dfe_sign_in_enabled && !Rails.application.config.enable_personas %>
-  <%= govuk_start_button(text: "Start now", href: '/auth/dfe_sign_in', as_button: true) %>
-<% else %>
-  <%= govuk_start_button(text: "Start now", href: sign_in_path) %>
-<% end %>
+You will be able to use the service from 2pm on Tuesday 18 February 2025.

--- a/app/views/appropriate_bodies/landing/show.md.erb
+++ b/app/views/appropriate_bodies/landing/show.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Sorry, the service is unavailable
+title: Sorry, the service is not available yet
 ---
 
 You will be able to use the service from 2pm on Tuesday 18 February 2025.

--- a/spec/features/visiting_the_service_spec.rb
+++ b/spec/features/visiting_the_service_spec.rb
@@ -36,7 +36,7 @@ private
 
   def i_am_redirected_to_the_ab_landing_page
     expect(current_path).to eql('/appropriate-body')
-    expect(page.title).to include('Record inductions as an appropriate body')
+    expect(page.title).to include('Sorry, the service is not available yet')
   end
 
   def then_i_see_the_school_landing_page


### PR DESCRIPTION
Landing page content changed for the interim to be a holding page. We will revert back to the landing page content once holding page is no longer needed.

Content consistent with the email that went out to ABs and has the same date and time: https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Teacher%20Continuing%20Professional%20Development/Teacher%20CPD%20Team/Register%20early%20career%20teachers/Record%20Inductions%20as%20an%20Appropriate%20Body/Content%20design/Service%20downtime%20content.docx?d=w4aae0068b02f4cbda84c1edf7b0cbc90&csf=1&web=1&e=Ldr9n8

Design and content pattern following: https://design-system.service.gov.uk/patterns/service-unavailable-pages/ 

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="1349" alt="Screenshot 2025-02-17 at 16 06 06" src="https://github.com/user-attachments/assets/af7a9f96-214c-4081-b9e7-e57f47dbcaf3" /> | <img width="1344" alt="Screenshot 2025-02-17 at 16 30 08" src="https://github.com/user-attachments/assets/9613c962-3ef5-4c76-a315-3af3de1f2c8e" /> |