### PR TITLE
Add fallback phase banner text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
     page_data(**parsed_yaml)
   end
 
-  def support_mailto_link
-    govuk_link_to(Rails.application.config.support_email_address, 'mailto:' + Rails.application.config.support_email_address)
+  def support_mailto_link(text = Rails.application.config.support_email_address)
+    govuk_link_to(text, 'mailto:' + Rails.application.config.support_email_address)
   end
 end

--- a/app/helpers/environment_helper.rb
+++ b/app/helpers/environment_helper.rb
@@ -7,8 +7,14 @@ module EnvironmentHelper
 
   def environment_specific_phase_banner
     tag_text = ENVIRONMENT_PHASE_BANNER_TAG || "Beta"
-    banner_text = ENVIRONMENT_PHASE_BANNER_CONTENT
+    banner_text = ENVIRONMENT_PHASE_BANNER_CONTENT || environment_phase_banner_default_content
 
     govuk_phase_banner(text: banner_text, tag: { text: tag_text, colour: ENVIRONMENT_COLOUR }.compact)
+  end
+
+private
+
+  def environment_phase_banner_default_content
+    "This is a new service – your #{support_mailto_link('feedback')} will help us to improve it.".html_safe
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -78,5 +78,14 @@ RSpec.describe ApplicationHelper, type: :helper do
         text: 'teacher.induction@education.gov.uk'
       )
     end
+
+    context 'when custom text is passed in' do
+      it 'adds the custom text into the link' do
+        expect(support_mailto_link('feedback')).to have_css(
+          %(a[href='mailto:teacher.induction@education.gov.uk'][class='govuk-link']),
+          text: 'feedback'
+        )
+      end
+    end
   end
 end

--- a/spec/helpers/environment_helper_spec.rb
+++ b/spec/helpers/environment_helper_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe EnvironmentHelper, type: :helper do
   include GovukLinkHelper
   include GovukVisuallyHiddenHelper
   include GovukComponentsHelper
+  include ApplicationHelper
 
   before do
     stub_const('ENVIRONMENT_COLOUR', nil)
@@ -31,6 +32,16 @@ RSpec.describe EnvironmentHelper, type: :helper do
 
     it 'has a govuk tag with no colour modifier' do
       expect(subject).to_not match(/govuk-tag--\w+/)
+    end
+
+    context 'when ENVIRONMENT_PHASE_BANNER_TAG is not set' do
+      it 'includes the default text' do
+        expect(subject).to match('This is a new service')
+      end
+
+      it 'includes the support email address' do
+        expect(subject).to match('teacher.induction@education.gov.uk')
+      end
     end
 
     context 'when ENVIRONMENT_COLOUR, ENVIRONMENT_PHASE_BANNER_CONTENT and ENVIRONMENT_PHASE_BANNER_TAG are set' do


### PR DESCRIPTION
We're missing this in production and there should be something there, or we may as well drop the banner altogether.
