### PR TITLE
[Migration] Allow existing Teacher to be updated by migration

### DIFF
--- a/app/migration/builders/teacher.rb
+++ b/app/migration/builders/teacher.rb
@@ -10,13 +10,34 @@ module Builders
     end
 
     def build
-      ::Teacher.create!(trn:, trs_first_name: parser.first_name, trs_last_name: parser.last_name, legacy_id:)
+      ActiveRecord::Base.transaction do
+        teacher = ::Teacher.find_by(trn:)
+
+        if teacher.present?
+          update_teacher!(teacher:)
+        else
+          create_teacher!
+        end
+      end
     rescue ActiveRecord::ActiveRecordError => e
       @error = e.message
       nil
     end
 
   private
+
+    def create_teacher!
+      ::Teacher.create!(trn:, trs_first_name: parser.first_name, trs_last_name: parser.last_name, legacy_id:)
+    end
+
+    def update_teacher!(teacher:)
+      # TODO: should the migrated data trump the corrected_name if there is one already or not?
+      if (parser.first_name != teacher.trs_first_name || parser.last_name != teacher.trs_last_name) && teacher.corrected_name.blank?
+        teacher.update!(corrected_name: full_name)
+      end
+
+      teacher
+    end
 
     def parser
       @parser ||= Teachers::FullNameParser.new(full_name:)


### PR DESCRIPTION
If a `Teacher` record already exists the migrator generates a migration failure error to reflect this. However in the real environment the majority of `Teacher` records will already exist, brought in via the AB data.
This PR prevents the error being generated and also if the `full_name` attribute from ECF does not match the `trs_first_name` and `trs_last_name` it will set the `corrected_name` attribute.