### PR TITLE
Add class for searching admin emails case insensitively

### DIFF
--- a/app/services/admin/user_search.rb
+++ b/app/services/admin/user_search.rb
@@ -1,0 +1,15 @@
+module Admin
+  class UserSearch
+    def find_by_email_case_insensitively!(email)
+      lowercase_column = Arel::Nodes::Node.new.lower(arel_table[:email])
+
+      User.find_by!(lowercase_column.eq(email.downcase))
+    end
+
+  private
+
+    def arel_table
+      User.arel_table
+    end
+  end
+end

--- a/app/services/sessions/users/dfe_user.rb
+++ b/app/services/sessions/users/dfe_user.rb
@@ -7,7 +7,7 @@ module Sessions
       attr_reader :id, :name, :user
 
       def initialize(email:, **)
-        @user = ::User.find_by!(email:)
+        @user = Admin::UserSearch.new.find_by_email_case_insensitively!(email)
         @id = user.id
         @name = user.name
 

--- a/spec/services/admin/user_search_spec.rb
+++ b/spec/services/admin/user_search_spec.rb
@@ -1,0 +1,17 @@
+describe 'Admin::UserSearch' do
+  describe '.find_by_email_case_insensitively!' do
+    subject { Admin::UserSearch.new }
+    context 'when the user exists' do
+      it 'lower cases the email address column and search term' do
+        shaggy = FactoryBot.create(:user, email: 'shaggy@EXAMPLE.com')
+        expect(subject.find_by_email_case_insensitively!('SHAGGY@example.com')).to eq(shaggy)
+      end
+    end
+
+    context 'when the user does not exist' do
+      it 'raises record not found error' do
+        expect { subject.find_by_email_case_insensitively!('SHAGGY@example.com') }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are not using Arel's .matches here because `ilike` adds some danger in that people could add wildcards to searches.

Instead convert both the email address column and search term to lower case. The users table is not likely to be around too much longer and will never be big, so this approach is fine.

This fixes a bug where people need to match the email exactly to be able to log in, and they won't have set it up themselves so don't know for certain what they need to do.
