### PR TITLE
Add a custom error when DfE Sign-in org not found

### DIFF
--- a/app/services/sessions/users/builder.rb
+++ b/app/services/sessions/users/builder.rb
@@ -2,15 +2,19 @@ module Sessions
   module Users
     class Builder
       class UnknownProvider < StandardError; end
+      class UnknownOrganisation < StandardError; end
 
       def session_user
         return appropriate_body_user if appropriate_body_user?
         return school_user if school_user?
+
+        raise(UnknownOrganisation, organisation) unless Rails.application.config.enable_personas
+
         return dfe_persona if dfe_persona?
         return school_persona if school_persona?
         return appropriate_body_persona if appropriate_body_persona?
 
-        raise UnknownProvider, provider
+        raise(UnknownProvider, provider)
       end
 
       def id_token = payload.credentials.id_token

--- a/spec/services/sessions/users/builder_spec.rb
+++ b/spec/services/sessions/users/builder_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Sessions::Users::Builder do
       end
     end
 
+    context 'when the organisation is unknown and Personas are disabled' do
+      before do
+        allow(Rails.application.config).to receive(:enable_personas).and_return(false)
+      end
+
+      let(:provider) { 'something_unexpected' }
+      let(:uid) { Faker::Internet.uuid }
+      let(:appropriate_body_id) { nil }
+      let(:school_urn) { nil }
+      let(:dfe_staff) { nil }
+      let(:organisation_id) { 'c399f5a7-44e4-4c86-bb4a-e3e2dbe69421' }
+      let(:organisation_urn) { nil }
+
+      it 'raises an UnknownProvider error' do
+        expect { subject }.to raise_error(described_class::UnknownOrganisation, Regexp.new(organisation_id))
+      end
+    end
+
     context 'when the provider is unknown' do
       let(:provider) { 'something_unexpected' }
       let(:uid) { Faker::Internet.uuid }


### PR DESCRIPTION
This should provide us a little more clarity on what's going on when the org isn't found and we can't fall back to personas.

Currently in Sentry the error doesn't make it clear who is failing to log in.
