### PR TITLE
Add hint text for dates on relevant pages

### DIFF
--- a/app/helpers/teacher_helper.rb
+++ b/app/helpers/teacher_helper.rb
@@ -4,4 +4,12 @@ module TeacherHelper
   def teacher_full_name(teacher)
     ::Teachers::Name.new(teacher).full_name
   end
+
+  def teacher_date_of_birth_hint_text
+    "For example, 20 4 2001"
+  end
+
+  def teacher_induction_date_hint_text
+    "For example, 20 4 #{Time.zone.today.year.pred}"
+  end
 end

--- a/app/helpers/teacher_helper.rb
+++ b/app/helpers/teacher_helper.rb
@@ -10,6 +10,6 @@ module TeacherHelper
   end
 
   def teacher_induction_date_hint_text
-    "For example, 20 4 #{Time.zone.today.year.pred}"
+    "For example, 20 4 #{Date.current.year.pred}"
   end
 end

--- a/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
@@ -21,7 +21,7 @@
     f.govuk_date_field(
       :date_of_birth,
       legend: { text: "Date of birth" },
-      hint: { text: "For example, 31 3 1980" },
+      hint: { text: teacher_date_of_birth_hint_text },
     )
   %>
 

--- a/app/views/appropriate_bodies/claim_an_ect/register_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/register_ect/edit.html.erb
@@ -9,7 +9,8 @@
 
   <%=
     f.govuk_date_field :started_on,
-      legend: { text: "When did #{pending_induction_submission_full_name(@pending_induction_submission)} start their induction with you?" }
+      legend: { text: "When did #{pending_induction_submission_full_name(@pending_induction_submission)} start their induction with you?" }, 
+      hint: { text: teacher_induction_date_hint_text }
   %>
 
   <%=

--- a/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
+++ b/app/views/appropriate_bodies/teachers/_outcome_form.html.erb
@@ -4,7 +4,8 @@
   f.govuk_date_field :finished_on,
     legend: {
       text: "When did they move from #{@appropriate_body.name}?"
-    }
+    },
+      hint: { text: teacher_induction_date_hint_text }
 %>
 
 <%=

--- a/spec/helpers/teacher_helper_spec.rb
+++ b/spec/helpers/teacher_helper_spec.rb
@@ -4,4 +4,14 @@ RSpec.describe TeacherHelper, type: :helper do
   describe '#teacher_full_name' do
     it { expect(teacher_full_name(teacher)).to eq('Barry White') }
   end
+
+  describe "#teacher_date_of_birth_hint_text" do
+    it { expect(teacher_date_of_birth_hint_text).to eql('For example, 20 4 2001') }
+  end
+
+  describe "#teacher_induction_date_hint_text" do
+    last_year = Date.current.year.pred
+
+    it { expect(teacher_induction_date_hint_text).to eql("For example, 20 4 #{last_year}") }
+  end
 end


### PR DESCRIPTION
Added hint text for dates so users know what format they should  be in. 

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1250 
NOT added to extensions as there is no date field in that journey. 

Added to:

- Release
- Pass/Fail
- Claim

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="707" alt="Screenshot 2025-02-19 at 14 59 06" src="https://github.com/user-attachments/assets/b94ab42b-4368-4b2c-b96b-e6020203d84f" /> | <img width="743" alt="Screenshot 2025-02-19 at 14 58 57" src="https://github.com/user-attachments/assets/b1231fb6-728b-4e9b-80b0-8294d63566dc" /> |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="676" alt="Screenshot 2025-02-19 at 14 58 45" src="https://github.com/user-attachments/assets/490bed78-4864-4322-89fa-c5840402fc99" /> | <img width="655" alt="Screenshot 2025-02-19 at 14 58 35" src="https://github.com/user-attachments/assets/19d496a0-8ccf-4f82-94f8-76392717cc4f" /> |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="773" alt="Screenshot 2025-02-19 at 14 58 13" src="https://github.com/user-attachments/assets/de3a076f-37d9-4251-ac43-fd1fe84cca81" /> | <img width="591" alt="Screenshot 2025-02-19 at 14 57 30" src="https://github.com/user-attachments/assets/ce1b0eeb-25c7-40e4-968f-786fb50fa1ba" /> |

Before and after screenshots: 
| Before | After |
|  ------ | ------ |
| <img width="1019" alt="Screenshot 2025-02-19 at 14 57 16" src="https://github.com/user-attachments/assets/5f88bf37-cae0-4fb0-ac09-87b633ce7f0b" /> | <img width="1012" alt="Screenshot 2025-02-19 at 14 56 17" src="https://github.com/user-attachments/assets/2a22c0a8-01a4-4474-9eb6-3f3703790735" /> |