### PR TITLE
Rename`legacy_id` type fields more appropriately

### DIFF
--- a/app/components/migration/induction_record_component.rb
+++ b/app/components/migration/induction_record_component.rb
@@ -9,7 +9,7 @@ module Migration
     def migrated_mentor
       return unless mentor_present?
 
-      Teacher.find_by(legacy_mentor_id: induction_record.mentor_profile_id)
+      Teacher.find_by(ecf_mentor_profile_id: induction_record.mentor_profile_id)
     end
 
     def mentor_present?

--- a/app/components/migration/mentorship_period_component.rb
+++ b/app/components/migration/mentorship_period_component.rb
@@ -32,11 +32,11 @@ module Migration
 
     def build_matched_attrs
       attrs = {
-        started_on: mentorship_period.legacy_start_id,
-        mentor: mentorship_period.legacy_start_id,
+        started_on: mentorship_period.ecf_start_induction_record_id,
+        mentor: mentorship_period.ecf_start_induction_record_id,
       }
-      if mentorship_period.legacy_end_id.present?
-        attrs[:finished_on] = mentorship_period.legacy_end_id
+      if mentorship_period.ecf_end_induction_record_id.present?
+        attrs[:finished_on] = mentorship_period.ecf_end_induction_record_id
       end
 
       attrs

--- a/app/components/migration/school_period_component.rb
+++ b/app/components/migration/school_period_component.rb
@@ -30,11 +30,11 @@ module Migration
 
     def build_matched_attrs
       attrs = {
-        started_on: school_period.legacy_start_id,
-        school: school_period.legacy_start_id,
+        started_on: school_period.ecf_start_induction_record_id,
+        school: school_period.ecf_start_induction_record_id,
       }
-      if school_period.legacy_end_id.present?
-        attrs[:finished_on] = school_period.legacy_end_id
+      if school_period.ecf_end_induction_record_id.present?
+        attrs[:finished_on] = school_period.ecf_end_induction_record_id
       end
 
       attrs

--- a/app/components/migration/teacher_migration_failure_component.rb
+++ b/app/components/migration/teacher_migration_failure_component.rb
@@ -27,10 +27,10 @@ module Migration
     def load_participant_profile
       pid = if teacher_migration_failure.migration_item_type == "Migration::ParticipantProfile"
               teacher_migration_failure.migration_item_id
-            elsif teacher.legacy_ect_id.present?
-              teacher.legacy_ect_id
-            elsif teacher.legacy_mentor_id.present?
-              teacher.legacy_mentor_id
+            elsif teacher.ecf_ect_profile_id.present?
+              teacher.ecf_ect_profile_id
+            elsif teacher.ecf_mentor_profile_id.present?
+              teacher.ecf_mentor_profile_id
             end
       Migration::ParticipantProfilePresenter.new(Migration::ParticipantProfile.find(pid)) if pid.present?
     end

--- a/app/components/migration/training_period_component.rb
+++ b/app/components/migration/training_period_component.rb
@@ -36,11 +36,11 @@ module Migration
 
     def build_matched_attrs
       attrs = {
-        started_on: training_period.legacy_start_id,
-        provider: training_period.legacy_start_id,
+        started_on: training_period.ecf_start_induction_record_id,
+        provider: training_period.ecf_start_induction_record_id,
       }
-      if school_period.legacy_end_id.present?
-        attrs[:finished_on] = training_period.legacy_end_id
+      if school_period.ecf_end_induction_record_id.present?
+        attrs[:finished_on] = training_period.ecf_end_induction_record_id
       end
 
       attrs

--- a/app/controllers/migration/teachers_controller.rb
+++ b/app/controllers/migration/teachers_controller.rb
@@ -42,23 +42,23 @@ private
   end
 
   def ect_profile
-    @ect_profile = if teacher.legacy_ect_id.present?
+    @ect_profile = if teacher.ecf_ect_profile_id.present?
                      Migration::ParticipantProfilePresenter.new(
-                       Migration::ParticipantProfile.find(teacher.legacy_ect_id)
+                       Migration::ParticipantProfile.find(teacher.ecf_ect_profile_id)
                      )
                    end
   end
 
   def mentor_profile
-    @mentor_profile = if teacher.legacy_mentor_id.present?
+    @mentor_profile = if teacher.ecf_mentor_profile_id.present?
                         Migration::ParticipantProfilePresenter.new(
-                          Migration::ParticipantProfile.find(teacher.legacy_mentor_id)
+                          Migration::ParticipantProfile.find(teacher.ecf_mentor_profile_id)
                         )
                       end
   end
 
   def user
-    @user ||= Migration::User.find(teacher.legacy_id)
+    @user ||= Migration::User.find(teacher.ecf_user_id)
   end
 
   def teacher

--- a/app/migration/builders/ect/school_periods.rb
+++ b/app/migration/builders/ect/school_periods.rb
@@ -16,8 +16,8 @@ module Builders
                                       school:,
                                       started_on: period.start_date,
                                       finished_on: period.end_date,
-                                      legacy_start_id: period.start_source_id,
-                                      legacy_end_id: period.end_source_id)
+                                      ecf_start_induction_record_id: period.start_source_id,
+                                      ecf_end_induction_record_id: period.end_source_id)
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -26,8 +26,8 @@ module Builders
                                    ect_at_school_period:,
                                    started_on: period.start_date,
                                    finished_on: period.end_date,
-                                   legacy_start_id: period.start_source_id,
-                                   legacy_end_id: period.end_source_id)
+                                   ecf_start_induction_record_id: period.start_source_id,
+                                   ecf_end_induction_record_id: period.end_source_id)
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentor/school_periods.rb
+++ b/app/migration/builders/mentor/school_periods.rb
@@ -16,8 +16,8 @@ module Builders
                                          school:,
                                          started_on: period.start_date,
                                          finished_on: period.end_date,
-                                         legacy_start_id: period.start_source_id,
-                                         legacy_end_id: period.end_source_id)
+                                         ecf_start_induction_record_id: period.start_source_id,
+                                         ecf_end_induction_record_id: period.end_source_id)
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -26,8 +26,8 @@ module Builders
                                    mentor_at_school_period:,
                                    started_on: period.start_date,
                                    finished_on: period.end_date,
-                                   legacy_start_id: period.start_source_id,
-                                   legacy_end_id: period.end_source_id)
+                                   ecf_start_induction_record_id: period.start_source_id,
+                                   ecf_end_induction_record_id: period.end_source_id)
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentorship_periods.rb
+++ b/app/migration/builders/mentorship_periods.rb
@@ -41,8 +41,8 @@ module Builders
                                    mentor: mentor_period,
                                    started_on: period.start_date,
                                    finished_on: period.end_date,
-                                   legacy_start_id: period.start_source_id,
-                                   legacy_end_id: period.end_source_id)
+                                   ecf_start_induction_record_id: period.start_source_id,
+                                   ecf_end_induction_record_id: period.end_source_id)
       rescue ActiveRecord::ActiveRecordError => e
         log_period_error(period:, message: e.message)
         success = false

--- a/app/migration/builders/teacher.rb
+++ b/app/migration/builders/teacher.rb
@@ -1,11 +1,11 @@
 module Builders
   class Teacher
-    attr_reader :trn, :full_name, :legacy_id, :error
+    attr_reader :trn, :full_name, :ecf_user_id, :error
 
-    def initialize(trn:, full_name:, legacy_id: nil)
+    def initialize(trn:, full_name:, ecf_user_id: nil)
       @trn = trn
       @full_name = full_name
-      @legacy_id = legacy_id
+      @ecf_user_id = ecf_user_id
       @error = nil
     end
 
@@ -27,7 +27,7 @@ module Builders
   private
 
     def create_teacher!
-      ::Teacher.create!(trn:, trs_first_name: parser.first_name, trs_last_name: parser.last_name, legacy_id:)
+      ::Teacher.create!(trn:, trs_first_name: parser.first_name, trs_last_name: parser.last_name, ecf_user_id:)
     end
 
     def update_teacher!(teacher:)

--- a/app/migration/mentorship_period_extractor.rb
+++ b/app/migration/mentorship_period_extractor.rb
@@ -31,7 +31,7 @@ private
       elsif current_mentor_id != mentor_id
         current_mentor_id = mentor_id
 
-        mentor_teacher = ::Teacher.find_by(legacy_mentor_id: mentor_id)
+        mentor_teacher = ::Teacher.find_by(ecf_mentor_profile_id: mentor_id)
 
         current_period = Migration::MentorshipPeriodData.new(mentor_teacher:,
                                                              start_date: induction_record.start_date,

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -29,7 +29,7 @@ module Migrators
     end
 
     def safe_migrate_mentorships(participant_profile:)
-      teacher = ::Teacher.find_by(legacy_ect_id: participant_profile.id)
+      teacher = ::Teacher.find_by(ecf_ect_profile_id: participant_profile.id)
 
       if teacher.nil?
         failure_manager.record_failure(participant_profile, "Cannot find Teacher for ECT in mentorship period")

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -36,7 +36,7 @@ module Migrators
       trn = teacher_profile.trn
       full_name = teacher_profile.user.full_name
 
-      builder = Builders::Teacher.new(trn:, full_name:, legacy_id: teacher_profile.user_id)
+      builder = Builders::Teacher.new(trn:, full_name:, ecf_user_id: teacher_profile.user_id)
       teacher = builder.build
       if teacher.nil?
         failure_manager.record_failure(teacher_profile, builder.error)
@@ -58,11 +58,11 @@ module Migrators
             training_period_data = TrainingPeriodExtractor.new(induction_records:)
 
             if participant_profile.ect?
-              teacher.update!(legacy_ect_id: participant_profile.id)
+              teacher.update!(ecf_ect_profile_id: participant_profile.id)
               sp_success = Builders::ECT::SchoolPeriods.new(teacher:, school_periods:).build
               tp_success = Builders::ECT::TrainingPeriods.new(teacher:, training_period_data:).build
             else
-              teacher.update!(legacy_mentor_id: participant_profile.id)
+              teacher.update!(ecf_mentor_profile_id: participant_profile.id)
               sp_success = Builders::Mentor::SchoolPeriods.new(teacher:, school_periods:).build
               tp_success = Builders::Mentor::TrainingPeriods.new(teacher:, training_period_data:).build
             end

--- a/app/presenters/migration/induction_record_presenter.rb
+++ b/app/presenters/migration/induction_record_presenter.rb
@@ -86,7 +86,7 @@ module Migration
     end
 
     def fetch_migrated_periods_by_type(klass)
-      klass.where(legacy_start_id: id).or(klass.where(legacy_end_id: id)).order(:started_on)
+      klass.where(ecf_start_induction_record_id: id).or(klass.where(ecf_end_induction_record_id: id)).order(:started_on)
     end
 
     def induction_programme

--- a/app/presenters/migration/migration_failure_presenter.rb
+++ b/app/presenters/migration/migration_failure_presenter.rb
@@ -41,14 +41,14 @@ module Migration
     end
 
     def profile_id_from_parent
-      return parent.legacy_ect_id if parent.legacy_ect_id.present?
-      return parent.legacy_mentor_id if parent.legacy_mentor_id.present?
+      return parent.ecf_ect_profile_id if parent.ecf_ect_profile_id.present?
+      return parent.ecf_mentor_profile_id if parent.ecf_mentor_profile_id.present?
 
-      if parent.legacy_id
+      if parent.ecf_user_id.present?
         # NOTE: if they have both ECT and Mentor profiles we don't know which had the issue
         #       and we're only returning the first from the DB but it feels that might be better
         #       than nothing.
-        Migration::User.find(parent.legacy_id).teacher_profile.participant_profiles.ect_or_mentor.first&.id
+        Migration::User.find(parent.ecf_user_id).teacher_profile.participant_profiles.ect_or_mentor.first&.id
       end
     end
 

--- a/app/presenters/migration/school_period_presenter.rb
+++ b/app/presenters/migration/school_period_presenter.rb
@@ -9,7 +9,7 @@ module Migration
     end
 
     def source_records
-      source_ids = [school_period.legacy_start_id, school_period.legacy_end_id].compact_blank
+      source_ids = [school_period.ecf_start_induction_record_id, school_period.ecf_end_induction_record_id].compact_blank
       Migration::InductionRecordPresenter.wrap(Migration::InductionRecord.where(id: source_ids).order(:start_date))
     end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -22,7 +22,7 @@ shared:
   - local_authority_code
   - establishment_number
   - dfe_sign_in_organisation_id
-  - legacy_id
+  - dqt_id
   :induction_periods:
   - id
   - appropriate_body_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -5,9 +5,9 @@ shared:
   - created_at
   - updated_at
   - trn
-  - legacy_id
-  - legacy_ect_id
-  - legacy_mentor_id
+  - ecf_user_id
+  - ecf_ect_profile_id
+  - ecf_mentor_profile_id
   - trs_qts_awarded_on
   - trs_qts_status_description
   - trs_induction_status

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -178,8 +178,8 @@
   - ect_at_school_period_id
   - mentor_at_school_period_id
   - range
-  - legacy_start_id
-  - legacy_end_id
+  - ecf_start_induction_record_id
+  - ecf_end_induction_record_id
   :teacher_migration_failures:
   - id
   - teacher_id
@@ -249,8 +249,8 @@
   - created_at
   - updated_at
   - range
-  - legacy_start_id
-  - legacy_end_id
+  - ecf_start_induction_record_id
+  - ecf_end_induction_record_id
   :mentor_at_school_periods:
   - id
   - school_id
@@ -260,8 +260,8 @@
   - created_at
   - updated_at
   - range
-  - legacy_start_id
-  - legacy_end_id
+  - ecf_start_induction_record_id
+  - ecf_end_induction_record_id
   - email
   :lead_providers:
   - id
@@ -303,8 +303,8 @@
   - created_at
   - updated_at
   - range
-  - legacy_start_id
-  - legacy_end_id
+  - ecf_start_induction_record_id
+  - ecf_end_induction_record_id
   - working_pattern
   - email
   :dfe_roles:

--- a/db/migrate/20250219165051_rename_appropriate_body_legacy_id_to_dqt_id.rb
+++ b/db/migrate/20250219165051_rename_appropriate_body_legacy_id_to_dqt_id.rb
@@ -1,0 +1,5 @@
+class RenameAppropriateBodyLegacyIdToDqtId < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :appropriate_bodies, :legacy_id, :dqt_id
+  end
+end

--- a/db/migrate/20250221132033_rename_legacy_migration_fields.rb
+++ b/db/migrate/20250221132033_rename_legacy_migration_fields.rb
@@ -1,0 +1,19 @@
+class RenameLegacyMigrationFields < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :ect_at_school_periods, :legacy_start_id, :ecf_start_induction_record_id
+    rename_column :ect_at_school_periods, :legacy_end_id, :ecf_end_induction_record_id
+
+    rename_column :mentor_at_school_periods, :legacy_start_id, :ecf_start_induction_record_id
+    rename_column :mentor_at_school_periods, :legacy_end_id, :ecf_end_induction_record_id
+
+    rename_column :mentorship_periods, :legacy_start_id, :ecf_start_induction_record_id
+    rename_column :mentorship_periods, :legacy_end_id, :ecf_end_induction_record_id
+
+    rename_column :teachers, :legacy_id, :ecf_user_id
+    rename_column :teachers, :legacy_ect_id, :ecf_ect_profile_id
+    rename_column :teachers, :legacy_mentor_id, :ecf_mentor_profile_id
+
+    rename_column :training_periods, :legacy_start_id, :ecf_start_induction_record_id
+    rename_column :training_periods, :legacy_end_id, :ecf_end_induction_record_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_21_132033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -144,8 +144,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
-    t.uuid "legacy_start_id"
-    t.uuid "legacy_end_id"
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
     t.enum "working_pattern", enum_type: "working_pattern"
     t.citext "email"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
@@ -276,8 +276,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
-    t.uuid "legacy_start_id"
-    t.uuid "legacy_end_id"
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
     t.citext "email"
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
@@ -293,8 +293,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
-    t.uuid "legacy_start_id"
-    t.uuid "legacy_end_id"
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_afd5cf131d", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_mentorship_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
@@ -500,9 +500,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
     t.string "trs_first_name", null: false
     t.string "trs_last_name", null: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(trs_first_name, ''::character varying))::text || ' '::text) || (COALESCE(trs_last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
-    t.uuid "legacy_id"
-    t.uuid "legacy_ect_id"
-    t.uuid "legacy_mentor_id"
+    t.uuid "ecf_user_id"
+    t.uuid "ecf_ect_profile_id"
+    t.uuid "ecf_mentor_profile_id"
     t.date "trs_qts_awarded_on"
     t.string "trs_qts_status_description"
     t.string "trs_induction_status", limit: 16
@@ -524,8 +524,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
     t.bigint "ect_at_school_period_id"
     t.bigint "mentor_at_school_period_id"
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
-    t.uuid "legacy_start_id"
-    t.uuid "legacy_end_id"
+    t.uuid "ecf_start_induction_record_id"
+    t.uuid "ecf_end_induction_record_id"
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_20_133917) do
     t.integer "local_authority_code"
     t.integer "establishment_number"
     t.uuid "dfe_sign_in_organisation_id"
-    t.uuid "legacy_id"
+    t.uuid "dqt_id"
     t.index ["dfe_sign_in_organisation_id"], name: "index_appropriate_bodies_on_dfe_sign_in_organisation_id", unique: true
   end
 

--- a/spec/migration/builders/ect/school_periods_spec.rb
+++ b/spec/migration/builders/ect/school_periods_spec.rb
@@ -22,14 +22,14 @@ describe Builders::ECT::SchoolPeriods do
       expect(periods.first.school).to eq school_1
       expect(periods.first.started_on).to eq period_1.start_date
       expect(periods.first.finished_on).to eq period_1.end_date
-      expect(periods.first.legacy_start_id).to eq period_1.start_source_id
-      expect(periods.first.legacy_end_id).to eq period_1.end_source_id
+      expect(periods.first.ecf_start_induction_record_id).to eq period_1.start_source_id
+      expect(periods.first.ecf_end_induction_record_id).to eq period_1.end_source_id
 
       expect(periods.last.school).to eq school_2
       expect(periods.last.started_on).to eq period_2.start_date
       expect(periods.last.finished_on).to be_blank
-      expect(periods.last.legacy_start_id).to eq period_2.start_source_id
-      expect(periods.last.legacy_end_id).to eq period_2.end_source_id
+      expect(periods.last.ecf_start_induction_record_id).to eq period_2.start_source_id
+      expect(periods.last.ecf_end_induction_record_id).to eq period_2.end_source_id
     end
 
     context "when the school does not exist" do

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -27,14 +27,14 @@ describe Builders::ECT::TrainingPeriods do
       expect(periods.first.provider_partnership).to eq partnership_1
       expect(periods.first.started_on).to eq training_period_1.start_date
       expect(periods.first.finished_on).to eq training_period_1.end_date
-      expect(periods.first.legacy_start_id).to eq training_period_1.start_source_id
-      expect(periods.first.legacy_end_id).to eq training_period_1.end_source_id
+      expect(periods.first.ecf_start_induction_record_id).to eq training_period_1.start_source_id
+      expect(periods.first.ecf_end_induction_record_id).to eq training_period_1.end_source_id
 
       expect(periods.last.provider_partnership).to eq partnership_2
       expect(periods.last.started_on).to eq training_period_2.start_date
       expect(periods.last.finished_on).to be_blank
-      expect(periods.last.legacy_start_id).to eq training_period_2.start_source_id
-      expect(periods.last.legacy_end_id).to eq training_period_2.end_source_id
+      expect(periods.last.ecf_start_induction_record_id).to eq training_period_2.start_source_id
+      expect(periods.last.ecf_end_induction_record_id).to eq training_period_2.end_source_id
     end
 
     context "when there is no ECTAtSchoolPeriod that contains the training dates" do

--- a/spec/migration/builders/mentor/school_periods_spec.rb
+++ b/spec/migration/builders/mentor/school_periods_spec.rb
@@ -22,14 +22,14 @@ describe Builders::Mentor::SchoolPeriods do
       expect(periods.first.school).to eq school_1
       expect(periods.first.started_on).to eq period_1.start_date
       expect(periods.first.finished_on).to eq period_1.end_date
-      expect(periods.first.legacy_start_id).to eq period_1.start_source_id
-      expect(periods.first.legacy_end_id).to eq period_1.end_source_id
+      expect(periods.first.ecf_start_induction_record_id).to eq period_1.start_source_id
+      expect(periods.first.ecf_end_induction_record_id).to eq period_1.end_source_id
 
       expect(periods.last.school).to eq school_2
       expect(periods.last.started_on).to eq period_2.start_date
       expect(periods.last.finished_on).to be_blank
-      expect(periods.last.legacy_start_id).to eq period_2.start_source_id
-      expect(periods.last.legacy_end_id).to eq period_2.end_source_id
+      expect(periods.last.ecf_start_induction_record_id).to eq period_2.start_source_id
+      expect(periods.last.ecf_end_induction_record_id).to eq period_2.end_source_id
     end
 
     context "when the school does not exist" do

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -27,14 +27,14 @@ describe Builders::Mentor::TrainingPeriods do
       expect(periods.first.provider_partnership).to eq partnership_1
       expect(periods.first.started_on).to eq training_period_1.start_date
       expect(periods.first.finished_on).to eq training_period_1.end_date
-      expect(periods.first.legacy_start_id).to eq training_period_1.start_source_id
-      expect(periods.first.legacy_end_id).to eq training_period_1.end_source_id
+      expect(periods.first.ecf_start_induction_record_id).to eq training_period_1.start_source_id
+      expect(periods.first.ecf_end_induction_record_id).to eq training_period_1.end_source_id
 
       expect(periods.last.provider_partnership).to eq partnership_2
       expect(periods.last.started_on).to eq training_period_2.start_date
       expect(periods.last.finished_on).to be_blank
-      expect(periods.last.legacy_start_id).to eq training_period_2.start_source_id
-      expect(periods.last.legacy_end_id).to eq training_period_2.end_source_id
+      expect(periods.last.ecf_start_induction_record_id).to eq training_period_2.start_source_id
+      expect(periods.last.ecf_end_induction_record_id).to eq training_period_2.end_source_id
     end
 
     context "when there is no MentorAtSchoolPeriod that contains the training dates" do

--- a/spec/migration/builders/mentorship_periods_spec.rb
+++ b/spec/migration/builders/mentorship_periods_spec.rb
@@ -46,14 +46,14 @@ describe Builders::MentorshipPeriods do
       expect(periods.first.mentor).to eq mentor_period_1
       expect(periods.first.started_on).to eq mentorship_period_1.start_date
       expect(periods.first.finished_on).to eq mentorship_period_1.end_date
-      expect(periods.first.legacy_start_id).to eq mentorship_period_1.start_source_id
-      expect(periods.first.legacy_end_id).to eq mentorship_period_1.end_source_id
+      expect(periods.first.ecf_start_induction_record_id).to eq mentorship_period_1.start_source_id
+      expect(periods.first.ecf_end_induction_record_id).to eq mentorship_period_1.end_source_id
 
       expect(periods.last.mentor).to eq mentor_period_2
       expect(periods.last.started_on).to eq mentorship_period_2.start_date
       expect(periods.last.finished_on).to eq mentorship_period_2.end_date
-      expect(periods.last.legacy_start_id).to eq mentorship_period_2.start_source_id
-      expect(periods.last.legacy_end_id).to eq mentorship_period_2.end_source_id
+      expect(periods.last.ecf_start_induction_record_id).to eq mentorship_period_2.start_source_id
+      expect(periods.last.ecf_end_induction_record_id).to eq mentorship_period_2.end_source_id
     end
 
     context "when there is no ECTAtSchoolPeriod that contains the training dates" do

--- a/spec/migration/builders/teacher_spec.rb
+++ b/spec/migration/builders/teacher_spec.rb
@@ -30,12 +30,12 @@ describe Builders::Teacher do
       expect(teacher.trs_last_name).to eq "Thompson"
     end
 
-    context "when a legacy_id is supplied" do
-      let(:legacy_id) { SecureRandom.uuid }
+    context "when an ECF User ID is supplied" do
+      let(:ecf_user_id) { SecureRandom.uuid }
 
-      it "stores the legacy_id" do
-        teacher = described_class.new(trn:, full_name:, legacy_id:).build
-        expect(teacher.legacy_id).to eq legacy_id
+      it "stores the id" do
+        teacher = described_class.new(trn:, full_name:, ecf_user_id:).build
+        expect(teacher.ecf_user_id).to eq ecf_user_id
       end
     end
 


### PR DESCRIPTION
The name `legacy_id` isn't much help, `dqt_id` at least hints at the source of the value.

Refs DFE-Digital/register-ects-project-board#1199

**Note**, this follows on from #240 and should be rebased once it's merged. No point in updating all the importer scripts with this change only to delete them.

This now includes renaming `legacy_` fields used for ECF migration into much nicer things