### PR TITLE
Fix navigation in the register ect journey

### DIFF
--- a/app/wizards/schools/register_ect_wizard/state_school_appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/state_school_appropriate_body_step.rb
@@ -14,7 +14,7 @@ module Schools
       end
 
       def previous_step
-        :start_date
+        :working_pattern
       end
     end
   end

--- a/spec/views/schools/register_ect_wizard/state_school_appropriate_body.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/state_school_appropriate_body.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/register_ect_wizard/state_school_appropriate_body.html.erb" do
-  let(:back_path) { schools_register_ect_wizard_start_date_path }
+  let(:back_path) { schools_register_ect_wizard_working_pattern_path }
   let(:continue_path) { schools_register_ect_wizard_check_answers_path }
   let(:step) { Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep.new }
   let(:ect) { double(full_name: 'John Smith') }

--- a/spec/wizards/schools/register_ect/state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect/state_school_appropriate_body_step_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep, type:
     subject { wizard.current_step }
 
     it 'returns the previous step' do
-      expect(subject.previous_step).to eq(:start_date)
+      expect(subject.previous_step).to eq(:working_pattern)
     end
   end
 


### PR DESCRIPTION
The previous page of State School Appropriate Body page was changed to the Working Pattern page in the Register ECT journey, but the change was never reflected in the code.

This PR sets the previous step to the correct step.
