### PR TITLE
Remove redundant require from spec files

### DIFF
--- a/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Appropriate Body teacher extensions edit", type: :request do
   include AuthHelper
   include ActionView::Helpers::SanitizeHelper

--- a/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Appropriate Body teacher extensions index", type: :request do
   include AuthHelper
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }

--- a/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Appropriate Body teacher extensions new", type: :request do
   include AuthHelper
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe "Appropriate Body teacher index page", type: :request do
   include AuthHelper
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }

--- a/spec/services/admin/current_teachers_spec.rb
+++ b/spec/services/admin/current_teachers_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe Admin::CurrentTeachers do
   describe '#current' do
     context 'with appropriate body IDs' do

--- a/spec/validators/appropriate_body_validator_spec.rb
+++ b/spec/validators/appropriate_body_validator_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe AppropriateBodyValidator do
   let(:test_class) do
     Class.new do

--- a/spec/validators/date_of_birth_validator_spec.rb
+++ b/spec/validators/date_of_birth_validator_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe DateOfBirthValidator do
   let(:test_class) do
     Class.new do

--- a/spec/validators/ect_start_date_validator_spec.rb
+++ b/spec/validators/ect_start_date_validator_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe ECTStartDateValidator do
   context "when date is in an invalid format" do
     let(:start_date) { { 1 => "invalid year", 2 => "invalid month" } }

--- a/spec/validators/programme_type_validator_spec.rb
+++ b/spec/validators/programme_type_validator_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe ProgrammeTypeValidator do
   let(:test_class) do
     Class.new do

--- a/spec/validators/working_pattern_validator_spec.rb
+++ b/spec/validators/working_pattern_validator_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe WorkingPatternValidator do
   let(:test_class) do
     Class.new do

--- a/spec/wizards/schools/register_ect/ect_spec.rb
+++ b/spec/wizards/schools/register_ect/ect_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe Schools::RegisterECTWizard::ECT do
   let(:school) { FactoryBot.create(:school) }
   let(:store) do

--- a/spec/wizards/schools/register_ect/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_ect/email_address_step_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Schools::RegisterECTWizard::EmailAddressStep, type: :model do
   describe 'validations' do
     subject { described_class.new(email:) }

--- a/spec/wizards/schools/register_ect/independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect/independent_school_appropriate_body_step_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep, type: :model do
   describe 'validations' do
     subject { described_class.new(appropriate_body_name:, appropriate_body_type:) }

--- a/spec/wizards/schools/register_ect/programme_type_step_spec.rb
+++ b/spec/wizards/schools/register_ect/programme_type_step_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Schools::RegisterECTWizard::ProgrammeTypeStep, type: :model do
   describe 'validations' do
     subject { described_class.new(programme_type:) }

--- a/spec/wizards/schools/register_ect/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect/start_date_step_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
   describe 'validations' do
     subject { described_class.new(start_date:) }

--- a/spec/wizards/schools/register_ect/state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect/state_school_appropriate_body_step_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep, type: :model do
   describe 'validations' do
     subject { described_class.new(appropriate_body_name:) }

--- a/spec/wizards/schools/register_ect/working_pattern_step_spec.rb
+++ b/spec/wizards/schools/register_ect/working_pattern_step_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Schools::RegisterECTWizard::WorkingPatternStep, type: :model do
   describe 'validations' do
     subject { described_class.new(working_pattern:) }


### PR DESCRIPTION
The rails_helper is configured in the .rspec to be loaded by default.