### PR TITLE
Add before and after scopes to interval

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -12,7 +12,10 @@ module Interval
     scope :finished, -> { where.not(finished_on: nil) }
     scope :earliest_first, -> { order(started_on: 'asc') }
     scope :latest_first, -> { order(started_on: 'desc') }
-
+    scope :started_before, ->(date) { where(arel_table[:started_on].lt(date)) }
+    scope :started_on_or_after, ->(date) { where(arel_table[:started_on].gteq(date)) }
+    scope :finished_before, ->(date) { where(arel_table[:finished_on].lt(date)) }
+    scope :finished_on_or_after, ->(date) { where(arel_table[:finished_on].gteq(date)) }
     scope :containing_period, ->(period) { where("range @> daterange(?, ?)", period.started_on, period.finished_on) }
   end
 

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -12,10 +12,10 @@ module Interval
     scope :finished, -> { where.not(finished_on: nil) }
     scope :earliest_first, -> { order(started_on: 'asc') }
     scope :latest_first, -> { order(started_on: 'desc') }
-    scope :started_before, ->(date) { where(arel_table[:started_on].lt(date)) }
-    scope :started_on_or_after, ->(date) { where(arel_table[:started_on].gteq(date)) }
-    scope :finished_before, ->(date) { where(arel_table[:finished_on].lt(date)) }
-    scope :finished_on_or_after, ->(date) { where(arel_table[:finished_on].gteq(date)) }
+    scope :started_before, ->(date) { where(started_on: ...date) }
+    scope :started_on_or_after, ->(date) { where(started_on: date..) }
+    scope :finished_before, ->(date) { where(finished_on: ...date) }
+    scope :finished_on_or_after, ->(date) { where(finished_on: date..) }
     scope :containing_period, ->(period) { where("range @> daterange(?, ?)", period.started_on, period.finished_on) }
   end
 

--- a/app/services/admin/update_induction_period_service.rb
+++ b/app/services/admin/update_induction_period_service.rb
@@ -49,10 +49,8 @@ module Admin
       )
     end
 
-    def earliest_period?
-      !InductionPeriod.where(teacher:)
-        .where("started_on < ?", induction_period.started_on)
-        .exists?
+    def earlier_periods?
+      !InductionPeriod.where(teacher:).started_before(induction_period.started_on).exists?
     end
   end
 end

--- a/app/services/admin/update_induction_period_service.rb
+++ b/app/services/admin/update_induction_period_service.rb
@@ -41,7 +41,8 @@ module Admin
     end
 
     def notify_trs_of_start_date_change(previous_start_date)
-      return unless earliest_period? && previous_start_date != induction_period.started_on
+      return if teacher_has_earlier_induction_periods?
+      return if previous_start_date == induction_period.started_on
 
       BeginECTInductionJob.perform_later(
         trn: teacher.trn,
@@ -49,8 +50,8 @@ module Admin
       )
     end
 
-    def earlier_periods?
-      !InductionPeriod.where(teacher:).started_before(induction_period.started_on).exists?
+    def teacher_has_earlier_induction_periods?
+      InductionPeriod.where(teacher:).started_before(induction_period.started_on).exists?
     end
   end
 end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -74,6 +74,30 @@ describe Interval do
         expect(DummyMentor.containing_period(FakePeriod.new('2021-09-01', '2023-12-31'))).to be_empty
       end
     end
+
+    describe '.started_before' do
+      it 'returns records where the started_on date is earlier than the provided date' do
+        expect(DummyMentor.started_before(Date.yesterday).to_sql).to end_with(%("started_on" < '#{Date.yesterday.iso8601}'))
+      end
+    end
+
+    describe '.started_on_or_after' do
+      it 'returns records where the started_on date is equal to or later than the provided date' do
+        expect(DummyMentor.started_on_or_after(Date.yesterday).to_sql).to end_with(%("started_on" >= '#{Date.yesterday.iso8601}'))
+      end
+    end
+
+    describe '.finished_before' do
+      it 'returns records where the finished_on date is earlier than the provided date' do
+        expect(DummyMentor.finished_before(Date.yesterday).to_sql).to end_with(%("finished_on" < '#{Date.yesterday.iso8601}'))
+      end
+    end
+
+    describe '.finished_on_or_after' do
+      it 'returns records where the finished_on date is equal to or later than the provided date' do
+        expect(DummyMentor.finished_on_or_after(Date.yesterday).to_sql).to end_with(%("finished_on" >= '#{Date.yesterday.iso8601}'))
+      end
+    end
   end
 
   describe "#finish!" do


### PR DESCRIPTION
We'll undoubtably need to filter all kinds of periods by whether they started before, on or after a certain date. This change adds some common scopes that means we can do it consistently without having to use snippets of SQL.

- **Add started before/on or after scopes to interval**
- **Use started_before scope instead of where clause**
