### PR TITLE
[971] - email address entered for a new mentor is already in use by an active teacher record with a different trn

### DIFF
--- a/app/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb
+++ b/app/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb
@@ -1,10 +1,10 @@
 ---
 title: You cannot assign an ECT as their own mentor
-backlink_href: <%= schools_register_mentor_wizard_find_mentor_path %>
+backlink_href: <%= @wizard.previous_step_path %>
 ---
 
 You have entered the same details for the mentor as the ECT you are assigning them to.
 
 You must assign someone else as the ECT's mentor.
 
-<%= govuk_button_link_to('Assign a different mentor', schools_register_mentor_wizard_find_mentor_path) %>
+<%= govuk_button_link_to('Assign a different mentor', @wizard.previous_step_path) %>

--- a/app/views/schools/register_mentor_wizard/cant_use_email.md.erb
+++ b/app/views/schools/register_mentor_wizard/cant_use_email.md.erb
@@ -1,0 +1,10 @@
+---
+title: This email is already in use for a different ECT or mentor
+backlink_href: <%= @wizard.previous_step_path %>
+---
+
+Make sure you use an email that belongs to the person you're registering.
+
+Do not use a generic email like [admin@example.com]('mailto:admin@example.com').
+
+<%= govuk_button_link_to('Try another email', @wizard.previous_step_path) %>

--- a/app/views/schools/register_mentor_wizard/change_email_address.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_email_address.html.erb
@@ -1,2 +1,1 @@
-<%= render 'email_address',
-           backlink_href: schools_register_mentor_wizard_check_answers_path %>
+<%= render 'email_address', backlink_href: @wizard.previous_step_path %>

--- a/app/views/schools/register_mentor_wizard/change_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_mentor_details.html.erb
@@ -1,2 +1,1 @@
-<%= render 'review_mentor_details',
-           backlink_href: schools_register_mentor_wizard_check_answers_path %>
+<%= render 'review_mentor_details', backlink_href: @wizard.previous_step_path %>

--- a/app/views/schools/register_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/register_mentor_wizard/check_answers.html.erb
@@ -1,4 +1,5 @@
-<% page_data(title: "Check your answers and confirm mentor details", backlink_href: schools_register_mentor_wizard_email_address_path) %>
+<% page_data(title: "Check your answers and confirm mentor details",
+             backlink_href: @wizard.previous_step_path) %>
 
 <%= govuk_summary_list do |summary_list|
   summary_list.with_row do |row|

--- a/app/views/schools/register_mentor_wizard/email_address.html.erb
+++ b/app/views/schools/register_mentor_wizard/email_address.html.erb
@@ -1,2 +1,1 @@
-<%= render 'email_address',
-           backlink_href: schools_register_mentor_wizard_review_mentor_details_path %>
+<%= render 'email_address', backlink_href: @wizard.previous_step_path %>

--- a/app/views/schools/register_mentor_wizard/national_insurance_number.html.erb
+++ b/app/views/schools/register_mentor_wizard/national_insurance_number.html.erb
@@ -1,4 +1,6 @@
-<% page_data(title: "We cannot find the mentor's details", error: @wizard.current_step.errors.present?, backlink_href: schools_register_mentor_wizard_find_mentor_path) %>
+<% page_data(title: "We cannot find the mentor's details",
+             error: @wizard.current_step.errors.present?,
+             backlink_href: @wizard.previous_step_path) %>
 
 <p class="govuk-body">We cannot find a match with the details you've given. You'll need to provide more information about the mentor to help us locate them.</p>
 

--- a/app/views/schools/register_mentor_wizard/not_found.md.erb
+++ b/app/views/schools/register_mentor_wizard/not_found.md.erb
@@ -6,4 +6,4 @@ You can check the mentor's teacher reference number (TRN) is accurate by [review
 
 Alternatively, you can ask the mentor to check their TRN by using the [Find a lost TRN service](https://find-a-lost-trn.education.gov.uk/start).
 
-<%= govuk_button_link_to("Try again", schools_register_mentor_wizard_find_mentor_path) %>
+<%= govuk_button_link_to("Try again", @wizard.previous_step_path) %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_details.html.erb
@@ -1,2 +1,1 @@
-<%= render 'review_mentor_details',
-           backlink_href: schools_register_mentor_wizard_find_mentor_path %>
+<%= render 'review_mentor_details', backlink_href: @wizard.previous_step_path %>

--- a/app/views/schools/register_mentor_wizard/start.html.erb
+++ b/app/views/schools/register_mentor_wizard/start.html.erb
@@ -1,4 +1,5 @@
-<% page_data(title: "What you'll need to add a new mentor for #{@ect_name}", error: false, backlink_href: schools_ects_home_path) %>
+<% page_data(title: "What you'll need to add a new mentor for #{@ect_name}",
+             backlink_href: schools_ects_home_path) %>
 
 <p class="govuk-body">You must provide the mentor's:</p>
 <ul class="govuk-list govuk-list--bullet">

--- a/app/wizards/schools/register_ect_wizard/cannot_register_ect_step.rb
+++ b/app/wizards/schools/register_ect_wizard/cannot_register_ect_step.rb
@@ -1,6 +1,9 @@
 module Schools
   module RegisterECTWizard
     class CannotRegisterECTStep < Step
+      def previous_step
+        :find_mentor
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/cannot_mentor_themself_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/cannot_mentor_themself_step.rb
@@ -3,6 +3,9 @@
 module Schools
   module RegisterMentorWizard
     class CannotMentorThemselfStep < Step
+      def previous_step
+        :find_mentor
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/cant_use_email_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/cant_use_email_step.rb
@@ -1,0 +1,13 @@
+module Schools
+  module RegisterMentorWizard
+    class CantUseEmailStep < Step
+      def next_step
+        :email_address
+      end
+
+      def previous_step
+        :email_address
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/change_email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/change_email_address_step.rb
@@ -1,6 +1,9 @@
 module Schools
   module RegisterMentorWizard
     class ChangeEmailAddressStep < EmailAddressStep
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/change_mentor_details_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/change_mentor_details_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
@@ -5,6 +5,10 @@ module Schools
         :confirmation
       end
 
+      def previous_step
+        :email_address
+      end
+
     private
 
       def persist

--- a/app/wizards/schools/register_mentor_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/email_address_step.rb
@@ -10,7 +10,13 @@ module Schools
       end
 
       def next_step
+        return :cant_use_email if mentor.cant_use_email?
+
         :check_answers
+      end
+
+      def previous_step
+        :review_mentor_details
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
@@ -19,6 +19,10 @@ module Schools
         :review_mentor_details
       end
 
+      def previous_step
+        :find_mentor
+      end
+
     private
 
       def persist

--- a/app/wizards/schools/register_mentor_wizard/not_found_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/not_found_step.rb
@@ -1,6 +1,9 @@
 module Schools
   module RegisterMentorWizard
     class NotFoundStep < Step
+      def previous_step
+        :find_mentor
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_details_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_details_step.rb
@@ -17,6 +17,12 @@ module Schools
         :email_address
       end
 
+      def previous_step
+        return :find_mentor if mentor.matches_trs_dob?
+
+        :national_insurance_number
+      end
+
     private
 
       def formatted_name

--- a/app/wizards/schools/register_mentor_wizard/trn_not_found_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/trn_not_found_step.rb
@@ -1,6 +1,9 @@
 module Schools
   module RegisterMentorWizard
     class TRNNotFoundStep < Step
+      def previous_step
+        :find_mentor
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -9,6 +9,7 @@ module Schools
             already_active_at_school: AlreadyActiveAtSchoolStep,
             cannot_mentor_themself: CannotMentorThemselfStep,
             cannot_register_mentor: CannotRegisterMentorStep,
+            cant_use_email: CantUseEmailStep,
             change_email_address: ChangeEmailAddressStep,
             change_mentor_details: ChangeMentorDetailsStep,
             check_answers: CheckAnswersStep,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,9 @@ Rails.application.routes.draw do
       get "email-address", action: :new
       post "email-address", action: :create
 
+      get "cant-use-email", action: :new
+      post "cant-use-email", action: :create
+
       get "check-answers", action: :new
       post "check-answers", action: :create
 

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
 
     started_on { generate(:base_ect_date) }
     finished_on { started_on + 5.days }
+    email { Faker::Internet.email }
 
     trait :active do
       finished_on { nil }

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
 
     started_on { generate(:base_mentor_date) }
     finished_on { started_on + 5.days }
+    email { Faker::Internet.email }
 
     trait :active do
       finished_on { nil }

--- a/spec/features/schools/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Registering a mentor' do
     when_i_click_continue
     then_i_should_be_taken_to_the_find_mentor_page
 
-    when_i_submit_the_trn_of_the_ect
+    when_i_submit_the_details_of_the_ect
     then_i_should_be_taken_to_the_cannot_mentor_themself_page
 
     when_i_click_on_assign_a_different_mentor
@@ -56,7 +56,7 @@ RSpec.describe 'Registering a mentor' do
     expect(page.url).to end_with(path)
   end
 
-  def when_i_submit_the_trn_of_the_ect
+  def when_i_submit_the_details_of_the_ect
     page.get_by_label('trn').fill(@ect.trn)
     page.get_by_label('day').fill('1')
     page.get_by_label('month').fill('2')
@@ -70,10 +70,5 @@ RSpec.describe 'Registering a mentor' do
 
   def when_i_click_on_assign_a_different_mentor
     page.get_by_role('link', name: 'Assign a different mentor').click
-  end
-
-  def then_i_should_be_taken_to_the_find_mentor_page
-    path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
   end
 end

--- a/spec/features/schools/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -1,0 +1,135 @@
+RSpec.describe 'Registering a mentor', :js do
+  include_context 'fake trs api client'
+
+  let(:trn) { '3002586' }
+
+  scenario 'Teacher with email in use' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_find_mentor_form
+    then_i_should_be_taken_to_the_review_mentor_details_page
+    and_i_should_see_the_mentor_details_in_the_review_page
+
+    when_i_select_that_my_mentor_name_is_incorrect
+    and_i_enter_the_corrected_name
+    and_i_click_confirm_and_continue
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_an_email_address_already_in_use
+    and_i_click_continue
+    then_i_should_be_taken_to_the_cant_use_email_page
+
+    when_i_click_try_another_email
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_an_email_address_already_in_use
+    and_i_click_continue
+    then_i_should_be_taken_to_the_cant_use_email_page
+
+    when_i_click_back
+    then_i_should_be_taken_to_the_email_address_page
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_submit_the_find_mentor_form
+    if ActiveModel::Type::Boolean.new.cast(ENV.fetch('TEST_GUIDANCE', false))
+      page.get_by_role(:row, name: trn).get_by_role(:button, name: "Select").first.click
+    else
+      page.get_by_label('trn').fill(trn)
+      page.get_by_label('day').fill('3')
+      page.get_by_label('month').fill('2')
+      page.get_by_label('year').fill('1977')
+    end
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+  end
+
+  def and_i_should_see_the_mentor_details_in_the_review_page
+    expect(page.get_by_text(trn)).to be_visible
+    expect(page.get_by_text("Kirk Van Houten")).to be_visible
+    expect(page.get_by_text("3 February 1977")).to be_visible
+  end
+
+  def when_i_select_that_my_mentor_name_is_incorrect
+    page.get_by_label("No, they changed their name or it's spelt wrong").check
+  end
+
+  def and_i_enter_the_corrected_name
+    page.get_by_label('Enter the correct full name').fill('Kirk Van Damme')
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role('button', name: 'Confirm and continue').click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page.url).to end_with('/school/register-mentor/email-address')
+  end
+
+  def when_i_enter_an_email_address_already_in_use
+    page.get_by_label('email').fill(@ect.email)
+  end
+
+  def and_i_click_continue
+    page.get_by_role('button', name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_cant_use_email_page
+    expect(page.url).to end_with('/school/register-mentor/cant-use-email')
+  end
+
+  def when_i_click_try_another_email
+    page.get_by_role('link', name: 'Try another email').click
+  end
+
+  def when_i_click_back
+    page.get_by_role('link', name: 'Back').click
+  end
+end

--- a/spec/features/schools/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -130,6 +130,6 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_back
-    page.get_by_role('link', name: 'Back').click
+    page.get_by_role('link', name: 'Back', exact: true).click
   end
 end

--- a/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "schools/register_mentor_wizard/already_active_at_school.md.erb" 
   let(:store) { double(trs_first_name: "John", trs_last_name: "Waters", corrected_name: "Jim Waters") }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :already_active_at_school, store:) }
   let(:mentor) { wizard.mentor }
-  let(:title) { "This mentor has already been registered" }
 
   before do
     assign(:wizard, wizard)
@@ -13,8 +12,8 @@ RSpec.describe "schools/register_mentor_wizard/already_active_at_school.md.erb" 
     render
   end
 
-  it "sets the page title to 'This mentor has already been registered'" do
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context "page title" do
+    it { expect(sanitize(view.content_for(:page_title))).to eql("This mentor has already been registered") }
   end
 
   it 'includes no back button' do

--- a/spec/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe "schools/register_mentor_wizard/cannot_mentor_themself.md.erb" do
   let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:title) { 'You cannot assign an ECT as their own mentor' }
+  let(:store) { double(trs_first_name: "John", trs_last_name: "Waters") }
+  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :cannot_mentor_themself, store:) }
 
   before do
+    assign(:wizard, wizard)
     render
   end
 
-  it "sets the page title to 'You cannot assign an ECT as their own mentor'" do
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context 'page title' do
+    it { expect(sanitize(view.content_for(:page_title))).to eql('You cannot assign an ECT as their own mentor') }
   end
 
   it 'includes a back button that links to find-mentor page of the journey' do

--- a/spec/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cannot_register_mentor.html.erb_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "schools/register_mentor_wizard/cannot_register_mentor" do
   let(:mentor) { double('Mentor', full_name: 'Jane Smith') }
-  let(:title) { "You cannot register #{mentor.full_name}" }
+  let(:title) {}
 
   before do
     assign(:mentor, mentor)
     render
   end
 
-  it "sets the page title to 'You cannot register Jane Smith'" do
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context 'page title' do
+    it { expect(sanitize(view.content_for(:page_title))).to eql('You cannot register Jane Smith') }
   end
 
   it "displays the cannot register mentor message" do

--- a/spec/views/schools/register_mentor_wizard/cant_use_email.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cant_use_email.md.erb_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'schools/register_mentor_wizard/cant_use_email.md.erb' do
+  let(:title) { 'This email is already in use for a different ECT or mentor' }
+  let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
+
+  before { render }
+
+  it "sets the page title" do
+    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  end
+
+  it 'includes a back button that links to find-mentor page of the journey' do
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: back_path)
+  end
+
+  it 'includes a try another email button that links to the find mentor page' do
+    expect(rendered).to have_link('Try another email', href: back_path)
+  end
+end

--- a/spec/views/schools/register_mentor_wizard/cant_use_email.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cant_use_email.md.erb_spec.rb
@@ -1,11 +1,15 @@
 RSpec.describe 'schools/register_mentor_wizard/cant_use_email.md.erb' do
-  let(:title) { 'This email is already in use for a different ECT or mentor' }
-  let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
+  let(:back_path) { schools_register_mentor_wizard_email_address_path }
+  let(:store) { double(trs_first_name: "John", trs_last_name: "Waters", email: 'a@email.com') }
+  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :cant_use_email, store:) }
 
-  before { render }
+  before do
+    assign(:wizard, wizard)
+    render
+  end
 
-  it "sets the page title" do
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context 'page title' do
+    it { expect(sanitize(view.content_for(:page_title))).to eql('This email is already in use for a different ECT or mentor') }
   end
 
   it 'includes a back button that links to find-mentor page of the journey' do

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   let(:back_path) { schools_register_mentor_wizard_email_address_path }
   let(:confirm_details_path) { schools_register_mentor_wizard_check_answers_path }
   let(:ect_name) { "Michael Dixon" }
-  let(:title) { "Check your answers and confirm mentor details" }
   let(:store) do
     FactoryBot.build(:session_repository,
                      trn: "1234567",
@@ -21,10 +20,10 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
     assign(:mentor, mentor)
   end
 
-  it "sets the page title to 'Check mentor details'" do
-    render
+  context 'page title' do
+    before { render }
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+    it { expect(sanitize(view.content_for(:page_title))).to eql('Check your answers and confirm mentor details') }
   end
 
   it 'includes a back button that links to trn and dob page of the journey' do

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
   let(:ect_name) { "Michale Dixon" }
   let(:your_ects_path) { schools_ects_home_path }
   let(:mentor) { wizard.mentor }
-  let(:title) { "You've assigned #{mentor.full_name} as a mentor" }
   let(:store) { double(trs_first_name: "John", trs_last_name: "Wayne", corrected_name: nil, already_active_at_school:) }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :confirmation, store:) }
 
@@ -15,8 +14,8 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
     render
   end
 
-  it "sets the page title to 'You've assigned <mentor name> as a mentor'" do
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context "page title" do
+    it { expect(sanitize(view.content_for(:page_title))).to eql("You've assigned #{mentor.full_name} as a mentor") }
   end
 
   it 'includes no back button' do

--- a/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
@@ -2,17 +2,16 @@ RSpec.describe "schools/register_mentor_wizard/find_mentor.html.erb" do
   let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
   let(:back_path) { schools_register_mentor_wizard_start_path(ect_id: ect.id) }
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:title) { "Find a mentor" }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, ect_id: ect.id) }
 
   before do
     assign(:wizard, wizard)
   end
 
-  it "sets the page title to 'Find a mentor'" do
-    render
+  context "page title" do
+    before { render }
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+    it { expect(sanitize(view.content_for(:page_title))).to eql('Find a mentor') }
   end
 
   it "prefixes the page with 'Error:' when the trn or date of birth values are invalid" do

--- a/spec/views/schools/register_mentor_wizard/national_insurance_number.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/national_insurance_number.html.erb_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe "schools/register_mentor_wizard/national_insurance_number.html.erb" do
   let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:continue_path) { schools_register_mentor_wizard_national_insurance_number_path }
-  let(:title) { "We cannot find the mentor's details" }
   let(:wizard) do
     FactoryBot.build(:register_mentor_wizard,
                      current_step: :national_insurance_number,
@@ -12,10 +11,10 @@ RSpec.describe "schools/register_mentor_wizard/national_insurance_number.html.er
     assign(:wizard, wizard)
   end
 
-  it "sets the page title to 'We cannot find the mentor's details'" do
-    render
+  context 'page title' do
+    before { render }
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+    it { expect(sanitize(view.content_for(:page_title))).to eql("We cannot find the mentor's details") }
   end
 
   it "prefixes the page with 'Error:' when the national insurance number is invalid" do

--- a/spec/views/schools/register_mentor_wizard/no_trn.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/no_trn.md.erb_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "schools/register_mentor_wizard/no_trn.md.erb" do
     render
   end
 
-  it "sets the page title to 'You cannot register a mentor without a TRN'" do
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context "page title" do
+    it { expect(sanitize(view.content_for(:page_title))).to eql('You cannot register a mentor without a TRN') }
   end
 
   it 'includes no back button' do

--- a/spec/views/schools/register_mentor_wizard/not_found.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/not_found.md.erb_spec.rb
@@ -2,35 +2,31 @@ RSpec.describe "schools/register_mentor_wizard/not_found.md.erb" do
   let(:find_a_lost_trn_path) { "https://find-a-lost-trn.education.gov.uk/start" }
   let(:review_teacher_record_path) { "https://www.gov.uk/guidance/check-a-teachers-record" }
   let(:try_again_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:title) { "We're unable to match the mentor with the details you provided" }
+  let(:store) { double(trs_first_name: "John", trs_last_name: "Waters") }
+  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :not_found, store:) }
 
-  it "sets the page title to 'We're unable to match the mentor with the details you provided'" do
+  before do
+    assign(:wizard, wizard)
     render
+  end
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+  context 'page title' do
+    it { expect(sanitize(view.content_for(:page_title))).to eql("We're unable to match the mentor with the details you provided") }
   end
 
   it 'includes no back button' do
-    render
-
     expect(view.content_for(:backlink_or_breadcrumb)).to be_blank
   end
 
   it 'includes a link to reviewing the teacher record' do
-    render
-
     expect(rendered).to have_link('reviewing their teacher record', href: review_teacher_record_path)
   end
 
   it 'includes a link to the Find a lost TRN service' do
-    render
-
     expect(rendered).to have_link('Find a lost TRN service', href: find_a_lost_trn_path)
   end
 
   it 'includes a try again button that links to the find mentor page' do
-    render
-
     expect(rendered).to have_link('Try again', href: try_again_path)
   end
 end

--- a/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
@@ -1,6 +1,5 @@
 RSpec.shared_examples "an email address step view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:mentor) { wizard.mentor }
-  let(:title) { "What is Jim Waters's email address?" }
   let(:email) { nil }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
   let(:store) do
@@ -18,10 +17,10 @@ RSpec.shared_examples "an email address step view" do |current_step:, back_path:
     assign(:mentor, mentor)
   end
 
-  it "sets the page title to 'What is Jim Waters's email address'" do
-    render
+  context 'page title' do
+    before { render }
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+    it { expect(sanitize(view.content_for(:page_title))).to eql("What is Jim Waters's email address?") }
   end
 
   context "when the email is invalid" do

--- a/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 RSpec.shared_examples "a review mentor details step view" do |current_step:,
                                                               back_path:,
                                                               back_step_name:,
@@ -9,7 +7,6 @@ RSpec.shared_examples "a review mentor details step view" do |current_step:,
                                                               check_details_step_name:|
   let(:date_of_birth) { "1950/1/1" }
   let(:national_insurance_number) { "AD12345ED" }
-  let(:title) { "Check mentor details" }
   let(:email) { nil }
   let(:store) do
     FactoryBot.build(:session_repository,
@@ -30,10 +27,10 @@ RSpec.shared_examples "a review mentor details step view" do |current_step:,
     assign(:mentor, mentor)
   end
 
-  it "sets the page title to 'Check mentor details'" do
-    render
+  context 'page title' do
+    before { render }
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+    it { expect(sanitize(view.content_for(:page_title))).to eql('Check mentor details') }
   end
 
   it "prefixes the page with 'Error:' when any step data is invalid" do

--- a/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
@@ -2,16 +2,16 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   let(:back_path) { schools_ects_home_path }
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:ect_name) { 'James Lorie' }
-  let(:title) { "What you'll need to add a new mentor for #{ect_name}" }
+  let(:title) {}
 
   before do
     assign(:ect_name, ect_name)
   end
 
-  it "sets the page title to 'What you'll need to add a new mentor for <ect_name>'" do
-    render
+  context "page title" do
+    before { render }
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+    it { expect(sanitize(view.content_for(:page_title))).to eql("What you'll need to add a new mentor for #{ect_name}") }
   end
 
   it 'includes a back button that links to the school home page' do

--- a/spec/views/schools/register_mentor_wizard/trn_not_found.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/trn_not_found.md.erb_spec.rb
@@ -2,12 +2,13 @@ RSpec.describe "schools/register_mentor_wizard/trn_not_found.md.erb" do
   let(:find_a_lost_trn_path) { "https://find-a-lost-trn.education.gov.uk/start" }
   let(:review_teacher_record_path) { "https://www.gov.uk/guidance/check-a-teachers-record" }
   let(:try_again_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:title) { "We're unable to match the mentor with the details you provided" }
 
-  it "sets the page title to 'We're unable to match the mentor with the details you provided'" do
-    render
+  context "page title" do
+    it do
+      render
 
-    expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))
+      expect(sanitize(view.content_for(:page_title))).to eql("We're unable to match the mentor with the details you provided")
+    end
   end
 
   it 'includes no back button' do

--- a/spec/wizards/schools/register_mentor_wizard/change_email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/change_email_address_step_spec.rb
@@ -1,5 +1,5 @@
 require_relative './shared_examples/email_step'
 
 describe Schools::RegisterMentorWizard::ChangeEmailAddressStep, type: :model do
-  it_behaves_like 'an email step', current_step: :change_email_address
+  it_behaves_like 'an email step', current_step: :change_email_address, previous_step: :check_answers
 end

--- a/spec/wizards/schools/register_mentor_wizard/change_mentor_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/change_mentor_details_step_spec.rb
@@ -4,4 +4,20 @@ describe Schools::RegisterMentorWizard::ChangeMentorDetailsStep, type: :model do
   it_behaves_like 'a review mentor details step',
                   current_step: :change_mentor_details,
                   next_step: :check_answers
+
+  describe '#previous_step' do
+    let(:store) do
+      FactoryBot.build(:session_repository,
+                       trn: '1234567',
+                       trs_first_name: 'John',
+                       trs_last_name: 'Wayne',
+                       corrected_name: 'Jim Wayne',
+                       date_of_birth: '01/01/1990',
+                       email: 'initial@email.com')
+    end
+    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :change_mentor_details, store:) }
+    subject { wizard.current_step }
+
+    it { expect(subject.previous_step).to eq(:check_answers) }
+  end
 end

--- a/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
@@ -1,5 +1,5 @@
 require_relative './shared_examples/email_step'
 
 describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
-  it_behaves_like 'an email step', current_step: :email_address
+  it_behaves_like 'an email step', current_step: :email_address, previous_step: :review_mentor_details
 end

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -54,6 +54,30 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
   end
 
+  describe '#cant_use_email?' do
+    context 'when there is an active ECT with the email in use' do
+      before { FactoryBot.create(:ect_at_school_period, :active, email: mentor.email) }
+
+      it 'returns true' do
+        expect(mentor.cant_use_email?).to be_truthy
+      end
+    end
+
+    context 'when there is an active mentor with the email in use' do
+      before { FactoryBot.create(:mentor_at_school_period, :active, email: mentor.email) }
+
+      it 'returns true' do
+        expect(mentor.cant_use_email?).to be_truthy
+      end
+    end
+
+    context 'otherwise' do
+      it 'returns false' do
+        expect(mentor.cant_use_email?).to be_falsey
+      end
+    end
+  end
+
   describe '#email' do
     it 'returns the email address' do
       expect(mentor.email).to eq("dusty@rhodes.com")

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -153,6 +153,14 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
   end
 
+  describe '#previous_step' do
+    subject { wizard.current_step }
+
+    it 'returns :find_mentor' do
+      expect(subject.previous_step).to eq(:find_mentor)
+    end
+  end
+
   context '#save!' do
     context 'when the step is not valid' do
       let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :national_insurance_number) }

--- a/spec/wizards/schools/register_mentor_wizard/review_mentor_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/review_mentor_details_step_spec.rb
@@ -4,4 +4,30 @@ describe Schools::RegisterMentorWizard::ReviewMentorDetailsStep, type: :model do
   it_behaves_like 'a review mentor details step',
                   current_step: :review_mentor_details,
                   next_step: :email_address
+
+  describe '#previous_step' do
+    let(:store) do
+      FactoryBot.build(:session_repository,
+                       trn: '1234567',
+                       trs_first_name: 'John',
+                       trs_last_name: 'Wayne',
+                       corrected_name: 'Jim Wayne',
+                       date_of_birth: '01/01/1990',
+                       email: 'initial@email.com')
+    end
+    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :review_mentor_details, store:) }
+    subject { wizard.current_step }
+
+    context "when the date of birth matches TRS" do
+      before { allow(wizard.mentor).to receive(:matches_trs_dob?).and_return(true) }
+
+      it { expect(subject.previous_step).to eq(:find_mentor) }
+    end
+
+    context "when the date of birth doesn't match TRS" do
+      before { allow(wizard.mentor).to receive(:matches_trs_dob?).and_return(false) }
+
+      it { expect(subject.previous_step).to eq(:national_insurance_number) }
+    end
+  end
 end

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "an email step" do |current_step:|
+RSpec.shared_examples "an email step" do |current_step:, previous_step:|
   let(:store) do
     FactoryBot.build(:session_repository,
                      trn: "1234567",
@@ -47,5 +47,15 @@ RSpec.shared_examples "an email step" do |current_step:|
     end
 
     it { expect(wizard.next_step).to eq(:check_answers) }
+  end
+
+  describe '#previous_step' do
+    let(:step_params) do
+      ActionController::Parameters.new("email_address" => { "email" => 'valid@email.com' })
+    end
+
+    subject { FactoryBot.build(:register_mentor_wizard, current_step:, step_params:).current_step }
+
+    it { expect(subject.previous_step).to eq(previous_step) }
   end
 end


### PR DESCRIPTION
Make sure the email registered by a mentor is not in use by any active ECT or Mentor.
New step in the journey to explain the user why their email is invalid.

![image](https://github.com/user-attachments/assets/3ea9c597-842b-4eeb-a384-1c7d59f29e9c)

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/971)


Video:

https://github.com/user-attachments/assets/43b851e5-613a-4012-8887-212dab79570d



Better review commit by commit