### PR TITLE
Record events for admin induction period updates

### DIFF
--- a/app/controllers/admin/induction_periods_controller.rb
+++ b/app/controllers/admin/induction_periods_controller.rb
@@ -8,7 +8,8 @@ module Admin
       @induction_period = InductionPeriod.find(params[:id])
       service = UpdateInductionPeriodService.new(
         induction_period: @induction_period,
-        params: induction_period_params
+        params: induction_period_params,
+        author: current_user
       )
 
       if service.update_induction!

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   EVENT_TYPES = %w[
+    admin_updates_induction_period
     appropriate_body_claims_teacher
     appropriate_body_releases_teacher
     appropriate_body_fails_teacher

--- a/app/services/events/describe_modifications.rb
+++ b/app/services/events/describe_modifications.rb
@@ -1,0 +1,28 @@
+module Events
+  # Describe the changes made in an ActiveRecord object so they
+  # can be recorded in the event log
+  #
+  # ActiveRecord shows changes in this format:
+  # ab = AppropriateBody.assign_attributes(local_authority_code: 419)
+  # ab.changes
+  # => {"local_authority_code"=>[418, 419]}
+  #
+  # We want them in a human-readable list:
+  #
+  # Local authority code changed from 418 to 419
+  class DescribeModifications
+    attr_reader :modifications
+
+    def initialize(modifications)
+      @modifications = modifications
+    end
+
+    def describe
+      return if modifications.nil?
+
+      modifications.map do |attribute_name, modification|
+        "#{attribute_name.humanize} changed from #{modification[0]} to #{modification[1]}"
+      end
+    end
+  end
+end

--- a/app/services/events/describe_modifications.rb
+++ b/app/services/events/describe_modifications.rb
@@ -21,8 +21,27 @@ module Events
       return if modifications.nil?
 
       modifications.map do |attribute_name, modification|
-        "#{attribute_name.humanize} changed from #{modification[0]} to #{modification[1]}"
+        if modification[0].blank?
+          "#{attribute_name.humanize} set to #{format(modification[1])}"
+        elsif modification[1].blank?
+          "#{attribute_name.humanize} #{format(modification[0])} removed"
+        else
+          "#{attribute_name.humanize} changed from #{format(modification[0])} to #{format(modification[1])}"
+        end
       end
+    end
+
+  private
+
+    def format(value)
+      formatted_value = case value
+                        when Date
+                          value.to_formatted_s(:govuk_short)
+                        else
+                          value
+                        end
+
+      %('#{formatted_value}')
     end
   end
 end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -20,7 +20,9 @@ module Events
                 :provider_partnership,
                 :lead_provider,
                 :delivery_partner,
-                :user
+                :user,
+                :modifications,
+                :metadata
 
     def initialize(
       author:,
@@ -40,7 +42,9 @@ module Events
       provider_partnership: nil,
       lead_provider: nil,
       delivery_partner: nil,
-      user: nil
+      user: nil,
+      modifications: nil,
+      metadata: nil
     )
       @author = author
       @event_type = event_type
@@ -60,6 +64,8 @@ module Events
       @lead_provider = lead_provider
       @delivery_partner = delivery_partner
       @user = user
+      @modifications = DescribeModifications.new(modifications).describe
+      @metadata = metadata || modifications
     end
 
     def record_event!
@@ -108,10 +114,20 @@ module Events
       new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
     end
 
+    # Admin events
+
+    def self.record_admin_updates_induction_period!(author:, modifications:, induction_period:, teacher:, appropriate_body:, happened_at: Time.zone.now)
+      event_type = :admin_updates_induction_period
+
+      heading = 'Induction period updated by admin'
+
+      new(event_type:, modifications:, author:, appropriate_body:, induction_period:, teacher:, heading:, happened_at:).record_event!
+    end
+
   private
 
     def attributes
-      { **event_attributes, **author_attributes, **relationship_attributes }
+      { **event_attributes, **author_attributes, **relationship_attributes, **changelog_attributes }
     end
 
     def event_attributes
@@ -150,6 +166,10 @@ module Events
         delivery_partner:,
         user:
       }.compact
+    end
+
+    def changelog_attributes
+      { modifications:, metadata: }.compact
     end
 
     def check_relationship_attributes_are_persisted

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -294,6 +294,7 @@
   - created_at
   - updated_at
   - metadata
+  - modifications
   :ect_at_school_periods:
   - id
   - school_id

--- a/db/migrate/20250221120813_add_modifications_field_to_events.rb
+++ b/db/migrate/20250221120813_add_modifications_field_to_events.rb
@@ -1,0 +1,5 @@
+class AddModificationsFieldToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :modifications, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -185,6 +185,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_132033) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "metadata"
+    t.string "modifications", array: true
     t.index ["appropriate_body_id"], name: "index_events_on_appropriate_body_id"
     t.index ["author_email"], name: "index_events_on_author_email"
     t.index ["author_id"], name: "index_events_on_author_id"

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -43,6 +43,27 @@ RSpec.describe Admin::InductionPeriodsController do
           expect(induction_period.induction_programme).to eq(valid_params[:induction_period][:induction_programme])
         end
 
+        it "triggers the creation of an admin updates induction period event" do
+          allow(Events::Record).to receive(:record_admin_updates_induction_period!).once.and_call_original
+
+          induction_period.assign_attributes(valid_params[:induction_period])
+          expected_modifications = induction_period.changes
+
+          patch admin_teacher_induction_period_path(induction_period.teacher, induction_period), params: valid_params
+
+          expect(Events::Record).to have_received(:record_admin_updates_induction_period!).once.with(
+            hash_including(
+              {
+                induction_period:,
+                teacher: induction_period.teacher,
+                appropriate_body: induction_period.appropriate_body,
+                modifications: expected_modifications,
+                author: kind_of(Sessions::User),
+              }
+            )
+          )
+        end
+
         context "when updating earliest period start date" do
           let!(:teacher) { FactoryBot.create(:teacher) }
           let!(:earliest_period) { FactoryBot.create(:induction_period, teacher:, started_on: 2.years.ago, finished_on: 18.months.ago) }

--- a/spec/services/admin/update_induction_period_service_spec.rb
+++ b/spec/services/admin/update_induction_period_service_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Admin::UpdateInductionPeriodService do
-  subject(:service) { described_class.new(induction_period:, params:) }
+  subject(:service) { described_class.new(induction_period:, params:, author:) }
 
+  let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
+  let(:author) { Sessions::Users::DfEPersona.new(email: admin.email) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:induction_period) do
     FactoryBot.create(

--- a/spec/services/events/describe_modifications_spec.rb
+++ b/spec/services/events/describe_modifications_spec.rb
@@ -1,0 +1,14 @@
+describe Events::DescribeModifications do
+  it 'converts a ActiveRecord changes to a human-readable list of changed fields' do
+    teacher = FactoryBot.create(:teacher, trs_first_name: 'Maurice', trs_last_name: 'Micklewhite')
+
+    teacher.assign_attributes(trs_first_name: 'Michael', trs_last_name: 'Caine')
+
+    description_of_changes = Events::DescribeModifications.new(teacher.changes).describe
+
+    expect(description_of_changes).to eql(
+      ['TRS first name changed from Maurice to Michael',
+       'TRS last name changed from Micklewhite to Caine']
+    )
+  end
+end

--- a/spec/services/events/describe_modifications_spec.rb
+++ b/spec/services/events/describe_modifications_spec.rb
@@ -1,14 +1,47 @@
 describe Events::DescribeModifications do
-  it 'converts a ActiveRecord changes to a human-readable list of changed fields' do
-    teacher = FactoryBot.create(:teacher, trs_first_name: 'Maurice', trs_last_name: 'Micklewhite')
+  context 'when the website field is added' do
+    it %(is: Website set to 'www.website.com') do
+      school = FactoryBot.create(:gias_school, website: nil)
+      school.assign_attributes(website: 'www.school.com')
+      description_of_changes = Events::DescribeModifications.new(school.changes).describe
 
-    teacher.assign_attributes(trs_first_name: 'Michael', trs_last_name: 'Caine')
+      expect(description_of_changes).to eql([%(Website set to 'www.school.com')])
+    end
+  end
 
-    description_of_changes = Events::DescribeModifications.new(teacher.changes).describe
+  context 'when the website field is removed' do
+    it %(is: Website 'www.school.com' removed) do
+      school = FactoryBot.create(:gias_school, website: 'www.school.com')
+      school.assign_attributes(website: '')
+      description_of_changes = Events::DescribeModifications.new(school.changes).describe
 
-    expect(description_of_changes).to eql(
-      ['TRS first name changed from Maurice to Michael',
-       'TRS last name changed from Micklewhite to Caine']
-    )
+      expect(description_of_changes).to eql([%(Website 'www.school.com' removed)])
+    end
+  end
+
+  context 'when both TRS first and last names are updated' do
+    let(:description_of_changes) do
+      teacher = FactoryBot.create(:teacher, trs_first_name: 'Maurice', trs_last_name: 'Micklewhite')
+      teacher.assign_attributes(trs_first_name: 'Michael', trs_last_name: 'Caine')
+      Events::DescribeModifications.new(teacher.changes).describe
+    end
+
+    it %(includes: TRS first name changed from 'Maurice' to 'Michael') do
+      expect(description_of_changes).to include(%(TRS first name changed from 'Maurice' to 'Michael'))
+    end
+
+    it %(includes: TRS last name changed from 'Micklewhite' to 'Caine') do
+      expect(description_of_changes).to include(%(TRS last name changed from 'Micklewhite' to 'Caine'))
+    end
+  end
+
+  context 'when a date is changed' do
+    it %(it is formatted in the GOV.UK short date style: Closed on set to '24 Jan 2025') do
+      school = FactoryBot.create(:gias_school, closed_on: nil)
+      school.assign_attributes(closed_on: Date.new(2025, 1, 24))
+      description_of_changes = Events::DescribeModifications.new(school.changes).describe
+
+      expect(description_of_changes).to eql([%(Closed on set to '24 Jan 2025')])
+    end
   end
 end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -173,7 +173,7 @@ describe Events::Record do
           heading: 'Induction period updated by admin',
           event_type: :admin_updates_induction_period,
           happened_at: Time.zone.now,
-          modifications: ["Started on changed from #{3.weeks.ago.to_date} to #{2.weeks.ago.to_date}"],
+          modifications: ["Started on changed from '#{3.weeks.ago.to_date.to_formatted_s(:govuk_short)}' to '#{2.weeks.ago.to_date.to_formatted_s(:govuk_short)}'"],
           metadata: raw_modifications,
           **author_params
         )


### PR DESCRIPTION
When admins make changes to induction periods we want to record an event that tells us what changed, and later, why.

We will do this by triggering an `Events::Record` method from the service class that does the update.

We'll have lots of this style of event in the future so we spent some time ensuring it's easy, and we don't end up with too much _change describing_ code littered around.

## Changes:

* there is a new column, `modifications`, on the `events` table, it's a `varchar[]` column and is intended to contain a human readable list of changes we can display in a `<ul>`
* there's a new class called `Events::DescribeModifications` which takes a set of changes from `ActiveRecord#changes` and convers them to the human readable list. We're using the word modifications instead of changes because changes is reserved by Rails and yield 'dangers name' errors
* the `UpdateInductionPeriodService` now takes an `author` argument and passes it, along with the modifications, to the event recording

## Preview

```
ecf2_development=# select * from events order by id desc limit 1;
┌─[ RECORD 1 ]───────────────┬──────────────────────────────────────────────────────┐
│ id                         │ 1                                                    │
│ heading                    │ Induction period updated by admin                    │
│ body                       │ (null)                                               │
│ event_type                 │ admin_updates_induction_period                       │
│ happened_at                │ 2025-02-21 15:38:45.819581                           │
│ teacher_id                 │ 10                                                   │
│ appropriate_body_id        │ 4                                                    │
│ induction_period_id        │ 9                                                    │
│ induction_extension_id     │ (null)                                               │
│ school_id                  │ (null)                                               │
│ ect_at_school_period_id    │ (null)                                               │
│ mentor_at_school_period_id │ (null)                                               │
│ training_period_id         │ (null)                                               │
│ mentorship_period_id       │ (null)                                               │
│ provider_partnership_id    │ (null)                                               │
│ lead_provider_id           │ (null)                                               │
│ delivery_partner_id        │ (null)                                               │
│ user_id                    │ (null)                                               │
│ author_type                │ dfe_staff_user                                       │
│ author_id                  │ 1                                                    │
│ author_name                │ Daphne Blake                                         │
│ author_email               │ daphne@example.com                                   │
│ created_at                 │ 2025-02-21 15:38:46.118555                           │
│ updated_at                 │ 2025-02-21 15:38:46.118555                           │
│ metadata                   │ {"started_on": ["2023-06-21", "2023-05-21"]}         │
│ modifications              │ {"Started on changed from 2023-06-21 to 2023-05-21"} │
└────────────────────────────┴──────────────────────────────────────────────────────┘
```

## Notes

I left `body` clear as I think it makes sense to use that instead of introducing a new 'reason' field. The raw changes are left in `metadata` too, which could be handy later.

## Final tasks

* [ ] find and manually add events for the handful of edits we already have in prod