### PR TITLE
Allow admins to add extra context on why they're making changes

### DIFF
--- a/app/controllers/admin/induction_periods_controller.rb
+++ b/app/controllers/admin/induction_periods_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class InductionPeriodsController < AdminController
+    include EditableByAdmin
+
     def edit
       @induction_period = InductionPeriod.find(params[:id])
     end
@@ -9,7 +11,8 @@ module Admin
       service = UpdateInductionPeriodService.new(
         induction_period: @induction_period,
         params: induction_period_params,
-        author: current_user
+        author: current_user,
+        editable_by_admin_params: editable_by_admin_params(params.require(:induction_period))
       )
 
       if service.update_induction!

--- a/app/controllers/concerns/editable_by_admin.rb
+++ b/app/controllers/concerns/editable_by_admin.rb
@@ -1,0 +1,9 @@
+module EditableByAdmin
+  extend ActiveSupport::Concern
+
+  included do
+    def editable_by_admin_params(required_params)
+      required_params.permit(:body, :zendesk_ticket_url)
+    end
+  end
+end

--- a/app/models/concerns/editable_by_admin.rb
+++ b/app/models/concerns/editable_by_admin.rb
@@ -1,0 +1,11 @@
+module EditableByAdmin
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :body, :zendesk_ticket_url
+
+    validates :zendesk_ticket_url,
+              format: URI::DEFAULT_PARSER.make_regexp('https'),
+              allow_blank: true
+  end
+end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -3,6 +3,7 @@ class InductionPeriod < ApplicationRecord
   OUTCOMES = %w[pass fail].freeze
 
   include Interval
+  include EditableByAdmin
   include SharedInductionPeriodValidation
   include SharedNumberOfTermsValidation
 

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -23,7 +23,8 @@ module Events
                 :delivery_partner,
                 :user,
                 :modifications,
-                :metadata
+                :metadata,
+                :zendesk_ticket_url
 
     def initialize(
       author:,
@@ -45,7 +46,8 @@ module Events
       delivery_partner: nil,
       user: nil,
       modifications: nil,
-      metadata: nil
+      metadata: nil,
+      zendesk_ticket_url: nil
     )
       @author = author
       @event_type = event_type
@@ -67,6 +69,7 @@ module Events
       @user = user
       @modifications = DescribeModifications.new(modifications).describe
       @metadata = metadata || modifications
+      @zendesk_ticket_url = zendesk_ticket_url
     end
 
     def record_event!
@@ -150,12 +153,15 @@ module Events
 
     # Admin events
 
-    def self.record_admin_updates_induction_period!(author:, modifications:, induction_period:, teacher:, appropriate_body:, happened_at: Time.zone.now)
+    def self.record_admin_updates_induction_period!(author:, modifications:, induction_period:, teacher:, appropriate_body:, editable_by_admin_params:, happened_at: Time.zone.now)
       event_type = :admin_updates_induction_period
 
       heading = 'Induction period updated by admin'
 
-      new(event_type:, modifications:, author:, appropriate_body:, induction_period:, teacher:, heading:, happened_at:).record_event!
+      body = editable_by_admin_params[:body]
+      zendesk_ticket_url = editable_by_admin_params[:zendesk_ticket_url]
+
+      new(event_type:, modifications:, author:, appropriate_body:, induction_period:, teacher:, heading:, happened_at:, body:, zendesk_ticket_url:).record_event!
     end
 
   private
@@ -170,6 +176,7 @@ module Events
         heading:,
         body:,
         happened_at:,
+        zendesk_ticket_url:
       }.compact
     end
 

--- a/app/views/admin/induction_periods/edit.html.erb
+++ b/app/views/admin/induction_periods/edit.html.erb
@@ -24,8 +24,9 @@
           width: 4,
           inputmode: "numeric" %>
 
-
       <%= f.govuk_collection_radio_buttons :induction_programme, induction_programme_choices, :identifier, :name, legend: { text: 'Induction programme' }  %>
+
+      <%= render partial: 'admin/shared/editable_by_admin_fields', locals: { f: } %>
 
       <%= f.submit "Update", class: "govuk-button" %>
     <% end %>

--- a/app/views/admin/shared/_editable_by_admin_fields.html.erb
+++ b/app/views/admin/shared/_editable_by_admin_fields.html.erb
@@ -1,0 +1,14 @@
+<h2 class="govuk-heading-m">Reasons for making the change</h2>
+<%=
+  f.govuk_text_field(
+    :zendesk_ticket_url,
+    label: { text: "Zendesk ticket URL" },
+  )
+%>
+
+<%=
+  f.govuk_text_area(
+    :body,
+    label: { text: "Why are you making this change?" },
+  )
+%>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -304,6 +304,7 @@
   - updated_at
   - metadata
   - modifications
+  - zendesk_ticket_url
   :ect_at_school_periods:
   - appropriate_body_type
   - id

--- a/db/migrate/20250222171826_add_zendesk_url_field_to_events.rb
+++ b/db/migrate/20250222171826_add_zendesk_url_field_to_events.rb
@@ -1,0 +1,5 @@
+class AddZendeskUrlFieldToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :zendesk_ticket_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_22_171826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -196,6 +196,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
     t.datetime "updated_at", null: false
     t.jsonb "metadata"
     t.string "modifications", array: true
+    t.string "zendesk_ticket_url"
     t.index ["appropriate_body_id"], name: "index_events_on_appropriate_body_id"
     t.index ["author_email"], name: "index_events_on_author_email"
     t.index ["author_id"], name: "index_events_on_author_id"


### PR DESCRIPTION
One of the weak areas of ECF1 was the inability to see a record of things that have happened previously to a teacher within the system. Being able to do it is vital for support teams so they can work out why records are in a particular state.

Since #250 we are recording events (DFE-Digital/register-ects-project-board#1013) when admins update induction periods.

For more information on events and how they work, see [this issue on NPQ](https://github.com/DFE-Digital/register-ects-project-board/issues/895).

## Adding extra information to the event

Events tell us what happened and who did it.

They don't tell us **why** it happened.

We have an opportunity to record a bit more info by adding an extra field (or two) to the edit forms:

* Zendesk ticket URL
* Description

## How might this information be displayed?

The original intention was to use [a timeline](https://design-patterns.service.justice.gov.uk/components/timeline/) showing the events that have happened to a record.

![image](https://github.com/user-attachments/assets/bf4bc30a-41ab-4744-81d1-3f7058605d04)

## How the form might look

This is an initial stab at adding new fields to the edit induction period form.

| New fields | Whole form |
| ----------- | ------------- |
| ![Screenshot From 2025-02-24 11-15-29](https://github.com/user-attachments/assets/e3fbf554-379e-4e4c-877b-7212bafbe6bf) |![Screenshot From 2025-02-24 10-43-31](https://github.com/user-attachments/assets/0e7a5a63-2f01-4edd-b4ed-4dacfd959430) |

## Extra tasks

* [ ] Think about the final design. Do the new form feels look mandatory? Should they be? Should they be sectioned off from the _main bit_ of the form?
* [ ] Which fields do we want? Can we get away with just a Zendesk URL and no place to add a reason for making the change? Should we capture the whole Zendesk URL or is the ticket ID enough?
* [ ] For devs, how do we make this easy to add to all the admin forms?