### PR TITLE
created helper and added content for non prohibited alerts

### DIFF
--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -56,6 +56,16 @@ module AppropriateBodyHelper
     "#{number_with_delimiter(count)} claimed #{'induction'.pluralize(count)}"
   end
 
+  def trs_alerts_text(alerts_present)
+    if alerts_present
+      link = govuk_link_to("Check a teacher's record service", 'https://www.gov.uk/guidance/check-a-teachers-record')
+
+      safe_join(["Yes", %(Use the #{link} to get more information.).html_safe], tag.br)
+    else
+      "No"
+    end
+  end
+
 private
 
   def pending_induction_submission_full_name(pending_induction_submission)

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -32,7 +32,7 @@
 
     sl.with_row do |r|
       r.with_key(text: "Has alerts")
-      r.with_value(text: @pending_induction_submission.trs_alerts.present? ? "Yes" : "No")
+      r.with_value(text: trs_alerts_text(@pending_induction_submission.trs_alerts.present?) )
     end
   end
 %>

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -79,4 +79,23 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
       end
     end
   end
+
+  describe '#trs_alerts_text' do
+    context 'when alerts are present' do
+      it 'returns yes' do
+        expect(trs_alerts_text(true)).to include('Yes')
+      end
+
+      it 'also returns a sentence about getting more info' do
+        expect(trs_alerts_text(true)).to include('Use the', 'to get more information')
+        expect(trs_alerts_text(true)).to include('https://www.gov.uk/guidance/check-a-teachers-record')
+      end
+    end
+
+    context 'when alerts are absent' do
+      it 'returns no' do
+        expect(trs_alerts_text(false)).to include('No')
+      end
+    end
+  end
 end

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -18,13 +18,33 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     context 'when signed in as an appropriate body user' do
       let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
-      xit 'finds the right PendingInductionSubmission record and renders the page' do
+      it 'finds the right PendingInductionSubmission record and renders the page' do
         allow(PendingInductionSubmissions::Search).to receive(:new).and_call_original
 
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
 
         expect(PendingInductionSubmissions::Search).to have_received(:new).once
         expect(response).to be_successful
+      end
+
+      context 'when alerts are present' do
+        let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_alerts: %w[some alerts]) }
+
+        it 'includes info about the check a teachers record service' do
+          get("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}/edit")
+
+          expect(response.parsed_body.at_css('.govuk-summary-list').text).to include(/Use the Check a teacher.s record service to get more information/)
+        end
+      end
+
+      context 'when alerts are absent' do
+        let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_alerts: %w[]) }
+
+        it 'does not include info about the check a teachers record service' do
+          get("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}/edit")
+
+          expect(response.parsed_body.at_css('.govuk-summary-list').text).not_to include(/Use the Check a teacher.s record service to get more information/)
+        end
       end
     end
   end


### PR DESCRIPTION
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1225
Added some context and next steps for when non prohibited alerts are present. Kept content and link similar to prohibited alert page (to use CTR service). 

Interim solution design / content wise as it's a pretty rare occurrence so we should revisit later down the line

Can't show before screenshot as no TRNs with alerts in staging environment but it just says 'Yes' with no other context currently.
Screenshots: 
| After |
| ------ |
| <img width="685" alt="Screenshot 2025-02-24 at 16 10 30" src="https://github.com/user-attachments/assets/ba309f20-de29-414f-872a-d72accab102e" /> |


 