### PR TITLE
Skip migrating record if FIP without partnership

### DIFF
--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -29,8 +29,7 @@ private
         # FIXME: recording a FIP programme without a partnership means that we cannot
         # add a training_period for it, so it doesn't make sense to include these but
         # is that the correct approach?
-        next if record_programme.training_programme == "full_induction_programme"
-          && record_programme.partnership.nil?
+        next if record_programme.training_programme == "full_induction_programme" && record_programme.partnership.nil?
 
         current_programme = record_programme
 

--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -25,13 +25,20 @@ private
       record_programme = induction_record.induction_programme
 
       if current_programme != record_programme
+
+        # FIXME: recording a FIP programme without a partnership means that we cannot
+        # add a training_period for it, so it doesn't make sense to include these but
+        # is that the correct approach?
+        next if record_programme.training_programme == "full_induction_programme"
+          && record_programme.partnership.nil?
+
         current_programme = record_programme
 
         lead_provider = current_programme.partnership&.lead_provider&.name
         delivery_partner = current_programme.partnership&.delivery_partner&.name
         core_materials = current_programme.core_induction_programme&.name
 
-        # might want to filter out FIP without partnership or CIP without materials?
+        # TODO: check - should we skip CIP without materials?
         current_period = Migration::TrainingPeriodData.new(training_programme: current_programme.training_programme,
                                                            lead_provider:,
                                                            delivery_partner:,


### PR DESCRIPTION
When extracting training periods from induction records, there are a lot of errors generated when there is no lead provider found.  This occurs when the `InductionProgramme` associated with the `InductionRecord` being processed does not have a `Partnership` assigned.

As we cannot add a `TrainingPeriod` without a valid provider, and there is no data available in ECFv1, we cannot add these so we should skip them.