### PR TITLE
Admin interface for viewing appropriate bodies

### DIFF
--- a/app/controllers/admin/appropriate_bodies/current_ects_controller.rb
+++ b/app/controllers/admin/appropriate_bodies/current_ects_controller.rb
@@ -1,0 +1,18 @@
+module Admin
+  module AppropriateBodies
+    class CurrentECTsController < AdminController
+      layout 'full', only: 'index'
+
+      def index
+        @appropriate_body = AppropriateBody.find(params[:appropriate_body_id])
+
+        @claimed_inductions_count = ::Teachers::Search.new(appropriate_bodies: @appropriate_body).search.count
+
+        @pagy, @teachers = pagy(
+          ::Teachers::Search.new(query_string: params[:q], appropriate_bodies: @appropriate_body).search,
+          limit: 30
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/admin/appropriate_bodies_controller.rb
+++ b/app/controllers/admin/appropriate_bodies_controller.rb
@@ -2,13 +2,18 @@ module Admin
   class AppropriateBodiesController < AdminController
     include Pagy::Backend
 
-    layout 'full'
+    layout 'full', only: 'index'
 
     def index
       @pagy, @appropriate_bodies = pagy(
-        AppropriateBodies::Search.new(params[:q]).search,
+        ::AppropriateBodies::Search.new(params[:q]).search,
         limit: 30
       )
+    end
+
+    def show
+      @appropriate_body = AppropriateBody.find(params[:id])
+      @current_ect_count = Teachers::Search.new(appropriate_bodies: @appropriate_body).search.count
     end
   end
 end

--- a/app/views/admin/appropriate_bodies/current_ects/index.html.erb
+++ b/app/views/admin/appropriate_bodies/current_ects/index.html.erb
@@ -1,0 +1,61 @@
+<% page_data(
+  caption: @appropriate_body.name,
+  title: "Current ECTs",
+  backlink_href: admin_appropriate_body_path(@appropriate_body)
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">
+      <%= claimed_inductions_text(@claimed_inductions_count) %>
+    </h2>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= form_with method: :get do |f| %>
+      <%= f.govuk_text_field(
+            "q",
+            value: params[:q],
+            label: { text: "Search ECTs", size: "s" },
+            hint: { text: "Enter a name or TRN" },
+          )
+      %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit("Search") %>
+        <%= govuk_link_to("Reset", admin_appropriate_body_current_ects_path(@appropriate_body), secondary: true) %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% @teachers.each do |teacher| %>
+      <%=
+        govuk_summary_card(title: Teachers::Name.new(teacher).full_name) do |card|
+          card.with_action { govuk_link_to("Show", admin_teacher_path(teacher)) }
+          card.with_summary_list(
+            actions: false,
+            rows: [
+              { key: { text: "TRN" }, value: { text: teacher.trn } },
+              {
+                key: { text: "Status" },
+                value: {
+                  text: govuk_tag(
+                    **Teachers::InductionStatus.new(
+                      teacher:,
+                      induction_periods: teacher.induction_periods,
+                      trs_induction_status: teacher.trs_induction_status
+                    ).status_tag_kwargs
+                  )
+                },
+              },
+            ]
+          )
+        end
+      %>
+    <% end %>
+
+    <%= govuk_pagination pagy: @pagy %>
+  </div>
+</div>

--- a/app/views/admin/appropriate_bodies/index.html.erb
+++ b/app/views/admin/appropriate_bodies/index.html.erb
@@ -1,8 +1,6 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% page_data(title: "Appropriate bodies") %>
-  </div>
+<% page_data(title: "Appropriate bodies") %>
 
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with method: :get do |f| %>
       <%=
@@ -18,7 +16,7 @@
 
     <% @appropriate_bodies.each do |appropriate_body| %>
       <%=
-        govuk_summary_card(title: govuk_link_to(appropriate_body.name, "#")) do |card|
+        govuk_summary_card(title: govuk_link_to(appropriate_body.name, admin_appropriate_body_path(appropriate_body))) do |card|
 
           card.with_summary_list do |summary_list|
             summary_list.with_row do |row|

--- a/app/views/admin/appropriate_bodies/show.html.erb
+++ b/app/views/admin/appropriate_bodies/show.html.erb
@@ -1,0 +1,29 @@
+<% page_data(
+  title: @appropriate_body.name,
+  backlink_href: admin_appropriate_bodies_path
+) %>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Current ECTs")
+      row.with_value(text: @current_ect_count)
+      row.with_action(text: 'View', href: admin_appropriate_body_current_ects_path(@appropriate_body), visually_hidden_text: 'current ECTs')
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Establishment number")
+      row.with_value(text: @appropriate_body.establishment_number)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Local authority code")
+      row.with_value(text: @appropriate_body.local_authority_code)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "DfE Sign-in organisation ID")
+      row.with_value(text: tag.code(@appropriate_body.dfe_sign_in_organisation_id))
+    end
+  end
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,9 @@ Rails.application.routes.draw do
 
     resources :organisations, only: %i[index] do
       collection do
-        resources :appropriate_bodies, only: %i[index], path: 'appropriate-bodies'
+        resources :appropriate_bodies, only: %i[index show], path: 'appropriate-bodies' do
+          resources :current_ects, only: :index, path: 'current-ects', controller: 'appropriate_bodies/current_ects'
+        end
         resources :schools, only: %i[index show], param: :urn
       end
     end

--- a/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe 'Listing and searching ECTs belonging to an appropriate body' do
+  describe 'GET /admin/organisations/appropriate-bodies/current-ects' do
+    let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+    context 'when not logged in' do
+      it "redirects to sign-in" do
+        get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"
+        expect(response).to redirect_to(sign_in_path)
+      end
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "requires authorisation" do
+        get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"
+
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "with an authenticated DfE user" do
+      include_context 'sign in as DfE user'
+
+      let!(:teacher_1) { FactoryBot.create(:teacher, trs_first_name: "Pam", trs_last_name: "Ferris") }
+      let!(:teacher_2) { FactoryBot.create(:teacher, trs_first_name: "Felicity", trs_last_name: "Kendall") }
+
+      let!(:induction_period_1) { FactoryBot.create(:induction_period, :active, teacher: teacher_1, appropriate_body:) }
+      let!(:induction_period_2) { FactoryBot.create(:induction_period, :active, teacher: teacher_2, appropriate_body:) }
+
+      it 'shows lists current ECTs' do
+        get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"
+
+        expect(response.body).to include('Pam Ferris', 'Felicity Kendall')
+      end
+
+      it 'only shows ECTs who belong to this appropriate body' do
+        expect(Teachers::Search).to receive(:new).with(appropriate_bodies: appropriate_body).once.and_call_original
+        expect(Teachers::Search).to receive(:new).with(query_string: nil, appropriate_bodies: appropriate_body).once.and_call_original
+
+        get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"
+      end
+
+      context 'when searching by name' do
+        let(:search_term) { "kend" }
+
+        it 'only shows matching ECTs' do
+          get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects?q=#{search_term}"
+
+          expect(response.body).to include('Felicity Kendall')
+          expect(response.body).not_to include('Pam Ferris')
+        end
+
+        it 'only shows ECTs who belong to this appropriate body' do
+          expect(Teachers::Search).to receive(:new).with(appropriate_bodies: appropriate_body).once.and_call_original
+          expect(Teachers::Search).to receive(:new).with(query_string: search_term, appropriate_bodies: appropriate_body).once.and_call_original
+
+          get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects?q=#{search_term}"
+        end
+      end
+    end
+  end
+end

--- a/spec/views/admin/appropriate_bodies/current_ects/index.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/current_ects/index.html.erb_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe 'admin/appropriate_bodies/current_ects/index.html.erb' do
+  include Pagy::Backend
+
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:number_of_teachers) { 2 }
+  let!(:teachers) { FactoryBot.create_list(:teacher, number_of_teachers) }
+
+  before do
+    pagy, teachers = pagy(Teacher.all)
+
+    assign(:appropriate_body, appropriate_body)
+    assign(:teachers, teachers)
+    assign(:pagy, pagy)
+
+    controller.request.path_parameters[:appropriate_body_id] = appropriate_body.id
+  end
+
+  it 'contains a list of teachers' do
+    render
+
+    expect(view.content_for(:page_title)).to start_with('Current ECTs')
+    expect(rendered).to have_css('.govuk-summary-card', count: number_of_teachers)
+  end
+
+  it 'shows each teacher name and a show link to their profile page' do
+    render
+
+    teachers.each do |teacher|
+      expect(rendered).to have_css('.govuk-summary-card__title', text: Teachers::Name.new(teacher).full_name)
+      expect(rendered).to have_link('Show', href: admin_teacher_path(teacher))
+    end
+  end
+
+  it 'shows a search form' do
+    render
+
+    expect(rendered).to have_css('form')
+    expect(rendered).to have_css('label', text: 'Search ECTs')
+  end
+end

--- a/spec/views/admin/appropriate_bodies/index.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/index.html.erb_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'admin/appropriate_bodies/index.html.erb' do
+  include Pagy::Backend
+
+  let(:number_of_appropriate_bodies) { 2 }
+  let(:appropriate_bodies) { FactoryBot.create_list(:appropriate_body, number_of_appropriate_bodies) }
+  let(:pagy) { pagy_array(appropriate_bodies, items: 5, page: 1) }
+
+  before do
+    assign(:appropriate_bodies, appropriate_bodies)
+    assign(:pagy, pagy)
+  end
+
+  it %(sets the main heading and page title to 'Appropriate bodies') do
+    render
+
+    expect(view.content_for(:page_title)).to eql('Appropriate bodies')
+    expect(view.content_for(:page_header)).to have_css('h1', text: 'Appropriate bodies')
+  end
+
+  it 'renders a list of appropriate bodies' do
+    render
+
+    expect(rendered).to have_css('.govuk-summary-card', count: number_of_appropriate_bodies)
+  end
+
+  it 'includes links by name to the individual appropriate body pages' do
+    render
+
+    appropriate_bodies.each do |appropriate_body|
+      expect(rendered).to have_link(appropriate_body.name, href: admin_appropriate_body_path(appropriate_body))
+    end
+  end
+end

--- a/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe 'admin/appropriate_bodies/show.html.erb' do
+  let(:current_ect_count) { 5 }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+  before do
+    assign(:appropriate_body, appropriate_body)
+    assign(:current_ect_count, current_ect_count)
+  end
+
+  it 'sets the main heading and page title to the appropriate body name' do
+    render
+
+    expect(view.content_for(:page_title)).to start_with(appropriate_body.name)
+    expect(view.content_for(:page_header)).to have_css('h1', text: appropriate_body.name)
+  end
+
+  it 'displays a count of current ECTs' do
+    render
+
+    expect(rendered).to have_css('.govuk-summary-list__value', text: current_ect_count)
+  end
+
+  it "displays a link to the appropriate body's ECTs" do
+    render
+
+    expect(rendered).to have_link('View current ECTs', href: admin_appropriate_body_current_ects_path(appropriate_body))
+  end
+end


### PR DESCRIPTION
This adds some basic admin functionality to the admin pages that allow information about appropriate bodies to be viewed and their ECTs listed/searched.

| Appropriate body page | ECTs at AB page |
| -------------- | ----------------- |
| ![Screenshot From 2025-02-24 18-49-23](https://github.com/user-attachments/assets/260115cd-5106-432c-8dbf-9f18123829af) | ![Screenshot From 2025-02-24 18-49-33](https://github.com/user-attachments/assets/cd6cd8b0-9eb5-40ac-b205-6a881d28d142) |

The AB ECT list page is more or less the same as the main ECT list page but searching is limited to ECTs who are currently with the ECT.