### PR TITLE
[Migration] Skip FIP induction programmes without partnerships

### DIFF
--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -29,8 +29,7 @@ private
         # FIXME: recording a FIP programme without a partnership means that we cannot
         # add a training_period for it, so it doesn't make sense to include these but
         # is that the correct approach?
-        next if record_programme.training_programme == "full_induction_programme"
-          && record_programme.partnership.nil?
+        next if record_programme.training_programme == "full_induction_programme" && record_programme.partnership.nil?
 
         current_programme = record_programme
 

--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -25,13 +25,20 @@ private
       record_programme = induction_record.induction_programme
 
       if current_programme != record_programme
+
+        # FIXME: recording a FIP programme without a partnership means that we cannot
+        # add a training_period for it, so it doesn't make sense to include these but
+        # is that the correct approach?
+        next if record_programme.training_programme == "full_induction_programme"
+          && record_programme.partnership.nil?
+
         current_programme = record_programme
 
         lead_provider = current_programme.partnership&.lead_provider&.name
         delivery_partner = current_programme.partnership&.delivery_partner&.name
         core_materials = current_programme.core_induction_programme&.name
 
-        # might want to filter out FIP without partnership or CIP without materials?
+        # TODO: check - should we skip CIP without materials?
         current_period = Migration::TrainingPeriodData.new(training_programme: current_programme.training_programme,
                                                            lead_provider:,
                                                            delivery_partner:,


### PR DESCRIPTION
This was previously a PR but had infra issues with creating the review app so has needed to be recreated

When trying to migrate InductionRecords into RECT, we attempt to build `TrainingPeriod` records to reflect the time spent with a LP/DP for FIP training. There are some FIP `InductionProgramme` records in ECF that do not have a `Partnership` associated with them and this means we cannot build a `TrainingPeriod` as there is no LP/DP for these.  This PR skips recording a FIP training period in these cases instead of (eventually) raising an error because it cannot find a `NULL` provider.