### PR TITLE
remove production from the list of restorable databases and also from the restoring job

### DIFF
--- a/.github/workflows/restore-app-main-db.yml
+++ b/.github/workflows/restore-app-main-db.yml
@@ -13,7 +13,7 @@ on:
         - sandbox
         - staging
         - test
-        - production
+        # - production
       confirm-production:
         description: Must be set to true if restoring production
         required: true
@@ -35,7 +35,9 @@ env:
 jobs:
   restore:
     name: Restore AKS Database
-    if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && inputs.confirm-production == 'true' )  }}
+    # Swap comments on the next 2 lines to be able to restore production's main db.
+    # if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && inputs.confirm-production == 'true' )  }}
+    if: ${{ inputs.environment != 'production' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     concurrency: deploy_${{ inputs.environment }}


### PR DESCRIPTION
To prevent accidentally restore the main database in the production environment of the service:
- Remove `production` from the list of restorable databases in the `environment` input field.
- Also only allow non production databases to be restored by the the restoring job