### PR TITLE
Extend Interval to cope with predecessors and successors siblings of an interval

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -7,7 +7,6 @@ module Interval
 
     # Scopes
     scope :overlapping_with, ->(period) { where("range && daterange(?, ?)", period.started_on, period.finished_on) }
-
     scope :ongoing, -> { where(finished_on: nil) }
     scope :finished, -> { where.not(finished_on: nil) }
     scope :earliest_first, -> { order(started_on: 'asc') }
@@ -32,4 +31,18 @@ module Interval
 
     errors.add(:finished_on, "The finish date must be later than the start date (#{started_on.to_fs(:govuk)})") if finished_on <= started_on
   end
+
+  def overlaps_with_siblings? = siblings.overlapping_with(self).exists?
+
+  def predecessors = siblings.started_before(started_on)
+
+  def predecessors? = predecessors.exists?
+
+  def siblings =  raise(NotImplementedError)
+
+  def siblings? = siblings.exists?
+
+  def successors = finished_on ? siblings.started_on_or_after(finished_on) : self.class.none
+
+  def successors? = successors.exists?
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -23,15 +23,16 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
   # Scopes
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
-  scope :siblings_of, ->(instance) { for_teacher(instance.teacher_id).where.not(id: instance.id) }
 
   # Instance methods
-  def current_mentorship
-    mentorship_periods.ongoing.last
-  end
+  def current_mentorship = mentorship_periods.ongoing.last
 
-  def current_mentor
-    current_mentorship&.mentor
+  def current_mentor = current_mentorship&.mentor
+
+  def siblings
+    return ECTAtSchoolPeriod.none unless teacher
+
+    teacher.ect_at_school_periods.excluding(self)
   end
 
   delegate :trn, to: :teacher
@@ -39,7 +40,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
 private
 
   def teacher_distinct_period
-    overlapping_siblings = ECTAtSchoolPeriod.siblings_of(self).overlapping_with(self).exists?
-    errors.add(:base, "Teacher ECT periods cannot overlap") if overlapping_siblings
+    errors.add(:base, "Teacher ECT periods cannot overlap") if overlaps_with_siblings?
   end
 end

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -27,17 +27,17 @@ class MentorAtSchoolPeriod < ApplicationRecord
   # Scopes
   scope :for_school, ->(school_id) { where(school_id:) }
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
-  scope :siblings_of, ->(instance) { for_teacher(instance.teacher_id).where.not(id: instance.id) }
-  scope :school_siblings_of, ->(instance) { siblings_of(instance).for_school(instance.school_id) }
+
+  # Instance methods
+  def siblings
+    return MentorAtSchoolPeriod.none unless teacher
+
+    teacher.mentor_at_school_periods.for_school(school_id).excluding(self)
+  end
 
 private
 
-  def siblings
-    self.class.where(teacher_id:).where.not(id:)
-  end
-
   def teacher_school_distinct_period
-    overlapping_siblings = MentorAtSchoolPeriod.school_siblings_of(self).overlapping_with(self).exists?
-    errors.add(:base, "Teacher School Mentor periods cannot overlap") if overlapping_siblings
+    errors.add(:base, "Teacher School Mentor periods cannot overlap") if overlaps_with_siblings?
   end
 end

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -32,7 +32,13 @@ class MentorshipPeriod < ApplicationRecord
   # Scopes
   scope :for_mentee, ->(id) { where(ect_at_school_period_id: id) }
   scope :for_mentor, ->(id) { where(mentor_at_school_period_id: id) }
-  scope :mentee_siblings_of, ->(instance) { for_mentee(instance.ect_at_school_period_id).where.not(id: instance.id) }
+
+  # Instance methods
+  def mentee_siblings
+    return MentorshipPeriod.none unless mentee
+
+    mentee.mentorship_periods.excluding(self)
+  end
 
 private
 
@@ -49,9 +55,7 @@ private
   end
 
   def mentee_distinct_period
-    return unless MentorshipPeriod.mentee_siblings_of(self).overlapping_with(self).exists?
-
-    errors.add(:base, "Mentee periods cannot overlap")
+    errors.add(:base, "Mentee periods cannot overlap") if overlaps_with_mentee_siblings?
   end
 
   def not_self_mentoring
@@ -60,4 +64,6 @@ private
 
     errors.add(:base, "A mentee cannot mentor themself")
   end
+
+  def overlaps_with_mentee_siblings? = mentee_siblings.overlapping_with(self).exists?
 end

--- a/app/services/admin/update_induction_period_service.rb
+++ b/app/services/admin/update_induction_period_service.rb
@@ -41,17 +41,13 @@ module Admin
     end
 
     def notify_trs_of_start_date_change(previous_start_date)
-      return if teacher_has_earlier_induction_periods?
+      return if induction_period.predecessors?
       return if previous_start_date == induction_period.started_on
 
       BeginECTInductionJob.perform_later(
         trn: teacher.trn,
         start_date: induction_period.started_on
       )
-    end
-
-    def teacher_has_earlier_induction_periods?
-      InductionPeriod.where(teacher:).started_before(induction_period.started_on).exists?
     end
   end
 end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -67,14 +67,6 @@ describe ECTAtSchoolPeriod do
         expect(described_class.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])
       end
     end
-
-    describe ".siblings_of" do
-      let(:ect_at_school_period) { FactoryBot.build(:ect_at_school_period, teacher:, school:, started_on: "2022-01-01", finished_on: "2023-01-01") }
-
-      it "returns ect periods only for the specified instance's teacher excluding the instance" do
-        expect(described_class.siblings_of(ect_at_school_period)).to match_array([period_1, period_2, period_3])
-      end
-    end
   end
 
   describe "#current_mentorship" do
@@ -125,7 +117,21 @@ describe ECTAtSchoolPeriod do
         FactoryBot.create(:mentorship_period, :active, mentee:, mentor:)
       end
 
-      it { expect(mentee.current_mentor).to eq(mentor) }
+      it { expect(mentee.current_mentor).to eql(mentor) }
+    end
+  end
+
+  describe "#siblings" do
+    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:school) { FactoryBot.create(:school) }
+    let!(:period_1) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let(:ect_at_school_period) { FactoryBot.build(:ect_at_school_period, teacher:, school:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+    it "returns ect periods only for the specified instance's teacher excluding the instance" do
+      expect(ect_at_school_period.siblings).to match_array([period_1, period_2, period_3])
     end
   end
 end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -198,26 +198,26 @@ describe InductionPeriod do
         expect(InductionPeriod.for_appropriate_body(456).to_sql).to end_with(%( WHERE "induction_periods"."appropriate_body_id" = 456))
       end
     end
+  end
 
-    describe ".siblings_of" do
-      let!(:teacher) { FactoryBot.create(:teacher) }
-      let!(:induction_period_1) { FactoryBot.create(:induction_period, teacher:, started_on: '2022-01-01', finished_on: '2022-06-01') }
-      let!(:induction_period_2) { FactoryBot.create(:induction_period, teacher:, started_on: '2022-06-01', finished_on: '2023-01-01') }
-      let!(:unrelated_induction_period) { FactoryBot.create(:induction_period, started_on: '2022-06-01', finished_on: '2023-01-01') }
+  describe "#siblings" do
+    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:induction_period_1) { FactoryBot.create(:induction_period, teacher:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+    let!(:induction_period_2) { FactoryBot.create(:induction_period, teacher:, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:unrelated_induction_period) { FactoryBot.create(:induction_period, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-      subject { InductionPeriod.siblings_of(induction_period_1) }
+    subject { induction_period_1.siblings }
 
-      it "only returns records that belong to the same mentee" do
-        expect(subject).to include(induction_period_2)
-      end
+    it "only returns records that belong to the same mentee" do
+      expect(subject).to include(induction_period_2)
+    end
 
-      it "doesn't include itself" do
-        expect(subject).not_to include(induction_period_1)
-      end
+    it "doesn't include itself" do
+      expect(subject).not_to include(induction_period_1)
+    end
 
-      it "doesn't include periods that belong to other mentees" do
-        expect(subject).not_to include(unrelated_induction_period)
-      end
+    it "doesn't include periods that belong to other mentees" do
+      expect(subject).not_to include(unrelated_induction_period)
     end
   end
 end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -82,21 +82,18 @@ describe MentorAtSchoolPeriod do
         expect(described_class.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])
       end
     end
+  end
 
-    describe ".siblings_of" do
-      let!(:mentor_at_school_period) { FactoryBot.build(:mentor_at_school_period, teacher:, school:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+  describe "#siblings" do
+    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:school) { FactoryBot.create(:school) }
+    let!(:school_2) { FactoryBot.create(:school) }
+    let!(:period_1) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { FactoryBot.create(:mentor_at_school_period, teacher:, school: school_2, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:mentor_at_school_period) { FactoryBot.build(:mentor_at_school_period, teacher:, school: school_2, started_on: "2022-01-01", finished_on: "2023-01-01") }
 
-      it "returns mentor periods only for the specified instance's teacher excluding the instance" do
-        expect(described_class.siblings_of(mentor_at_school_period)).to match_array([period_1, period_2, period_3])
-      end
-    end
-
-    describe ".school_siblings_of" do
-      let!(:mentor_at_school_period) { FactoryBot.build(:mentor_at_school_period, teacher:, school: school_2, started_on: "2022-01-01", finished_on: "2023-01-01") }
-
-      it "returns mentor periods for the specified instance's teacher and school excluding the instance" do
-        expect(described_class.school_siblings_of(mentor_at_school_period)).to match_array([period_2])
-      end
+    it "returns mentor periods for the specified instance's teacher and school excluding the instance" do
+      expect(mentor_at_school_period.siblings).to match_array([period_2])
     end
   end
 end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -146,29 +146,29 @@ describe MentorshipPeriod do
         expect(MentorshipPeriod.for_mentor(456).to_sql).to end_with(%(WHERE "mentorship_periods"."mentor_at_school_period_id" = 456))
       end
     end
+  end
 
-    describe ".mentee_siblings_of" do
-      let!(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
-      let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: '2021-01-01') }
-      let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-01-01', finished_on: '2022-06-01') }
-      let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-06-01', finished_on: '2023-01-01') }
+  describe "#mentee_siblings" do
+    let!(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+    let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-      let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
-      let!(:unrelated_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:unrelated_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-      subject { MentorshipPeriod.mentee_siblings_of(period_1) }
+    subject { period_1.mentee_siblings }
 
-      it "only returns records that belong to the same mentee" do
-        expect(subject).to include(period_2)
-      end
+    it "only returns records that belong to the same mentee" do
+      expect(subject).to include(period_2)
+    end
 
-      it "doesn't include itself" do
-        expect(subject).not_to include(period_1)
-      end
+    it "doesn't include itself" do
+      expect(subject).not_to include(period_1)
+    end
 
-      it "doesn't include periods that belong to other mentees" do
-        expect(subject).not_to include(unrelated_period)
-      end
+    it "doesn't include periods that belong to other mentees" do
+      expect(subject).not_to include(unrelated_period)
     end
   end
 end


### PR DESCRIPTION
- replace scopes of type `siblings_of(instance)` with instance methods `instance#siblings`
- throw `NotImplementedError` exception on `Interval#siblings` method to indicate that models including the `Interval` module should overide this method.
- define a set of instance methods in `Interval` to deal with predecessors and successors of a given `*Period` instance
- override `siblings` in `ECTAtSchoolPeriod` to define it based on the `ect_at_school_periods` of the `teacher` of an instance.
- same for `InductionPeriod` model.
- for `MentorAtSchoolPeriod` mode, overide it based on the `teacher` and `school` of the given instance.
- `MentorshipPeriod`: leave `#mentee_siblings` for now. Maybe in the future we should renamed it to just `siblings` and benefit from the new methods defined on `Interval` should the necessity arise.
- `TrainingPeriod`: merge some validations for ect or mentor into unique one based on trainee instead: currently for mentors the same validation was running twice. Like `MentorshipPeriod` the current `training_siblings` method on `TrainingPeriod` could be renamed to just `siblings` based on future necessities.