### PR TITLE
Add a service class for creating induction periods

### DIFF
--- a/app/controllers/admin/induction_periods_controller.rb
+++ b/app/controllers/admin/induction_periods_controller.rb
@@ -12,7 +12,7 @@ module Admin
         author: current_user
       )
 
-      if service.update_induction!
+      if service.update_induction_period!
         redirect_to admin_teacher_path(@induction_period.teacher),
                     notice: "Induction period updated successfully"
       end

--- a/app/controllers/admin/induction_periods_controller.rb
+++ b/app/controllers/admin/induction_periods_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
     def update
       @induction_period = InductionPeriod.find(params[:id])
-      service = UpdateInductionPeriodService.new(
+      service = UpdateInductionPeriod.new(
         induction_period: @induction_period,
         params: induction_period_params,
         author: current_user
@@ -16,7 +16,7 @@ module Admin
         redirect_to admin_teacher_path(@induction_period.teacher),
                     notice: "Induction period updated successfully"
       end
-    rescue UpdateInductionPeriodService::RecordedOutcomeError => e
+    rescue UpdateInductionPeriod::RecordedOutcomeError => e
       @induction_period.errors.add(:base, e.message)
       render :edit, status: :unprocessable_entity
     rescue ActiveRecord::RecordInvalid

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   EVENT_TYPES = %w[
+    admin_creates_induction_period
     admin_updates_induction_period
     appropriate_body_claims_teacher
     appropriate_body_releases_teacher

--- a/app/services/admin/create_induction_period.rb
+++ b/app/services/admin/create_induction_period.rb
@@ -1,0 +1,69 @@
+module Admin
+  class CreateInductionPeriod
+    attr_reader :induction_period, :author, :induction_period_params, :appropriate_body_id, :teacher_id
+
+    def initialize(author:, appropriate_body_id:, teacher_id:, started_on:, induction_programme:, finished_on: nil, number_of_terms: nil)
+      @author = author
+
+      @appropriate_body_id = appropriate_body_id
+      @teacher_id = teacher_id
+      @induction_period_params = {
+        started_on:,
+        finished_on:,
+        induction_programme:,
+        number_of_terms:,
+      }
+    end
+
+    def create_induction_period!
+      build_induction_period.tap do |induction_period|
+        ActiveRecord::Base.transaction do
+          modifications = induction_period.changes
+          success = [
+            induction_period.save,
+            record_event(modifications),
+            notify_trs_of_new_induction_start
+          ].all?
+
+          success or raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+  private
+
+    def build_induction_period
+      @induction_period = InductionPeriod.new(appropriate_body:, teacher:, **induction_period_params)
+    end
+
+    def teacher
+      @teacher ||= Teacher.find(teacher_id)
+    end
+
+    def appropriate_body
+      @appropriate_body ||= AppropriateBody.find(appropriate_body_id)
+    end
+
+    def record_event(modifications)
+      return unless induction_period.persisted?
+
+      Events::Record.record_admin_creates_induction_period!(author:, modifications:, induction_period:, teacher:, appropriate_body:, happened_at: Time.zone.now)
+    end
+
+    # FIXME: there's no separate way to inform TRS of a new induction start date
+    #        so we're reusing the BeginECTInductionJob here. We need to make sure
+    #        we don't create induction periods for ECTs who have already passed/failed
+    def notify_trs_of_new_induction_start
+      return if teacher_has_earlier_induction_periods?
+
+      BeginECTInductionJob.perform_later(
+        trn: teacher.trn,
+        start_date: induction_period.started_on
+      )
+    end
+
+    def teacher_has_earlier_induction_periods?
+      InductionPeriod.where(teacher:).started_before(induction_period.started_on).exists?
+    end
+  end
+end

--- a/app/services/admin/update_induction_period.rb
+++ b/app/services/admin/update_induction_period.rb
@@ -10,7 +10,7 @@ module Admin
       @author = author
     end
 
-    def update_induction!
+    def update_induction_period!
       validate_can_update!
 
       previous_start_date = induction_period.started_on

--- a/app/services/admin/update_induction_period.rb
+++ b/app/services/admin/update_induction_period.rb
@@ -1,5 +1,5 @@
 module Admin
-  class UpdateInductionPeriodService
+  class UpdateInductionPeriod
     class RecordedOutcomeError < StandardError; end
 
     attr_reader :induction_period, :params, :author

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -124,6 +124,14 @@ module Events
       new(event_type:, modifications:, author:, appropriate_body:, induction_period:, teacher:, heading:, happened_at:).record_event!
     end
 
+    def self.record_admin_creates_induction_period!(author:, modifications:, induction_period:, teacher:, appropriate_body:, happened_at: Time.zone.now)
+      event_type = :admin_creates_induction_period
+
+      heading = 'Induction period created by admin'
+
+      new(event_type:, modifications:, author:, appropriate_body:, induction_period:, teacher:, heading:, happened_at:).record_event!
+    end
+
   private
 
     def attributes

--- a/spec/services/admin/create_induction_period_spec.rb
+++ b/spec/services/admin/create_induction_period_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Admin::CreateInductionPeriod do
+  let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
+  let(:author) { Sessions::Users::DfEPersona.new(email: admin.email) }
+
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body_id) { appropriate_body.id }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher_id) { teacher.id }
+  let(:started_on) { Date.new(2025, 1, 1) }
+  let(:finished_on) { nil }
+  let(:induction_programme) { 'fip' }
+  let(:number_of_terms) { nil }
+
+  let(:params) do
+    { author:, appropriate_body_id:, teacher_id:, started_on:, finished_on:, induction_programme:, number_of_terms: }
+  end
+
+  subject { Admin::CreateInductionPeriod.new(author:, **params).create_induction_period! }
+
+  describe '#create_induction_period!' do
+    include ActiveJob::TestHelper
+
+    it 'returns a saved induction period record' do
+      expect(subject).to be_a(InductionPeriod)
+      expect(subject).to be_persisted
+    end
+
+    it 'has the right attributes' do
+      aggregate_failures('assigning the right attributes') do
+        expect(subject.appropriate_body).to eql(appropriate_body)
+        expect(subject.teacher).to eql(teacher)
+        expect(subject.started_on).to eql(started_on)
+        expect(subject.induction_programme).to eql(induction_programme)
+        expect(subject.number_of_terms).to be_nil
+        expect(subject.finished_on).to be_nil
+      end
+    end
+
+    it 'writes an event' do
+      expect(Events::Record).to receive(:record_admin_creates_induction_period!).once.and_call_original
+
+      induction_period = subject
+
+      perform_enqueued_jobs
+
+      event = Event.last
+
+      aggregate_failures do
+        expect(event.event_type).to eql('admin_creates_induction_period')
+        expect(event.appropriate_body).to eql(appropriate_body)
+        expect(event.teacher).to eql(teacher)
+        expect(event.induction_period).to eql(induction_period)
+      end
+    end
+
+    context 'when it begins earlier than any sibling induction periods' do
+      it 'notifies TRS of the new induction start date'
+    end
+
+    context 'when finished' do
+      let(:finished_on) { Date.new(2025, 2, 2) }
+      let(:number_of_terms) { 1 }
+
+      it 'returns a saved induction period record' do
+        expect(subject).to be_persisted
+      end
+
+      it 'has the right attributes' do
+        aggregate_failures('assigning the right attributes') do
+          expect(subject.number_of_terms).to eq(number_of_terms)
+          expect(subject.finished_on).to eql(finished_on)
+        end
+      end
+    end
+
+    context 'when invalid' do
+      let(:finished_on) { started_on - 1.day }
+
+      it 'returns an unsaved induction period record' do
+        expect(subject).not_to be_persisted
+      end
+
+      it 'the induction period has errors' do
+        expect(subject.errors).to have_key(:finished_on)
+      end
+    end
+  end
+end

--- a/spec/services/admin/update_induction_period_spec.rb
+++ b/spec/services/admin/update_induction_period_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Admin::UpdateInductionPeriodService do
+RSpec.describe Admin::UpdateInductionPeriod do
   subject(:service) { described_class.new(induction_period:, params:, author:) }
 
   let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
@@ -41,7 +41,7 @@ RSpec.describe Admin::UpdateInductionPeriodService do
 
       it "raises an error" do
         expect { service.update_induction! }.to raise_error(
-          Admin::UpdateInductionPeriodService::RecordedOutcomeError,
+          Admin::UpdateInductionPeriod::RecordedOutcomeError,
           "Cannot edit induction period with recorded outcome"
         )
       end

--- a/spec/services/admin/update_induction_period_spec.rb
+++ b/spec/services/admin/update_induction_period_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
   end
   let(:params) { {} }
 
-  describe "#update" do
+  describe "#update_induction_period" do
     context "with valid params" do
       let(:params) do
         {
@@ -29,7 +29,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
       end
 
       it "updates the induction period" do
-        expect { service.update_induction! }.to change { induction_period.reload.started_on }.to(Date.parse("2024-01-01"))
+        expect { service.update_induction_period! }.to change { induction_period.reload.started_on }.to(Date.parse("2024-01-01"))
           .and change { induction_period.reload.finished_on }.to(Date.parse("2024-12-31"))
           .and change { induction_period.reload.number_of_terms }.to(3)
           .and change { induction_period.reload.induction_programme }.to("cip")
@@ -40,7 +40,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
       let(:induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: "2023-06-01", finished_on: "2023-12-31", outcome: "pass") }
 
       it "raises an error" do
-        expect { service.update_induction! }.to raise_error(
+        expect { service.update_induction_period! }.to raise_error(
           Admin::UpdateInductionPeriod::RecordedOutcomeError,
           "Cannot edit induction period with recorded outcome"
         )
@@ -57,7 +57,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
         end
 
         it "raises an error" do
-          expect { service.update_induction! }.to raise_error(
+          expect { service.update_induction_period! }.to raise_error(
             ActiveRecord::RecordInvalid,
             "Validation failed: Finished on The finish date must be later than the start date (31 December 2023)"
           )
@@ -69,7 +69,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
         let(:params) { { started_on: "2022-12-31" } }
 
         it "raises an error" do
-          expect { service.update_induction! }.to raise_error(
+          expect { service.update_induction_period! }.to raise_error(
             ActiveRecord::RecordInvalid,
             "Validation failed: Started on Start date cannot be before QTS award date (1 January 2023)"
           )
@@ -89,7 +89,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
           let(:params) { { started_on: "2023-05-01" } }
 
           it "raises an error" do
-            expect { service.update_induction! }.to raise_error(
+            expect { service.update_induction_period! }.to raise_error(
               ActiveRecord::RecordInvalid,
               "Validation failed: Started on Start date cannot overlap another induction period"
             )
@@ -108,7 +108,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
           let(:params) { { finished_on: "2023-12-01" } }
 
           it "raises an error" do
-            expect { service.update_induction! }.to raise_error(
+            expect { service.update_induction_period! }.to raise_error(
               ActiveRecord::RecordInvalid,
               "Validation failed: Finished on End date cannot overlap another induction period"
             )
@@ -125,7 +125,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
       end
 
       it "enqueues BeginECTInductionJob" do
-        service.update_induction!
+        service.update_induction_period!
 
         expect(BeginECTInductionJob).to have_received(:perform_later).with(
           trn: teacher.trn,
@@ -143,7 +143,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
         end
 
         it "does not enqueue BeginECTInductionJob" do
-          service.update_induction!
+          service.update_induction_period!
 
           expect(BeginECTInductionJob).not_to have_received(:perform_later)
         end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -154,6 +154,39 @@ describe Events::Record do
     end
   end
 
+  describe '.record_admin_creates_induction_period!' do
+    let(:three_weeks_ago) { 3.weeks.ago.to_date }
+    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:induction_period) do
+      FactoryBot.build(:induction_period, :active, started_on: three_weeks_ago, appropriate_body:, induction_programme: 'cip')
+    end
+
+    it 'queues a RecordEventJob with the correct values' do
+      raw_modifications = induction_period.changes
+      induction_period.save!
+
+      freeze_time do
+        Events::Record.record_admin_creates_induction_period!(author:, teacher:, appropriate_body:, induction_period:, modifications: raw_modifications)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          induction_period:,
+          teacher:,
+          appropriate_body:,
+          heading: 'Induction period created by admin',
+          event_type: :admin_creates_induction_period,
+          happened_at: Time.zone.now,
+          modifications: [
+            "Appropriate body set to '#{appropriate_body.id}'",
+            "Started on set to '#{3.weeks.ago.to_date.to_formatted_s(:govuk_short)}'",
+            "Induction programme set to 'cip'"
+          ],
+          metadata: raw_modifications,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe '.record_admin_updates_induction_period!' do
     let(:three_weeks_ago) { 3.weeks.ago.to_date }
     let(:two_weeks_ago) { 2.weeks.ago.to_date }


### PR DESCRIPTION
This class is intended to be used to create induction periods when the corresponding teacher and appropriate body records already exist.

It's not entirely consistent with the related `Admin::UpdateInductionPeriod` service but I'll adjust them so they're more similar in a subsquent change.

- **Drop Service suffix from Update class**
- **Rename update_induction to update_induction_period**
- **Add Admin::CreateInductionPeriod class**
- **Add admin_creates_induction_period event type**
