### PR TITLE
Ensure only available email addresses can be used when registering an ECT

### DIFF
--- a/app/services/schools/teacher_email.rb
+++ b/app/services/schools/teacher_email.rb
@@ -1,0 +1,24 @@
+module Schools
+  class TeacherEmail
+    def initialize(email:, trn:)
+      @email = email
+      @trn = trn
+    end
+
+    def is_currently_used?
+      email_in_use_by_ongoing_ect? || email_in_use_by_ongoing_mentor?
+    end
+
+  private
+
+    attr_reader :email, :trn
+
+    def email_in_use_by_ongoing_mentor?
+      MentorAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).ongoing.exists?
+    end
+
+    def email_in_use_by_ongoing_ect?
+      ECTAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).ongoing.exists?
+    end
+  end
+end

--- a/app/views/schools/register_ect_wizard/cant_use_email.html.erb
+++ b/app/views/schools/register_ect_wizard/cant_use_email.html.erb
@@ -1,0 +1,11 @@
+<% page_data(
+    title: "This email is already in use for a different ECT or mentor",
+    error: false,
+    backlink_href: @wizard.previous_step_path,
+) %>
+
+<p class="govuk-body">Make sure you use an email that belongs to the person you're registering.</p>
+
+<p class="govuk-body">Do not use a generic email like <a href="mailto:admin@example.com">admin@example.com</a></p>
+
+<%= govuk_button_link_to('Try another email', @wizard.previous_step_path) %>

--- a/app/wizards/schools/register_ect_wizard/cant_use_email_step.rb
+++ b/app/wizards/schools/register_ect_wizard/cant_use_email_step.rb
@@ -1,0 +1,9 @@
+module Schools
+  module RegisterECTWizard
+    class CantUseEmailStep < Step
+      def previous_step
+        :email_address
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -2,6 +2,10 @@ module Schools
   module RegisterECTWizard
     # This class is a decorator for the SessionRepository
     class ECT < SimpleDelegator
+      def cant_use_email?
+        Schools::TeacherEmail.new(email:, trn:).is_currently_used?
+      end
+
       def full_name
         corrected_name.presence || [trs_first_name, trs_last_name].join(" ").strip
       end

--- a/app/wizards/schools/register_ect_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_ect_wizard/email_address_step.rb
@@ -12,6 +12,8 @@ module Schools
       end
 
       def next_step
+        return :cant_use_email if ect.cant_use_email?
+
         :start_date
       end
 

--- a/app/wizards/schools/register_ect_wizard/wizard.rb
+++ b/app/wizards/schools/register_ect_wizard/wizard.rb
@@ -10,6 +10,7 @@ module Schools
           {
             already_active_at_school: AlreadyActiveAtSchoolStep,
             cannot_register_ect: CannotRegisterECTStep,
+            cant_use_email: CantUseEmailStep,
             change_email_address: ChangeEmailAddressStep,
             change_independent_school_appropriate_body: ChangeIndependentSchoolAppropriateBodyStep,
             change_lead_provider: ChangeLeadProviderStep,

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -16,7 +16,7 @@ module Schools
       end
 
       def cant_use_email?
-        email_in_use_by_active_ect? || email_in_use_by_active_mentor?
+        Schools::TeacherEmail.new(email:, trn:).is_currently_used?
       end
 
       def corrected_name?
@@ -60,14 +60,6 @@ module Schools
       end
 
     private
-
-      def email_in_use_by_active_mentor?
-        MentorAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).ongoing.exists?
-      end
-
-      def email_in_use_by_active_ect?
-        ECTAtSchoolPeriod.joins(:teacher).where(email:).where.not(teacher: { trn: }).ongoing.exists?
-      end
 
       # The wizard store object where we delegate the rest of methods
       def wizard_store

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,9 @@ Rails.application.routes.draw do
       get "change-lead-provider", action: :new
       post "change-lead-provider", action: :create
 
+      get "cant-use-email", action: :new
+      post "cant-use-email", action: :create
+
       get "confirmation", action: :new
     end
   end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -12,5 +12,10 @@ FactoryBot.define do
     trait :active do
       finished_on { nil }
     end
+
+    trait :finished do
+      started_on { generate(:base_ect_date) - 10.days }
+      finished_on { started_on + 1.day }
+    end
   end
 end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -10,12 +10,8 @@ FactoryBot.define do
     email { Faker::Internet.email }
 
     trait :active do
+      started_on { generate(:base_ect_date) + 1.year }
       finished_on { nil }
-    end
-
-    trait :finished do
-      started_on { generate(:base_ect_date) - 10.days }
-      finished_on { started_on + 1.day }
     end
   end
 end

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     email { Faker::Internet.email }
 
     trait :active do
+      started_on { generate(:base_mentor_date) + 1.year }
       finished_on { nil }
     end
   end

--- a/spec/features/schools/register_an_ect/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/cant_use_email_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe 'Registering an ECT', :js do
+  include_context 'fake trs api client'
+
+  let(:trn) { '3002586' }
+
+  scenario 'Teacher with email in use' do
+    given_there_is_a_school_in_the_service
+    and_an_ongoing_ect_is_assigned_to_the_school
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+
+    when_i_start_adding_an_ect
+    and_i_click_the_continue_link
+    and_i_submit_the_find_ect_form(trn:, dob_day: '3', dob_month: '2', dob_year: '1977')
+    and_i_select_the_ect_details_are_correct
+    and_i_click_confirm_and_continue
+    and_i_enter_an_email_address_already_in_use_by_an_ongoing_teacher
+    and_i_click_continue
+    then_i_should_be_taken_to_the_cant_use_email_page
+
+    when_i_click_try_another_email
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_an_email_address_of_a_teacher_from_their_finished_school_periods
+    and_i_click_continue
+    then_i_should_be_taken_to_the_ect_start_date_page
+  end
+
+  def and_i_click_the_continue_link
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_an_ongoing_ect_is_assigned_to_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_start_adding_an_ect
+    page.get_by_role('link', name: 'Add an ECT').click
+  end
+
+  def and_i_click_continue
+    page.get_by_role('button', name: "Continue").click
+  end
+
+  def and_i_submit_the_find_ect_form(trn:, dob_day:, dob_month:, dob_year:)
+    page.get_by_label('trn').fill(trn)
+    page.get_by_label('day').fill(dob_day)
+    page.get_by_label('month').fill(dob_month)
+    page.get_by_label('year').fill(dob_year)
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def and_i_select_the_ect_details_are_correct
+    page.get_by_label("Yes").check
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role('button', name: 'Confirm and continue').click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page.url).to end_with('/schools/register-ect/email-address')
+  end
+
+  def and_i_enter_an_email_address_already_in_use_by_an_ongoing_teacher
+    page.get_by_label('email').fill(@ect.email)
+  end
+
+  def when_i_enter_an_email_address_of_a_teacher_from_their_finished_school_periods
+    finished_ect = FactoryBot.create(:ect_at_school_period)
+    page.get_by_label('email').fill(finished_ect.email)
+  end
+
+  def then_i_should_be_taken_to_the_cant_use_email_page
+    expect(page.url).to end_with('/schools/register-ect/cant-use-email')
+  end
+
+  def when_i_click_try_another_email
+    page.get_by_role('link', name: 'Try another email').click
+  end
+
+  def then_i_should_be_taken_to_the_ect_start_date_page
+    expect(page.url).to end_with('/schools/register-ect/start-date')
+  end
+end

--- a/spec/services/schools/teacher_email_spec.rb
+++ b/spec/services/schools/teacher_email_spec.rb
@@ -37,7 +37,7 @@ describe Schools::TeacherEmail do
     context "when the email has been used by the same teacher in the past" do
       let(:teacher) { ongoing_ect_at_school_period.teacher }
       let(:trn) { teacher.trn }
-      let(:email) { FactoryBot.create(:ect_at_school_period, :finished, teacher:).email }
+      let(:email) { FactoryBot.create(:ect_at_school_period, teacher:).email }
 
       it "returns false" do
         expect(subject.is_currently_used?).to be false

--- a/spec/services/schools/teacher_email_spec.rb
+++ b/spec/services/schools/teacher_email_spec.rb
@@ -1,0 +1,39 @@
+describe Schools::TeacherEmail do
+  let(:email) { "test@example.com" }
+  let(:trn) { "123456" }
+  subject { described_class.new(email:, trn:) }
+
+  describe "#is_currently_used?" do
+    before do
+      allow(subject).to receive(:email_in_use_by_ongoing_ect?).and_return(ect_in_use)
+      allow(subject).to receive(:email_in_use_by_ongoing_mentor?).and_return(mentor_in_use)
+    end
+
+    context "when the email is in use by an ongoing ECT" do
+      let(:ect_in_use) { true }
+      let(:mentor_in_use) { false }
+
+      it "returns true" do
+        expect(subject.is_currently_used?).to be true
+      end
+    end
+
+    context "when the email is in use by an ongoing Mentor" do
+      let(:ect_in_use) { false }
+      let(:mentor_in_use) { true }
+
+      it "returns true" do
+        expect(subject.is_currently_used?).to be true
+      end
+    end
+
+    context "when the email is not in use" do
+      let(:ect_in_use) { false }
+      let(:mentor_in_use) { false }
+
+      it "returns false" do
+        expect(subject.is_currently_used?).to be false
+      end
+    end
+  end
+end

--- a/spec/services/schools/teacher_email_spec.rb
+++ b/spec/services/schools/teacher_email_spec.rb
@@ -1,17 +1,16 @@
 describe Schools::TeacherEmail do
-  let(:email) { "test@example.com" }
-  let(:trn) { "123456" }
+  let(:finished_ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
+  let(:ongoing_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+
+  let(:finished_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
+  let(:ongoing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+
+  let(:trn) { '123456' }
   subject { described_class.new(email:, trn:) }
 
   describe "#is_currently_used?" do
-    before do
-      allow(subject).to receive(:email_in_use_by_ongoing_ect?).and_return(ect_in_use)
-      allow(subject).to receive(:email_in_use_by_ongoing_mentor?).and_return(mentor_in_use)
-    end
-
     context "when the email is in use by an ongoing ECT" do
-      let(:ect_in_use) { true }
-      let(:mentor_in_use) { false }
+      let(:email) { ongoing_ect_at_school_period.email }
 
       it "returns true" do
         expect(subject.is_currently_used?).to be true
@@ -19,17 +18,50 @@ describe Schools::TeacherEmail do
     end
 
     context "when the email is in use by an ongoing Mentor" do
-      let(:ect_in_use) { false }
-      let(:mentor_in_use) { true }
+      let(:email) { ongoing_mentor_at_school_period.email }
 
       it "returns true" do
         expect(subject.is_currently_used?).to be true
       end
     end
 
-    context "when the email is not in use" do
-      let(:ect_in_use) { false }
-      let(:mentor_in_use) { false }
+    context "when the email is in use by the same teacher" do
+      let(:trn) { ongoing_ect_at_school_period.teacher.trn }
+      let(:email) { ongoing_ect_at_school_period.email }
+
+      it "returns false" do
+        expect(subject.is_currently_used?).to be false
+      end
+    end
+
+    context "when the email has been used by the same teacher in the past" do
+      let(:teacher) { ongoing_ect_at_school_period.teacher }
+      let(:trn) { teacher.trn }
+      let(:email) { FactoryBot.create(:ect_at_school_period, :finished, teacher:).email }
+
+      it "returns false" do
+        expect(subject.is_currently_used?).to be false
+      end
+    end
+
+    context "when the email was used by an ECT in the past" do
+      let(:email) { finished_ect_at_school_period.email }
+
+      it "returns false" do
+        expect(subject.is_currently_used?).to be false
+      end
+    end
+
+    context "when the email was used by a Mentor in the past" do
+      let(:email) { finished_mentor_at_school_period.email }
+
+      it "returns false" do
+        expect(subject.is_currently_used?).to be false
+      end
+    end
+
+    context "when the email has never been used before" do
+      let(:email) { 'never_been_used@example.com' }
 
       it "returns false" do
         expect(subject.is_currently_used?).to be false

--- a/spec/views/schools/register_ect_wizard/cant_use_email.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/cant_use_email.html.erb_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe 'schools/register_ect_wizard/cant_use_email.html.erb' do
+  let(:back_path) { schools_register_ect_wizard_email_address_path }
+  let(:store) { FactoryBot.build(:session_repository, trs_first_name: "John", trs_last_name: "Waters", email: 'a@email.com') }
+  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :cant_use_email, store:) }
+
+  before do
+    assign(:wizard, wizard)
+    render
+  end
+
+  context 'page title' do
+    it { expect(sanitize(view.content_for(:page_title))).to eql('This email is already in use for a different ECT or mentor') }
+  end
+
+  it 'includes a back button that links to find-mentor page of the journey' do
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: back_path)
+  end
+
+  it 'includes a try another email button that links to the find mentor page' do
+    expect(rendered).to have_link('Try another email', href: back_path)
+  end
+end

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -186,4 +186,28 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
       expect(ect.active_at_school?(school:)).to be_falsey
     end
   end
+
+  describe '#cant_use_email?' do
+    let(:teacher_email_service) { instance_double(Schools::TeacherEmail) }
+
+    before do
+      allow(Schools::TeacherEmail).to receive(:new).with(email: ect.email, trn: ect.trn).and_return(teacher_email_service)
+    end
+
+    context "when the email is used in an ongoing school period" do
+      before { allow(teacher_email_service).to receive(:is_currently_used?).and_return(true) }
+
+      it "returns true" do
+        expect(subject.cant_use_email?).to be true
+      end
+    end
+
+    context "when the email is not used in an ongoing school period" do
+      before { allow(teacher_email_service).to receive(:is_currently_used?).and_return(false) }
+
+      it "returns false" do
+        expect(subject.cant_use_email?).to be false
+      end
+    end
+  end
 end

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -55,25 +55,25 @@ describe Schools::RegisterMentorWizard::Mentor do
   end
 
   describe '#cant_use_email?' do
-    context 'when there is an active ECT with the email in use' do
-      before { FactoryBot.create(:ect_at_school_period, :active, email: mentor.email) }
+    let(:teacher_email_service) { instance_double(Schools::TeacherEmail) }
 
-      it 'returns true' do
-        expect(mentor.cant_use_email?).to be_truthy
+    before do
+      allow(Schools::TeacherEmail).to receive(:new).with(email: mentor.email, trn: mentor.trn).and_return(teacher_email_service)
+    end
+
+    context "when the email is used in an ongoing school period" do
+      before { allow(teacher_email_service).to receive(:is_currently_used?).and_return(true) }
+
+      it "returns true" do
+        expect(subject.cant_use_email?).to be true
       end
     end
 
-    context 'when there is an active mentor with the email in use' do
-      before { FactoryBot.create(:mentor_at_school_period, :active, email: mentor.email) }
+    context "when the email is not used in an ongoing school period" do
+      before { allow(teacher_email_service).to receive(:is_currently_used?).and_return(false) }
 
-      it 'returns true' do
-        expect(mentor.cant_use_email?).to be_truthy
-      end
-    end
-
-    context 'otherwise' do
-      it 'returns false' do
-        expect(mentor.cant_use_email?).to be_falsey
+      it "returns false" do
+        expect(subject.cant_use_email?).to be false
       end
     end
   end


### PR DESCRIPTION
This PR introduces a new step in the Register an ECT journey to prevent the use of email addresses already associated with an ongoing school period.

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/964

### Changes:
- Adds the `Schools::TeacherEmail` service class to check if a given email is used by any other teacher in their ongoing school period
- Introduces a new page that informs schools when an email is unavailable and prompts them to provide a different one
- Refactors the equivalent Mentor decorator to re-use the `Schools::TeacherEmail`

### Screenshot:
![screenshot](https://github.com/user-attachments/assets/c55a11b2-5596-40f5-88c6-2f09713cc915)