### PR TITLE
Redirect to root path when not authenticated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,14 +40,19 @@ private
     return if authenticated?
 
     session_manager.requested_path = request.fullpath
-    redirect_to(sign_in_path)
+
+    redirect_to(pre_login_redirect_path(request.fullpath))
   end
 
   def authenticated?
     current_user.present?
   end
 
-  def login_redirect_path
+  def pre_login_redirect_path(requested_path)
+    requested_path.start_with?("/admin") ? sign_in_path : root_path
+  end
+
+  def post_login_redirect_path
     session_manager.requested_path || admin_home_path || ab_home_path || school_home_path || fail(UnredirectableError)
   end
 

--- a/app/controllers/otp_sessions_controller.rb
+++ b/app/controllers/otp_sessions_controller.rb
@@ -30,7 +30,7 @@ class OTPSessionsController < ApplicationController
       session_manager.begin_session!(session_user)
 
       if authenticated?
-        redirect_to(login_redirect_path)
+        redirect_to(post_login_redirect_path)
       else
         session_manager.end_session!
         redirect_to(otp_sign_in_path)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@ class PagesController < ApplicationController
   skip_before_action :authenticate
 
   def home
-    redirect_to(login_redirect_path) and return if authenticated?
+    redirect_to(post_login_redirect_path) and return if authenticated?
 
     redirect_to(ab_landing_path) unless Rails.application.config.enable_schools_interface
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     session_manager.begin_session!(session_user, id_token:)
 
     if authenticated?
-      redirect_to(login_redirect_path)
+      redirect_to(post_login_redirect_path)
     else
       session_manager.end_session!
       redirect_to(sign_in_path)

--- a/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'Listing and searching ECTs belonging to an appropriate body' do
     let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
     context 'when not logged in' do
-      it "redirects to sign-in" do
+      it "redirects to sign in path" do
         get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"
         expect(response).to redirect_to(sign_in_path)
       end

--- a/spec/requests/admin/appropriate_bodies/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Viewing the appropriate bodies index", type: :request do
   describe "GET /admin/appropriate-bodies" do
-    it "redirects to sign-in" do
+    it "redirects to sign in path" do
       get "/admin/organisations/appropriate-bodies"
       expect(response).to redirect_to(sign_in_path)
     end

--- a/spec/requests/admin/teachers/index_spec.rb
+++ b/spec/requests/admin/teachers/index_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Admin teachers index", type: :request do
   describe "GET /admin/teachers" do
-    it "redirects to sign-in" do
+    it "redirects to sign in path" do
       get "/admin/teachers"
       expect(response).to redirect_to(sign_in_path)
     end

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Admin::Teachers#show", type: :request do
   let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
 
   describe "GET /admin/teachers/:id" do
-    it "redirects to sign-in" do
+    it "redirects to sign in path" do
       get admin_teacher_path(teacher)
       expect(response).to redirect_to(sign_in_path)
     end

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
 
   describe 'GET /appropriate-body/claim-an-ect/check-ect/:id/edit' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -31,11 +31,11 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
 
   describe 'POST /appropriate-body/claim-an-ect/check-ect/:id' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         patch("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
 
   describe 'GET /appropriate-body/claim-an-ect/find-ect' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get('/appropriate-body/claim-an-ect/find-ect/new')
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -31,11 +31,11 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
 
   describe 'POST /appropriate-body/claim-an-ect/find-ect' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         post('/appropriate-body/claim-an-ect/find-ect')
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
 
   describe 'GET /appropriate-body/claim-an-ect/register-ect/:id/edit' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to end_with(root_url)
       end
     end
 
@@ -33,11 +33,11 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
 
   describe 'POST /appropriate-body/claim-an-ect/register-ect/:id' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         patch("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -125,11 +125,11 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
 
   describe 'GET /appropriate-body/claim-an-ect/register-ect/:id' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe "Appropriate Body teacher extensions index", type: :request do
   let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
 
   describe 'when not signed in' do
-    it 'redirects to the signin page' do
+    it 'redirects to the root page' do
       get("/appropriate-body/teachers/#{teacher.id}/extensions")
 
       expect(response).to be_redirection
-      expect(response.redirect_url).to end_with('/sign-in')
+      expect(response.redirect_url).to eql(root_url)
     end
   end
 

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
 
   describe 'GET /appropriate-body/teachers' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/teachers")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
 
   describe 'GET /appropriate-body/teachers/:id/record-failed-outcome/new' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome/new")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -51,11 +51,11 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
 
   describe 'POST /appropriate-body/teachers/:id/record-failed-outcome' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         post("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -162,11 +162,11 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
     end
 
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
 
   describe 'GET /appropriate-body/teachers/:teacher_id/record-passed-outcome/new' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome/new")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -51,11 +51,11 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
 
   describe 'POST /appropriate-body/teachers/:teacher_id/record-passed-outcome' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         post("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -162,11 +162,11 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
     end
 
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe 'Appropriate body releasing an ECT' do
 
   describe 'GET /appropriate-body/teachers/:id/release/new' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/release/new")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -37,11 +37,11 @@ RSpec.describe 'Appropriate body releasing an ECT' do
 
   describe 'POST /appropriate-body/teachers/:id/release' do
     context 'when not signed in' do
-      it 'redirects to the signin page' do
+      it 'redirects to the root page' do
         post("/appropriate-body/teachers/#{teacher.id}/release")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
 
   describe 'GET /school/ects/:id/mentorship/new' do
     context 'when not signed in' do
-      it 'redirects to the sign in page' do
+      it 'redirects to the root page' do
         get("/school/ects/#{ect.id}/mentorship/new")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -33,11 +33,11 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
 
   describe 'POST /school/ects/:id/mentorship' do
     context 'when not signed in' do
-      it 'redirects to the sign in page' do
+      it 'redirects to the root page' do
         post("/school/ects/#{ect.id}/mentorship")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 
@@ -90,11 +90,11 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
 
   describe 'GET /school/ects/:id/mentorship/confirmation' do
     context 'when not signed in' do
-      it 'redirects to the sign in page' do
+      it 'redirects to the root page' do
         get("/school/ects/#{ect.id}/mentorship/confirmation")
 
         expect(response).to be_redirection
-        expect(response.redirect_url).to end_with('/sign-in')
+        expect(response.redirect_url).to eql(root_url)
       end
     end
 


### PR DESCRIPTION
We've had people ending up on the sign-in page in production and it's only really intended for use by admins. We should redirect to the homepage instead when someone's not authenticated.

This is an improvement over #274 because it properly handles admin login.
