### PR TITLE
ECT show template redesign surfacing data

### DIFF
--- a/app/components/teachers/current_induction_period_component.html.erb
+++ b/app/components/teachers/current_induction_period_component.html.erb
@@ -4,7 +4,7 @@
   govuk_summary_list(card: { title: current_period.appropriate_body.name, actions: }) do |sl|
     sl.with_row do |row|
       row.with_key(text: "Induction programme")
-      row.with_value(text: helpers.induction_programme_choice_name(current_period.induction_programme))
+      row.with_value(text: ::INDUCTION_PROGRAMMES[current_period.induction_programme.to_sym])
     end
 
     sl.with_row do |row|

--- a/app/components/teachers/past_induction_periods_component.html.erb
+++ b/app/components/teachers/past_induction_periods_component.html.erb
@@ -7,7 +7,7 @@
         govuk_summary_list(card: { title: period.appropriate_body.name, actions: can_edit?(period) ? [edit_link(period)] : [] }) do |sl|
           sl.with_row do |row|
             row.with_key(text: "Induction programme")
-            row.with_value(text: helpers.induction_programme_choice_name(period.induction_programme))
+            row.with_value(text: ::INDUCTION_PROGRAMMES[period.induction_programme.to_sym])
           end
 
           sl.with_row do |row|

--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -1,30 +1,16 @@
 module AppropriateBodyHelper
-  InductionProgrammeChoice = Struct.new(:identifier, :name)
-  InductionOutcomeChoice = Struct.new(:identifier, :name)
+  FormChoice = Data.define(:identifier, :name)
 
   def induction_programme_choices
-    [
-      InductionProgrammeChoice.new(identifier: 'fip', name: 'Full induction programme'),
-      InductionProgrammeChoice.new(identifier: 'cip', name: 'Core induction programme'),
-      InductionProgrammeChoice.new(identifier: 'diy', name: 'School-based induction programme')
-    ]
+    ::INDUCTION_PROGRAMMES.map { |key, value| FormChoice.new(key.to_s, value) }
   end
 
-  def induction_programme_choice_name(identifier)
-    # FIXME: this is a temporary solution until we have real induction programme data
-    induction_programme_choices.find { |choice| choice.identifier == identifier }&.name
-  end
-
+  # TODO: not currently in use?
   def induction_outcome_choices
-    [
-      InductionProgrammeChoice.new(identifier: 'pass', name: 'Passed'),
-      InductionProgrammeChoice.new(identifier: 'fail', name: 'Failed'),
-    ]
+    ::INDUCTION_OUTCOMES.map { |key, value| FormChoice.new(key.to_s, value) }
   end
 
   def summary_card_for_teacher(teacher:)
-    induction_start_date = Teachers::InductionPeriod.new(teacher).induction_start_date&.to_fs(:govuk)
-
     govuk_summary_card(title: Teachers::Name.new(teacher).full_name) do |card|
       card.with_action { govuk_link_to("Show", ab_teacher_path(teacher)) }
       card.with_summary_list(
@@ -33,7 +19,7 @@ module AppropriateBodyHelper
           { key: { text: "TRN" }, value: { text: teacher.trn } },
           {
             key: { text: "Induction start date" },
-            value: { text: induction_start_date },
+            value: { text: Teachers::InductionPeriod.new(teacher).formatted_induction_start_date },
           },
           {
             key: { text: "Status" },

--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -36,7 +36,7 @@ module ECTHelper
 
   # @param ect [ECTAtSchoolPeriod]
   def ect_programme_type(ect)
-    ProgrammeTypeValidator::VALID_PROGRAMME_TYPES.fetch(ect.programme_type, 'Programme type is not recognised')
+    ::PROGRAMME_TYPES.fetch(ect.programme_type.to_sym, 'Programme type is not recognised')
   end
 
 private

--- a/app/helpers/teacher_helper.rb
+++ b/app/helpers/teacher_helper.rb
@@ -9,6 +9,21 @@ module TeacherHelper
     "TRN: #{teacher.trn}"
   end
 
+  # @param teacher [Teacher]
+  def teacher_induction_start_date(teacher)
+    Teachers::InductionPeriod.new(teacher).formatted_induction_start_date
+  end
+
+  # @param teacher [Teacher]
+  def teacher_induction_programme(teacher)
+    Teachers::InductionPeriod.new(teacher).induction_programme
+  end
+
+  # @param teacher [Teacher]
+  def teacher_induction_ab_name(teacher)
+    Teachers::InductionPeriod.new(teacher).appropriate_body_name
+  end
+
   def teacher_date_of_birth_hint_text
     "For example, 20 4 2001"
   end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -36,6 +36,14 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
   delegate :trn, to: :teacher
 
+  def provider_led?
+    programme_type == 'provider_led'
+  end
+
+  def school_led?
+    programme_type == 'school_led'
+  end
+
 private
 
   def teacher_distinct_period

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -5,8 +5,12 @@ class TrainingPeriod < ApplicationRecord
   belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :training_periods
   belongs_to :mentor_at_school_period, inverse_of: :training_periods
   belongs_to :provider_partnership
+
   has_many :declarations, inverse_of: :training_period
   has_many :events
+
+  has_one :lead_provider, through: :provider_partnership
+  has_one :delivery_partner, through: :provider_partnership
 
   # Validations
   validates :started_on,

--- a/app/services/teachers/induction_period.rb
+++ b/app/services/teachers/induction_period.rb
@@ -9,6 +9,22 @@ class Teachers::InductionPeriod
     first_induction_period&.started_on
   end
 
+  def formatted_induction_start_date
+    induction_start_date&.to_fs(:govuk)
+  end
+
+  def induction_programme
+    return unless first_induction_period
+
+    ::INDUCTION_PROGRAMMES[first_induction_period.induction_programme.to_sym]
+  end
+
+  def appropriate_body_name
+    return unless first_induction_period
+
+    first_induction_period.appropriate_body.name
+  end
+
   def active_induction_period
     # FIXME: this works if finished_on cannot be set to a future date
     # If that becomes possible, this query will need to be updated

--- a/app/validators/programme_type_validator.rb
+++ b/app/validators/programme_type_validator.rb
@@ -1,13 +1,8 @@
 class ProgrammeTypeValidator < ActiveModel::EachValidator
-  VALID_PROGRAMME_TYPES = {
-    'provider_led' => 'Provider-led',
-    'school_led' => 'School-led'
-  }.freeze
-
   def validate_each(record, attribute, value)
     if value.blank?
       record.errors.add(attribute, "Select either 'Provider-led' or 'School-led' training")
-    elsif !VALID_PROGRAMME_TYPES.keys.include?(value)
+    elsif !::PROGRAMME_TYPES.keys.include?(value.to_sym)
       record.errors.add(attribute, "'#{value}' is not a valid programme type")
     end
   end

--- a/app/validators/working_pattern_validator.rb
+++ b/app/validators/working_pattern_validator.rb
@@ -1,10 +1,8 @@
 class WorkingPatternValidator < ActiveModel::EachValidator
-  VALID_WORKING_PATTERNS = %w[part_time full_time].freeze
-
   def validate_each(record, attribute, value)
     if value.blank?
       record.errors.add(attribute, "Select if the ECT's working pattern is full or part time")
-    elsif !VALID_WORKING_PATTERNS.include?(value)
+    elsif !::WORKING_PATTERNS.keys.include?(value.to_sym)
       record.errors.add(attribute, "'#{value}' is not a valid working pattern")
     end
   end

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -1,13 +1,13 @@
-<% 
+<%
   page_data(
-    title: teacher_full_name(@ect.teacher), 
+    title: teacher_full_name(@ect.teacher),
     backlink_href: schools_ects_home_path,
     caption: teacher_trn(@ect.teacher),
-    caption_size: 'l',    
-  ) 
+    caption_size: 'l',
+  )
 %>
-<h2 class='govuk-heading-m'>Personal details</h2>
-<%= 
+<h2 class='govuk-heading-m'>ECT details</h2>
+<%=
   govuk_summary_list(
     rows: [
       { key: { text: 'Name' },              value: { text: teacher_full_name(@ect.teacher) } },
@@ -18,19 +18,9 @@
     ]
   )
 %>
-<%= 
-  govuk_summary_card(title: 'Current training details') do |card|
-    card.with_summary_list(
-      rows: [
-        { key: { text: 'Appropriate body (reported by AB)' }, value: { text: @ect.teacher.induction_periods.last&.appropriate_body&.name } },
-        { key: { text: 'Programme type (reported by AB)' },   value: { text: induction_programme_choice_name(@ect.teacher.induction_periods.last&.induction_programme) } },
-        { key: { text: 'Lead provider (reported by LP)' },    value: { text: @ect.training_periods.last&.provider_partnership&.lead_provider&.name } },
-      ]
-    )
-  end
-%>
-<%= 
-  govuk_summary_card(title: 'School requested details') do |card|
+<h2 class='govuk-heading-m'>ECTE training details</h2>
+<%=
+  govuk_summary_card(title: 'Reported to us by your school') do |card|
     card.with_summary_list(
       rows: [
         { key: { text: 'Appropriate body' }, value: { text: @ect.appropriate_body&.name } },
@@ -38,5 +28,44 @@
         { key: { text: 'Lead provider' },    value: { text: @ect.lead_provider&.name } },
       ]
     )
+  end
+%>
+<%=
+  if @ect.provider_led?
+    govuk_summary_card(title: 'Reported to us by your lead provider') do |card|
+      if (period = @ect.training_periods.last)    
+        card.with_summary_list(
+          rows: [
+            { key: { text: 'Lead provider' },    value: { text: period.lead_provider.name } },
+            { key: { text: 'Delivery partner' }, value: { text: period.delivery_partner.name } },
+          ]
+        )
+      else
+        card.with_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_value(text: 'Your lead provider nas not reported any information to us yet.')
+          end
+        end
+      end      
+    end
+  end
+%>
+<%=
+  govuk_summary_card(title: 'Reported to us by your appropriate body') do |card|
+    if @ect.teacher.induction_periods.any?
+      card.with_summary_list(
+        rows: [
+          { key: { text: 'Appropriate body' },      value: { text: teacher_induction_ab_name(@ect.teacher) } },
+          { key: { text: 'Programme type' },        value: { text: teacher_induction_programme(@ect.teacher) } },
+          { key: { text: 'Induction start date' },  value: { text: teacher_induction_start_date(@ect.teacher) } },
+        ]
+      )
+    else
+      card.with_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_value(text: 'Your appropriate body nas not reported any information to us yet.')
+        end
+      end
+    end
   end
 %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,20 @@
+PROGRAMME_TYPES = {
+  provider_led: 'Provider-led',
+  school_led: 'School-led'
+}.freeze
+
+INDUCTION_PROGRAMMES = {
+  fip: 'Full induction programme',
+  cip: 'Core induction programme',
+  diy: 'School-based induction programme'
+}.freeze
+
+INDUCTION_OUTCOMES = {
+  pass: 'Passed',
+  fail: 'Failed'
+}.freeze
+
+WORKING_PATTERNS = {
+  part_time: 'Part-time',
+  full_time: 'Full-time'
+}.freeze

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -132,7 +132,7 @@ brookfield_school = schools_indexed_by_urn.fetch(2_976_163)
 print_seed_info("Adding appropriate bodies")
 
 AppropriateBody.create!(name: 'Canvas Teaching School Hub', local_authority_code: 109, establishment_number: 2367)
-AppropriateBody.create!(name: 'South Yorkshire Studio Hub', local_authority_code: 678, establishment_number: 9728)
+south_yorkshire_studio_hub = AppropriateBody.create!(name: 'South Yorkshire Studio Hub', local_authority_code: 678, establishment_number: 9728)
 AppropriateBody.create!(name: 'Ochre Education Partnership', local_authority_code: 238, establishment_number: 6582)
 umber_teaching_school_hub = AppropriateBody.create!(name: 'Umber Teaching School Hub', local_authority_code: 957, establishment_number: 7361, dfe_sign_in_organisation_id: 'd245ec79-534e-4547-a7e4-ccd98803b627')
 golden_leaf_teaching_school_hub = AppropriateBody.create!(name: 'Golden Leaf Teaching School Hub', local_authority_code: 648, establishment_number: 3986)
@@ -252,7 +252,11 @@ kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   teacher: kate_winslet,
   school: ackley_bridge,
   email: 'kate.winslet@titanic.com',
-  started_on: 1.year.ago
+  started_on: 1.year.ago,
+  lead_provider: grove_institute,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  programme_type: 'school_led',
+  working_pattern: 'full_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -294,7 +298,11 @@ alan_rickman_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   teacher: alan_rickman,
   school: ackley_bridge,
   email: 'alan.rickman@diehard.com',
-  started_on: 2.years.ago
+  started_on: 2.years.ago,
+  lead_provider: wildflower_trust,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  programme_type: 'provider_led',
+  working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -332,7 +340,11 @@ hugh_grant_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
   teacher: hugh_grant,
   school: abbey_grove_school,
   email: 'hugh.grant@wonka.com',
-  started_on: 2.years.ago
+  started_on: 2.years.ago,
+  lead_provider: grove_institute,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  programme_type: 'school_led',
+  working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -367,7 +379,11 @@ jamie_parsons_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
   teacher: jamie_parsons,
   school: abbey_grove_school,
   email: 'jamie.parsons@aol.com',
-  started_on: 2.years.ago
+  started_on: 2.years.ago,
+  lead_provider: wildflower_trust,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  programme_type: 'school_led',
+  working_pattern: 'full_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -447,7 +463,11 @@ imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
   teacher: imogen_stubbs,
   school: mallory_towers,
   email: 'imogen.stubbs@eriktheviking.com',
-  started_on: 2.years.ago
+  started_on: 2.years.ago,
+  lead_provider: wildflower_trust,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  programme_type: 'school_led',
+  working_pattern: 'full_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -475,7 +495,11 @@ gemma_jones_at_malory_towers = ECTAtSchoolPeriod.create!(
   teacher: gemma_jones,
   school: mallory_towers,
   email: 'gemma.jones@rocketman.com',
-  started_on: 21.months.ago
+  started_on: 21.months.ago,
+  lead_provider: wildflower_trust,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  programme_type: 'provider_led',
+  working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -510,7 +534,11 @@ anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
   teacher: anthony_hopkins,
   school: brookfield_school,
   email: 'anthony.hopkins@favabeans.com',
-  started_on: 2.years.ago
+  lead_provider: national_meadows_institute,
+  appropriate_body: umber_teaching_school_hub,
+  programme_type: 'provider_led',
+  started_on: 2.years.ago,
+  working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(
@@ -525,7 +553,11 @@ stephen_fry_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
   teacher: stephen_fry,
   school: brookfield_school,
   email: 'stephen.fry@sausage.com',
-  started_on: 2.years.ago
+  started_on: 2.years.ago,
+  lead_provider: national_meadows_institute,
+  appropriate_body: south_yorkshire_studio_hub,
+  programme_type: 'provider_led',
+  working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 TrainingPeriod.create!(

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -4,10 +4,14 @@ FactoryBot.define do
   factory(:ect_at_school_period) do
     association :school
     association :teacher
+    association :lead_provider
+    association :appropriate_body
 
     started_on { generate(:base_ect_date) }
     finished_on { started_on + 5.days }
     email { Faker::Internet.email }
+    programme_type { PROGRAMME_TYPES.keys.sample }
+    working_pattern { WORKING_PATTERNS.keys.sample }
 
     trait :active do
       finished_on { nil }

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
   include GovukVisuallyHiddenHelper
 
   describe "#induction_programme_choices" do
-    it "returns an array of InductionProgrammeChoice" do
+    it "returns an array of FormChoice" do
       expect(induction_programme_choices).to be_an(Array)
-      expect(induction_programme_choices).to all(be_a(AppropriateBodyHelper::InductionProgrammeChoice))
+      expect(induction_programme_choices).to all(be_a(AppropriateBodyHelper::FormChoice))
     end
 
-    it "has keys for the old (pre-2025) induction choices" do
+    it "has identifiers for the old (pre-2025) induction choices" do
       expect(induction_programme_choices.map(&:identifier)).to eql(%w[fip cip diy])
     end
 
@@ -19,6 +19,21 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
         'Core induction programme',
         'School-based induction programme'
       ])
+    end
+  end
+
+  describe "#induction_outcome_choices" do
+    it "returns an array of FormChoice" do
+      expect(induction_outcome_choices).to be_an(Array)
+      expect(induction_outcome_choices).to all(be_a(AppropriateBodyHelper::FormChoice))
+    end
+
+    it "has identifiers for induction outcomes" do
+      expect(induction_outcome_choices.map(&:identifier)).to eql(%w[pass fail])
+    end
+
+    it "has names for induction outcomes" do
+      expect(induction_outcome_choices.map(&:name)).to eql(%w[Passed Failed])
     end
   end
 

--- a/spec/helpers/teacher_helper_spec.rb
+++ b/spec/helpers/teacher_helper_spec.rb
@@ -23,4 +23,39 @@ RSpec.describe TeacherHelper, type: :helper do
 
     it { expect(teacher_induction_date_hint_text).to eql("For example, 20 4 #{last_year}") }
   end
+
+  describe '#teacher_induction_start_date' do
+    context 'when training' do
+      before { FactoryBot.create(:induction_period, teacher:) }
+
+      it { expect(teacher_induction_start_date(teacher)).to eq(1.year.ago.to_date.to_fs(:govuk)) }
+    end
+    context 'when not training' do
+      it { expect(teacher_induction_start_date(teacher)).to be_nil }
+    end
+  end
+
+  describe '#teacher_induction_programme' do
+    context 'when training' do
+      before { FactoryBot.create(:induction_period, teacher:) }
+
+      it { expect(teacher_induction_programme(teacher)).to eq('Full induction programme') }
+    end
+
+    context 'when not training' do
+      it { expect(teacher_induction_programme(teacher)).to be_nil }
+    end
+  end
+
+  describe '#teacher_induction_ab_name' do
+    context 'when training' do
+      before { FactoryBot.create(:induction_period, teacher:) }
+
+      it { expect(teacher_induction_ab_name(teacher)).to match(/Appropriate Body \d/) }
+    end
+
+    context 'when not training' do
+      it { expect(teacher_induction_ab_name(teacher)).to be_nil }
+    end
+  end
 end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -5,6 +5,8 @@ describe TrainingPeriod do
     it { is_expected.to belong_to(:provider_partnership) }
     it { is_expected.to have_many(:declarations).inverse_of(:training_period) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_one(:lead_provider).through(:provider_partnership) }
+    it { is_expected.to have_one(:delivery_partner).through(:provider_partnership) }
   end
 
   describe "validations" do

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -1,28 +1,33 @@
 RSpec.describe 'schools/ects/show.html.erb' do
-  let(:back_path) { schools_ects_home_path }
-
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White') }
-  let(:school_1) { FactoryBot.create(:school, urn: '123456') }
-  let(:school_2) { FactoryBot.create(:school, urn: '987654') }
+  let(:academic_year) { FactoryBot.create(:academic_year) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Ambition institute') }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:provider_partnership) { FactoryBot.create(:provider_partnership, lead_provider:, delivery_partner:, academic_year:) }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Alpha Teaching School Hub') }
+  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White', corrected_name: 'Baz White') }
+  let(:previous_school) { FactoryBot.create(:school, urn: '123456') }
+  let(:current_school) { FactoryBot.create(:school, urn: '987654') }
+  let(:requested_lead_provider) { FactoryBot.create(:lead_provider, name: 'Requested LP') }
+  let(:requested_appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Requested AB') }
 
   before do
-    FactoryBot.create(:ect_at_school_period,
-                      started_on: '2024-01-11',
-                      finished_on: '2025-01-11',
-                      teacher:,
-                      school: school_1,
-                      working_pattern: 'part_time',
-                      email: 'previous-address@whale.com')
+    FactoryBot.create(:ect_at_school_period, teacher:,
+                                             started_on: '2024-01-11',
+                                             finished_on: '2025-01-11',
+                                             school: previous_school,
+                                             email: 'previous-address@whale.com')
   end
 
   let!(:current_ect_period) do
-    FactoryBot.create(:ect_at_school_period,
-                      started_on: '2025-01-11',
-                      finished_on: nil,
-                      teacher:,
-                      school: school_2,
-                      working_pattern: 'full_time',
-                      email: 'love@whale.com')
+    FactoryBot.create(:ect_at_school_period, teacher:,
+                                             started_on: '2025-01-11',
+                                             finished_on: nil,
+                                             lead_provider: requested_lead_provider,
+                                             appropriate_body: requested_appropriate_body,
+                                             school: current_school,
+                                             working_pattern: 'full_time',
+                                             programme_type: 'provider_led',
+                                             email: 'love@whale.com')
   end
 
   before do
@@ -31,24 +36,24 @@ RSpec.describe 'schools/ects/show.html.erb' do
   end
 
   it 'has title' do
-    expect(view.content_for(:page_title)).to eql('Barry White')
+    expect(view.content_for(:page_title)).to eql('Baz White')
   end
 
   it 'includes a back button that links to the school home page' do
-    expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: back_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: schools_ects_home_path)
   end
 
-  describe 'personal details summary' do
+  describe 'ECT details' do
     it 'title' do
-      expect(rendered).to have_css('h2.govuk-heading-m', text: 'Personal details')
+      expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECT details')
     end
 
     it 'full name' do
       expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Name')
-      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Barry White')
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Baz White')
     end
 
-    it 'email address' do
+    it 'current email address' do
       expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Email address')
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'love@whale.com')
     end
@@ -57,7 +62,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
       context 'when assigned' do
         before do
           mentor = FactoryBot.create(:teacher, trs_first_name: 'Moby', trs_last_name: 'Dick')
-          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: school_2, teacher: mentor)
+          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: current_school, teacher: mentor)
 
           FactoryBot.create(:mentorship_period, :active,
                             started_on: current_ect_period.started_on,
@@ -92,14 +97,8 @@ RSpec.describe 'schools/ects/show.html.erb' do
     end
   end
 
-  describe 'current training details summary card' do
+  describe 'ECTE training details' do
     before do
-      academic_year = FactoryBot.create(:academic_year)
-      lead_provider = FactoryBot.create(:lead_provider, name: 'Ambition institute')
-      delivery_partner = FactoryBot.create(:delivery_partner)
-      provider_partnership = FactoryBot.create(:provider_partnership, lead_provider:, delivery_partner:, academic_year:)
-      appropriate_body = FactoryBot.create(:appropriate_body, name: 'Alpha Teaching School Hub')
-
       FactoryBot.create(:training_period, :active, :for_ect, provider_partnership:,
                                                              ect_at_school_period: current_ect_period,
                                                              started_on: current_ect_period.started_on)
@@ -109,23 +108,29 @@ RSpec.describe 'schools/ects/show.html.erb' do
       render
     end
 
-    it 'title' do
-      expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Current training details')
+    it 'titles' do
+      expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECTE training details')
+      expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
+      expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
+      expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your appropriate body')
     end
 
-    it 'appropriate body' do
+    it 'keys' do
       expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Appropriate body')
-      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Alpha Teaching School Hub')
-    end
-
-    it 'programme type' do
       expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Programme type')
-      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Full induction programme')
+      expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+      expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Delivery partner')
+      expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Induction start date')
     end
 
-    it 'lead provider' do
-      expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+    it 'values' do
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Alpha Teaching School Hub')
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Full induction programme')
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Ambition institute')
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Provider-led')
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 1.year.ago.to_date.to_fs(:govuk))
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Requested LP')
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Requested AB')
     end
   end
 end


### PR DESCRIPTION
- refactor constants to be reusable hashes
- update ECT show template design
- add extra teacher and AB helper methods
- update seed data and factories
- associate training periods to lead providers and delivery partners