### PR TITLE
Set the sentry environment from the env var

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,9 @@
-# frozen_string_literal: true
-
 if Rails.application.config.enable_sentry
   Sentry.init do |config|
     config.dsn = Rails.application.config.sentry_dsn
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.release = ENV["COMMIT_SHA"]
+    config.environment = ENV["ENVIRONMENT_NAME"]
 
     config.enable_tracing = true
     config.traces_sample_rate = 0.1


### PR DESCRIPTION
It's currently unset and appears to default to `production` in Sentry, so all errors from review apps, staging, sandbox etc look like production ones.
