### PR TITLE
Display the ECT’s TRS full name by default on the details review page

### DIFF
--- a/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
@@ -7,7 +7,7 @@
 <%= govuk_summary_list do |summary_list|
   summary_list.with_row do |row|
     row.with_key(text: 'Name')
-    row.with_value(text: @ect.full_name)
+    row.with_value(text: @ect.trs_full_name)
   end
 
   summary_list.with_row do |row|

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -7,7 +7,7 @@ module Schools
       end
 
       def full_name
-        corrected_name.presence || [trs_first_name, trs_last_name].join(" ").strip
+        (corrected_name.presence || trs_full_name).strip
       end
 
       def govuk_date_of_birth
@@ -88,6 +88,10 @@ module Schools
 
       def lead_provider
         LeadProvider.find(lead_provider_id) if provider_led?
+      end
+
+      def trs_full_name
+        [trs_first_name, trs_last_name].join(" ").strip
       end
     end
   end

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -7,7 +7,7 @@ module Schools
       end
 
       def full_name
-        (corrected_name.presence || trs_full_name).strip
+        (corrected_name.presence || trs_full_name)&.strip
       end
 
       def govuk_date_of_birth
@@ -91,7 +91,7 @@ module Schools
       end
 
       def trs_full_name
-        [trs_first_name, trs_last_name].join(" ").strip
+        Teachers::Name.new(self).full_name_in_trs
       end
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     end
   end
 
+  describe '#trs_full_name' do
+    it 'returns the full name of the ECT' do
+      expect(ect.trs_full_name).to eq("Dusty Rhodes")
+    end
+  end
+
   describe '#govuk_date_of_birth' do
     it 'formats the date of birth in the govuk format' do
       expect(ect.govuk_date_of_birth).to eq("11 October 1945")


### PR DESCRIPTION
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1303

This PR fixes a bug on the ECT's review details page where the TRS full name gets replaced when the name is corrected.

