### PR TITLE
Remove the DoB from the check answers page

### DIFF
--- a/app/views/schools/register_ect_wizard/check_answers.html.erb
+++ b/app/views/schools/register_ect_wizard/check_answers.html.erb
@@ -16,11 +16,6 @@
   end
 
   summary_list.with_row do |row|
-    row.with_key(text: 'Date of birth')
-    row.with_value(text: @ect.govuk_date_of_birth)
-  end
-
-  summary_list.with_row do |row|
     row.with_key(text: 'Email address')
     row.with_value(text: @ect.email)
     row.with_action(text: 'Change',

--- a/spec/features/schools/register_an_ect/happy_path_spec.rb
+++ b/spec/features/schools/register_an_ect/happy_path_spec.rb
@@ -179,7 +179,6 @@ RSpec.describe 'Registering an ECT' do
   def and_i_should_see_all_the_ect_data_on_the_page
     expect(page.get_by_text(trn)).to be_visible
     expect(page.get_by_text("Kirk Van Damme")).to be_visible
-    expect(page.get_by_text("3 February 1977")).to be_visible
     expect(page.get_by_text('example@example.com')).to be_visible
     expect(page.get_by_text("#{Date::MONTHNAMES[one_month_ago_today.month]} #{one_month_ago_today.year}")).to be_visible
     expect(page.get_by_text('Golden Leaf Teaching Hub')).to be_visible


### PR DESCRIPTION
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1302

This PR removes the date of birth from the check your answers page for ECT registration by schools