### PR TITLE
[xxx] Use smart quotes on the `What you’ll need to register a new ECT` page

### DIFF
--- a/app/views/schools/register_ect_wizard/start.html.erb
+++ b/app/views/schools/register_ect_wizard/start.html.erb
@@ -1,7 +1,7 @@
-<% page_data(title: "What you'll need to register a new ECT", error: false) %>
+<% page_data(title: "What you’ll need to register a new ECT", error: false) %>
 
 <h2 class="govuk-heading-m">Personal information</h2>
-<p class="govuk-body">You must provide your ECT's:</p>
+<p class="govuk-body">You must provide your ECT’s:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>name</li>
   <li>date of birth</li>
@@ -19,6 +19,6 @@
 </ul>
 
 <p class="govuk-body">If you have not assigned a mentor for your ECT, you can still register them by providing the
-  mentor's details later.</p>
+  mentor’s details later.</p>
 
 <%= govuk_button_link_to("Continue", schools_register_ect_wizard_find_ect_path) %>

--- a/spec/views/schools/register_ect_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/start.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "schools/register_ect_wizard/start.html.erb" do
   it "sets the page title" do
     render
-    expect(sanitize(view.content_for(:page_title))).to eql("What you'll need to register a new ECT")
+    expect(sanitize(view.content_for(:page_title))).to eql("What you’ll need to register a new ECT")
   end
 
   it 'includes a continue button' do


### PR DESCRIPTION
### Context

We use smart quotes on gov.uk services.

https://smartquotesforsmartpeople.com/

| Before | After |
---------|--------
|<img width="710" alt="image" src="https://github.com/user-attachments/assets/983f99a3-0be4-4d8c-a771-da10086b55c9" />|<img width="739" alt="image" src="https://github.com/user-attachments/assets/aaae1081-35d0-4523-9ded-c3cc8b5a53e2" />|