### PR TITLE
Add validation errors to guard against non-existent dates

### DIFF
--- a/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
@@ -5,18 +5,17 @@ module AppropriateBodies
         @pending_induction_submission = find_pending_induction_submission
       end
 
+      # OPTIMIZE: Pre-model validations are required to guard against
+      # ActiveRecord::MultiparameterAssignmentErrors
+      # when dates are non-existent or incorrect dates when one day from the month's end
+      # for example 31st Sept becomes 1st Oct
+      # or when negative numbers are passed in by mistake
       def update
-        register_ect = AppropriateBodies::ClaimAnECT::RegisterECT
-          .new(
-            appropriate_body: @appropriate_body,
-            pending_induction_submission: find_pending_induction_submission,
-            author: current_user
-          )
-
-        if register_ect.register(update_params)
+        if hash_date.valid? && register_ect.register(update_params)
           redirect_to(ab_claim_an_ect_register_path(register_ect.pending_induction_submission))
         else
           @pending_induction_submission = register_ect.pending_induction_submission
+          @pending_induction_submission.errors.add(:started_on, hash_date.error_message) unless hash_date.valid?
 
           render(:edit)
         end
@@ -34,6 +33,22 @@ module AppropriateBodies
 
       def find_pending_induction_submission
         PendingInductionSubmissions::Search.new(appropriate_body: @appropriate_body).pending_induction_submissions.find(params[:id])
+      end
+
+      def register_ect
+        @register_ect ||= AppropriateBodies::ClaimAnECT::RegisterECT.new(
+          appropriate_body: @appropriate_body,
+          pending_induction_submission: find_pending_induction_submission,
+          author: current_user
+        )
+      end
+
+      def hash_date
+        @hash_date ||= Schools::Validation::HashDate.new({
+          1 => update_params['started_on(1i)'], # Year
+          2 => update_params['started_on(2i)'], # Month
+          3 => update_params['started_on(3i)']  # Day
+        })
       end
     end
   end

--- a/lib/schools/validation/hash_date.rb
+++ b/lib/schools/validation/hash_date.rb
@@ -3,7 +3,6 @@ module Schools
     class HashDate
       DATE_MISSING_MESSAGE = "Enter a date".freeze
       INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998".freeze # TODO: Dates before 1999 are not supported so change this content?
-      NEGATIVE_INTEGER_MESSAGE = "Enter positive numbers only".freeze # Date.new will still accept these creating strange results
 
       attr_reader :date_as_hash, :error_message
 
@@ -24,7 +23,7 @@ module Schools
       end
 
       def value_as_date
-        @value_as_date ||= Date.new(*date_as_hash.values_at(1, 2, 3).map(&:to_i))
+        @value_as_date ||= Date.new(*date_as_integers)
       end
 
       def date_missing?
@@ -40,14 +39,17 @@ module Schools
         true
       end
 
+      def date_as_integers
+        date_as_hash.values_at(1, 2, 3).map(&:to_i)
+      end
+
       def negative_date?
-        date_as_hash.values_at(1, 2, 3).map(&:to_i).any?(&:negative?)
+        date_as_integers.any?(&:negative?)
       end
 
       def validate
         return self.class::DATE_MISSING_MESSAGE if date_missing?
-        return self.class::INVALID_FORMAT_MESSAGE if invalid_date?
-        return self.class::NEGATIVE_INTEGER_MESSAGE if negative_date?
+        return self.class::INVALID_FORMAT_MESSAGE if invalid_date? || negative_date?
 
         extra_validation_error_message
       end

--- a/lib/schools/validation/hash_date.rb
+++ b/lib/schools/validation/hash_date.rb
@@ -2,7 +2,8 @@ module Schools
   module Validation
     class HashDate
       DATE_MISSING_MESSAGE = "Enter a date".freeze
-      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998".freeze
+      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998".freeze # TODO: Dates before 1999 are not supported so change this content?
+      NEGATIVE_INTEGER_MESSAGE = "Enter positive numbers only".freeze # Date.new will still accept these creating strange results
 
       attr_reader :date_as_hash, :error_message
 
@@ -39,9 +40,14 @@ module Schools
         true
       end
 
+      def negative_date?
+        date_as_hash.values_at(1, 2, 3).map(&:to_i).any?(&:negative?)
+      end
+
       def validate
         return self.class::DATE_MISSING_MESSAGE if date_missing?
         return self.class::INVALID_FORMAT_MESSAGE if invalid_date?
+        return self.class::NEGATIVE_INTEGER_MESSAGE if negative_date?
 
         extra_validation_error_message
       end

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Claiming an ECT' do
       and_i_submit_the_form
       now_i_should_be_on_the_register_an_ect_form_page
 
-      expect(page.get_by_role("link", name: "Enter positive numbers only")).to be_visible
+      expect(page.get_by_role("link", name: "Enter the date in the correct format, for example 12 03 1998")).to be_visible
       expect(PendingInductionSubmission.last.reload.started_on).to be_nil
     end
   end

--- a/spec/lib/schools/validation/hash_date_spec.rb
+++ b/spec/lib/schools/validation/hash_date_spec.rb
@@ -26,6 +26,6 @@ RSpec.describe Schools::Validation::HashDate do
     end
 
     it { expect(hash_date).not_to be_valid }
-    it { expect(hash_date.error_message).to eq('Enter positive numbers only') }
+    it { expect(hash_date.error_message).to eq('Enter the date in the correct format, for example 12 03 1998') }
   end
 end

--- a/spec/lib/schools/validation/hash_date_spec.rb
+++ b/spec/lib/schools/validation/hash_date_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Schools::Validation::HashDate do
+  subject(:hash_date) { described_class.new(date_hash) }
+
+  before { hash_date.valid? }
+
+  context 'when value is not a real date' do
+    let(:date_hash) do
+      {
+        1 => '2022',
+        2 => '2',
+        3 => '30'
+      }
+    end
+
+    it { expect(hash_date).not_to be_valid }
+    it { expect(hash_date.error_message).to eq('Enter the date in the correct format, for example 12 03 1998') }
+  end
+
+  context 'when value includes negative numbers' do
+    let(:date_hash) do
+      {
+        1 => '2022',
+        2 => '2',
+        3 => '-28'
+      }
+    end
+
+    it { expect(hash_date).not_to be_valid }
+    it { expect(hash_date.error_message).to eq('Enter positive numbers only') }
+  end
+end

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
         end
 
         before do
+          allow_any_instance_of(Schools::Validation::HashDate).to receive(:valid?).and_return(true)
+
           allow_any_instance_of(AppropriateBodies::ClaimAnECT::RegisterECT).to receive(:register).and_call_original
         end
 


### PR DESCRIPTION
Validate a pending induction submission date prior to submitting multipart params