### PR TITLE
[1329] Add helper method to render smart quotes using RubyPants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "rotp"
 gem "rubyzip"
 gem "savon"
 
+# Render smart quotes
+gem 'rubypants'
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,6 +580,7 @@ GEM
     rubocop-rspec (3.3.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
+    rubypants (0.7.1)
     rubyzip (2.4.1)
     safely_block (0.4.1)
     savon (2.15.1)
@@ -721,6 +722,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  rubypants
   rubyzip
   savon
   sentry-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,4 +34,19 @@ module ApplicationHelper
   def support_mailto_link(text = Rails.application.config.support_email_address)
     govuk_link_to(text, 'mailto:' + Rails.application.config.support_email_address)
   end
+
+  def ruby_pants_options
+    {
+      double_left_quote: '“',
+      double_right_quote: '”',
+      single_left_quote: '‘',
+      single_right_quote: '’',
+    }
+  end
+
+  def smart_quotes(string)
+    return string if string.blank?
+
+    RubyPants.new(string, %i[quotes], ruby_pants_options).to_html
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -88,4 +88,30 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#smart_quotes' do
+    it 'converts straight single quotes to smart single quotes' do
+      expect(helper.smart_quotes("It's a test")).to eq("It’s a test")
+    end
+
+    it 'converts straight double quotes to smart double quotes' do
+      expect(helper.smart_quotes('"Hello"')).to eq('“Hello”')
+    end
+
+    it 'does not alter text without quotes' do
+      expect(helper.smart_quotes("Just some plain text")).to eq("Just some plain text")
+    end
+
+    it 'handles mixed quotes correctly' do
+      expect(helper.smart_quotes(%q('Hello' "world"))).to eq("‘Hello’ “world”")
+    end
+
+    it 'returns nil if input is nil' do
+      expect(helper.smart_quotes(nil)).to be_nil
+    end
+
+    it 'returns an empty string if input is blank' do
+      expect(helper.smart_quotes("")).to eq("")
+    end
+  end
 end


### PR DESCRIPTION
### Context

**Add helper method to convert 'dumb' quotes to 'smart' quotes using RubyPants.**

This PR introduces a helper method: `smart_quotes`, that automatically converts straight quotes (`"`, `'`) into smart quotes (`“`, `”`, `‘`, `’`). This will help to maintain a consistent gov.uk typography style across the app.

---

### Changes proposed

- Added the RubyPants gem
- Added `smart_quotes` helper method.
- Configured `RubyPants` with custom smart quote options.

---

### Usage

#### In Views
You can wrap text output with the helper to apply smart quotes automatically:

```erb
<p><%= smart_quotes("He said 'hello'") %></p>
```

outputs: 

<img width="193" alt="image" src="https://github.com/user-attachments/assets/6a05a3f9-4d74-48dc-8836-dbe5258d2cec" />


### Ticket

https://github.com/DFE-Digital/register-ects-project-board/issues/1329
