### PR TITLE
Timeline

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-assets-path: "/";
 // app styles
 @import "header/colour-overrides";
 @import "header/navigation";
+@import "timeline";
 
 // library styles
 @import "accessible-autocomplete/src/autocomplete";

--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -1,0 +1,105 @@
+// timeline
+//
+// borrowed from the MoJ frontend library, moj- replaced with app- as
+// we will likely customise this to suit our needs
+//
+// https://design-patterns.service.justice.gov.uk/components/timeline/
+.app-timeline {
+  margin-bottom: govuk-spacing(4);
+  overflow: hidden;
+  position: relative;
+
+  &::before {
+    background-color: $govuk-brand-colour;
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 5px;
+  }
+}
+
+.app-timeline--full {
+  margin-bottom: 0;
+
+  &::before {
+    height: calc(100% - 75px);
+  }
+}
+
+.app-timeline__item {
+  padding-bottom: govuk-spacing(6);
+  padding-left: govuk-spacing(4);
+  position: relative;
+
+  &::before {
+    background-color: $govuk-brand-colour;
+    content: "";
+    height: 5px;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 15px;
+  }
+}
+
+.app-timeline__title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline;
+}
+
+.app-timeline__byline {
+  @include govuk-font($size: 19);
+  color: $govuk-secondary-text-colour;
+  display: inline;
+  margin: 0;
+}
+
+.app-timeline__date {
+  @include govuk-font($size: 16);
+  margin-top: govuk-spacing(1);
+  margin-bottom: 0;
+}
+
+.app-timeline__description {
+  @include govuk-font($size: 19);
+  margin-top: govuk-spacing(4);
+}
+
+.app-timeline__documents {
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.app-timeline__document-item {
+  margin-bottom: govuk-spacing(1);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.app-timeline__document-icon {
+  float: left;
+  margin-top: 4px;
+  margin-right: 4px;
+  fill: currentcolor;
+
+  @media screen and (forced-colors: active) {
+    fill: linkText;
+  }
+}
+
+.app-timeline__document-link {
+  // background-image: url(#{$app-images-path}icon-document.svg);
+  background-repeat: no-repeat;
+  background-size: 20px 16px;
+  background-position: 0 50%;
+  padding-left: govuk-spacing(5);
+
+  &:focus {
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
+  }
+}

--- a/app/components/timeline_component.rb
+++ b/app/components/timeline_component.rb
@@ -1,0 +1,57 @@
+class TimelineComponent < ViewComponent::Base
+  renders_many :items, "ItemComponent"
+
+  attr_reader :events
+
+  def initialize(events)
+    events.each { |event| with_item(event) }
+  end
+
+  def call
+    tag.div(class: "app-timeline") do
+      safe_join(items)
+    end
+  end
+
+  class ItemComponent < ViewComponent::Base
+    attr_reader :event
+
+    def initialize(event)
+      @event = event
+    end
+
+    def call
+      tag.div(class: "app-timeline__item") do
+        safe_join([header, timestamp, description])
+      end
+    end
+
+  private
+
+    def header
+      tag.div(class: "app-timeline__header") do
+        safe_join([title, byline], " ")
+      end
+    end
+
+    def title
+      tag.h2(event.heading, class: "app-timeline__title")
+    end
+
+    def timestamp
+      tag.p(class: "app-timeline__date") do
+        tag.time(event.happened_at.to_fs(:govuk_short), datetime: event.happened_at.to_fs(:iso8601))
+      end
+    end
+
+    def description
+      tag.div(class: "app-timeline__description") { event.body }
+    end
+
+    def byline
+      attribution = event.author_name || event.author&.name || event.author_type
+
+      tag.p("by #{attribution}", class: "app-timeline__byline")
+    end
+  end
+end

--- a/app/controllers/admin/teachers/timeline_controller.rb
+++ b/app/controllers/admin/teachers/timeline_controller.rb
@@ -1,0 +1,6 @@
+class Admin::Teachers::TimelineController < AdminController
+  def show
+    @teacher = Teacher.find(params[:teacher_id])
+    @events = Event.where(teacher: @teacher)
+  end
+end

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -13,7 +13,9 @@ module Admin
 
     def show
       @page = params[:page] || 1
-      @teacher = TeacherPresenter.new(Teacher.find_by(id: params[:id]))
+      teacher = Teacher.find_by(id: params[:id])
+      @teacher = TeacherPresenter.new(teacher)
+      @events = teacher.events.latest_first
     end
   end
 end

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def index
       @appropriate_bodies = AppropriateBody.order(:name)
       @pagy, @teachers = pagy(
-        Teachers::Search.new(
+        ::Teachers::Search.new(
           query_string: params[:q]
         ).search
       )

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -36,6 +36,9 @@ class Event < ApplicationRecord
   validate :check_author_present
   validate :event_happened_in_the_past
 
+  scope :earliest_first, -> { order(happened_at: 'asc') }
+  scope :latest_first, -> { order(happened_at: 'desc') }
+
 private
 
   def check_author_present

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -14,4 +14,11 @@
   component.with_past_induction_periods(enable_edit: true)
 end %>
 
+<h2 class='govuk-heading-m'>Timeline</h2>
+<% if @events.any? %>
+  <%= render(TimelineComponent.new(@events)) %>
+<% else %>
+  <p class='govuk-body'>No timeline of events for this teacher.</p>
+<% end %>
+
 <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") if @teacher.has_migration_failures? %>

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -14,11 +14,4 @@
   component.with_past_induction_periods(enable_edit: true)
 end %>
 
-<h2 class='govuk-heading-m'>Timeline</h2>
-<% if @events.any? %>
-  <%= render(TimelineComponent.new(@events)) %>
-<% else %>
-  <p class='govuk-body'>No timeline of events for this teacher.</p>
-<% end %>
-
 <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") if @teacher.has_migration_failures? %>

--- a/app/views/admin/teachers/timeline/show.html.erb
+++ b/app/views/admin/teachers/timeline/show.html.erb
@@ -1,0 +1,15 @@
+<%
+  page_data(
+    title: smart_quotes(teacher_full_name(@teacher) + "'s timeline"),
+    caption: teacher_trn(@teacher),
+    caption_size: 'm',
+    error: false,
+    backlink_href: admin_teacher_path(@teacher)
+  )
+%>
+
+<% if @events.any? %>
+  <%= render(TimelineComponent.new(@events)) %>
+<% else %>
+  <p class='govuk-body'>No timeline of events for this teacher.</p>
+<% end %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,4 +1,8 @@
-# https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+# https://www.gov.uk/guidance/style-guide/a-to-z#dates
 Date::DATE_FORMATS[:govuk]        = "%-d %B %Y" # 2 January 1998
 Date::DATE_FORMATS[:govuk_short]  = "%-d %b %Y" # 2 Jan 1998
 Date::DATE_FORMATS[:govuk_approx] = "%B %Y"     # January 1998
+
+# https://www.gov.uk/guidance/style-guide/a-to-z#times
+Time::DATE_FORMATS[:govuk] = %(#{Date::DATE_FORMATS[:govuk]}, %-l:%M%P)             # 2 January 1998, 5:30pm
+Time::DATE_FORMATS[:govuk_short] = %(#{Date::DATE_FORMATS[:govuk_short]}, %-l:%M%P) # 2 Jan 1998, 5:30pm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
 
     resources :teachers, only: %i[index show] do
       resources :induction_periods, only: %i[edit update], path: 'induction-periods'
+      resource :timeline, only: %i[show], controller: 'teachers/timeline'
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -695,7 +695,7 @@ end
 print_seed_info('Adding funding exemptions:')
 
 # completed_during_early_roll_out
-EarlyRollOutMentor.create!(trn: imogen_stubbs.trn).tap { describe_ero_mentor(imogen_stubbs) }
+EarlyRollOutMentor.create!(trn: hugh_laurie.trn).tap { describe_ero_mentor(hugh_laurie) }
 EarlyRollOutMentor.create!(trn: harriet_walter.trn).tap { describe_ero_mentor(harriet_walter) }
 EarlyRollOutMentor.create!(trn: '3002582').tap { describe_ero_mentor('Robson Scottie') }
 EarlyRollOutMentor.create!(trn: '3002580').tap { describe_ero_mentor('Muhammed Ali') }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,3 @@
-# some sample users/personas
-
 ECT_COLOUR = :magenta
 MENTOR_COLOUR = :yellow
 
@@ -77,6 +75,16 @@ end
 
 def describe_user(user)
   print_seed_info("Added DfE staff user #{user.name} #{user.email}", indent: 2)
+end
+
+def describe_ero_mentor(mentor)
+  if mentor.is_a?(Teacher)
+    mentor_name = Colourize.text("#{mentor.trs_first_name} #{mentor.trs_last_name}", MENTOR_COLOUR)
+
+    print_seed_info(mentor_name, indent: 2)
+  else
+    print_seed_info(Colourize.text(mentor, :red), indent: 2)
+  end
 end
 
 print_seed_info("Adding teachers")
@@ -215,7 +223,7 @@ _wildflower_rising_partnership_2024 = ProviderPartnership.create!(
   delivery_partner: rising_minds
 ).tap { |pp| describe_provider_partnership(pp) }
 
-print_seed_info("Adding teachers:")
+print_seed_info("Adding teacher histories:")
 
 print_seed_info("Emma Thompson (mentor)", indent: 2, colour: MENTOR_COLOUR)
 
@@ -673,7 +681,7 @@ MentorshipPeriod.create!(
   finished_on: nil
 ).tap { |mp| describe_mentorship_period(mp) }
 
-print_seed_info("Adding persona users")
+print_seed_info("Adding persona users:")
 
 YAML.load_file(Rails.root.join('config/personas.yml'))
     .select { |p| p['type'] == 'DfE staff' }
@@ -684,10 +692,10 @@ YAML.load_file(Rails.root.join('config/personas.yml'))
       .then { |user| describe_user(user) }
 end
 
-print_seed_info('Adding funding exemptions:', colour: :red)
+print_seed_info('Adding funding exemptions:')
 
 # completed_during_early_roll_out
-EarlyRollOutMentor.create!(trn: imogen_stubbs.trn)
-EarlyRollOutMentor.create!(trn: harriet_walter.trn)
-EarlyRollOutMentor.create!(trn: '3002582') # Robson Scottie
-EarlyRollOutMentor.create!(trn: '3002580') # Muhammed Ali
+EarlyRollOutMentor.create!(trn: imogen_stubbs.trn).tap { describe_ero_mentor(imogen_stubbs) }
+EarlyRollOutMentor.create!(trn: harriet_walter.trn).tap { describe_ero_mentor(harriet_walter) }
+EarlyRollOutMentor.create!(trn: '3002582').tap { describe_ero_mentor('Robson Scottie') }
+EarlyRollOutMentor.create!(trn: '3002580').tap { describe_ero_mentor('Muhammed Ali') }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,10 @@ def print_seed_info(text, indent: 0, colour: nil)
   end
 end
 
+def teacher_name(teacher)
+  Teachers::Name.new(teacher).full_name
+end
+
 def describe_period_duration(period)
   period.finished_on ? "between #{period.started_on} and #{period.finished_on}" : "since #{period.started_on}"
 end
@@ -40,6 +44,34 @@ def describe_induction_period(ip)
   suffix = "(induction period)"
 
   print_seed_info("* is having their induction overseen by #{ip.appropriate_body.name} (AB) #{describe_period_duration(ip)} #{suffix}", indent: 4)
+
+  author_attributes = {
+    author_email: 'fkend@appropriate-body.org',
+    author_name: 'Felicity Kendall',
+    author_type: 'appropriate_body_user',
+  }
+
+  Event.create!(
+    event_type: 'appropriate_body_claims_teacher',
+    induction_period: ip,
+    teacher: ip.teacher,
+    appropriate_body: ip.appropriate_body,
+    heading: "#{teacher_name(ip.teacher)} was claimed by #{ip.appropriate_body.name}",
+    happened_at: ip.started_on.at_midday + rand(-300..300).minutes,
+    **author_attributes
+  )
+
+  if ip.finished_on
+    Event.create!(
+      event_type: 'appropriate_body_claims_teacher',
+      induction_period: ip,
+      teacher: ip.teacher,
+      appropriate_body: ip.appropriate_body,
+      heading: "#{teacher_name(ip.teacher)} was released by #{ip.appropriate_body.name}",
+      happened_at: ip.finished_on.at_midday + rand(-300..300).minutes,
+      **author_attributes
+    )
+  end
 end
 
 def describe_training_period(tp)
@@ -274,6 +306,15 @@ TrainingPeriod.create!(
   started_on: 1.year.ago,
   provider_partnership: grove_artisan_partnership_2023
 ).tap { |tp| describe_training_period(tp) }
+
+InductionPeriod.create!(
+  teacher: kate_winslet,
+  started_on: 3.years.ago,
+  finished_on: 2.years.ago,
+  number_of_terms: 3,
+  appropriate_body: golden_leaf_teaching_school_hub,
+  induction_programme: 'fip'
+).tap { |ip| describe_induction_period(ip) }
 
 InductionPeriod.create!(
   teacher: kate_winslet,

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe TimelineComponent, type: :component do
+  let(:component) { TimelineComponent.new(events) }
+
+  let(:one_day_ago) { FactoryBot.build(:event, :with_body, created_at: 1.day.ago) }
+  let(:two_days_ago) { FactoryBot.build(:event, :with_body, created_at: 2.days.ago) }
+  let(:three_days_ago) { FactoryBot.build(:event, :with_body, created_at: 3.days.ago) }
+  let(:events) { [two_days_ago, one_day_ago, three_days_ago] }
+
+  before { render_inline(component) }
+
+  it "displays all of the events in a timeline" do
+    expect(rendered_content).to have_css(".app-timeline__item", count: events.size)
+  end
+
+  it "shows a timestamp for each event" do
+    events.each do |event|
+      expect(rendered_content).to have_css("time", text: event.happened_at.to_fs(:govuk_short))
+      expect(rendered_content).to have_css("time[datetime='#{event.happened_at.to_fs(:iso8601)}']")
+    end
+  end
+
+  it "shows the title and byline in the header" do
+    events.each do |event|
+      expect(rendered_content).to have_css(".app-timeline__header > .app-timeline__title", text: event.heading)
+      expect(rendered_content).to have_css(".app-timeline__header > .app-timeline__byline", text: event.author_name)
+    end
+  end
+
+  it "shows the body for each event" do
+    events.each do |event|
+      expect(rendered_content).to have_css(".app-timeline__item > .app-timeline__description", text: event.body)
+    end
+  end
+end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     trait(:school_user) do
       author_type { :school_user }
     end
+
+    trait(:with_body) do
+      body { Faker::Lorem.paragraph }
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -18,6 +18,20 @@ describe Event do
     it { is_expected.to belong_to(:author).class_name('User').optional }
   end
 
+  describe 'scopes' do
+    describe '#earliest_first' do
+      it 'adds an order by clause for happened_at asc to the query' do
+        expect(Event.earliest_first.to_sql).to include('ORDER BY "events"."happened_at" ASC')
+      end
+    end
+
+    describe '#latest_first' do
+      it 'adds an order by clause for happened_at desc to the query' do
+        expect(Event.latest_first.to_sql).to include('ORDER BY "events"."happened_at" DESC')
+      end
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:heading) }
     it { is_expected.to validate_presence_of(:event_type) }


### PR DESCRIPTION
Add a timeline to visualise events.

We record events when key things happen in the app, like beginning or ending an induction period.

There's no way to see them yet. This PR uses the [MoJ Timeline](https://design-patterns.service.justice.gov.uk/components/timeline/) component to do that.

For now I just added the component to the bottom of the teacher 'profile' page in the admin section.

| Zoomed in | Full page |
| ----- | ----- |
|![Screenshot From 2025-03-05 13-05-22](https://github.com/user-attachments/assets/7112e269-53e6-4550-8de4-a71fbd5c074d) | ![Screenshot From 2025-03-05 13-05-56](https://github.com/user-attachments/assets/fa712e92-1631-4cc6-b0a4-8f0849f89fdc) |