### PR TITLE
Use previous steps in the school wizards for the back links

### DIFF
--- a/app/views/schools/register_ect_wizard/_email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/_email_address.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "What is #{@ect.full_name}'s email address?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <p class="govuk-body">You must provide an email address that your ECT can access. You can update it later if needed.</p>

--- a/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "Which appropriate body will be supporting #{@ect.full_name}'s induction?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <p class="govuk-body">Appropriate bodies are responsible for assuring the quality of the statutory induction of ECTs.</p>

--- a/app/views/schools/register_ect_wizard/_lead_provider.html.erb
+++ b/app/views/schools/register_ect_wizard/_lead_provider.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "Which lead provider will be training #{@ect.full_name}?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <p class="govuk-body">

--- a/app/views/schools/register_ect_wizard/_programme_type.html.erb
+++ b/app/views/schools/register_ect_wizard/_programme_type.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "What training programme will #{@ect.full_name} follow?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>

--- a/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "Check if this is your ECT",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <%= govuk_summary_list do |summary_list|

--- a/app/views/schools/register_ect_wizard/_start_date.html.erb
+++ b/app/views/schools/register_ect_wizard/_start_date.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "What is the date #{@ect.full_name} started or will start teaching as an ECT at your school?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>

--- a/app/views/schools/register_ect_wizard/_state_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_state_school_appropriate_body.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "Which appropriate body will be supporting #{@ect.full_name}'s induction?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <p class="govuk-body">Appropriate bodies are responsible for assuring the quality of the statutory induction of ECTs.</p>

--- a/app/views/schools/register_ect_wizard/_working_pattern.html.erb
+++ b/app/views/schools/register_ect_wizard/_working_pattern.html.erb
@@ -1,7 +1,7 @@
 <% page_data(
     title: "Is #{@ect.full_name}'s working pattern full or part time?",
     error: @wizard.current_step.errors.present?,
-    backlink_href:,
+    backlink_href: @wizard.previous_step_path,
 ) %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>

--- a/app/views/schools/register_ect_wizard/change_email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/change_email_address.html.erb
@@ -1,2 +1,1 @@
-<%= render 'email_address',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'email_address' %>

--- a/app/views/schools/register_ect_wizard/change_independent_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/change_independent_school_appropriate_body.html.erb
@@ -1,2 +1,1 @@
-<%= render 'independent_school_appropriate_body',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'independent_school_appropriate_body' %>

--- a/app/views/schools/register_ect_wizard/change_lead_provider.html.erb
+++ b/app/views/schools/register_ect_wizard/change_lead_provider.html.erb
@@ -1,2 +1,1 @@
-<%= render 'lead_provider',
-           backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'lead_provider' %>

--- a/app/views/schools/register_ect_wizard/change_programme_type.html.erb
+++ b/app/views/schools/register_ect_wizard/change_programme_type.html.erb
@@ -1,2 +1,1 @@
-<%= render 'programme_type',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'programme_type' %>

--- a/app/views/schools/register_ect_wizard/change_review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/change_review_ect_details.html.erb
@@ -1,2 +1,1 @@
-<%= render 'review_ect_details',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'review_ect_details' %>

--- a/app/views/schools/register_ect_wizard/change_start_date.html.erb
+++ b/app/views/schools/register_ect_wizard/change_start_date.html.erb
@@ -1,2 +1,1 @@
-<%= render 'start_date',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'start_date' %>

--- a/app/views/schools/register_ect_wizard/change_state_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/change_state_school_appropriate_body.html.erb
@@ -1,2 +1,1 @@
-<%= render 'state_school_appropriate_body',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'state_school_appropriate_body' %>

--- a/app/views/schools/register_ect_wizard/change_working_pattern.html.erb
+++ b/app/views/schools/register_ect_wizard/change_working_pattern.html.erb
@@ -1,2 +1,1 @@
-<%= render 'working_pattern',
-            backlink_href: schools_register_ect_wizard_check_answers_path %>
+<%= render 'working_pattern' %>

--- a/app/views/schools/register_ect_wizard/email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/email_address.html.erb
@@ -1,2 +1,1 @@
-<%= render 'email_address',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'email_address' %>

--- a/app/views/schools/register_ect_wizard/independent_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/independent_school_appropriate_body.html.erb
@@ -1,2 +1,1 @@
-<%= render 'independent_school_appropriate_body',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'independent_school_appropriate_body' %>

--- a/app/views/schools/register_ect_wizard/lead_provider.html.erb
+++ b/app/views/schools/register_ect_wizard/lead_provider.html.erb
@@ -1,2 +1,1 @@
-<%= render 'lead_provider',
-           backlink_href: @wizard.previous_step_path %>
+<%= render 'lead_provider' %>

--- a/app/views/schools/register_ect_wizard/national_insurance_number.html.erb
+++ b/app/views/schools/register_ect_wizard/national_insurance_number.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: "We cannot find your ECT's details", error: @wizard.current_step.errors.present?, backlink_href: schools_register_ect_wizard_find_ect_path) %>
+<% page_data(title: "We cannot find your ECT's details", error: @wizard.current_step.errors.present?, backlink_href: @wizard.previous_step_path) %>
 
 <p class="govuk-body">We cannot find a match with the details you've given. You'll need to provide more information about your ECT to help us locate them.</p>
 

--- a/app/views/schools/register_ect_wizard/programme_type.html.erb
+++ b/app/views/schools/register_ect_wizard/programme_type.html.erb
@@ -1,2 +1,1 @@
-<%= render 'programme_type',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'programme_type' %>

--- a/app/views/schools/register_ect_wizard/review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/review_ect_details.html.erb
@@ -1,2 +1,1 @@
-<%= render 'review_ect_details',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'review_ect_details' %>

--- a/app/views/schools/register_ect_wizard/start_date.html.erb
+++ b/app/views/schools/register_ect_wizard/start_date.html.erb
@@ -1,2 +1,1 @@
-<%= render 'start_date',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'start_date' %>

--- a/app/views/schools/register_ect_wizard/state_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/state_school_appropriate_body.html.erb
@@ -1,2 +1,1 @@
-<%= render 'state_school_appropriate_body',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'state_school_appropriate_body' %>

--- a/app/views/schools/register_ect_wizard/working_pattern.html.erb
+++ b/app/views/schools/register_ect_wizard/working_pattern.html.erb
@@ -1,2 +1,1 @@
-<%= render 'working_pattern',
-            backlink_href: @wizard.previous_step_path %>
+<%= render 'working_pattern' %>

--- a/app/views/schools/register_mentor_wizard/_email_address.html.erb
+++ b/app/views/schools/register_mentor_wizard/_email_address.html.erb
@@ -1,6 +1,6 @@
 <% page_data(title: "What is #{@mentor.full_name}'s email address?",
              error: @wizard.current_step.errors.present?,
-             backlink_href:) %>
+             backlink_href: @wizard.previous_step_path) %>
 
 <p class="govuk-body">We need an email so we can ask for their consent to share their details if needed for
   training.</p>

--- a/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
@@ -1,6 +1,6 @@
 <% page_data(title: "Check mentor details",
              error: @wizard.current_step.errors.present?,
-             backlink_href:) %>
+             backlink_href: @wizard.previous_step_path) %>
 
 <p>There is a teacher record that matches the details you have provided.</p>
 

--- a/app/views/schools/register_mentor_wizard/change_email_address.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_email_address.html.erb
@@ -1,1 +1,1 @@
-<%= render 'email_address', backlink_href: @wizard.previous_step_path %>
+<%= render 'email_address' %>

--- a/app/views/schools/register_mentor_wizard/change_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_mentor_details.html.erb
@@ -1,1 +1,1 @@
-<%= render 'review_mentor_details', backlink_href: @wizard.previous_step_path %>
+<%= render 'review_mentor_details' %>

--- a/app/views/schools/register_mentor_wizard/email_address.html.erb
+++ b/app/views/schools/register_mentor_wizard/email_address.html.erb
@@ -1,1 +1,1 @@
-<%= render 'email_address', backlink_href: @wizard.previous_step_path %>
+<%= render 'email_address' %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_details.html.erb
@@ -1,1 +1,1 @@
-<%= render 'review_mentor_details', backlink_href: @wizard.previous_step_path %>
+<%= render 'review_mentor_details' %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
@@ -1,7 +1,7 @@
 <% 
   page_data(
     title: "#{@mentor.full_name} can receive mentor training", 
-    backlink_href: schools_register_mentor_wizard_email_address_path
+    backlink_href: @wizard.previous_step_path
   ) 
 %>
 

--- a/app/wizards/schools/register_ect_wizard/change_email_address_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_email_address_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/change_programme_type_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_programme_type_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/change_review_ect_details_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_review_ect_details_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/change_start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_start_date_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/change_working_pattern_step.rb
+++ b/app/wizards/schools/register_ect_wizard/change_working_pattern_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :check_answers
+      end
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_ect_wizard/national_insurance_number_step.rb
@@ -19,6 +19,10 @@ module Schools
         :review_ect_details
       end
 
+      def previous_step
+        :find_ect
+      end
+
     private
 
       def persist

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -4,6 +4,10 @@ module Schools
       def next_step
         :check_answers
       end
+
+      def previous_step
+        :email_address
+      end
     end
   end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_email_address_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_email_address_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeEmailAddressStep, type: :model 
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeIndependentSchoolAppropriateBod
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_programme_type_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_programme_type_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeProgrammeTypeStep, type: :model
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_review_ect_details_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_review_ect_details_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeReviewECTDetailsStep, type: :mo
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_start_date_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeStartDateStep, type: :model do
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeStateSchoolAppropriateBodyStep,
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/change_working_pattern_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_working_pattern_step_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Schools::RegisterECTWizard::ChangeWorkingPatternStep, type: :mode
       expect(subject.next_step).to eq(:check_answers)
     end
   end
+
+  describe "#previous_step" do
+    it "returns :check_answers" do
+      expect(subject.next_step).to eq(:check_answers)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `previous_step` methods in the school wizard steps and uses `@wizard.previous_step_path` for the back links in the views.

Changes:
- Added `previous_step` methods to wizard steps that were missing them
- Updated views to replace path helper methods with `@wizard.previous_step_path` for back links



Ticket: https://github.com/DFE-Digital/register-early-career-teachers-public/issues/275