### PR TITLE
Stop streaming the mentor completion date and completion reason fields to BigQuery

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -11,8 +11,6 @@ shared:
   - trs_initial_teacher_training_provider_name
   - trs_initial_teacher_training_end_date
   - trs_data_last_refreshed_at
-  - mentor_completion_date
-  - mentor_completion_reason
   :appropriate_bodies:
   - id
   - name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -207,6 +207,8 @@
   - ecf_user_id
   - ecf_ect_profile_id
   - ecf_mentor_profile_id
+  - mentor_completion_date
+  - mentor_completion_reason
   :pending_induction_submissions:
   - id
   - appropriate_body_id


### PR DESCRIPTION
The analytics team requested to blocklist the `mentor_completion_date` and `mentor_completion_reason` fields.