### PR TITLE
Extract finding and initializing logic into Teachers::Manage service

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,9 @@ class Event < ApplicationRecord
     appropriate_body_fails_teacher
     appropriate_body_passes_teacher
     teacher_name_updated_by_trs
+    teacher_created_in_trs
+    qts_awarded_on_updated_by_trs
+    itt_provider_name_updated_by_trs
     import_from_dqt
   ].freeze
 

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -114,6 +114,27 @@ module Events
       new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
     end
 
+    def self.teacher_created_in_trs!(author:, teacher:, appropriate_body: nil, happened_at: Time.zone.now)
+      event_type = :teacher_created_in_trs
+      heading = "#{Teachers::Name.new(teacher).full_name_in_trs} was created in TRS"
+
+      new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
+    end
+
+    def self.qts_awarded_on_changed_in_trs!(old_award_date:, new_award_date:, author:, teacher:, appropriate_body: nil, happened_at: Time.zone.now)
+      event_type = :qts_awarded_on_updated_by_trs
+      heading = "QTS award date changed from #{old_award_date} to #{new_award_date}"
+
+      new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
+    end
+
+    def self.itt_provider_name_changed_in_trs!(itt_provider_before:, itt_provider_after:, author:, teacher:, appropriate_body: nil, happened_at: Time.zone.now)
+      event_type = :itt_provider_name_updated_by_trs
+      heading = "ITT provider name changed from #{itt_provider_before} to #{itt_provider_after}"
+
+      new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
+    end
+
     # Admin events
 
     def self.record_admin_updates_induction_period!(author:, modifications:, induction_period:, teacher:, appropriate_body:, happened_at: Time.zone.now)

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -79,8 +79,12 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
       it "enqueues BeginECTInductionJob" do
         expect {
           subject.register(pending_induction_submission_params)
-        }.to have_enqueued_job(BeginECTInductionJob)
-          .with(hash_including(trn: "1234567", start_date: Date.new(2023, 5, 2)))
+        }.to have_enqueued_job(BeginECTInductionJob).with(
+          hash_including(
+            trn: "1234567",
+            start_date: Date.new(2023, 5, 2)
+          )
+        )
       end
 
       it "records an appropriate_body_claims_teacher event" do
@@ -111,11 +115,6 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
           trs_qts_awarded_on:
         }
       end
-
-      it "can perform jobs without erroring" do
-        subject.register(pending_induction_submission_params)
-        perform_enqueued_jobs
-      end
     end
 
     context 'when registering an existing teacher' do
@@ -139,7 +138,14 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
 
       context 'when the teacher has no existing induction periods' do
         it "does enqueues BeginECTInductionJob" do
-          expect { subject.register(pending_induction_submission_params) }.to have_enqueued_job(BeginECTInductionJob)
+          expect {
+            subject.register(pending_induction_submission_params)
+          }.to have_enqueued_job(BeginECTInductionJob).with(
+            hash_including(
+              trn: "1234567",
+              start_date: Date.new(2023, 5, 2)
+            )
+          )
         end
       end
 
@@ -175,7 +181,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
 
           perform_enqueued_jobs
 
-          expect(Event.all.map(&:event_type)).to match_array(%w[teacher_name_updated_by_trs appropriate_body_claims_teacher])
+          expect(Event.all.map(&:event_type)).to match_array(%w[teacher_name_updated_by_trs appropriate_body_claims_teacher qts_awarded_on_updated_by_trs itt_provider_name_updated_by_trs])
         end
 
         it 'saves the pending_induction_submission' do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -154,6 +154,75 @@ describe Events::Record do
     end
   end
 
+  describe '.teacher_created_in_trs!' do
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        Events::Record.teacher_created_in_trs!(author:, teacher:, appropriate_body:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          appropriate_body:,
+          heading: 'Rhys Ifans was created in TRS',
+          event_type: :teacher_created_in_trs,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
+  describe '.qts_awarded_on_changed_in_trs!' do
+    let(:old_award_date) { 3.weeks.ago.to_date }
+    let(:new_award_date) { 2.weeks.ago.to_date }
+
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        Events::Record.qts_awarded_on_changed_in_trs!(
+          old_award_date:,
+          new_award_date:,
+          author:,
+          teacher:,
+          appropriate_body:
+        )
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          appropriate_body:,
+          heading: "QTS award date changed from #{old_award_date} to #{new_award_date}",
+          event_type: :qts_awarded_on_updated_by_trs,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
+  describe '.itt_provider_name_changed_in_trs!' do
+    let(:itt_provider_before) { 'Old ITT Provider' }
+    let(:itt_provider_after) { 'New ITT Provider' }
+
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        Events::Record.itt_provider_name_changed_in_trs!(
+          itt_provider_before:,
+          itt_provider_after:,
+          author:,
+          teacher:,
+          appropriate_body:
+        )
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          appropriate_body:,
+          heading: "ITT provider name changed from #{itt_provider_before} to #{itt_provider_after}",
+          event_type: :itt_provider_name_updated_by_trs,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe '.record_admin_updates_induction_period!' do
     let(:three_weeks_ago) { 3.weeks.ago.to_date }
     let(:two_weeks_ago) { 2.weeks.ago.to_date }

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -5,6 +5,80 @@ RSpec.describe Teachers::Manage do
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'Allen') }
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:event_metadata) { { author:, appropriate_body: } }
+
+  describe '.find_or_initialize_by' do
+    before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+    context 'when the teacher does not exist' do
+      let(:trn) { '1234567' }
+      let(:trs_first_name) { 'John' }
+      let(:trs_last_name) { 'Doe' }
+
+      it 'creates a new teacher and records a creation event' do
+        freeze_time do
+          expect {
+            described_class.find_or_initialize_by(
+              trn:,
+              trs_first_name:,
+              trs_last_name:,
+              event_metadata:
+            )
+          }.to change(Teacher, :count).by(1)
+
+          teacher = Teacher.find_by(trn:)
+          expect(teacher.trs_first_name).to eq(trs_first_name)
+          expect(teacher.trs_last_name).to eq(trs_last_name)
+
+          expect(RecordEventJob).to have_received(:perform_later).with(
+            author_email: 'christopher.biggins@education.gov.uk',
+            author_id: author.id,
+            author_name: 'Christopher Biggins',
+            author_type: :dfe_staff_user,
+            event_type: :teacher_created_in_trs,
+            happened_at: Time.zone.now,
+            heading: "John Doe was created in TRS",
+            teacher:,
+            appropriate_body:
+          )
+        end
+      end
+    end
+
+    context 'when the teacher already exists' do
+      let(:existing_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Existing', trs_last_name: 'Teacher') }
+
+      it 'does not create a new teacher or record a creation event' do
+        allow(Teacher).to receive(:find_by).and_return(existing_teacher)
+        allow(existing_teacher).to receive(:new_record?).and_return(false)
+
+        result = described_class.find_or_initialize_by(
+          trn: existing_teacher.trn,
+          trs_first_name: 'New',
+          trs_last_name: 'Name',
+          event_metadata:
+        )
+
+        expect(result.teacher).to eq(existing_teacher)
+        expect(RecordEventJob).not_to have_received(:perform_later).with(
+          hash_including(event_type: :teacher_created_in_trs)
+        )
+      end
+
+      it 'returns a manage instance with the existing teacher' do
+        manage = described_class.find_or_initialize_by(
+          trn: existing_teacher.trn,
+          trs_first_name: 'New',
+          trs_last_name: 'Name',
+          event_metadata:
+        )
+
+        expect(manage.teacher).to eq(existing_teacher)
+        expect(manage.author).to eq(author)
+        expect(manage.appropriate_body).to eq(appropriate_body)
+      end
+    end
+  end
 
   describe '#update_name!' do
     before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
@@ -23,6 +97,62 @@ RSpec.describe Teachers::Manage do
           happened_at: Time.zone.now,
           heading: 'Name changed from Barry Allen to John Doe',
           teacher:
+        )
+      end
+    end
+  end
+
+  describe '#update_qts_awarded_on!' do
+    before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+    it 'records a QTS award date change event' do
+      old_award_date = Date.new(2020, 1, 1)
+      new_award_date = Date.new(2020, 2, 1)
+      teacher.trs_qts_awarded_on = old_award_date
+
+      freeze_time do
+        service.update_qts_awarded_on!(trs_qts_awarded_on: new_award_date)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          hash_including(
+            appropriate_body:,
+            author_email: 'christopher.biggins@education.gov.uk',
+            author_id: author.id,
+            author_name: 'Christopher Biggins',
+            author_type: :dfe_staff_user,
+            event_type: :qts_awarded_on_updated_by_trs,
+            happened_at: Time.zone.now,
+            heading: "QTS award date changed from #{old_award_date} to #{new_award_date}",
+            teacher:
+          )
+        )
+      end
+    end
+  end
+
+  describe '#update_itt_provider_name!' do
+    before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+    it 'records an ITT provider name change event' do
+      itt_provider_before = 'Old ITT Provider'
+      itt_provider_after = 'New ITT Provider'
+      teacher.trs_initial_teacher_training_provider_name = itt_provider_before
+
+      freeze_time do
+        service.update_itt_provider_name!(trs_initial_teacher_training_provider_name: itt_provider_after)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          hash_including(
+            appropriate_body:,
+            author_email: 'christopher.biggins@education.gov.uk',
+            author_id: author.id,
+            author_name: 'Christopher Biggins',
+            author_type: :dfe_staff_user,
+            event_type: :itt_provider_name_updated_by_trs,
+            happened_at: Time.zone.now,
+            heading: "ITT provider name changed from #{itt_provider_before} to #{itt_provider_after}",
+            teacher:
+          )
         )
       end
     end


### PR DESCRIPTION
Moving all teacher managing logic from RegisterECT service to Teachers::Manage service 

Also implement these events:
- teacher_created_in_trs
- qts_awarded_on_updated_by_trs
- itt_provider_name_updated_by_trs