### PR TITLE
Add service rules for induction extensions

### DIFF
--- a/app/views/appropriate_bodies/teachers/extensions/edit.html.erb
+++ b/app/views/appropriate_bodies/teachers/extensions/edit.html.erb
@@ -39,7 +39,7 @@
         An ECT may appeal an extension to their induction. You must advise the ECT of their right to appeal and provide them with information about who to appeal to, and the time limit for doing so. More information can be found here
       </p>
 
-      <%= f.govuk_submit "Continue" %>
+      <%= f.govuk_submit "Update extension" %>
     <% end %>
   </div>
 </div>

--- a/app/views/appropriate_bodies/teachers/extensions/new.html.erb
+++ b/app/views/appropriate_bodies/teachers/extensions/new.html.erb
@@ -42,7 +42,7 @@
         hint: { text: "You can use up to one decimal place if the induction term is not a whole number. For example, for 2 and a half terms enter 2.5" }
       ) %>
 
-      <%= f.govuk_submit "Continue" %>
+      <%= f.govuk_submit "Add extension" %>
     <% end %>
   </div>
 </div>

--- a/documentation/service-rules/appropriate-body-users.md
+++ b/documentation/service-rules/appropriate-body-users.md
@@ -213,7 +213,14 @@ The fail process takes place with the following steps:
 
 ## Extensions
 
-If an ECT's induction is [interrupted by more than 30 working days](/policy/induction-arrangements-for-school-teachers-in-england#para-8-1) it can be extended.
+An ECT's induction must be extended if it is [interrupted by more than 30 working days for ad hoc purposes](/policy/induction-arrangements-for-school-teachers-in-england#para-8-1).
+
+An ECT's induction may be extended if:
+- It is interrupted by statutory maternity, paternity, adoption, shared parental, parental bereavement or carer’s leave
+- The ECT is determined not to have met the Teaching Standards when they were due to complete their induction, and an Appropriate Body makes a decision that an extension to their induction is appropriate.
+
+Appropriate Bodies only need to record the latter type of extension on the service, where an induction has been extended due to the ECT failing to meet the Teaching Standards. ECTs are able to appeal this type of extension.
+
 
 Extensions are recorded at the teacher level, **induction periods are not extended**.
 

--- a/documentation/service-rules/appropriate-body-users.md
+++ b/documentation/service-rules/appropriate-body-users.md
@@ -211,3 +211,40 @@ The fail process takes place with the following steps:
   - partial terms must be entered as decimals
   - value must be between 0 and 16 weeks
 
+## Extensions
+
+If an ECT's induction is [interrupted by more than 30 working days](/policy/induction-arrangements-for-school-teachers-in-england#para-8-1) it can be extended.
+
+Extensions are recorded at the teacher level, **induction periods are not extended**.
+
+The extension record just holds the number of terms.
+
+The number of terms value refers to full time equivalent (FTE) terms.
+
+The number of extensions must be:
+  - present
+  - a numeric value
+  - between 0.1 and 16 (used to keep the value sensible, not a policy-enforced limit)
+  - 0 or 1 decimal place (1 and 1.5 are valid, 1.25 is not)
+
+There is no validation preventing a teacher having an unlimited number of extensions.
+
+### Viewing extensions
+
+When an ECT has extensions the view ECT screen displays the sum of all extensions and has a 'View' link that takes you to the extensions page.
+
+When an ECT has no extensions the view ECT screen shows 'None' and has a 'Add' link that takes you to the extensions page.
+
+### Adding an extension
+
+1. From the view ECT screen click 'Add' or 'View' in the 'Extensions' row
+2. Click the 'Add extension' button
+3. Enter a number in the 'Number of terms' field. The number must adhere to the validation rules above.
+4. Click 'Add extension'
+
+### Editing an extension
+
+1. From the view ECT screen click 'Add' or 'View' in the 'Extensions' row
+2. Click the 'Edit' link next to the extension you intend to modify
+3. Enter a number in the 'Number of terms' field. The number must adhere to the validation rules above.
+4. Click 'Update extension'


### PR DESCRIPTION
This change adds service rules for the extensions.

It also changes the button text on the forms for 'Add extension' and' Update extension' because 'Continue' is misleading.

@PriyaNahar2 I think we need to do a bit of surgery on the edit page next week, I'm not sure it makes sense at the moment!