### PR TITLE
Make statuses dependant on induction period presence

### DIFF
--- a/app/services/teachers/induction_status.rb
+++ b/app/services/teachers/induction_status.rb
@@ -9,27 +9,27 @@ class Teachers::InductionStatus
 
   def status_tag_kwargs
     case induction_info
-    in { teacher_present: true, has_an_open_induction_period: true }
+    in { teacher_with_induction_periods_present: true, has_an_open_induction_period: true }
       in_progress
-    in { teacher_present: true, has_an_open_induction_period: false, has_an_induction_outcome: false }
+    in { teacher_with_induction_periods_present: true, has_an_open_induction_period: false, has_an_induction_outcome: false }
       paused
-    in { teacher_present: true, has_an_open_induction_period: false, induction_outcome: 'pass' }
+    in { teacher_with_induction_periods_present: true, has_an_open_induction_period: false, induction_outcome: 'pass' }
       passed
-    in { teacher_present: true, has_an_open_induction_period: false, induction_outcome: 'fail' }
+    in { teacher_with_induction_periods_present: true, has_an_open_induction_period: false, induction_outcome: 'fail' }
       failed
-    in { teacher_present: false, trs_induction_status: 'RequiredToComplete' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'RequiredToComplete' }
       required_to_complete
-    in { teacher_present: false, trs_induction_status: 'Exempt' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'Exempt' }
       exempt
-    in { teacher_present: false, trs_induction_status: 'InProgress' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'InProgress' }
       in_progress
-    in { teacher_present: false, trs_induction_status: 'Failed' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'Failed' }
       failed
-    in { teacher_present: false, trs_induction_status: 'Passed' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'Passed' }
       passed
-    in { teacher_present: false, trs_induction_status: 'FailedInWales' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'FailedInWales' }
       failed_in_wales
-    in { teacher_present: false, trs_induction_status: 'None' }
+    in { teacher_with_induction_periods_present: false, trs_induction_status: 'None' }
       none
     else
       unknown
@@ -54,7 +54,7 @@ private
     {
       has_an_open_induction_period: has_any_open_induction_periods?,
       has_an_induction_outcome: has_an_induction_outcome?,
-      teacher_present: teacher.present?,
+      teacher_with_induction_periods_present: teacher.present? && induction_periods.present?,
       induction_outcome:,
       trs_induction_status:,
     }

--- a/spec/services/teachers/induction_status_spec.rb
+++ b/spec/services/teachers/induction_status_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe Teachers::InductionStatus do
   context 'when the teacher record exists in our database' do
     let(:trs_induction_status) { nil }
 
+    context 'when the ECT has no induction periods' do
+      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:induction_periods) { [] }
+      let(:trs_induction_status) { 'Exempt' }
+
+      it "returns the TRS induction status" do
+        expect(service.induction_status).to eql('Exempt')
+      end
+    end
+
     context 'when the ECT has an open induction period' do
       let(:teacher) { FactoryBot.create(:teacher) }
       let(:induction_periods) do


### PR DESCRIPTION
We ran into a bug in staging where teachers with no induction periods are marked as 'Induction paused' because they have no ongoing induction periods either.

This shouldn't happen in production yet but we can still fix the bug by only overriding the TRS induction status when we have both a teacher record and it has induction periods.
