### PR TITLE
[Migration] Add created_at to view components

### DIFF
--- a/app/components/migration/induction_record_component.html.erb
+++ b/app/components/migration/induction_record_component.html.erb
@@ -61,5 +61,9 @@
       row.with_key(text: "Training status")
       row.with_value(text: induction_record.training_status)
     end
+    list.with_row do |row|
+      row.with_key(text: "Created at")
+      row.with_value(text: induction_record.created_at)
+    end
   end
 end %>

--- a/app/components/migration/participant_profile_component.html.erb
+++ b/app/components/migration/participant_profile_component.html.erb
@@ -51,5 +51,9 @@
       row.with_key(text: "Cohort changed after payments frozen")
       row.with_value(text: participant_profile.cohort_changed_after_payments_frozen.to_s)
     end
+    list.with_row do |row|
+      row.with_key(text: "Created at")
+      row.with_value(text: participant_profile.created_at)
+    end
   end
 end %>


### PR DESCRIPTION
Add `created_at` timestamp to view of `ParticipantProfile` and `InductionRecord` in the migration UI.