### PR TITLE
Refactor `ECT details` summary list into `ViewComponent`

### DIFF
--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -1,0 +1,5 @@
+<%=
+  govuk_summary_list(
+    rows:
+  )
+%>

--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -1,5 +1,0 @@
-<%=
-  govuk_summary_list(
-    rows:
-  )
-%>

--- a/app/components/schools/teacher_profile_summary_list_component.rb
+++ b/app/components/schools/teacher_profile_summary_list_component.rb
@@ -1,0 +1,42 @@
+module Schools
+  class TeacherProfileSummaryListComponent < ViewComponent::Base
+    include TeacherHelper
+    include ECTHelper
+
+    def initialize(ect)
+      @ect = ect
+    end
+
+    def rows
+      [
+        name_row,
+        email_row,
+        mentor_row,
+        school_start_date_row,
+        working_pattern_row
+      ]
+    end
+
+  private
+
+    def name_row
+      { key: { text: 'Name' }, value: { text: teacher_full_name(@ect.teacher) } }
+    end
+
+    def email_row
+      { key: { text: 'Email address' }, value: { text: @ect.email } }
+    end
+
+    def mentor_row
+      { key: { text: 'Mentor' }, value: { text: ect_mentor_details(@ect) } }
+    end
+
+    def school_start_date_row
+      { key: { text: 'School start date' }, value: { text: ect_start_date(@ect) } }
+    end
+
+    def working_pattern_row
+      { key: { text: 'Working pattern' }, value: { text: @ect.working_pattern&.humanize } }
+    end
+  end
+end

--- a/app/components/schools/teacher_profile_summary_list_component.rb
+++ b/app/components/schools/teacher_profile_summary_list_component.rb
@@ -17,6 +17,10 @@ module Schools
       ]
     end
 
+    def call
+      safe_join([tag.h2('ECT details', class: 'govuk-heading-m'), govuk_summary_list(rows:)])
+    end
+
   private
 
     def name_row

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -7,17 +7,9 @@
   )
 %>
 <h2 class='govuk-heading-m'>ECT details</h2>
-<%=
-  govuk_summary_list(
-    rows: [
-      { key: { text: 'Name' },              value: { text: teacher_full_name(@ect.teacher) } },
-      { key: { text: 'Email address' },     value: { text: @ect.email } },
-      { key: { text: 'Mentor' },            value: { text: ect_mentor_details(@ect) } },
-      { key: { text: 'School start date' }, value: { text: ect_start_date(@ect) } },
-      { key: { text: 'Working pattern' },   value: { text: @ect.working_pattern&.humanize } },
-    ]
-  )
-%>
+
+<%= render Schools::TeacherProfileSummaryListComponent.new(@ect) %>
+
 <h2 class='govuk-heading-m'>ECTE training details</h2>
 <%=
   govuk_summary_card(title: 'Reported to us by your school') do |card|

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -6,7 +6,6 @@
     caption_size: 'l',
   )
 %>
-<h2 class='govuk-heading-m'>ECT details</h2>
 
 <%= render Schools::TeacherProfileSummaryListComponent.new(@ect) %>
 

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,12 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
-  include TeacherHelper
-  include ECTHelper
-
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+  let(:teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
+  let(:teacher_2) { FactoryBot.create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-  let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee: ect, mentor:) }
+  let(:mentor_2) { FactoryBot.create(:mentor_at_school_period, :active, teacher: teacher_2, started_on: 3.years.ago) }
+  let(:ect) do
+    FactoryBot.create(:ect_at_school_period, :active, teacher:, started_on: Date.new(2021, 9, 1),
+                                                      email: 'foobarect@madeup.com', working_pattern: 'full_time')
+  end
+
+  let!(:ongoing_mentorship) do
+    FactoryBot.create(:mentorship_period, :active, mentee: ect, mentor:, started_on: 3.years.ago, finished_on: 2.years.ago)
+  end
+
+  let!(:ongoing_mentorship_2) do
+    FactoryBot.create(:mentorship_period, :active, mentee: ect, mentor: mentor_2, started_on: 2.years.ago)
+  end
 
   before do
     render_inline(described_class.new(ect))
@@ -18,26 +28,26 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
 
   it "renders the name row with correct value" do
     expect(page).to have_selector(".govuk-summary-list__row", text: "Name")
-    expect(page).to have_text(teacher_full_name(ect.teacher))
+    expect(page).to have_text('Kakarot SSJ')
   end
 
   it "renders the email row with correct value" do
     expect(page).to have_selector(".govuk-summary-list__row", text: "Email address")
-    expect(page).to have_text(ect.email)
+    expect(page).to have_text('foobarect@madeup.com')
   end
 
   it "renders the mentor row with correct value" do
     expect(page).to have_selector(".govuk-summary-list__row", text: "Mentor")
-    expect(page).to have_text(ect_mentor_details(ect))
+    expect(page).to have_text('Naruto Ninetails')
   end
 
   it "renders the school start date row with correct value" do
     expect(page).to have_selector(".govuk-summary-list__row", text: "School start date")
-    expect(page).to have_text(ect_start_date(ect))
+    expect(page).to have_text('September 2021')
   end
 
   it "renders the working pattern row with correct value" do
     expect(page).to have_selector(".govuk-summary-list__row", text: "Working pattern")
-    expect(page).to have_text(ect.working_pattern&.humanize)
+    expect(page).to have_text('Full time')
   end
 end

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,25 +1,19 @@
 require "rails_helper"
 
 RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
-  let(:teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
-  let(:teacher_2) { FactoryBot.create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-  let(:mentor_2) { FactoryBot.create(:mentor_at_school_period, :active, teacher: teacher_2, started_on: 3.years.ago) }
-  let(:ect) do
-    FactoryBot.create(:ect_at_school_period, :active, teacher:, started_on: Date.new(2021, 9, 1),
+  let(:mentee_teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
+  let(:mentor_teacher) { FactoryBot.create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }
+  let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher, started_on: 3.years.ago) }
+  let(:mentee) do
+    FactoryBot.create(:ect_at_school_period, :active, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
                                                       email: 'foobarect@madeup.com', working_pattern: 'full_time')
   end
 
-  let!(:ongoing_mentorship) do
-    FactoryBot.create(:mentorship_period, :active, mentee: ect, mentor:, started_on: 3.years.ago, finished_on: 2.years.ago)
-  end
-
-  let!(:ongoing_mentorship_2) do
-    FactoryBot.create(:mentorship_period, :active, mentee: ect, mentor: mentor_2, started_on: 2.years.ago)
-  end
-
   before do
-    render_inline(described_class.new(ect))
+    FactoryBot.create(:mentorship_period, :active, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago)
+    FactoryBot.create(:mentorship_period, :active, mentee:, mentor: current_mentor, started_on: 2.years.ago)
+    render_inline(described_class.new(mentee))
   end
 
   it "renders the summary list container" do

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
+  include TeacherHelper
+  include ECTHelper
+
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+  let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee: ect, mentor:) }
+
+  before do
+    render_inline(described_class.new(ect))
+  end
+
+  it "renders the summary list container" do
+    expect(page).to have_selector(".govuk-summary-list")
+  end
+
+  it "renders the name row with correct value" do
+    expect(page).to have_selector(".govuk-summary-list__row", text: "Name")
+    expect(page).to have_text(teacher_full_name(ect.teacher))
+  end
+
+  it "renders the email row with correct value" do
+    expect(page).to have_selector(".govuk-summary-list__row", text: "Email address")
+    expect(page).to have_text(ect.email)
+  end
+
+  it "renders the mentor row with correct value" do
+    expect(page).to have_selector(".govuk-summary-list__row", text: "Mentor")
+    expect(page).to have_text(ect_mentor_details(ect))
+  end
+
+  it "renders the school start date row with correct value" do
+    expect(page).to have_selector(".govuk-summary-list__row", text: "School start date")
+    expect(page).to have_text(ect_start_date(ect))
+  end
+
+  it "renders the working pattern row with correct value" do
+    expect(page).to have_selector(".govuk-summary-list__row", text: "Working pattern")
+    expect(page).to have_text(ect.working_pattern&.humanize)
+  end
+end

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -44,4 +44,10 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     expect(page).to have_selector(".govuk-summary-list__row", text: "Working pattern")
     expect(page).to have_text('Full time')
   end
+
+  describe '#rows' do
+    it 'returns the correct number of rows' do
+      expect(described_class.new(mentee).rows.count).to eq(5)
+    end
+  end
 end


### PR DESCRIPTION
## Overview

This PR introduces the `TeacherProfileSummaryListComponent` component, which renders a summary list with key details about an ECT (Early Career Teacher). The component displays the following information:

- Teacher's name
- Email address
- Mentor information
- School start date
- Working pattern

## Changes

- Add `TeacherProfileSummaryListComponent` to render a summary list of ECT details.
- Include helper methods to format teacher name, mentor details and school start date.
- Add tests for the component to ensure it renders the correct details.
