### PR TITLE
restore from any dump in any azure storage account

### DIFF
--- a/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
@@ -81,7 +81,7 @@ runs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: Direct copy ${{ inputs.environment }}->snapshot database succeeded
+        SLACK_TITLE: Direct copy ${{ inputs.environment }}->snapshot database success
         SLACK_MESSAGE: ${{ inputs.app-name }} - the direct copy of ${{ inputs.environment }}->snapshot db succeeded
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLACK_COLOR: success
@@ -92,7 +92,7 @@ runs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: Direct copy ${{ inputs.environment }}->snapshot database failed
+        SLACK_TITLE: Direct copy ${{ inputs.environment }}->snapshot database failure
         SLACK_MESSAGE: ${{ inputs.app-name }} - the direct copy of ${{ inputs.environment }}->snapshot db failed
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLACK_COLOR: failures

--- a/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
@@ -127,7 +127,7 @@ runs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: Snapshot database restore succeeded
+        SLACK_TITLE: Snapshot database restore success
         SLACK_MESSAGE: ${{ inputs.app-name }} - snapshot restore job from ${{ inputs.storage-account }} / database-backup / ${{ inputs.backup-file }} succeeded!
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLACK_COLOR: success
@@ -138,7 +138,7 @@ runs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: Snapshot database restore failed
+        SLACK_TITLE: Snapshot database restore failure
         SLACK_MESSAGE: ${{ inputs.app-name }} snapshot restore job from ${{ inputs.storage-account }} / database-backup / ${{ inputs.backup-file }} failed!
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLACK_COLOR: failure

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -138,8 +138,19 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_USERNAME: CI Deployment
-          SLACK_TITLE: ${{ env.APP_NAME }} - ${{ env.DEPLOY_ENV }} database backup job succeeded
-          SLACK_MESSAGE: ${{ env.DEPLOY_ENV }} database dump stored in Azure Storage (${{ env.STORAGE_ACCOUNT_NAME }} / database-backup / ${{ env.BACKUP_FILE }}.sql) - Success
+          SLACK_TITLE: ${{ env.DEPLOY_ENV }} database backup success
+          SLACK_MESSAGE: ${{ env.APP_NAME }} - ${{ env.DEPLOY_ENV }} database dump stored in Azure Storage (${{ env.STORAGE_ACCOUNT_NAME }} / database-backup / ${{ env.BACKUP_FILE }}.sql) - Succeeded
           SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
           SLACK_COLOR: success
+          SLACK_FOOTER: Sent from backup-db workflow
+
+      - name: Notify Slack channel on job failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: ${{ env.DEPLOY_ENV }} database backup failure
+          SLACK_MESSAGE: ${{ env.APP_NAME }} - ${{ env.DEPLOY_ENV }} database dump to be stored in Azure Storage (${{ env.STORAGE_ACCOUNT_NAME }} / database-backup / ${{ env.BACKUP_FILE }}.sql) - Failed!
+          SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
           SLACK_FOOTER: Sent from backup-db workflow

--- a/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
+++ b/.github/workflows/nightly-copy-production_db_into_snapshot_db_and_store_dump.yml
@@ -23,7 +23,7 @@ jobs:
     needs: generate-day_of_week
     with:
       environment: production
-      backup-file: cpdec2_production_adhoc_${{ needs.generate-day_of_week.outputs.today_day }}
+      backup-file: cpdec2_production_nightly_copy_${{ needs.generate-day_of_week.outputs.today_day }}
     secrets:
       azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/restore-snapshot-db-from-azure-storage.yml
     with:
       environment: production
-      backup-file: cpdec2_production_adhoc_${{ needs.generate-day_of_week.outputs.today_day }}
+      backup-file: cpdec2_production_nightly_copy_${{ needs.generate-day_of_week.outputs.today_day }}
     secrets:
       azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/restore-app-main-db.yml
+++ b/.github/workflows/restore-app-main-db.yml
@@ -39,9 +39,6 @@ on:
           - staging,st
           - production,pd
 
-permissions:
- id-token: write
-
 env:
   SERVICE_NAME: cpd-ec2
   SERVICE_SHORT: cpdec2
@@ -79,11 +76,10 @@ jobs:
         # Set Azure environment variables
         echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
         echo "NAMESPACE=$(jq -r '.namespace' ${tf_vars_file})" >> $GITHUB_ENV
-
         FROM_ENV="${{ github.event.inputs.from-environment }}"
         FROM_ENV_NAME=$(echo "$FROM_ENV" | cut -d',' -f1)
         FROM_ENV_CONFIG_SHORT=$(echo "$FROM_ENV" | cut -d',' -f2)
-        echo "FROM_ENV=${FROM_ENV}" >> $GITHUB_ENV
+        echo "FROM_ENV_NAME=${FROM_ENV_NAME}" >> $GITHUB_ENV
         echo "FROM_ENV_CONFIG_SHORT=${FROM_ENV_CONFIG_SHORT}" >> $GITHUB_ENV
         echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${FROM_ENV_CONFIG_SHORT}-rg" >> $GITHUB_ENV
         if [ $FROM_ENV_NAME != "production" ]; then
@@ -139,7 +135,7 @@ jobs:
       env:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: ${{ inputs.environment }} database restore success
-        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.FROM_ENV }} - ${{ env.BACKUP_FILE_IN_STORAGE }} succeeded!
+        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.FROM_ENV_NAME }} - ${{ env.BACKUP_FILE_IN_STORAGE }} succeeded!
         SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
         SLACK_COLOR: success
         SLACK_FOOTER: Sent from restore-app-main workflow
@@ -150,7 +146,7 @@ jobs:
       env:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: ${{ inputs.environment }} database restore failure
-        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.FROM_ENV }} - ${{ env.BACKUP_FILE_IN_STORAGE }} failed!
+        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.FROM_ENV_NAME }} - ${{ env.BACKUP_FILE_IN_STORAGE }} failed!
         SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
         SLACK_COLOR: failure
         SLACK_FOOTER: Sent from restore-app-main workflow

--- a/.github/workflows/restore-app-main-db.yml
+++ b/.github/workflows/restore-app-main-db.yml
@@ -24,9 +24,23 @@ on:
         - 'false'
         - 'true'
       backup-file:
-        description: Name of the backup file in Azure storage. e.g. cpdec2_prod_2024-08-09.sql.gz. The default value is today's scheduled backup.
+        description: Name of the backup file in Azure storage. e.g. cpdec2_pd_adhoc_2024-08-09.sql.gz. The default value is today's adhoc backup.
         type: string
         required: false
+      from-environment:
+        description: Environment of the Azure Storage account containing the backup-file
+        required: true
+        default: development,dv
+        type: choice
+        options:
+          - development,dv
+          - migration,mg
+          - sandbox,sb
+          - staging,st
+          - production,pd
+
+permissions:
+ id-token: write
 
 env:
   SERVICE_NAME: cpd-ec2
@@ -65,8 +79,18 @@ jobs:
         # Set Azure environment variables
         echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
         echo "NAMESPACE=$(jq -r '.namespace' ${tf_vars_file})" >> $GITHUB_ENV
-        echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
-        echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}dbbkp${CONFIG_SHORT}sa" >> $GITHUB_ENV
+
+        FROM_ENV="${{ github.event.inputs.from-environment }}"
+        FROM_ENV_NAME=$(echo "$FROM_ENV" | cut -d',' -f1)
+        FROM_ENV_CONFIG_SHORT=$(echo "$FROM_ENV" | cut -d',' -f2)
+        echo "FROM_ENV=${FROM_ENV}" >> $GITHUB_ENV
+        echo "FROM_ENV_CONFIG_SHORT=${FROM_ENV_CONFIG_SHORT}" >> $GITHUB_ENV
+        echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${FROM_ENV_CONFIG_SHORT}-rg" >> $GITHUB_ENV
+        if [ $FROM_ENV_NAME != "production" ]; then
+          echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}${FROM_ENV_CONFIG_SHORT}tfsa" >> $GITHUB_ENV
+        else
+          echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}dbbkp${FROM_ENV_CONFIG_SHORT}sa" >> $GITHUB_ENV
+        fi
         echo "APP_NAME=${SERVICE_NAME}-${{ inputs.environment }}-web" >> $GITHUB_ENV
         echo "DB_SERVER=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg" >> $GITHUB_ENV
         echo "KEYVAULT_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-inf-kv" >> $GITHUB_ENV
@@ -82,7 +106,7 @@ jobs:
         if [ "${{ inputs.backup-file }}" != "" ]; then
           BACKUP_FILE=${{ inputs.backup-file }}
         else
-          BACKUP_FILE=${SERVICE_SHORT}_${CONFIG_SHORT}_${TODAY}.sql.gz
+          BACKUP_FILE=${SERVICE_SHORT}_${{ env.FROM_ENV_CONFIG_SHORT }}_adhoc_${TODAY}.sql.gz
         fi
         echo "BACKUP_FILE=$BACKUP_FILE" >> $GITHUB_ENV
         echo "BACKUP_FILE_IN_STORAGE=${STORAGE_ACCOUNT_NAME} / database-backup / ${BACKUP_FILE}" >> $GITHUB_ENV
@@ -114,8 +138,8 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: CI Deployment
-        SLACK_TITLE: ${{ inputs.environment }} database restore succeeded
-        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.BACKUP_FILE_IN_STORAGE }} succeeded!
+        SLACK_TITLE: ${{ inputs.environment }} database restore success
+        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.FROM_ENV }} - ${{ env.BACKUP_FILE_IN_STORAGE }} succeeded!
         SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
         SLACK_COLOR: success
         SLACK_FOOTER: Sent from restore-app-main workflow
@@ -126,7 +150,7 @@ jobs:
       env:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: ${{ inputs.environment }} database restore failure
-        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.BACKUP_FILE_IN_STORAGE }} failed!
+        SLACK_MESSAGE: ${{ env.APP_NAME }} - restore main db job from ${{ env.FROM_ENV }} - ${{ env.BACKUP_FILE_IN_STORAGE }} failed!
         SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
         SLACK_COLOR: failure
         SLACK_FOOTER: Sent from restore-app-main workflow


### PR DESCRIPTION
- Fix the workflow that restores the main database of an environment to be able to do it from any file stored in any other environment's Azure storage account.
- Add failure notification to the workflow that dumps an environment's main database and stores it in their Azure Storage account.