### PR TITLE
Replace induction status 'Pass' with 'Passed'

### DIFF
--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -38,7 +38,7 @@ module Schools
       end
 
       def induction_completed?
-        trs_induction_status == 'Pass'
+        trs_induction_status == 'Passed'
       end
 
       def induction_exempt?

--- a/documentation/service-rules/appropriate-body-users.md
+++ b/documentation/service-rules/appropriate-body-users.md
@@ -175,7 +175,7 @@ The pass process takes place with the following steps:
 2. Pass the ECT by entering the following information:
     * The end date of the induction period
     * The number of terms carried out during the induction period
-3. When submitted the current (open) induction period is updated with the provided end date and number of terms. This closes the induction period. The 'Pass' state and induction completion date are written to the teacher's record via the TRS API.
+3. When submitted the current (open) induction period is updated with the provided end date and number of terms. This closes the induction period. The 'Passed' state and induction completion date are written to the teacher's record via the TRS API.
 
 ### Validation
 
@@ -198,7 +198,7 @@ The fail process takes place with the following steps:
 2. Fail the ECT by entering the following information:
     * The end date of the induction period
     * The number of terms carried out during the induction period
-3. When submitted the current (open) induction period is updated with the provided end date and number of terms. This closes the induction period. The 'Pass' state and induction completion date are written to the teacher's record via the TRS API.
+3. When submitted the current (open) induction period is updated with the provided end date and number of terms. This closes the induction period. The 'Failed' state and induction completion date are written to the teacher's record via the TRS API.
 
 ### Validation
 

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -15,7 +15,7 @@ describe Teachers::RefreshTRSAttributes do
         # these values are returned by the fake API client
         expect(teacher.trs_first_name).to eql('Kirk')
         expect(teacher.trs_last_name).to eql('Van Houten')
-        expect(teacher.trs_induction_status).to eql('Pass')
+        expect(teacher.trs_induction_status).to eql('Passed')
         expect(teacher.trs_qts_awarded_on).to eql(3.years.ago.to_date)
         expect(teacher.trs_qts_status_description).to eql('Passed')
         expect(teacher.trs_initial_teacher_training_provider_name).to eql('Example Provider Ltd.')

--- a/spec/support/shared_contexts/fake_trs_api_client.rb
+++ b/spec/support/shared_contexts/fake_trs_api_client.rb
@@ -39,7 +39,7 @@ end
 
 shared_context 'fake trs api client that finds teacher that has passed their induction' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: 'Pass'))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: 'Passed'))
   end
 end
 
@@ -53,7 +53,7 @@ shared_context 'fake trs api returns a teacher and then a teacher that has compl
   before do
     allow(TRS::APIClient).to receive(:new).and_return(
       TRS::FakeAPIClient.new,
-      TRS::FakeAPIClient.new(induction_status: 'Pass')
+      TRS::FakeAPIClient.new(induction_status: 'Passed')
     )
   end
 end


### PR DESCRIPTION
'Pass' was used in DQT but since moving to TRS the status is 'Passed'.

https://preprod.teacher-qualifications-api.education.gov.uk/swagger/index.html#model-InductionStatus
