### PR TITLE
Fix the induction event happened_at values

### DIFF
--- a/app/services/appropriate_bodies/release_ect.rb
+++ b/app/services/appropriate_bodies/release_ect.rb
@@ -34,6 +34,10 @@ module AppropriateBodies
     end
 
     def ongoing_induction_period
+      @ongoing_induction_period ||= find_ongoing_induction_period
+    end
+
+    def find_ongoing_induction_period
       ongoing_induction_periods = InductionPeriod.ongoing.for_teacher(teacher)
 
       if ongoing_induction_periods.count.zero?

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1,6 +1,7 @@
 module Events
   class InvalidAuthor < StandardError; end
   class NotPersistedRecord < StandardError; end
+  class NoInductionPeriod < StandardError; end
 
   class Record
     attr_reader :author,
@@ -77,30 +78,42 @@ module Events
 
     # Appropriate body events
 
-    def self.record_appropriate_body_claims_teacher_event!(author:, appropriate_body:, induction_period:, teacher:, happened_at: Time.zone.now)
+    def self.record_appropriate_body_claims_teacher_event!(author:, appropriate_body:, induction_period:, teacher:)
+      fail(NoInductionPeriod) unless induction_period
+
       event_type = :appropriate_body_claims_teacher
       heading = "#{Teachers::Name.new(teacher).full_name} was claimed by #{appropriate_body.name}"
+      happened_at = induction_period.started_on
 
       new(event_type:, author:, appropriate_body:, teacher:, induction_period:, heading:, happened_at:).record_event!
     end
 
-    def self.record_appropriate_body_releases_teacher_event!(author:, appropriate_body:, induction_period:, teacher:, happened_at: Time.zone.now)
+    def self.record_appropriate_body_releases_teacher_event!(author:, appropriate_body:, induction_period:, teacher:)
+      fail(NoInductionPeriod) unless induction_period
+
       event_type = :appropriate_body_releases_teacher
       heading = "#{Teachers::Name.new(teacher).full_name} was released by #{appropriate_body.name}"
+      happened_at = induction_period.finished_on
 
       new(event_type:, author:, appropriate_body:, teacher:, induction_period:, heading:, happened_at:).record_event!
     end
 
-    def self.record_appropriate_body_passes_teacher_event(author:, appropriate_body:, induction_period:, teacher:, happened_at: Time.zone.now)
+    def self.record_appropriate_body_passes_teacher_event(author:, appropriate_body:, induction_period:, teacher:)
+      fail(NoInductionPeriod) unless induction_period
+
       event_type = :appropriate_body_passes_teacher
       heading = "#{Teachers::Name.new(teacher).full_name} passed induction"
+      happened_at = induction_period.finished_on
 
       new(event_type:, author:, appropriate_body:, teacher:, induction_period:, heading:, happened_at:).record_event!
     end
 
-    def self.record_appropriate_body_fails_teacher_event(author:, appropriate_body:, induction_period:, teacher:, happened_at: Time.zone.now)
+    def self.record_appropriate_body_fails_teacher_event(author:, appropriate_body:, induction_period:, teacher:)
+      fail(NoInductionPeriod) unless induction_period
+
       event_type = :appropriate_body_fails_teacher
       heading = "#{Teachers::Name.new(teacher).full_name} failed induction"
+      happened_at = induction_period.finished_on
 
       new(event_type:, author:, appropriate_body:, teacher:, induction_period:, heading:, happened_at:).record_event!
     end

--- a/db/scripts/set_induction_period_event_happened_at_times_so_they_are_teacher_orientated.rb
+++ b/db/scripts/set_induction_period_event_happened_at_times_so_they_are_teacher_orientated.rb
@@ -1,0 +1,28 @@
+# This script fixes appropriate body events where the happened_at timestamp
+# is set to the time the event happened (i.e., the time the AB reported
+# the fact to us) rather than the time the thing happened to the teacher.
+#
+# We already hold the time the event was recorded in `created_at` so we don't
+# lose anything by switching these.
+#
+# It will result in us being able to choose whether we show the timeline in the
+# order of the thing being recorded vs the actual date the thing
+# happened. Additionally, it might provide some insight into delays between the
+# two.
+
+since_go_live_date = (Date.new(2025, 2, 19)..)
+closure_events = %w[
+  appropriate_body_releases_teacher
+  appropriate_body_releases_teacher
+  appropriate_body_fails_teacher
+]
+
+Event.transaction do
+  Event
+    .where(created_at: since_go_live_date, event_type: 'appropriate_body_claims_teacher')
+    .find_each { |e| e.update!(happened_at: e.induction_period.started_on) }
+
+  Event
+    .where(created_at: since_go_live_date, event_type: closure_events)
+    .find_each { |e| e.update!(happened_at: e.induction_period.finished_on) }
+end

--- a/spec/services/appropriate_bodies/release_ect_spec.rb
+++ b/spec/services/appropriate_bodies/release_ect_spec.rb
@@ -58,6 +58,8 @@ describe AppropriateBodies::ReleaseECT do
     it "records the event" do
       subject.release!
 
+      induction_period.reload
+
       expect(Events::Record).to have_received(:new).with(
         hash_including(
           author:,

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -111,10 +111,16 @@ describe Events::Record do
           appropriate_body:,
           heading: 'Rhys Ifans was claimed by Burns Slant Drilling Co.',
           event_type: :appropriate_body_claims_teacher,
-          happened_at: Time.zone.now,
+          happened_at: induction_period.started_on,
           **author_params
         )
       end
+    end
+
+    it 'fails when induction period is missing' do
+      expect {
+        Events::Record.record_appropriate_body_fails_teacher_event(author:, teacher:, appropriate_body:, induction_period: nil)
+      }.to raise_error(Events::NoInductionPeriod)
     end
   end
 
@@ -129,10 +135,16 @@ describe Events::Record do
           appropriate_body:,
           heading: 'Rhys Ifans passed induction',
           event_type: :appropriate_body_passes_teacher,
-          happened_at: Time.zone.now,
+          happened_at: induction_period.finished_on,
           **author_params
         )
       end
+    end
+
+    it 'fails when induction period is missing' do
+      expect {
+        Events::Record.record_appropriate_body_fails_teacher_event(author:, teacher:, appropriate_body:, induction_period: nil)
+      }.to raise_error(Events::NoInductionPeriod)
     end
   end
 
@@ -147,10 +159,16 @@ describe Events::Record do
           appropriate_body:,
           heading: 'Rhys Ifans failed induction',
           event_type: :appropriate_body_fails_teacher,
-          happened_at: Time.zone.now,
+          happened_at: induction_period.finished_on,
           **author_params
         )
       end
+    end
+
+    it 'fails when induction period is missing' do
+      expect {
+        Events::Record.record_appropriate_body_fails_teacher_event(author:, teacher:, appropriate_body:, induction_period: nil)
+      }.to raise_error(Events::NoInductionPeriod)
     end
   end
 

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -51,7 +51,7 @@ describe 'InductionPeriods::CreateInductionPeriod' do
 
             expect(last_event.appropriate_body).to eql(appropriate_body)
             expect(last_event.teacher).to eql(teacher)
-            expect(last_event.happened_at).to eql(Time.zone.now)
+            expect(last_event.happened_at.to_date).to eql(started_on)
           end
         end
 


### PR DESCRIPTION
I implemented this wrong first time around because I was thinking of the event from the point of view of when it was recorded, not from the actual final timeline.

On the timeline we want the date the person started or finished an induction period, not the date the AB informed us.

We'll need to fix some records in prod but that is thankfully straightfoward.
