### PR TITLE
Mentor wizard: redirect user to the first allowed step

### DIFF
--- a/app/controllers/schools/register_mentor_wizard_controller.rb
+++ b/app/controllers/schools/register_mentor_wizard_controller.rb
@@ -1,8 +1,8 @@
 module Schools
   class RegisterMentorWizardController < SchoolsController
     before_action :initialize_wizard, only: %i[new create]
-    before_action :check_allowed_step, except: %i[start]
     before_action :reset_wizard, only: :new
+    before_action :check_allowed_step, except: %i[start]
 
     FORM_KEY = :register_mentor_wizard
     WIZARD_CLASS = Schools::RegisterMentorWizard::Wizard.freeze

--- a/app/controllers/schools/register_mentor_wizard_controller.rb
+++ b/app/controllers/schools/register_mentor_wizard_controller.rb
@@ -1,6 +1,7 @@
 module Schools
   class RegisterMentorWizardController < SchoolsController
     before_action :initialize_wizard, only: %i[new create]
+    before_action :check_allowed_step, except: %i[start]
     before_action :reset_wizard, only: :new
 
     FORM_KEY = :register_mentor_wizard
@@ -35,6 +36,10 @@ module Schools
       )
       @ect_name = Teachers::Name.new(@wizard.ect.teacher).full_name
       @mentor = @wizard.mentor
+    end
+
+    def check_allowed_step
+      redirect_to @wizard.allowed_step_path unless @wizard.allowed_step?
     end
 
     def current_step

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -41,6 +41,8 @@ module Schools
     end
 
     def register!
+      not_registered_as_an_ect!
+
       ActiveRecord::Base.transaction do
         update_school_choices!
         create_teacher!
@@ -54,11 +56,12 @@ module Schools
       ::Teacher.find_by_trn(trn)&.ect_at_school_periods&.exists?
     end
 
-    def create_teacher!
+    def not_registered_as_an_ect!
       raise ActiveRecord::RecordInvalid if already_registered_as_an_ect?
+    end
 
-      @teacher = ::Teacher.create_with(trs_first_name:, trs_last_name:, corrected_name:)
-                          .find_or_create_by!(trn:)
+    def create_teacher!
+      @teacher = ::Teacher.create_with(trs_first_name:, trs_last_name:, corrected_name:).find_or_create_by!(trn:)
     end
 
     def start_at_school!

--- a/app/wizards/application_wizard.rb
+++ b/app/wizards/application_wizard.rb
@@ -1,0 +1,9 @@
+class ApplicationWizard < DfE::Wizard::Base
+  def allowed_steps = raise NotImplementedError
+
+  def allowed_step? = allowed_steps.include?(current_step_name)
+
+  def allowed_step_klass = find_step(allowed_steps.last)
+
+  def allowed_step_path = current_step.next_step_path(allowed_step_klass)
+end

--- a/app/wizards/application_wizard.rb
+++ b/app/wizards/application_wizard.rb
@@ -3,7 +3,9 @@ class ApplicationWizard < DfE::Wizard::Base
 
   def allowed_step? = allowed_steps.include?(current_step_name)
 
-  def allowed_step_klass = find_step(allowed_steps.last)
-
   def allowed_step_path = current_step.next_step_path(allowed_step_klass)
+
+private
+
+  def allowed_step_klass = find_step(allowed_steps.last)
 end

--- a/app/wizards/schools/register_mentor_wizard/cannot_mentor_themself_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/cannot_mentor_themself_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterMentorWizard
     class CannotMentorThemselfStep < Step

--- a/app/wizards/schools/register_mentor_wizard/cannot_register_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/cannot_register_mentor_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterMentorWizard
     class CannotRegisterMentorStep < Step

--- a/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
@@ -12,7 +12,12 @@ module Schools
     private
 
       def persist
-        AssignMentor.new(ect:, mentor: mentor.register!).assign!
+        ActiveRecord::Base.transaction do
+          AssignMentor.new(ect:, mentor: mentor.register!).assign!
+        end
+      rescue StandardError => e
+        mentor.registered = false
+        raise e
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
@@ -15,7 +15,7 @@ module Schools
         return :cannot_mentor_themself if mentor.trn == ect.trn
         return :national_insurance_number unless mentor.matches_trs_dob?
         return :already_active_at_school if mentor.active_at_school?
-        return :cannot_register_mentor if trs_teacher.prohibited_from_teaching?
+        return :cannot_register_mentor if mentor.prohibited_from_teaching
 
         :review_mentor_details
       end
@@ -29,6 +29,7 @@ module Schools
       def persist
         mentor.update(trn: formatted_trn,
                       date_of_birth: date_of_birth.values.join("-"),
+                      prohibited_from_teaching: trs_teacher.prohibited_from_teaching?,
                       trs_date_of_birth: trs_teacher.date_of_birth,
                       trs_first_name: trs_teacher.first_name,
                       trs_last_name: trs_teacher.last_name)

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -61,7 +61,9 @@ module Schools
                                     school_urn:,
                                     email:,
                                     **check_ero_mentor.to_h)
-                               .register!
+                               .register!.tap do
+          self.registered = true
+        end
       end
 
       def school

--- a/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
@@ -27,6 +27,8 @@ module Schools
 
       def persist
         mentor.update(national_insurance_number:,
+                      prohibited_from_teaching: trs_teacher.prohibited_from_teaching?,
+                      trs_date_of_birth: trs_teacher.date_of_birth,
                       trs_first_name: trs_teacher.first_name,
                       trs_last_name: trs_teacher.last_name)
       end

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_details_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_details_step.rb
@@ -32,12 +32,7 @@ module Schools
       end
 
       def persist
-        mentor.update(corrected_name: formatted_name)
-      end
-
-      def pre_populate_attributes
-        self.corrected_name = mentor.corrected_name
-        self.change_name = corrected_name.present? ? 'yes' : 'no'
+        mentor.update(change_name:, corrected_name: formatted_name)
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/step.rb
+++ b/app/wizards/schools/register_mentor_wizard/step.rb
@@ -11,13 +11,13 @@ module Schools
         persist if valid_step?
       end
 
-    private
-
       def fetch_trs_teacher(**args)
         ::TRS::APIClient.new.find_teacher(**args)
       rescue TRS::Errors::TeacherNotFound
         TRS::Teacher.new({})
       end
+
+    private
 
       def persist = mentor.update(step_params)
 

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -56,9 +56,12 @@ module Schools
               return [:confirmation]
             end
 
-            return steps + %i[cannot_register_mentor] if trs_teacher.prohibited_from_teaching?
+            return steps + %i[cannot_register_mentor] if mentor.prohibited_from_teaching
 
-            steps += %i[review_mentor_details email_address]
+            steps << :review_mentor_details
+            return steps unless mentor.change_name
+
+            steps << :email_address
             return steps unless mentor.email
             return steps + %i[cant_use_email] if mentor.cant_use_email?
 
@@ -71,10 +74,6 @@ module Schools
 
       def mentor
         @mentor ||= Mentor.new(store)
-      end
-
-      def trs_teacher
-        current_step.fetch_trs_teacher(trn: mentor.trn)
       end
     end
   end

--- a/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "schools/register_mentor_wizard/already_active_at_school.md.erb" do
   let(:assign_mentor_path) { wizard.current_step_path }
   let(:ect_name) { Faker::Name.name }
-  let(:store) { double(trs_first_name: "John", trs_last_name: "Waters", corrected_name: "Jim Waters") }
+  let(:store) { double(trs_first_name: "John", trs_last_name: "Waters", change_name: "yes", corrected_name: "Jim Waters") }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :already_active_at_school, store:) }
   let(:mentor) { wizard.mentor }
 

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
                      trn: "1234567",
                      trs_first_name: "John",
                      trs_last_name: "Wayne",
+                     change_name: 'yes',
                      corrected_name: "Jim Wayne",
                      email: "john.wayne@example.com")
   end

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       trn: '0000007',
       trs_first_name: "John",
       trs_last_name: "Wayne",
+      change_name: 'no',
       corrected_name: nil,
       already_active_at_school:,
       eligible_for_mentor_funding?: true

--- a/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
@@ -8,6 +8,7 @@ RSpec.shared_examples "an email address step view" do |current_step:, back_path:
                      trs_first_name: "John",
                      trs_last_name: "Waters",
                      trs_date_of_birth: "1950-01-01",
+                     change_name: "yes",
                      corrected_name: "Jim Waters",
                      email:)
   end

--- a/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
@@ -14,6 +14,7 @@ RSpec.shared_examples "a review mentor details step view" do |current_step:,
                      trs_first_name: "John",
                      trs_last_name: "Wayne",
                      trs_date_of_birth: "1950-01-01",
+                     change_name: "no",
                      corrected_name: nil,
                      date_of_birth:,
                      national_insurance_number:,
@@ -34,6 +35,7 @@ RSpec.shared_examples "a review mentor details step view" do |current_step:,
   end
 
   it "prefixes the page with 'Error:' when any step data is invalid" do
+    store.change_name = 'yes'
     store.corrected_name = 'a' * 100
     wizard.valid_step?
 

--- a/spec/wizards/application_wizard_spec.rb
+++ b/spec/wizards/application_wizard_spec.rb
@@ -1,0 +1,30 @@
+describe ApplicationWizard do
+  let(:current_step) { :first_step }
+  let(:wizard) { described_class.new(store: {}, current_step:) }
+
+  describe '#allowed_steps' do
+    subject { wizard.allowed_steps }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#allowed_step?' do
+    subject { wizard.allowed_step? }
+
+    before { allow(wizard).to receive(:allowed_steps).and_return(%i[first_step]) }
+
+    context 'when the current step is included in the list of allowed steps' do
+      let(:current_step) { :first_step }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the current step is not included in the list of allowed steps' do
+      let(:current_step) { :last_step }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
   let(:school) { FactoryBot.create(:school) }
   let(:store) do
     FactoryBot.build(:session_repository,
+                     change_name: 'no',
                      corrected_name: nil,
                      date_of_birth: "11-10-1945",
                      email: "dusty@rhodes.com",
@@ -97,6 +98,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
     context 'when corrected_name is set' do
       before do
+        store.change_name = 'yes'
         store.corrected_name = 'Randy Marsh'
       end
 

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -6,6 +6,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
                      trn: "1234567",
                      trs_first_name: "John",
                      trs_last_name: "Wayne",
+                     change_name: "yes",
                      corrected_name: "Jim Wayne",
                      date_of_birth: "01/01/1990")
   end

--- a/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
@@ -101,7 +101,10 @@ describe Schools::RegisterECTWizard::ReviewECTDetailsStep, type: :model do
 
       it 'updates the wizard ect corrected name' do
         expect { subject.save! }
-          .to change(subject.ect, :corrected_name).from(nil).to('John Smith')
+          .to change(subject.ect, :corrected_name)
+                .from(nil).to('John Smith')
+                .and change(subject.ect, :change_name)
+                       .from(nil).to('yes')
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/change_mentor_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/change_mentor_details_step_spec.rb
@@ -13,6 +13,7 @@ describe Schools::RegisterMentorWizard::ChangeMentorDetailsStep, type: :model do
                        trn: '1234567',
                        trs_first_name: 'John',
                        trs_last_name: 'Wayne',
+                       change_name: 'yes',
                        corrected_name: 'Jim Wayne',
                        date_of_birth: '01/01/1990',
                        email: 'initial@email.com')

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -6,6 +6,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
                      trn: '1234567',
                      trs_first_name: 'John',
                      trs_last_name: 'Wayne',
+                     change_name: 'yes',
                      corrected_name: 'Jim Wayne',
                      date_of_birth: '01/01/1990',
                      email: 'initial@email.com',

--- a/spec/wizards/schools/register_mentor_wizard/review_mentor_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/review_mentor_details_step_spec.rb
@@ -13,6 +13,7 @@ describe Schools::RegisterMentorWizard::ReviewMentorDetailsStep, type: :model do
                        trn: '1234567',
                        trs_first_name: 'John',
                        trs_last_name: 'Wayne',
+                       change_name: 'yes',
                        corrected_name: 'Jim Wayne',
                        date_of_birth: '01/01/1990',
                        email: 'initial@email.com')

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
                      trn: '1234567',
                      trs_first_name: 'John',
                      trs_last_name: 'Wayne',
+                     change_name: 'yes',
                      corrected_name: 'Jim Wayne',
                      date_of_birth: '01/01/1990',
                      email: 'initial@email.com')
@@ -100,7 +101,11 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
       end
 
       it "'updates the wizard's mentor corrected name'" do
-        expect { subject.save! }.to change(subject.mentor, :corrected_name).from(nil).to('Paul Saints')
+        expect { subject.save! }
+          .to change(subject.mentor, :corrected_name)
+                .from(nil).to('Paul Saints')
+                .and change(subject.mentor, :change_name)
+                       .from(nil).to('yes')
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -1,0 +1,295 @@
+describe Schools::RegisterMentorWizard::Wizard do
+  let(:current_step) { :find_mentor }
+  let(:ect_teacher) { FactoryBot.create(:teacher, trn: "7654321") }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher: ect_teacher) }
+  let(:ect_id) { ect.id }
+  let(:mentor_trn) { "1234567" }
+  let(:mentor_date_of_birth) { "1977-02-03" }
+  let(:prohibited_from_teaching) { false }
+  let(:school_urn) { '1212121' }
+  let(:trs_date_of_birth) { "1977-02-03" }
+  let(:trs_first_name) { "Mentor" }
+  let(:trs_last_name) { "LastName" }
+  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:, ect_id:) }
+
+  describe '#allowed_steps' do
+    subject { wizard.allowed_steps }
+
+    context 'when no data has been set yet' do
+      let(:store) { FactoryBot.build(:session_repository, school_urn:) }
+
+      it { is_expected.to eq(%i[no_trn find_mentor]) }
+    end
+
+    context 'when only TRN has been set' do
+      let(:store) { FactoryBot.build(:session_repository, trn: mentor_trn, school_urn:) }
+
+      described_class.steps.first.each_key do |step|
+        context "when the requested step is #{step}" do
+          let(:current_step) { step }
+
+          it { is_expected.to eq(%i[no_trn find_mentor]) }
+        end
+      end
+    end
+
+    context 'when only TRN and DoB have been set' do
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:)
+      end
+
+      context 'when the mentor has not been found in TRS' do
+        let(:prohibited_from_teaching) { nil }
+        let(:trs_date_of_birth) { nil }
+        let(:trs_first_name) { nil }
+        let(:trs_last_name) { nil }
+
+        it { is_expected.to eq(%i[no_trn find_mentor trn_not_found]) }
+      end
+
+      context 'when the mentor trn has matched that of the ECT' do
+        let(:mentor_trn) { ect.trn }
+
+        it { is_expected.to eq(%i[no_trn find_mentor cannot_mentor_themself]) }
+      end
+
+      context "when the date of birth didn't match that on TRS" do
+        let(:mentor_date_of_birth) { "2000-01-01" }
+
+        it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number]) }
+      end
+
+      context 'when the mentor is already active at the school' do
+        let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
+        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+        let(:school_urn) { active_mentor_period.school.urn }
+
+        it { is_expected.to eq(%i[no_trn find_mentor already_active_at_school]) }
+      end
+
+      context 'when the mentor is prohibited from teaching' do
+        let(:prohibited_from_teaching) { true }
+
+        it { is_expected.to eq(%i[no_trn find_mentor cannot_register_mentor]) }
+      end
+
+      context 'when the mentor is not prohibited from teaching' do
+        it { is_expected.to eq(%i[no_trn find_mentor review_mentor_details]) }
+      end
+    end
+
+    context 'when only TRN, DoB and Nino have been set' do
+      let(:mentor_date_of_birth) { "2000-01-01" }
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         national_insurance_number: 'ZZ123456A')
+      end
+
+      context 'when the mentor has not been found in TRS' do
+        let(:prohibited_from_teaching) { nil }
+        let(:trs_date_of_birth) { nil }
+        let(:trs_first_name) { nil }
+        let(:trs_last_name) { nil }
+
+        it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number not_found]) }
+      end
+
+      context 'when the mentor is already active at the school' do
+        let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
+        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+        let(:school_urn) { active_mentor_period.school.urn }
+
+        it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number already_active_at_school]) }
+      end
+
+      context 'when the mentor is prohibited from teaching' do
+        let(:prohibited_from_teaching) { true }
+
+        it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number cannot_register_mentor]) }
+      end
+
+      context 'when the mentor is not prohibited from teaching' do
+        it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number review_mentor_details]) }
+      end
+    end
+
+    context 'when only TRN, DoB and already active at school have been set' do
+      let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+      let(:school_urn) { active_mentor_period.school.urn }
+      let(:already_active_at_school) { true }
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         already_active_at_school:)
+      end
+
+      it { is_expected.to eq(%i[confirmation]) }
+    end
+
+    context 'when only TRN, DoB, Nino and already active at school have been set' do
+      let(:mentor_date_of_birth) { "2000-01-01" }
+      let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+      let(:school_urn) { active_mentor_period.school.urn }
+      let(:already_active_at_school) { true }
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         national_insurance_number: 'ZZ123456A',
+                         already_active_at_school:)
+      end
+
+      it { is_expected.to eq(%i[confirmation]) }
+    end
+
+    context 'when only TRN, DoB and change name (and maybe corrected name) have been set' do
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         change_name: 'no')
+      end
+
+      it { is_expected.to eq(%i[no_trn find_mentor review_mentor_details email_address]) }
+    end
+
+    context 'when only TRN, DoB, Nino and change name (and maybe corrected name) have been set' do
+      let(:mentor_date_of_birth) { "2000-01-01" }
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         national_insurance_number: 'ZZ123456A',
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         change_name: 'yes',
+                         corrected_name: 'Mentor CorrectedName')
+      end
+
+      it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number review_mentor_details email_address]) }
+    end
+
+    context 'when only TRN, DoB, change name (and maybe corrected name) and email have been set' do
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         change_name: 'no',
+                         email: 'any@email.address')
+      end
+
+      context 'when the email is in use by another participant' do
+        before { allow(wizard.mentor).to receive(:cant_use_email?).and_return(true) }
+
+        it { is_expected.to eq(%i[no_trn find_mentor review_mentor_details email_address cant_use_email]) }
+      end
+
+      context 'when the mentor is eligible for funding' do
+        before { allow(wizard.mentor).to receive(:funding_available?).and_return(true) }
+
+        it do
+          expect(subject).to eq(%i[no_trn
+                                   find_mentor
+                                   review_mentor_details
+                                   email_address
+                                   review_mentor_eligibility
+                                   change_mentor_details
+                                   change_email_address
+                                   check_answers])
+        end
+      end
+    end
+
+    context 'when only TRN, DoB, Nino, change name (and maybe corrected name) and email address have been set' do
+      let(:mentor_date_of_birth) { "2000-01-01" }
+      let(:store) do
+        FactoryBot.build(:session_repository,
+                         school_urn:,
+                         trn: mentor_trn,
+                         date_of_birth: mentor_date_of_birth,
+                         national_insurance_number: 'ZZ123456A',
+                         prohibited_from_teaching:,
+                         trs_date_of_birth:,
+                         trs_first_name:,
+                         trs_last_name:,
+                         change_name: 'yes',
+                         corrected_name: 'Mentor CorrectedName',
+                         email: 'any@email.address')
+      end
+
+      context 'when the email is in use by another participant' do
+        before { allow(wizard.mentor).to receive(:cant_use_email?).and_return(true) }
+
+        it { is_expected.to eq(%i[no_trn find_mentor national_insurance_number review_mentor_details email_address cant_use_email]) }
+      end
+
+      context 'when the mentor is eligible for funding' do
+        before { allow(wizard.mentor).to receive(:funding_available?).and_return(true) }
+
+        it do
+          expect(subject).to eq(%i[no_trn
+                                   find_mentor
+                                   national_insurance_number
+                                   review_mentor_details
+                                   email_address
+                                   review_mentor_eligibility
+                                   change_mentor_details
+                                   change_email_address
+                                   check_answers])
+        end
+      end
+    end
+  end
+
+  describe '#allowed_step_path' do
+    subject { wizard.allowed_step_path }
+
+    let(:store) { FactoryBot.build(:session_repository, school_urn:) }
+
+    before { allow(wizard).to receive(:allowed_steps).and_return(%i[find_mentor check_answers]) }
+
+    it "returns the path to the last allowed one" do
+      expect(subject).to eq("/school/register-mentor/check-answers")
+    end
+  end
+end


### PR DESCRIPTION
[Issue](https://github.com/DFE-Digital/register-early-career-teachers-public/issues/268)

Even though each step of the Register Mentor journey has a previous_step and next_step logic included to redirect the user to the appropriate next step, nothing prevents them from redirecting their browser to any random step at any time or navigate though them via the back and forward buttons of the browser.

Therefore, we need a way to be able to redirect the user's browser to the appropriate next step based on the overall state in the journey and the currently visited step.

The proposal in this PR is to extend the journey with functionality so that it can compute the list of allowed steps (steps we consider 'visitable') based on the current overall state in the journey, the actually visited step and automatically redirect the user to the last of those allowed steps if the current one is not included in that list.