### PR TITLE
Improve event retrieval

### DIFF
--- a/app/controllers/admin/teachers/timeline_controller.rb
+++ b/app/controllers/admin/teachers/timeline_controller.rb
@@ -1,6 +1,6 @@
 class Admin::Teachers::TimelineController < AdminController
   def show
     @teacher = Teacher.find(params[:teacher_id])
-    @events = Event.where(teacher: @teacher)
+    @events = Events::List.new.for_teacher(@teacher)
   end
 end

--- a/app/services/events/list.rb
+++ b/app/services/events/list.rb
@@ -1,0 +1,13 @@
+module Events
+  class List
+    attr_accessor :scope
+
+    def initialize
+      @scope = Event.latest_first
+    end
+
+    def for_teacher(teacher)
+      scope.where(teacher:)
+    end
+  end
+end

--- a/spec/services/events/list_spec.rb
+++ b/spec/services/events/list_spec.rb
@@ -1,0 +1,15 @@
+describe 'Events::List' do
+  describe 'default scope' do
+    it 'orders by latest first by default' do
+      expect(Events::List.new.scope.to_sql).to include(%(ORDER BY "events"."happened_at" DESC))
+    end
+  end
+
+  describe '.for_teacher' do
+    it 'selects only events with a teacher_id matching the provided teacher' do
+      teacher = FactoryBot.create(:teacher)
+
+      expect(Events::List.new.for_teacher(teacher).to_sql).to include(%(WHERE "events"."teacher_id" = #{teacher.id}))
+    end
+  end
+end

--- a/spec/services/events/list_spec.rb
+++ b/spec/services/events/list_spec.rb
@@ -6,7 +6,7 @@ describe 'Events::List' do
   end
 
   describe '.for_teacher' do
-    it 'selects only events with a teacher_id matching the provided teacher' do
+    it 'only selects events with a teacher_id matching the provided teacher' do
       teacher = FactoryBot.create(:teacher)
 
       expect(Events::List.new.for_teacher(teacher).to_sql).to include(%(WHERE "events"."teacher_id" = #{teacher.id}))


### PR DESCRIPTION
Follows on from #297

This PR adds `Events::List`, a class responsible for pulling the events from the database for a given record (and eventually) filtering and ordering them.
