### PR TITLE
Use sequences for test teacher names

### DIFF
--- a/spec/factories/pending_induction_submission_factory.rb
+++ b/spec/factories/pending_induction_submission_factory.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     association :appropriate_body
     sequence(:trn, 3_000_000)
     date_of_birth { Faker::Date.between(from: 80.years.ago, to: 20.years.ago) }
-    trs_first_name { Faker::Name.first_name }
-    trs_last_name { Faker::Name.last_name }
+    sequence(:trs_first_name) { |n| "First name #{n}" }
+    sequence(:trs_last_name) { |n| "Last name #{n}" }
     trs_induction_status { "None" }
     started_on { 1.year.ago }
     trs_qts_awarded_on { 2.years.ago }

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory(:teacher) do
     sequence(:trn, 1_000_000)
-    trs_first_name { Faker::Name.name }
-    trs_last_name { Faker::Name.last_name }
+    sequence(:trs_first_name) { |n| "First name #{n}" }
+    sequence(:trs_last_name) { |n| "Last name #{n}" }
 
     trait :with_corrected_name do
       corrected_name { [trs_first_name, Faker::Name.middle_name, trs_last_name].join(' ') }


### PR DESCRIPTION
We have some flaky specs caused by some Faker names containing apostrophes, i.e., O'Conner

There's no need for tests to be random so let's use a sequence instead.

Fixes DFE-Digital/register-ects-project-board#1185
