### PR TITLE
Refactor `govuk_summary_cards` used in `ects/show` into a ViewComponent

### DIFF
--- a/app/components/schools/summary_card_component.rb
+++ b/app/components/schools/summary_card_component.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Schools
+  class SummaryCardComponent < ViewComponent::Base
+    include AppropriateBodyHelper
+    include ProgrammeHelper
+    include TeacherHelper
+
+    DATA_SOURCES = %i[school lead_provider appropriate_body].freeze
+
+    NO_INFORMATION_REPORTED = {
+      lead_provider: [{ value: { text: 'Your lead provider has not reported any information to us yet.' } }],
+      appropriate_body: [{ value: { text: 'Your appropriate body has not reported any information to us yet.' } }]
+    }.freeze
+
+    def initialize(title:, ect:, data_source:)
+      raise ArgumentError, "Invalid data source" unless DATA_SOURCES.include?(data_source)
+
+      @title = title
+      @ect = ect
+      @data_source = data_source
+    end
+
+    def call
+      govuk_summary_card(title: @title) do |card|
+        card.with_summary_list do |list|
+          rows.each do |row|
+            list.with_row do |r|
+              r.with_key(text: row[:key][:text]) if row[:key].present?
+              r.with_value(text: row[:value][:text])
+            end
+          end
+        end
+      end
+    end
+
+  private
+
+    def rows
+      case @data_source
+      when :school
+        school_rows
+      when :lead_provider
+        lead_provider_rows
+      when :appropriate_body
+        appropriate_body_rows
+      else
+        NO_INFORMATION_REPORTED[@data_source]
+      end
+    end
+
+    def school_rows
+      [
+        { key: { text: 'Appropriate body' }, value: { text: appropriate_body_name(appropriate_body_type: @ect.appropriate_body_type, appropriate_body: @ect.appropriate_body) } },
+        { key: { text: 'Programme type' }, value: { text: programme_type_name(@ect.programme_type) } }
+      ].tap do |rows|
+        rows << { key: { text: 'Lead provider' }, value: { text: @ect.lead_provider_name } } if @ect.provider_led?
+      end
+    end
+
+    def lead_provider_rows
+      return NO_INFORMATION_REPORTED[:lead_provider] unless (period = @ect.training_periods.earliest_first.last)
+
+      [
+        { key: { text: 'Lead provider' }, value: { text: period.lead_provider.name } },
+        { key: { text: 'Delivery partner' }, value: { text: period.delivery_partner.name } }
+      ]
+    end
+
+    def appropriate_body_rows
+      return NO_INFORMATION_REPORTED[:appropriate_body] unless @ect.teacher.induction_periods.any?
+
+      [
+        { key: { text: 'Appropriate body' }, value: { text: teacher_induction_ab_name(@ect.teacher) } },
+        { key: { text: 'Programme type' }, value: { text: teacher_induction_programme(@ect.teacher) } },
+        { key: { text: 'Induction start date' }, value: { text: teacher_induction_start_date(@ect.teacher) } }
+      ]
+    end
+  end
+end

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -9,69 +9,12 @@
 
 <%= render Schools::TeacherProfileSummaryListComponent.new(@ect) %>
 
-<h2 class='govuk-heading-m'>ECTE training details</h2>
-<%=
-  govuk_summary_card(title: 'Reported to us by your school') do |card|
-    if @ect.provider_led?
-      card.with_summary_list(
-        rows: [
-          { key: { text: 'Appropriate body' },
-            value: { text: appropriate_body_name(appropriate_body_type: @ect.appropriate_body_type,
-                                                 appropriate_body: @ect.appropriate_body) } },
-          { key: { text: 'Programme type' },   value: { text: programme_type_name(@ect.programme_type) } },
-          { key: { text: 'Lead provider' },    value: { text: @ect.lead_provider_name } },
-        ]
-      )
-    else
-      card.with_summary_list(
-        rows: [
-          { key: { text: 'Appropriate body' },
-            value: { text:appropriate_body_name(appropriate_body_type: @ect.appropriate_body_type,
-                                                appropriate_body: @ect.appropriate_body) } },
-          { key: { text: 'Programme type' },   value: { text: programme_type_name(@ect.programme_type)  } },
-        ]
-      )
-    end
-  end
-%>
+<h2 class="govuk-heading-m">ECTE training details</h2>
 
-<%=
-  if @ect.provider_led?
-    govuk_summary_card(title: 'Reported to us by your lead provider') do |card|
-      if (period = @ect.training_periods.earliest_first.last)
-        card.with_summary_list(
-          rows: [
-            { key: { text: 'Lead provider' },    value: { text: period.lead_provider.name } },
-            { key: { text: 'Delivery partner' }, value: { text: period.delivery_partner.name } },
-          ]
-        )
-      else
-        card.with_summary_list do |summary_list|
-          summary_list.with_row do |row|
-            row.with_value(text: 'Your lead provider has not reported any information to us yet.')
-          end
-        end
-      end
-    end
-  end
-%>
+<%= render Schools::SummaryCardComponent.new(title: 'Reported to us by your school', ect: @ect, data_source: :school) %>
 
-<%=
-  govuk_summary_card(title: 'Reported to us by your appropriate body') do |card|
-    if @ect.teacher.induction_periods.any?
-      card.with_summary_list(
-        rows: [
-          { key: { text: 'Appropriate body' },      value: { text: teacher_induction_ab_name(@ect.teacher) } },
-          { key: { text: 'Programme type' },        value: { text: teacher_induction_programme(@ect.teacher) } },
-          { key: { text: 'Induction start date' },  value: { text: teacher_induction_start_date(@ect.teacher) } },
-        ]
-      )
-    else
-      card.with_summary_list do |summary_list|
-        summary_list.with_row do |row|
-          row.with_value(text: 'Your appropriate body has not reported any information to us yet.')
-        end
-      end
-    end
-  end
-%>
+<% if @ect.provider_led? %>
+  <%= render Schools::SummaryCardComponent.new(title: 'Reported to us by your lead provider', ect: @ect, data_source: :lead_provider) %>
+<% end %>
+
+<%= render Schools::SummaryCardComponent.new(title: 'Reported to us by your appropriate body', ect: @ect, data_source: :appropriate_body) %>

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -1,0 +1,148 @@
+require "rails_helper"
+
+RSpec.describe Schools::SummaryCardComponent, type: :component do
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'an org that assures the quality of statutory teacher induction') }
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'An org that designs the training') }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'An org that delivers the training') }
+  let(:provider_partnership) { FactoryBot.create(:provider_partnership, lead_provider:, delivery_partner:) }
+
+  let(:school_led_ect) do
+    FactoryBot.create(:ect_at_school_period, :active, :school_led, :teaching_school_hub, appropriate_body:)
+  end
+
+  let(:provider_led_ect) { FactoryBot.create(:ect_at_school_period, :active, :provider_led, :teaching_school_hub, appropriate_body:, lead_provider:, started_on: '2021-01-01') }
+
+  let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: provider_led_ect, provider_partnership:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+
+  context 'when data is reported by the school' do
+    before { render_inline(described_class.new(title: 'Reported to us by your school', ect: school_led_ect, data_source: :school)) }
+
+    it 'renders the summary card' do
+      expect(page).to have_selector(".govuk-summary-card")
+    end
+
+    it 'renders the correct title' do
+      expect(page).to have_selector(".govuk-summary-card__title", text: "Reported to us by your school")
+    end
+
+    it 'renders the appropriate body' do
+      within page.find(".govuk-summary-list__row", text: "Appropriate body") do
+        expect(page).to have_text('an org that assures the quality of statutory teacher induction')
+      end
+    end
+
+    it 'renders the programme type' do
+      within page.find(".govuk-summary-list__row", text: "Programme type") do
+        expect(page).to have_text("School-led")
+      end
+    end
+
+    it 'does not render the lead provider' do
+      expect(page).not_to have_selector(".govuk-summary-list__row", text: "Lead provider")
+    end
+
+    context "when the ECT is provider-led and reported by the school" do
+      let(:ect) { provider_led_ect }
+
+      before { render_inline(described_class.new(title: "Reported to us by your school", ect:, data_source: :school)) }
+
+      it "renders the lead provider" do
+        within page.find(".govuk-summary-list__row", text: "Lead provider") do
+          expect(page).to have_text("An org that designs the training")
+        end
+      end
+    end
+  end
+
+  context 'when data is reported by the lead provider' do
+    before { render_inline(described_class.new(title: 'Reported to us by your lead provider', ect: provider_led_ect, data_source: :lead_provider)) }
+
+    it 'renders the summary card' do
+      expect(page).to have_selector(".govuk-summary-card")
+    end
+
+    it 'renders the correct title' do
+      expect(page).to have_selector(".govuk-summary-card__title", text: "Reported to us by your lead provider")
+    end
+
+    it 'renders the lead provider' do
+      within page.find(".govuk-summary-list__row", text: "Lead provider") do
+        expect(page).to have_text("An org that designs the training")
+      end
+    end
+
+    it 'renders the delivery partner' do
+      within page.find(".govuk-summary-list__row", text: "Delivery partner") do
+        expect(page).to have_text("An org that delivers the training")
+      end
+    end
+  end
+
+  context 'when data is reported by the appropriate body' do
+    let(:school_led_ect_with_induction) do
+      ect = FactoryBot.create(:ect_at_school_period, :active, :school_led, :teaching_school_hub, appropriate_body:)
+      FactoryBot.create(:induction_period, teacher: ect.teacher, started_on: '2023-01-01')
+      ect
+    end
+
+    before { render_inline(described_class.new(title: 'Reported to us by your appropriate body', ect: school_led_ect_with_induction, data_source: :appropriate_body)) }
+
+    it 'renders the summary card' do
+      expect(page).to have_selector(".govuk-summary-card")
+    end
+
+    it 'renders the correct title' do
+      expect(page).to have_selector(".govuk-summary-card__title", text: "Reported to us by your appropriate body")
+    end
+
+    it 'renders the appropriate body' do
+      within page.find(".govuk-summary-list__row", text: "Appropriate body") do
+        expect(page).to have_text("an org that assures the quality of statutory teacher induction")
+      end
+    end
+
+    it 'renders the programme type' do
+      within page.find(".govuk-summary-list__row", text: "Programme type") do
+        expect(page).to have_text("School-led")
+      end
+    end
+
+    it 'renders the induction start date' do
+      within page.find(".govuk-summary-list__row", text: "Induction start date") do
+        expect(page).to have_text("1 January 2023")
+      end
+    end
+  end
+
+  context 'when no data is available' do
+    before { render_inline(described_class.new(title: 'Reported to us by your appropriate body', ect: school_led_ect, data_source: :appropriate_body)) }
+
+    it 'renders a message indicating no information is available' do
+      expect(page).to have_text('Your appropriate body has not reported any information to us yet.')
+    end
+
+    it 'does not render an empty key column' do
+      expect(page).not_to have_selector('.govuk-summary-list__key:empty')
+    end
+  end
+
+  context 'when no training periods exist for a provider-led ECT' do
+    let(:provider_led_ect_without_training_periods) do
+      FactoryBot.create(:ect_at_school_period, :active, :provider_led, :teaching_school_hub, appropriate_body:, lead_provider:)
+    end
+
+    before { render_inline(described_class.new(title: 'Reported to us by your lead provider', ect: provider_led_ect_without_training_periods, data_source: :lead_provider)) }
+
+    it 'renders a message indicating no information is available' do
+      within page.find(".govuk-summary-card", text: "Reported to us by your lead provider") do
+        expect(page).to have_text('Your lead provider has not reported any information to us yet.')
+      end
+    end
+
+    it 'does not render any summary list rows' do
+      within page.find(".govuk-summary-card", text: "Reported to us by your lead provider") do
+        expect(page).not_to have_selector(".govuk-summary-list__row")
+      end
+    end
+  end
+end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
 
     trait :school_led do
       programme_type { 'school_led' }
+      lead_provider { nil }
     end
 
     trait :teaching_induction_panel do

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -141,8 +141,16 @@ RSpec.describe 'schools/ects/show.html.erb' do
       let(:programme_type) { 'school_led' }
       let(:requested_lead_provider) { nil }
 
-      it 'hides Lead Provider' do
-        expect(rendered).not_to have_css('dd.govuk-summary-list__value', text: 'Requested LP')
+      it 'does not render the lead provider summary card' do
+        expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
+      end
+    end
+
+    context 'when provider-led' do
+      let(:programme_type) { 'provider_led' }
+
+      it 'renders the lead provider summary card' do
+        expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
       end
     end
 


### PR DESCRIPTION
### Context

Following on from #313, we are refactoring the `govuk_summary_cards` used in `ects/show` into a ViewComponent.

This change improves reusability and enables us to write targeted tests for the component, ensuring consistent rendering across different contexts.

### Thoughts/Considerations 🤔 

I considered making this more generic so it could be used for other summary cards, with helper methods in the view. However, that would introduce a lot of logic into the view, making it harder to maintain. Since this component is scoped to schools, I felt it was reasonable to tie it more closely to this domain.

Would a more generic summary card component be worth considering, or does keeping it scoped to schools feel like the right level of abstraction for now?

### Screenshots

#### School Rows
- **Not `provider_led`**  
  ![School rows - Not provider_led](https://github.com/user-attachments/assets/f8cb46bb-3969-450a-b345-0b1e4f4a14a9)

- **`provider_led`**  
  ![School rows - provider_led](https://github.com/user-attachments/assets/4c88ccc9-fcbe-4650-8646-af550a90e13a)

---

#### Lead Provider Rows
- **With `training_periods`**  
  ![Lead provider rows](https://github.com/user-attachments/assets/df1c7dea-57ed-4f3d-8890-87261777eddf)

- **No `training_periods`**  

![Lead provider rows - No training periods](https://github.com/user-attachments/assets/ee07eb27-ece4-44f2-b338-502009cf3479)

---

#### Appropriate Body Rows
- **With `induction_periods`**  
  ![Appropriate body rows](https://github.com/user-attachments/assets/f3597654-f5a6-46bc-814c-ae7a90f3de29)

- **No `induction_periods`**  
  ![Appropriate body rows - No induction periods](https://github.com/user-attachments/assets/d133f5be-475c-4453-a0b0-19f5cc7bdab5)