### PR TITLE
Add `ENVIRONMENT` var to sandbox's config

### DIFF
--- a/config/global_config/sandbox.sh
+++ b/config/global_config/sandbox.sh
@@ -1,4 +1,5 @@
 CONFIG=sandbox
+ENVIRONMENT=sandbox
 CONFIG_SHORT=sb
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
 AZURE_RESOURCE_PREFIX=s189p01


### PR DESCRIPTION
This was missing and made the aks-ssh make command fail as it was incorrectly building this name `"cpd-ec2--web"` instead of `"cpd-ec2-sandbox-web"`.

Fixes #270
