### PR TITLE
Stop attempted real connection to TRS API

### DIFF
--- a/spec/services/admin/create_induction_period_spec.rb
+++ b/spec/services/admin/create_induction_period_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Admin::CreateInductionPeriod do
   describe '#create_induction_period!' do
     include ActiveJob::TestHelper
 
+    before do
+      allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+    end
+
     it 'returns a saved induction period record' do
       expect(subject).to be_a(InductionPeriod)
       expect(subject).to be_persisted


### PR DESCRIPTION
Prevent a spec from attempting to make a real connection to a (non existent) TRS API.

Somehow #266 was automerged despite having a failing test, something I'll investigate.