### PR TITLE
Remove unnecessary requirement of 'rails_helper'

### DIFF
--- a/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
   let(:teacher) { nil }
   let(:current_appropriate_body) { FactoryBot.create(:appropriate_body) }

--- a/spec/components/navigation/primary_navigation_component_spec.rb
+++ b/spec/components/navigation/primary_navigation_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Navigation::PrimaryNavigationComponent, type: :component do
   let(:current_path) { "/" }
   let(:current_user_type) { nil }

--- a/spec/components/navigation/sub_navigation_component_spec.rb
+++ b/spec/components/navigation/sub_navigation_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 class TestSubNavigationStructureTwoLevels < Navigation::Structures::BaseSubNavigation
   def get
     [

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
   let(:mentee_teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
   let(:mentor_teacher) { FactoryBot.create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }

--- a/spec/components/teachers/details/current_induction_period_component_spec.rb
+++ b/spec/components/teachers/details/current_induction_period_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :component do
   include AppropriateBodyHelper
   include Rails.application.routes.url_helpers

--- a/spec/components/teachers/details/induction_summary_component_spec.rb
+++ b/spec/components/teachers/details/induction_summary_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Details::InductionSummaryComponent, type: :component do
   include AppropriateBodyHelper
   include Rails.application.routes.url_helpers

--- a/spec/components/teachers/details/itt_details_component_spec.rb
+++ b/spec/components/teachers/details/itt_details_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Details::ITTDetailsComponent, type: :component do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:component) { described_class.new(teacher:) }

--- a/spec/components/teachers/details/past_induction_periods_component_spec.rb
+++ b/spec/components/teachers/details/past_induction_periods_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Details::PastInductionPeriodsComponent, type: :component do
   include AppropriateBodyHelper
 

--- a/spec/components/teachers/details/personal_details_component_spec.rb
+++ b/spec/components/teachers/details/personal_details_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Details::PersonalDetailsComponent, type: :component do
   include TeacherHelper
 

--- a/spec/components/teachers/details_component_spec.rb
+++ b/spec/components/teachers/details_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::DetailsComponent, type: :component do
   include ActionView::Helpers::TagHelper
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/components/test_guidance_component_spec.rb
+++ b/spec/components/test_guidance_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 describe TestGuidanceComponent, type: :component do
   it "renders when TEST_GUIDANCE is true" do
     with_env_var("TEST_GUIDANCE", "true") do

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe TimelineComponent, type: :component do
   let(:component) { TimelineComponent.new(events) }
 

--- a/spec/initializers/markdown_renderer_spec.rb
+++ b/spec/initializers/markdown_renderer_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe MarkdownRenderer do
   let(:template) { double("template") }
   let(:erb_handler) { double("erb_handler") }

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Admin::InductionPeriodsController do
   include ActionView::Helpers::SanitizeHelper
 

--- a/spec/requests/admin/root_spec.rb
+++ b/spec/requests/admin/root_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Admin root", type: :request do
   describe "GET /admin" do
     it "redirects to teachers path" do

--- a/spec/requests/admin/teachers/index_spec.rb
+++ b/spec/requests/admin/teachers/index_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Admin teachers index", type: :request do
   describe "GET /admin/teachers" do
     it "redirects to sign in path" do

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Admin::Teachers#show", type: :request do
   include ActionView::Helpers::SanitizeHelper
 

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Participant declarations API", type: :request do
   describe "#create" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Delivery partners API", type: :request do
   describe "#index" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/participant_transfers_spec.rb
+++ b/spec/requests/api/v3/participant_transfers_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Participant transfers API", type: :request do
   describe "#index" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Participants API", type: :request do
   describe "#index" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Partnerships API", type: :request do
   describe "#create" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Schools API", type: :request do
   describe "#index" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Statements API", type: :request do
   describe "#index" do
     it "returns method not allowed" do

--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Unfunded mentors API", type: :request do
   describe "#index" do
     it "returns method not allowed" do

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -1,4 +1,3 @@
-require "rails_helper"
 require "dfe/analytics/rspec/matchers"
 
 RSpec.describe "DfE Analytics", type: :request do

--- a/spec/services/admin/create_induction_period_spec.rb
+++ b/spec/services/admin/create_induction_period_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Admin::CreateInductionPeriod do
   let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
   let(:author) { Sessions::Users::DfEPersona.new(email: admin.email) }

--- a/spec/services/admin/update_induction_period_spec.rb
+++ b/spec/services/admin/update_induction_period_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Admin::UpdateInductionPeriod do
   subject(:service) { described_class.new(induction_period:, params:, author:) }
 

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe AppropriateBodies::RecordOutcome do
   include ActiveJob::TestHelper
   include_context 'fake trs api client'

--- a/spec/services/teachers/extensions/create_extension_spec.rb
+++ b/spec/services/teachers/extensions/create_extension_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Extensions::CreateExtension do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:service) { described_class.new(teacher, valid_params) }

--- a/spec/services/teachers/extensions/update_extension_spec.rb
+++ b/spec/services/teachers/extensions/update_extension_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe Teachers::Extensions::UpdateExtension do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 1) }


### PR DESCRIPTION
These aren't needed any more, `rails_helper` is already present.

For future reference, done with [sd](https://github.com/chmln/sd) via:

```
sd "require \"rails_helper\"\n\n" "" spec/{components,helpers,forms,jobs,lib,mailers,models,validators,services,requests,views,wizards}/**/*.rb
```
