### PR TITLE
Add support for rendering `DetailsComponent` for admins

### DIFF
--- a/app/components/teachers/details_component.rb
+++ b/app/components/teachers/details_component.rb
@@ -8,8 +8,8 @@ module Teachers
       Teachers::Details::ITTDetailsComponent.new(teacher:)
     }
 
-    renders_one :induction_summary, -> {
-      Teachers::Details::InductionSummaryComponent.new(teacher:)
+    renders_one :induction_summary, ->(is_admin: false) {
+      Teachers::Details::InductionSummaryComponent.new(teacher:, is_admin:)
     }
 
     renders_one :current_induction_period, ->(enable_release: nil, enable_edit: nil) {

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -9,7 +9,7 @@
 %>
 
 <%= render Teachers::DetailsComponent.new(mode: :admin, teacher: @teacher) do |component|
-  component.with_induction_summary
+  component.with_induction_summary(is_admin: true)
   component.with_current_induction_period(enable_edit: true)
   component.with_past_induction_periods(enable_edit: true)
 end %>

--- a/spec/components/teachers/details_component_spec.rb
+++ b/spec/components/teachers/details_component_spec.rb
@@ -92,4 +92,26 @@ RSpec.describe Teachers::DetailsComponent, type: :component do
       expect(Teachers::Details::PersonalDetailsComponent).to have_received(:new).with(teacher:)
     end
   end
+
+  describe "InductionSummaryComponent" do
+    before do
+      allow(Teachers::Details::InductionSummaryComponent).to receive(:new).and_call_original
+    end
+
+    context "when is_admin is true" do
+      it "passes the correct is_admin argument to InductionSummaryComponent" do
+        render_inline(component) { |c| c.with_induction_summary(is_admin: true) }
+
+        expect(Teachers::Details::InductionSummaryComponent).to have_received(:new).with(teacher:, is_admin: true)
+      end
+    end
+
+    context "when is_admin is not specified" do
+      it "defaults is_admin to false" do
+        render_inline(component, &:with_induction_summary)
+
+        expect(Teachers::Details::InductionSummaryComponent).to have_received(:new).with(teacher:, is_admin: false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What's Changed

- Added support for passing an `is_admin` flag to `DetailsComponent`.
- Updated `InductionSummaryComponent` to handle `is_admin`, ensuring correct rendering.

### Why
The **extensions section** in the teacher view incorrectly displays **Add/View** links in the **admin console**. These links should only appear in the **Appropriate Body (AB) interface**, but the shared component wasn’t handling this correctly.

This update ensures that the `DetailsComponent` behaves correctly across different views.

[Sentry errors](https://dfe-teacher-services.sentry.io/issues/6223619216/?environment=production&project=4508369974788096&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0)

### Screenshot

![image](https://github.com/user-attachments/assets/c77a4827-ea42-4d7b-bd57-321f2655fc3d)