### PR TITLE
Temporarily remove sandbox from deployment flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,9 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [staging, sandbox]
+        environment:
+          - staging
+          # - sandbox
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
We are having some statefile issues with sandbox so want to bypass it while we're fixing them.
