### PR TITLE
Fix Capybara Rubocop Violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,8 @@ Naming/MethodParameterName:
 
 Lint/MissingSuper:
   Enabled: false
+
+RSpec/Capybara/CurrentPathExpectation:
+  Exclude:
+    - 'spec/features/**/*' # Excluded in feature specs because we use Playwright (not Capybara) for those. Leaving it enabled elsewhere in case Capybara matchers are used in other test types.
+

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,21 +54,6 @@ RSpec/ContextWording:
 RSpec/DescribedClass:
   Enabled: false
 
-# Offense count: 11
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/EmptyLineAfterFinalLet:
-  Exclude:
-    - 'spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb'
-    - 'spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb'
-    - 'spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb'
-    - 'spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb'
-    - 'spec/services/teachers/extensions/create_extension_spec.rb'
-    - 'spec/services/teachers/extensions/update_extension_spec.rb'
-    - 'spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb'
-    - 'spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb'
-    - 'spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb'
-    - 'spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb'
-
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: CustomTransform, IgnoredWords, DisallowedExamples.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Capybara/CurrentPathExpectation:
-  Exclude:
-    - 'spec/features/visiting_the_service_spec.rb'
-
 # Offense count: 1
 Capybara/VisibilityMatcher:
   Exclude:
@@ -58,17 +52,27 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 
-# Offense count: 80
+# Offense count: 84
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.
 # SupportedStyles: described_class, explicit
 RSpec/DescribedClass:
   Enabled: false
 
-# Offense count: 52
+# Offense count: 11
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/EmptyLineAfterFinalLet:
-  Enabled: false
+  Exclude:
+    - 'spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb'
+    - 'spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb'
+    - 'spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb'
+    - 'spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb'
+    - 'spec/services/teachers/extensions/create_extension_spec.rb'
+    - 'spec/services/teachers/extensions/update_extension_spec.rb'
+    - 'spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb'
+    - 'spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb'
+    - 'spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb'
+    - 'spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb'
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
@@ -119,12 +123,12 @@ RSpec/ImplicitSubject:
     - 'spec/models/school_spec.rb'
     - 'spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb'
 
-# Offense count: 78
+# Offense count: 83
 # Configuration parameters: Max, AllowedIdentifiers, AllowedPatterns.
 RSpec/IndexedLet:
   Enabled: false
 
-# Offense count: 91
+# Offense count: 95
 RSpec/LetSetup:
   Enabled: false
 
@@ -234,7 +238,7 @@ RSpec/VariableDefinition:
   Exclude:
     - 'spec/validators/ect_start_date_validator_spec.rb'
 
-# Offense count: 26
+# Offense count: 25
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Enabled: false
@@ -287,7 +291,7 @@ Rails/SaveBang:
   Exclude:
     - 'spec/support/rspec_playwright.rb'
 
-# Offense count: 3125
+# Offense count: 3157
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
 # SupportedStyles: single_quotes, double_quotes

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-Capybara/VisibilityMatcher:
-  Exclude:
-    - 'spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb'
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 FactoryBot/FactoryClassName:

--- a/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
 
   context "with teacher" do
     let(:teacher) { FactoryBot.create(:teacher) }
+
     context "when teacher is registered with another appropriate body" do
       let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
       let!(:induction_period) do

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
 
     context 'when signed in' do
       let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
+
       before { allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).with(any_args).and_call_original }
 
       context "when the submission is valid" do

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
       let(:author_last_name) { 'Benning' }
       let(:author_email) { 'ab@something.com' }
       let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:, method: :dfe_sign_in, first_name: author_first_name, last_name: author_last_name, email: author_email) }
+
       before { allow(AppropriateBodies::ClaimAnECT::RegisterECT).to receive(:new).with(any_args).and_call_original }
 
       context 'when the submission is valid' do
@@ -110,6 +111,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
 
       context "when the submission is invalid" do
         let(:registration_params) { { induction_programme: "xyz", } }
+
         it 'passes the parameters to the AppropriateBodies::ClaimAnECT::RegisterECT but does not redirect and rerenders the form' do
           patch(
             "/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}",

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
           trs_qts_awarded_on:
         }
       end
+
       it "fails because invalid" do
         expect(subject.register(pending_induction_submission_params)).to be_falsey
         expect(subject.pending_induction_submission.errors.key?(:started_on)).to be true

--- a/spec/services/teachers/extensions/create_extension_spec.rb
+++ b/spec/services/teachers/extensions/create_extension_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Teachers::Extensions::CreateExtension do
   describe "#create_extension" do
     context "with valid params" do
       let(:valid_params) { { number_of_terms: 1 } }
+
       it "creates a new induction extension" do
         expect { service.create_extension }.to change(InductionExtension, :count).by(1)
       end

--- a/spec/services/teachers/extensions/update_extension_spec.rb
+++ b/spec/services/teachers/extensions/update_extension_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Teachers::Extensions::UpdateExtension do
   describe "#update_extension" do
     context "with valid params" do
       let(:valid_params) { { number_of_terms: 2 } }
+
       it "updates the extension attributes" do
         service.update_extension
         extension.reload

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
   it 'includes an inset with the names of the mentor and ECT associated' do
     render
-    expect(rendered).to have_selector(".govuk-inset-text", text: 'Jim Wayne will mentor Michael Dixon', visible: true)
+    expect(rendered).to have_selector(".govuk-inset-text", text: 'Jim Wayne will mentor Michael Dixon', visible: :visible)
   end
 
   it 'includes a Confirm details button that posts to the check answers page' do

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
   describe 'page title' do
     let(:title) { sanitize(view.content_for(:page_title)) }
+
     before { render }
 
     it { expect(title).to eql("Check your answers and confirm mentor details") }

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -53,6 +53,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     context 'when the teacher is prohibited from teaching' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+
       before do
         fake_client = TRS::FakeAPIClient.new
 

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -138,6 +138,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context 'when the mentor is prohibited from teaching' do
       let(:teacher) { create(:teacher, trn: '1234568') }
+
       before do
         fake_client = TRS::FakeAPIClient.new
 

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -111,6 +111,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context 'when the mentor is prohibited from teaching' do
       let(:teacher) { create(:teacher, trn: '1234568') }
+
       before do
         fake_client = TRS::FakeAPIClient.new
 


### PR DESCRIPTION
### Context

We're gradually working through the rubocop violations listed in `.rubocop_todo.yml`.

### Changes proposed

Here we clean up the following violations: 

- **Abide by** [Capybara/CurrentPathExpectation](https://www.rubydoc.info/gems/rubocop-rspec/1.19.0/RuboCop/Cop/RSpec/Capybara/CurrentPathExpectation) (this change excludes the feature tests from this cop because we use Playwright (not Capybara) for those. Leaving it enabled elsewhere in case Capybara matchers are used in other test types.)

- **Exclude feature tests from** [Capybara/VisibilityMatcher](https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/VisibilityMatcher) (this change helps to avoid ambiguity by being more explicit and using the preferred `:visible` symbol instead of `true`.)

### Guidance to review

I've addressed each cop in single commit, so it would make the most sense to review commit by commit.