### PR TITLE
Enable content security policy (CSP)

### DIFF
--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -12,6 +12,6 @@
   <%= favicon_link_tag asset_path('images/govuk-icon-mask.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b1c0c" %>
   <%= favicon_link_tag asset_path('images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
-  <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  <%= stylesheet_link_tag "application", "data-turbo-track": "reload", nonce: true %>
+  <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true, nonce: true %>
 </head>

--- a/app/views/layouts/shared/_js_enabled.html.erb
+++ b/app/views/layouts/shared/_js_enabled.html.erb
@@ -1,3 +1,3 @@
-<script>
+<%= javascript_tag(nonce: true) do %>
   document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
-</script>
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,13 @@
-# Be sure to restart your server when you modify this file.
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
+  end
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
-
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+  config.content_security_policy_nonce_generator = ->(request) { request.session[:nonce] ||= SecureRandom.hex }
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
+end


### PR DESCRIPTION
Before/after

```diff
  HTTP/2.0 200 OK
  cache-control: max-age=0, private, must-revalidate
  content-length: 0
+ content-security-policy: default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src 'self' https: 'nonce-'; style-src 'self' https: 'nonce-'
  content-type: text/html; charset=utf-8
  link: </assets/application-a2ba66bf.css>; rel=preload; as=style; nopush
  referrer-policy: strict-origin-when-cross-origin
  strict-transport-security: max-age=31536000; includeSubDomains
  vary: Accept
  x-content-type-options: nosniff
  x-frame-options: SAMEORIGIN
  x-permitted-cross-domain-policies: none
  x-xss-protection: 0
```

Note, [viewing in dev tools won't show nonces](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce#accessing_nonces_and_nonce_hiding) (seriously it took me like an hour of debugging to work out why they were all blank 😭) but if you view source they're present.

![image](https://github.com/user-attachments/assets/cae1fb20-7d2c-460f-9340-a449baad0f98)

