### PR TITLE
Update email label to discourage use of generic addresses

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,0 +1,9 @@
+module ContentHelper
+  def generic_email_label
+    safe_join([
+      "Do not use a generic email like ",
+      govuk_link_to("admin@example.com", "#", no_visited_state: true),
+      "."
+    ])
+  end
+end

--- a/app/views/schools/register_ect_wizard/_email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/_email_address.html.erb
@@ -1,15 +1,17 @@
 <% page_data(
-    title: "What is #{@ect.full_name}'s email address?",
+    title: "What is #{@ect.full_name}’s email address?",
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
 
-<p class="govuk-body">You must provide an email address that your ECT can access. You can update it later if needed.</p>
+<p class="govuk-body">We ask for an email so we can share their details if needed for training.</p>
+
+<p class="govuk-body">Please make sure you use an email the ECT can access. You can update it later if they haven’t got a school email set up yet.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_email_field(:email, label: { text: "Enter your ECT's email address.", class: 'govuk-!-margin-bottom-4' }) %>
+  <%= f.govuk_email_field(:email, label: { text: generic_email_label, class: 'govuk-!-margin-bottom-4' }) %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe ContentHelper, type: :helper do
+  describe "#generic_email_label" do
+    let(:label) { helper.generic_email_label }
+
+    it 'returns the label' do
+      expect(label).to include('Do not use a generic email like')
+      expect(label).to end_with(".")
+    end
+
+    it 'renders the link' do
+      expect(label).to include('admin@example.com')
+      expect(label).to include("govuk-link--no-visited-state")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Update the email field label to discourage use of generic email addresses (e.g. admin@example.com).
## Changes proposed

- Extracted a new helper method `generic_email_label` in `ContentHelper` to render the label text.
- Included a `govuk_link_to` link styled with `govuk-link--no-visited-state`.
- Updated the content on the form page to use this new helper.
- Use smart quotes

## Before / After

| Before | After |
|--------|-------|
| <img width="618" alt="image" src="https://github.com/user-attachments/assets/ed1da5e4-abd8-4bc4-bc89-bb45b8e11132" /> | <img width="699" alt="image" src="https://github.com/user-attachments/assets/133064ad-a037-4b65-9829-2630a727f6e5" /> |


## Notes and Observations

This change affects the **Register ECT** email page in the following places:

- **When registering an ECT**  
  `app/views/schools/register_ect_wizard/_email_address.html.erb`

- **When editing a new ECT from the check answers page**  
  `app/views/schools/register_ect_wizard/change_email_address.html.erb`

---

**Mentor creation and editing** use a *different* partial (with the same filename):

- **When creating a mentor**  
  `app/views/schools/register_mentor_wizard/email_address.html.erb`

- **When editing a mentor**  
  `app/views/schools/register_mentor_wizard/change_email_address.html.erb`
