### PR TITLE
Update organisation roles guidance in the ECT registration journey

### DIFF
--- a/app/views/schools/register_ect_wizard/_appropriate_body_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_appropriate_body_details.html.erb
@@ -1,11 +1,20 @@
 <div class="govuk-!-margin-top-5">
-  <%= govuk_details(summary_text: 'Find out more about appropriate bodies') do %>
-    <p class="govuk-body">Teaching school hubs are the main provider of appropriate body services, except for the 2 specialist appropriate body services for some independent and overseas schools.</p>
-    <p class="govuk-body">Appropriate bodies:</p>
-    <%= govuk_list [
-                     "ensure schools follow correct procedures for ECTs, including providing an ECF-based induction",
-                     "make sure ECTs receive their statutory entitlements (time off timetable and mentoring)",
-                     "monitor ECT progress during induction and advise schools on how to support improvement"
-                   ], type: :bullet %>
+  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+    <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of 
+      ECTs.
+    </p>
+
+    <p class="govuk-body">For provider-led training, the lead provider provides the online learning platform used for 
+      training ECTs and mentors, while the delivery partner delivers training events.
+    </p>
+
+    <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate 
+      body might be the same organisation as the delivery partner.
+    </p>
+
+    <p class="govuk-body">For school-led training your school will still work with an appropriate body to quality 
+      assure the induction process. You might choose to design your own training programme or use materials created by 
+      different lead providers.
+    </p>
   <% end %>
 </div>

--- a/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
@@ -1,12 +1,12 @@
 <% page_data(
-    title: "Which appropriate body will be supporting #{@ect.full_name}'s induction?",
+    title: "Which appropriate body will be supporting #{@ect.full_name}’s induction?",
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
 
 <p class="govuk-body">Appropriate bodies are responsible for assuring the quality of the statutory induction of ECTs.</p>
 
-<p class="govuk-body">We share the ECT's details with the appropriate body to check the ECT has been registered correctly.</p>
+<p class="govuk-body">We share the ECT’s details with the appropriate body to check the ECT has been registered correctly.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/register_ect_wizard/_lead_provider.html.erb
+++ b/app/views/schools/register_ect_wizard/_lead_provider.html.erb
@@ -9,7 +9,7 @@ Lead providers are responsible for creating the materials used for training ECTs
 </p>
 
 <p class="govuk-body">
-We will let the lead provider know your school wants to work with them so they can arrange training. They'll confirm which delivery partner they'll be working with to deliver training events.
+We will let the lead provider know your school wants to work with them so they can arrange training. They’ll confirm which delivery partner they’ll be working with to deliver training events.
 </p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>

--- a/app/views/schools/register_ect_wizard/_lead_provider_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_lead_provider_details.html.erb
@@ -1,9 +1,13 @@
 <div class="govuk-!-margin-top-5">
-  <%= govuk_details(summary_text: 'Find out more about lead providers') do %>
-    <p class="govuk-body">They are organisations that:</p>
-    <%= govuk_list [
-                     "train mentors and trainers who deliver the early career framework training to ECTs",
-                     "report on the progress and effectiveness of the training programme to the Department for Education (DfE)",
-                   ], type: :bullet %>
+  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+    <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of ECTs.
+       A lead provider provides the online learning platform used for training ECTs and mentors, while the delivery 
+       partner delivers training events.
+    </p>
+
+    <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate 
+      body might be the same organisation as the delivery partner.
+    </p>
   <% end %>
 </div>
+

--- a/app/views/schools/register_ect_wizard/_state_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_state_school_appropriate_body.html.erb
@@ -1,12 +1,12 @@
 <% page_data(
-    title: "Which appropriate body will be supporting #{@ect.full_name}'s induction?",
+    title: "Which appropriate body will be supporting #{@ect.full_name}’s induction?",
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
 
 <p class="govuk-body">Appropriate bodies are responsible for assuring the quality of the statutory induction of ECTs.</p>
 
-<p class="govuk-body">We share the ECT's details with the appropriate body to check the ECT has been registered correctly.</p>
+<p class="govuk-body">We share the ECT’s details with the appropriate body to check the ECT has been registered correctly.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -36,5 +36,19 @@ end %>
     <%= f.govuk_radio_button :use_previous_ect_choices, :false, label: { text: "No" } %>
   <% end %>
 
+  <div class="govuk-!-margin-top-5">
+    <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+      <p class="govuk-body">
+        An appropriate body is responsible for assuring the quality of the statutory induction of ECTs. A lead provider provides the online learning platform used for training ECTs and mentors, while the delivery partner delivers training events.
+      </p>
+
+      <p class="govuk-body">
+        These roles are sometimes undertaken by the same organisation, for example an appropriate body might be the same organisation as the delivery partner.
+      </p>
+    <% end %>
+  </div>
+
+
   <%= f.govuk_submit "Continue" %>
 <% end %>
+

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -36,17 +36,25 @@ end %>
     <%= f.govuk_radio_button :use_previous_ect_choices, :false, label: { text: "No" } %>
   <% end %>
 
-  <div class="govuk-!-margin-top-5">
-    <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
-      <p class="govuk-body">
-        An appropriate body is responsible for assuring the quality of the statutory induction of ECTs. A lead provider provides the online learning platform used for training ECTs and mentors, while the delivery partner delivers training events.
-      </p>
+<div class="govuk-!-margin-top-5">
+  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+    <p class="govuk-body">
+      An appropriate body is responsible for assuring the quality of the statutory induction of ECTs.
+    </p>
 
-      <p class="govuk-body">
-        These roles are sometimes undertaken by the same organisation, for example an appropriate body might be the same organisation as the delivery partner.
-      </p>
-    <% end %>
-  </div>
+    <p class="govuk-body">
+      For provider-led training, the lead provider provides the online learning platform used for training ECTs and mentors, while the delivery partner delivers training events.
+    </p>
+
+    <p class="govuk-body">
+      These roles are sometimes undertaken by the same organisation, for example an appropriate body might be the same organisation as the delivery partner.
+    </p>
+
+    <p class="govuk-body">
+      For school-led training your school will still work with an appropriate body to quality assure the induction process. You might choose to design your own training programme or use materials created by different lead providers.
+    </p>
+  <% end %>
+</div>
 
 
   <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -36,7 +36,6 @@ end %>
     <%= f.govuk_radio_button :use_previous_ect_choices, :false, label: { text: "No" } %>
   <% end %>
 
-<div class="govuk-!-margin-top-5">
   <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
     <p class="govuk-body">
       An appropriate body is responsible for assuring the quality of the statutory induction of ECTs.
@@ -54,8 +53,6 @@ end %>
       For school-led training your school will still work with an appropriate body to quality assure the induction process. You might choose to design your own training programme or use materials created by different lead providers.
     </p>
   <% end %>
-</div>
-
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/schools/register_ect_wizard/start.html.erb
+++ b/app/views/schools/register_ect_wizard/start.html.erb
@@ -1,24 +1,27 @@
-<% page_data(title: "What you’ll need to register a new ECT", error: false) %>
+<% page_data(title: "What you’ll need to register a new ECT", error: false, backlink_href: schools_ects_home_path) %>
 
-<h2 class="govuk-heading-m">Personal information</h2>
-<p class="govuk-body">You must provide your ECT’s:</p>
+<p class="govuk-body">You’ll need the ECT’s:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>name</li>
+  <li>teacher reference number (TRN)</li>
   <li>date of birth</li>
   <li>email address</li>
-  <li>teacher reference number (TRN)</li>
-</ul>
-
-<h2 class="govuk-heading-m">Training details</h2>
-<p class="govuk-body">You will also need to tell us about your choice of:</p>
-<ul class="govuk-list govuk-list--bullet">
+  <li>start date at your school as an ECT</li>
+  <li>working pattern (full or part time)</li>
   <li>appropriate body</li>
-  <li>lead provider and delivery partner</li>
-  <li>programme type</li>
-  <li>mentor</li>
+  <li>training programme (provider-led or school-led)</li>
+  <li>lead provider (if it’s a provider-led programme)</li>
+  <li>mentor (you can provide these details later if you need to)</li>
 </ul>
 
-<p class="govuk-body">If you have not assigned a mentor for your ECT, you can still register them by providing the
-  mentor’s details later.</p>
+<%= govuk_details(summary_text: "What are the roles of an appropriate body, lead provider and delivery partner?") do %>
+  <p>An appropriate body is responsible for assuring the quality of the statutory induction of ECTs.</p>
+
+  <p>For provider-led training, the lead provider provides the online learning platform used for training ECTs and mentors, while the delivery partner delivers training events.</p>
+
+  <p>These roles are sometimes undertaken by the same organisation, for example an appropriate body might be the same organisation as the delivery partner.</p>
+
+  <p>For school-led training your school will still work with an appropriate body to quality assure the induction process. You might choose to design your own training programme or use materials created by different lead providers.</p>
+<% end %>
 
 <%= govuk_button_link_to("Continue", schools_register_ect_wizard_find_ect_path) %>

--- a/spec/features/schools/register_an_ect/happy_path_spec.rb
+++ b/spec/features/schools/register_an_ect/happy_path_spec.rb
@@ -177,7 +177,9 @@ RSpec.describe 'Registering an ECT' do
 
   def and_i_should_see_the_previous_programme_choices
     expect(page.get_by_text(school.chosen_appropriate_body.name)).to be_visible
-    expect(page.get_by_text('Provider-Led')).to be_visible
+    row = page.locator('.govuk-summary-list__row', has: page.locator('text=Programme type'))
+    expect(row.text_content).to include('Programme type')
+    expect(row.text_content).to include('Provider-led')
     expect(page.get_by_text(school.chosen_lead_provider_name).first).to be_visible
   end
 

--- a/spec/views/schools/register_ect_wizard/shared_examples/independent_school_appropriate_body_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/independent_school_appropriate_body_view.rb
@@ -9,10 +9,10 @@ RSpec.shared_examples "an independent school appropriate body view" do |current_
     assign(:ect, ect)
   end
 
-  it "sets the page title to 'Which appropriate body will be supporting John Smith's induction?'" do
+  it "sets the page title to 'Which appropriate body will be supporting John Smith’s induction?'" do
     render
 
-    expect(sanitize(view.content_for(:page_title))).to eql("Which appropriate body will be supporting John Smith's induction?")
+    expect(sanitize(view.content_for(:page_title))).to eql("Which appropriate body will be supporting John Smith’s induction?")
   end
 
   context "when the appropriate body name is invalid" do

--- a/spec/views/schools/register_ect_wizard/shared_examples/state_school_appropriate_body_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/state_school_appropriate_body_view.rb
@@ -10,10 +10,10 @@ RSpec.shared_examples "a state school appropriate body view" do |current_step:, 
     assign(:ect, ect)
   end
 
-  it "sets the page title to 'Which appropriate body will be supporting John Smith's induction?'" do
+  it "sets the page title to 'Which appropriate body will be supporting John Smith’s induction?'" do
     render
 
-    expect(sanitize(view.content_for(:page_title))).to eql("Which appropriate body will be supporting John Smith's induction?")
+    expect(sanitize(view.content_for(:page_title))).to eql("Which appropriate body will be supporting John Smith’s induction?")
   end
 
   context "when the appropriate body name is invalid" do

--- a/spec/views/schools/register_ect_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/start.html.erb_spec.rb
@@ -1,11 +1,17 @@
 RSpec.describe "schools/register_ect_wizard/start.html.erb" do
-  it "sets the page title" do
+  before do
     render
+  end
+
+  it "sets the page title" do
     expect(sanitize(view.content_for(:page_title))).to eql("What you’ll need to register a new ECT")
   end
 
+  it "sets the back link path" do
+    expect(view.content_for(:backlink_or_breadcrumb)).to include(schools_ects_home_path)
+  end
+
   it 'includes a continue button' do
-    render
     expect(rendered).to have_link('Continue', href: schools_register_ect_wizard_find_ect_path)
   end
 end


### PR DESCRIPTION
## Context 

We are updating some of the content in the journey to register an ECT that explains the different organisation types, as well as some other content updates on the first page of the journey.

## Before/After (`what-you-will-need` page)

| Before | After |
|--------|-------|
| <img width="738" alt="image" src="https://github.com/user-attachments/assets/d7d98cda-c10f-43f8-a645-c40e9d220869" /> | <img width="692" alt="image" src="https://github.com/user-attachments/assets/5f590fda-2431-41ef-a17e-44b885839bc8" /> |


## Before/After (`independent-school-appropriate-body` page)

| Before | After |
|--------|-------|
| <img width="748" alt="image" src="https://github.com/user-attachments/assets/4eeef28f-a8a9-472c-985a-a978eff74c96" /> | <img width="735" alt="image" src="https://github.com/user-attachments/assets/ea30fc89-3d3f-4a8a-8dc2-dc4f7b541aaa" /> |

## Before/After (`state-school-appropriate-body` page)

| Before | After |
|--------|-------|
| <img width="731" alt="image" src="https://github.com/user-attachments/assets/a8bb130a-7f04-4619-8158-9bfa10b1cd4d" />| <img width="730" alt="image" src="https://github.com/user-attachments/assets/e2af96c8-c55c-4a5a-9ee6-3c75912a4d9e" />|


## Before/After (`register-ect/lead-provider` page)

| Before | After |
|--------|-------|
|<img width="379" alt="image" src="https://github.com/user-attachments/assets/8eac0a04-df34-48c5-bc70-afbffb0104c4" />|<img width="396" alt="image" src="https://github.com/user-attachments/assets/e1b9a976-497a-42a7-9f2d-c4658e537d20" />|


## Before/After (`use-previous-ect-choices` page)


| Before | After |
|--------|-------|
|<img width="564" alt="image" src="https://github.com/user-attachments/assets/436e484d-6fe3-48fd-93bc-0117c9ca00c8" />|<img width="579" alt="image" src="https://github.com/user-attachments/assets/45a1b9a7-8aa0-4c50-a869-83ee10c924f7" />|


> **Note:**  
> This change will affect both the `add` and `change` flows:
>
> - `change_use_previous_ect_choices.html.erb`
> - `use_previous_ect_choices.html.erb`
