### PR TITLE
Update email label

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -2,7 +2,7 @@ module ContentHelper
   def generic_email_label
     safe_join([
       "Do not use a generic email like ",
-      govuk_link_to("admin@example.com", "#", no_visited_state: true),
+      govuk_link_to("headteacher@school.com", "#", no_visited_state: true),
       "."
     ])
   end

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ContentHelper, type: :helper do
     end
 
     it 'renders the link' do
-      expect(label).to include('admin@example.com')
+      expect(label).to include('headteacher@school.com')
       expect(label).to include("govuk-link--no-visited-state")
     end
   end


### PR DESCRIPTION
### Context

Updating the email label so that it is more reflective of the user who sees it.

Addresses this comment which was left after the PR was merged:: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/382/files#r2013905454