### PR TITLE
Override Blazer's CSP settings

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -78,3 +78,5 @@ check_schedules:
 #   url: <%= ENV["BLAZER_UPLOADS_URL"] %>
 #   schema: uploads
 #   data_source: main
+
+override_csp: true


### PR DESCRIPTION
Blazer was being blocked by the CSP changes made in #374 and I didn't test it at the time. Blazer comes with an `override_csp` setting that lets Blazer use its own settings without affecting the rest of the app.

I've tested this locally and it works, we don't have Blazer enabled in review apps so it won't be testable there.

In prod when looking at the browser console there was lots of this kind of error:

```
Content-Security-Policy: The page’s settings blocked an inline style (style-src-elem) 
```