### PR TITLE
Remove unnecessary top margins

### DIFF
--- a/app/views/schools/register_ect_wizard/_appropriate_body_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_appropriate_body_details.html.erb
@@ -1,20 +1,18 @@
-<div class="govuk-!-margin-top-5">
-  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
-    <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of 
-      ECTs.
-    </p>
+<%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+  <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of 
+    ECTs.
+  </p>
 
-    <p class="govuk-body">For provider-led training, the lead provider provides the online learning platform used for 
-      training ECTs and mentors, while the delivery partner delivers training events.
-    </p>
+  <p class="govuk-body">For provider-led training, the lead provider provides the online learning platform used for 
+    training ECTs and mentors, while the delivery partner delivers training events.
+  </p>
 
-    <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate 
-      body might be the same organisation as the delivery partner.
-    </p>
+  <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate 
+    body might be the same organisation as the delivery partner.
+  </p>
 
-    <p class="govuk-body">For school-led training your school will still work with an appropriate body to quality 
-      assure the induction process. You might choose to design your own training programme or use materials created by 
-      different lead providers.
-    </p>
-  <% end %>
-</div>
+  <p class="govuk-body">For school-led training your school will still work with an appropriate body to quality 
+    assure the induction process. You might choose to design your own training programme or use materials created by 
+    different lead providers.
+  </p>
+<% end %>

--- a/app/views/schools/register_ect_wizard/_lead_provider_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_lead_provider_details.html.erb
@@ -1,13 +1,11 @@
-<div class="govuk-!-margin-top-5">
-  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
-    <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of ECTs.
-       A lead provider provides the online learning platform used for training ECTs and mentors, while the delivery 
-       partner delivers training events.
-    </p>
+<%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+  <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of ECTs.
+      A lead provider provides the online learning platform used for training ECTs and mentors, while the delivery 
+      partner delivers training events.
+  </p>
 
-    <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate 
-      body might be the same organisation as the delivery partner.
-    </p>
-  <% end %>
-</div>
+  <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate 
+    body might be the same organisation as the delivery partner.
+  </p>
+<% end %>
 


### PR DESCRIPTION
### Context

This removes unnecessary `govuk-!-margin-top-5` classes that wasn't affecting the layout. Simplifies the markup slightly without changing the visual appearance.

Recommend hiding whitespace changes to make the diff clearer - it’s a very small change.