### PR TITLE
[1399] -  add type to appropriate bodies

### DIFF
--- a/app/components/schools/summary_card_component.rb
+++ b/app/components/schools/summary_card_component.rb
@@ -51,7 +51,7 @@ module Schools
 
     def school_rows
       [
-        { key: { text: 'Appropriate body' }, value: { text: appropriate_body_name(appropriate_body_type: @ect.appropriate_body_type, appropriate_body: @ect.appropriate_body) } },
+        { key: { text: 'Appropriate body' }, value: { text: @ect.school_reported_appropriate_body_name } },
         { key: { text: 'Programme type' }, value: { text: programme_type_name(@ect.programme_type) } }
       ].tap do |rows|
         rows << { key: { text: 'Lead provider' }, value: { text: @ect.lead_provider_name } } if @ect.provider_led?

--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -1,10 +1,8 @@
 module AppropriateBodyHelper
   FormChoice = Data.define(:identifier, :name)
 
-  def appropriate_body_name(appropriate_body_type:, appropriate_body: nil)
-    return appropriate_body&.name unless appropriate_body_type == 'teaching_induction_panel'
-
-    AppropriateBody::NAME_FOR_TEACHING_INDUCTION_PANEL_TYPE
+  def appropriate_bodies_options_for_collection
+    AppropriateBody.teaching_school_hub.select(:id, :name).all
   end
 
   def induction_programme_choices

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,6 +1,4 @@
 class AppropriateBody < ApplicationRecord
-  ISTIP = 'Independent Schools Teacher Induction Panel (ISTIP)'.freeze
-
   # Enums
   enum :body_type,
        { local_authority: 'local_authority',
@@ -38,8 +36,4 @@ class AppropriateBody < ApplicationRecord
               message: 'Must be a number between 1000 and 9999',
               allow_blank: true
             }
-
-  def self.istip
-    find_by_name(ISTIP)
-  end
 end

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,5 +1,12 @@
 class AppropriateBody < ApplicationRecord
-  NAME_FOR_TEACHING_INDUCTION_PANEL_TYPE = 'Independent Schools Teacher Induction Panel (ISTIP)'.freeze
+  ISTIP = 'Independent Schools Teacher Induction Panel (ISTIP)'.freeze
+
+  # Enums
+  enum :body_type,
+       { local_authority: 'local_authority',
+         national: 'national',
+         teaching_school_hub: 'teaching_school_hub' },
+       validate: { message: "Must be local authority, national or teaching school hub" }
 
   # Associations
   has_many :pending_induction_submissions
@@ -14,8 +21,8 @@ class AppropriateBody < ApplicationRecord
   validates :local_authority_code,
             presence: { message: 'Enter a local authority code', allow_blank: true },
             inclusion: {
-              in: 100..999,
-              message: 'Must be a number between 100 and 999',
+              in: 50..999,
+              message: 'Must be a number between 50 and 999',
               allow_blank: true
             },
             uniqueness: {
@@ -31,4 +38,8 @@ class AppropriateBody < ApplicationRecord
               message: 'Must be a number between 1000 and 9999',
               allow_blank: true
             }
+
+  def self.istip
+    find_by_name(ISTIP)
+  end
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -11,7 +11,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   # Associations
   belongs_to :school, inverse_of: :ect_at_school_periods
   belongs_to :teacher, inverse_of: :ect_at_school_periods
-  belongs_to :school_reported_appropriate_body, class_name: 'AppropriateBody', optional: true
+  belongs_to :school_reported_appropriate_body, class_name: 'AppropriateBody'
   belongs_to :lead_provider
 
   has_many :mentorship_periods, inverse_of: :mentee

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -60,8 +60,9 @@ class ECTAtSchoolPeriod < ApplicationRecord
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
 
   # Instance methods
-  # appropriate_body_name
-  delegate :name, to: :appropriate_body, prefix: true, allow_nil: true
+  def school_reported_appropriate_body_name = school_reported_appropriate_body&.name
+
+  def school_reported_appropriate_body_type = school_reported_appropriate_body&.body_type
 
   # lead_provider_name
   delegate :name, to: :lead_provider, prefix: true, allow_nil: true

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -9,8 +9,8 @@ class School < ApplicationRecord
 
   # Associations
   belongs_to :gias_school, class_name: "GIAS::School", foreign_key: :urn, inverse_of: :school
-  belongs_to :chosen_appropriate_body, class_name: 'AppropriateBody', optional: true
-  belongs_to :chosen_lead_provider, class_name: 'LeadProvider', optional: true
+  belongs_to :chosen_appropriate_body, class_name: 'AppropriateBody'
+  belongs_to :chosen_lead_provider, class_name: 'LeadProvider'
 
   has_many :ect_at_school_periods, inverse_of: :school
   has_many :ect_teachers, -> { distinct }, through: :ect_at_school_periods, source: :teacher

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,12 +1,5 @@
 class School < ApplicationRecord
   # Enums
-  enum :chosen_appropriate_body_type,
-       { teaching_induction_panel: "teaching_induction_panel",
-         teaching_school_hub: "teaching_school_hub" },
-       validate: { message: "Must be nil or teaching induction panel or teaching school hub",
-                   allow_nil: true },
-       suffix: :ab_type_chosen
-
   enum :chosen_programme_type,
        { provider_led: "provider_led",
          school_led: "school_led" },
@@ -26,23 +19,6 @@ class School < ApplicationRecord
   has_many :mentor_teachers, -> { distinct }, through: :mentor_at_school_periods, source: :teacher
 
   # Validations
-  validates :chosen_appropriate_body_id,
-            presence: {
-              message: 'Must contain the ID of an appropriate body',
-              if: -> { teaching_school_hub_ab_type_chosen? }
-            },
-            absence: {
-              message: 'Must be nil',
-              unless: -> { teaching_school_hub_ab_type_chosen? }
-            }
-
-  validates :chosen_appropriate_body_type,
-            presence: {
-              message: 'Must be teaching school hub',
-              if: -> { state_funded? },
-              allow_nil: true
-            }
-
   validates :chosen_lead_provider_id,
             presence: {
               message: 'Must contain the id of a lead provider',
@@ -56,8 +32,14 @@ class School < ApplicationRecord
   validates :chosen_programme_type,
             presence: {
               message: 'Must be provider-led',
-              if: -> { chosen_appropriate_body_id }
+              if: -> { chosen_lead_provider_id }
             }
+
+  validate :chosen_appropriate_body_for_independent_school,
+           if: -> { independent? }
+
+  validate :chosen_appropriate_body_for_state_funded_school,
+           if: -> { state_funded? }
 
   validates :urn,
             presence: true,
@@ -95,6 +77,8 @@ class School < ApplicationRecord
   # chosen_appropriate_body_name
   delegate :name, to: :chosen_appropriate_body, prefix: true, allow_nil: true
 
+  def chosen_appropriate_body_type = chosen_appropriate_body&.body_type
+
   # chosen_lead_provider_name
   delegate :name, to: :chosen_lead_provider, prefix: true, allow_nil: true
 
@@ -103,15 +87,27 @@ class School < ApplicationRecord
   def programme_choices
     {
       appropriate_body_id: chosen_appropriate_body_id,
-      appropriate_body_type: chosen_appropriate_body_type,
       programme_type: chosen_programme_type,
       lead_provider_id: chosen_lead_provider_id
     }.compact
   end
 
-  def programme_choices? = chosen_appropriate_body_type && chosen_programme_type
+  def programme_choices? = chosen_appropriate_body_id && chosen_programme_type
 
   def state_funded? = GIAS::Types::STATE_SCHOOL_TYPES.include?(type_name)
+
+  def chosen_appropriate_body_for_independent_school
+    return unless chosen_appropriate_body&.local_authority?
+
+    errors.add(:chosen_appropriate_body_id, 'Must be national or teaching school hub')
+  end
+
+  def chosen_appropriate_body_for_state_funded_school
+    return if chosen_appropriate_body.blank?
+    return if chosen_appropriate_body.teaching_school_hub?
+
+    errors.add(:chosen_appropriate_body_id, 'Must be teaching school hub')
+  end
 
   def to_param = urn
 end

--- a/app/services/appropriate_bodies/search.rb
+++ b/app/services/appropriate_bodies/search.rb
@@ -1,9 +1,19 @@
 module AppropriateBodies
   class Search
+    ISTIP = 'Independent Schools Teacher Induction Panel (ISTIP)'.freeze
+
     def initialize(query_string = nil)
       @scope = AppropriateBody
 
       @query_string = query_string
+    end
+
+    def self.istip
+      new(ISTIP).search.first || raise(ActiveRecord::RecordNotFound, "ISTIP appropriate body not found!")
+    end
+
+    def find_by_dfe_sign_in_organisation_id(dfe_sign_in_organisation_id)
+      @scope.find_by(dfe_sign_in_organisation_id:)
     end
 
     def search
@@ -14,10 +24,6 @@ module AppropriateBodies
               end
 
       query.order(name: 'asc')
-    end
-
-    def find_by_dfe_sign_in_organisation_id(dfe_sign_in_organisation_id)
-      @scope.find_by(dfe_sign_in_organisation_id:)
     end
   end
 end

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -62,13 +62,15 @@ module Schools
     end
 
     def start_at_school!
-      teacher.ect_at_school_periods.create!(school_reported_appropriate_body:,
-                                            email:,
-                                            lead_provider:,
-                                            programme_type:,
-                                            school:,
-                                            started_on:,
-                                            working_pattern:)
+      teacher.ect_at_school_periods.build(school_reported_appropriate_body:,
+                                          email:,
+                                          lead_provider:,
+                                          programme_type:,
+                                          school:,
+                                          started_on:,
+                                          working_pattern:) do |ect|
+        ect.save!(context: :register_ect)
+      end
     end
 
     def update_school_choices!

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -1,7 +1,6 @@
 module Schools
   class RegisterECT
-    attr_reader :appropriate_body,
-                :appropriate_body_type,
+    attr_reader :school_reported_appropriate_body,
                 :corrected_name,
                 :email,
                 :lead_provider,
@@ -14,8 +13,7 @@ module Schools
                 :trs_last_name,
                 :working_pattern
 
-    def initialize(appropriate_body:,
-                   appropriate_body_type:,
+    def initialize(school_reported_appropriate_body:,
                    corrected_name:,
                    email:,
                    lead_provider:,
@@ -26,8 +24,7 @@ module Schools
                    trs_first_name:,
                    trs_last_name:,
                    working_pattern:)
-      @appropriate_body = appropriate_body
-      @appropriate_body_type = appropriate_body_type
+      @school_reported_appropriate_body = school_reported_appropriate_body
       @corrected_name = corrected_name
       @email = email
       @lead_provider = lead_provider
@@ -65,8 +62,7 @@ module Schools
     end
 
     def start_at_school!
-      teacher.ect_at_school_periods.create!(appropriate_body:,
-                                            appropriate_body_type:,
+      teacher.ect_at_school_periods.create!(school_reported_appropriate_body:,
                                             email:,
                                             lead_provider:,
                                             programme_type:,
@@ -76,8 +72,7 @@ module Schools
     end
 
     def update_school_choices!
-      school.update!(chosen_appropriate_body: appropriate_body,
-                     chosen_appropriate_body_type: appropriate_body_type,
+      school.update!(chosen_appropriate_body: school_reported_appropriate_body,
                      chosen_lead_provider: lead_provider,
                      chosen_programme_type: programme_type)
     end

--- a/app/validators/appropriate_body_validator.rb
+++ b/app/validators/appropriate_body_validator.rb
@@ -1,12 +1,25 @@
 class AppropriateBodyValidator < ActiveModel::Validator
-  # OPTIMIZE: Validate appropriate_body_id against a list of known appropriate bodies
   def validate(record)
-    if record.appropriate_body_type.blank?
-      record.errors.add(:appropriate_body_type, "Select the appropriate body which will be supporting the ECT's induction")
-    end
+    must_be_present(record)
+    cannot_be_local_authority(record) if record.appropriate_body
+    must_be_school_teaching_hub(record) if record.school&.state_funded? && record.appropriate_body
+  end
 
-    if record.appropriate_body_type == 'teaching_school_hub' && record.appropriate_body_id.blank?
-      record.errors.add(:appropriate_body_id, "Enter the name of the appropriate body which will be supporting the ECT's induction")
-    end
+  def must_be_present(record)
+    return if record.appropriate_body
+
+    record.errors.add(:appropriate_body, "Select the appropriate body which will be supporting the ECT's induction")
+  end
+
+  def cannot_be_local_authority(record)
+    return unless record.appropriate_body.local_authority?
+
+    record.errors.add(:appropriate_body, "Select a valid appropriate body which will be supporting the ECT's induction")
+  end
+
+  def must_be_school_teaching_hub(record)
+    return if record.appropriate_body.teaching_school_hub?
+
+    record.errors.add(:appropriate_body, "Select a teaching school hub appropriate body which will be supporting the ECT's induction")
   end
 end

--- a/app/views/schools/mentorships/new.html.erb
+++ b/app/views/schools/mentorships/new.html.erb
@@ -4,7 +4,7 @@
 
 <%=
   # TODO: consolidate into #page_data :backlink_href if possible
-  content_for(:backlink_or_breadcrumb) { govuk_back_link(href: schools_ects_home_path) } 
+  content_for(:backlink_or_breadcrumb) { govuk_back_link(href: schools_ects_home_path) }
 %>
 
 <%= form_with model: @mentor_form,

--- a/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
@@ -14,15 +14,15 @@
   <%= f.govuk_radio_buttons_fieldset :appropriate_body_type, legend: { text: "What type of appropriate body will be supporting #{@ect.full_name}'s induction", hidden: true } do %>
 
     <%= f.govuk_radio_button :appropriate_body_type,
-      :teaching_induction_panel,
-      label: { text: "Independent Schools Teacher Induction Panel (ISTIP)" }, link_errors: true %>
+                             :national,
+                             label: { text: AppropriateBody::ISTIP }, link_errors: true %>
 
     <%= f.govuk_radio_button :appropriate_body_type,
       :teaching_school_hub,
       label: { text: "A different appropriate body (teaching school hub)" } do %>
 
       <%= f.govuk_collection_select(:appropriate_body_id,
-                                    @ect.possible_appropriate_bodies,
+                                    appropriate_bodies_options_for_collection,
                                     :id,
                                     :name,
                                     label: { text: "Enter appropriate body name" },

--- a/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_independent_school_appropriate_body.html.erb
@@ -15,7 +15,7 @@
 
     <%= f.govuk_radio_button :appropriate_body_type,
                              :national,
-                             label: { text: AppropriateBody::ISTIP }, link_errors: true %>
+                             label: { text: AppropriateBodies::Search::ISTIP }, link_errors: true %>
 
     <%= f.govuk_radio_button :appropriate_body_type,
       :teaching_school_hub,

--- a/app/views/schools/register_ect_wizard/_state_school_appropriate_body.html.erb
+++ b/app/views/schools/register_ect_wizard/_state_school_appropriate_body.html.erb
@@ -12,7 +12,7 @@
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%= f.govuk_collection_select(:appropriate_body_id,
-                                @ect.possible_appropriate_bodies,
+                                appropriate_bodies_options_for_collection,
                                 :id,
                                 :name,
                                 label: { text: "Enter appropriate body name" },

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -7,8 +7,7 @@
 <%= govuk_summary_list do |summary_list|
   summary_list.with_row do |row|
     row.with_key(text: 'Appropriate body')
-    row.with_value(text: appropriate_body_name(appropriate_body_type: @school.chosen_appropriate_body_type,
-                                               appropriate_body: @school.chosen_appropriate_body))
+    row.with_value(text: @school.chosen_appropriate_body_name)
   end
 
   summary_list.with_row do |row|

--- a/app/views/schools/register_ect_wizard/check_answers.html.erb
+++ b/app/views/schools/register_ect_wizard/check_answers.html.erb
@@ -42,8 +42,7 @@
 
   summary_list.with_row do |row|
     row.with_key(text: 'Appropriate body')
-    row.with_value(text: appropriate_body_name(appropriate_body_type: @ect.appropriate_body_type,
-                                               appropriate_body: @ect.appropriate_body))
+    row.with_value(text: @ect.appropriate_body_name)
     row.with_action(text: 'Change',
                     href: change_appropriate_body_path(@school),
                     visually_hidden_text: 'appropriate body')

--- a/app/wizards/schools/register_ect_wizard/appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/appropriate_body_step.rb
@@ -1,0 +1,25 @@
+module Schools
+  module RegisterECTWizard
+    class AppropriateBodyStep < Step
+      attr_accessor :appropriate_body_id
+
+      validates :appropriate_body, appropriate_body: true
+
+      def self.permitted_params = %i[appropriate_body_id]
+
+      def appropriate_body
+        @appropriate_body ||= AppropriateBody.find_by_id(appropriate_body_id) if appropriate_body_id
+      end
+
+      def appropriate_body_type = appropriate_body&.body_type
+
+      def next_step = :programme_type
+
+      def previous_step
+        return :use_previous_ect_choices if school.programme_choices?
+
+        :working_pattern
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -96,14 +96,6 @@ module Schools
         programme_type == 'school_led'
       end
 
-      def teaching_induction_panel?
-        appropriate_body_type == 'teaching_induction_panel'
-      end
-
-      def teaching_school_hub?
-        appropriate_body_type == 'teaching_school_hub'
-      end
-
       def trs_full_name
         Teachers::Name.new(self).full_name_in_trs
       end

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -77,8 +77,7 @@ module Schools
       end
 
       def register!(school)
-        Schools::RegisterECT.new(appropriate_body: (appropriate_body if teaching_school_hub?),
-                                 appropriate_body_type:,
+        Schools::RegisterECT.new(school_reported_appropriate_body: appropriate_body,
                                  corrected_name:,
                                  email:,
                                  lead_provider: (lead_provider if provider_led?),

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -62,11 +62,6 @@ module Schools
         trs_date_of_birth.to_date == date_of_birth.to_date
       end
 
-      # Extract into their own SO if this logic becomes dependant of the ECT being assigned
-      def possible_appropriate_bodies
-        @possible_appropriate_bodies ||= AppropriateBody.select(:id, :name).all
-      end
-
       # Extract into their own SO when this logic becomes dependant of the ECT being assigned
       def possible_lead_providers
         @possible_lead_providers ||= LeadProvider.select(:id, :name).all

--- a/app/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step.rb
@@ -1,28 +1,23 @@
 module Schools
   module RegisterECTWizard
-    class IndependentSchoolAppropriateBodyStep < Step
-      attr_accessor :appropriate_body_id, :appropriate_body_type
-
-      validates_with AppropriateBodyValidator
-
-      def self.permitted_params
-        %i[appropriate_body_id appropriate_body_type]
-      end
-
-      def next_step
-        :programme_type
-      end
-
-      def previous_step
-        return :use_previous_ect_choices if school.programme_choices?
-
-        :working_pattern
-      end
+    class IndependentSchoolAppropriateBodyStep < AppropriateBodyStep
+      def self.permitted_params = %i[appropriate_body_id appropriate_body_type]
 
     private
 
-      def persist
-        ect.update!(appropriate_body_id:, appropriate_body_type:)
+      def initialize(opts = {})
+        if opts[:appropriate_body_type] == 'national'
+          @appropriate_body = AppropriateBody.istip
+          opts[:appropriate_body_id] = @appropriate_body.id.to_s
+        end
+
+        super(**opts.except(:appropriate_body_type))
+      end
+
+      def persist = ect.update(appropriate_body_id:)
+
+      def pre_populate_attributes
+        self.appropriate_body_id = ect.appropriate_body_id
       end
     end
   end

--- a/app/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step.rb
@@ -7,7 +7,7 @@ module Schools
 
       def initialize(opts = {})
         if opts[:appropriate_body_type] == 'national'
-          @appropriate_body = AppropriateBody.istip
+          @appropriate_body = AppropriateBodies::Search.istip
           opts[:appropriate_body_id] = @appropriate_body.id.to_s
         end
 

--- a/app/wizards/schools/register_ect_wizard/state_school_appropriate_body_step.rb
+++ b/app/wizards/schools/register_ect_wizard/state_school_appropriate_body_step.rb
@@ -1,32 +1,6 @@
 module Schools
   module RegisterECTWizard
-    class StateSchoolAppropriateBodyStep < Step
-      attr_accessor :appropriate_body_id
-
-      # OPTIMIZE: Validate appropriate_body_id against a list of known appropriate bodies
-      validates :appropriate_body_id, presence: {
-        message: "Enter the name of the appropriate body which will be supporting the ECT's induction"
-      }
-
-      def self.permitted_params
-        %i[appropriate_body_id]
-      end
-
-      def next_step
-        :programme_type
-      end
-
-      def previous_step
-        return :use_previous_ect_choices if school.programme_choices?
-
-        :working_pattern
-      end
-
-    private
-
-      def persist
-        ect.update!(appropriate_body_type: 'teaching_school_hub', appropriate_body_id:)
-      end
+    class StateSchoolAppropriateBodyStep < AppropriateBodyStep
     end
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -10,7 +10,7 @@ shared:
     - dfe_sign_in_organisation_id
     - dqt_id
   :ect_at_school_periods:
-    - appropriate_body_id
+    - school_reported_appropriate_body_id
     - lead_provider_id
     - programme_type
   :induction_extensions:

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,15 +1,17 @@
 ---
 :shared:
+  :appropriate_bodies:
+    - body_type
   :blazer_queries:
-  - id
-  - creator_id
-  - name
-  - description
-  - statement
-  - data_source
-  - status
-  - created_at
-  - updated_at
+    - id
+    - creator_id
+    - name
+    - description
+    - statement
+    - data_source
+    - status
+    - created_at
+    - updated_at
   :blazer_dashboard_queries:
   - id
   - dashboard_id
@@ -189,7 +191,6 @@
   - created_at
   - updated_at
   :schools:
-  - chosen_appropriate_body_type
   - chosen_appropriate_body_id
   - chosen_lead_provider_id
   - chosen_programme_type
@@ -305,7 +306,6 @@
   - metadata
   - modifications
   :ect_at_school_periods:
-  - appropriate_body_type
   - id
   - school_id
   - teacher_id

--- a/db/migrate/20250319234928_add_type_to_appropriate_bodies.rb
+++ b/db/migrate/20250319234928_add_type_to_appropriate_bodies.rb
@@ -1,0 +1,31 @@
+class AddTypeToAppropriateBodies < ActiveRecord::Migration[8.0]
+  def up
+    rename_enum_value :appropriate_body_type, from: 'teaching_induction_panel', to: 'national'
+    add_enum_value :appropriate_body_type, 'local_authority', before: 'national', if_not_exists: true
+
+    add_column :appropriate_bodies, :body_type, :appropriate_body_type, default: 'teaching_school_hub'
+
+    AppropriateBody.find_each do |appropriate_body|
+      appropriate_body.update_column(:body_type, type_from_name(appropriate_body.name))
+    end
+
+    remove_column :ect_at_school_periods, :appropriate_body_type, :appropriate_body_type
+    rename_column :ect_at_school_periods, :appropriate_body_id, :school_reported_appropriate_body_id
+    remove_column :schools, :chosen_appropriate_body_type, :appropriate_body_type
+  end
+
+  def down
+    add_column :schools, :chosen_appropriate_body_type, :appropriate_body_type
+    rename_column :ect_at_school_periods, :school_reported_appropriate_body_id, :appropriate_body_id
+    add_column :ect_at_school_periods, :appropriate_body_type, :appropriate_body_type
+    remove_column :appropriate_bodies, :body_type, :appropriate_body_type
+
+    rename_enum_value :appropriate_body_type, from: 'national', to: 'teaching_induction_panel'
+  end
+
+private
+
+  def type_from_name(name)
+    name == AppropriateBody::ISTIP ? 'national' : 'teaching_school_hub'
+  end
+end

--- a/db/migrate/20250319234928_add_type_to_appropriate_bodies.rb
+++ b/db/migrate/20250319234928_add_type_to_appropriate_bodies.rb
@@ -26,6 +26,6 @@ class AddTypeToAppropriateBodies < ActiveRecord::Migration[8.0]
 private
 
   def type_from_name(name)
-    name == AppropriateBody::ISTIP ? 'national' : 'teaching_school_hub'
+    name == AppropriateBodies::Search::ISTIP ? 'national' : 'teaching_school_hub'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_19_234928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "appropriate_body_type", ["teaching_induction_panel", "teaching_school_hub"]
+  create_enum "appropriate_body_type", ["local_authority", "national", "teaching_school_hub"]
   create_enum "dfe_role_type", ["admin", "super_admin", "finance"]
   create_enum "event_author_types", ["appropriate_body_user", "school_user", "dfe_staff_user", "system"]
   create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
@@ -44,6 +44,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
     t.integer "establishment_number"
     t.uuid "dfe_sign_in_organisation_id"
     t.uuid "dqt_id"
+    t.enum "body_type", default: "teaching_school_hub", enum_type: "appropriate_body_type"
     t.index ["dfe_sign_in_organisation_id"], name: "index_appropriate_bodies_on_dfe_sign_in_organisation_id", unique: true
   end
 
@@ -157,15 +158,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
     t.uuid "ecf_end_induction_record_id"
     t.enum "working_pattern", enum_type: "working_pattern"
     t.citext "email"
-    t.bigint "appropriate_body_id"
+    t.bigint "school_reported_appropriate_body_id"
     t.bigint "lead_provider_id"
     t.enum "programme_type", enum_type: "programme_type"
-    t.enum "appropriate_body_type", enum_type: "appropriate_body_type"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
-    t.index ["appropriate_body_id"], name: "index_ect_at_school_periods_on_appropriate_body_id"
     t.index ["lead_provider_id"], name: "index_ect_at_school_periods_on_lead_provider_id"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
+    t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
     t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
   end
@@ -374,7 +374,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
     t.integer "urn", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.enum "chosen_appropriate_body_type", enum_type: "appropriate_body_type"
     t.bigint "chosen_appropriate_body_id"
     t.bigint "chosen_lead_provider_id"
     t.enum "chosen_programme_type", enum_type: "programme_type"
@@ -569,7 +568,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_102720) do
   end
 
   add_foreign_key "dfe_roles", "users"
-  add_foreign_key "ect_at_school_periods", "appropriate_bodies"
+  add_foreign_key "ect_at_school_periods", "appropriate_bodies", column: "school_reported_appropriate_body_id"
   add_foreign_key "ect_at_school_periods", "lead_providers"
   add_foreign_key "ect_at_school_periods", "schools"
   add_foreign_key "ect_at_school_periods", "teachers"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -172,14 +172,15 @@ brookfield_school = schools_indexed_by_urn.fetch(2_976_163)
 
 print_seed_info("Adding appropriate bodies")
 
-AppropriateBody.create!(name: 'Canvas Teaching School Hub', local_authority_code: 109, establishment_number: 2367)
-south_yorkshire_studio_hub = AppropriateBody.create!(name: 'South Yorkshire Studio Hub', local_authority_code: 678, establishment_number: 9728)
-AppropriateBody.create!(name: 'Ochre Education Partnership', local_authority_code: 238, establishment_number: 6582)
-umber_teaching_school_hub = AppropriateBody.create!(name: 'Umber Teaching School Hub', local_authority_code: 957, establishment_number: 7361, dfe_sign_in_organisation_id: 'd245ec79-534e-4547-a7e4-ccd98803b627')
-golden_leaf_teaching_school_hub = AppropriateBody.create!(name: 'Golden Leaf Teaching School Hub', local_authority_code: 648, establishment_number: 3986)
-AppropriateBody.create!(name: 'Frame University London', local_authority_code: 832, establishment_number: 6864)
-AppropriateBody.create!(name: 'Easelcroft Teaching School Hub', local_authority_code: 573, establishment_number: 9273)
-AppropriateBody.create!(name: 'Vista College', local_authority_code: 418, establishment_number: 3735)
+AppropriateBody.create!(body_type: 'national', name: AppropriateBody::ISTIP, local_authority_code: 50, dfe_sign_in_organisation_id: "203606a4-4199-46a9-84e4-56fbc5da2a36", dqt_id: "6ae042bb-c7ae-e311-b8ed-005056822391")
+AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Canvas Teaching School Hub', local_authority_code: 109, establishment_number: 2367)
+south_yorkshire_studio_hub = AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'South Yorkshire Studio Hub', local_authority_code: 678, establishment_number: 9728)
+AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Ochre Education Partnership', local_authority_code: 238, establishment_number: 6582)
+umber_teaching_school_hub = AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Umber Teaching School Hub', local_authority_code: 957, establishment_number: 7361, dfe_sign_in_organisation_id: 'd245ec79-534e-4547-a7e4-ccd98803b627')
+golden_leaf_teaching_school_hub = AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Golden Leaf Teaching School Hub', local_authority_code: 648, establishment_number: 3986)
+AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Frame University London', local_authority_code: 832, establishment_number: 6864)
+AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Easelcroft Teaching School Hub', local_authority_code: 573, establishment_number: 9273)
+AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Vista College', local_authority_code: 418, establishment_number: 3735)
 
 active_appropriate_bodies = [umber_teaching_school_hub, golden_leaf_teaching_school_hub]
 
@@ -297,7 +298,6 @@ kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   lead_provider: nil,
   appropriate_body: golden_leaf_teaching_school_hub,
   working_pattern: 'full_time',
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'school_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -353,13 +353,11 @@ alan_rickman_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   lead_provider: wildflower_trust,
   appropriate_body: golden_leaf_teaching_school_hub,
   working_pattern: 'part_time',
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'provider_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 ackley_bridge.update!(chosen_lead_provider: wildflower_trust,
                       chosen_appropriate_body: golden_leaf_teaching_school_hub,
-                      chosen_appropriate_body_type: 'teaching_school_hub',
                       chosen_programme_type: 'provider_led')
 
 TrainingPeriod.create!(
@@ -401,7 +399,6 @@ hugh_grant_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
   lead_provider: nil,
   appropriate_body: golden_leaf_teaching_school_hub,
   working_pattern: 'part_time',
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'school_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -441,13 +438,11 @@ colin_firth_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
   lead_provider: nil,
   appropriate_body: golden_leaf_teaching_school_hub,
   working_pattern: 'full_time',
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'school_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 abbey_grove_school.update!(chosen_lead_provider: nil,
                            chosen_appropriate_body: golden_leaf_teaching_school_hub,
-                           chosen_appropriate_body_type: 'teaching_school_hub',
                            chosen_programme_type: 'school_led')
 
 TrainingPeriod.create!(
@@ -531,7 +526,6 @@ imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
   lead_provider: nil,
   appropriate_body: golden_leaf_teaching_school_hub,
   working_pattern: 'full_time',
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'school_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -564,13 +558,11 @@ gemma_jones_at_malory_towers = ECTAtSchoolPeriod.create!(
   lead_provider: wildflower_trust,
   appropriate_body: golden_leaf_teaching_school_hub,
   working_pattern: 'part_time',
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'provider_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 mallory_towers.update!(chosen_lead_provider: wildflower_trust,
                        chosen_appropriate_body: golden_leaf_teaching_school_hub,
-                       chosen_appropriate_body_type: 'teaching_school_hub',
                        chosen_programme_type: 'provider_led')
 
 TrainingPeriod.create!(
@@ -607,7 +599,6 @@ anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
   email: 'anthony.hopkins@favabeans.com',
   lead_provider: national_meadows_institute,
   appropriate_body: umber_teaching_school_hub,
-  appropriate_body_type: 'teaching_school_hub',
   programme_type: 'provider_led',
   started_on: 2.years.ago,
   working_pattern: 'part_time'
@@ -629,13 +620,11 @@ stephen_fry_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
   lead_provider: national_meadows_institute,
   appropriate_body: south_yorkshire_studio_hub,
   programme_type: 'provider_led',
-  working_pattern: 'part_time',
-  appropriate_body_type: 'teaching_school_hub'
+  working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
 brookfield_school.update!(chosen_lead_provider: national_meadows_institute,
                           chosen_appropriate_body: south_yorkshire_studio_hub,
-                          chosen_appropriate_body_type: 'teaching_school_hub',
                           chosen_programme_type: 'provider_led')
 
 TrainingPeriod.create!(
@@ -652,7 +641,6 @@ ECTAtSchoolPeriod.create!(
   email: 'harriet-walter@history.com',
   started_on: 2.years.ago,
   lead_provider: national_meadows_institute,
-  appropriate_body_type: 'teaching_school_hub',
   appropriate_body: south_yorkshire_studio_hub,
   programme_type: 'provider_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -172,7 +172,7 @@ brookfield_school = schools_indexed_by_urn.fetch(2_976_163)
 
 print_seed_info("Adding appropriate bodies")
 
-AppropriateBody.create!(body_type: 'national', name: AppropriateBody::ISTIP, local_authority_code: 50, dfe_sign_in_organisation_id: "203606a4-4199-46a9-84e4-56fbc5da2a36", dqt_id: "6ae042bb-c7ae-e311-b8ed-005056822391")
+AppropriateBody.create!(body_type: 'national', name: AppropriateBodies::Search::ISTIP, local_authority_code: 50, dfe_sign_in_organisation_id: "203606a4-4199-46a9-84e4-56fbc5da2a36", dqt_id: "6ae042bb-c7ae-e311-b8ed-005056822391")
 AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Canvas Teaching School Hub', local_authority_code: 109, establishment_number: 2367)
 south_yorkshire_studio_hub = AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'South Yorkshire Studio Hub', local_authority_code: 678, establishment_number: 9728)
 AppropriateBody.create!(body_type: 'teaching_school_hub', name: 'Ochre Education Partnership', local_authority_code: 238, establishment_number: 6582)

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -1,16 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Schools::SummaryCardComponent, type: :component do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'an org that assures the quality of statutory teacher induction') }
+  let(:school_reported_appropriate_body) { FactoryBot.create(:appropriate_body, name: 'an org that assures the quality of statutory teacher induction') }
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'An org that designs the training') }
   let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'An org that delivers the training') }
   let(:provider_partnership) { FactoryBot.create(:provider_partnership, lead_provider:, delivery_partner:) }
 
   let(:school_led_ect) do
-    FactoryBot.create(:ect_at_school_period, :active, :school_led, :teaching_school_hub, appropriate_body:)
+    FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:)
   end
 
-  let(:provider_led_ect) { FactoryBot.create(:ect_at_school_period, :active, :provider_led, :teaching_school_hub, appropriate_body:, lead_provider:, started_on: '2021-01-01') }
+  let(:provider_led_ect) do
+    FactoryBot.create(:ect_at_school_period,
+                      :active,
+                      :provider_led,
+                      school_reported_appropriate_body:,
+                      lead_provider:,
+                      started_on: '2021-01-01')
+  end
 
   let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: provider_led_ect, provider_partnership:, started_on: '2022-01-01', finished_on: '2022-06-01') }
 
@@ -79,13 +86,14 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   end
 
   context 'when data is reported by the appropriate body' do
-    let(:school_led_ect_with_induction) do
-      ect = FactoryBot.create(:ect_at_school_period, :active, :school_led, :teaching_school_hub, appropriate_body:)
-      FactoryBot.create(:induction_period, teacher: ect.teacher, started_on: '2023-01-01')
-      ect
-    end
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:) }
 
-    before { render_inline(described_class.new(title: 'Reported to us by your appropriate body', ect: school_led_ect_with_induction, data_source: :appropriate_body)) }
+    before do
+      FactoryBot.create(:induction_period, teacher: ect.teacher, started_on: '2023-01-01')
+      render_inline(described_class.new(title: 'Reported to us by your appropriate body',
+                                        ect:,
+                                        data_source: :appropriate_body))
+    end
 
     it 'renders the summary card' do
       expect(page).to have_selector(".govuk-summary-card")
@@ -115,7 +123,11 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   end
 
   context 'when no data is available' do
-    before { render_inline(described_class.new(title: 'Reported to us by your appropriate body', ect: school_led_ect, data_source: :appropriate_body)) }
+    before do
+      render_inline(described_class.new(title: 'Reported to us by your appropriate body',
+                                        ect: school_led_ect,
+                                        data_source: :appropriate_body))
+    end
 
     it 'renders a message indicating no information is available' do
       expect(page).to have_text('Your appropriate body has not reported any information to us yet.')
@@ -128,7 +140,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
 
   context 'when no training periods exist for a provider-led ECT' do
     let(:provider_led_ect_without_training_periods) do
-      FactoryBot.create(:ect_at_school_period, :active, :provider_led, :teaching_school_hub, appropriate_body:, lead_provider:)
+      FactoryBot.create(:ect_at_school_period, :active, :provider_led, school_reported_appropriate_body:, lead_provider:)
     end
 
     before { render_inline(described_class.new(title: 'Reported to us by your lead provider', ect: provider_led_ect_without_training_periods, data_source: :lead_provider)) }

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     trait :istip do
       body_type { 'national' }
-      name { AppropriateBody::ISTIP }
+      name { AppropriateBodies::Search::ISTIP }
       local_authority_code { 50 }
       dfe_sign_in_organisation_id { "203606a4-4199-46a9-84e4-56fbc5da2a36" }
     end

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,8 +1,28 @@
 FactoryBot.define do
   factory(:appropriate_body) do
     sequence(:name) { |n| "Appropriate Body #{n}" }
-    sequence(:local_authority_code, 100)
-    sequence(:establishment_number, 1000)
+    sequence(:local_authority_code, 55) { |n| 55 + (n % 945) }
+    sequence(:establishment_number) { |n| 1000 + (n / 945) }
     dfe_sign_in_organisation_id { SecureRandom.uuid }
+    teaching_school_hub
+
+    trait :istip do
+      body_type { 'national' }
+      name { AppropriateBody::ISTIP }
+      local_authority_code { 50 }
+      dfe_sign_in_organisation_id { "203606a4-4199-46a9-84e4-56fbc5da2a36" }
+    end
+
+    trait :local_authority do
+      body_type { 'local_authority' }
+    end
+
+    trait :national do
+      body_type { 'national' }
+    end
+
+    trait :teaching_school_hub do
+      body_type { 'teaching_school_hub' }
+    end
   end
 end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -2,11 +2,10 @@ FactoryBot.define do
   sequence(:base_ect_date) { |n| 3.years.ago.to_date + (2 * n).days }
 
   factory(:ect_at_school_period) do
-    association :school, :independent
     association :teacher
 
+    independent_school
     provider_led
-    teaching_induction_panel
 
     started_on { generate(:base_ect_date) }
     finished_on { started_on + 1.day }
@@ -28,14 +27,26 @@ FactoryBot.define do
       lead_provider { nil }
     end
 
-    trait :teaching_induction_panel do
-      appropriate_body_type { 'teaching_induction_panel' }
-      appropriate_body { nil }
+    trait :independent_school do
+      association :school, :independent
+      national_ab
     end
 
-    trait :teaching_school_hub do
-      appropriate_body_type { 'teaching_school_hub' }
-      appropriate_body { association :appropriate_body }
+    trait :state_funded_school do
+      association :school, :state_funded
+      teaching_school_hub_ab
+    end
+
+    trait :local_authority_ab do
+      association :school_reported_appropriate_body, :local_authority, factory: :appropriate_body
+    end
+
+    trait :national_ab do
+      association :school_reported_appropriate_body, :national, factory: :appropriate_body
+    end
+
+    trait :teaching_school_hub_ab do
+      association :school_reported_appropriate_body, :teaching_school_hub, factory: :appropriate_body
     end
   end
 end

--- a/spec/factories/school_factory.rb
+++ b/spec/factories/school_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory(:school) do
     urn { Faker::Number.unique.decimal_part(digits: 7).to_s }
-    state_funded
+    independent
 
     trait :independent do
       gias_school { association :gias_school, :independent_school_type, urn: }
@@ -20,14 +20,16 @@ FactoryBot.define do
       chosen_programme_type { 'school_led' }
     end
 
-    trait :teaching_induction_panel_chosen do
-      chosen_appropriate_body_type { 'teaching_induction_panel' }
-      chosen_appropriate_body { nil }
+    trait :local_authority_ab_chosen do
+      association :chosen_appropriate_body, :local_authority, factory: :appropriate_body
     end
 
-    trait :teaching_school_hub_chosen do
-      chosen_appropriate_body_type { 'teaching_school_hub' }
-      association :chosen_appropriate_body, factory: :appropriate_body
+    trait :national_ab_chosen do
+      association :chosen_appropriate_body, :national, factory: :appropriate_body
+    end
+
+    trait :teaching_school_hub_ab_chosen do
+      association :chosen_appropriate_body, :teaching_school_hub, factory: :appropriate_body
     end
   end
 end

--- a/spec/features/schools/register_an_ect/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Registering an ECT' do
 
   def given_i_am_logged_in_as_an_independent_school_user
     school = FactoryBot.create(:school, :independent)
+    FactoryBot.create(:appropriate_body, :istip)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/register_an_ect/happy_path_spec.rb
+++ b/spec/features/schools/register_an_ect/happy_path_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Registering an ECT' do
   include_context 'fake trs api client'
 
-  let(:school) { FactoryBot.create(:school, :state_funded, :provider_led_chosen, :teaching_school_hub_chosen) }
+  let(:school) { FactoryBot.create(:school, :state_funded, :provider_led_chosen, :teaching_school_hub_ab_chosen) }
   let(:trn) { '9876543' }
 
   before do

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -3,24 +3,6 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
   include GovukLinkHelper
   include GovukVisuallyHiddenHelper
 
-  describe '#appropriate_body_name' do
-    context "when appropriate_body_type is 'teaching_induction_panel'" do
-      specify do
-        expect(appropriate_body_name(appropriate_body_type: 'teaching_induction_panel'))
-          .to eq('Independent Schools Teacher Induction Panel (ISTIP)')
-      end
-    end
-
-    context "when appropriate_body_type is not 'teaching_induction_panel'" do
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body, id: 1, name: 'Another body') }
-
-      it 'returns the name' do
-        expect(appropriate_body_name(appropriate_body_type: 'teaching_school_hub', appropriate_body:))
-          .to eq('Another body')
-      end
-    end
-  end
-
   describe "#induction_programme_choices" do
     it "returns an array of FormChoice" do
       expect(induction_programme_choices).to be_an(Array)

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -4,8 +4,8 @@ describe Builders::ECT::TrainingPeriods do
   let(:academic_year) { FactoryBot.create(:academic_year) }
   let(:partnership_1) { FactoryBot.create(:provider_partnership, academic_year:) }
   let(:partnership_2) { FactoryBot.create(:provider_partnership, academic_year:) }
-  let(:school_1) { FactoryBot.create(:school, urn: "123456") }
-  let(:school_2) { FactoryBot.create(:school, urn: "987654") }
+  let(:school_1) { FactoryBot.create(:school, :independent, urn: "123456") }
+  let(:school_2) { FactoryBot.create(:school, :independent, urn: "987654") }
   let(:teacher) { FactoryBot.create(:teacher) }
   let!(:school_period_1) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
   let!(:school_period_2) { FactoryBot.create(:ect_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -37,14 +37,4 @@ describe AppropriateBody do
       end
     end
   end
-
-  describe ".istip" do
-    subject { described_class.istip }
-
-    let!(:istip) { FactoryBot.create(:appropriate_body, name: described_class::ISTIP) }
-
-    before { FactoryBot.create(:appropriate_body) }
-
-    it { is_expected.to eq(istip) }
-  end
 end

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -1,4 +1,15 @@
 describe AppropriateBody do
+  describe "enums" do
+    it do
+      expect(subject).to define_enum_for(:body_type)
+                           .with_values({ local_authority: 'local_authority',
+                                          national: 'national',
+                                          teaching_school_hub: 'teaching_school_hub' })
+                           .validating
+                           .backed_by_column_of_type(:enum)
+    end
+  end
+
   describe "associations" do
     it { is_expected.to have_many(:induction_periods) }
     it { is_expected.to have_many(:pending_induction_submissions) }
@@ -12,7 +23,7 @@ describe AppropriateBody do
     it { is_expected.to validate_uniqueness_of(:name) }
 
     it { is_expected.to validate_presence_of(:local_authority_code).with_message('Enter a local authority code').allow_blank }
-    it { is_expected.to validate_inclusion_of(:local_authority_code).in_range(100..999).allow_blank.with_message('Must be a number between 100 and 999') }
+    it { is_expected.to validate_inclusion_of(:local_authority_code).in_range(50..999).allow_blank.with_message('Must be a number between 50 and 999') }
 
     it { is_expected.to validate_presence_of(:establishment_number).with_message('Enter a establishment number').allow_blank }
     it { is_expected.to validate_inclusion_of(:establishment_number).in_range(1000..9999).allow_blank.with_message('Must be a number between 1000 and 9999') }
@@ -25,5 +36,15 @@ describe AppropriateBody do
         expect(duplicate_ab.errors.messages.fetch(:local_authority_code)).to include(/local authority code and establishment number already exists/)
       end
     end
+  end
+
+  describe ".istip" do
+    subject { described_class.istip }
+
+    let!(:istip) { FactoryBot.create(:appropriate_body, name: described_class::ISTIP) }
+
+    before { FactoryBot.create(:appropriate_body) }
+
+    it { is_expected.to eq(istip) }
   end
 end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -22,7 +22,7 @@ describe ECTAtSchoolPeriod do
   describe "associations" do
     it { is_expected.to belong_to(:school).inverse_of(:ect_at_school_periods) }
     it { is_expected.to belong_to(:teacher).inverse_of(:ect_at_school_periods) }
-    it { is_expected.to belong_to(:appropriate_body) }
+    it { is_expected.to belong_to(:school_reported_appropriate_body).class_name('AppropriateBody').optional }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to have_many(:mentorship_periods).inverse_of(:mentee) }
     it { is_expected.to have_many(:training_periods) }
@@ -70,10 +70,11 @@ describe ECTAtSchoolPeriod do
 
             before { subject.valid?(:register_ect) }
 
-        it do
-          is_expected.not_to validate_absence_of(:appropriate_body_id)
-        end
-      end
+            it do
+              expect(subject.errors.messages[:school_reported_appropriate_body_id])
+                .to contain_exactly('Must be teaching school hub')
+            end
+          end
 
           context "when teaching school hub ab chosen" do
             subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -1,15 +1,6 @@
 describe ECTAtSchoolPeriod do
   describe "enums" do
     it do
-      is_expected.to define_enum_for(:appropriate_body_type)
-                       .with_values({ teaching_induction_panel: 'teaching_induction_panel',
-                                      teaching_school_hub: 'teaching_school_hub' })
-                       .validating
-                       .with_suffix(:ab_type)
-                       .backed_by_column_of_type(:enum)
-    end
-
-    it do
       is_expected.to define_enum_for(:programme_type)
                        .with_values({ provider_led: "provider_led",
                                       school_led: "school_led" })

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -35,43 +35,107 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to validate_presence_of(:school_id) }
     it { is_expected.to validate_presence_of(:teacher_id) }
 
-    context "appropriate_body_id" do
-      context "when appropriate_body_type is 'teaching_school_hub'" do
-        subject { FactoryBot.build(:ect_at_school_period, :teaching_school_hub) }
+    context "school_reported_appropriate_body_id on :register_ect" do
+      context ":register_ect context" do
+        context "when the school is independent" do
+          context "when national ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :national_ab) }
 
-        it do
-          is_expected.to validate_presence_of(:appropriate_body_id)
-                           .with_message('Must contain the ID of an appropriate body')
+            it { is_expected.to be_valid(:register_ect) }
+          end
+
+          context "when teaching school hub ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
+
+            it { is_expected.to be_valid(:register_ect) }
+          end
+
+          context "when local authority ab chosen" do
+            subject { FactoryBot.build(:ect_at_school_period, :independent_school, :local_authority_ab) }
+
+            before { subject.valid?(:register_ect) }
+
+            it do
+              expect(subject.errors.messages[:school_reported_appropriate_body_id])
+                .to contain_exactly('Must be national or teaching school hub')
+            end
+          end
         end
+
+        context "when the school is state_funded" do
+          subject { FactoryBot.build(:ect_at_school_period, :state_funded_school) }
+
+          context "when national ab chosen" do
+            subject { FactoryBot.build(:ect_at_school_period, :state_funded_school, :national_ab) }
+
+            before { subject.valid?(:register_ect) }
 
         it do
           is_expected.not_to validate_absence_of(:appropriate_body_id)
         end
       end
 
-      context "when appropriate_body_type is not 'teaching_school_hub'" do
-        subject { FactoryBot.build(:ect_at_school_period, :teaching_induction_panel) }
+          context "when teaching school hub ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }
 
-        it { is_expected.not_to validate_presence_of(:appropriate_body_id) }
-        it { is_expected.to validate_absence_of(:appropriate_body_id).with_message('Must be nil') }
+            it { is_expected.to be_valid(:register_ect) }
+          end
+
+          context "when local authority ab chosen" do
+            subject { FactoryBot.build(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
+
+            before { subject.valid?(:register_ect) }
+
+            it do
+              expect(subject.errors.messages[:school_reported_appropriate_body_id])
+                .to contain_exactly('Must be teaching school hub')
+            end
+          end
+        end
       end
-    end
 
-    context "appropriate_body_type" do
-      subject { FactoryBot.build(:ect_at_school_period) }
+      context "no context" do
+        context "when the school is independent" do
+          context "when national ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :national_ab) }
 
-      it do
-        is_expected.to validate_inclusion_of(:appropriate_body_type)
-                         .in_array(%w[teaching_induction_panel teaching_school_hub])
-                         .with_message("Must be teaching induction panel or teaching school hub")
-      end
+            it { is_expected.to be_valid }
+          end
 
-      context "for a state school" do
-        subject { FactoryBot.build(:ect_at_school_period, school:) }
+          context "when teaching school hub ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
 
-        let(:school) { FactoryBot.build(:school, :state_funded) }
+            it { is_expected.to be_valid }
+          end
 
-        it { is_expected.to validate_presence_of(:appropriate_body_type).with_message("Must be teaching school hub") }
+          context "when local authority ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :local_authority_ab) }
+
+            it { is_expected.to be_valid }
+          end
+        end
+
+        context "when the school is state_funded" do
+          subject { FactoryBot.build(:ect_at_school_period, :state_funded_school) }
+
+          context "when national ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :national_ab) }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when teaching school hub ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when local authority ab chosen" do
+            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
+
+            it { is_expected.to be_valid }
+          end
+        end
       end
     end
 
@@ -146,8 +210,8 @@ describe ECTAtSchoolPeriod do
                          .with_message("Must be provider-led or school-led")
       end
 
-      context "when appropriate_body has been set" do
-        subject { FactoryBot.build(:ect_at_school_period, appropriate_body_id: 123) }
+      context "when lead_provider has been set" do
+        subject { FactoryBot.create(:ect_at_school_period) }
 
         it { is_expected.to validate_presence_of(:programme_type).with_message("Must be provider-led") }
       end
@@ -156,11 +220,11 @@ describe ECTAtSchoolPeriod do
 
   describe "scopes" do
     let!(:teacher) { FactoryBot.create(:teacher) }
-    let!(:school) { FactoryBot.create(:school) }
-    let!(:period_1) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:period_3) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
-    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let!(:school) { period_1.school }
+    let!(:period_1) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: period_1.finished_on, finished_on: "2023-12-11") }
+    let!(:period_3) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
+    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
 
     describe ".for_teacher" do
       it "returns ect periods only for the specified teacher" do
@@ -225,12 +289,12 @@ describe ECTAtSchoolPeriod do
 
   describe "#siblings" do
     let!(:teacher) { FactoryBot.create(:teacher) }
-    let!(:school) { FactoryBot.create(:school) }
-    let!(:period_1) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:period_3) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
-    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
-    let(:ect_at_school_period) { FactoryBot.build(:ect_at_school_period, teacher:, school:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+    let!(:school) { period_1.school }
+    let!(:period_1) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: '2022-12-01', finished_on: '2023-06-01') }
+    let!(:period_2) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: period_1.finished_on, finished_on: '2024-01-01') }
+    let!(:period_3) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
+    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: '2022-01-01', finished_on: period_1.started_on) }
 
     it "returns ect periods only for the specified instance's teacher excluding the instance" do
       expect(ect_at_school_period.siblings).to match_array([period_1, period_2, period_3])

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
 
   let(:ect) { FactoryBot.create(:ect_at_school_period, :active, school:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school:) }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { FactoryBot.create(:school, :independent) }
 
   describe 'GET /school/ects/:id/mentorship/new' do
     context 'when not signed in' do

--- a/spec/services/appropriate_bodies/search_spec.rb
+++ b/spec/services/appropriate_bodies/search_spec.rb
@@ -4,6 +4,24 @@ describe AppropriateBodies::Search do
 
     let(:query_string) { nil }
 
+    describe ".istip" do
+      subject { described_class.istip }
+
+      context 'when ISTIP has been registered' do
+        let!(:istip) { FactoryBot.create(:appropriate_body, :istip) }
+
+        it 'returns it' do
+          expect(subject).to eq(istip)
+        end
+      end
+
+      context 'when ISTIP has not been registered' do
+        it 'raises an exception' do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound, 'ISTIP appropriate body not found!')
+        end
+      end
+    end
+
     describe "#search" do
       context 'when the search string is blank' do
         let(:query_string) { ' ' }

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Schools::RegisterECT do
   subject(:service) do
-    described_class.new(appropriate_body:,
-                        appropriate_body_type:,
+    described_class.new(school_reported_appropriate_body:,
                         corrected_name:,
                         email:,
                         lead_provider:,
@@ -14,8 +13,7 @@ RSpec.describe Schools::RegisterECT do
                         working_pattern:)
   end
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:appropriate_body_type) { 'teaching_school_hub' }
+  let(:school_reported_appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:corrected_name) { "Randy Marsh" }
   let(:email) { "randy@tegridyfarms.com" }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -66,20 +64,18 @@ RSpec.describe Schools::RegisterECT do
       expect(ect_at_school_period.started_on).to eq(started_on)
       expect(ect_at_school_period.working_pattern).to eq(working_pattern)
       expect(ect_at_school_period.email).to eq(email)
-      expect(ect_at_school_period.appropriate_body_id).to eq(appropriate_body.id)
+      expect(ect_at_school_period.school_reported_appropriate_body_id).to eq(school_reported_appropriate_body.id)
       expect(ect_at_school_period.lead_provider_id).to eq(lead_provider.id)
       expect(ect_at_school_period.programme_type).to eq(programme_type)
     end
 
-    it 'sets ab and provider choices to the school' do
+    it 'sets ab and provider choices for the school' do
       expect { service.register! }
-        .to change(school, :chosen_appropriate_body_type)
-              .to(appropriate_body_type)
-              .and change(school, :chosen_appropriate_body_id)
-                     .to(appropriate_body.id)
-                     .and change(school, :chosen_programme_type)
-                            .to(programme_type)
-                            .and change(school, :chosen_lead_provider_id).to(lead_provider.id)
+        .to change(school, :chosen_appropriate_body_id)
+              .to(school_reported_appropriate_body.id)
+              .and change(school, :chosen_programme_type)
+                     .to(programme_type)
+                     .and change(school, :chosen_lead_provider_id).to(lead_provider.id)
     end
   end
 end

--- a/spec/validators/working_pattern_validator_spec.rb
+++ b/spec/validators/working_pattern_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe WorkingPatternValidator, type: :model do
     context 'is invalid when working_pattern is nil' do
       let(:working_pattern) { nil }
 
-      it 'it adds an error' do
+      it 'adds an error' do
         expect(subject).not_to be_valid
         expect(subject.errors[:working_pattern]).to include("Select if the ECT's working pattern is full or part time")
       end

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
   let(:academic_year) { FactoryBot.create(:academic_year) }
   let!(:current_ect_period) do
     FactoryBot.create(:ect_at_school_period,
-                      appropriate_body_type,
+                      :teaching_school_hub_ab,
                       teacher:,
                       started_on: '2025-01-11',
                       finished_on: nil,
@@ -13,7 +13,6 @@ RSpec.describe 'schools/ects/show.html.erb' do
                       programme_type:,
                       email: 'love@whale.com')
   end
-  let(:appropriate_body_type) { :teaching_school_hub }
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Ambition institute') }
   let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
   let(:provider_partnership) { FactoryBot.create(:provider_partnership, lead_provider:, delivery_partner:, academic_year:) }
@@ -26,11 +25,12 @@ RSpec.describe 'schools/ects/show.html.erb' do
   let(:programme_type) { 'provider_led' }
 
   before do
-    FactoryBot.create(:ect_at_school_period, teacher:,
-                                             started_on: '2024-01-11',
-                                             finished_on: '2025-01-11',
-                                             school: previous_school,
-                                             email: 'previous-address@whale.com')
+    FactoryBot.create(:ect_at_school_period, :state_funded_school,
+                      teacher:,
+                      started_on: '2024-01-11',
+                      finished_on: '2025-01-11',
+                      school: previous_school,
+                      email: 'previous-address@whale.com')
     assign(:ect, current_ect_period)
     render
   end
@@ -147,16 +147,6 @@ RSpec.describe 'schools/ects/show.html.erb' do
 
       it 'renders the lead provider summary card' do
         expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
-      end
-    end
-
-    context 'when school is independent' do
-      let(:current_school) { FactoryBot.create(:school, :independent, urn: '987654') }
-      let(:requested_appropriate_body) { nil }
-      let(:appropriate_body_type) { :teaching_induction_panel }
-
-      it 'replaces AB name with ISTIP' do
-        expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Independent Schools Teacher Induction Panel (ISTIP)')
       end
     end
   end

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
                       started_on: '2025-01-11',
                       finished_on: nil,
                       lead_provider: requested_lead_provider,
-                      appropriate_body: requested_appropriate_body,
+                      school_reported_appropriate_body: requested_appropriate_body,
                       school: current_school,
                       working_pattern: 'full_time',
                       programme_type:,

--- a/spec/views/schools/register_ect_wizard/shared_examples/independent_school_appropriate_body_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/independent_school_appropriate_body_view.rb
@@ -1,7 +1,6 @@
 RSpec.shared_examples "an independent school appropriate body view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:ect) { wizard.ect }
-  let(:appropriate_body_name) { nil }
-  let(:store) { FactoryBot.build(:session_repository, appropriate_body_name:, trs_first_name: 'John', trs_last_name: 'Smith') }
+  let(:store) { FactoryBot.build(:session_repository, trs_first_name: 'John', trs_last_name: 'Smith') }
   let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step:, store:) }
 
   before do

--- a/spec/wizards/schools/register_ect_wizard/appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/appropriate_body_step_spec.rb
@@ -1,0 +1,124 @@
+RSpec.describe Schools::RegisterECTWizard::AppropriateBodyStep, type: :model do
+  let(:school) { FactoryBot.create(:school, :state_funded) }
+  let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123') }
+  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:) }
+
+  describe '#initialize' do
+    subject { described_class.new(wizard:, **params) }
+
+    let(:appropriate_body_id) { 'provided_ab_name' }
+
+    context 'when the appropriate_body_id is provided' do
+      let(:params) { { appropriate_body_id: } }
+
+      it 'populate the instance from it' do
+        expect(subject.appropriate_body_id).to eq(appropriate_body_id)
+      end
+    end
+
+    context 'when no appropriate_body_id is provided' do
+      let(:params) { {} }
+
+      it 'populate it from the wizard store' do
+        expect(subject.appropriate_body_id).to eq('123')
+      end
+    end
+  end
+
+  describe 'validations' do
+    subject { described_class.new(wizard:, appropriate_body_id:) }
+
+    context 'when appropriate_body_id is blank' do
+      let(:appropriate_body_id) { nil }
+
+      it 'adds an error' do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:appropriate_body]).to include("Select the appropriate body which will be supporting the ECT's induction")
+      end
+    end
+
+    context 'when the appropriate_body is not registered' do
+      let(:appropriate_body_id) { '999999999' }
+
+      it 'add an error' do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:appropriate_body]).to include("Select the appropriate body which will be supporting the ECT's induction")
+      end
+    end
+
+    context 'when the appropriate_body is a local authority' do
+      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :local_authority) }
+
+      it 'adds an error' do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:appropriate_body]).to include("Select a valid appropriate body which will be supporting the ECT's induction")
+      end
+    end
+  end
+
+  describe 'steps' do
+    subject { wizard.current_step }
+
+    let(:wizard) do
+      FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:)
+    end
+
+    describe '#next_step' do
+      it 'returns the next step' do
+        expect(subject.next_step).to eq(:programme_type)
+      end
+    end
+
+    describe '#previous_step' do
+      context 'when the school has no programme choices' do
+        it 'returns the previous step' do
+          expect(subject.previous_step).to eq(:working_pattern)
+        end
+      end
+
+      context 'when the school has programme choices' do
+        let(:school) { FactoryBot.create(:school, :independent, :national_ab_chosen, :school_led_chosen) }
+
+        it 'returns the previous step' do
+          expect(subject.previous_step).to eq(:use_previous_ect_choices)
+        end
+      end
+    end
+  end
+
+  describe '#save!' do
+    subject { wizard.current_step }
+
+    let(:step_params) do
+      ActionController::Parameters.new(
+        "state_school_appropriate_body" => {
+          "appropriate_body_id" => '1',
+        }
+      )
+    end
+
+    let(:wizard) do
+      FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, step_params:)
+    end
+
+    context 'when the step is not valid' do
+      before do
+        allow(wizard.current_step).to receive(:valid?).and_return(false)
+      end
+
+      it 'does not update any data in the wizard ect' do
+        expect { subject.save! }.not_to change(subject.ect, :appropriate_body_id)
+      end
+    end
+
+    context 'when the step is valid' do
+      before do
+        allow(wizard.current_step).to receive(:valid?).and_return(true)
+      end
+
+      it 'updates the wizard ect appropriate_body_id' do
+        expect { subject.save! }.to change(subject.ect, :appropriate_body_id).from(nil).to('1')
+      end
+    end
+  end
+end

--- a/spec/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeIndependentSchoolAppropriateBod
 
   describe "#next_step" do
     context 'when the school has programme choices' do
-      let(:school) { FactoryBot.create(:school, :independent, :teaching_induction_panel_chosen, :school_led_chosen) }
+      let(:school) { FactoryBot.create(:school, :independent, :national_ab_chosen, :school_led_chosen) }
 
       it { expect(subject.next_step).to eq(:change_programme_type) }
     end
@@ -26,7 +26,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeIndependentSchoolAppropriateBod
 
   describe "#previous_step" do
     context 'when the school has programme choices' do
-      let(:school) { FactoryBot.create(:school, :independent, :teaching_induction_panel_chosen, :school_led_chosen) }
+      let(:school) { FactoryBot.create(:school, :independent, :national_ab_chosen, :school_led_chosen) }
 
       it { expect(subject.previous_step).to eq(:change_use_previous_ect_choices) }
     end

--- a/spec/wizards/schools/register_ect_wizard/change_lead_provider_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_lead_provider_step_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeLeadProviderStep, type: :model 
 
   describe "#previous_step" do
     context 'when the school has programme choices' do
-      let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_chosen, :provider_led_chosen) }
+      let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_chosen, :provider_led_chosen) }
 
       it { expect(subject.previous_step).to eq(:change_programme_type) }
     end

--- a/spec/wizards/schools/register_ect_wizard/change_programme_type_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_programme_type_step_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeProgrammeTypeStep, type: :model
       let(:new_programme_type) { 'provider_led' }
 
       context 'when the school has programme choices' do
-        let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_chosen, :school_led_chosen) }
+        let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_chosen, :school_led_chosen) }
 
         it { expect(subject.next_step).to eq(:change_lead_provider) }
       end
@@ -78,16 +78,17 @@ RSpec.describe Schools::RegisterECTWizard::ChangeProgrammeTypeStep, type: :model
 
         context 'when the ect lead provider has already been set' do
           let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
+          let(:school) { FactoryBot.create(:school, school_type, :teaching_school_hub_ab_chosen, :school_led_chosen) }
 
           context 'when the school has programme choices' do
             context 'independent school' do
-              let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_chosen, :school_led_chosen) }
+              let(:school_type) { :independent }
 
               it { expect(subject.previous_step).to eq(:change_independent_school_appropriate_body) }
             end
 
             context 'state funded school' do
-              let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_chosen, :school_led_chosen) }
+              let(:school_type) { :state_funded }
 
               it { expect(subject.previous_step).to eq(:change_state_school_appropriate_body) }
             end
@@ -104,16 +105,17 @@ RSpec.describe Schools::RegisterECTWizard::ChangeProgrammeTypeStep, type: :model
 
     context 'when the ect programme type is school led' do
       let(:new_programme_type) { 'school_led' }
+      let(:school) { FactoryBot.create(:school, school_type, :teaching_school_hub_ab_chosen, :school_led_chosen) }
 
       context 'when the school has programme choices' do
         context 'independent school' do
-          let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_chosen, :school_led_chosen) }
+          let(:school_type) { :independent }
 
           it { expect(subject.previous_step).to eq(:change_independent_school_appropriate_body) }
         end
 
         context 'state funded school' do
-          let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_chosen, :school_led_chosen) }
+          let(:school_type) { :state_funded }
 
           it { expect(subject.previous_step).to eq(:change_state_school_appropriate_body) }
         end

--- a/spec/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeStateSchoolAppropriateBodyStep,
 
   describe "#next_step" do
     context 'when the school has programme choices' do
-      let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_chosen, :provider_led_chosen) }
+      let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_ab_chosen, :provider_led_chosen) }
 
       it { expect(subject.next_step).to eq(:change_programme_type) }
     end
@@ -26,7 +26,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeStateSchoolAppropriateBodyStep,
 
   describe "#previous_step" do
     context 'when the school has programme choices' do
-      let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_chosen, :school_led_chosen) }
+      let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_ab_chosen, :school_led_chosen) }
 
       it { expect(subject.previous_step).to eq(:change_use_previous_ect_choices) }
     end

--- a/spec/wizards/schools/register_ect_wizard/change_use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_use_previous_ect_choices_step_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeUsePreviousECTChoicesStep, type
   let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
   let(:use_previous_ect_choices) { false }
   let(:new_use_previous_ect_choices) { false }
-  let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_chosen, :school_led_chosen) }
+  let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_chosen, :school_led_chosen) }
   let(:store) { FactoryBot.build(:session_repository, use_previous_ect_choices:, lead_provider_id:) }
   let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :change_use_previous_ect_choices, store:, school:) }
 
@@ -27,13 +27,13 @@ RSpec.describe Schools::RegisterECTWizard::ChangeUsePreviousECTChoicesStep, type
       let(:new_use_previous_ect_choices) { false }
 
       context 'independent school' do
-        let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_chosen, :school_led_chosen) }
+        let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_chosen, :school_led_chosen) }
 
         it { expect(subject.next_step).to eq(:change_independent_school_appropriate_body) }
       end
 
       context 'state funded school' do
-        let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_chosen, :school_led_chosen) }
+        let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_ab_chosen, :school_led_chosen) }
 
         it { expect(subject.next_step).to eq(:change_state_school_appropriate_body) }
       end

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -1,14 +1,15 @@
 RSpec.describe Schools::RegisterECTWizard::ECT do
   subject(:ect) { described_class.new(store) }
 
-  let(:school) { FactoryBot.create(:school) }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body, :national) }
+  let(:school) { FactoryBot.create(:school, :independent) }
   let(:store) do
     FactoryBot.build(:session_repository,
                      change_name: 'no',
                      corrected_name: nil,
                      date_of_birth: "11-10-1945",
                      email: "dusty@rhodes.com",
-                     appropriate_body_type: 'teaching_induction_panel',
+                     appropriate_body_id: appropriate_body.id,
                      programme_type: "school_led",
                      start_date: 'January 2025',
                      trn: "3002586",
@@ -233,7 +234,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
       expect(ect_at_school_period.school_id).to eq(school.id)
       expect(ect_at_school_period.started_on).to eq(Date.parse('January 2025'))
       expect(ect_at_school_period.email).to eq('dusty@rhodes.com')
-      expect(ect_at_school_period.appropriate_body_type).to eq('teaching_induction_panel')
+      expect(ect_at_school_period.school_reported_appropriate_body_type).to eq('national')
     end
   end
 
@@ -255,28 +256,6 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
       it 'returns false' do
         expect(ect.school_led?).to be_falsey
-      end
-    end
-  end
-
-  describe '#teaching_induction_panel?' do
-    before do
-      store.appropriate_body_type = 'teaching_induction_panel'
-    end
-
-    context "when appropriate_body_type is 'teaching_induction_panel'" do
-      it 'returns true' do
-        expect(ect.teaching_induction_panel?).to be_truthy
-      end
-    end
-
-    context "when appropriate_body_type is not 'teaching_induction_panel'" do
-      before do
-        store.appropriate_body_type = nil
-      end
-
-      it 'returns false' do
-        expect(ect.teaching_induction_panel?).to be_falsey
       end
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -119,7 +119,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     context 'when the ect is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_ect_period) { FactoryBot.create(:ect_at_school_period, :active, teacher:, school:) }
+      let(:active_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :active, teacher:, school:) }
 
       before do
         wizard.store.update!(school_urn: active_ect_period.school.urn)

--- a/spec/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step_spec.rb
@@ -1,21 +1,40 @@
 RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep, type: :model do
+  subject { described_class.new(wizard:, appropriate_body_id: '123') }
+
   let(:school) { FactoryBot.create(:school, :independent) }
+  let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123') }
+  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :independent_school_appropriate_body, store:, school:) }
+
+  describe "inheritance" do
+    it "inherits from AppropriateBodyStep" do
+      expect(subject).to be_a(Schools::RegisterECTWizard::AppropriateBodyStep)
+    end
+  end
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
 
-    let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123', appropriate_body_type: 'prepopulated_type') }
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :independent_school_appropriate_body, store:) }
-
-    let(:appropriate_body_id) { 'provided_name' }
+    let(:appropriate_body_id) { 'provided_id' }
     let(:appropriate_body_type) { 'provided_type' }
 
     context 'when the appropriate_body_id is provided' do
       let(:params) { { appropriate_body_id:, appropriate_body_type: } }
 
-      it 'populate the instance from it' do
-        expect(subject.appropriate_body_id).to eq(appropriate_body_id)
-        expect(subject.appropriate_body_type).to eq(appropriate_body_type)
+      context "when the type is 'national'" do
+        let(:appropriate_body_type) { 'national' }
+        let!(:istip) { FactoryBot.create(:appropriate_body, :istip) }
+
+        it 'populate the instance from ISTIP' do
+          expect(subject.appropriate_body_id).to eq(istip.id.to_s)
+        end
+      end
+
+      context "when the type is not 'national'" do
+        let(:appropriate_body_id) { '5678' }
+
+        it 'populate the instance from the arguments' do
+          expect(subject.appropriate_body_id).to eq('5678')
+        end
       end
     end
 
@@ -24,105 +43,28 @@ RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep,
 
       it 'populate it from the wizard store' do
         expect(subject.appropriate_body_id).to eq('123')
-        expect(subject.appropriate_body_type).to eq('prepopulated_type')
       end
     end
   end
 
   describe 'validations' do
-    subject { described_class.new(appropriate_body_id:, appropriate_body_type:) }
+    subject { described_class.new(wizard:, appropriate_body_id:, appropriate_body_type:) }
 
-    context 'when the appropriate_body_type is not present' do
-      let(:appropriate_body_type) { nil }
-      let(:appropriate_body_id) { nil }
+    context 'when the appropriate_body is a national' do
+      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :istip).id }
+      let(:appropriate_body_type) { 'national' }
 
-      it 'is not valid' do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:appropriate_body_type]).to include("Select the appropriate body which will be supporting the ECT's induction")
+      it 'adds no error' do
+        expect(subject).to be_valid
       end
     end
 
-    context 'when the appropriate_body_type is present but the appropriate_body_id is not' do
+    context 'when the appropriate_body is a teaching school hub' do
+      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :teaching_school_hub).id }
       let(:appropriate_body_type) { 'teaching_school_hub' }
-      let(:appropriate_body_id) { nil }
 
-      it 'is not valid' do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:appropriate_body_id]).to include("Enter the name of the appropriate body which will be supporting the ECT's induction")
-      end
-    end
-
-    context 'when the appropriate_body_type is present and the appropriate_body_id is also present' do
-      let(:appropriate_body_type) { 'teacher_school_hub' }
-      let(:appropriate_body_id) { '1' }
-
-      it { expect(subject).to be_valid }
-    end
-  end
-
-  describe 'steps' do
-    subject { wizard.current_step }
-
-    let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :independent_school_appropriate_body, school:)
-    end
-
-    describe '#next_step' do
-      it 'returns the next step' do
-        expect(subject.next_step).to eq(:programme_type)
-      end
-    end
-
-    describe '#previous_step' do
-      context 'when the school has no programme choices' do
-        it 'returns the previous step' do
-          expect(subject.previous_step).to eq(:working_pattern)
-        end
-      end
-
-      context 'when the school has programme choices' do
-        let(:school) { FactoryBot.create(:school, :independent, :teaching_induction_panel_chosen, :school_led_chosen) }
-
-        it 'returns the previous step' do
-          expect(subject.previous_step).to eq(:use_previous_ect_choices)
-        end
-      end
-    end
-  end
-
-  describe '#save!' do
-    subject { wizard.current_step }
-
-    let(:step_params) do
-      ActionController::Parameters.new(
-        "independent_school_appropriate_body" => {
-          "appropriate_body_type" => 'teaching_school_hub',
-          "appropriate_body_id" => '1',
-        }
-      )
-    end
-
-    let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :independent_school_appropriate_body, step_params:)
-    end
-
-    context 'when invalid' do
-      before do
-        allow(subject).to receive(:valid?).and_return(false)
-      end
-
-      it 'does not update any data in the wizard ect' do
-        expect { subject.save! }.not_to change(subject.ect, :appropriate_body_id)
-      end
-    end
-
-    context 'when valid' do
-      before do
-        allow(subject).to receive(:valid?).and_return(true)
-      end
-
-      it 'updates the wizard ect appropriate_body_id' do
-        expect { subject.save! }.to change(subject.ect, :appropriate_body_id).from(nil).to('1')
+      it 'adds no error' do
+        expect(subject).to be_valid
       end
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/state_school_appropriate_body_step_spec.rb
@@ -3,44 +3,25 @@ RSpec.describe Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep, type:
   let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123') }
   let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:) }
 
-  describe '#initialize' do
-    subject { described_class.new(wizard:, **params) }
-
-    let(:appropriate_body_id) { 'provided_ab_name' }
-
-    context 'when the appropriate_body_id is provided' do
-      let(:params) { { appropriate_body_id: } }
-
-      it 'populate the instance from it' do
-        expect(subject.appropriate_body_id).to eq(appropriate_body_id)
-      end
-    end
-
-    context 'when no appropriate_body_id is provided' do
-      let(:params) { {} }
-
-      it 'populate it from the wizard store' do
-        expect(subject.appropriate_body_id).to eq('123')
-      end
-    end
-  end
-
   describe 'validations' do
-    subject { described_class.new(appropriate_body_id:) }
+    subject { described_class.new(wizard:, appropriate_body_id:) }
 
-    context 'when the appropriate_body_id is not present' do
-      let(:appropriate_body_id) { nil }
+    context 'when the appropriate_body is a national' do
+      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :national).id }
 
       it 'is not valid' do
         expect(subject).not_to be_valid
-        expect(subject.errors[:appropriate_body_id]).to include("Enter the name of the appropriate body which will be supporting the ECT's induction")
+        expect(subject.errors[:appropriate_body]).to include("Select a teaching school hub appropriate body which will be supporting the ECT's induction")
       end
     end
 
-    context 'when the appropriate_body_id is present' do
-      let(:appropriate_body_id) { '1' }
+    context 'when the appropriate_body is a teaching school hub' do
+      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :teaching_school_hub).id }
+      let(:appropriate_body_type) { 'teaching_school_hub' }
 
-      it { expect(subject).to be_valid }
+      it 'adds no error' do
+        expect(subject).to be_valid
+      end
     end
   end
 
@@ -50,64 +31,6 @@ RSpec.describe Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep, type:
     describe '#next_step' do
       it 'returns the next step' do
         expect(subject.next_step).to eq(:programme_type)
-      end
-    end
-
-    describe '#previous_step' do
-      subject { wizard.current_step }
-
-      context 'when the school has no programme choices' do
-        it 'returns the previous step' do
-          expect(subject.previous_step).to eq(:working_pattern)
-        end
-      end
-
-      context 'when the school has programme choices' do
-        let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_chosen, :provider_led_chosen) }
-
-        it 'returns the previous step' do
-          expect(subject.previous_step).to eq(:use_previous_ect_choices)
-        end
-      end
-    end
-  end
-
-  describe '#save!' do
-    subject { wizard.current_step }
-
-    let(:step_params) do
-      ActionController::Parameters.new(
-        "state_school_appropriate_body" => {
-          "appropriate_body_id" => '1',
-        }
-      )
-    end
-
-    let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, step_params:)
-    end
-
-    context 'when the step is not valid' do
-      before do
-        allow(subject).to receive(:valid?).and_return(false)
-      end
-
-      it 'does not update any data in the wizard ect' do
-        expect { subject.save! }.not_to change(subject.ect, :appropriate_body_id)
-      end
-    end
-
-    context 'when the step is valid' do
-      before do
-        allow(subject).to receive(:valid?).and_return(true)
-      end
-
-      it 'updates the wizard ect appropriate_body_id' do
-        expect { subject.save! }
-          .to change(subject.ect, :appropriate_body_id)
-                .from(nil).to('1')
-                .and change(subject.ect, :appropriate_body_type)
-                       .from(nil).to('teaching_school_hub')
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -1,0 +1,68 @@
+describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
+  subject { wizard.current_step }
+
+  let(:programme_type) { 'provider_led' }
+  let(:use_previous_ect_choices) { true }
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :check_answers, store:, ect_id:) }
+
+  describe 'steps' do
+    let(:ect_id) { '1234' }
+
+    describe '#next_step' do
+      it { expect(subject.next_step).to eq(:confirmation) }
+    end
+
+    describe '#previous_step' do
+      context 'when the mentor is available for funding' do
+        before do
+          allow(wizard.mentor).to receive(:funding_available?).and_return(true)
+        end
+
+        it { expect(subject.previous_step).to eq(:review_mentor_eligibility) }
+      end
+
+      context 'when the mentor is not available for funding' do
+        before do
+          allow(wizard.mentor).to receive(:funding_available?).and_return(false)
+        end
+
+        it { expect(subject.previous_step).to eq(:email_address) }
+      end
+    end
+  end
+
+  context '#save!' do
+    let(:ect) { FactoryBot.create(:ect_at_school_period) }
+    let(:ect_id) { ect.id }
+
+    context 'when the step is not valid' do
+      before do
+        allow(wizard.current_step).to receive(:valid?).and_return(false)
+      end
+
+      it 'does not update any data in the wizard ect' do
+        expect { subject.save! }.not_to change(subject.mentor, :registered)
+      end
+    end
+
+    context 'when the step is valid' do
+      let(:new_mentor) { double }
+
+      before do
+        allow(wizard.current_step).to receive(:valid?).and_return(true)
+        allow(subject.mentor).to receive(:register!).and_return(new_mentor)
+        allow(Schools::AssignMentor).to receive(:new).and_return(double(assign!: true))
+        subject.save!
+      end
+
+      it 'registers the mentor' do
+        expect(subject.mentor).to have_received(:register!)
+      end
+
+      it 'assigns the created mentor to the ECT' do
+        expect(Schools::AssignMentor).to have_received(:new).with(ect: wizard.ect, mentor: new_mentor)
+      end
+    end
+  end
+end

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
@@ -19,11 +19,11 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
     let(:corrected_name) { 'Right Name' }
 
     context 'when the corrected name or change name are provided' do
-      let(:params) { { corrected_name: } }
+      let(:params) { { corrected_name:, change_name: 'yes' } }
 
       it 'populate the instance from it' do
         expect(subject.corrected_name).to eq(corrected_name)
-        expect(subject.change_name).to be_nil
+        expect(subject.change_name).to eq('yes')
       end
     end
 


### PR DESCRIPTION
The first versions of register ECT journey recorded everything programme-wise into the ECTAtSchoolPeriod instance created. 

Now that we have decided the types ABs can have on `ECF2` (`teaching_school_hub`, `local_authority`, `national`), this PR will add that field to the model and remove it from  `ECTAtSchoolPeriod` and `School` (last registration choices).

This change needs the journey steps themselves to be accommodated accordingly.

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/1399)
