### PR TITLE
Update from Ubuntu 20.04 to latest for running specs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   backend-tests:
     name: Run rspec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     env:


### PR DESCRIPTION
Not sure why we were using this old version but support's about to expire so let's switch to a more modern one.
