### PR TITLE
Fix the appropriate bodies show page

### DIFF
--- a/app/controllers/admin/appropriate_bodies_controller.rb
+++ b/app/controllers/admin/appropriate_bodies_controller.rb
@@ -13,7 +13,7 @@ module Admin
 
     def show
       @appropriate_body = AppropriateBody.find(params[:id])
-      @current_ect_count = Teachers::Search.new(appropriate_bodies: @appropriate_body).search.count
+      @current_ect_count = ::Teachers::Search.new(appropriate_bodies: @appropriate_body).search.count
     end
   end
 end

--- a/spec/requests/admin/appropriate_bodies/show_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/show_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe "Viewing the appropriate bodies index", type: :request do
+  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+  describe "GET /admin/appropriate-bodies/:id" do
+    it "redirects to sign in path" do
+      get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}"
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "requires authorisation" do
+        get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}"
+
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "with an authenticated DfE user" do
+      include_context 'sign in as DfE user'
+
+      it "display appropriate bodies" do
+        get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}"
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include(appropriate_body.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem was caused by the clash of the `Teachers` namespace so changing to `::Teachers` is necessary.
