### PR TITLE
Fix rake tasks failing in review app

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -47,7 +47,5 @@ namespace :db do
   end
 end
 
-Rake::Task['db:create'].enhance do
-  Rake::Task['db:setup_search_configuration'].invoke
-end
+Rake::Task['db:schema:load'].enhance(['db:setup_search_configuration'])
 Rake::Task['db:prepare'].enhance(['db:setup_search_configuration'])


### PR DESCRIPTION
For some reason the review apps have started failing since changing the rake task search config setup ordering. We're not entirely sure what the issue is, but it seems to be enough to have the safety net of creating the DB if it doesn't exist in the search config rake task.

Revert the enhancements to the ones that worked. Retain the DB creation if not exist.