### PR TITLE
Revert "Fix `db:prepare` rake task when ran without database"

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,17 +1,6 @@
 namespace :db do
   desc 'Add search config'
   task setup_search_configuration: :environment do
-    database_exists = ::ActiveRecord::Base.connection_pool.with_connection do |connection|
-      connection.active?
-    rescue ActiveRecord::ConnectionNotEstablished
-      false
-    end
-
-    unless database_exists
-      Rails.logger.info("Database does not exist, creating it...")
-      Rake::Task['db:create'].invoke
-    end
-
     Rails.logger.info("Checking if full text search unaccented configuration exists")
     result = ActiveRecord::Base.connection.execute("select count(*) FROM pg_ts_config where cfgname = 'unaccented';")
 


### PR DESCRIPTION
This reverts commit 6a16570c410a5eae29233894d3559be5b7e47944. The change appears to be flakey; it will sometimes boot the review app and other times it will fail when running the migrations.

Reverting to unblock the pipeline until we can can fix it properly.