### PR TITLE
[1416] Only show content for `provider-led` on "Programme choices used by your school previously" page

### DIFF
--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -23,7 +23,9 @@
   end
 end %>
 
-<p class="govuk-body"><%= @school.chosen_lead_provider_name %> will confirm if they'll be working with your school and which delivery partner will deliver training events.</p>
+<% if @school.provider_led_programme_type_chosen? %>
+  <p class="govuk-body"><%= @school.chosen_lead_provider_name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.</p>
+<% end %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
@@ -56,4 +56,32 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
     expect(rendered).to have_button('Continue')
     expect(rendered).to have_selector("form[action='#{send(continue_path)}']")
   end
+
+  context "when school-led" do
+    let(:school) { FactoryBot.create(:school, :school_led_chosen) }
+
+    before do
+      assign(:school, school)
+    end
+
+    it "does not render the content" do
+      render
+
+      expect(rendered).not_to have_content("will confirm if they’ll be working with your school and which delivery partner will deliver training events.")
+    end
+  end
+
+  context "when provider-led" do
+    let(:school) { FactoryBot.create(:school, :provider_led_chosen) }
+
+    before do
+      assign(:school, school)
+    end
+
+    it "renders the content" do
+      render
+
+      expect(rendered).to have_content("will confirm if they’ll be working with your school and which delivery partner will deliver training events.")
+    end
+  end
 end


### PR DESCRIPTION
### Context

This change ensures a small piece of content is only rendered if the previously chosen programme type is **provider-led**.
If any other programme type was selected, the content will not be shown.


### Before/After

| Before | After |
|--------|-------|
|<img width="895" alt="image" src="https://github.com/user-attachments/assets/2fc2c152-9137-4281-8863-d2d5e5d99dd8" />|<img width="811" alt="image" src="https://github.com/user-attachments/assets/96bc3bf7-e360-418d-a70f-52cd38b566bf" />|


### Tech notes

The second commit is only here to get the review app deploying and will be dropped before merging. I've opened a separate PR with that fix [here](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/441).