### PR TITLE
Fix review app deployments by explicitly declaring `body_type` as a string

### DIFF
--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,4 +1,6 @@
 class AppropriateBody < ApplicationRecord
+  attribute :body_type, :string
+
   # Enums
   enum :body_type,
        { local_authority: 'local_authority',


### PR DESCRIPTION
### Context

Review apps are failing to deploy with the following error: 

```
Undeclared attribute type for enum `body_type` in `AppropriateBody`. Enums must be backed by a database column or declared with an explicit type via `attribute`.
```

This happens because rails loads models during `db:prepare`, before migrations have run. At that point, the `body_type` column doesn't exist yet, so rails can't infer the type of the enum and raises an error.


### Solution

Declaring the attribute type explicitly avoids this issue by telling rails what to expect during boot. 

### Steps to reproduce the error locally

- Ensure you are working in your local environment and on the **main** branch
- Drop your local database (`rails db:drop`)
- Run `rails db:create`
- Run `rails db:prepare`
- Everything should look like it worked
- Start the server and visit the site, you should see the runtime error regarding the undeclared enum attribute. 
- Repeat on **this branch** and everything should work without any errors.

### Link for more context

https://github.com/rails/rails/issues/52607