### PR TITLE
Increase snapshot db to B2s from B1ms sku

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -8,6 +8,7 @@
         291418
     ],
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
+    "postgres_snapshot_flexible_server_sku": "B_Standard_B2s",
     "deploy_snapshot_database": true,
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true


### PR DESCRIPTION
## Context
s189p01-cpdec2-pd-pg-snapshot isn't very healthy
Need to recreate db server and will increase to a B2s from B1ms (from 2G to 4G memory)

## Changes proposed in this pull request
add postgres_snapshot_flexible_server_sku to production tfvars

## Guidance to review
make production terraform-plan