### PR TITLE
Populate appropriate bodies via SQL in a migration

### DIFF
--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,6 +1,4 @@
 class AppropriateBody < ApplicationRecord
-  attribute :body_type, :string
-
   # Enums
   enum :body_type,
        { local_authority: 'local_authority',


### PR DESCRIPTION
Do not call `AppropriateBody` model inside migrations.
Replace it with pure SQL to prevent errors recreating the database (CI for instance) if the model code or its columns change in future migrations.