### PR TITLE
Fix TRS sync ordering bug

### DIFF
--- a/app/jobs/teachers/schedule_trs_sync_job.rb
+++ b/app/jobs/teachers/schedule_trs_sync_job.rb
@@ -5,7 +5,7 @@ module Teachers
     BATCH_SIZE = 1200
 
     def perform
-      teachers = Teacher.order(trs_data_last_refreshed_at: :asc).limit(BATCH_SIZE)
+      teachers = Teacher.ordered_by_trs_data_last_refreshed_at_nulls_first.limit(BATCH_SIZE)
 
       teachers.each_with_index do |teacher, i|
         Teachers::SyncTeacherWithTRSJob.set(wait: (i * 3).seconds).perform_later(teacher:)

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -39,6 +39,10 @@ class Teacher < ApplicationRecord
     )
   }
 
+  scope :ordered_by_trs_data_last_refreshed_at_nulls_first, -> {
+    order(arel_table[:trs_data_last_refreshed_at].asc.nulls_first)
+  }
+
   # Instance methods
   def eligible_for_mentor_funding?
     mentor_completion_date.blank? && mentor_completion_reason.blank?

--- a/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
+++ b/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Teachers::ScheduleTRSSyncJob, type: :job do
   describe "#perform" do
+    let!(:teacher0) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: nil) }
     let!(:teacher1) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 5.days.ago) }
     let!(:teacher2) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 4.days.ago) }
     let!(:teacher3) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 3.days.ago) }
@@ -8,11 +9,12 @@ RSpec.describe Teachers::ScheduleTRSSyncJob, type: :job do
 
     it "schedules sync jobs for teachers ordered by trs_data_last_refreshed_at" do
       [
-        [teacher1, 0],
-        [teacher2, 3],
-        [teacher3, 6],
-        [teacher4, 9],
-        [teacher5, 12],
+        [teacher0, 0],
+        [teacher1, 3],
+        [teacher2, 6],
+        [teacher3, 9],
+        [teacher4, 12],
+        [teacher5, 15],
       ].each do |teacher, wait_time|
         allow(Teachers::SyncTeacherWithTRSJob).to receive(:set).with(wait: wait_time.seconds).and_return(Teachers::SyncTeacherWithTRSJob)
 
@@ -26,11 +28,12 @@ RSpec.describe Teachers::ScheduleTRSSyncJob, type: :job do
       stub_const("Teachers::ScheduleTRSSyncJob::BATCH_SIZE", 3)
 
       # We expect the first 3 teachers to be processed (oldest refresh first)
+      expect(Teachers::SyncTeacherWithTRSJob).to receive(:perform_later).with(teacher: teacher0)
       expect(Teachers::SyncTeacherWithTRSJob).to receive(:perform_later).with(teacher: teacher1)
       expect(Teachers::SyncTeacherWithTRSJob).to receive(:perform_later).with(teacher: teacher2)
-      expect(Teachers::SyncTeacherWithTRSJob).to receive(:perform_later).with(teacher: teacher3)
 
       # We don't expect the newer teachers to be processed
+      expect(Teachers::SyncTeacherWithTRSJob).not_to receive(:perform_later).with(teacher: teacher3)
       expect(Teachers::SyncTeacherWithTRSJob).not_to receive(:perform_later).with(teacher: teacher4)
       expect(Teachers::SyncTeacherWithTRSJob).not_to receive(:perform_later).with(teacher: teacher5)
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -31,7 +31,7 @@ describe Teacher do
   end
 
   describe 'scopes' do
-    describe '#search' do
+    describe '.search' do
       it "searches the 'search' column using a tsquery" do
         expect(Teacher.search('Joey').to_sql).to end_with(%{WHERE (teachers.search @@ to_tsquery('unaccented', 'Joey:*'))})
       end
@@ -85,6 +85,14 @@ describe Teacher do
 
           expect(results).not_to include(other)
         end
+      end
+    end
+
+    describe '.ordered_by_trs_data_last_refreshed_at_nulls_first' do
+      it 'constructs the query so results are ascending but nulls are placed before the rows with values' do
+        expected_clause = %(ORDER BY "teachers"."trs_data_last_refreshed_at" ASC NULLS FIRST)
+
+        expect(Teacher.ordered_by_trs_data_last_refreshed_at_nulls_first.to_sql).to end_with(expected_clause)
       end
     end
   end


### PR DESCRIPTION
@emily-prudence-dfe noticed a bug where the same TRS records were being repeatedly refreshed. This is because, when ordering by a column `asc` it defaults to `nulls last`:

> The `NULLS FIRST` and `NULLS LAST` options can be used to determine whether nulls appear before or after non-null values in the sort ordering. By default, null values sort as if larger than any non-null value; that is, **`NULLS FIRST` is the default for `DESC` order, and `NULLS LAST` otherwise.**

## What happened

Given we have an assortment of present and null refresh timestamps:

```
ecf2_development=# select id, trs_data_last_refreshed_at from teachers order by id asc;
┌────┬────────────────────────────┐
│ id │ trs_data_last_refreshed_at │
├────┼────────────────────────────┤
│  1 │ 2025-04-10 10:59:46.707283 │
│  2 │ 2025-04-10 10:59:48.211057 │
│  3 │ (null)                     │
│  4 │ (null)                     │
│  5 │ (null)                     │
│  6 │ (null)                     │
│  7 │ (null)                     │
│  8 │ 2025-04-10 10:59:21.947482 │
│  9 │ 2025-04-10 10:59:20.675614 │
│ 10 │ 2025-04-10 10:59:18.267423 │
│ 11 │ (null)                     │
│ 12 │ 2025-04-10 10:59:16.58761  │
│ 13 │ 2025-04-10 10:59:15.555685 │
│ 14 │ 2025-04-10 10:59:09.627476 │
└────┴────────────────────────────┘
```

The code currently orders by `trs_data_last_refreshed_at asc`, giving us this result:

```
ecf2_development=# select id, trs_data_last_refreshed_at from teachers order by trs_data_last_refreshed_at asc;
┌────┬────────────────────────────┐
│ id │ trs_data_last_refreshed_at │
├────┼────────────────────────────┤
│ 14 │ 2025-04-10 10:59:09.627476 │
│ 13 │ 2025-04-10 10:59:15.555685 │
│ 12 │ 2025-04-10 10:59:16.58761  │
│ 10 │ 2025-04-10 10:59:18.267423 │
│  9 │ 2025-04-10 10:59:20.675614 │
│  8 │ 2025-04-10 10:59:21.947482 │
│  1 │ 2025-04-10 10:59:46.707283 │
│  2 │ 2025-04-10 10:59:48.211057 │
│ 11 │ (null)                     │
│  7 │ (null)                     │
│  6 │ (null)                     │
│  5 │ (null)                     │
│  4 │ (null)                     │
│  3 │ (null)                     │
└────┴────────────────────────────┘
```

After this change, we'll be running this query instead with `trs_data_last_refreshed_at asc nulls first`:

```
ecf2_development=# select id, trs_data_last_refreshed_at from teachers order by trs_data_last_refreshed_at asc nulls first;
┌────┬────────────────────────────┐
│ id │ trs_data_last_refreshed_at │
├────┼────────────────────────────┤
│  3 │ (null)                     │
│  4 │ (null)                     │
│  5 │ (null)                     │
│  6 │ (null)                     │
│  7 │ (null)                     │
│ 11 │ (null)                     │
│ 14 │ 2025-04-10 10:59:09.627476 │
│ 13 │ 2025-04-10 10:59:15.555685 │
│ 12 │ 2025-04-10 10:59:16.58761  │
│ 10 │ 2025-04-10 10:59:18.267423 │
│  9 │ 2025-04-10 10:59:20.675614 │
│  8 │ 2025-04-10 10:59:21.947482 │
│  1 │ 2025-04-10 10:59:46.707283 │
│  2 │ 2025-04-10 10:59:48.211057 │
└────┴────────────────────────────┘
```
