### PR TITLE
adapt interval scopes to future dates

### DIFF
--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -52,8 +52,8 @@ describe Interval do
     end
 
     describe '.ongoing' do
-      it 'returns records where the finished_on date is null' do
-        expect(DummyMentor.ongoing.to_sql).to end_with(%("finished_on" IS NULL))
+      it 'returns records where their dates range contains today' do
+        expect(DummyMentor.ongoing.to_sql).to end_with("#{DummyMentor.table_name}.range is NULL OR '#{Date.current}'::date <@ #{DummyMentor.table_name}.range)")
       end
     end
 
@@ -115,13 +115,13 @@ describe Interval do
 
   describe '#ongoing?' do
     context 'without finished_on' do
-      subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: nil) }
+      subject(:interval) { DummyInterval.new(range: 1.week.ago...) }
 
       it { is_expected.to be_ongoing }
     end
 
     context 'with finished_on' do
-      subject(:interval) { DummyInterval.new(started_on: 1.week.ago, finished_on: 1.day.ago) }
+      subject(:interval) { DummyInterval.new(range: 1.week.ago..1.day.ago) }
 
       it { is_expected.not_to be_ongoing }
     end


### PR DESCRIPTION
PR to experiment how life would be if we add pure periods with future dates to the service:

- we should try to pass dates to every service/scope to minimize the issues that time travel creates on specs.
- we should try to put special attention to add specs for all the different dates a service/scope/method might make to behave differently.
- we should time travel to different dates and check the different behaviours of end-to-end scenarios.
- queries get more complicated because we need to add conditions about date ranges most of the time. Is it worth to pay this price?
- by allowing any past, present, future periods to be persisted we can be certain we are reflecting faithfully the reality and not contraining the service at all. However, is it worth the complexity added?
- If we assumed (under investigation by Tony) that every not-pending period in the db started in the past, things would get less complicated when it comes to searching periods: all ongoing periods would have null `finished_on` date which makes our queries straight forward and the service less error-prone, for instance.
- However, is that approach too restrictive so that the data at some point doesn't fully matches the reality? I can't think of any case now but would it make the service buggy because of that for certain features?