### PR TITLE
Spike for marking future date periods with pending flag

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -87,6 +87,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
     teacher.ect_at_school_periods.excluding(self)
   end
 
+  def has_overlap_with_siblings? = siblings.excluding_pending.overlapping_with(self).exists?
+
 private
 
   def appropriate_body_for_independent_school

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -87,8 +87,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
     teacher.ect_at_school_periods.excluding(self)
   end
 
-  def has_overlap_with_siblings? = siblings.excluding_pending.overlapping_with(self).exists?
-
 private
 
   def appropriate_body_for_independent_school

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -182,6 +182,7 @@
   - range
   - ecf_start_induction_record_id
   - ecf_end_induction_record_id
+  - pending
   :teacher_migration_failures:
   - id
   - teacher_id
@@ -261,6 +262,7 @@
   - range
   - ecf_start_induction_record_id
   - ecf_end_induction_record_id
+  - pending
   :mentor_at_school_periods:
   - id
   - school_id
@@ -273,6 +275,7 @@
   - ecf_start_induction_record_id
   - ecf_end_induction_record_id
   - email
+  - pending
   :lead_providers:
   - id
   - name
@@ -318,6 +321,7 @@
   - ecf_end_induction_record_id
   - working_pattern
   - email
+  - pending
   :dfe_roles:
   - id
   - role_type

--- a/db/migrate/20250409134608_add_pending_to_periods.rb
+++ b/db/migrate/20250409134608_add_pending_to_periods.rb
@@ -1,0 +1,8 @@
+class AddPendingToPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ect_at_school_periods, :pending, :boolean, default: false
+    add_column :mentor_at_school_periods, :pending, :boolean, default: false
+    add_column :mentorship_periods, :pending, :boolean, default: false
+    add_column :training_periods, :pending, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_19_234928) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_09_134608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -161,6 +161,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_19_234928) do
     t.bigint "school_reported_appropriate_body_id"
     t.bigint "lead_provider_id"
     t.enum "programme_type", enum_type: "programme_type"
+    t.boolean "pending", default: false
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["lead_provider_id"], name: "index_ect_at_school_periods_on_lead_provider_id"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
@@ -295,6 +296,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_19_234928) do
     t.uuid "ecf_start_induction_record_id"
     t.uuid "ecf_end_induction_record_id"
     t.citext "email"
+    t.boolean "pending", default: false
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
@@ -311,6 +313,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_19_234928) do
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.uuid "ecf_start_induction_record_id"
     t.uuid "ecf_end_induction_record_id"
+    t.boolean "pending", default: false
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_afd5cf131d", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_mentorship_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
@@ -549,6 +552,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_19_234928) do
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.uuid "ecf_start_induction_record_id"
     t.uuid "ecf_end_induction_record_id"
+    t.boolean "pending", default: false
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"


### PR DESCRIPTION
Spike future school joiners by using a pending flag or status attribute on the `ECTAtSchoolPeriod` and adjusting the scopes accordingly
While attempting this is felt difficult to achieve without making the other related periods `pending` because queries would always have to relate back to `ECTAtSchoolPeriod` to check whether the related models were also pending and this felt like it could be done using the `started_on` making the `pending` flag redundant.
Therefore have expanded migration to add `pending` flag to the `MentorAtSchoolPeriod`, `MentorshipPeriod` and `TrainingPeriod` also. Should've also added `InductionPeriod` too because that's probably now broken.

I don't think this is a great solution, but also I'm not sure we've understood the requirements we have around supporting these future events and how we might need to:

* handle periods added before these are made "live"
* changes to these before they are "live"
* how we should handle validations in a mix of pending and non-pending records and at what point in the lifecycle
* which scopes should filter pending records by default
* which service users care about pending records and should have visibility of them
