### PR TITLE
Fix status change events

### DIFF
--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -80,10 +80,12 @@ class Teachers::Manage
         trs_qts_status_description:,
         trs_qts_awarded_on:,
         trs_initial_teacher_training_provider_name:,
-        trs_initial_teacher_training_end_date:,
-        trs_data_last_refreshed_at:
+        trs_initial_teacher_training_end_date:
       )
+
       record_teacher_trs_attribute_update(modifications: teacher.changes)
+
+      teacher.trs_data_last_refreshed_at = trs_data_last_refreshed_at
       teacher.save!
     end
   end

--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -36,10 +36,10 @@ class Teachers::Manage
 
   def update_name!(trs_first_name:, trs_last_name:)
     Teacher.transaction do
-      @old_name = full_name
+      old_name = full_name
       teacher.assign_attributes(trs_first_name:, trs_last_name:)
-      @new_name = full_name
-      record_name_change_event
+      new_name = full_name
+      record_name_change_event(old_name, new_name)
       teacher.save!
     end
   end
@@ -51,7 +51,6 @@ class Teachers::Manage
       @old_award_date = teacher.trs_qts_awarded_on
       teacher.assign_attributes(trs_qts_awarded_on:)
       @new_award_date = teacher.trs_qts_awarded_on
-      record_award_change_event
       teacher.save!
     end
   end
@@ -60,19 +59,17 @@ class Teachers::Manage
   #        provider name
   def update_itt_provider_name!(trs_initial_teacher_training_provider_name:)
     Teacher.transaction do
-      @old_itt_provider = teacher.trs_initial_teacher_training_provider_name
       teacher.assign_attributes(trs_initial_teacher_training_provider_name:)
-      @new_itt_provider = teacher.trs_initial_teacher_training_provider_name
       teacher.save!
     end
   end
 
   def update_trs_induction_status!(trs_induction_status:)
     Teacher.transaction do
-      @old_induction_status = teacher.trs_induction_status
+      old_induction_status = teacher.trs_induction_status
       teacher.assign_attributes(trs_induction_status:)
-      @new_induction_status = teacher.trs_induction_status
-      record_induction_status_change_event
+      new_induction_status = teacher.trs_induction_status
+      record_induction_status_change_event(old_induction_status, new_induction_status)
       teacher.save!
     end
   end
@@ -93,61 +90,21 @@ class Teachers::Manage
 
 private
 
-  attr_reader :new_name, :old_name, :new_award_date, :old_award_date, :old_induction_status, :new_induction_status
-
   def full_name
     ::Teachers::Name.new(teacher).full_name_in_trs
   end
 
-  # State ----------------------------------------------------------------------
-  def name_changed?
-    return false if old_name.nil?
-
-    new_name != old_name
-  end
-
-  def qts_awarded_on_changed?
-    return false if teacher.trs_qts_awarded_on.nil?
-
-    new_award_date != old_award_date
-  end
-
-  def induction_status_changed?
-    old_induction_status != new_induction_status
-  end
-
-  # Deltas ---------------------------------------------------------------------
-  def changed_names
-    { old_name:, new_name: }
-  end
-
-  def changed_qts_awarded_on
-    { old_award_date:, new_award_date: }
-  end
-
-  def changed_status
-    { old_induction_status:, new_induction_status: }
-  end
-
   # Events ---------------------------------------------------------------------
-  def record_name_change_event
-    return true unless name_changed?
+  def record_name_change_event(old_name, new_name)
+    return if old_name == new_name
 
-    Events::Record.teacher_name_changed_in_trs!(author:, teacher:, appropriate_body:, **changed_names)
+    Events::Record.teacher_name_changed_in_trs!(author:, teacher:, appropriate_body:, old_name:, new_name:)
   end
 
-  # TODO: implement tracking award changes?
-  def record_award_change_event
-    return true unless qts_awarded_on_changed?
+  def record_induction_status_change_event(old_induction_status, new_induction_status)
+    return if old_induction_status == new_induction_status
 
-    :no_op
-    # Events::Record.qts_awarded_on_changed_in_trs!(author:, teacher:, appropriate_body:, **manage_teacher.changed_qts_awarded_on)
-  end
-
-  def record_induction_status_change_event
-    return true unless induction_status_changed?
-
-    Events::Record.teacher_induction_status_changed_in_trs!(author:, teacher:, appropriate_body:, **changed_status)
+    Events::Record.teacher_induction_status_changed_in_trs!(author:, teacher:, appropriate_body:, old_induction_status:, new_induction_status:)
   end
 
   def record_teacher_trs_attribute_update(modifications:)

--- a/db/scripts/remove_incorrectly_created_trs_sync_events.rb
+++ b/db/scripts/remove_incorrectly_created_trs_sync_events.rb
@@ -1,0 +1,26 @@
+# Remove incorrectly created TRS sync events. These happened because of a bug
+# in the sync script that meant:
+# - teacher_induction_status_updated_by_trs were created with blank statuses
+#   every time the job was run
+# - teacher_attributes_updated_from_trs was created with just the update of
+#   the trs_data_last_refreshed_at even if nothing else was changed
+#
+# As it's only been running for a couple of days we'll clear them all and
+# start fresh.
+#
+# See https://github.com/DFE-Digital/register-early-career-teachers-public/pull/462/ for more
+# details
+Event.transaction do
+  Event.where(event_type: 'teacher_induction_status_updated_by_trs').delete_all
+
+  # get rid of teacher_attributes_updated_from_trs events where the modifications length
+  # is 98 i.e., this:
+  #
+  # TRS data last refreshed at changed from '2025-04-11 13:20:31 UTC' to '2025-04-14 04:24:22 UTC'
+  #
+  # because trs_data_last_refreshed_at will always be present it's the minimum
+  Event
+    .where(event_type: 'teacher_attributes_updated_from_trs')
+    .where('length(modifications::varchar) = 98')
+    .delete_all
+end

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Teachers::Manage do
 
   let(:user) { FactoryBot.create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'Allen') }
+  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'Allen', trs_induction_status: 'InProgress') }
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   describe '#update_name!' do
@@ -65,6 +65,80 @@ RSpec.describe Teachers::Manage do
             "TRS data last refreshed at set to '#{Time.zone.now}'"
           ]
         )
+      end
+    end
+  end
+
+  describe '#update_trs_induction_status!' do
+    before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+    context 'when the new induction status is different' do
+      it 'updates the teacher record' do
+        service.update_trs_induction_status!(trs_induction_status: 'Passed')
+
+        expect(teacher.trs_induction_status).to eql('Passed')
+      end
+
+      it 'records an event' do
+        freeze_time do
+          service.update_trs_induction_status!(trs_induction_status: 'Passed')
+
+          expect(RecordEventJob).to have_received(:perform_later).with(
+            author_email: 'christopher.biggins@education.gov.uk',
+            author_id: author.id,
+            author_name: 'Christopher Biggins',
+            author_type: :dfe_staff_user,
+            event_type: :teacher_induction_status_updated_by_trs,
+            appropriate_body:,
+            teacher:,
+            happened_at: Time.zone.now,
+            heading: %(Induction status changed from 'InProgress' to 'Passed')
+          )
+        end
+      end
+    end
+
+    context 'when the new induction status is the same' do
+      it 'does not records an event' do
+        service.update_trs_induction_status!(trs_induction_status: 'InProgress')
+
+        expect(RecordEventJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+
+  describe '#update_qts_awarded_on!' do
+    before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+    context 'when the new induction status is different' do
+      it 'updates the teacher record' do
+        service.update_qts_awarded_on!(trs_qts_awarded_on: 1.year.ago)
+
+        expect(teacher.trs_qts_awarded_on).to eql(1.year.ago.to_date)
+      end
+
+      it 'does not records an event' do
+        service.update_qts_awarded_on!(trs_qts_awarded_on: 1.year.ago)
+
+        expect(RecordEventJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+
+  describe '#update_itt_provider_name!' do
+    before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+    context 'when the new induction status is different' do
+      it 'updates the teacher record' do
+        service.update_itt_provider_name!(trs_initial_teacher_training_provider_name: 'Some other training provider')
+
+        expect(teacher.trs_initial_teacher_training_provider_name).to eql('Some other training provider')
+      end
+
+      it 'does not records an event' do
+        service.update_qts_awarded_on!(trs_qts_awarded_on: 1.year.ago)
+
+        expect(RecordEventJob).not_to have_received(:perform_later)
       end
     end
   end

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Teachers::Manage do
           heading: "TRS attributes updated",
           teacher:,
           metadata: {
-            trs_data_last_refreshed_at: [nil, Time.zone.now],
             trs_initial_teacher_training_end_date: [nil, 2.years.ago.to_date],
             trs_initial_teacher_training_provider_name: [nil, "ITT provider"],
             trs_qts_awarded_on: [nil, 3.years.ago.to_date],
@@ -62,10 +61,25 @@ RSpec.describe Teachers::Manage do
             "TRS qts status description set to 'QTS status description'",
             "TRS initial teacher training provider name set to 'ITT provider'",
             "TRS initial teacher training end date set to '#{2.years.ago.to_date.to_fs(:govuk_short)}'",
-            "TRS data last refreshed at set to '#{Time.zone.now}'"
           ]
         )
       end
+    end
+
+    it 'updates the trs_data_last_refreshed_at on the teacher' do
+      refresh_time = 2.hours.ago
+
+      service.update_trs_attributes!(
+        trs_qts_status_description:,
+        trs_qts_awarded_on:,
+        trs_initial_teacher_training_provider_name:,
+        trs_initial_teacher_training_end_date:,
+        trs_data_last_refreshed_at: refresh_time
+      )
+
+      teacher.reload
+
+      expect(teacher.trs_data_last_refreshed_at).to be_within(0.0001).of(refresh_time)
     end
   end
 


### PR DESCRIPTION
There's a problem in production where events are always being written regardless of whether a name has changed or not.

It was caused by a mismatch between the variable names `induction_status_before` and `new_induction_status`. Because we were using instance variables they were interpolated as empty strings which were written to the events log.
