### PR TITLE
Spike for adding a separate model for future joiners

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -3,6 +3,9 @@ class LeadProvider < ApplicationRecord
   has_many :provider_partnerships, inverse_of: :lead_provider
   has_many :events
   has_many :pending_school_joiners, inverse_of: :lead_provider
+  has_many :pending_schools, -> { distinct }, through: :pending_school_joiners, source: :school
+  # TODO: this may be better as a scope so we could do something more complex such as exluding records
+  #       where a partnership was in place if that was more useful
 
   # Validations
   validates :name,

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -2,6 +2,7 @@ class LeadProvider < ApplicationRecord
   # Associations
   has_many :provider_partnerships, inverse_of: :lead_provider
   has_many :events
+  has_many :pending_school_joiners, inverse_of: :lead_provider
 
   # Validations
   validates :name,

--- a/app/models/pending_school_joiner.rb
+++ b/app/models/pending_school_joiner.rb
@@ -7,15 +7,15 @@ class PendingSchoolJoiner < ApplicationRecord
        suffix: :programme_type
 
   enum :role_type,
-       { ect: "ect", mentor: "mentor" },
-       validate: { message: "Must be ECT or mentor" },
-       suffix: :role_type
+    { ect: "ect", mentor: "mentor" },
+    validate: { message: "Must be ECT or mentor" },
+    suffix: :role_type
 
   belongs_to :teacher, inverse_of: :pending_school_starts
   belongs_to :school, inverse_of: :pending_school_joiners
 
   belongs_to :mentor_at_school_period, optional: true
-  belongs_to :lead_provider, optional: true
+  belongs_to :lead_provider, inverse_of: :pending_school_joiners, optional: true
   belongs_to :appropriate_body, optional: true
 
   # TODO: check for future date too

--- a/app/models/pending_school_joiner.rb
+++ b/app/models/pending_school_joiner.rb
@@ -19,5 +19,7 @@ class PendingSchoolJoiner < ApplicationRecord
   belongs_to :appropriate_body, optional: true
 
   # TODO: check for future date too
+  # TODO: validate uniqueness for teacher_id/school_id perhaps (+ db constraint)
+  #
   validates :starting_on, presence: { message: "Must have a starting_on date" }
 end

--- a/app/models/pending_school_joiner.rb
+++ b/app/models/pending_school_joiner.rb
@@ -1,0 +1,23 @@
+class PendingSchoolJoiner < ApplicationRecord
+  # from ECTAtSchoolPeriod
+  enum :programme_type,
+       { provider_led: "provider_led",
+         school_led: "school_led" },
+       validate: { message: "Must be provider-led or school-led" },
+       suffix: :programme_type
+
+  enum :role_type,
+       { ect: "ect", mentor: "mentor" },
+       validate: { message: "Must be ECT or mentor" },
+       suffix: :role_type
+
+  belongs_to :teacher, inverse_of: :pending_school_starts
+  belongs_to :school, inverse_of: :pending_school_joiners
+
+  belongs_to :mentor_at_school_period, optional: true
+  belongs_to :lead_provider, optional: true
+  belongs_to :appropriate_body, optional: true
+
+  # TODO: check for future date too
+  validates :starting_on, presence: { message: "Must have a starting_on date" }
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -17,6 +17,8 @@ class School < ApplicationRecord
   has_many :events
   has_many :mentor_at_school_periods, inverse_of: :school
   has_many :mentor_teachers, -> { distinct }, through: :mentor_at_school_periods, source: :teacher
+  has_many :pending_school_joiners, inverse_of: :school
+  has_many :pending_teachers, through: :pending_school_joiners, source: :teacher
 
   # Validations
   validates :chosen_lead_provider_id,

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -16,6 +16,9 @@ class Teacher < ApplicationRecord
   has_many :induction_periods
   has_many :appropriate_bodies, through: :induction_periods
   has_many :events
+  has_many :pending_school_starts, class_name: "PendingSchoolJoiner", inverse_of: :teacher
+  has_many :pending_schools, through: :pending_school_starts, source: :school
+  has_many :pending_providers, through: :pending_school_starts, source: :lead_provider
 
   # TODO: remove after migration complete
   has_many :teacher_migration_failures

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -356,3 +356,15 @@
   - trn
   - created_at
   - updated_at
+  :pending_school_joiners:
+  - id
+  - teacher_id
+  - school_id
+  - role_type
+  - starting_on
+  - programme_type
+  - mentor_at_school_period_id
+  - lead_provider_id
+  - appropriate_body_id
+  - created_at
+  - updated_at

--- a/db/migrate/20250414131145_create_pending_school_joiners.rb
+++ b/db/migrate/20250414131145_create_pending_school_joiners.rb
@@ -1,0 +1,15 @@
+class CreatePendingSchoolJoiners < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pending_school_joiners do |t|
+      t.references :teacher, foreign_key: true
+      t.references :school, foreign_key: true
+      t.string :role_type, null: false, default: "ect"
+      t.date :starting_on, null: false
+      t.enum :programme_type, enum_type: :programme_type
+      t.references :mentor_at_school_period, foreign_key: true, null: true
+      t.references :lead_provider, foreign_key: true, null: true
+      t.references :appropriate_body, foreign_key: true, null: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_11_105110) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_14_131145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -358,6 +358,24 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_11_105110) do
     t.index ["appropriate_body_id"], name: "index_pending_induction_submissions_on_appropriate_body_id"
   end
 
+  create_table "pending_school_joiners", force: :cascade do |t|
+    t.bigint "teacher_id"
+    t.bigint "school_id"
+    t.string "role_type", default: "ect", null: false
+    t.date "starting_on", null: false
+    t.enum "programme_type", enum_type: "programme_type"
+    t.bigint "mentor_at_school_period_id"
+    t.bigint "lead_provider_id"
+    t.bigint "appropriate_body_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appropriate_body_id"], name: "index_pending_school_joiners_on_appropriate_body_id"
+    t.index ["lead_provider_id"], name: "index_pending_school_joiners_on_lead_provider_id"
+    t.index ["mentor_at_school_period_id"], name: "index_pending_school_joiners_on_mentor_at_school_period_id"
+    t.index ["school_id"], name: "index_pending_school_joiners_on_school_id"
+    t.index ["teacher_id"], name: "index_pending_school_joiners_on_teacher_id"
+  end
+
   create_table "provider_partnerships", force: :cascade do |t|
     t.bigint "academic_year_id", null: false
     t.bigint "lead_provider_id", null: false
@@ -595,6 +613,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_11_105110) do
   add_foreign_key "mentorship_periods", "ect_at_school_periods"
   add_foreign_key "mentorship_periods", "mentor_at_school_periods"
   add_foreign_key "pending_induction_submissions", "appropriate_bodies"
+  add_foreign_key "pending_school_joiners", "appropriate_bodies"
+  add_foreign_key "pending_school_joiners", "lead_providers"
+  add_foreign_key "pending_school_joiners", "mentor_at_school_periods"
+  add_foreign_key "pending_school_joiners", "schools"
+  add_foreign_key "pending_school_joiners", "teachers"
   add_foreign_key "provider_partnerships", "academic_years", primary_key: "year"
   add_foreign_key "provider_partnerships", "delivery_partners"
   add_foreign_key "provider_partnerships", "lead_providers"


### PR DESCRIPTION
This approach adds a separate model to hold the details of a future school starter.  It assumes that we will in all circumstances (new registration and existing participant) have a `Teacher` model to keep things simpler.

#### Mandatory attributes:

Teacher, School, "role_type" - ECT or mentor, programme_type - school-led or provider-led, starting_on

#### Optional attributes:

Lead Provider, Appropriate Body, MentorAtSchoolPeriod

I've added associations that permit:

- A school to see who is a future joiner
- A teacher to see their future schools and provider
- A provider to see their future joiners and schools

It is trivial to get a list of future starts by provider, school or AB:

`PendingSchoolJoiner.where(lead_provider: x)`

`PendingSchoolJoiner.where(school: x)` or `school.pending_school_joiners` or `school.pending_teachers`

`PendingSchoolJoiner.where(appropriate_body: x)`

It seems like it would be easy to make changes to it if we wanted to allow the school (or admin) that functionality

It doesn't change the existing period models so no need to calculate dates or workout what is active - if it is live it is in a period if it is pending it is in the pending model.

We'd need a job to run daily that actions the pending joiners on the `starting_on` date which would:
- add the `ECTAtSchoolPeriod` (or MentorAtSchoolPeriod` if we wanted to allow that at some point)
- add a `MentorshipPeriod` as appropriate
- add a `TrainingPeriod` as appropriate as either an EOI or linked to a confirmed partnership
- close any existing `ECTAtSchool/Mentorship/TrainingPeriod`s if present (i.e. from a previous school)
- removes the `PendingSchoolJoiner` record or marks it as done in someway

I've not added specs but have played with this on the console to get a feel for it and it seems like a nice approach