### PR TITLE
[1301] View Individual Mentor Details

### DIFF
--- a/app/components/schools/mentors/details_component.rb
+++ b/app/components/schools/mentors/details_component.rb
@@ -3,10 +3,9 @@ module Schools
     class DetailsComponent < ViewComponent::Base
       include TeacherHelper
 
-      def initialize(teacher:, mentor:, ects:)
+      def initialize(teacher:, mentor:)
         @teacher = teacher
         @mentor = mentor
-        @ects = ects
       end
 
       def call
@@ -44,7 +43,7 @@ module Schools
         {
           key: { text: 'Assigned ECTs' },
           value: {
-            text: safe_join(@ects.map do |ect|
+            text: safe_join(assigned_ects.map do |ect|
               govuk_link_to(
                 teacher_full_name(ect.teacher),
                 schools_ect_path(ect, back_to_mentor: true, mentor_id: @mentor.id)
@@ -52,6 +51,10 @@ module Schools
             end, tag.br)
           }
         }
+      end
+
+      def assigned_ects
+        @assigned_ects ||= @mentor.currently_assigned_ects
       end
     end
   end

--- a/app/components/schools/mentors/details_component.rb
+++ b/app/components/schools/mentors/details_component.rb
@@ -43,14 +43,20 @@ module Schools
         {
           key: { text: 'Assigned ECTs' },
           value: {
-            text: safe_join(assigned_ects.map do |ect|
-              govuk_link_to(
-                teacher_full_name(ect.teacher),
-                schools_ect_path(ect, back_to_mentor: true, mentor_id: @mentor.id)
-              )
-            end, tag.br)
+            text: assigned_ects_value
           }
         }
+      end
+
+      def assigned_ects_value
+        return 'No ECTs assigned' if assigned_ects.empty?
+
+        safe_join(assigned_ects.map do |ect|
+          govuk_link_to(
+            teacher_full_name(ect.teacher),
+            schools_ect_path(ect, back_to_mentor: true, mentor_id: @mentor.id)
+          )
+        end, tag.br)
       end
 
       def assigned_ects

--- a/app/components/schools/mentors/details_component.rb
+++ b/app/components/schools/mentors/details_component.rb
@@ -1,0 +1,58 @@
+module Schools
+  module Mentors
+    class DetailsComponent < ViewComponent::Base
+      include TeacherHelper
+
+      def initialize(teacher:, mentor:, ects:)
+        @teacher = teacher
+        @mentor = mentor
+        @ects = ects
+      end
+
+      def call
+        safe_join([
+          tag.h2('Mentor details', class: 'govuk-heading-m'),
+          govuk_summary_list(rows:)
+        ])
+      end
+
+      def rows
+        [
+          name_row,
+          email_row,
+          assigned_ects_row
+        ]
+      end
+
+    private
+
+      def name_row
+        {
+          key: { text: 'Name' },
+          value: { text: teacher_full_name(@teacher) }
+        }
+      end
+
+      def email_row
+        {
+          key: { text: 'Email address' },
+          value: { text: @mentor.email }
+        }
+      end
+
+      def assigned_ects_row
+        {
+          key: { text: 'Assigned ECTs' },
+          value: {
+            text: safe_join(@ects.map do |ect|
+              govuk_link_to(
+                teacher_full_name(ect.teacher),
+                schools_ect_path(ect, back_to_mentor: true, mentor_id: @mentor.id)
+              )
+            end, tag.br)
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
@@ -1,0 +1,26 @@
+<h2 class="govuk-heading-m">ECT mentor training details</h2>
+
+<% if eligible_for_training? %>
+  <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do %>
+    <%= govuk_summary_list do |list| %>
+      <% list.with_row do |row| %>
+        <% row.with_key { "Lead provider" } %>
+        <% row.with_value { "Some value" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
+    <%= govuk_summary_list do |list| %>
+      <% list.with_row do |row| %>
+        <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p class="govuk-body">
+    <%= teacher_full_name(teacher) %> cannot do ECTE mentor training according to our records.
+    This could be because they’ve undertaken it before.
+  </p>
+<% end %>
+

--- a/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m">ECT mentor training details</h2>
+<h2 class="govuk-heading-m">ECTE mentor training details</h2>
 
 <% if eligible_for_training? %>
   <%= govuk_summary_card(title: "Reported to us by your school") do %>

--- a/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
@@ -5,7 +5,7 @@
     <%= govuk_summary_list do |list| %>
       <% list.with_row do |row| %>
         <% row.with_key { "Lead provider" } %>
-        <% row.with_value { first_ect_lead_provider_name } %>
+        <% row.with_value { first_lead_provider_name } %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.html.erb
@@ -1,16 +1,16 @@
 <h2 class="govuk-heading-m">ECT mentor training details</h2>
 
 <% if eligible_for_training? %>
-  <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do %>
+  <%= govuk_summary_card(title: "Reported to us by your school") do %>
     <%= govuk_summary_list do |list| %>
       <% list.with_row do |row| %>
         <% row.with_key { "Lead provider" } %>
-        <% row.with_value { "Some value" } %>
+        <% row.with_value { first_ect_lead_provider_name } %>
       <% end %>
     <% end %>
   <% end %>
 
-  <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
+  <%= govuk_summary_card(title: "Reported to us by your lead provider") do %>
     <%= govuk_summary_list do |list| %>
       <% list.with_row do |row| %>
         <% row.with_value { "Your lead provider has not reported any information to us yet" } %>

--- a/app/components/schools/mentors/ect_mentor_training_details_component.rb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.rb
@@ -1,0 +1,23 @@
+module Schools
+  module Mentors
+    class ECTMentorTrainingDetailsComponent < ViewComponent::Base
+      include TeacherHelper
+
+      attr_reader :teacher, :mentor, :ects
+
+      def initialize(teacher:, mentor:, ects:)
+        @teacher = teacher
+        @mentor = mentor
+        @ects = ects
+      end
+
+      def render?
+        ects.any? { |ect| ect.programme_type == "provider_led" }
+      end
+
+      def eligible_for_training?
+        teacher.mentor_completion_date.nil?
+      end
+    end
+  end
+end

--- a/app/components/schools/mentors/ect_mentor_training_details_component.rb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.rb
@@ -18,6 +18,10 @@ module Schools
       def eligible_for_training?
         teacher.mentor_completion_date.nil?
       end
+
+      def first_ect_lead_provider_name
+        ects.find { |ect| ect.lead_provider.present? }&.lead_provider&.name
+      end
     end
   end
 end

--- a/app/components/schools/mentors/ect_mentor_training_details_component.rb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.rb
@@ -3,16 +3,15 @@ module Schools
     class ECTMentorTrainingDetailsComponent < ViewComponent::Base
       include TeacherHelper
 
-      attr_reader :teacher, :mentor, :ects
+      attr_reader :teacher, :mentor
 
-      def initialize(teacher:, mentor:, ects:)
+      def initialize(teacher:, mentor:)
         @teacher = teacher
         @mentor = mentor
-        @ects = ects
       end
 
       def render?
-        ects.any?(&:provider_led?)
+        assigned_ects.any?(&:provider_led?)
       end
 
       def eligible_for_training?
@@ -20,11 +19,15 @@ module Schools
       end
 
       def first_lead_provider_name
-        ects
+        assigned_ects
           .select { |ect| ect.lead_provider.present? }
           .min_by(&:started_on)
           &.lead_provider
           &.name
+      end
+
+      def assigned_ects
+        @assigned_ects ||= @mentor.currently_assigned_ects
       end
     end
   end

--- a/app/components/schools/mentors/ect_mentor_training_details_component.rb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.rb
@@ -12,15 +12,19 @@ module Schools
       end
 
       def render?
-        ects.any? { |ect| ect.programme_type == "provider_led" }
+        ects.any?(&:provider_led?)
       end
 
       def eligible_for_training?
         teacher.mentor_completion_date.nil?
       end
 
-      def first_ect_lead_provider_name
-        ects.find { |ect| ect.lead_provider.present? }&.lead_provider&.name
+      def first_lead_provider_name
+        ects
+          .select { |ect| ect.lead_provider.present? }
+          .min_by(&:started_on)
+          &.lead_provider
+          &.name
       end
     end
   end

--- a/app/components/schools/mentors/summary_component.rb
+++ b/app/components/schools/mentors/summary_component.rb
@@ -20,7 +20,7 @@ module Schools
     private
 
       def link_to_mentor
-        govuk_link_to(teacher_full_name(@mentor.teacher), '#')
+        govuk_link_to(teacher_full_name(@mentor.teacher), schools_mentor_path(@mentor))
       end
 
       def trn_row

--- a/app/controllers/schools/mentors_controller.rb
+++ b/app/controllers/schools/mentors_controller.rb
@@ -2,14 +2,34 @@ module Schools
   class MentorsController < SchoolsController
     layout "full"
 
+    before_action :set_school_home
+    before_action :set_mentor, only: :show
+    before_action :set_teacher, only: :show
+    before_action :set_ects, only: :show
+
     def index
-      @pagy, @mentors = pagy(Schools::Home.new(school:).mentors_with_ects, limit: 20)
+      @pagy, @mentors = pagy(@school_home.mentors_with_ects, limit: 20)
     end
 
     def show
+    end
+
+  private
+
+    def set_school_home
+      @school_home = Schools::Home.new(school:)
+    end
+
+    def set_mentor
       @mentor = MentorAtSchoolPeriod.find(params[:id])
+    end
+
+    def set_teacher
       @teacher = @mentor.teacher
-      @ects = Schools::Home.new(school:).ects_with_mentors
+    end
+
+    def set_ects
+      @ects = @school_home.ects_with_mentors
     end
   end
 end

--- a/app/controllers/schools/mentors_controller.rb
+++ b/app/controllers/schools/mentors_controller.rb
@@ -5,5 +5,11 @@ module Schools
     def index
       @pagy, @mentors = pagy(Schools::Home.new(school:).mentors_with_ects, limit: 20)
     end
+
+    def show
+      @mentor = MentorAtSchoolPeriod.find(params[:id])
+      @teacher = @mentor.teacher
+      @ects = Schools::Home.new(school:).ects_with_mentors
+    end
   end
 end

--- a/app/helpers/mentor_helper.rb
+++ b/app/helpers/mentor_helper.rb
@@ -1,6 +1,6 @@
 module MentorHelper
   # @param mentor [MentorAtSchoolPeriod]
   def link_to_mentor(mentor)
-    govuk_link_to(teacher_full_name(mentor.teacher), '#', no_visited_state: true)
+    govuk_link_to(teacher_full_name(mentor.teacher), schools_mentor_path(mentor))
   end
 end

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -1,7 +1,7 @@
 <%
   page_data(
     title: teacher_full_name(@ect.teacher),
-    backlink_href: schools_ects_home_path,
+    backlink_href: params[:back_to_mentor] == "true" ? schools_mentor_path(params[:mentor_id]) : schools_ects_home_path,
     caption: teacher_trn(@ect.teacher),
     caption_size: 'l',
   )

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -2,30 +2,35 @@
   title: teacher_full_name(@teacher),
   caption: "TRN: #{@teacher.trn}",
   header: teacher_full_name(@teacher),
-  backlink_href: schools_mentors_home_path) %>
+  backlink_href: schools_mentors_home_path
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h2 class="govuk-heading-m">Mentor details</h2>
 
-    <%= govuk_summary_list do |summary_list|
-      summary_list.with_row do |row|
-      row.with_key { 'Name' }
-      row.with_value { teacher_full_name(@teacher) }
-      end; summary_list.with_row do |row|
-      row.with_key(text: 'Email address')
-      row.with_value(text: @mentor.email)
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { 'Name' } %>
+        <% row.with_value { teacher_full_name(@teacher) } %>
+      <% end %>
 
-      end; summary_list.with_row do |row|
-      row.with_key(text: 'Assigned ECTs')
-      row.with_value { safe_join(@ects.map { |ect| govuk_link_to teacher_full_name(ect.teacher), schools_ect_path(ect)}, tag.br) }
-      end; end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: 'Email address') %>
+        <% row.with_value(text: @mentor.email) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: 'Assigned ECTs') %>
+        <% row.with_value { safe_join(@ects.map { |ect| govuk_link_to teacher_full_name(ect.teacher), schools_ect_path(ect) }, tag.br) } %>
+      <% end %>
+    <% end %>
 
     <h2 class="govuk-heading-m">ECT mentor training details</h2>
 
     <% if @teacher.mentor_completion_date.nil? %>
-      <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do |card| %>
+      <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do %>
         <%= govuk_summary_list do |list| %>
           <% list.with_row do |row| %>
             <% row.with_key { "Lead provider" } %>
@@ -34,20 +39,19 @@
         <% end %>
       <% end %>
 
-        <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
-          <%= govuk_summary_list do |list| %>
-            <% list.with_row do |row| %>
-              <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
-            <% end %>
+      <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
+        <%= govuk_summary_list do |list| %>
+          <% list.with_row do |row| %>
+            <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
           <% end %>
         <% end %>
+      <% end %>
 
     <% else %>
       <p class="govuk-body">
         <%= teacher_full_name(@teacher) %> cannot do ECTE mentor training according to our records.
         This could be because they’ve undertaken it before.
       </p>
-      
     <% end %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -37,6 +37,11 @@
           <% end %>
         <% end %>
       <% end %>
+    <% else %>
+      <p class="govuk-body">
+        <%= Teachers::Name.new(@teacher).full_name %> cannot do ECTE mentor training according to our records.
+        This could be because they’ve undertaken it before.
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -1,23 +1,27 @@
 <% page_data(
-  title: Teachers::Name.new(@teacher).full_name,
+  title: teacher_full_name(@teacher),
   caption: "TRN: #{@teacher.trn}",
-  header: Teachers::Name.new(@teacher).full_name,
+  header: teacher_full_name(@teacher),
   backlink_href: schools_mentors_home_path) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <h2 class="govuk-heading-m">Mentor details</h2>
+
     <%= govuk_summary_list do |summary_list|
       summary_list.with_row do |row|
       row.with_key { 'Name' }
-      row.with_value { Teachers::Name.new(@teacher).full_name }
+      row.with_value { teacher_full_name(@teacher) }
       end; summary_list.with_row do |row|
       row.with_key(text: 'Email address')
       row.with_value(text: @mentor.email)
 
       end; summary_list.with_row do |row|
       row.with_key(text: 'Assigned ECTs')
-      row.with_value { safe_join(@ects.map { |ect| govuk_link_to Teachers::Name.new(ect.teacher).full_name, schools_ect_path(ect)}, tag.br) }
+      row.with_value { safe_join(@ects.map { |ect| govuk_link_to teacher_full_name(ect.teacher), schools_ect_path(ect)}, tag.br) }
       end; end %>
+
     <h2 class="govuk-heading-m">ECT mentor training details</h2>
 
     <% if @teacher.mentor_completion_date.nil? %>
@@ -30,18 +34,20 @@
         <% end %>
       <% end %>
 
-        <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do |card| %>
-        <%= govuk_summary_list do |list| %>
-          <% list.with_row do |row| %>
-            <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
+        <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
+          <%= govuk_summary_list do |list| %>
+            <% list.with_row do |row| %>
+              <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
+
     <% else %>
       <p class="govuk-body">
-        <%= Teachers::Name.new(@teacher).full_name %> cannot do ECTE mentor training according to our records.
+        <%= teacher_full_name(@teacher) %> cannot do ECTE mentor training according to our records.
         This could be because they’ve undertaken it before.
       </p>
+      
     <% end %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -1,0 +1,24 @@
+<% page_data(
+  title: Teachers::Name.new(@teacher).full_name,
+  caption: "TRN: #{@teacher.trn}",
+  header: Teachers::Name.new(@teacher).full_name,
+  backlink_href: schools_mentors_home_path)
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">Mentor details</h2>
+      <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+      row.with_key { 'Name' }
+      row.with_value { Teachers::Name.new(@teacher).full_name }
+      end; summary_list.with_row do |row|
+      row.with_key(text: 'Email address')
+      row.with_value(text: @mentor.email)
+
+      end; summary_list.with_row do |row|
+      row.with_key(text: 'Assigned ECTs')
+      row.with_value { safe_join(@ects.map { |ect| govuk_link_to Teachers::Name.new(ect.teacher).full_name, schools_ect_path(ect)}, tag.br) }
+      end; end %>
+  </div>
+</div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -27,31 +27,34 @@
       <% end %>
     <% end %>
 
-    <h2 class="govuk-heading-m">ECT mentor training details</h2>
+    <% if @ects.any? { |ect| ect.programme_type == "provider_led" } %>
 
-    <% if @teacher.mentor_completion_date.nil? %>
-      <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do %>
-        <%= govuk_summary_list do |list| %>
-          <% list.with_row do |row| %>
-            <% row.with_key { "Lead provider" } %>
-            <% row.with_value { "Some value" } %>
+      <h2 class="govuk-heading-m">ECT mentor training details</h2>
+
+        <% if @teacher.mentor_completion_date.nil? %>
+          <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do %>
+            <%= govuk_summary_list do |list| %>
+              <% list.with_row do |row| %>
+                <% row.with_key { "Lead provider" } %>
+                <% row.with_value { "Some value" } %>
+              <% end %>
+            <% end %>
           <% end %>
-        <% end %>
-      <% end %>
 
-      <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
-        <%= govuk_summary_list do |list| %>
-          <% list.with_row do |row| %>
-            <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
+          <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
+            <%= govuk_summary_list do |list| %>
+              <% list.with_row do |row| %>
+                <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
+              <% end %>
+            <% end %>
           <% end %>
-        <% end %>
-      <% end %>
 
-    <% else %>
-      <p class="govuk-body">
-        <%= teacher_full_name(@teacher) %> cannot do ECTE mentor training according to our records.
-        This could be because they’ve undertaken it before.
-      </p>
+        <% else %>
+          <p class="govuk-body">
+            <%= teacher_full_name(@teacher) %> cannot do ECTE mentor training according to our records.
+            This could be because they’ve undertaken it before.
+          </p>
+        <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -10,14 +10,12 @@
 
     <%= render Schools::Mentors::DetailsComponent.new(
       teacher: @teacher,
-      mentor: @mentor,
-      ects: @ects
+      mentor: @mentor
     ) %>
 
     <%= render Schools::Mentors::ECTMentorTrainingDetailsComponent.new(
           teacher: @teacher,
-          mentor: @mentor,
-          ects: @ects
+          mentor: @mentor
         ) %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -2,13 +2,11 @@
   title: Teachers::Name.new(@teacher).full_name,
   caption: "TRN: #{@teacher.trn}",
   header: Teachers::Name.new(@teacher).full_name,
-  backlink_href: schools_mentors_home_path)
-%>
-
+  backlink_href: schools_mentors_home_path) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">Mentor details</h2>
-      <%= govuk_summary_list do |summary_list|
+    <h2 class="govuk-heading-m">Mentor details</h2>
+    <%= govuk_summary_list do |summary_list|
       summary_list.with_row do |row|
       row.with_key { 'Name' }
       row.with_value { Teachers::Name.new(@teacher).full_name }
@@ -20,5 +18,25 @@
       row.with_key(text: 'Assigned ECTs')
       row.with_value { safe_join(@ects.map { |ect| govuk_link_to Teachers::Name.new(ect.teacher).full_name, schools_ect_path(ect)}, tag.br) }
       end; end %>
+    <h2 class="govuk-heading-m">ECT mentor training details</h2>
+
+    <% if @teacher.mentor_completion_date.nil? %>
+      <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do |card| %>
+        <%= govuk_summary_list do |list| %>
+          <% list.with_row do |row| %>
+            <% row.with_key { "Lead provider" } %>
+            <% row.with_value { "Some value" } %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+        <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do |card| %>
+        <%= govuk_summary_list do |list| %>
+          <% list.with_row do |row| %>
+            <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -8,53 +8,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-m">Mentor details</h2>
+    <%= render Schools::Mentors::DetailsComponent.new(
+      teacher: @teacher,
+      mentor: @mentor,
+      ects: @ects
+    ) %>
 
-    <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.with_row do |row| %>
-        <% row.with_key { 'Name' } %>
-        <% row.with_value { teacher_full_name(@teacher) } %>
-      <% end %>
-
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: 'Email address') %>
-        <% row.with_value(text: @mentor.email) %>
-      <% end %>
-
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: 'Assigned ECTs') %>
-        <% row.with_value { safe_join(@ects.map { |ect| govuk_link_to teacher_full_name(ect.teacher), schools_ect_path(ect) }, tag.br) } %>
-      <% end %>
-    <% end %>
-
-    <% if @ects.any? { |ect| ect.programme_type == "provider_led" } %>
-
-      <h2 class="govuk-heading-m">ECT mentor training details</h2>
-
-        <% if @teacher.mentor_completion_date.nil? %>
-          <%= govuk_summary_card(title: "Reported to us by your school", actions: [{ href: "#", text: "Lead provider" }]) do %>
-            <%= govuk_summary_list do |list| %>
-              <% list.with_row do |row| %>
-                <% row.with_key { "Lead provider" } %>
-                <% row.with_value { "Some value" } %>
-              <% end %>
-            <% end %>
-          <% end %>
-
-          <%= govuk_summary_card(title: "Reported to us by your lead provider", actions: [{ href: "#", text: "Lead provider" }]) do %>
-            <%= govuk_summary_list do |list| %>
-              <% list.with_row do |row| %>
-                <% row.with_value { "Your lead provider has not reported any information to us yet" } %>
-              <% end %>
-            <% end %>
-          <% end %>
-
-        <% else %>
-          <p class="govuk-body">
-            <%= teacher_full_name(@teacher) %> cannot do ECTE mentor training according to our records.
-            This could be because they’ve undertaken it before.
-          </p>
-        <% end %>
-    <% end %>
+    <%= render Schools::Mentors::ECTMentorTrainingDetailsComponent.new(
+          teacher: @teacher,
+          mentor: @mentor,
+          ects: @ects
+        ) %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
   end
 
   namespace :schools do
+    resources :mentors, only: %i[show]
     get "/home/ects", to: "ects#index", as: :ects_home
     get "/home/mentors", to: "mentors#index", as: :mentors_home
 

--- a/spec/components/schools/mentors/details_component_spec.rb
+++ b/spec/components/schools/mentors/details_component_spec.rb
@@ -30,7 +30,14 @@ RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
   end
 
   it 'renders links for assigned ECTs' do
-    expect(page).to have_link('Konohamaru Sarutobi', href: schools_ect_path(ect_period_1))
-    expect(page).to have_link('Boruto Uzumaki', href: schools_ect_path(ect_period_2))
+    expect(page).to have_link(
+      'Konohamaru Sarutobi',
+      href: schools_ect_path(ect_period_1, back_to_mentor: true, mentor_id: mentor.id)
+    )
+
+    expect(page).to have_link(
+      'Boruto Uzumaki',
+      href: schools_ect_path(ect_period_2, back_to_mentor: true, mentor_id: mentor.id)
+    )
   end
 end

--- a/spec/components/schools/mentors/details_component_spec.rb
+++ b/spec/components/schools/mentors/details_component_spec.rb
@@ -32,35 +32,39 @@ RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
            finished_on: nil)
   end
 
-  before do
-    create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
-    create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
+  context 'when there are ECTs assigned to the mentor' do
+    before do
+      create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
 
-    render_inline(described_class.new(teacher: mentor_teacher, mentor:))
-  end
+      render_inline(described_class.new(teacher: mentor_teacher, mentor:))
+    end
 
-  it 'renders the section heading' do
-    expect(page).to have_css('h2.govuk-heading-m', text: 'Mentor details')
-  end
+    it 'renders the section heading' do
+      expect(page).to have_css('h2.govuk-heading-m', text: 'Mentor details')
+    end
 
-  it 'shows the mentors name' do
-    expect(page).to have_text('Naruto Uzumaki')
-  end
+    it 'shows the mentors name' do
+      expect(page).to have_css('.govuk-summary-list__value', text: 'Naruto Uzumaki')
+    end
 
-  it 'shows the mentors email address' do
-    expect(page).to have_text(mentor.email)
-  end
+    it 'shows the mentors email address' do
+      expect(page).to have_css('.govuk-summary-list__value', text: mentor.email)
+    end
 
-  it 'renders links for assigned ECTs' do
-    expect(page).to have_link(
-      'Konohamaru Sarutobi',
-      href: schools_ect_path(ect_period_1, back_to_mentor: true, mentor_id: mentor.id)
-    )
+    it 'renders links for assigned ECTs' do
+      within('.govuk-summary-list__value') do
+        expect(page).to have_link(
+          'Konohamaru Sarutobi',
+          href: schools_ect_path(ect_period_1, back_to_mentor: true, mentor_id: mentor.id)
+        )
 
-    expect(page).to have_link(
-      'Boruto Uzumaki',
-      href: schools_ect_path(ect_period_2, back_to_mentor: true, mentor_id: mentor.id)
-    )
+        expect(page).to have_link(
+          'Boruto Uzumaki',
+          href: schools_ect_path(ect_period_2, back_to_mentor: true, mentor_id: mentor.id)
+        )
+      end
+    end
   end
 
   context 'when there are ECTs not assigned to this mentor' do
@@ -75,11 +79,21 @@ RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
 
     before do
       create(:mentorship_period, mentor: other_mentor, mentee: unrelated_ect, started_on:, finished_on: nil)
+      render_inline(described_class.new(teacher: mentor_teacher, mentor:))
     end
 
     it 'does not render ECTs assigned to other mentors' do
+      expect(page).not_to have_css('.govuk-summary-list__value', text: 'Sauske Uchiha')
+    end
+  end
+
+  context 'when there are no ECTs assigned to the mentor' do
+    before do
       render_inline(described_class.new(teacher: mentor_teacher, mentor:))
-      expect(rendered_content).not_to include('Sauske Uchiha')
+    end
+
+    it 'renders the no ECTS assigned text' do
+      expect(page).to have_css('.govuk-summary-list__value', text: 'No ECTs assigned')
     end
   end
 end

--- a/spec/components/schools/mentors/details_component_spec.rb
+++ b/spec/components/schools/mentors/details_component_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  before do
+    render_inline(described_class.new(teacher: mentor_teacher, mentor:, ects:))
+  end
+
+  let(:school) { create(:school) }
+  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:mentor) { create(:mentor_at_school_period, teacher: mentor_teacher, school:) }
+
+  let(:ect_teacher_1) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+  let(:ect_teacher_2) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
+
+  let(:ect_period_1) { create(:ect_at_school_period, teacher: ect_teacher_1, school:) }
+  let(:ect_period_2) { create(:ect_at_school_period, teacher: ect_teacher_2, school:) }
+
+  let(:ects) { [ect_period_1, ect_period_2] }
+
+  it 'renders the section heading' do
+    expect(page).to have_css('h2.govuk-heading-m', text: 'Mentor details')
+  end
+
+  it 'shows the mentors name' do
+    expect(page).to have_text('Naruto Uzumaki')
+  end
+
+  it 'shows the mentors email address' do
+    expect(page).to have_text(mentor.email)
+  end
+
+  it 'renders links for assigned ECTs' do
+    expect(page).to have_link('Konohamaru Sarutobi', href: schools_ect_path(ect_period_1))
+    expect(page).to have_link('Boruto Uzumaki', href: schools_ect_path(ect_period_2))
+  end
+end

--- a/spec/components/schools/mentors/details_component_spec.rb
+++ b/spec/components/schools/mentors/details_component_spec.rb
@@ -1,21 +1,43 @@
 RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  before do
-    render_inline(described_class.new(teacher: mentor_teacher, mentor:, ects:))
-  end
-
   let(:school) { create(:school) }
   let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
-  let(:mentor) { create(:mentor_at_school_period, teacher: mentor_teacher, school:) }
+  let(:started_on) { Date.new(2023, 9, 1) }
+
+  let(:mentor) do
+    create(:mentor_at_school_period,
+           teacher: mentor_teacher,
+           school:,
+           started_on:,
+           finished_on: nil)
+  end
 
   let(:ect_teacher_1) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
   let(:ect_teacher_2) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
 
-  let(:ect_period_1) { create(:ect_at_school_period, teacher: ect_teacher_1, school:) }
-  let(:ect_period_2) { create(:ect_at_school_period, teacher: ect_teacher_2, school:) }
+  let(:ect_period_1) do
+    create(:ect_at_school_period,
+           teacher: ect_teacher_1,
+           school:,
+           started_on:,
+           finished_on: nil)
+  end
 
-  let(:ects) { [ect_period_1, ect_period_2] }
+  let(:ect_period_2) do
+    create(:ect_at_school_period,
+           teacher: ect_teacher_2,
+           school:,
+           started_on:,
+           finished_on: nil)
+  end
+
+  before do
+    create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
+    create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
+
+    render_inline(described_class.new(teacher: mentor_teacher, mentor:))
+  end
 
   it 'renders the section heading' do
     expect(page).to have_css('h2.govuk-heading-m', text: 'Mentor details')
@@ -39,5 +61,25 @@ RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
       'Boruto Uzumaki',
       href: schools_ect_path(ect_period_2, back_to_mentor: true, mentor_id: mentor.id)
     )
+  end
+
+  context 'when there are ECTs not assigned to this mentor' do
+    let(:other_teacher) { create(:teacher, trs_first_name: 'Kakashi', trs_last_name: 'Hatake') }
+    let(:other_mentor) do
+      create(:mentor_at_school_period, teacher: other_teacher, school:, started_on:, finished_on: nil)
+    end
+    let(:unrelated_ect_teacher) { create(:teacher, trs_first_name: 'Sauske', trs_last_name: 'Uchiha') }
+    let(:unrelated_ect) do
+      create(:ect_at_school_period, teacher: unrelated_ect_teacher, school:, started_on:, finished_on: nil)
+    end
+
+    before do
+      create(:mentorship_period, mentor: other_mentor, mentee: unrelated_ect, started_on:, finished_on: nil)
+    end
+
+    it 'does not render ECTs assigned to other mentors' do
+      render_inline(described_class.new(teacher: mentor_teacher, mentor:))
+      expect(rendered_content).not_to include('Sauske Uchiha')
+    end
   end
 end

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
 
     it 'renders the summary cards' do
       render_inline(described_class.new(teacher:, mentor:))
-      expect(rendered_content).to have_css('h2', text: 'ECT mentor training details')
+      expect(rendered_content).to have_css('h2', text: 'ECTE mentor training details')
       expect(rendered_content).to have_text('Reported to us by your school')
       expect(rendered_content).to have_text('Reported to us by your lead provider')
     end

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -3,8 +3,9 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
   let(:mentor) { create(:mentor_at_school_period, teacher:, school:) }
   let(:teacher) { create(:teacher, mentor_completion_date: nil) }
 
-  context 'when teacher is eligible and there is a provider-led ECT' do
+  context 'when teacher is eligible and there is a provider-led ECT with a lead provider' do
     let(:provider_led_ect) { create(:ect_at_school_period, programme_type: 'provider_led', school:) }
+    let(:ect) { create(:ect_at_school_period, programme_type: "provider_led", lead_provider: create(:lead_provider, name: "Hidden leaf village")) }
 
     it 'renders the summary cards' do
       render_inline(described_class.new(teacher:, mentor:, ects: [provider_led_ect]))
@@ -12,6 +13,11 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
       expect(rendered_content).to have_css('h2', text: 'ECT mentor training details')
       expect(rendered_content).to have_text('Reported to us by your school')
       expect(rendered_content).to have_text('Reported to us by your lead provider')
+    end
+
+    it "shows the lead provider name from the first provider-led ECT" do
+      render_inline(described_class.new(teacher:, mentor:, ects: [ect]))
+      expect(rendered_content).to have_text("Hidden leaf village")
     end
   end
 

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :component do
+  let(:school) { create(:school) }
+  let(:mentor) { create(:mentor_at_school_period, teacher:, school:) }
+  let(:teacher) { create(:teacher, mentor_completion_date: nil) }
+
+  context 'when teacher is eligible and there is a provider-led ECT' do
+    let(:provider_led_ect) { create(:ect_at_school_period, programme_type: 'provider_led', school:) }
+
+    it 'renders the summary cards' do
+      render_inline(described_class.new(teacher:, mentor:, ects: [provider_led_ect]))
+
+      expect(rendered_content).to have_css('h2', text: 'ECT mentor training details')
+      expect(rendered_content).to have_text('Reported to us by your school')
+      expect(rendered_content).to have_text('Reported to us by your lead provider')
+    end
+  end
+
+  context 'when teacher is not eligible' do
+    let(:teacher) { create(:teacher, mentor_completion_date: Date.new(2024, 1, 1)) }
+    let(:provider_led_ect) { create(:ect_at_school_period, programme_type: 'provider_led', school:) }
+
+    it 'renders the ineligible message' do
+      render_inline(described_class.new(teacher:, mentor:, ects: [provider_led_ect]))
+
+      expect(rendered_content).to have_css('.govuk-body', text: /cannot do ECTE mentor training according to our records/)
+    end
+  end
+
+  context 'when all ECTs are school-led' do
+    let(:school_led_ect) { create(:ect_at_school_period, programme_type: 'school_led', lead_provider: nil, school:) }
+
+    it 'does not render' do
+      component = described_class.new(teacher:, mentor:, ects: [school_led_ect])
+
+      expect(component.render?).to be false
+    end
+  end
+end

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -1,43 +1,81 @@
 RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :component do
   let(:school) { create(:school) }
-  let(:mentor) { create(:mentor_at_school_period, teacher:, school:) }
+  let(:mentor_start_date) { Date.new(2023, 1, 1) }
+  let(:mentor) { create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date, finished_on: nil) }
   let(:teacher) { create(:teacher, mentor_completion_date: nil) }
 
   context 'when teacher is eligible and there is a provider-led ECT with a lead provider' do
-    let(:provider_led_ect) { create(:ect_at_school_period, programme_type: 'provider_led', school:) }
-    let(:ect) { create(:ect_at_school_period, programme_type: "provider_led", lead_provider: create(:lead_provider, name: "Hidden leaf village")) }
+    let(:lead_provider) { create(:lead_provider, name: 'Hidden leaf village') }
+    let(:ect_teacher) { create(:teacher) }
+    let(:ect_start_date) { mentor_start_date + 1.month }
+    let(:ect) do
+      create(:ect_at_school_period,
+             teacher: ect_teacher,
+             school:,
+             programme_type: 'provider_led',
+             lead_provider:,
+             started_on: ect_start_date,
+             finished_on: nil)
+    end
+
+    before do
+      create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+    end
 
     it 'renders the summary cards' do
-      render_inline(described_class.new(teacher:, mentor:, ects: [provider_led_ect]))
-
+      render_inline(described_class.new(teacher:, mentor:))
       expect(rendered_content).to have_css('h2', text: 'ECT mentor training details')
       expect(rendered_content).to have_text('Reported to us by your school')
       expect(rendered_content).to have_text('Reported to us by your lead provider')
     end
 
-    it "shows the lead provider name from the first provider-led ECT" do
-      render_inline(described_class.new(teacher:, mentor:, ects: [ect]))
+    it 'shows the lead provider name from the first provider-led ECT' do
+      render_inline(described_class.new(teacher:, mentor:))
       expect(rendered_content).to have_text("Hidden leaf village")
     end
   end
 
   context 'when teacher is not eligible' do
     let(:teacher) { create(:teacher, mentor_completion_date: Date.new(2024, 1, 1)) }
-    let(:provider_led_ect) { create(:ect_at_school_period, programme_type: 'provider_led', school:) }
+    let(:ect_teacher) { create(:teacher) }
+    let(:ect_start_date) { mentor_start_date + 1.month }
+    let(:ect) do
+      create(:ect_at_school_period,
+             teacher: ect_teacher,
+             school:,
+             programme_type: 'provider_led',
+             started_on: ect_start_date,
+             finished_on: nil)
+    end
+
+    before do
+      create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+    end
 
     it 'renders the ineligible message' do
-      render_inline(described_class.new(teacher:, mentor:, ects: [provider_led_ect]))
-
+      render_inline(described_class.new(teacher:, mentor:))
       expect(rendered_content).to have_css('.govuk-body', text: /cannot do ECTE mentor training according to our records/)
     end
   end
 
   context 'when all ECTs are school-led' do
-    let(:school_led_ect) { create(:ect_at_school_period, programme_type: 'school_led', lead_provider: nil, school:) }
+    let(:ect_teacher) { create(:teacher) }
+    let(:school_led_ect) do
+      create(:ect_at_school_period,
+             teacher: ect_teacher,
+             school:,
+             programme_type: 'school_led',
+             lead_provider: nil,
+             started_on: mentor_start_date + 1.month,
+             finished_on: nil)
+    end
+
+    before do
+      create(:mentorship_period, mentor:, mentee: school_led_ect, started_on: school_led_ect.started_on, finished_on: nil)
+    end
 
     it 'does not render' do
-      component = described_class.new(teacher:, mentor:, ects: [school_led_ect])
-
+      component = described_class.new(teacher:, mentor:)
       expect(component.render?).to be false
     end
   end

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe "Viewing a mentor" do
+  scenario 'Happy path' do
+    given_that_i_have_an_active_mentor
+    and_i_sign_in_as_a_school
+    when_i_visit_the_index_page
+    and_i_click_on_a_mentor
+    then_i_am_on_the_mentor_details_page
+
+    given_i_click_the_back_link
+    then_i_am_on_the_mentors_index_page
+  end
+
+private
+
+
+  def given_that_i_have_an_active_mentor_with_an_ect
+    start_date = Date.new(2023, 9, 1)
+
+    @school = create(:school, urn: '1234567')
+    @mentor_teacher = create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki')
+    @mentor = create(:mentor_at_school_period, teacher: @mentor_teacher, school: @school, started_on: start_date, finished_on: nil, id: 1)
+
+    @ect_teacher = create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki')
+    @ect = create(
+      :ect_at_school_period,
+      :provider_led,
+      teacher: @ect_teacher,
+      school: @school,
+      started_on: start_date,
+      finished_on: nil
+    )
+
+    create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
+  end
+
+  def given_i_click_on_an_assigned_ect
+    page.get_by_role('link', name: 'Boruto Uzumaki').click
+  end
+
+  def and_i_am_on_the_ect_details_page
+    expect(page.url).to end_with(schools_ect_path(@ect, back_to_mentor: true, mentor_id: @mentor.id))
+  end
+
+  def then_i_am_back_on_the_mentor_details_page
+    expect(page.url).to end_with(schools_mentor_path(@mentor))
+  end
+
+  def and_i_sign_in_as_a_school
+    sign_in_as_school_user(school: @school)
+  end
+
+  def when_i_visit_the_index_page
+    page.goto(schools_mentors_home_path)
+  end
+
+  def and_i_click_on_a_mentor
+    page.get_by_role('link', name: 'Naruto Uzumaki').click
+  end
+
+  def then_i_am_on_the_mentor_details_page
+    expect(page.url).to end_with('/schools/mentors/1')
+  end
+
+  def then_i_am_on_the_mentors_index_page
+    expect(page.url).to end_with('/schools/home/mentors')
+  end
+end

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -1,17 +1,21 @@
 RSpec.describe "Viewing a mentor" do
   scenario 'Happy path' do
-    given_that_i_have_an_active_mentor
+    given_that_i_have_an_active_mentor_with_an_ect
     and_i_sign_in_as_a_school
     when_i_visit_the_index_page
     and_i_click_on_a_mentor
     then_i_am_on_the_mentor_details_page
+
+    given_i_click_on_an_assigned_ect
+    and_i_am_on_the_ect_details_page
+    when_i_click_the_back_link
+    then_i_am_back_on_the_mentor_details_page
 
     given_i_click_the_back_link
     then_i_am_on_the_mentors_index_page
   end
 
 private
-
 
   def given_that_i_have_an_active_mentor_with_an_ect
     start_date = Date.new(2023, 9, 1)
@@ -58,7 +62,7 @@ private
   end
 
   def then_i_am_on_the_mentor_details_page
-    expect(page.url).to end_with('/schools/mentors/1')
+    expect(page.url).to end_with("/schools/mentors/#{@mentor.id}")
   end
 
   def then_i_am_on_the_mentors_index_page

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
 
   config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
+  config.include Features::ViewHelpers, type: :feature
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!

--- a/spec/support/features/view_helpers.rb
+++ b/spec/support/features/view_helpers.rb
@@ -1,0 +1,10 @@
+module Features
+  module ViewHelpers
+    def given_i_click_the_back_link
+      page.locator('a.govuk-back-link').click
+    end
+
+    alias_method :when_i_click_back_link, :given_i_click_the_back_link
+    alias_method :and_i_click_back_link, :given_i_click_the_back_link
+  end
+end

--- a/spec/support/features/view_helpers.rb
+++ b/spec/support/features/view_helpers.rb
@@ -4,7 +4,7 @@ module Features
       page.locator('a.govuk-back-link').click
     end
 
-    alias_method :when_i_click_back_link, :given_i_click_the_back_link
-    alias_method :and_i_click_back_link, :given_i_click_the_back_link
+    alias_method :when_i_click_the_back_link, :given_i_click_the_back_link
+    alias_method :and_i_click_the_back_link, :given_i_click_the_back_link
   end
 end

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -81,4 +81,22 @@ RSpec.describe 'schools/mentors/show.html.erb' do
       end
     end
   end
+
+  context 'when all ECTs are school-led' do
+    let(:ect_period) do
+      create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: end_date)
+    end
+
+    it 'does not render the ECT mentor training details H2' do
+      expect(rendered).not_to have_css('h2.govuk-heading-m', text: 'ECT mentor training details')
+    end
+
+    it 'does not render the school summary card' do
+      expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
+    end
+
+    it 'does not render the lead provider row' do
+      expect(rendered).not_to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+    end
+  end
 end

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -1,90 +1,110 @@
 RSpec.describe 'schools/mentors/show.html.erb' do
-  let(:programme_type) { 'provider_led' }
   let(:school) { create(:school) }
-  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
   let(:start_date) { Date.new(2023, 9, 1) }
-  let(:end_date)   { Date.new(2024, 7, 1) }
 
-  let(:mentor_period) do
-    create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: end_date)
+  let(:mentor_teacher) do
+    create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki', mentor_completion_date:)
   end
 
-  let(:ect_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+  let(:mentor_completion_date) { nil }
+
+  let(:mentor_period) do
+    create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: nil)
+  end
+
+  let(:lead_provider) { create(:lead_provider, name: 'Hidden leaf village') }
+
+  let(:ect_teacher) do
+    create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi')
+  end
 
   let(:ect_period) do
-    create(:ect_at_school_period, teacher: ect_teacher, school:, started_on: start_date, finished_on: end_date, lead_provider: create(:lead_provider, name: "Hidden leaf village"))
+    create(
+      :ect_at_school_period,
+      teacher: ect_teacher,
+      school:,
+      started_on: start_date,
+      finished_on: nil,
+      lead_provider:,
+      programme_type: 'provider_led'
+    )
   end
 
   let!(:mentorship_period) do
-    create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: end_date)
+    create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: nil)
   end
 
   before do
     assign(:mentor, mentor_period)
     assign(:teacher, mentor_teacher)
-    assign(:ects, [ect_period])
+    assign(:ects, mentor_period.currently_assigned_ects)
     render
   end
 
-  it 'renders the ECT mentor training details H2' do
-    expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECT mentor training details')
-  end
-
-  context 'when ECT is provider led' do
-    context 'when mentor_completion_date is not present' do
-      it 'renders the school summary card' do
-        expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
-      end
-
-      it 'renders the lead provider row with the correct label' do
-        expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
-      end
-
-      it 'renders the lead provider row with a value' do
-        expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Hidden leaf village')
-      end
-
-      it 'renders the lead provider summary card' do
-        expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
-      end
-
-      it 'shows the text that no information has been reported by the lead provider' do
-        expect(rendered).to have_text('Your lead provider has not reported any information to us yet')
-      end
+  context 'when mentor is eligible (no completion date)' do
+    it 'renders the ECT mentor training details H2' do
+      expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECT mentor training details')
     end
 
-    context 'when mentor_completion_date is present' do
-      let(:mentor_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi', mentor_completion_date: Date.new(2025, 4, 9)) }
+    it 'renders the school summary card' do
+      expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
+    end
 
-      it 'does not render the ect teacher cannot do training text' do
-        expect(rendered).to have_css('.govuk-body', text: /Konohamaru Sarutobi cannot do ECTE mentor training/)
-      end
+    it 'renders the lead provider row with the correct label' do
+      expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+    end
 
-      it 'does not render the school summary card' do
-        expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
-      end
+    it 'renders the lead provider row with a value' do
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Hidden leaf village')
+    end
 
-      it 'does not render the lead provider row with the correct label' do
-        expect(rendered).not_to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
-      end
+    it 'renders the lead provider summary card' do
+      expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
+    end
 
-      it 'does not render the lead provider row with a value' do
-        expect(rendered).not_to have_css('dd.govuk-summary-list__value', text: 'Some value')
-      end
+    it 'shows the text that no information has been reported by the lead provider' do
+      expect(rendered).to have_text('Your lead provider has not reported any information to us yet')
+    end
+  end
 
-      it 'does not render the lead provider summary card' do
-        expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
-      end
+  context 'when mentor is not eligible (has mentor_completion_date)' do
+    let(:mentor_completion_date) { Date.new(2024, 1, 1) }
 
-      it 'does not render the text that no information has been reported by the lead provider' do
-        expect(rendered).not_to have_text('Your lead provider has not reported any information to us yet')
-      end
+    it 'renders the ineligible message' do
+      expect(rendered).to have_css('.govuk-body', text: /Naruto Uzumaki cannot do ECTE mentor training/)
+    end
+
+    it 'does not render the school summary card' do
+      expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
+    end
+
+    it 'does not render the lead provider summary card' do
+      expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
+    end
+
+    it 'does not render the lead provider row with the correct label' do
+      expect(rendered).not_to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+    end
+
+    it 'does not render the lead provider row with a value' do
+      expect(rendered).not_to have_css('dd.govuk-summary-list__value', text: 'Hidden leaf village')
+    end
+
+    it 'does not show the no info text' do
+      expect(rendered).not_to have_text('Your lead provider has not reported any information to us yet')
     end
   end
 
   context 'when all ECTs are school-led' do
     let(:ect_period) do
-      create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: end_date)
+      create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
+    end
+
+    before do
+      assign(:mentor, mentor_period)
+      assign(:teacher, mentor_teacher)
+      assign(:ects, mentor_period.currently_assigned_ects)
+      render
     end
 
     it 'does not render the ECT mentor training details H2' do

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
 
   context 'when mentor is eligible (no completion date)' do
     it 'renders the ECT mentor training details H2' do
-      expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECT mentor training details')
+      expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECTE mentor training details')
     end
 
     it 'renders the school summary card' do

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
   let(:ect_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
 
   let(:ect_period) do
-    create(:ect_at_school_period, teacher: ect_teacher, school:, started_on: start_date, finished_on: end_date)
+    create(:ect_at_school_period, teacher: ect_teacher, school:, started_on: start_date, finished_on: end_date, lead_provider: create(:lead_provider, name: "Hidden leaf village"))
   end
 
   let!(:mentorship_period) do
@@ -41,7 +41,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
       end
 
       it 'renders the lead provider row with a value' do
-        expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Some value')
+        expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Hidden leaf village')
       end
 
       it 'renders the lead provider summary card' do

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe 'schools/mentors/show.html.erb' do
+  let(:programme_type) { 'provider_led' }
+  let(:school) { create(:school) }
+  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:start_date) { Date.new(2023, 9, 1) }
+  let(:end_date)   { Date.new(2024, 7, 1) }
+
+  let(:mentor_period) do
+    create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: end_date)
+  end
+
+  let(:ect_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+
+  let(:ect_period) do
+    create(:ect_at_school_period, teacher: ect_teacher, school:, started_on: start_date, finished_on: end_date)
+  end
+
+  let!(:mentorship_period) do
+    create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: end_date)
+  end
+
+  before do
+    assign(:mentor, mentor_period)
+    assign(:teacher, mentor_teacher)
+    assign(:ects, [ect_period])
+    render
+  end
+
+  it 'renders the ECT mentor training details H2' do
+    expect(rendered).to have_css('h2.govuk-heading-m', text: 'ECT mentor training details')
+  end
+
+  context 'when ECT is provider led' do
+    context 'when mentor_completion_date is not present' do
+      it 'renders the school summary card' do
+        expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
+      end
+
+      it 'renders the lead provider row with the correct label' do
+        expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+      end
+
+      it 'renders the lead provider row with a value' do
+        expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Some value')
+      end
+
+      it 'renders the lead provider summary card' do
+        expect(rendered).to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
+      end
+
+      it 'shows the text that no information has been reported by the lead provider' do
+        expect(rendered).to have_text('Your lead provider has not reported any information to us yet')
+      end
+    end
+
+    context 'when mentor_completion_date is present' do
+      let(:mentor_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi', mentor_completion_date: Date.new(2025, 4, 9)) }
+
+      it 'does not render the ect teacher cannot do training text' do
+        expect(rendered).to have_css('.govuk-body', text: /Konohamaru Sarutobi cannot do ECTE mentor training/)
+      end
+
+      it 'does not render the school summary card' do
+        expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your school')
+      end
+
+      it 'does not render the lead provider row with the correct label' do
+        expect(rendered).not_to have_css('dt.govuk-summary-list__key', text: 'Lead provider')
+      end
+
+      it 'does not render the lead provider row with a value' do
+        expect(rendered).not_to have_css('dd.govuk-summary-list__value', text: 'Some value')
+      end
+
+      it 'does not render the lead provider summary card' do
+        expect(rendered).not_to have_css('h2.govuk-summary-card__title', text: 'Reported to us by your lead provider')
+      end
+
+      it 'does not render the text that no information has been reported by the lead provider' do
+        expect(rendered).not_to have_text('Your lead provider has not reported any information to us yet')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This PR introduces the ability to view individual mentor details and full end to end navigation support between mentors and ECTs.

### Screenshots

#### If there are only school-led ECTs

<img width="800" alt="image" src="https://github.com/user-attachments/assets/a56f8d4b-6179-43c9-baeb-69751ca4b082" />

#### If there is at least one `provider-led` ECT **and** `mentor_completion_date` **is** `nil`

<img width="738" alt="image" src="https://github.com/user-attachments/assets/c8b8f83b-8e51-4aec-a176-16d7bee1cf73" />

#### If there is at least one `provider-led` ECT and `mentor_completion_date` **is not** `nil`

<img width="717" alt="image" src="https://github.com/user-attachments/assets/af3fcab5-a292-4034-80a6-22b15691bcf8" />




---

### What's new

- **New route, controller action, and view** for `/schools/mentors/:id`
- **Mentor summary details**: name, email, and list of assigned ECTs
- **ECT mentor training section**, rendered only when relevant (i.e. for `provider-led` ECTs)
- **Dynamic Back link navigation** between mentor show and ECT show pages
- **Helper methods** to enable easier testing
-  New `Schools::Mentors::DetailsComponent`
- New `Schools::Mentors::ECTMentorTrainingDetailsComponent`
**Conditionally render training section** if at least one ECT is `provider-led`

---

### Behaviour

When viewing a mentor:
- You'll see their details and a list of assigned ECTs
- If any ECTs are **provider-led**, the "ECT mentor training details" section will render
- If the ECT has already completed training (`mentor_completion_date` is present), a message will be shown instead of the cards

When clicking on an ECT:
- You land on the ECT details page with a dynamic **back link**
- That link takes you back to the mentor you came from

---


### How to test

1. Navigate to `/schools/home/mentors`
2. Click on a mentor (e.g. Emma Thompson)
3. View their summary and assigned ECTs
4. Click an ECT (e.g. Hugh Grant)
5. Click the back link - you should land back on the mentor show page
6. Click back again - you should return to the mentors index page

---

Let me know if you'd like me to split anything into a separate PR, but this keeps everything tightly scoped and tested in one PR.