### PR TITLE
Only write a TRS attrs updated event when things change

### DIFF
--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -110,6 +110,8 @@ private
   end
 
   def record_teacher_trs_attribute_update(modifications:)
+    return if modifications.empty?
+
     Events::Record.teacher_attributes_updated_from_trs!(author:, teacher:, modifications:)
   end
 end

--- a/db/scripts/remove_blank_teacher_attributes_updated_from_trs_events.rb
+++ b/db/scripts/remove_blank_teacher_attributes_updated_from_trs_events.rb
@@ -1,0 +1,13 @@
+# Remove blank teacher_attributes_updated_from_trs events
+#
+# We recorded events where the modifications hash was empty which adds noise
+# to timelines. The fix was made in #471 and this script will clear out the
+# empty events
+
+Event.transaction do
+  # Empty JSON object when converted to varchar is '{}'
+  Event
+    .where(event_type: 'teacher_attributes_updated_from_trs')
+    .where('length(modifications::varchar) = 2')
+    .delete_all
+end


### PR DESCRIPTION
We currently write the event regardless of whether anything actually changed.

This change skips the event recording when the modifications hash is empty. It also adds some more specs
