### PR TITLE
[1344] Update mentor list and mentor details page to show assigned ECTs

### DIFF
--- a/app/components/schools/mentors/summary_component.rb
+++ b/app/components/schools/mentors/summary_component.rb
@@ -1,0 +1,50 @@
+module Schools
+  module Mentors
+    class SummaryComponent < ViewComponent::Base
+      include TeacherHelper
+
+      def initialize(mentor:, school:)
+        @mentor = mentor
+        @school = school
+      end
+
+      def call
+        govuk_summary_card(title: link_to_mentor(@mentor)) do |card|
+          card.with_summary_list(
+            classes: %w[govuk-summary-list--no-border],
+            rows: [trn_row, assigned_ects_row]
+          )
+        end
+      end
+
+    private
+
+      def link_to_mentor(mentor)
+        govuk_link_to(teacher_full_name(mentor.teacher), schools_mentor_path(mentor))
+      end
+
+      def trn_row
+        { key: { text: 'TRN' }, value: { text: trn } }
+      end
+
+      def assigned_ects_row
+        { key: { text: 'Assigned ECTs' }, value: { text: assigned_ects_summary } }
+      end
+
+      def trn
+        @mentor.teacher.trn
+      end
+
+      def assigned_ects
+        @assigned_ects ||= @mentor.currently_assigned_ects
+      end
+
+      def assigned_ects_summary
+        return "No ECTs assigned" if assigned_ects.empty?
+        return "#{assigned_ects.count} assigned ECTs" if assigned_ects.count > 5
+
+        safe_join(assigned_ects.map { |ect| teacher_full_name(ect.teacher) }, tag.br)
+      end
+    end
+  end
+end

--- a/app/components/schools/mentors/summary_component.rb
+++ b/app/components/schools/mentors/summary_component.rb
@@ -9,7 +9,7 @@ module Schools
       end
 
       def call
-        govuk_summary_card(title: link_to_mentor(@mentor)) do |card|
+        govuk_summary_card(title: link_to_mentor) do |card|
           card.with_summary_list(
             classes: %w[govuk-summary-list--no-border],
             rows: [trn_row, assigned_ects_row]
@@ -19,8 +19,8 @@ module Schools
 
     private
 
-      def link_to_mentor(mentor)
-        govuk_link_to(teacher_full_name(mentor.teacher), schools_mentor_path(mentor))
+      def link_to_mentor
+        govuk_link_to(teacher_full_name(@mentor.teacher), schools_mentor_path(@mentor))
       end
 
       def trn_row

--- a/app/components/schools/mentors/summary_component.rb
+++ b/app/components/schools/mentors/summary_component.rb
@@ -20,7 +20,7 @@ module Schools
     private
 
       def link_to_mentor
-        govuk_link_to(teacher_full_name(@mentor.teacher), schools_mentor_path(@mentor))
+        govuk_link_to(teacher_full_name(@mentor.teacher), '#')
       end
 
       def trn_row

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -7,6 +7,10 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_many :mentorship_periods, inverse_of: :mentor
   has_many :training_periods, inverse_of: :mentor_at_school_period
   has_many :events
+  has_many :currently_assigned_ects,
+           -> { ongoing.includes(:teacher) },
+           through: :mentorship_periods,
+           source: :mentee
 
   # Validations
   validates :email,

--- a/app/views/schools/mentors/index.html.erb
+++ b/app/views/schools/mentors/index.html.erb
@@ -19,14 +19,7 @@
 
   <div class='govuk-grid-column-two-thirds'>
     <% @mentors.map do |mentor| %>
-      <%= 
-        govuk_summary_card(title: link_to_mentor(mentor)) do |card|
-          card.with_summary_list(
-            classes: %w[govuk-summary-list--no-border govuk-!-margin-bottom-0],
-            rows: []
-          )
-        end 
-      %>
+      <%= render Schools::Mentors::SummaryComponent.new(mentor: mentor, school: @school) %>
     <% end %>
 
     <%= govuk_pagination pagy: @pagy %>

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
+  let(:school) { create(:school) }
+  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:started_on) { Date.new(2023, 9, 1) }
+  let(:mentor) { create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on:, finished_on: nil) }
+
+  context 'with no ECTs' do
+    it 'shows No ECTs assigned' do
+      render_inline(described_class.new(mentor:, school:))
+      expect(rendered_content).to have_css('.govuk-summary-list__row', text: 'Assigned ECTs')
+      expect(rendered_content).to have_css('.govuk-summary-list__value', text: 'No ECTs assigned')
+    end
+  end
+
+  context 'with less than or equal to 5 ECTs' do
+    let!(:ects) do
+      (1..5).map do |i|
+        teacher = create(:teacher, trs_first_name: "First name #{i}", trs_last_name: "Last name #{i}")
+        ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
+        create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
+        teacher
+      end
+    end
+
+    it 'lists ECT names' do
+      render_inline(described_class.new(mentor:, school:))
+
+      ects.each do |teacher|
+        expect(rendered_content).to include("#{teacher.trs_first_name} #{teacher.trs_last_name}")
+      end
+    end
+  end
+
+  context 'with more than 5 ECTs' do
+    before do
+      (1..6).each do |i|
+        teacher = create(:teacher, trs_first_name: "First#{i}", trs_last_name: "Last#{i}")
+        ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
+        create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
+      end
+    end
+
+    it 'shows ECT count instead of listing names' do
+      render_inline(described_class.new(mentor:, school:))
+      expect(rendered_content).to have_css('.govuk-summary-list__value', text: '6 assigned ECTs')
+    end
+  end
+
+  context 'when there are multiple mentors' do
+    let(:mentor2_teacher) { create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
+    let(:mentor2) { create(:mentor_at_school_period, teacher: mentor2_teacher, school:, started_on:, finished_on: nil) }
+
+    let(:ect1_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+    let(:ect2_teacher) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
+
+    let(:ect1) { create(:ect_at_school_period, teacher: ect1_teacher, school:, started_on:, finished_on: nil) }
+    let(:ect2) { create(:ect_at_school_period, teacher: ect2_teacher, school:, started_on:, finished_on: nil) }
+
+    before do
+      create(:mentorship_period, mentor:, mentee: ect1, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor: mentor2, mentee: ect2, started_on:, finished_on: nil)
+    end
+
+    it 'only shows ECTs assigned to the specific mentor' do
+      render_inline(described_class.new(mentor:, school:))
+      expect(rendered_content).to have_css('.govuk-summary-list__value', text: 'Konohamaru Sarutobi')
+      expect(rendered_content).not_to have_css('.govuk-summary-list__value', text: 'Boruto Uzumaki')
+    end
+  end
+end

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'with more than 5 ECTs' do
     before do
-      (1..6).each do |i|
+      6.times do |i|
         teacher = create(:teacher, trs_first_name: "First#{i}", trs_last_name: "Last#{i}")
         ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
         create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
@@ -48,7 +48,7 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'when there are multiple mentors' do
     let(:mentor2_teacher) { create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
-    let(:mentor2) { create(:mentor_at_school_period, teacher: mentor2_teacher, school:, started_on:, finished_on: nil) }
+    let(:mentor2) { create(:mentor_at_school_period, :active, teacher: mentor2_teacher, school:, started_on:) }
 
     let(:ect1_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
     let(:ect2_teacher) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'with less than or equal to 5 ECTs' do
     let!(:ects) do
-      (1..5).map do |i|
-        teacher = create(:teacher, trs_first_name: "First name #{i}", trs_last_name: "Last name #{i}")
+      create_list(:teacher, 5).map do |teacher|
         ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
         create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
         teacher
@@ -26,15 +25,14 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
       render_inline(described_class.new(mentor:, school:))
 
       ects.each do |teacher|
-        expect(rendered_content).to include("#{teacher.trs_first_name} #{teacher.trs_last_name}")
+        expect(rendered_content).to have_css('.govuk-summary-list__value', text: "#{teacher.trs_first_name} #{teacher.trs_last_name}")
       end
     end
   end
 
   context 'with more than 5 ECTs' do
     before do
-      6.times do |i|
-        teacher = create(:teacher, trs_first_name: "First#{i}", trs_last_name: "Last#{i}")
+      create_list(:teacher, 6).each do |teacher|
         ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
         create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
       end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -5,6 +5,7 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to have_many(:mentorship_periods).inverse_of(:mentor) }
     it { is_expected.to have_many(:training_periods) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_many(:currently_assigned_ects).through(:mentorship_periods).source(:mentee) }
   end
 
   describe "validations" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure do |config|
   ]
 
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include FactoryBot::Syntax::Methods
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
### Context

This PR updates the mentors index page to display the mentor's TRN and their currently assigned ECTs. 

To keep the view clean and maintainable, the summary card has been extracted into a dedicated SummaryComponent.

**Note:** The last commit with the route, is only here to make the view work. It's part of #464, so there's no need to review that commit.

### Before/After

| Before | After |
|--------|-------|
|<img width="759" alt="image" src="https://github.com/user-attachments/assets/b0adfdbb-7851-49d6-8882-2413788b5aec" />|<img width="821" alt="image" src="https://github.com/user-attachments/assets/1fd90426-22d0-435d-ad00-3d3228d1e010" />|