### PR TITLE
Add list of modifications to the timeline

### DIFF
--- a/app/components/timeline_component.rb
+++ b/app/components/timeline_component.rb
@@ -45,7 +45,18 @@ class TimelineComponent < ViewComponent::Base
     end
 
     def description
-      tag.div(class: "app-timeline__description") { event.body }
+      tag.div(class: "app-timeline__description") { safe_join([event.body, modifications_list]) }
+    end
+
+    def modifications_list
+      return if event.modifications.blank?
+
+      safe_join(
+        [
+          tag.h3('Changes', class: 'govuk-heading-s'),
+          govuk_list(event.modifications)
+        ]
+      )
     end
 
     def byline

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -31,4 +31,28 @@ RSpec.describe TimelineComponent, type: :component do
       expect(rendered_content).to have_css(".app-timeline__item > .app-timeline__description", text: event.body)
     end
   end
+
+  describe 'modifications' do
+    context 'when modifications are present' do
+      let(:one_day_ago) { FactoryBot.build(:event, :with_body, :with_modifications, created_at: 3.days.ago) }
+
+      it "renders a 'Changes' heading" do
+        expect(rendered_content).to have_css('h3', text: 'Changes')
+      end
+
+      it "lists modifications when they're present" do
+        expect(rendered_content).to have_css('.govuk-list', text: 'Something has changed')
+      end
+    end
+
+    context 'when no modifications are present' do
+      it "renders no heading" do
+        expect(rendered_content).not_to have_css('h3', text: 'Changes')
+      end
+
+      it "renders no list" do
+        expect(rendered_content).not_to have_css('.govuk-list')
+      end
+    end
+  end
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -20,5 +20,9 @@ FactoryBot.define do
     trait(:with_body) do
       body { Faker::Lorem.paragraph }
     end
+
+    trait(:with_modifications) do
+      modifications { ["Something has changed"] }
+    end
   end
 end


### PR DESCRIPTION
We have been recording a list of what changed on a record for certain event types for a while, but not exposing that data in the timeline.

This change just adds a 'Changes' header with a list of the changes pulled directly from the modifications column. When there are no modifications listed neither the heading or list are rendered.


Preview

![image](https://github.com/user-attachments/assets/521f6279-fe58-49b6-b97b-acad5ef726d1)



## How the real change data looks

* TRS QTS awarded on set to '14 Jan 2024'
* TRS QTS status description set to 'Qualified'
* TRS initial teacher training provider name set to 'Something'


