### PR TITLE
Change sorting on schools' ECT index page

### DIFF
--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -3,7 +3,7 @@ module Schools
     layout "full"
 
     def index
-      @ects = Schools::Home.new(school:).ects_with_mentors
+      @pagy, @teachers = pagy_array(Teachers::Search.new(ect_at_school: school).search)
     end
 
     def show

--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -7,6 +7,7 @@ module Schools
     end
 
     def show
+      # FIXME: restrict this to ECTAtSchoolPeriods belonging to the current school
       @ect = ::ECTAtSchoolPeriod.find(params[:id])
     end
   end

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -11,10 +11,14 @@ module Teachers
     end
 
     def search
-      scope.order(:trs_last_name, :trs_first_name, :id)
+      scope.order(order)
     end
 
   private
+
+    def order
+      %i[trs_last_name trs_first_name id]
+    end
 
     def matching(query_string)
       return if query_string == :ignore

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -2,9 +2,10 @@ module Teachers
   class Search
     attr_reader :scope
 
-    def initialize(query_string: :ignore, appropriate_bodies: :ignore)
+    def initialize(query_string: :ignore, appropriate_bodies: :ignore, ect_at_school: :ignore)
       @scope = Teacher.all
 
+      where_ect_at(ect_at_school)
       where_appropriate_bodies_in(appropriate_bodies)
       matching(query_string)
     end
@@ -38,6 +39,16 @@ module Teachers
       return if query_string.blank?
 
       @scope.merge!(@scope.search(query_string))
+    end
+
+    def where_ect_at(school)
+      return if school == :ignore
+
+      @scope.merge!(
+        @scope.eager_load(ect_at_school_periods: [:school, { mentorship_periods: { mentor: :teacher } }])
+              .where(ect_at_school_periods: { school: })
+              .merge(ECTAtSchoolPeriod.ongoing)
+      )
     end
   end
 end

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class='govuk-grid-column-two-thirds'>
-    <% @ects.map do |ect| %>
+    <% @teachers.map { |t| t.ect_at_school_periods.first }.each do |ect| %>
       <%=
         govuk_summary_card(title: link_to_ect(ect)) do |card|
           card.with_summary_list(
@@ -31,5 +31,7 @@
         end
       %>
     <% end %>
+
+    <%= govuk_pagination(pagy: @pagy) %>
   </div>
 </div>

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -1,10 +1,10 @@
-<% 
+<%
   page_data(
-    title: "Early career teachers (ECT)", 
-    error: false, 
-    caption: @school.name, 
+    title: "Early career teachers (ECT)",
+    error: false,
+    caption: @school.name,
     caption_size: 'l'
-  ) 
+  )
 %>
 
 <%= govuk_button_link_to("Add an ECT", schools_register_ect_wizard_start_path) %>
@@ -19,16 +19,16 @@
 
   <div class='govuk-grid-column-two-thirds'>
     <% @ects.map do |ect| %>
-      <%= 
+      <%=
         govuk_summary_card(title: link_to_ect(ect)) do |card|
           card.with_summary_list(
-            classes: %w[govuk-summary-list--no-border govuk-!-margin-bottom-0],
+            borders: false,
             rows: [
               { key: { text: 'Status' }, value: { text: ect_status(ect) } },
               { key: { text: 'Mentor' }, value: { text: ect_mentor_details(ect) } },
             ]
           )
-        end 
+        end
       %>
     <% end %>
   </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,5 +4,5 @@ require 'pagy/extras/size'
 
 Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
 Pagy::DEFAULT[:size] = [1, 1, 1, 1].freeze
-Pagy::DEFAULT[:limit] = 10
+Pagy::DEFAULT[:limit] = 20
 Pagy::DEFAULT.freeze

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
       end
 
       context "when there are more than 10 claimed ECTs" do
+        # FIXME: move this to a view spec
         let!(:additional_teachers) do
-          FactoryBot.create_list(:teacher, 11, trs_first_name: "John", trs_last_name: "Smith").tap do |teachers|
+          FactoryBot.create_list(:teacher, 21, trs_first_name: "John", trs_last_name: "Smith").tap do |teachers|
             teachers.each do |teacher|
               FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:)
             end

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -9,20 +9,20 @@ describe Teachers::Search do
     end
 
     context 'with appropriate_bodies parameter' do
-      subject { described_class.new(appropriate_bodies: ab) }
+      context 'when there is one appropriate body' do
+        subject { described_class.new(appropriate_bodies: 123) }
 
-      let(:ab) { FactoryBot.create(:appropriate_body) }
-      let(:ects_service) { instance_double(AppropriateBodies::ECTs) }
-      let(:ects_scope) { instance_double(ActiveRecord::Relation) }
-
-      before do
-        allow(AppropriateBodies::ECTs).to receive(:new).with(ab).and_return(ects_service)
-        allow(ects_service).to receive(:current_or_completed_while_at_appropriate_body).and_return(ects_scope)
+        it 'applies appropriate_bodies filter for the given appropriate body' do
+          expect(subject.search.to_sql).to include(%(INNER JOIN "induction_periods" ON "induction_periods"."teacher_id" = "teachers"."id" WHERE "induction_periods"."appropriate_body_id" = 123))
+        end
       end
 
-      it 'applies appropriate_bodies filter' do
-        subject
-        expect(AppropriateBodies::ECTs).to have_received(:new).with(ab)
+      context 'when there are multiple appropriate bodies' do
+        subject { described_class.new(appropriate_bodies: [123, 456]) }
+
+        it 'applies appropriate_bodies filter for all specified appropriate bodies' do
+          expect(subject.search.to_sql).to include(%(INNER JOIN "induction_periods" ON "induction_periods"."teacher_id" = "teachers"."id" WHERE "induction_periods"."appropriate_body_id" IN (123, 456)))
+        end
       end
     end
 

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -46,6 +46,38 @@ describe Teachers::Search do
         expect { described_class.new(query_string: nil) }.not_to raise_error
       end
     end
+
+    describe 'ect_at_school parameter' do
+      context 'when one school is present' do
+        it 'only selects ECTs who are currently at the given school' do
+          query = Teachers::Search.new(ect_at_school: 123).search
+
+          expect(query.to_sql).to include(%("ect_at_school_periods"."school_id" = 123))
+        end
+
+        it 'only selects ongoing ECT at school periods' do
+          query = Teachers::Search.new(ect_at_school: 123).search
+
+          expect(query.to_sql).to include(%("ect_at_school_periods"."finished_on" IS NULL))
+        end
+      end
+
+      context 'when multiple schools are present' do
+        it 'only selects ECTs who are currently at the given school' do
+          query = Teachers::Search.new(ect_at_school: [123, 456]).search
+
+          expect(query.to_sql).to include(%{"ect_at_school_periods"."school_id" IN (123, 456)})
+        end
+      end
+
+      context 'when absent' do
+        it 'does not join ect_at_school_periods' do
+          query = Teachers::Search.new(ect_at_school: 123).search
+
+          expect(query).not_to include('ect_at_school_periods')
+        end
+      end
+    end
   end
 
   describe '#search' do

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -8,74 +8,9 @@ describe Teachers::Search do
       end
     end
 
-    context 'with appropriate_bodies parameter' do
-      context 'when there is one appropriate body' do
-        subject { described_class.new(appropriate_bodies: 123) }
-
-        it 'applies appropriate_bodies filter for the given appropriate body' do
-          expect(subject.search.to_sql).to include(%(INNER JOIN "induction_periods" ON "induction_periods"."teacher_id" = "teachers"."id" WHERE "induction_periods"."appropriate_body_id" = 123))
-        end
-      end
-
-      context 'when there are multiple appropriate bodies' do
-        subject { described_class.new(appropriate_bodies: [123, 456]) }
-
-        it 'applies appropriate_bodies filter for all specified appropriate bodies' do
-          expect(subject.search.to_sql).to include(%(INNER JOIN "induction_periods" ON "induction_periods"."teacher_id" = "teachers"."id" WHERE "induction_periods"."appropriate_body_id" IN (123, 456)))
-        end
-      end
-    end
-
-    context 'with query_string parameter' do
-      subject { described_class.new(query_string: 'Unique Name') }
-
-      let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Unique', trs_last_name: 'Name') }
-
-      before do
-        allow(Teacher).to receive(:search).and_return(Teacher.where(id: teacher.id))
-      end
-
-      it 'applies query matching' do
-        expect(subject.scope).to include(teacher)
-        expect(subject.scope.count).to eq(1)
-      end
-    end
-
     context 'with nil query_string' do
       it 'ignores nil query strings' do
         expect { described_class.new(query_string: nil) }.not_to raise_error
-      end
-    end
-
-    describe 'ect_at_school parameter' do
-      context 'when one school is present' do
-        it 'only selects ECTs who are currently at the given school' do
-          query = Teachers::Search.new(ect_at_school: 123).search
-
-          expect(query.to_sql).to include(%("ect_at_school_periods"."school_id" = 123))
-        end
-
-        it 'only selects ongoing ECT at school periods' do
-          query = Teachers::Search.new(ect_at_school: 123).search
-
-          expect(query.to_sql).to include(%("ect_at_school_periods"."finished_on" IS NULL))
-        end
-      end
-
-      context 'when multiple schools are present' do
-        it 'only selects ECTs who are currently at the given school' do
-          query = Teachers::Search.new(ect_at_school: [123, 456]).search
-
-          expect(query.to_sql).to include(%{"ect_at_school_periods"."school_id" IN (123, 456)})
-        end
-      end
-
-      context 'when absent' do
-        it 'does not join ect_at_school_periods' do
-          query = Teachers::Search.new(ect_at_school: 123).search
-
-          expect(query).not_to include('ect_at_school_periods')
-        end
       end
     end
   end

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -139,9 +139,9 @@ describe Teachers::Search do
 
       context 'when absent' do
         it 'does not join ect_at_school_periods' do
-          query = Teachers::Search.new(ect_at_school: 123).search
+          query = Teachers::Search.new.search
 
-          expect(query).not_to include('ect_at_school_periods')
+          expect(query.to_sql).not_to include('ect_at_school_periods')
         end
       end
 


### PR DESCRIPTION
This change was more difficult that originally thought.

As outlined in [this comment](https://github.com/DFE-Digital/register-ects-project-board/issues/1266#issuecomment-2809341690), sorting ECTs by whether they have a mentor is complex.


| Before | After (2 items per page for demo purposes) |
| ----- | ------ |
| ![image](https://github.com/user-attachments/assets/517bca44-1400-46b9-8dfd-5ffe2484d695) |![Screenshot From 2025-04-17 14-56-37](https://github.com/user-attachments/assets/3444252a-1f81-4735-9eef-9b50e5572263) |
 
## Changes

1. Make the ECT index page use `Teachers::Search`
2. Allow `Teachers::Search` to find teachers who are currently ECTs at a school
3. Add a custom sort order so we can put mentorless ECTs first, and then sort by most-recently registered
4. change the global pagination 'per page' setting to 20 (ok'd with @emily-prudence-dfe)

## Notes

1. The view isn't idea. It currently is based around `@ects` rather than `@teachers` which doesn't really make sense as it's a list of teachers. I'll raise an issue to refactor that 
2. Due to the item above, it's a bit of a pain to test pagination in a view spec.
3. I added a FIXME to an unrelated pagination spec that will be done as a follow up
4. I suggest reviewing commit by commit, they're quite concise

Fixes DFE-Digital/register-ects-project-board#1266