### PR TITLE
Remove `plpgsql` from `azure_extensions`

### DIFF
--- a/config/terraform/application/database.tf
+++ b/config/terraform/application/database.tf
@@ -12,7 +12,7 @@ module "postgres" {
   azure_enable_monitoring        = var.enable_monitoring
   azure_enable_backup_storage    = var.azure_enable_backup_storage
   server_version                 = "16"
-  azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm", "unaccent"]
+  azure_extensions               = ["btree_gin", "citext", "pg_trgm", "unaccent"]
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_maintenance_window       = var.azure_maintenance_window
@@ -34,7 +34,7 @@ module "postgres-snapshot" {
   azure_enable_monitoring        = false
   azure_enable_backup_storage    = false
   server_version                 = "16"
-  azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm", "unaccent"]
+  azure_extensions               = ["btree_gin", "citext", "pg_trgm", "unaccent"]
   azure_enable_high_availability = false
   azure_sku_name                 = var.postgres_snapshot_flexible_server_sku
 }


### PR DESCRIPTION
### Context

Remove `plpgsql` from `azure_extensions`.

This is causing deploys to fail with the error `ServerParameterToCMSUnAllowedParameterValue`.

Azure treats `plpgsql` like a system level feature, so it should not be included manually.

See corresponding PR for NPQ: https://github.com/DFE-Digital/npq-registration/pull/2403