### PR TITLE
Fix flaky spec in main by setting `random number_of_terms` to `1` in factory

### DIFF
--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     started_on { 1.year.ago }
     finished_on { 1.month.ago }
-    number_of_terms { Faker::Number.within(range: 1..6) }
+    number_of_terms { 1 }
     induction_programme { "fip" }
 
     trait :active do

--- a/spec/services/admin/update_induction_period_spec.rb
+++ b/spec/services/admin/update_induction_period_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
       :induction_period,
       teacher:,
       started_on: "2023-06-01",
-      finished_on: "2023-12-31",
-      number_of_terms: 2
+      finished_on: "2023-12-31"
     )
   end
   let(:params) { {} }


### PR DESCRIPTION
### Context

We have a flakey spec in `spec/services/admin/update_induction_period_spec.rb:43`

The factory sets a `random number_of_terms` between `1` and `6`, which sometimes matches the expected value of `4` in a test. This caused the `.to change` matcher to fail since the value didn't actually change.


### Proposed Fix

There is no value in setting this number dynamically so we are setting it to `1` in the factory as that is the most common `number_of_terms`.