### PR TITLE
Add disaster recovery hint to app config

### DIFF
--- a/config/terraform/application/application.tf
+++ b/config/terraform/application/application.tf
@@ -55,6 +55,11 @@ module "web_application" {
   max_memory = var.webapp_memory_max
 
   enable_logit = var.enable_logit
+
+  # Uncomment this when we want traffic to be redirected to the maintenance
+  # page during disaster recovery (i.e., while waiting for a database to be
+  # recreated)
+  # send_traffic_to_maintenance_page = true
 }
 
 module "worker_application" {


### PR DESCRIPTION
Set `send_traffic_to_maintenance_page = true` can be used to send traffic to the maintenance page regardless of the app's state. Leaving it in the config as when we need it it might not be obvious where to put it, etc
