### PR TITLE
[1500] Make extensions visible on the claim ECT record check page

### DIFF
--- a/app/helpers/appropriate_body_helper.rb
+++ b/app/helpers/appropriate_body_helper.rb
@@ -56,6 +56,16 @@ module AppropriateBodyHelper
     end
   end
 
+  def induction_extensions(teacher)
+    return if teacher.blank?
+
+    @induction_extensions ||= Teachers::InductionExtensions.new(teacher)
+  end
+
+  def show_extensions_row?(teacher)
+    induction_extensions(teacher)&.extended?
+  end
+
 private
 
   def pending_induction_submission_full_name(pending_induction_submission)

--- a/app/services/teachers/induction_extensions.rb
+++ b/app/services/teachers/induction_extensions.rb
@@ -12,7 +12,7 @@ class Teachers::InductionExtensions
   def formatted_number_of_terms
     return "None" if number_of_terms.zero?
 
-    [number_of_terms, "term".pluralize(number_of_terms.round)].join(" ")
+    "#{number_of_terms} #{'term'.pluralize(number_of_terms)}"
   end
 
   def extended?

--- a/app/services/teachers/induction_extensions.rb
+++ b/app/services/teachers/induction_extensions.rb
@@ -22,6 +22,6 @@ class Teachers::InductionExtensions
 private
 
   def number_of_terms
-    teacher.induction_extensions.sum(&:number_of_terms)
+    teacher.induction_extensions.sum(:number_of_terms)
   end
 end

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -84,13 +84,14 @@
       )
     end if @pending_induction_submission.trs_induction_status.present?
 
-    extensions = @teacher && Teachers::InductionExtensions.new(@teacher)
-    sl.with_row do |r|
+  if show_extensions_row?(@teacher)
+      sl.with_row do |r| 
       r.with_key(text: "Extensions")
-      r.with_value(text: extensions.formatted_number_of_terms)
-    end if extensions&.extended?
-  end
-%>
+      r.with_value(text: induction_extensions(@teacher).formatted_number_of_terms)
+    end
+ end
+
+  end %>
 
 <% if @teacher.present? %>
   <%= render Teachers::DetailsComponent.new(mode: :appropriate_body, teacher: @teacher) do |component|

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -84,14 +84,14 @@
       )
     end if @pending_induction_submission.trs_induction_status.present?
 
-  if show_extensions_row?(@teacher)
-      sl.with_row do |r| 
-      r.with_key(text: "Extensions")
-      r.with_value(text: induction_extensions(@teacher).formatted_number_of_terms)
+    if show_extensions_row?(@teacher)
+      sl.with_row do |r|
+        r.with_key(text: "Extensions")
+        r.with_value(text: induction_extensions(@teacher).formatted_number_of_terms)
+      end
     end
- end
-
-  end %>
+  end
+%>
 
 <% if @teacher.present? %>
   <%= render Teachers::DetailsComponent.new(mode: :appropriate_body, teacher: @teacher) do |component|

--- a/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb
@@ -83,6 +83,12 @@
         )
       )
     end if @pending_induction_submission.trs_induction_status.present?
+
+    extensions = @teacher && Teachers::InductionExtensions.new(@teacher)
+    sl.with_row do |r|
+      r.with_key(text: "Extensions")
+      r.with_value(text: extensions.formatted_number_of_terms)
+    end if extensions&.extended?
   end
 %>
 

--- a/spec/services/teachers/induction_extensions_spec.rb
+++ b/spec/services/teachers/induction_extensions_spec.rb
@@ -22,22 +22,28 @@ describe Teachers::InductionExtensions do
       allow(teacher.induction_extensions).to receive(:sum).and_return(total)
     end
 
-    context "when gt 1" do
+    context "when greater than 1" do
       let(:total) { 5.1 }
 
       it { expect(formatted_number_of_terms).to eql("#{total} terms") }
     end
 
-    context "when lt 1" do
+    context "when less than 1" do
       let(:total) { 0.777777 }
+
+      it { expect(formatted_number_of_terms).to eql("#{total} terms") }
+    end
+
+    context "when 1" do
+      let(:total) { 1.0 }
 
       it { expect(formatted_number_of_terms).to eql("#{total} term") }
     end
 
-    context "when eq 1" do
-      let(:total) { 1.0 }
+    context "when 1.2" do
+      let(:total) { 1.2 }
 
-      it { expect(formatted_number_of_terms).to eql("#{total} term") }
+      it { expect(formatted_number_of_terms).to eql("#{total} terms") }
     end
   end
 end

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -84,4 +84,34 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
       end
     end
   end
+
+  describe 'extensions' do
+    context 'with no extensions but with a teacher' do
+      it 'does not display the row' do
+        render
+        expect(rendered).not_to have_css('.govuk-summary-list__key', text: 'Extensions')
+        expect(rendered).not_to have_css('.govuk-summary-list__value', text: '0.0')
+      end
+    end
+
+    context 'with no extensions and no teacher' do
+      let(:teacher) { nil }
+
+      it 'does not display the row' do
+        render
+        expect(rendered).not_to have_css('.govuk-summary-list__key', text: 'Extensions')
+        expect(rendered).not_to have_css('.govuk-summary-list__value', text: '0.0')
+      end
+    end
+
+    context 'with extensions and teacher' do
+      let!(:extension) { create(:induction_extension, teacher:) }
+
+      it 'displays the row' do
+        render
+        expect(rendered).to have_css('.govuk-summary-list__key', text: 'Extensions')
+        expect(rendered).to have_css('.govuk-summary-list__value', text: '1.2 terms')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Surfacing the `extensions` number on the check ECT record page because it's useful information for appropriate bodies.

### Before/After

| Before | After |
|--------|-------|
|<img width="565" alt="image" src="https://github.com/user-attachments/assets/8dcc7ac3-cac6-4acc-9a3b-34df47a8403c" />|<img width="583" alt="image" src="https://github.com/user-attachments/assets/35642a98-26be-4b7a-8879-c1f1bf9a9fd2" />|

### Changes proposed

- Fix pluralisation of decimal term counts
- Surface extensions on the check details page
- Optimise calculation by using active record