### PR TITLE
Enable admin user to reopen a completed induction

### DIFF
--- a/app/components/teachers/details_component.rb
+++ b/app/components/teachers/details_component.rb
@@ -1,5 +1,9 @@
 module Teachers
   class DetailsComponent < ViewComponent::Base
+    renders_one :reopen_period_button, -> {
+      "Banana"
+    }
+
     renders_one :personal_details, -> {
       Teachers::Details::PersonalDetailsComponent.new(teacher:)
     }

--- a/app/components/teachers/details_component.rb
+++ b/app/components/teachers/details_component.rb
@@ -1,9 +1,5 @@
 module Teachers
   class DetailsComponent < ViewComponent::Base
-    renders_one :reopen_period_button, -> {
-      "Banana"
-    }
-
     renders_one :personal_details, -> {
       Teachers::Details::PersonalDetailsComponent.new(teacher:)
     }

--- a/app/controllers/admin/teachers/reopen_induction_controller.rb
+++ b/app/controllers/admin/teachers/reopen_induction_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+  module Teachers
+    class ReopenInductionController < AdminController
+      def update
+        @teacher = Teacher.find(params[:teacher_id])
+
+        if last_induction_period.blank? || last_induction_period.ongoing?
+          redirect_to admin_teacher_path(@teacher), notice: "No completed induction period found"
+        end
+
+        Admin::ReopenInductionPeriod.new(author: current_user, induction_period: last_induction_period).reopen_induction_period!
+
+        redirect_to admin_teacher_path(@teacher)
+      end
+
+    private
+
+      def last_induction_period
+        @last_induction_period ||= ::Teachers::InductionPeriod.new(@teacher).last_induction_period
+      end
+    end
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -10,4 +10,8 @@ module AdminHelper
   def admin_teachers_list_links(teachers)
     govuk_list(teachers.map { |teacher| admin_teacher_name_link(teacher) })
   end
+
+  def admin_latest_induction_period_complete?(teacher)
+    !!Teachers::InductionPeriod.new(teacher).last_induction_period&.complete?
+  end
 end

--- a/app/jobs/reopen_induction_job.rb
+++ b/app/jobs/reopen_induction_job.rb
@@ -1,0 +1,11 @@
+class ReopenInductionJob < ApplicationJob
+  def perform(trn:, start_date:)
+    api_client.reopen_teacher_induction!(trn:, start_date:)
+  end
+
+private
+
+  def api_client
+    TRS::APIClient.new
+  end
+end

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -60,6 +60,8 @@ module Interval
 
   def ongoing? = finished_on.nil?
 
+  def complete? = finished_on.present?
+
   def incomplete? = [started_on, finished_on].any?(&:blank?)
 
   def has_overlap_with_siblings? = siblings.overlapping_with(self).exists?

--- a/app/services/admin/reopen_induction_period.rb
+++ b/app/services/admin/reopen_induction_period.rb
@@ -1,0 +1,65 @@
+module Admin
+  class ReopenInductionPeriod
+    class ReopenInductionError < StandardError; end
+
+    attr_reader :author, :induction_period
+
+    def initialize(author:, induction_period:)
+      @author = author
+      @induction_period = induction_period
+    end
+
+    def reopen_induction_period!
+      check_can_reopen_period!
+
+      existing_outcome = induction_period.outcome
+      induction_period.finished_on = nil
+      induction_period.number_of_terms = nil
+      induction_period.outcome = nil
+      modifications = induction_period.changes
+
+      ActiveRecord::Base.transaction do
+        induction_period.save!
+        record_reopen_event!(modifications)
+        notify_trs_of_outcome_change! if existing_outcome.present?
+      end
+    end
+
+  private
+
+    delegate :teacher, :appropriate_body, to: :induction_period
+
+    def check_can_reopen_period!
+      check_induction_period_is_complete!
+      check_induction_period_is_the_latest!
+    end
+
+    def check_induction_period_is_complete!
+      raise ReopenPeriodError, "Cannot reopen an ongoing induction" unless induction_period.complete?
+    end
+
+    def check_induction_period_is_the_latest!
+      last_period = ::Teachers::InductionPeriod.new(teacher).last_induction_period
+
+      raise ReopenPeriodError, "Only the latest period can be reopened" unless induction_period == last_period
+    end
+
+    def record_reopen_event!(modifications)
+      Events::Record.record_induction_period_reopened_event!(
+        author:,
+        induction_period:,
+        modifications:,
+        teacher:,
+        appropriate_body:
+      )
+    end
+
+    def notify_trs_of_outcome_change!
+      ReopenInductionJob.perform_later(trn: teacher.trn, start_date: induction_start_date)
+    end
+
+    def induction_start_date
+      @induction_start_date ||= ::Teachers::Induction.new(teacher).induction_start_date
+    end
+  end
+end

--- a/app/services/admin/reopen_induction_period.rb
+++ b/app/services/admin/reopen_induction_period.rb
@@ -12,7 +12,7 @@ module Admin
     def reopen_induction_period!
       check_can_reopen_period!
 
-      existing_outcome = induction_period.outcome
+      previous_outcome = induction_period.outcome
       induction_period.finished_on = nil
       induction_period.number_of_terms = nil
       induction_period.outcome = nil
@@ -21,7 +21,7 @@ module Admin
       ActiveRecord::Base.transaction do
         induction_period.save!
         record_reopen_event!(modifications)
-        notify_trs_of_outcome_change! if existing_outcome.present?
+        notify_trs_of_outcome_change! if previous_outcome.present?
       end
     end
 

--- a/app/services/admin/reopen_induction_period.rb
+++ b/app/services/admin/reopen_induction_period.rb
@@ -35,13 +35,13 @@ module Admin
     end
 
     def check_induction_period_is_complete!
-      raise ReopenPeriodError, "Cannot reopen an ongoing induction" unless induction_period.complete?
+      raise ReopenInductionError, "Cannot reopen an ongoing induction" unless induction_period.complete?
     end
 
     def check_induction_period_is_the_latest!
       last_period = ::Teachers::InductionPeriod.new(teacher).last_induction_period
 
-      raise ReopenPeriodError, "Only the latest period can be reopened" unless induction_period == last_period
+      raise ReopenInductionError, "Only the latest period can be reopened" unless induction_period == last_period
     end
 
     def record_reopen_event!(modifications)

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -215,7 +215,7 @@ module Events
       event_type = :induction_period_reopened
       happened_at = Time.zone.now
 
-      heading = 'Induction period reopened by admin'
+      heading = 'Induction period reopened'
 
       new(event_type:, induction_period:, modifications:, author:, appropriate_body:, teacher:, heading:, happened_at:, body:).record_event!
     end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -211,6 +211,15 @@ module Events
       new(event_type:, author:, appropriate_body:, teacher:, induction_extension:, modifications:, heading:, happened_at:).record_event!
     end
 
+    def self.record_induction_period_reopened_event!(author:, induction_period:, modifications:, teacher:, appropriate_body:, body: nil)
+      event_type = :induction_period_reopened
+      happened_at = Time.zone.now
+
+      heading = 'Induction period reopened by admin'
+
+      new(event_type:, induction_period:, modifications:, author:, appropriate_body:, teacher:, heading:, happened_at:, body:).record_event!
+    end
+
   private
 
     def attributes

--- a/app/services/teachers/induction_period.rb
+++ b/app/services/teachers/induction_period.rb
@@ -33,14 +33,14 @@ class Teachers::InductionPeriod
     teacher.induction_periods.ongoing.first
   end
 
+  def last_induction_period
+    induction_periods.last
+  end
+
 private
 
   def first_induction_period
     induction_periods.first
-  end
-
-  def last_induction_period
-    induction_periods.last
   end
 
   def induction_periods

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -8,6 +8,10 @@
   )
 %>
 
+<% if admin_latest_induction_period_complete?(@teacher) %>
+  <%= govuk_button_to "Reopen induction", admin_teacher_reopen_induction_path(@teacher), method: :put, warning: true %>
+<% end %>
+
 <%= render Teachers::DetailsComponent.new(mode: :admin, teacher: @teacher) do |component|
   component.with_induction_outcome_actions
   component.with_induction_summary(is_admin: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
       resources :induction_periods, only: %i[new create edit update], path: 'induction-periods'
       resource :record_passed_outcome, only: %i[new create show], path: 'record-passed-outcome', controller: 'teachers/record_passed_outcome'
       resource :record_failed_outcome, only: %i[new create show], path: 'record-failed-outcome', controller: 'teachers/record_failed_outcome'
+      resource :reopen_induction, only: %i[update], path: 'reopen-induction', controller: 'teachers/reopen_induction'
     end
   end
 

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -75,13 +75,23 @@ module TRS
       )
     end
 
+    def reopen_teacher_induction!(trn:, start_date:, modified_at: Time.zone.now)
+      update_induction_status(
+        trn:,
+        status: 'InProgress',
+        start_date: start_date.iso8601,
+        completed_date: nil,
+        modified_at: modified_at.iso8601(3)
+      )
+    end
+
   private
 
     def update_induction_status(trn:, status:, modified_at:, start_date:, completed_date: nil)
       payload = { 'status' => status,
                   'startDate' => start_date,
                   'completedDate' => completed_date,
-                  'modifiedOn' => modified_at }.compact.to_json
+                  'modifiedOn' => modified_at }.to_json
 
       response = @connection.put(persons_path(trn, suffix: 'cpd-induction'), payload)
 

--- a/spec/jobs/reopen_induction_job_spec.rb
+++ b/spec/jobs/reopen_induction_job_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ReopenInductionJob, type: :job do
+  describe "#perform" do
+    let(:trn) { "1234567" }
+    let(:start_date) { 1.year.ago }
+    let(:trs_client) { instance_double(TRS::APIClient) }
+
+    before do
+      allow(TRS::APIClient).to receive(:new).and_return(trs_client)
+      allow(trs_client).to receive(:reopen_teacher_induction)
+    end
+
+    it "calls the TRS API to reopen the teacher's induction" do
+      expect(trs_client).to receive(:reopen_teacher_induction).with(trn:, start_date:)
+      described_class.new.perform(trn:, start_date:)
+    end
+  end
+end

--- a/spec/jobs/reopen_induction_job_spec.rb
+++ b/spec/jobs/reopen_induction_job_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe ReopenInductionJob, type: :job do
 
     before do
       allow(TRS::APIClient).to receive(:new).and_return(trs_client)
-      allow(trs_client).to receive(:reopen_teacher_induction)
+      allow(trs_client).to receive(:reopen_teacher_induction!)
     end
 
     it "calls the TRS API to reopen the teacher's induction" do
-      expect(trs_client).to receive(:reopen_teacher_induction).with(trn:, start_date:)
+      expect(trs_client).to receive(:reopen_teacher_induction!).with(trn:, start_date:)
       described_class.new.perform(trn:, start_date:)
     end
   end

--- a/spec/services/admin/reopen_induction_period_spec.rb
+++ b/spec/services/admin/reopen_induction_period_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe Admin::ReopenInductionPeriod do
+  subject(:service) { described_class.new(author:, induction_period:) }
+
+  let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
+  let(:author) { Sessions::Users::DfEPersona.new(email: admin.email) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:outcome) { nil }
+
+  let(:induction_period) do
+    FactoryBot.create(
+      :induction_period,
+      teacher:,
+      outcome:,
+      number_of_terms: 4.5,
+      started_on: "2023-06-01",
+      finished_on: "2023-12-31"
+    )
+  end
+
+  describe "#reopen_induction_period!" do
+    it "reopens the induction period" do
+      expect {
+        service.reopen_induction_period!
+      }.to change { induction_period.reload.finished_on }.to(nil)
+        .and change { induction_period.reload.number_of_terms }.to(nil)
+    end
+
+    it "adds an event" do
+      induction_period.finished_on = induction_period.number_of_terms = nil
+      modifications = induction_period.changes
+      appropriate_body = induction_period.appropriate_body
+      induction_period.reload
+
+      expect(Events::Record).to receive(:record_induction_period_reopened_event!)
+        .with(author:, induction_period:, modifications:, teacher:, appropriate_body:)
+
+      service.reopen_induction_period!
+    end
+
+    context "when induction period has an outcome" do
+      let(:outcome) { "pass" }
+
+      it "removes the outcome" do
+        expect { service.reopen_induction_period! }.to change { induction_period.reload.outcome }.to(nil)
+      end
+
+      it "queues a job that updates the TRS status" do
+        expect {
+          service.reopen_induction_period!
+        }.to have_enqueued_job(ReopenInductionJob).with(trn: teacher.trn, start_date: induction_period.started_on)
+      end
+    end
+  end
+end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -550,7 +550,7 @@ RSpec.describe Events::Record do
           teacher:,
           induction_period:,
           appropriate_body:,
-          heading: 'Induction period reopened by admin',
+          heading: 'Induction period reopened',
           event_type: :induction_period_reopened,
           happened_at: Time.zone.now,
           modifications: anything,

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -533,4 +533,31 @@ RSpec.describe Events::Record do
       end
     end
   end
+
+  describe '.record_induction_period_reopened_event!' do
+    let(:induction_period) { FactoryBot.create(:induction_period, :pass, teacher:, appropriate_body:) }
+
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        induction_period.outcome = nil
+        induction_period.finished_on = nil
+        induction_period.number_of_terms = nil
+        raw_modifications = induction_period.changes
+
+        Events::Record.record_induction_period_reopened_event!(author:, induction_period:, modifications: raw_modifications, teacher:, appropriate_body:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          induction_period:,
+          appropriate_body:,
+          heading: 'Induction period reopened by admin',
+          event_type: :induction_period_reopened,
+          happened_at: Time.zone.now,
+          modifications: anything,
+          metadata: raw_modifications,
+          **author_params
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Enable admins to reopen an induction, either with an outcome or one that was released and is on hold.  Typically this arises when a user passes or fails instead of releasing a teacher.

The "Reopen induction" button is only present if the latest induction period has a `finished_on` date.

This action will:
 - only work when the latest induction period has a `finished_on` date
 - remove the `finished_on`, `number_of_terms` and `outcome` on the latest induction period
 - adds an "induction period reopened" event
 - if an outcome is present it will update TRS with a `status` of "InProgress" and clear the `completedDate` for the teacher
 
![image](https://github.com/user-attachments/assets/d512f7f6-aa5d-4d51-abe1-d10c57470408)

![image](https://github.com/user-attachments/assets/ea7620ee-5c73-406d-a6c8-40ce51516585)

