### PR TITLE
Partnership model investigation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,6 +84,6 @@ Naming/MethodParameterName:
 Lint/MissingSuper:
   Enabled: false
 
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
   Exclude:
     - "spec/features/**/*" # Excluded in feature specs because we use Playwright (not Capybara) for those. Leaving it enabled elsewhere in case Capybara matchers are used in other test types.

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ gem 'rubypants'
 # For the API
 gem "blueprinter"
 gem "oj"
-gem "pagy"
 
 group :development do
   gem 'better_errors'

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,11 @@ gem "savon"
 # Render smart quotes
 gem 'rubypants'
 
+# For the API
+gem "blueprinter"
+gem "oj"
+gem "pagy"
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       csv
       railties (>= 7.1)
       safely_block (>= 0.4)
+    blueprinter (1.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (7.0.2)
@@ -396,6 +397,9 @@ GEM
       bigdecimal
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
+    oj (3.16.10)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -421,6 +425,7 @@ GEM
       webfinger (~> 2.0)
     optimist (3.2.0)
     os (1.1.4)
+    ostruct (0.6.1)
     pagy (9.3.4)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -713,6 +718,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   blazer
+  blueprinter
   bootsnap
   brakeman
   capybara
@@ -730,9 +736,11 @@ DEPENDENCIES
   mail-notify
   nanoc
   nanoc-live
+  oj
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect
+  pagy
   pg (~> 1.5)
   playwright-ruby-client
   propshaft

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -740,7 +740,6 @@ DEPENDENCIES
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect
-  pagy
   pg (~> 1.5)
   playwright-ruby-client
   propshaft

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,33 @@
 module API
-  class BaseController < ActionController::Base
+  class BaseController < ActionController::API
+    before_action :set_cache_headers
+    before_action :remove_charset
+
+    include API::TokenAuthenticatable
+    include ActionController::MimeResponds
+    include API::LoggerPayload
+
+    rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response
+    rescue_from ActionController::BadRequest, with: :bad_request_response
+    rescue_from ArgumentError, with: :bad_request_response
+
+  private
+
+    def remove_charset
+      ActionDispatch::Response.default_charset = nil
+    end
+
+    def unpermitted_parameter_response(exception)
+      render json: { errors: API::Errors::Response.new(error: I18n.t("api.errors.unpermitted_parameters"), params: exception.params).call }, status: :unprocessable_entity
+    end
+
+    def bad_request_response(exception)
+      Sentry.capture_exception(exception)
+      render json: { errors: API::Errors::Response.new(error: I18n.t("api.errors.bad_request"), params: exception.message).call }, status: :bad_request
+    end
+
+    def set_cache_headers
+      no_store
+    end
   end
 end

--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -1,10 +1,34 @@
 module API
   module V3
     class PartnershipsController < BaseController
+      include Pagination
+
+      def index
+        render json: to_json(paginate(partnerships_query.partnerships))
+      end
+
+      def show
+        render json: to_json(partnerships_query.partnership(id: partnership_params[:id]))
+      end
+
       def create = head(:method_not_allowed)
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
       def update = head(:method_not_allowed)
+
+    private
+
+      def partnerships_query
+        conditions = { lead_provider: current_lead_provider }
+
+        Partnerships::Query.new(**conditions.compact)
+      end
+
+      def partnership_params
+        params.permit(:id)
+      end
+
+      def to_json(obj)
+        PartnershipSerializer.render(obj, root: "data")
+      end
     end
   end
 end

--- a/app/controllers/concerns/api/errors/response.rb
+++ b/app/controllers/concerns/api/errors/response.rb
@@ -1,0 +1,35 @@
+module API
+  module Errors
+    class Response
+      attr_reader :error, :params
+
+      def initialize(error:, params:)
+        @params = params
+        @error = error
+      end
+
+      def call
+        params.map do |param|
+          {
+            title: error,
+            detail: param,
+          }
+        end
+      rescue StandardError
+        [{
+          title: error,
+          detail: params,
+        }]
+      end
+
+      def self.from(service)
+        {
+          errors: service
+            .errors
+            .messages
+            .map { |error, detail| new(error:, params: detail.uniq).call }.flatten,
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/logger_payload.rb
+++ b/app/controllers/concerns/api/logger_payload.rb
@@ -1,0 +1,37 @@
+module API
+  module LoggerPayload
+    def append_info_to_payload(payload)
+      super
+      params = {}
+
+      params[:current_user_class] = current_lead_provider&.class&.name
+      params[:current_user_id] = current_lead_provider&.id
+      params[:current_user_name] = current_lead_provider&.name
+
+      params[:request_query_params] = request.query_parameters&.to_hash
+      params[:request_headers] = request.env.slice(
+        "HTTP_HOST",
+        "HTTP_ACCEPT",
+        "HTTP_ACCEPT_ENCODING",
+        "HTTP_CONNECTION",
+        "HTTP_CACHE_CONTROL",
+      ).transform_values(&:to_s)
+      params[:request_body] = request.raw_post
+
+      params[:response_headers] = response.headers.transform_values(&:to_s)
+      if response.status != 200
+        params[:response_body] = response.body
+      end
+
+      params.transform_values! do |val|
+        if val.is_a?(Hash)
+          val = val.present? ? val.to_json : nil
+        end
+
+        val.presence
+      end
+
+      payload.merge!(params)
+    end
+  end
+end

--- a/app/controllers/concerns/api/logger_payload.rb
+++ b/app/controllers/concerns/api/logger_payload.rb
@@ -14,7 +14,7 @@ module API
         "HTTP_ACCEPT",
         "HTTP_ACCEPT_ENCODING",
         "HTTP_CONNECTION",
-        "HTTP_CACHE_CONTROL",
+        "HTTP_CACHE_CONTROL"
       ).transform_values(&:to_s)
       params[:request_body] = request.raw_post
 

--- a/app/controllers/concerns/api/pagination.rb
+++ b/app/controllers/concerns/api/pagination.rb
@@ -1,0 +1,42 @@
+module API
+  module Pagination
+    extend ActiveSupport::Concern
+    include Pagy::Backend
+
+    included do
+      rescue_from Pagy::VariableError, with: :invalid_pagination_response
+    end
+
+  private
+
+    def paginate(scope)
+      _pagy, paginated_records = pagy_countless(scope, limit: per_page, page:)
+
+      paginated_records
+    end
+
+    def per_page
+      [(page_params.dig(:page, :per_page) || default_per_page).to_i, max_per_page].min
+    end
+
+    def default_per_page
+      100
+    end
+
+    def max_per_page
+      3000
+    end
+
+    def page
+      (page_params.dig(:page, :page) || 1).to_i
+    end
+
+    def page_params
+      params.permit(page: %i[per_page page])
+    end
+
+    def invalid_pagination_response(_exception)
+      render json: { errors: API::Errors::Response.new(error: I18n.t("api.errors.bad_request"), params: I18n.t("api.errors.invalid_page_parameters")).call }, status: :bad_request
+    end
+  end
+end

--- a/app/controllers/concerns/api/token_authenticatable.rb
+++ b/app/controllers/concerns/api/token_authenticatable.rb
@@ -1,0 +1,34 @@
+module API
+  module TokenAuthenticatable
+    extend ActiveSupport::Concern
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+
+    included do
+      before_action :authenticate
+    end
+
+  private
+
+    def authenticate
+      authenticate_token || render_unauthorized
+    end
+
+    def authenticate_token
+      authenticate_with_http_token do |unhashed_token|
+        @current_api_token = APIToken.find_by_unhashed_token(unhashed_token).tap do |api_token|
+          if api_token
+            api_token.update!(last_used_at: Time.zone.now)
+          end
+        end
+      end
+    end
+
+    def render_unauthorized
+      render json: { error: I18n.t("api.errors.unauthorized") }.to_json, status: :unauthorized
+    end
+
+    def current_lead_provider
+      @current_api_token&.lead_provider
+    end
+  end
+end

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -15,9 +15,11 @@ module Builders
         training_period_data.each do |period|
           next unless period.training_programme == "full_induction_programme"
 
-          school_partnership = ::SchoolPartnership.where(lead_provider: ::LeadProvider.find_by!(name: period.lead_provider),
-                                                         delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
-                                                         registration_period_id: period.cohort_year).first
+          lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
+          delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
+          lead_provider_active_period = ::LeadProviderActivePeriod.where(lead_provider:, registration_period_id: period.cohort_year)
+          lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.where(lead_provider_active_period:, delivery_partner:)
+          school_partnership = ::SchoolPartnership.find_by(lead_provider_delivery_partnership:)
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -20,6 +20,7 @@ module Builders
           lead_provider_active_period = ::LeadProviderActivePeriod.where(lead_provider:, registration_period_id: period.cohort_year)
           lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.where(lead_provider_active_period:, delivery_partner:)
           school_partnership = ::SchoolPartnership.find_by(lead_provider_delivery_partnership:)
+          expression_of_interest = ::LeadProviderActivePeriod.find_by!(lead_provider:, registration_period_id: period.cohort_year)
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first
@@ -29,7 +30,8 @@ module Builders
                                    started_on: period.start_date,
                                    finished_on: period.end_date,
                                    ecf_start_induction_record_id: period.start_source_id,
-                                   ecf_end_induction_record_id: period.end_source_id)
+                                   ecf_end_induction_record_id: period.end_source_id,
+                                   expression_of_interest:)
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -15,9 +15,11 @@ module Builders
         training_period_data.each do |period|
           next unless period.training_programme == "full_induction_programme"
 
-          school_partnership = ::SchoolPartnership.where(lead_provider: ::LeadProvider.find_by!(name: period.lead_provider),
-                                                         delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
-                                                         registration_period_id: period.cohort_year).first
+          lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
+          delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
+          lead_provider_active_period = ::LeadProviderActivePeriod.where(lead_provider:, registration_period_id: period.cohort_year)
+          lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.where(lead_provider_active_period:, delivery_partner:)
+          school_partnership = ::SchoolPartnership.find_by(lead_provider_delivery_partnership:)
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -20,6 +20,7 @@ module Builders
           lead_provider_active_period = ::LeadProviderActivePeriod.where(lead_provider:, registration_period_id: period.cohort_year)
           lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.where(lead_provider_active_period:, delivery_partner:)
           school_partnership = ::SchoolPartnership.find_by(lead_provider_delivery_partnership:)
+          expression_of_interest = ::LeadProviderActivePeriod.find_by!(lead_provider:, registration_period_id: period.cohort_year)
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first
@@ -29,7 +30,8 @@ module Builders
                                    started_on: period.start_date,
                                    finished_on: period.end_date,
                                    ecf_start_induction_record_id: period.start_source_id,
-                                   ecf_end_induction_record_id: period.end_source_id)
+                                   ecf_end_induction_record_id: period.end_source_id,
+                                   expression_of_interest:)
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,0 +1,20 @@
+class APIToken < ApplicationRecord
+  has_secure_token :hashed_token, length: 32
+  encrypts :hashed_token, deterministic: true
+
+  belongs_to :lead_provider
+
+  validates :hashed_token, presence: true
+
+  def self.create_with_random_token!(**options)
+    create!(**options).hashed_token
+  end
+
+  def self.find_by_unhashed_token(unhashed_token)
+    find_by(hashed_token: unhashed_token)
+  end
+
+  def self.create_with_known_token!(token, **options)
+    find_or_create_by!(hashed_token: token, **options)
+  end
+end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,7 +1,6 @@
 class DeliveryPartner < ApplicationRecord
   # Associations
   has_many :lead_provider_delivery_partnerships
-  has_many :school_partnerships, inverse_of: :delivery_partner
   has_many :events
 
   # Validations

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,6 +1,7 @@
 class DeliveryPartner < ApplicationRecord
   # Associations
   has_many :lead_provider_delivery_partnerships
+  has_many :school_partnerships, inverse_of: :delivery_partner
   has_many :events
 
   # Validations

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,5 +1,6 @@
 class DeliveryPartner < ApplicationRecord
   # Associations
+  has_many :lead_provider_delivery_partnerships
   has_many :school_partnerships, inverse_of: :delivery_partner
   has_many :events
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,5 +1,6 @@
 class LeadProvider < ApplicationRecord
   # Associations
+  has_many :active_periods, inverse_of: :lead_provider, class_name: "LeadProviderActivePeriod"
   has_many :school_partnerships, inverse_of: :lead_provider
   has_many :events
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,7 +1,6 @@
 class LeadProvider < ApplicationRecord
   # Associations
   has_many :active_periods, inverse_of: :lead_provider, class_name: "LeadProviderActivePeriod"
-  has_many :school_partnerships, inverse_of: :lead_provider
   has_many :events
 
   # Validations

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,6 +1,7 @@
 class LeadProvider < ApplicationRecord
   # Associations
   has_many :active_periods, inverse_of: :lead_provider, class_name: "LeadProviderActivePeriod"
+  has_many :school_partnerships, inverse_of: :lead_provider
   has_many :events
 
   # Validations

--- a/app/models/lead_provider_active_period.rb
+++ b/app/models/lead_provider_active_period.rb
@@ -6,4 +6,5 @@ class LeadProviderActivePeriod < ApplicationRecord
 
   validates :lead_provider, presence: true
   validates :registration_period, presence: true
+  validates :registration_period_id, uniqueness: { scope: :lead_provider_id }
 end

--- a/app/models/lead_provider_active_period.rb
+++ b/app/models/lead_provider_active_period.rb
@@ -1,0 +1,8 @@
+class LeadProviderActivePeriod < ApplicationRecord
+  belongs_to :lead_provider
+  belongs_to :registration_period
+  has_many :delivery_partnerships, class_name: "LeadProviderDeliveryPartnership"
+
+  validates :lead_provider, presence: true
+  validates :registration_period, presence: true
+end

--- a/app/models/lead_provider_active_period.rb
+++ b/app/models/lead_provider_active_period.rb
@@ -2,6 +2,7 @@ class LeadProviderActivePeriod < ApplicationRecord
   belongs_to :lead_provider
   belongs_to :registration_period
   has_many :delivery_partnerships, class_name: "LeadProviderDeliveryPartnership"
+  has_many :expressions_of_interest, class_name: "TrainingPeriod", inverse_of: :expression_of_interest
 
   validates :lead_provider, presence: true
   validates :registration_period, presence: true

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -1,0 +1,7 @@
+class LeadProviderDeliveryPartnership < ApplicationRecord
+  belongs_to :lead_provider_active_period
+  belongs_to :delivery_partner
+
+  validates :lead_provider_active_period, presence: true
+  validates :delivery_partner, presence: true
+end

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -7,4 +7,5 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
 
   validates :lead_provider_active_period, presence: true
   validates :delivery_partner, presence: true
+  validates :lead_provider_active_period_id, uniqueness: { scope: :delivery_partner_id }
 end

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -1,4 +1,5 @@
 class LeadProviderDeliveryPartnership < ApplicationRecord
+  has_many :school_partnerships
   belongs_to :lead_provider_active_period
   belongs_to :delivery_partner
 

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -2,6 +2,8 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
   has_many :school_partnerships
   belongs_to :lead_provider_active_period
   belongs_to :delivery_partner
+  has_one :lead_provider, through: :lead_provider_active_period
+  has_one :registration_period, through: :lead_provider_active_period
 
   validates :lead_provider_active_period, presence: true
   validates :delivery_partner, presence: true

--- a/app/models/registration_period.rb
+++ b/app/models/registration_period.rb
@@ -5,7 +5,6 @@ class RegistrationPeriod < ApplicationRecord
 
   # Associations
   has_many :lead_provider_active_periods
-  has_many :school_partnerships, inverse_of: :registration_period
 
   # Validations
   validates :year,

--- a/app/models/registration_period.rb
+++ b/app/models/registration_period.rb
@@ -5,6 +5,7 @@ class RegistrationPeriod < ApplicationRecord
 
   # Associations
   has_many :lead_provider_active_periods
+  has_many :school_partnerships, inverse_of: :registration_period
 
   # Validations
   validates :year,

--- a/app/models/registration_period.rb
+++ b/app/models/registration_period.rb
@@ -4,6 +4,7 @@ class RegistrationPeriod < ApplicationRecord
   ECF_FIRST_YEAR = 2020
 
   # Associations
+  has_many :lead_provider_active_periods
   has_many :school_partnerships, inverse_of: :registration_period
 
   # Validations

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,6 +8,7 @@ class School < ApplicationRecord
        suffix: :programme_type_chosen
 
   # Associations
+  has_many :school_partnerships
   belongs_to :gias_school, class_name: "GIAS::School", foreign_key: :urn, inverse_of: :school
   belongs_to :chosen_appropriate_body, class_name: 'AppropriateBody'
   belongs_to :chosen_lead_provider, class_name: 'LeadProvider'

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -83,6 +83,16 @@ class School < ApplicationRecord
   # chosen_lead_provider_name
   delegate :name, to: :chosen_lead_provider, prefix: true, allow_nil: true
 
+  def cip_only? = !eligible? && open? && cip_only_type?
+
+  def eligible? = open? && in_england && (eligible_establishment_type? || section_41_approved)
+
+  def open? = status.in?(%w[open proposed_to_close])
+
+  def cip_only_type? = type_name.in?(GIAS::Types::CIP_ONLY_TYPES)
+
+  def eligible_establishment_type? = type_name.in?(GIAS::Types::ELIGIBLE_TYPES)
+
   def independent? = GIAS::Types::INDEPENDENT_SCHOOLS_TYPES.include?(type_name)
 
   def programme_choices

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -1,11 +1,15 @@
 class SchoolPartnership < ApplicationRecord
   # Associations
+  belongs_to :lead_provider_delivery_partnership
+  belongs_to :school
   belongs_to :registration_period, inverse_of: :school_partnerships
   belongs_to :lead_provider, inverse_of: :school_partnerships
   belongs_to :delivery_partner, inverse_of: :school_partnerships
   has_many :events
 
   # Validations
+  validates :school, presence: true
+
   validates :registration_period_id,
             presence: true,
             uniqueness: { scope: %i[lead_provider_id delivery_partner_id],

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -3,6 +3,7 @@ class SchoolPartnership < ApplicationRecord
   belongs_to :lead_provider_delivery_partnership
   belongs_to :school
   has_many :events
+  has_many :training_periods, inverse_of: :school_partnership
   has_one :lead_provider, through: :lead_provider_delivery_partnership
   has_one :delivery_partner, through: :lead_provider_delivery_partnership
   has_one :registration_period, through: :lead_provider_delivery_partnership

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -2,27 +2,17 @@ class SchoolPartnership < ApplicationRecord
   # Associations
   belongs_to :lead_provider_delivery_partnership
   belongs_to :school
-  belongs_to :registration_period, inverse_of: :school_partnerships
-  belongs_to :lead_provider, inverse_of: :school_partnerships
-  belongs_to :delivery_partner, inverse_of: :school_partnerships
   has_many :events
+  has_one :lead_provider, through: :lead_provider_delivery_partnership
+  has_one :delivery_partner, through: :lead_provider_delivery_partnership
+  has_one :registration_period, through: :lead_provider_delivery_partnership
 
   # Validations
   validates :school, presence: true
-
-  validates :registration_period_id,
-            presence: true,
-            uniqueness: { scope: %i[lead_provider_id delivery_partner_id],
-                          message: "has already been added" }
-
-  validates :lead_provider_id,
-            presence: true
-
-  validates :delivery_partner_id,
-            presence: true
+  validates :lead_provider_delivery_partnership, presence: true, uniqueness: { scope: :school_id }
 
   # Scopes
-  scope :for_registration_period, ->(year) { where(registration_period_id: year) }
-  scope :for_lead_provider, ->(lead_provider_id) { where(lead_provider_id:) }
-  scope :for_delivery_partner, ->(delivery_partner_id) { where(delivery_partner_id:) }
+  scope :for_registration_period, ->(year) { joins(lead_provider_delivery_partnership: :lead_provider_active_period).where(lead_provider_active_period: { registration_period_id: year }) }
+  scope :for_lead_provider, ->(lead_provider_id) { joins(lead_provider_delivery_partnership: :lead_provider_active_period).where(lead_provider_active_period: { lead_provider_id: }) }
+  scope :for_delivery_partner, ->(delivery_partner_id) { joins(:lead_provider_delivery_partnership).where(lead_provider_delivery_partnership: { delivery_partner_id: }) }
 end

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -7,6 +7,7 @@ class SchoolPartnership < ApplicationRecord
   has_one :lead_provider, through: :lead_provider_delivery_partnership
   has_one :delivery_partner, through: :lead_provider_delivery_partnership
   has_one :registration_period, through: :lead_provider_delivery_partnership
+  has_one :lead_provider_active_period, through: :lead_provider_delivery_partnership
 
   # Validations
   validates :school, presence: true

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -26,6 +26,10 @@ class TrainingPeriod < ApplicationRecord
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
   scope :for_mentor, ->(mentor_at_school_period_id) { where(mentor_at_school_period_id:) }
   scope :for_school_partnership, ->(school_partnership_id) { where(school_partnership_id:) }
+  scope :for_school, ->(school) do
+    left_outer_joins(:ect_at_school_period, :mentor_at_school_period)
+    .where("ect_at_school_periods.school_id = :school_id OR mentor_at_school_periods.school_id = :school_id", school_id: school.id)
+  end
 
   # Instance methods
   def for_ect?

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -20,6 +20,7 @@ class TrainingPeriod < ApplicationRecord
   validate :one_id_of_trainee_present
   validate :trainee_distinct_period
   validate :enveloped_by_trainee_at_school_period
+  validate :school_partnership_school_is_consistent
 
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
@@ -46,6 +47,13 @@ class TrainingPeriod < ApplicationRecord
   end
 
 private
+
+  def school_partnership_school_is_consistent
+    school_ids = [school_partnership&.school_id, ect_at_school_period&.school_id, mentor_at_school_period&.school_id].compact
+    return if school_ids.uniq.one?
+
+    errors.add(:base, "School partnership is not consistent with the trainee's school")
+  end
 
   def at_least_one_partnership
     ids = [expression_of_interest_id, school_partnership_id]

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -4,7 +4,8 @@ class TrainingPeriod < ApplicationRecord
   # Associations
   belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :training_periods
   belongs_to :mentor_at_school_period, inverse_of: :training_periods
-  belongs_to :school_partnership
+  belongs_to :school_partnership, optional: true
+  belongs_to :expression_of_interest, class_name: "LeadProviderActivePeriod", inverse_of: :expressions_of_interest
 
   has_many :declarations, inverse_of: :training_period
   has_many :events
@@ -13,12 +14,9 @@ class TrainingPeriod < ApplicationRecord
   has_one :delivery_partner, through: :school_partnership
 
   # Validations
-  validates :started_on,
-            presence: true
+  validates :started_on, presence: true
 
-  validates :school_partnership_id,
-            presence: true
-
+  validate :at_least_one_partnership
   validate :one_id_of_trainee_present
   validate :trainee_distinct_period
   validate :enveloped_by_trainee_at_school_period
@@ -48,6 +46,11 @@ class TrainingPeriod < ApplicationRecord
   end
 
 private
+
+  def at_least_one_partnership
+    ids = [expression_of_interest_id, school_partnership_id]
+    errors.add(:base, "An expression of interest or school partnership is required") if ids.none?
+  end
 
   def one_id_of_trainee_present
     ids = [ect_at_school_period_id, mentor_at_school_period_id]

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -30,6 +30,7 @@ class TrainingPeriod < ApplicationRecord
     left_outer_joins(:ect_at_school_period, :mentor_at_school_period)
     .where("ect_at_school_periods.school_id = :school_id OR mentor_at_school_periods.school_id = :school_id", school_id: school.id)
   end
+  scope :pending, -> { where(school_partnership_id: nil) }
 
   # Instance methods
   def for_ect?

--- a/app/serializers/api/partnership_serializer.rb
+++ b/app/serializers/api/partnership_serializer.rb
@@ -1,0 +1,23 @@
+module API
+  class PartnershipSerializer < Blueprinter::Base
+    class AttributesSerializer < Blueprinter::Base
+      exclude :id
+
+      field(:cohort) { |p, _| p.registration_period.year.to_s }
+      field(:urn) { |p, _| p.school.urn.to_s }
+      field(:school_id) { |p, _| p.school.id }
+      field(:delivery_partner_id) { |p, _| p.delivery_partner.id }
+      field(:delivery_partner_name) { |p, _| p.delivery_partner.name }
+
+      field :created_at
+      field :updated_at
+    end
+
+    identifier :id
+    field(:type) { "partnership" }
+
+    association :attributes, blueprint: AttributesSerializer do |partnership|
+      partnership
+    end
+  end
+end

--- a/app/services/api/concerns/filter_ignorable.rb
+++ b/app/services/api/concerns/filter_ignorable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module API
+  module Concerns
+    module FilterIgnorable
+      extend ActiveSupport::Concern
+
+      def ignore?(filter:)
+        filter == :ignore || (!filter.nil? && filter.blank?)
+      end
+    end
+  end
+end

--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module API::SchoolPartnerships
+  class Create
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :registration_year
+    attribute :school_ecf_id
+    attribute :lead_provider_ecf_id
+    attribute :delivery_partner_ecf_id
+
+    validates :registration_year, :school_ecf_id, :lead_provider_ecf_id, :delivery_partner_ecf_id, presence: true
+    validate :registration_period_exists
+    validate :lead_provider_exists
+    validate :school_exists
+    validate :school_is_not_cip_only
+    validate :school_is_eligible
+    validate :delivery_partner_exists
+    validate :lead_provider_delivery_partnership_exists
+    validate :school_partnership_does_not_already_exists
+    validate :school_training_period_exists
+
+    def create
+      return false unless valid?
+
+      SchoolPartnership.create!(
+        school:,
+        lead_provider_delivery_partnership:
+      ).tap { |school_partnership| accept_expressions_of_interest(school_partnership) }
+    end
+
+  private
+
+    def accept_expressions_of_interest(school_partnership)
+      expressions_of_interest = school_partnership.lead_provider_active_period.expressions_of_interest
+      expressions_of_interest.for_school(school).each do |expression_of_interest|
+        expression_of_interest.update!(school_partnership:)
+      end
+    end
+
+    def registration_period
+      @registration_period ||= RegistrationPeriod.find_by(year: registration_year) if registration_year
+    end
+
+    def lead_provider
+      @lead_provider ||= LeadProvider.find_by(ecf_id: lead_provider_ecf_id) if lead_provider_ecf_id
+    end
+
+    def school
+      @school ||= School.find_by(ecf_id: school_ecf_id) if school_ecf_id
+    end
+
+    def delivery_partner
+      @delivery_partner ||= DeliveryPartner.find_by(ecf_id: delivery_partner_ecf_id) if delivery_partner_ecf_id
+    end
+
+    def registration_period_exists
+      errors.add(:registration_year, "Registration year does not exist") unless registration_period
+    end
+
+    def lead_provider_exists
+      errors.add(:lead_provider_ecf_id, "Lead provider does not exist") unless lead_provider
+    end
+
+    def school_exists
+      errors.add(:school_ecf_id, "School does not exist") unless school
+    end
+
+    def school_is_not_cip_only
+      errors.add(:school_ecf_id, "School is CIP only") if school&.cip_only?
+    end
+
+    def school_is_eligible
+      errors.add(:school_ecf_id, "School is not eligible") unless school&.eligible?
+    end
+
+    def school_partnership_does_not_already_exists
+      return unless school && lead_provider_delivery_partnership
+
+      existing_school_partnership = school.school_partnerships.exists?(lead_provider_delivery_partnership:)
+
+      errors.add(:school_ecf_id, "School partnership already exists for the lead provider, delivery partner and registration year") if existing_school_partnership
+    end
+
+    def school_training_period_exists
+      return unless school
+
+      training_periods = TrainingPeriod.for_school(school)
+
+      errors.add(:school_ecf_id, "School does not have any FIP participants") unless training_periods.exists?
+    end
+
+    def delivery_partner_exists
+      errors.add(:delivery_partner_ecf_id, "Delivery partner does not exist") unless delivery_partner
+    end
+
+    def lead_provider_active_period
+      return unless lead_provider && registration_period
+
+      @lead_provider_active_period ||= lead_provider.active_periods.find_by(registration_period:)
+    end
+
+    def lead_provider_delivery_partnership
+      return unless lead_provider_active_period && delivery_partner
+
+      @lead_provider_delivery_partnership ||= delivery_partner.lead_provider_delivery_partnerships.find_by(lead_provider_active_period:, delivery_partner:)
+    end
+
+    def lead_provider_delivery_partnership_exists
+      return unless lead_provider && delivery_partner
+
+      errors.add(:delivery_partner_ecf_id, "Lead provider and delivery partner do not have a partnership") unless lead_provider_delivery_partnership
+    end
+  end
+end

--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -33,7 +33,7 @@ module API::SchoolPartnerships
   private
 
     def accept_expressions_of_interest(school_partnership)
-      expressions_of_interest = school_partnership.lead_provider_active_period.expressions_of_interest
+      expressions_of_interest = school_partnership.lead_provider_active_period.expressions_of_interest.pending
       expressions_of_interest.for_school(school).each do |expression_of_interest|
         expression_of_interest.update!(school_partnership:)
       end

--- a/app/services/api/school_partnerships/update.rb
+++ b/app/services/api/school_partnerships/update.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module API::SchoolPartnerships
+  class Update
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :school_partnership
+    attribute :delivery_partner_ecf_id
+
+    validates :school_partnership, :delivery_partner_ecf_id, presence: true
+    validate :delivery_partner_exists
+    validate :lead_provider_delivery_partnership_exists
+    validate :school_partnership_does_not_already_exists
+
+    def update
+      return false unless valid?
+
+      school_partnership.update!(lead_provider_delivery_partnership:)
+    end
+
+  private
+
+    def delivery_partner
+      @delivery_partner ||= DeliveryPartner.find_by(ecf_id: delivery_partner_ecf_id) if delivery_partner_ecf_id
+    end
+
+    def lead_provider
+      @lead_provider ||= school_partnership.lead_provider
+    end
+
+    def lead_provider_active_period
+      @lead_provider_active_period ||= school_partnership.lead_provider_active_period
+    end
+
+    def lead_provider_delivery_partnership
+      return unless school_partnership && delivery_partner
+
+      @lead_provider_delivery_partnership ||= delivery_partner.lead_provider_delivery_partnerships.find_by(lead_provider_active_period:, delivery_partner:)
+    end
+
+    def delivery_partner_exists
+      errors.add(:delivery_partner_ecf_id, "Delivery partner does not exist") unless delivery_partner
+    end
+
+    def lead_provider_delivery_partnership_exists
+      return unless school_partnership && delivery_partner
+
+      errors.add(:delivery_partner_ecf_id, "Lead provider and delivery partner do not have a partnership") unless lead_provider_delivery_partnership
+    end
+
+    def school_partnership_does_not_already_exists
+      return unless school_partnership && lead_provider_delivery_partnership
+
+      existing_school_partnership = school_partnership.school.school_partnerships.exists?(lead_provider_delivery_partnership:)
+
+      errors.add(:school_ecf_id, "School partnership already exists for the lead provider, delivery partner and registration year") if existing_school_partnership
+    end
+  end
+end

--- a/app/services/partnerships/query.rb
+++ b/app/services/partnerships/query.rb
@@ -1,0 +1,36 @@
+module Partnerships
+  class Query
+    include API::Concerns::FilterIgnorable
+
+    attr_reader :scope
+
+    def initialize(lead_provider: :ignore)
+      @scope = all_partnerships
+
+      where_lead_provider_is(lead_provider)
+    end
+
+    def partnerships
+      scope.order(created_at: :asc)
+    end
+
+    def partnership(id: nil)
+      scope.where(id:)
+    end
+
+  private
+
+    def where_lead_provider_is(lead_provider)
+      return if ignore?(filter: lead_provider)
+
+      scope.merge!(SchoolPartnership.for_lead_provider(lead_provider.id))
+    end
+
+    def all_partnerships
+      SchoolPartnership
+        .includes(:school,
+                  :delivery_partner,
+                  :registration_period)
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -360,3 +360,15 @@
   - trn
   - created_at
   - updated_at
+  :lead_provider_delivery_partnerships:
+  - id
+  - lead_provider_active_period_id
+  - delivery_partner_id
+  - created_at
+  - updated_at
+  :lead_provider_active_periods:
+  - id
+  - lead_provider_id
+  - registration_period_id
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,5 +1,12 @@
 ---
 :shared:
+  :api_tokens:
+  - id
+  - lead_provider_id
+  - hashed_token
+  - last_used_at
+  - created_at
+  - updated_at
   :appropriate_bodies:
     - body_type
   :blazer_queries:

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -197,6 +197,7 @@
   - chosen_lead_provider_id
   - chosen_programme_type
   - id
+  - ecf_id
   - created_at
   - updated_at
   - urn
@@ -279,6 +280,7 @@
   - email
   :lead_providers:
   - id
+  - ecf_id
   - name
   - created_at
   - updated_at
@@ -330,6 +332,7 @@
   - updated_at
   :delivery_partners:
   - id
+  - ecf_id
   - name
   - created_at
   - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -203,6 +203,8 @@
   - registration_period_id
   - lead_provider_id
   - delivery_partner_id
+  - lead_provider_delivery_partnership_id
+  - school_id
   - created_at
   - updated_at
   :teachers:

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -182,6 +182,8 @@
   - range
   - ecf_start_induction_record_id
   - ecf_end_induction_record_id
+  - expression_of_interest_id
+  - school_partnership_id
   :teacher_migration_failures:
   - id
   - teacher_id

--- a/config/initializers/blueprinter.rb
+++ b/config/initializers/blueprinter.rb
@@ -1,0 +1,5 @@
+Blueprinter.configure do |config|
+  config.generator = Oj
+  config.datetime_format = ->(datetime) { datetime&.rfc3339 }
+  config.sort_fields_by = :definition
+end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,6 +1,7 @@
 require 'pagy/extras/array'
 require 'pagy/extras/overflow'
 require 'pagy/extras/size'
+require 'pagy/extras/countless'
 
 Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
 Pagy::DEFAULT[:size] = [1, 1, 1, 1].freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,7 @@
+en:
+  api:
+    errors:
+      bad_request: "Bad request"
+      invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
+      unauthorized: "HTTP Token: Access denied"
+      unpermitted_parameters: "Unpermitted parameters"

--- a/db/migrate/20250428131716_create_lead_provider_active_periods.rb
+++ b/db/migrate/20250428131716_create_lead_provider_active_periods.rb
@@ -1,0 +1,10 @@
+class CreateLeadProviderActivePeriods < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lead_provider_active_periods do |t|
+      t.references :lead_provider, null: false, foreign_key: true
+      t.references :registration_period, null: false, foreign_key: { primary_key: :year }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250428131723_create_lead_provider_delivery_partnerships.rb
+++ b/db/migrate/20250428131723_create_lead_provider_delivery_partnerships.rb
@@ -1,0 +1,10 @@
+class CreateLeadProviderDeliveryPartnerships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lead_provider_delivery_partnerships do |t|
+      t.references :lead_provider_active_period, null: false, foreign_key: true
+      t.references :delivery_partner, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250428132559_update_school_partnerships_with_lead_provider_delivery_partnership_and_school.rb
+++ b/db/migrate/20250428132559_update_school_partnerships_with_lead_provider_delivery_partnership_and_school.rb
@@ -1,0 +1,8 @@
+class UpdateSchoolPartnershipsWithLeadProviderDeliveryPartnershipAndSchool < ActiveRecord::Migration[8.0]
+  def change
+    change_table :school_partnerships do |t|
+      t.references :lead_provider_delivery_partnership, null: false, foreign_key: true # rubocop:disable Rails/NotNullColumn
+      t.references :school, null: false, foreign_key: true # rubocop:disable Rails/NotNullColumn
+    end
+  end
+end

--- a/db/migrate/20250428134603_remove_redundant_columns_from_school_partnerships.rb
+++ b/db/migrate/20250428134603_remove_redundant_columns_from_school_partnerships.rb
@@ -1,0 +1,9 @@
+class RemoveRedundantColumnsFromSchoolPartnerships < ActiveRecord::Migration[8.0]
+  def change
+    change_table :school_partnerships do |t|
+      t.remove_references :lead_provider, foreign_key: true
+      t.remove_references :registration_period, foreign_key: true
+      t.remove_references :delivery_partner, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20250429090835_add_expression_of_interest_reference_to_training_period.rb
+++ b/db/migrate/20250429090835_add_expression_of_interest_reference_to_training_period.rb
@@ -1,0 +1,6 @@
+class AddExpressionOfInterestReferenceToTrainingPeriod < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :training_periods, :expression_of_interest, null: true, foreign_key: { to_table: :lead_provider_active_periods }
+    change_column_null :training_periods, :school_partnership_id, true
+  end
+end

--- a/db/migrate/20250429103001_add_unique_index_to_lead_provider_active_periods.rb
+++ b/db/migrate/20250429103001_add_unique_index_to_lead_provider_active_periods.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLeadProviderActivePeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_index :lead_provider_active_periods, %i[registration_period_id lead_provider_id], unique: true
+  end
+end

--- a/db/migrate/20250429103024_add_unique_index_to_lead_provider_delivery_partnerships.rb
+++ b/db/migrate/20250429103024_add_unique_index_to_lead_provider_delivery_partnerships.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLeadProviderDeliveryPartnerships < ActiveRecord::Migration[8.0]
+  def change
+    add_index :lead_provider_delivery_partnerships, %i[lead_provider_active_period_id delivery_partner_id], unique: true
+  end
+end

--- a/db/migrate/20250429103043_add_unique_index_to_school_partnerships.rb
+++ b/db/migrate/20250429103043_add_unique_index_to_school_partnerships.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToSchoolPartnerships < ActiveRecord::Migration[8.0]
+  def change
+    add_index :school_partnerships, %i[school_id lead_provider_delivery_partnership_id], unique: true
+  end
+end

--- a/db/migrate/20250429103738_create_api_tokens.rb
+++ b/db/migrate/20250429103738_create_api_tokens.rb
@@ -1,0 +1,13 @@
+class CreateAPITokens < ActiveRecord::Migration[8.0]
+  def change
+    create_table :api_tokens do |t|
+      t.references :lead_provider, null: false, foreign_key: true
+      t.string :hashed_token, null: false
+      t.datetime :last_used_at
+
+      t.index :hashed_token, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250501130805_add_ecf_id_to_models.rb
+++ b/db/migrate/20250501130805_add_ecf_id_to_models.rb
@@ -1,0 +1,7 @@
+class AddECFIdToModels < ActiveRecord::Migration[8.0]
+  def change
+    add_column :schools, :ecf_id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_column :lead_providers, :ecf_id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_column :delivery_partners, :ecf_id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_28_132559) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_28_134603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -381,18 +381,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_132559) do
   end
 
   create_table "school_partnerships", force: :cascade do |t|
-    t.bigint "registration_period_id", null: false
-    t.bigint "lead_provider_id", null: false
-    t.bigint "delivery_partner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "lead_provider_delivery_partnership_id"
     t.bigint "school_id", null: false
-    t.index ["delivery_partner_id"], name: "index_school_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_delivery_partnership_id"], name: "idx_on_lead_provider_delivery_partnership_id_628487f752"
-    t.index ["lead_provider_id"], name: "index_school_partnerships_on_lead_provider_id"
-    t.index ["registration_period_id", "lead_provider_id", "delivery_partner_id"], name: "yearly_unique_provider_partnerships", unique: true
-    t.index ["registration_period_id"], name: "index_school_partnerships_on_registration_period_id"
     t.index ["school_id"], name: "index_school_partnerships_on_school_id"
   end
 
@@ -625,10 +618,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_132559) do
   add_foreign_key "mentorship_periods", "ect_at_school_periods"
   add_foreign_key "mentorship_periods", "mentor_at_school_periods"
   add_foreign_key "pending_induction_submissions", "appropriate_bodies"
-  add_foreign_key "school_partnerships", "delivery_partners"
   add_foreign_key "school_partnerships", "lead_provider_delivery_partnerships"
-  add_foreign_key "school_partnerships", "lead_providers"
-  add_foreign_key "school_partnerships", "registration_periods", primary_key: "year"
   add_foreign_key "school_partnerships", "schools"
   add_foreign_key "schools", "appropriate_bodies", column: "chosen_appropriate_body_id"
   add_foreign_key "schools", "gias_schools", column: "urn", primary_key: "urn"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_01_130805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -123,6 +123,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["name"], name: "index_delivery_partners_on_name", unique: true
   end
 
@@ -295,6 +296,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["name"], name: "index_lead_providers_on_name", unique: true
   end
 
@@ -399,6 +401,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
     t.bigint "chosen_appropriate_body_id"
     t.bigint "chosen_lead_provider_id"
     t.enum "chosen_programme_type", enum_type: "programme_type"
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["chosen_appropriate_body_id"], name: "index_schools_on_chosen_appropriate_body_id"
     t.index ["chosen_lead_provider_id"], name: "index_schools_on_chosen_lead_provider_id"
     t.index ["urn"], name: "schools_unique_urn", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_01_130805) do
   create_enum "programme_type", ["provider_led", "school_led"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
+  create_table "api_tokens", force: :cascade do |t|
+    t.bigint "lead_provider_id", null: false
+    t.string "hashed_token", null: false
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["hashed_token"], name: "index_api_tokens_on_hashed_token", unique: true
+    t.index ["lead_provider_id"], name: "index_api_tokens_on_lead_provider_id"
+  end
+
   create_table "appropriate_bodies", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -594,6 +604,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_01_130805) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "api_tokens", "lead_providers"
   add_foreign_key "dfe_roles", "users"
   add_foreign_key "ect_at_school_periods", "appropriate_bodies", column: "school_reported_appropriate_body_id"
   add_foreign_key "ect_at_school_periods", "lead_providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_28_121350) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_28_131723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -269,6 +269,24 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_121350) do
     t.enum "outcome", enum_type: "induction_outcomes"
     t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
     t.index ["teacher_id"], name: "index_induction_periods_on_teacher_id"
+  end
+
+  create_table "lead_provider_active_periods", force: :cascade do |t|
+    t.bigint "lead_provider_id", null: false
+    t.bigint "registration_period_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lead_provider_id"], name: "index_lead_provider_active_periods_on_lead_provider_id"
+    t.index ["registration_period_id"], name: "index_lead_provider_active_periods_on_registration_period_id"
+  end
+
+  create_table "lead_provider_delivery_partnerships", force: :cascade do |t|
+    t.bigint "lead_provider_active_period_id", null: false
+    t.bigint "delivery_partner_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["delivery_partner_id"], name: "idx_on_delivery_partner_id_fcb95e8215"
+    t.index ["lead_provider_active_period_id"], name: "idx_on_lead_provider_active_period_id_90f3e9110a"
   end
 
   create_table "lead_providers", force: :cascade do |t|
@@ -594,6 +612,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_121350) do
   add_foreign_key "induction_extensions", "teachers"
   add_foreign_key "induction_periods", "appropriate_bodies"
   add_foreign_key "induction_periods", "teachers"
+  add_foreign_key "lead_provider_active_periods", "lead_providers"
+  add_foreign_key "lead_provider_active_periods", "registration_periods", primary_key: "year"
+  add_foreign_key "lead_provider_delivery_partnerships", "delivery_partners"
+  add_foreign_key "lead_provider_delivery_partnerships", "lead_provider_active_periods"
   add_foreign_key "mentor_at_school_periods", "schools"
   add_foreign_key "mentor_at_school_periods", "teachers"
   add_foreign_key "mentorship_periods", "ect_at_school_periods"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_28_134603) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_29_090835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -558,7 +558,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_134603) do
   end
 
   create_table "training_periods", force: :cascade do |t|
-    t.bigint "school_partnership_id", null: false
+    t.bigint "school_partnership_id"
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
@@ -568,9 +568,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_134603) do
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.uuid "ecf_start_induction_record_id"
     t.uuid "ecf_end_induction_record_id"
+    t.bigint "expression_of_interest_id"
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"
+    t.index ["expression_of_interest_id"], name: "index_training_periods_on_expression_of_interest_id"
     t.index ["mentor_at_school_period_id"], name: "index_training_periods_on_mentor_at_school_period_id"
     t.index ["school_partnership_id", "ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "provider_partnership_trainings", unique: true
     t.index ["school_partnership_id"], name: "index_training_periods_on_school_partnership_id"
@@ -631,6 +633,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_134603) do
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "teacher_migration_failures", "teachers"
   add_foreign_key "training_periods", "ect_at_school_periods"
+  add_foreign_key "training_periods", "lead_provider_active_periods", column: "expression_of_interest_id"
   add_foreign_key "training_periods", "mentor_at_school_periods"
   add_foreign_key "training_periods", "school_partnerships"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_090835) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -277,6 +277,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_090835) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["lead_provider_id"], name: "index_lead_provider_active_periods_on_lead_provider_id"
+    t.index ["registration_period_id", "lead_provider_id"], name: "idx_on_registration_period_id_lead_provider_id_4b486019d3", unique: true
     t.index ["registration_period_id"], name: "index_lead_provider_active_periods_on_registration_period_id"
   end
 
@@ -286,6 +287,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_090835) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["delivery_partner_id"], name: "idx_on_delivery_partner_id_fcb95e8215"
+    t.index ["lead_provider_active_period_id", "delivery_partner_id"], name: "idx_on_lead_provider_active_period_id_delivery_part_82d12bafba", unique: true
     t.index ["lead_provider_active_period_id"], name: "idx_on_lead_provider_active_period_id_90f3e9110a"
   end
 
@@ -386,6 +388,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_090835) do
     t.bigint "lead_provider_delivery_partnership_id"
     t.bigint "school_id", null: false
     t.index ["lead_provider_delivery_partnership_id"], name: "idx_on_lead_provider_delivery_partnership_id_628487f752"
+    t.index ["school_id", "lead_provider_delivery_partnership_id"], name: "idx_on_school_id_lead_provider_delivery_partnership_7b2d6a6684", unique: true
     t.index ["school_id"], name: "index_school_partnerships_on_school_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_28_131723) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_28_132559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -386,10 +386,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_131723) do
     t.bigint "delivery_partner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "lead_provider_delivery_partnership_id"
+    t.bigint "school_id", null: false
     t.index ["delivery_partner_id"], name: "index_school_partnerships_on_delivery_partner_id"
+    t.index ["lead_provider_delivery_partnership_id"], name: "idx_on_lead_provider_delivery_partnership_id_628487f752"
     t.index ["lead_provider_id"], name: "index_school_partnerships_on_lead_provider_id"
     t.index ["registration_period_id", "lead_provider_id", "delivery_partner_id"], name: "yearly_unique_provider_partnerships", unique: true
     t.index ["registration_period_id"], name: "index_school_partnerships_on_registration_period_id"
+    t.index ["school_id"], name: "index_school_partnerships_on_school_id"
   end
 
   create_table "schools", force: :cascade do |t|
@@ -622,8 +626,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_28_131723) do
   add_foreign_key "mentorship_periods", "mentor_at_school_periods"
   add_foreign_key "pending_induction_submissions", "appropriate_bodies"
   add_foreign_key "school_partnerships", "delivery_partners"
+  add_foreign_key "school_partnerships", "lead_provider_delivery_partnerships"
   add_foreign_key "school_partnerships", "lead_providers"
   add_foreign_key "school_partnerships", "registration_periods", primary_key: "year"
+  add_foreign_key "school_partnerships", "schools"
   add_foreign_key "schools", "appropriate_bodies", column: "chosen_appropriate_body_id"
   add_foreign_key "schools", "gias_schools", column: "urn", primary_key: "urn"
   add_foreign_key "schools", "lead_providers", column: "chosen_lead_provider_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,6 +220,7 @@ grove_artisan_partnership_2021 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2021, delivery_partner: artisan_education_group),
   school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
+grove_artisan_expression_of_interest_2021 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2021)
 
 grove_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2022)
 SchoolPartnership.create!(
@@ -232,12 +233,14 @@ grove_artisan_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2023, delivery_partner: artisan_education_group),
   school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
+grove_artisan_expression_of_interest_2023 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2023)
 
 national_meadows_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
 meadow_grain_partnership_2022 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2022, delivery_partner: grain_teaching_school_hub),
   school: brookfield_school
 ).tap { |pp| describe_school_partnership(pp) }
+meadow_grain_expression_of_interest_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
 
 national_meadows_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
 _meadow_grain_partnership_2023 = SchoolPartnership.create!(
@@ -272,7 +275,8 @@ TrainingPeriod.create!(
   mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
   started_on: 3.years.ago,
   finished_on: 140.weeks.ago,
-  school_partnership: grove_artisan_partnership_2021
+  school_partnership: grove_artisan_partnership_2021,
+  expression_of_interest: grove_artisan_expression_of_interest_2021
 ).tap { |tp| describe_training_period(tp) }
 
 # 10 week break
@@ -281,7 +285,8 @@ TrainingPeriod.create!(
   mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
   started_on: 130.weeks.ago,
   finished_on: nil,
-  school_partnership: grove_artisan_partnership_2021
+  school_partnership: grove_artisan_partnership_2021,
+  expression_of_interest: grove_artisan_expression_of_interest_2021
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Kate Winslet (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -300,7 +305,8 @@ kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: kate_winslet_ect_at_ackley_bridge,
   started_on: 1.year.ago,
-  school_partnership: grove_artisan_partnership_2023
+  school_partnership: grove_artisan_partnership_2023,
+  expression_of_interest: grove_artisan_expression_of_interest_2023
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -331,7 +337,8 @@ hugh_laurie_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: hugh_laurie_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Alan Rickman (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -354,7 +361,8 @@ ackley_bridge.update!(chosen_lead_provider: wildflower_trust,
 TrainingPeriod.create!(
   ect_at_school_period: alan_rickman_ect_at_ackley_bridge,
   started_on: 2.years.ago + 1.month,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -397,7 +405,8 @@ TrainingPeriod.create!(
   ect_at_school_period: hugh_grant_ect_at_abbey_grove,
   started_on: 2.years.ago,
   finished_on: 1.week.ago,
-  school_partnership: grove_artisan_partnership_2021
+  school_partnership: grove_artisan_partnership_2021,
+  expression_of_interest: grove_artisan_expression_of_interest_2021
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -440,7 +449,8 @@ TrainingPeriod.create!(
   ect_at_school_period: colin_firth_ect_at_abbey_grove,
   started_on: 2.years.ago,
   finished_on: 1.week.ago,
-  school_partnership: grove_artisan_partnership_2021
+  school_partnership: grove_artisan_partnership_2021,
+  expression_of_interest: grove_artisan_expression_of_interest_2021
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -523,7 +533,8 @@ imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: imogen_stubbs_at_malory_towers,
   started_on: 1.year.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 InductionExtension.create!(
@@ -559,7 +570,8 @@ mallory_towers.update!(chosen_lead_provider: wildflower_trust,
 TrainingPeriod.create!(
   ect_at_school_period: gemma_jones_at_malory_towers,
   started_on: 20.months.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 InductionExtension.create!(
@@ -579,7 +591,8 @@ andre_roussimoff_mentoring_at_ackley_bridge = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: andre_roussimoff_mentoring_at_ackley_bridge,
   started_on: 1.year.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Anthony Hopkins (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -598,7 +611,8 @@ anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: anthony_hopkins_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Stephen Fry (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -621,7 +635,8 @@ brookfield_school.update!(chosen_lead_provider: national_meadows_institute,
 TrainingPeriod.create!(
   ect_at_school_period: stephen_fry_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Harriet Walter (ECT) with multiple induction periods", indent: 2, colour: ECT_COLOUR)
@@ -648,7 +663,8 @@ helen_mirren_mentoring_at_brookfield_school = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: helen_mirren_mentoring_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("John Withers (mentor)", indent: 2, colour: MENTOR_COLOUR)
@@ -663,7 +679,8 @@ john_withers_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: john_withers_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022
+  school_partnership: meadow_grain_partnership_2022,
+  expression_of_interest: meadow_grain_expression_of_interest_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Adding mentorships:")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -750,3 +750,9 @@ EarlyRollOutMentor.create!(trn: hugh_laurie.trn).tap { describe_ero_mentor(hugh_
 EarlyRollOutMentor.create!(trn: harriet_walter.trn).tap { describe_ero_mentor(harriet_walter) }
 EarlyRollOutMentor.create!(trn: '3002582').tap { describe_ero_mentor('Robson Scottie') }
 EarlyRollOutMentor.create!(trn: '3002580').tap { describe_ero_mentor('Muhammed Ali') }
+
+print_seed_info('Adding APITokens:')
+
+lead_provider = LeadProvider.find_by_name("National Meadows Institute")
+APIToken.create_with_known_token!("national-token", lead_provider:)
+print_seed_info("Added APIToken for #{lead_provider.name}: 'national-token'", indent: 2)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,7 +220,6 @@ grove_artisan_partnership_2021 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2021, delivery_partner: artisan_education_group),
   school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
-grove_artisan_expression_of_interest_2021 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2021)
 
 grove_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2022)
 SchoolPartnership.create!(
@@ -233,14 +232,12 @@ grove_artisan_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2023, delivery_partner: artisan_education_group),
   school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
-grove_artisan_expression_of_interest_2023 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2023)
 
 national_meadows_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
 meadow_grain_partnership_2022 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2022, delivery_partner: grain_teaching_school_hub),
   school: brookfield_school
 ).tap { |pp| describe_school_partnership(pp) }
-meadow_grain_expression_of_interest_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
 
 national_meadows_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
 _meadow_grain_partnership_2023 = SchoolPartnership.create!(
@@ -248,13 +245,13 @@ _meadow_grain_partnership_2023 = SchoolPartnership.create!(
   school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
 
-wildflower_trust_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
+wildflower_trust_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: wildflower_trust, registration_period: registration_period_2023)
 _wildflower_rising_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2023, delivery_partner: rising_minds),
   school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
-wildflower_trust_active_period_2024 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2024)
+wildflower_trust_active_period_2024 = LeadProviderActivePeriod.create!(lead_provider: wildflower_trust, registration_period: registration_period_2024)
 _wildflower_rising_partnership_2024 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2024, delivery_partner: rising_minds),
   school: mallory_towers
@@ -276,7 +273,7 @@ TrainingPeriod.create!(
   started_on: 3.years.ago,
   finished_on: 140.weeks.ago,
   school_partnership: grove_artisan_partnership_2021,
-  expression_of_interest: grove_artisan_expression_of_interest_2021
+  expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
 # 10 week break
@@ -286,7 +283,7 @@ TrainingPeriod.create!(
   started_on: 130.weeks.ago,
   finished_on: nil,
   school_partnership: grove_artisan_partnership_2021,
-  expression_of_interest: grove_artisan_expression_of_interest_2021
+  expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Kate Winslet (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -306,7 +303,7 @@ TrainingPeriod.create!(
   ect_at_school_period: kate_winslet_ect_at_ackley_bridge,
   started_on: 1.year.ago,
   school_partnership: grove_artisan_partnership_2023,
-  expression_of_interest: grove_artisan_expression_of_interest_2023
+  expression_of_interest: grove_active_period_2023
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -338,7 +335,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: hugh_laurie_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Alan Rickman (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -362,7 +359,7 @@ TrainingPeriod.create!(
   ect_at_school_period: alan_rickman_ect_at_ackley_bridge,
   started_on: 2.years.ago + 1.month,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -406,7 +403,7 @@ TrainingPeriod.create!(
   started_on: 2.years.ago,
   finished_on: 1.week.ago,
   school_partnership: grove_artisan_partnership_2021,
-  expression_of_interest: grove_artisan_expression_of_interest_2021
+  expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -450,7 +447,7 @@ TrainingPeriod.create!(
   started_on: 2.years.ago,
   finished_on: 1.week.ago,
   school_partnership: grove_artisan_partnership_2021,
-  expression_of_interest: grove_artisan_expression_of_interest_2021
+  expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
 InductionPeriod.create!(
@@ -534,7 +531,7 @@ TrainingPeriod.create!(
   ect_at_school_period: imogen_stubbs_at_malory_towers,
   started_on: 1.year.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 InductionExtension.create!(
@@ -571,7 +568,7 @@ TrainingPeriod.create!(
   ect_at_school_period: gemma_jones_at_malory_towers,
   started_on: 20.months.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 InductionExtension.create!(
@@ -592,7 +589,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: andre_roussimoff_mentoring_at_ackley_bridge,
   started_on: 1.year.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Anthony Hopkins (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -612,7 +609,7 @@ TrainingPeriod.create!(
   ect_at_school_period: anthony_hopkins_ect_at_brookfield_school,
   started_on: 2.years.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Stephen Fry (ECT)", indent: 2, colour: ECT_COLOUR)
@@ -636,7 +633,7 @@ TrainingPeriod.create!(
   ect_at_school_period: stephen_fry_ect_at_brookfield_school,
   started_on: 2.years.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Harriet Walter (ECT) with multiple induction periods", indent: 2, colour: ECT_COLOUR)
@@ -664,7 +661,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: helen_mirren_mentoring_at_brookfield_school,
   started_on: 2.years.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("John Withers (mentor)", indent: 2, colour: MENTOR_COLOUR)
@@ -680,7 +677,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: john_withers_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
   school_partnership: meadow_grain_partnership_2022,
-  expression_of_interest: meadow_grain_expression_of_interest_2022
+  expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Adding mentorships:")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -216,27 +216,49 @@ _registration_period_2025 = RegistrationPeriod.create!(year: 2025, started_on: D
 print_seed_info("Adding provider partnerships")
 
 grove_active_period_2021 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2021)
-grove_artisan_partnership_2021 = SchoolPartnership.create!(
-  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2021, delivery_partner: artisan_education_group),
+grove_2021_artisan_active_period = LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2021, delivery_partner: artisan_education_group)
+grove_artisan_abbey_partnership_2021 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: grove_2021_artisan_active_period,
+  school: abbey_grove_school
+).tap { |pp| describe_school_partnership(pp) }
+
+grove_artisan_ackley_partnership_2021 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: grove_2021_artisan_active_period,
   school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
 
 grove_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2022)
-SchoolPartnership.create!(
+_grove_artisan_abbey_school_partnership_2022 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2022, delivery_partner: artisan_education_group),
   school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
 grove_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2023)
-grove_artisan_partnership_2023 = SchoolPartnership.create!(
+_grove_artisan_mallory_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2023, delivery_partner: artisan_education_group),
   school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
 
 national_meadows_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
-meadow_grain_partnership_2022 = SchoolPartnership.create!(
-  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2022, delivery_partner: grain_teaching_school_hub),
+meadows_2022_grain_active_period = LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2022, delivery_partner: grain_teaching_school_hub)
+meadow_grain_brookfield_partnership_2022 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: meadows_2022_grain_active_period,
   school: brookfield_school
+).tap { |pp| describe_school_partnership(pp) }
+
+meadow_grain_mallory_partnership_2022 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: meadows_2022_grain_active_period,
+  school: mallory_towers
+).tap { |pp| describe_school_partnership(pp) }
+
+meadow_grain_ackley_partnership_2022 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: meadows_2022_grain_active_period,
+  school: ackley_bridge
+).tap { |pp| describe_school_partnership(pp) }
+
+meadow_grain_abbey_partnership_2022 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: meadows_2022_grain_active_period,
+  school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
 national_meadows_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
@@ -252,7 +274,7 @@ _wildflower_rising_partnership_2023 = SchoolPartnership.create!(
 ).tap { |pp| describe_school_partnership(pp) }
 
 wildflower_trust_active_period_2024 = LeadProviderActivePeriod.create!(lead_provider: wildflower_trust, registration_period: registration_period_2024)
-_wildflower_rising_partnership_2024 = SchoolPartnership.create!(
+_wildflower_rising_mallory_partnership_2024 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2024, delivery_partner: rising_minds),
   school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
@@ -272,7 +294,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
   started_on: 3.years.ago,
   finished_on: 140.weeks.ago,
-  school_partnership: grove_artisan_partnership_2021,
+  school_partnership: grove_artisan_abbey_partnership_2021,
   expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
@@ -282,7 +304,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
   started_on: 130.weeks.ago,
   finished_on: nil,
-  school_partnership: grove_artisan_partnership_2021,
+  school_partnership: grove_artisan_abbey_partnership_2021,
   expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
@@ -302,7 +324,7 @@ kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: kate_winslet_ect_at_ackley_bridge,
   started_on: 1.year.ago,
-  school_partnership: grove_artisan_partnership_2023,
+  school_partnership: grove_artisan_ackley_partnership_2021,
   expression_of_interest: grove_active_period_2023
 ).tap { |tp| describe_training_period(tp) }
 
@@ -334,7 +356,7 @@ hugh_laurie_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: hugh_laurie_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_abbey_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -358,7 +380,7 @@ ackley_bridge.update!(chosen_lead_provider: wildflower_trust,
 TrainingPeriod.create!(
   ect_at_school_period: alan_rickman_ect_at_ackley_bridge,
   started_on: 2.years.ago + 1.month,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_ackley_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -402,7 +424,7 @@ TrainingPeriod.create!(
   ect_at_school_period: hugh_grant_ect_at_abbey_grove,
   started_on: 2.years.ago,
   finished_on: 1.week.ago,
-  school_partnership: grove_artisan_partnership_2021,
+  school_partnership: grove_artisan_abbey_partnership_2021,
   expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
@@ -446,7 +468,7 @@ TrainingPeriod.create!(
   ect_at_school_period: colin_firth_ect_at_abbey_grove,
   started_on: 2.years.ago,
   finished_on: 1.week.ago,
-  school_partnership: grove_artisan_partnership_2021,
+  school_partnership: grove_artisan_abbey_partnership_2021,
   expression_of_interest: grove_active_period_2021
 ).tap { |tp| describe_training_period(tp) }
 
@@ -530,7 +552,7 @@ imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: imogen_stubbs_at_malory_towers,
   started_on: 1.year.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_mallory_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -567,7 +589,7 @@ mallory_towers.update!(chosen_lead_provider: wildflower_trust,
 TrainingPeriod.create!(
   ect_at_school_period: gemma_jones_at_malory_towers,
   started_on: 20.months.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_mallory_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -588,7 +610,7 @@ andre_roussimoff_mentoring_at_ackley_bridge = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: andre_roussimoff_mentoring_at_ackley_bridge,
   started_on: 1.year.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_ackley_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -608,7 +630,7 @@ anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: anthony_hopkins_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_brookfield_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -632,7 +654,7 @@ brookfield_school.update!(chosen_lead_provider: national_meadows_institute,
 TrainingPeriod.create!(
   ect_at_school_period: stephen_fry_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_brookfield_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -660,7 +682,7 @@ helen_mirren_mentoring_at_brookfield_school = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: helen_mirren_mentoring_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_brookfield_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 
@@ -676,7 +698,7 @@ john_withers_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: john_withers_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
-  school_partnership: meadow_grain_partnership_2022,
+  school_partnership: meadow_grain_abbey_partnership_2022,
   expression_of_interest: national_meadows_active_period_2022
 ).tap { |tp| describe_training_period(tp) }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -218,63 +218,42 @@ print_seed_info("Adding provider partnerships")
 grove_active_period_2021 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2021)
 grove_artisan_partnership_2021 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2021, delivery_partner: artisan_education_group),
-  registration_period: registration_period_2021,
-  lead_provider: grove_institute,
-  delivery_partner: artisan_education_group,
   school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
 
 grove_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2022)
 SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2022, delivery_partner: artisan_education_group),
-  registration_period: registration_period_2022,
-  lead_provider: grove_institute,
-  delivery_partner: artisan_education_group,
   school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
 grove_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2023)
 grove_artisan_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2023, delivery_partner: artisan_education_group),
-  registration_period: registration_period_2023,
-  lead_provider: grove_institute,
-  delivery_partner: artisan_education_group,
   school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
 
 national_meadows_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
 meadow_grain_partnership_2022 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2022, delivery_partner: grain_teaching_school_hub),
-  registration_period: registration_period_2022,
-  lead_provider: national_meadows_institute,
-  delivery_partner: grain_teaching_school_hub,
   school: brookfield_school
 ).tap { |pp| describe_school_partnership(pp) }
 
 national_meadows_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
 _meadow_grain_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2023, delivery_partner: grain_teaching_school_hub),
-  registration_period: registration_period_2023,
-  lead_provider: national_meadows_institute,
-  delivery_partner: grain_teaching_school_hub,
   school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
 
 wildflower_trust_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
 _wildflower_rising_partnership_2023 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2023, delivery_partner: rising_minds),
-  registration_period: registration_period_2023,
-  lead_provider: wildflower_trust,
-  delivery_partner: rising_minds,
   school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
 wildflower_trust_active_period_2024 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2024)
 _wildflower_rising_partnership_2024 = SchoolPartnership.create!(
   lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2024, delivery_partner: rising_minds),
-  registration_period: registration_period_2024,
-  lead_provider: wildflower_trust,
-  delivery_partner: rising_minds,
   school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -215,46 +215,67 @@ _registration_period_2025 = RegistrationPeriod.create!(year: 2025, started_on: D
 
 print_seed_info("Adding provider partnerships")
 
+grove_active_period_2021 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2021)
 grove_artisan_partnership_2021 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2021, delivery_partner: artisan_education_group),
   registration_period: registration_period_2021,
   lead_provider: grove_institute,
-  delivery_partner: artisan_education_group
+  delivery_partner: artisan_education_group,
+  school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
 
+grove_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2022)
 SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2022, delivery_partner: artisan_education_group),
   registration_period: registration_period_2022,
   lead_provider: grove_institute,
-  delivery_partner: artisan_education_group
+  delivery_partner: artisan_education_group,
+  school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
+grove_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: grove_institute, registration_period: registration_period_2023)
 grove_artisan_partnership_2023 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: grove_active_period_2023, delivery_partner: artisan_education_group),
   registration_period: registration_period_2023,
   lead_provider: grove_institute,
-  delivery_partner: artisan_education_group
+  delivery_partner: artisan_education_group,
+  school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
 
+national_meadows_active_period_2022 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2022)
 meadow_grain_partnership_2022 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2022, delivery_partner: grain_teaching_school_hub),
   registration_period: registration_period_2022,
   lead_provider: national_meadows_institute,
-  delivery_partner: grain_teaching_school_hub
+  delivery_partner: grain_teaching_school_hub,
+  school: brookfield_school
 ).tap { |pp| describe_school_partnership(pp) }
 
+national_meadows_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
 _meadow_grain_partnership_2023 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: national_meadows_active_period_2023, delivery_partner: grain_teaching_school_hub),
   registration_period: registration_period_2023,
   lead_provider: national_meadows_institute,
-  delivery_partner: grain_teaching_school_hub
+  delivery_partner: grain_teaching_school_hub,
+  school: ackley_bridge
 ).tap { |pp| describe_school_partnership(pp) }
 
+wildflower_trust_active_period_2023 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2023)
 _wildflower_rising_partnership_2023 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2023, delivery_partner: rising_minds),
   registration_period: registration_period_2023,
   lead_provider: wildflower_trust,
-  delivery_partner: rising_minds
+  delivery_partner: rising_minds,
+  school: abbey_grove_school
 ).tap { |pp| describe_school_partnership(pp) }
 
+wildflower_trust_active_period_2024 = LeadProviderActivePeriod.create!(lead_provider: national_meadows_institute, registration_period: registration_period_2024)
 _wildflower_rising_partnership_2024 = SchoolPartnership.create!(
+  lead_provider_delivery_partnership: LeadProviderDeliveryPartnership.create!(lead_provider_active_period: wildflower_trust_active_period_2024, delivery_partner: rising_minds),
   registration_period: registration_period_2024,
   lead_provider: wildflower_trust,
-  delivery_partner: rising_minds
+  delivery_partner: rising_minds,
+  school: mallory_towers
 ).tap { |pp| describe_school_partnership(pp) }
 
 print_seed_info("Adding teacher histories:")

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'An org that delivers the training') }
   let(:lead_provider_active_period) { FactoryBot.create(:lead_provider_active_period, lead_provider:) }
   let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:, delivery_partner:) }
-  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school: provider_led_ect.school) }
 
   let(:school_led_ect) do
     FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:)

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -2,7 +2,9 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   let(:school_reported_appropriate_body) { FactoryBot.create(:appropriate_body, name: 'an org that assures the quality of statutory teacher induction') }
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'An org that designs the training') }
   let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'An org that delivers the training') }
-  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider:, delivery_partner:) }
+  let(:lead_provider_active_period) { FactoryBot.create(:lead_provider_active_period, lead_provider:) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:, delivery_partner:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
 
   let(:school_led_ect) do
     FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:)

--- a/spec/factories/lead_provider_active_period_factory.rb
+++ b/spec/factories/lead_provider_active_period_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:lead_provider_active_period) do
+    association :lead_provider
+    association :registration_period
+  end
+end

--- a/spec/factories/lead_provider_delivery_partnership_factory.rb
+++ b/spec/factories/lead_provider_delivery_partnership_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:lead_provider_delivery_partnership) do
+    association :lead_provider_active_period
+    association :delivery_partner
+  end
+end

--- a/spec/factories/school_partnership_factory.rb
+++ b/spec/factories/school_partnership_factory.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     association :registration_period
     association :lead_provider
     association :delivery_partner
+    association :school
   end
 end

--- a/spec/factories/school_partnership_factory.rb
+++ b/spec/factories/school_partnership_factory.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory(:school_partnership) do
-    association :registration_period
-    association :lead_provider
-    association :delivery_partner
+    association :lead_provider_delivery_partnership
     association :school
   end
 end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -3,8 +3,11 @@ FactoryBot.define do
 
   factory(:training_period) do
     for_ect
-    association :school_partnership
     association :expression_of_interest, factory: :lead_provider_active_period
+    school_partnership do
+      school = ect_at_school_period&.school || mentor_at_school_period&.school || build(:school)
+      association(:school_partnership, school:)
+    end
 
     started_on { generate(:base_training_date) }
     finished_on { started_on + 1.day }

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory(:training_period) do
     for_ect
     association :school_partnership
+    association :expression_of_interest, factory: :lead_provider_active_period
 
     started_on { generate(:base_training_date) }
     finished_on { started_on + 1.day }

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -16,11 +16,6 @@ describe Builders::ECT::TrainingPeriods do
   let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: registration_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
-  before do
-    create(:lead_provider_active_period, lead_provider: partnership_1.lead_provider, registration_period:)
-    create(:lead_provider_active_period, lead_provider: partnership_2.lead_provider, registration_period:)
-  end
-
   describe "#build" do
     it "creates TrainingPeriod records for the school periods" do
       expect {
@@ -37,12 +32,14 @@ describe Builders::ECT::TrainingPeriods do
       expect(periods.first.finished_on).to eq training_period_1.end_date
       expect(periods.first.ecf_start_induction_record_id).to eq training_period_1.start_source_id
       expect(periods.first.ecf_end_induction_record_id).to eq training_period_1.end_source_id
+      expect(periods.first.expression_of_interest).to eq lead_provider_active_period
 
       expect(periods.last.school_partnership).to eq partnership_2
       expect(periods.last.started_on).to eq training_period_2.start_date
       expect(periods.last.finished_on).to be_blank
       expect(periods.last.ecf_start_induction_record_id).to eq training_period_2.start_source_id
       expect(periods.last.ecf_end_induction_record_id).to eq training_period_2.end_source_id
+      expect(periods.last.expression_of_interest).to eq lead_provider_active_period
     end
 
     context "when there is no ECTAtSchoolPeriod that contains the training dates" do

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -1,9 +1,12 @@
 describe Builders::ECT::TrainingPeriods do
   subject(:service) { described_class.new(teacher:, training_period_data:) }
 
-  let(:registration_period) { FactoryBot.create(:registration_period) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, registration_period:) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, registration_period:) }
+  let(:lead_provider_active_period) { FactoryBot.create(:lead_provider_active_period) }
+  let(:registration_period) { lead_provider_active_period.registration_period }
+  let(:lead_provider_delivery_partnership_1) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
+  let(:lead_provider_delivery_partnership_2) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
+  let(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_1) }
+  let(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_2) }
   let(:school_1) { FactoryBot.create(:school, :independent, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, :independent, urn: "987654") }
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -5,8 +5,8 @@ describe Builders::ECT::TrainingPeriods do
   let(:registration_period) { lead_provider_active_period.registration_period }
   let(:lead_provider_delivery_partnership_1) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
   let(:lead_provider_delivery_partnership_2) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_1) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_2) }
+  let(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_1, school: school_1) }
+  let(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_2, school: school_2) }
   let(:school_1) { FactoryBot.create(:school, :independent, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, :independent, urn: "987654") }
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -16,6 +16,11 @@ describe Builders::ECT::TrainingPeriods do
   let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: registration_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
+  before do
+    create(:lead_provider_active_period, lead_provider: partnership_1.lead_provider, registration_period:)
+    create(:lead_provider_active_period, lead_provider: partnership_2.lead_provider, registration_period:)
+  end
+
   describe "#build" do
     it "creates TrainingPeriod records for the school periods" do
       expect {

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -16,11 +16,6 @@ describe Builders::Mentor::TrainingPeriods do
   let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: registration_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
-  before do
-    create(:lead_provider_active_period, lead_provider: partnership_1.lead_provider, registration_period:)
-    create(:lead_provider_active_period, lead_provider: partnership_2.lead_provider, registration_period:)
-  end
-
   describe "#build" do
     it "creates TrainingPeriod records for the school periods" do
       expect {
@@ -37,12 +32,14 @@ describe Builders::Mentor::TrainingPeriods do
       expect(periods.first.finished_on).to eq training_period_1.end_date
       expect(periods.first.ecf_start_induction_record_id).to eq training_period_1.start_source_id
       expect(periods.first.ecf_end_induction_record_id).to eq training_period_1.end_source_id
+      expect(periods.first.expression_of_interest).to eq lead_provider_active_period
 
       expect(periods.last.school_partnership).to eq partnership_2
       expect(periods.last.started_on).to eq training_period_2.start_date
       expect(periods.last.finished_on).to be_blank
       expect(periods.last.ecf_start_induction_record_id).to eq training_period_2.start_source_id
       expect(periods.last.ecf_end_induction_record_id).to eq training_period_2.end_source_id
+      expect(periods.last.expression_of_interest).to eq lead_provider_active_period
     end
 
     context "when there is no MentorAtSchoolPeriod that contains the training dates" do

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -1,9 +1,12 @@
 describe Builders::Mentor::TrainingPeriods do
   subject(:service) { described_class.new(teacher:, training_period_data:) }
 
-  let(:registration_period) { FactoryBot.create(:registration_period) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, registration_period:) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, registration_period:) }
+  let(:lead_provider_active_period) { FactoryBot.create(:lead_provider_active_period) }
+  let(:registration_period) { lead_provider_active_period.registration_period }
+  let(:lead_provider_delivery_partnership_1) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
+  let(:lead_provider_delivery_partnership_2) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
+  let(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_1) }
+  let(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_2) }
   let(:school_1) { FactoryBot.create(:school, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, urn: "987654") }
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -5,8 +5,8 @@ describe Builders::Mentor::TrainingPeriods do
   let(:registration_period) { lead_provider_active_period.registration_period }
   let(:lead_provider_delivery_partnership_1) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
   let(:lead_provider_delivery_partnership_2) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider_active_period:) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_1) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_2) }
+  let(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_1, school: school_1) }
+  let(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership_2, school: school_2) }
   let(:school_1) { FactoryBot.create(:school, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, urn: "987654") }
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -16,6 +16,11 @@ describe Builders::Mentor::TrainingPeriods do
   let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: registration_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
+  before do
+    create(:lead_provider_active_period, lead_provider: partnership_1.lead_provider, registration_period:)
+    create(:lead_provider_active_period, lead_provider: partnership_2.lead_provider, registration_period:)
+  end
+
   describe "#build" do
     it "creates TrainingPeriod records for the school periods" do
       expect {

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -1,5 +1,6 @@
 describe DeliveryPartner do
   describe "associations" do
+    it { is_expected.to have_many(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
   end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -1,6 +1,7 @@
 describe DeliveryPartner do
   describe "associations" do
     it { is_expected.to have_many(:lead_provider_delivery_partnerships) }
+    it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
   end
 

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -1,7 +1,6 @@
 describe DeliveryPartner do
   describe "associations" do
     it { is_expected.to have_many(:lead_provider_delivery_partnerships) }
-    it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
   end
 

--- a/spec/models/lead_provider_active_period_spec.rb
+++ b/spec/models/lead_provider_active_period_spec.rb
@@ -3,6 +3,7 @@ describe LeadProviderActivePeriod do
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:registration_period) }
     it { is_expected.to have_many(:delivery_partnerships).class_name("LeadProviderDeliveryPartnership") }
+    it { is_expected.to have_many(:expressions_of_interest).class_name("TrainingPeriod").inverse_of(:expression_of_interest) }
   end
 
   describe "validations" do

--- a/spec/models/lead_provider_active_period_spec.rb
+++ b/spec/models/lead_provider_active_period_spec.rb
@@ -7,7 +7,10 @@ describe LeadProviderActivePeriod do
   end
 
   describe "validations" do
+    subject { build(:lead_provider_active_period) }
+
     it { is_expected.to validate_presence_of(:lead_provider) }
     it { is_expected.to validate_presence_of(:registration_period) }
+    it { is_expected.to validate_uniqueness_of(:registration_period_id).scoped_to(:lead_provider_id) }
   end
 end

--- a/spec/models/lead_provider_active_period_spec.rb
+++ b/spec/models/lead_provider_active_period_spec.rb
@@ -1,0 +1,12 @@
+describe LeadProviderActivePeriod do
+  describe "associations" do
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to belong_to(:registration_period) }
+    it { is_expected.to have_many(:delivery_partnerships).class_name("LeadProviderDeliveryPartnership") }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:lead_provider) }
+    it { is_expected.to validate_presence_of(:registration_period) }
+  end
+end

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -1,0 +1,11 @@
+describe LeadProviderDeliveryPartnership do
+  describe "associations" do
+    it { is_expected.to belong_to(:lead_provider_active_period) }
+    it { is_expected.to belong_to(:delivery_partner) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:lead_provider_active_period) }
+    it { is_expected.to validate_presence_of(:delivery_partner) }
+  end
+end

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -1,5 +1,6 @@
 describe LeadProviderDeliveryPartnership do
   describe "associations" do
+    it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to belong_to(:lead_provider_active_period) }
     it { is_expected.to belong_to(:delivery_partner) }
   end

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -1,8 +1,9 @@
 describe LeadProviderDeliveryPartnership do
   describe "associations" do
-    it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to belong_to(:lead_provider_active_period) }
     it { is_expected.to belong_to(:delivery_partner) }
+    it { is_expected.to have_one(:lead_provider).through(:lead_provider_active_period) }
+    it { is_expected.to have_one(:registration_period).through(:lead_provider_active_period) }
   end
 
   describe "validations" do

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -7,7 +7,10 @@ describe LeadProviderDeliveryPartnership do
   end
 
   describe "validations" do
+    subject { build(:lead_provider_delivery_partnership) }
+
     it { is_expected.to validate_presence_of(:lead_provider_active_period) }
     it { is_expected.to validate_presence_of(:delivery_partner) }
+    it { is_expected.to validate_uniqueness_of(:lead_provider_active_period_id).scoped_to(:delivery_partner_id) }
   end
 end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -1,5 +1,6 @@
 describe LeadProvider do
   describe "associations" do
+    it { is_expected.to have_many(:active_periods).inverse_of(:lead_provider).class_name("LeadProviderActivePeriod") }
     it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
   end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -1,7 +1,6 @@
 describe LeadProvider do
   describe "associations" do
     it { is_expected.to have_many(:active_periods).inverse_of(:lead_provider).class_name("LeadProviderActivePeriod") }
-    it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
   end
 

--- a/spec/models/registration_period_spec.rb
+++ b/spec/models/registration_period_spec.rb
@@ -1,5 +1,6 @@
 describe RegistrationPeriod do
   describe "associations" do
+    it { is_expected.to have_many(:lead_provider_active_periods) }
     it { is_expected.to have_many(:school_partnerships) }
   end
 

--- a/spec/models/registration_period_spec.rb
+++ b/spec/models/registration_period_spec.rb
@@ -1,7 +1,6 @@
 describe RegistrationPeriod do
   describe "associations" do
     it { is_expected.to have_many(:lead_provider_active_periods) }
-    it { is_expected.to have_many(:school_partnerships) }
   end
 
   describe "validations" do

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -6,6 +6,7 @@ describe SchoolPartnership do
     it { is_expected.to have_one(:lead_provider).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:delivery_partner).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:registration_period).through(:lead_provider_delivery_partnership) }
+    it { is_expected.to have_one(:lead_provider_active_period).through(:lead_provider_delivery_partnership) }
   end
 
   describe "validations" do

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -1,53 +1,39 @@
 describe SchoolPartnership do
   describe "associations" do
-    it { is_expected.to belong_to(:registration_period).inverse_of(:school_partnerships) }
-    it { is_expected.to belong_to(:lead_provider).inverse_of(:school_partnerships) }
-    it { is_expected.to belong_to(:delivery_partner).inverse_of(:school_partnerships) }
     it { is_expected.to have_many(:events) }
-    it { is_expected.to belong_to(:lead_provider_delivery_partnership).optional }
+    it { is_expected.to belong_to(:lead_provider_delivery_partnership) }
     it { is_expected.to belong_to(:school) }
+    it { is_expected.to have_one(:lead_provider).through(:lead_provider_delivery_partnership) }
+    it { is_expected.to have_one(:delivery_partner).through(:lead_provider_delivery_partnership) }
+    it { is_expected.to have_one(:registration_period).through(:lead_provider_delivery_partnership) }
   end
 
   describe "validations" do
     subject { FactoryBot.create(:school_partnership) }
 
     it { is_expected.to validate_presence_of(:school) }
-    it { is_expected.to validate_presence_of(:registration_period_id) }
-    it { is_expected.to validate_presence_of(:lead_provider_id) }
-    it { is_expected.to validate_presence_of(:delivery_partner_id) }
-
-    context "uniqueness of registration_period scoped to lead_provider_id and delivery_partner_id" do
-      context "when the provider partnership matches the lead_provider_id, delivery_partner_id and registration_period values
-               of an existing provider partnership" do
-        subject { FactoryBot.build(:school_partnership, registration_period_id:, lead_provider_id:, delivery_partner_id:) }
-
-        let!(:existing_partnership) { FactoryBot.create(:school_partnership) }
-        let(:registration_period_id) { existing_partnership.registration_period_id }
-        let(:lead_provider_id) { existing_partnership.lead_provider_id }
-        let(:delivery_partner_id) { existing_partnership.delivery_partner_id }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(registration_period_id: ["has already been added"])
-        end
-      end
-    end
+    it { is_expected.to validate_presence_of(:lead_provider_delivery_partnership) }
+    it { is_expected.to validate_uniqueness_of(:lead_provider_delivery_partnership).scoped_to(:school_id) }
   end
 
   describe "scopes" do
-    let!(:ay_1) { FactoryBot.create(:registration_period) }
-    let!(:ay_2) { FactoryBot.create(:registration_period) }
-    let!(:lp_1) { FactoryBot.create(:lead_provider) }
-    let!(:lp_2) { FactoryBot.create(:lead_provider) }
-    let!(:dp_1) { FactoryBot.create(:delivery_partner) }
-    let!(:dp_2) { FactoryBot.create(:delivery_partner) }
-    let!(:partnership_1) { FactoryBot.create(:school_partnership, registration_period: ay_1, lead_provider: lp_1, delivery_partner: dp_1) }
-    let!(:partnership_2) { FactoryBot.create(:school_partnership, registration_period: ay_1, lead_provider: lp_1, delivery_partner: dp_2) }
-    let!(:partnership_3) { FactoryBot.create(:school_partnership, registration_period: ay_1, lead_provider: lp_2, delivery_partner: dp_1) }
-    let!(:partnership_4) { FactoryBot.create(:school_partnership, registration_period: ay_2, lead_provider: lp_1, delivery_partner: dp_2) }
+    let(:ay_1) { FactoryBot.create(:registration_period) }
+    let(:ay_2) { FactoryBot.create(:registration_period) }
+    let(:lp_1) { FactoryBot.create(:lead_provider) }
+    let(:lp_2) { FactoryBot.create(:lead_provider) }
+    let(:dp_1) { FactoryBot.create(:delivery_partner) }
+    let(:dp_2) { FactoryBot.create(:delivery_partner) }
+    let(:lpap_1) { create(:lead_provider_active_period, lead_provider: lp_1, registration_period: ay_1) }
+    let(:lpap_2) { create(:lead_provider_active_period, lead_provider: lp_2, registration_period: ay_1) }
+    let(:lpap_3) { create(:lead_provider_active_period, lead_provider: lp_1, registration_period: ay_2) }
+    let(:lpdp_1) { create(:lead_provider_delivery_partnership, lead_provider_active_period: lpap_1, delivery_partner: dp_1) }
+    let(:lpdp_2) { create(:lead_provider_delivery_partnership, lead_provider_active_period: lpap_1, delivery_partner: dp_2) }
+    let(:lpdp_3) { create(:lead_provider_delivery_partnership, lead_provider_active_period: lpap_2, delivery_partner: dp_1) }
+    let(:lpdp_4) { create(:lead_provider_delivery_partnership, lead_provider_active_period: lpap_3, delivery_partner: dp_2) }
+    let!(:partnership_1) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lpdp_1) }
+    let!(:partnership_2) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lpdp_2) }
+    let!(:partnership_3) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lpdp_3) }
+    let!(:partnership_4) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lpdp_4) }
 
     describe ".for_registration_period" do
       it "returns provider partnerships only for the specified academic year" do

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -9,7 +9,7 @@ describe SchoolPartnership do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:school_partnership) }
+    subject { build(:school_partnership) }
 
     it { is_expected.to validate_presence_of(:school) }
     it { is_expected.to validate_presence_of(:lead_provider_delivery_partnership) }

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -4,11 +4,14 @@ describe SchoolPartnership do
     it { is_expected.to belong_to(:lead_provider).inverse_of(:school_partnerships) }
     it { is_expected.to belong_to(:delivery_partner).inverse_of(:school_partnerships) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to belong_to(:lead_provider_delivery_partnership).optional }
+    it { is_expected.to belong_to(:school) }
   end
 
   describe "validations" do
     subject { FactoryBot.create(:school_partnership) }
 
+    it { is_expected.to validate_presence_of(:school) }
     it { is_expected.to validate_presence_of(:registration_period_id) }
     it { is_expected.to validate_presence_of(:lead_provider_id) }
     it { is_expected.to validate_presence_of(:delivery_partner_id) }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -122,4 +122,148 @@ describe School do
       end
     end
   end
+
+  describe "#eligible_establishment_type?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(type_name:) }
+
+    context "when an eligible establishment type" do
+      let(:type_name) { GIAS::Types::ELIGIBLE_TYPES.sample }
+
+      it { is_expected.to be_eligible_establishment_type }
+    end
+
+    context "when not an eligible establishment type" do
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+
+      it { is_expected.not_to be_eligible_establishment_type }
+    end
+  end
+
+  describe "#cip_only_type?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(type_name:) }
+
+    context "when a CIP only type" do
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+
+      it { is_expected.to be_cip_only_type }
+    end
+
+    context "when not a CIP only type" do
+      let(:type_name) { (GIAS::Types::ALL_TYPES - GIAS::Types::CIP_ONLY_TYPES).sample }
+
+      it { is_expected.not_to be_cip_only_type }
+    end
+  end
+
+  describe "#open?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(status:) }
+
+    context "when status is open" do
+      let(:status) { :open }
+
+      it { is_expected.to be_open }
+    end
+
+    context "when status is proposed_to_close" do
+      let(:status) { :proposed_to_close }
+
+      it { is_expected.to be_open }
+    end
+
+    context "when status is closed" do
+      let(:status) { :closed }
+
+      it { is_expected.not_to be_open }
+    end
+  end
+
+  describe "#eligible?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(status:, type_name:, in_england:, section_41_approved:) }
+
+    context "when open, in england and an eligible establishment type" do
+      let(:status) { :open }
+      let(:in_england) { true }
+      let(:type_name) { GIAS::Types::ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.to be_eligible }
+    end
+
+    context "when open, in england and an section 41 approved" do
+      let(:status) { :open }
+      let(:in_england) { true }
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { true }
+
+      it { is_expected.to be_eligible }
+    end
+
+    context "when not open, in engliand and an eligible establishment type" do
+      let(:status) { :closed }
+      let(:in_england) { true }
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.not_to be_eligible }
+    end
+
+    context "when open, not in england and section 41 approved" do
+      let(:status) { :open }
+      let(:in_england) { false }
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { true }
+
+      it { is_expected.not_to be_eligible }
+    end
+  end
+
+  describe "#cip_only?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(status:, type_name:, in_england:, section_41_approved:) }
+
+    context "when ineligible, open and a cip only type" do
+      let(:in_england) { false }
+      let(:status) { :open }
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.to be_cip_only }
+    end
+
+    context "when eligible, open and a cip only type" do
+      let(:in_england) { true }
+      let(:status) { :open }
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+      let(:section_41_approved) { true }
+
+      it { is_expected.not_to be_cip_only }
+    end
+
+    context "when ineligible, closed and a cip only type" do
+      let(:in_england) { false }
+      let(:status) { :closed }
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.not_to be_cip_only }
+    end
+
+    context "when ineligible, open and not a cip only type" do
+      let(:in_england) { false }
+      let(:status) { :open }
+      let(:type_name) { (GIAS::Types::ALL_TYPES - GIAS::Types::CIP_ONLY_TYPES).sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.not_to be_cip_only }
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -17,6 +17,7 @@ describe School do
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:mentor_at_school_periods).inverse_of(:school) }
     it { is_expected.to have_many(:mentor_teachers).through(:mentor_at_school_periods).source(:teacher) }
+    it { is_expected.to have_many(:school_partnerships) }
   end
 
   describe 'validations' do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -32,14 +32,14 @@ describe TrainingPeriod do
       end
 
       context "when only school_partnership is present" do
-        let(:school_partnership) { create(:school_partnership) }
+        let(:school_partnership) { create(:school_partnership, school: ect_at_school_period.school) }
 
         it { is_expected.to be_valid }
       end
 
       context "when both expression_of_interest and school_partnership are present" do
         let(:expression_of_interest) { create(:lead_provider_active_period) }
-        let(:school_partnership) { create(:school_partnership) }
+        let(:school_partnership) { create(:school_partnership, school: ect_at_school_period.school) }
 
         it { is_expected.to be_valid }
       end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -175,6 +175,20 @@ describe TrainingPeriod do
         expect(TrainingPeriod.for_mentor(456).to_sql).to end_with(%(WHERE "training_periods"."mentor_at_school_period_id" = 456))
       end
     end
+
+    describe ".for_school" do
+      it "returns training periods only for the specified school" do
+        ect_at_school_period_1 = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
+        training_period_1 = create(:training_period, ect_at_school_period: ect_at_school_period_1, started_on: 1.month.ago, finished_on: 1.week.ago)
+        ect_at_school_period_2 = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
+        training_period_2 = create(:training_period, ect_at_school_period: ect_at_school_period_2, started_on: 1.month.ago, finished_on: 1.week.ago)
+        mentor_at_school_period = create(:mentor_at_school_period, school: training_period_1.ect_at_school_period.school, started_on: 1.year.ago, finished_on: 1.week.ago)
+        training_period_3 = create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on: 1.month.ago)
+
+        expect(TrainingPeriod.for_school(training_period_1.ect_at_school_period.school)).to contain_exactly(training_period_1, training_period_3)
+        expect(TrainingPeriod.for_school(training_period_2.ect_at_school_period.school)).to contain_exactly(training_period_2)
+      end
+    end
   end
 
   describe "#siblings" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -164,6 +164,16 @@ describe TrainingPeriod do
   end
 
   describe "scopes" do
+    describe ".pending" do
+      subject { described_class.pending }
+
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+      let!(:actioned_expression_of_interest) { create(:training_period, ect_at_school_period:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+      let!(:pending_expression_of_interest) { create(:training_period, ect_at_school_period:, school_partnership: nil, started_on: '2022-06-01', finished_on: '2023-01-01') }
+
+      it { is_expected.to contain_exactly(pending_expression_of_interest) }
+    end
+
     describe ".for_ect" do
       it "returns training periods only for the specified ect at school period" do
         expect(TrainingPeriod.for_ect(123).to_sql).to end_with(%(WHERE "training_periods"."ect_at_school_period_id" = 123))

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -5,8 +5,6 @@ describe TrainingPeriod do
     it { is_expected.to belong_to(:school_partnership) }
     it { is_expected.to have_many(:declarations).inverse_of(:training_period) }
     it { is_expected.to have_many(:events) }
-    it { is_expected.to have_one(:lead_provider).through(:school_partnership) }
-    it { is_expected.to have_one(:delivery_partner).through(:school_partnership) }
   end
 
   describe "validations" do

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,28 +1,28 @@
 RSpec.describe "Participant declarations API", type: :request do
   describe "#create" do
     it "returns method not allowed" do
-      post api_v3_declarations_path
+      api_post(api_v3_declarations_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_declarations_path
+      api_get(api_v3_declarations_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_declaration_path(123)
+      api_get(api_v3_declaration_path(123))
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#void" do
     it "returns method not allowed" do
-      put api_v3_declaration_void_path(123)
+      api_put(api_v3_declaration_void_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "Delivery partners API", type: :request do
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_delivery_partners_path
+      api_get(api_v3_delivery_partners_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_delivery_partner_path(123)
+      api_get(api_v3_delivery_partner_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/participant_transfers_spec.rb
+++ b/spec/requests/api/v3/participant_transfers_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "Participant transfers API", type: :request do
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_transfers_path
+      api_get(api_v3_transfers_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_participant_transfers_path(123)
+      api_get(api_v3_participant_transfers_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,42 +1,44 @@
 RSpec.describe "Participants API", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_participants_path
+      api_get(api_v3_participants_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_participant_path(123)
+      api_get(api_v3_participant_path(123))
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#change_schedule" do
     it "returns method not allowed" do
-      put api_v3_participant_change_schedule_path(123)
+      api_put(api_v3_participant_change_schedule_path(123))
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#defer" do
     it "returns method not allowed" do
-      put api_v3_participant_defer_path(123)
+      api_put(api_v3_participant_defer_path(123))
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#resume" do
     it "returns method not allowed" do
-      put api_v3_participant_resume_path(123)
+      api_put(api_v3_participant_resume_path(123))
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#withdraw" do
     it "returns method not allowed" do
-      put api_v3_participant_withdraw_path(123)
+      api_put(api_v3_participant_withdraw_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -1,28 +1,34 @@
 RSpec.describe "Partnerships API", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+
   describe "#create" do
     it "returns method not allowed" do
-      post api_v3_partnerships_path
+      api_post(api_v3_partnerships_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_partnerships_path
-      expect(response).to be_method_not_allowed
+      api_get(api_v3_partnerships_path)
+
+      expect(response).to be_successful
+      expect(parsed_response["data"]).to be_empty
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_partnership_path(123)
-      expect(response).to be_method_not_allowed
+      api_get(api_v3_partnership_path(123))
+
+      expect(response).to be_successful
+      expect(parsed_response["data"]).to be_empty
     end
   end
 
   describe "#update" do
     it "returns method not allowed" do
-      put api_v3_partnership_path(123)
+      api_put(api_v3_partnership_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "Schools API", type: :request do
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_schools_path
+      api_get(api_v3_schools_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_school_path(123)
+      api_get(api_v3_school_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "Statements API", type: :request do
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_statements_path
+      api_get(api_v3_statements_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_statement_path(123)
+      api_get(api_v3_statement_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe "Unfunded mentors API", type: :request do
   describe "#index" do
     it "returns method not allowed" do
-      get api_v3_unfunded_mentors_path
+      api_get(api_v3_unfunded_mentors_path)
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
     it "returns method not allowed" do
-      get api_v3_unfunded_mentor_path(123)
+      api_get(api_v3_unfunded_mentor_path(123))
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -152,6 +152,17 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
       expect(expression_of_interest.reload.school_partnership).to eq(created_school_partnership)
     end
 
+    it "ignores expressions of interest that have already been actioned" do
+      ect_at_school_period = create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      expression_of_interest: lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+
+      expect { create_school_partnership }.not_to(change { expression_of_interest.reload.school_partnership })
+    end
+
     it "ignores expressions of interest for the lead provider active period if the school is different" do
       ect_at_school_period = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
       expression_of_interest = create(:training_period,

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -1,0 +1,187 @@
+RSpec.describe API::SchoolPartnerships::Create, type: :model do
+  let(:service) do
+    described_class.new(
+      registration_year:,
+      school_ecf_id:,
+      lead_provider_ecf_id:,
+      delivery_partner_ecf_id:
+    )
+  end
+
+  let(:registration_period) { create(:registration_period) }
+  let(:registration_year) { registration_period.year }
+
+  let(:gias_school) { create(:gias_school, :eligible_for_fip, :eligible_type) }
+  let(:school) { create(:school, urn: gias_school.urn, gias_school: nil) }
+  let(:school_ecf_id) { school.ecf_id }
+
+  let(:lead_provider) { create(:lead_provider) }
+  let(:lead_provider_ecf_id) { lead_provider.ecf_id }
+
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:delivery_partner_ecf_id) { delivery_partner.ecf_id }
+
+  let!(:lead_provider_active_period) { create(:lead_provider_active_period, lead_provider:, registration_period:) }
+  let!(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, lead_provider_active_period:, delivery_partner:) }
+
+  let(:ect_at_school_period) { create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago) }
+  let!(:fip_participant) { create(:training_period, ect_at_school_period:, started_on: 2.months.ago, finished_on: 1.month.ago) }
+
+  describe "validations" do
+    subject { service }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:registration_year) }
+    it { is_expected.to validate_presence_of(:school_ecf_id) }
+    it { is_expected.to validate_presence_of(:lead_provider_ecf_id) }
+    it { is_expected.to validate_presence_of(:delivery_partner_ecf_id) }
+
+    context "when the registration year does not exist" do
+      let(:registration_year) { registration_period.year - 1 }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:registration_year]).to include("Registration year does not exist")
+      end
+    end
+
+    context "when the lead provider does not exist" do
+      let(:lead_provider_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:lead_provider_ecf_id]).to include("Lead provider does not exist")
+      end
+    end
+
+    context "when the school does not exist" do
+      let(:school_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School does not exist")
+      end
+    end
+
+    context "when the school is CIP only" do
+      let(:gias_school) { create(:gias_school, :cip_only) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School is CIP only")
+      end
+    end
+
+    context "when the school is not eligible" do
+      let(:gias_school) { create(:gias_school, :not_eligible_type) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School is not eligible")
+      end
+    end
+
+    context "when the school partnership already exists" do
+      before { create(:school_partnership, school:, lead_provider_delivery_partnership:) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School partnership already exists for the lead provider, delivery partner and registration year")
+      end
+    end
+
+    context "when a school training period does not exist" do
+      let(:other_school) { create(:school) }
+
+      before { ect_at_school_period.update!(school: other_school) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School does not have any FIP participants")
+      end
+    end
+
+    context "when a mentor at school period exists" do
+      let(:mentor_at_school_period) { create(:mentor_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago) }
+      let!(:fip_participant) { create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on: 1.month.ago) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the delivery partner does not exist" do
+      let(:delivery_partner_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Delivery partner does not exist")
+      end
+    end
+
+    context "when a lead provider delivery partnership does not exist" do
+      let(:lead_provider_delivery_partnership) { nil }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Lead provider and delivery partner do not have a partnership")
+      end
+    end
+  end
+
+  describe "#create" do
+    subject(:create_school_partnership) { service.create }
+
+    it "creates a school partnership" do
+      created_school_partnership = nil
+
+      expect { created_school_partnership = create_school_partnership }.to change(SchoolPartnership, :count).by(1)
+
+      expect(created_school_partnership).to have_attributes(school:, lead_provider_delivery_partnership:)
+    end
+
+    it "accepts expressions of interest for the lead provider active period providing the school is consistent" do
+      ect_at_school_period = create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      school_partnership: nil,
+                                      expression_of_interest: lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+      created_school_partnership = create_school_partnership
+
+      expect(expression_of_interest.reload.school_partnership).to eq(created_school_partnership)
+    end
+
+    it "ignores expressions of interest for the lead provider active period if the school is different" do
+      ect_at_school_period = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      school_partnership: nil,
+                                      expression_of_interest: lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+
+      expect { create_school_partnership }.not_to(change { expression_of_interest.reload.school_partnership })
+    end
+
+    it "ignores expressions of interest for other lead provider active periods" do
+      other_lead_provider_active_period = create(:lead_provider_active_period, registration_period:)
+      ect_at_school_period = create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      school_partnership: nil,
+                                      expression_of_interest: other_lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+
+      expect { create_school_partnership }.not_to(change { expression_of_interest.reload.school_partnership })
+    end
+
+    context "when invalid" do
+      let(:school_ecf_id) { SecureRandom.uuid }
+
+      it { is_expected.to be(false) }
+      it { expect { create_school_partnership }.not_to change(SchoolPartnership, :count) }
+    end
+  end
+end

--- a/spec/services/api/school_partnerships/update_spec.rb
+++ b/spec/services/api/school_partnerships/update_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe API::SchoolPartnerships::Update, type: :model do
+  let(:service) do
+    described_class.new(
+      school_partnership:,
+      delivery_partner_ecf_id:
+    )
+  end
+
+  let(:school_partnership) { create(:school_partnership) }
+
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:delivery_partner_ecf_id) { delivery_partner.ecf_id }
+
+  let!(:lead_provider_active_period) { school_partnership.lead_provider_active_period }
+  let!(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, lead_provider_active_period:, delivery_partner:) }
+
+  describe "validations" do
+    subject { service }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:school_partnership) }
+    it { is_expected.to validate_presence_of(:delivery_partner_ecf_id) }
+
+    context "when the delivery partner does not exist" do
+      let(:delivery_partner_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Delivery partner does not exist")
+      end
+    end
+
+    context "when a lead provider delivery partnership does not exist" do
+      let(:lead_provider_delivery_partnership) { nil }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Lead provider and delivery partner do not have a partnership")
+      end
+    end
+
+    context "when the school partnership already exists" do
+      before { create(:school_partnership, school: school_partnership.school, lead_provider_delivery_partnership:) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School partnership already exists for the lead provider, delivery partner and registration year")
+      end
+    end
+  end
+
+  describe "#update" do
+    subject(:update_school_partnership) { service.update }
+
+    it "update the school partnership" do
+      expect { update_school_partnership }.to change(school_partnership, :delivery_partner).to(delivery_partner)
+    end
+
+    context "when invalid" do
+      let(:delivery_partner_ecf_id) { SecureRandom.uuid }
+
+      it { is_expected.to be(false) }
+      it { expect { update_school_partnership }.not_to change(school_partnership, :delivery_partner) }
+    end
+  end
+end

--- a/spec/support/requests/api_helpers.rb
+++ b/spec/support/requests/api_helpers.rb
@@ -1,0 +1,40 @@
+module Helpers
+  module APIHelpers
+    def api_get(url, params: {}, headers: {}, token: nil)
+      token ||= lead_provider_token
+      headers ||= {}
+      headers["Authorization"] = "Bearer #{token}"
+
+      get url, params:, headers:
+    end
+
+    def api_post(url, params: {}, headers: {}, token: nil)
+      token ||= lead_provider_token
+      headers ||= {}
+      headers["Authorization"] = "Bearer #{token}"
+      headers["Content-Type"] = "application/json"
+
+      post url, params: params.to_json, headers:
+    end
+
+    def api_put(url, params: {}, headers: {}, token: nil)
+      token ||= lead_provider_token
+      headers ||= {}
+      headers["Authorization"] = "Bearer #{token}"
+      headers["Content-Type"] = "application/json"
+
+      put url, params: params.to_json, headers:
+    end
+
+    def parsed_response
+      Oj.load(response.body)
+    end
+
+    def lead_provider_token
+      lead_provider = current_lead_provider if defined?(current_lead_provider)
+      lead_provider ||= FactoryBot.create(:lead_provider)
+
+      APIToken.create_with_random_token!(lead_provider:)
+    end
+  end
+end

--- a/spec/support/testing_request_specs.rb
+++ b/spec/support/testing_request_specs.rb
@@ -4,6 +4,9 @@ RSpec.configure do |config|
   # Set a timeout for request specs
   config.add_setting :request_timeout, default: 3
 
+  # Include helpers for API testing
+  config.include Helpers::APIHelpers, type: :request
+
   # Set a timeout for each request spec
   config.around(:each, type: :request) do |example|
     Timeout.timeout(config.request_timeout) do

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
                       programme_type:,
                       email: 'love@whale.com')
   end
-  let(:school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, school: current_ect_period.school) }
   let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Alpha Teaching School Hub') }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White', corrected_name: 'Baz White') }
   let(:previous_school) { FactoryBot.create(:school, urn: '123456') }

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe 'schools/ects/show.html.erb' do
-  let(:registration_period) { FactoryBot.create(:registration_period) }
   let!(:current_ect_period) do
     FactoryBot.create(:ect_at_school_period,
                       :teaching_school_hub_ab,
@@ -13,9 +12,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
                       programme_type:,
                       email: 'love@whale.com')
   end
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Ambition institute') }
-  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider:, delivery_partner:, registration_period:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership) }
   let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Alpha Teaching School Hub') }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White', corrected_name: 'Baz White') }
   let(:previous_school) { FactoryBot.create(:school, urn: '123456') }
@@ -126,7 +123,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
     it 'values' do
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Alpha Teaching School Hub')
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Full induction programme')
-      expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Ambition institute')
+      expect(rendered).to have_css('dd.govuk-summary-list__value', text: school_partnership.lead_provider.name)
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Provider-led')
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 1.year.ago.to_date.to_fs(:govuk))
       expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Requested LP')


### PR DESCRIPTION
[Jira-4215](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4215)

- Add new partnership models

Adds the new `LeadProviderActivePeriod` and `LeadProviderDeliveryPartnership` models along with minimal validation rules.

- Add school and lead_provider_delivery_partnership to SchoolPartnership

These two relationships define the new way to retrieve the lead provider, delivery partner and registration period for a `SchoolPartnership`. The direct relationships this replaces will be removed in a following commit.

- Replace direct relationships on SchoolPartnership

Remove the direct relationships to `lead_provider`, `delivery_partner` and `registration_period`. Going forward, these will be via `lead_provider_delivery_partnership` and `lead_provider_active_period` to allow greater flexibility in how schools engage with lead providers and delivery partners across registration periods.

- Add expression_of_interest to TrainingPeriod

Add the `expression_of_interest` to the `TrainingPeriod` model. Going forward the `TrainingPeriod` will require an `expression_of_interest` or `school_partnership` (or both, but at least one).

## Notes

- `LeadProviderActivePeriod` is used to define which of the lead providers are active for a given registration year.
- `LeadProviderDeliveryPartnership` describes which delivery partners are associated with which lead provider for each registration year.

These two models will be created up-front by RECT to align with how we setup a new academic year in ECF at the moment (which I believe involves importing the active lead providers and delivery partners from a CSV).

- `TrainingPeriod` describes a period in which a participant is in training. 
- Think of this as the induction record replacement to show how a participant's training changes over time.
- It will have an `expression_of_interest` or a `school_partnership` (or both, but at least one).
- When a participant is on-boarded their training period will either be:
  - Assigned to a `SchoolPartnership` through `school_partnership` if one already exists for the desired school/delivery partner.
  - Assigned to a `LeadProviderActivePeriod` as an `expression_of_interest`
 - Once the lead provider confirms an `expression_of_interest` a `SchoolPartnership` will be created and the `school_partnership` assigned.

We are currently expecting one delivery partner per school per lead provider, but in the future/after looking at the existing data we may need to support multiple. The schema would allow for that.

```mermaid
erDiagram
    LeadProvider ||--|{ ActiveLeadProvider : ""
    RegistrationPeriod ||--|{ ActiveLeadProvider : ""
    ActiveLeadProvider ||--|{ LeadProviderDeliveryPartnership : ""
    DeliveryPartner ||--|{ LeadProviderDeliveryPartnership : ""
    LeadProviderDeliveryPartnership ||--|{ SchoolPartnership : ""
    ActiveLeadProvider |o..|{ TrainingPeriod : "expression_of_interest"
    School ||--|{ SchoolPartnership : ""
    SchoolPartnership |o..|{ TrainingPeriod : "confirmed_school_partnership"
```