### PR TITLE
Run CI on all pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   merge_group:
 
 permissions:


### PR DESCRIPTION
At the moment, if we branch off a branch other than `main` and raise a PR it will not trigger a CI run.

As we are working on a non-main base branch for the partnerships spike we would like to run CI on all pull requests.

PR to demonstrate it working: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/535