### PR TITLE
[1498] Handle no teachers on ECT and Mentor index pages

### DIFF
--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -7,31 +7,40 @@
   )
 %>
 
-<%= govuk_button_link_to("Add an ECT", schools_register_ect_wizard_start_path) %>
+<%= govuk_button_link_to(@teachers.present? ? "Add an ECT" : "Register an ECT starting at your school", schools_register_ect_wizard_start_path) %>
 
 <hr class="govuk-section-break--m" />
 
 <div class="govuk-grid-row">
+  <% if @teachers.present? %>
 
-  <div class="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-m">Search by name</h2>
-  </div>
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m">Search by name</h2>
+    </div>
 
-  <div class='govuk-grid-column-two-thirds'>
-    <% @teachers.map { |t| t.ect_at_school_periods.first }.each do |ect| %>
-      <%=
-        govuk_summary_card(title: link_to_ect(ect)) do |card|
-          card.with_summary_list(
-            borders: false,
-            rows: [
-              { key: { text: 'Status' }, value: { text: ect_status(ect) } },
-              { key: { text: 'Mentor' }, value: { text: ect_mentor_details(ect) } },
-            ]
-          )
-        end
-      %>
-    <% end %>
+        <div class='govuk-grid-column-two-thirds'>
+          <% @teachers.map { |t| t.ect_at_school_periods.first }.each do |ect| %>
+            <%=
+              govuk_summary_card(title: link_to_ect(ect)) do |card|
+                card.with_summary_list(
+                  borders: false,
+                  rows: [
+                    { key: { text: 'Status' }, value: { text: ect_status(ect) } },
+                    { key: { text: 'Mentor' }, value: { text: ect_mentor_details(ect) } },
+                  ]
+                )
+              end
+            %>
+          <% end %>
 
-    <%= govuk_pagination(pagy: @pagy) %>
-  </div>
+          <%= govuk_pagination(pagy: @pagy) %>
+        </div>
+
+  <% else %>
+
+    <div class='govuk-grid-column-two-thirds'>
+      <p class="govuk-body">Your school currently has no registered early career teachers.</p>
+    </div>
+    
+  <% end %>
 </div>

--- a/app/views/schools/mentors/index.html.erb
+++ b/app/views/schools/mentors/index.html.erb
@@ -12,16 +12,25 @@
 <hr class="govuk-section-break--m" />
 
 <div class="govuk-grid-row">
+  <% if @mentors.present? %>
+  
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m">Search by name or teacher reference number (TRN)</h2>
+    </div>
 
-  <div class="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-m">Search by name or teacher reference number (TRN)</h2>
-  </div>
+    <div class='govuk-grid-column-two-thirds'>
+      <% @mentors.map do |mentor| %>
+        <%= render Schools::Mentors::SummaryComponent.new(mentor: mentor, school: @school) %>
+      <% end %>
 
-  <div class='govuk-grid-column-two-thirds'>
-    <% @mentors.map do |mentor| %>
-      <%= render Schools::Mentors::SummaryComponent.new(mentor: mentor, school: @school) %>
-    <% end %>
+      <%= govuk_pagination pagy: @pagy %>
+    </div>
 
-    <%= govuk_pagination pagy: @pagy %>
-  </div>
+  <% else %>
+
+    <div class='govuk-grid-column-two-thirds'>
+      <p class="govuk-body">Your school currently has no registered mentors.</p>
+    </div>
+
+  <% end %>
 </div>

--- a/spec/features/schools/register_an_ect/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_start_adding_an_ect
-    page.get_by_role('link', name: 'Add an ECT').click
+    page.get_by_role('link', name: 'Register an ECT starting at your school').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/register_an_ect/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/register_an_ect/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_start_adding_an_ect
-    page.get_by_role('link', name: 'Add an ECT').click
+    page.get_by_role('link', name: 'Register an ECT starting at your school').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/register_an_ect/happy_path_spec.rb
+++ b/spec/features/schools/register_an_ect/happy_path_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_start_adding_an_ect
-    page.get_by_role('link', name: 'Add an ECT').click
+    page.get_by_role('link', name: 'Register an ECT starting at your school').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/views/schools/ects/index.html.erb_spec.rb
+++ b/spec/views/schools/ects/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'schools/ects/index.html.erb' do
-  let(:school) { create(:school) }
+  let(:school) { FactoryBot.create(:school) }
 
   before do
     assign(:ects, [])
@@ -19,8 +19,8 @@ RSpec.describe 'schools/ects/index.html.erb' do
   end
 
   context 'when there are teachers' do
-    let(:teacher) { create(:teacher) }
-    let(:ect_period) { create(:ect_at_school_period, teacher:, school:) }
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:) }
 
     before do
       assign(:ects, [ect_period])

--- a/spec/views/schools/ects/index.html.erb_spec.rb
+++ b/spec/views/schools/ects/index.html.erb_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'schools/ects/index.html.erb' do
+  let(:school) { create(:school) }
+
+  before do
+    assign(:ects, [])
+    assign(:teachers, [])
+    assign(:school, school)
+    render
+  end
+
+  context 'when there are no teachers' do
+    it 'shows a message that there are no registered ECTs' do
+      expect(rendered).to have_css('div.govuk-grid-column-two-thirds p.govuk-body', text: 'Your school currently has no registered early career teachers.')
+    end
+
+    it 'shows the Register an ECT starting at your school button' do
+      expect(rendered).to have_css('a.govuk-button', text: 'Register an ECT starting at your school')
+    end
+  end
+
+  context 'when there are teachers' do
+    let(:teacher) { create(:teacher) }
+    let(:ect_period) { create(:ect_at_school_period, teacher:, school:) }
+
+    before do
+      assign(:ects, [ect_period])
+      assign(:teachers, [teacher])
+      assign(:school, school)
+      render
+    end
+
+    it 'shows the "Add an ECT" button' do
+      expect(rendered).to have_css('a.govuk-button', text: 'Add an ECT')
+    end
+  end
+end

--- a/spec/views/schools/mentors/index.html.erb_spec.rb
+++ b/spec/views/schools/mentors/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'schools/mentors/index.html.erb' do
-  let(:school) { create(:school) }
+  let(:school) { FactoryBot.create(:school) }
 
   before do
     assign(:school, school)

--- a/spec/views/schools/mentors/index.html.erb_spec.rb
+++ b/spec/views/schools/mentors/index.html.erb_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe 'schools/mentors/index.html.erb' do
+  let(:school) { create(:school) }
+
+  before do
+    assign(:school, school)
+    assign(:mentors, [])
+    render
+  end
+
+  context 'when there are no mentors' do
+    it 'shows a message that there are no mentors' do
+      expect(rendered).to have_css('div.govuk-grid-column-two-thirds p.govuk-body', text: 'Your school currently has no registered mentors.')
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to render different content on the mentor and ECT index pages when there are no teachers. 

Note that on the ECT index page, we are also rendering different content on the CTA button. The previous content will render if there are teachers.

### ECT index page (with no teachers) screenshot

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/9c47f232-a8e6-42ee-a070-45ae367429bc" />

### Mentor index page (with no teachers) screenshot

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/d88ce04f-41cb-45e2-b6ee-507b85a158b8" />


