### PR TITLE
Reword edit induction spec end date variable

### DIFF
--- a/spec/features/admin/teachers/edit_induction_period_spec.rb
+++ b/spec/features/admin/teachers/edit_induction_period_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Admin amending number of terms of an induction period" do
     when_i_click_edit_link
     then_i_should_be_on_the_edit_induction_period_page
 
-    last_year_following_month = 11.months.ago.to_date
-    when_i_set_end_date(last_year_following_month.month.to_s, last_year_following_month.year.to_s)
+    new_finish_date = induction_period.started_on + 1.week
+    when_i_set_end_date(new_finish_date.month.to_s, new_finish_date.year.to_s)
     when_i_update_the_number_of_terms(5)
     and_i_click_submit
 


### PR DESCRIPTION
The previous change (28cda12ef15982d873) fixed a flaky spec but it wasn't clear why it failed - because the factory creates a start date `1.year.ago` but we hardcoded the finish date, so eventually it stopped working.

This makes it clearer that we're setting the finish date after the start date.
