### PR TITLE
Fix typo on mentor TRN not found page

### DIFF
--- a/app/views/schools/register_mentor_wizard/trn_not_found.md.erb
+++ b/app/views/schools/register_mentor_wizard/trn_not_found.md.erb
@@ -2,7 +2,8 @@
 title: We're unable to match the mentor with the details you provided
 ---
 
-You can check the mentor's teacher reference number (TRN) is accurate by [reviewing their teacher record](https://www.gov.uk/guidance/check-a-teachers-record)
-Alternatively, you can ask the mentor to check their TRN by using the [Find a lost TRN service](https://find-a-lost-trn.education.gov.uk/start)
+You can check the mentor's teacher reference number (TRN) is accurate by [reviewing their teacher record](https://www.gov.uk/guidance/check-a-teachers-record).
+
+Alternatively, you can ask the mentor to check their TRN by using the [Find a lost TRN service](https://find-a-lost-trn.education.gov.uk/start).
 
 <%= govuk_button_link_to("Try again", schools_register_mentor_wizard_find_mentor_path) %>


### PR DESCRIPTION
This fixes:
- the lack of a break
- the lack of full stops