### PR TITLE
Support creating/updating partnerships

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -83,6 +83,16 @@ class School < ApplicationRecord
   # chosen_lead_provider_name
   delegate :name, to: :chosen_lead_provider, prefix: true, allow_nil: true
 
+  def cip_only? = !eligible? && open? && cip_only_type?
+
+  def eligible? = open? && in_england && (eligible_establishment_type? || section_41_approved)
+
+  def open? = status.in?(%w[open proposed_to_close])
+
+  def cip_only_type? = type_name.in?(GIAS::Types::CIP_ONLY_TYPES)
+
+  def eligible_establishment_type? = type_name.in?(GIAS::Types::ELIGIBLE_TYPES)
+
   def independent? = GIAS::Types::INDEPENDENT_SCHOOLS_TYPES.include?(type_name)
 
   def programme_choices

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -7,6 +7,7 @@ class SchoolPartnership < ApplicationRecord
   has_one :lead_provider, through: :lead_provider_delivery_partnership
   has_one :delivery_partner, through: :lead_provider_delivery_partnership
   has_one :registration_period, through: :lead_provider_delivery_partnership
+  has_one :lead_provider_active_period, through: :lead_provider_delivery_partnership
 
   # Validations
   validates :school, presence: true

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -26,6 +26,10 @@ class TrainingPeriod < ApplicationRecord
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
   scope :for_mentor, ->(mentor_at_school_period_id) { where(mentor_at_school_period_id:) }
   scope :for_school_partnership, ->(school_partnership_id) { where(school_partnership_id:) }
+  scope :for_school, ->(school) do
+    left_outer_joins(:ect_at_school_period, :mentor_at_school_period)
+    .where("ect_at_school_periods.school_id = :school_id OR mentor_at_school_periods.school_id = :school_id", school_id: school.id)
+  end
 
   # Instance methods
   def for_ect?

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -30,6 +30,7 @@ class TrainingPeriod < ApplicationRecord
     left_outer_joins(:ect_at_school_period, :mentor_at_school_period)
     .where("ect_at_school_periods.school_id = :school_id OR mentor_at_school_periods.school_id = :school_id", school_id: school.id)
   end
+  scope :pending, -> { where(school_partnership_id: nil) }
 
   # Instance methods
   def for_ect?

--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module API::SchoolPartnerships
+  class Create
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :registration_year
+    attribute :school_ecf_id
+    attribute :lead_provider_ecf_id
+    attribute :delivery_partner_ecf_id
+
+    validates :registration_year, :school_ecf_id, :lead_provider_ecf_id, :delivery_partner_ecf_id, presence: true
+    validate :registration_period_exists
+    validate :lead_provider_exists
+    validate :school_exists
+    validate :school_is_not_cip_only
+    validate :school_is_eligible
+    validate :delivery_partner_exists
+    validate :lead_provider_delivery_partnership_exists
+    validate :school_partnership_does_not_already_exists
+    validate :school_training_period_exists
+
+    def create
+      return false unless valid?
+
+      SchoolPartnership.create!(
+        school:,
+        lead_provider_delivery_partnership:
+      ).tap { |school_partnership| accept_expressions_of_interest(school_partnership) }
+    end
+
+  private
+
+    def accept_expressions_of_interest(school_partnership)
+      expressions_of_interest = school_partnership.lead_provider_active_period.expressions_of_interest
+      expressions_of_interest.for_school(school).each do |expression_of_interest|
+        expression_of_interest.update!(school_partnership:)
+      end
+    end
+
+    def registration_period
+      @registration_period ||= RegistrationPeriod.find_by(year: registration_year) if registration_year
+    end
+
+    def lead_provider
+      @lead_provider ||= LeadProvider.find_by(ecf_id: lead_provider_ecf_id) if lead_provider_ecf_id
+    end
+
+    def school
+      @school ||= School.find_by(ecf_id: school_ecf_id) if school_ecf_id
+    end
+
+    def delivery_partner
+      @delivery_partner ||= DeliveryPartner.find_by(ecf_id: delivery_partner_ecf_id) if delivery_partner_ecf_id
+    end
+
+    def registration_period_exists
+      errors.add(:registration_year, "Registration year does not exist") unless registration_period
+    end
+
+    def lead_provider_exists
+      errors.add(:lead_provider_ecf_id, "Lead provider does not exist") unless lead_provider
+    end
+
+    def school_exists
+      errors.add(:school_ecf_id, "School does not exist") unless school
+    end
+
+    def school_is_not_cip_only
+      errors.add(:school_ecf_id, "School is CIP only") if school&.cip_only?
+    end
+
+    def school_is_eligible
+      errors.add(:school_ecf_id, "School is not eligible") unless school&.eligible?
+    end
+
+    def school_partnership_does_not_already_exists
+      return unless school && lead_provider_delivery_partnership
+
+      existing_school_partnership = school.school_partnerships.exists?(lead_provider_delivery_partnership:)
+
+      errors.add(:school_ecf_id, "School partnership already exists for the lead provider, delivery partner and registration year") if existing_school_partnership
+    end
+
+    def school_training_period_exists
+      return unless school
+
+      training_periods = TrainingPeriod.for_school(school)
+
+      errors.add(:school_ecf_id, "School does not have any FIP participants") unless training_periods.exists?
+    end
+
+    def delivery_partner_exists
+      errors.add(:delivery_partner_ecf_id, "Delivery partner does not exist") unless delivery_partner
+    end
+
+    def lead_provider_active_period
+      return unless lead_provider && registration_period
+
+      @lead_provider_active_period ||= lead_provider.active_periods.find_by(registration_period:)
+    end
+
+    def lead_provider_delivery_partnership
+      return unless lead_provider_active_period && delivery_partner
+
+      @lead_provider_delivery_partnership ||= delivery_partner.lead_provider_delivery_partnerships.find_by(lead_provider_active_period:, delivery_partner:)
+    end
+
+    def lead_provider_delivery_partnership_exists
+      return unless lead_provider && delivery_partner
+
+      errors.add(:delivery_partner_ecf_id, "Lead provider and delivery partner do not have a partnership") unless lead_provider_delivery_partnership
+    end
+  end
+end

--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -33,7 +33,7 @@ module API::SchoolPartnerships
   private
 
     def accept_expressions_of_interest(school_partnership)
-      expressions_of_interest = school_partnership.lead_provider_active_period.expressions_of_interest
+      expressions_of_interest = school_partnership.lead_provider_active_period.expressions_of_interest.pending
       expressions_of_interest.for_school(school).each do |expression_of_interest|
         expression_of_interest.update!(school_partnership:)
       end

--- a/app/services/api/school_partnerships/update.rb
+++ b/app/services/api/school_partnerships/update.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module API::SchoolPartnerships
+  class Update
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :school_partnership
+    attribute :delivery_partner_ecf_id
+
+    validates :school_partnership, :delivery_partner_ecf_id, presence: true
+    validate :delivery_partner_exists
+    validate :lead_provider_delivery_partnership_exists
+    validate :school_partnership_does_not_already_exists
+
+    def update
+      return false unless valid?
+
+      school_partnership.update!(lead_provider_delivery_partnership:)
+    end
+
+  private
+
+    def delivery_partner
+      @delivery_partner ||= DeliveryPartner.find_by(ecf_id: delivery_partner_ecf_id) if delivery_partner_ecf_id
+    end
+
+    def lead_provider
+      @lead_provider ||= school_partnership.lead_provider
+    end
+
+    def lead_provider_active_period
+      @lead_provider_active_period ||= school_partnership.lead_provider_active_period
+    end
+
+    def lead_provider_delivery_partnership
+      return unless school_partnership && delivery_partner
+
+      @lead_provider_delivery_partnership ||= delivery_partner.lead_provider_delivery_partnerships.find_by(lead_provider_active_period:, delivery_partner:)
+    end
+
+    def delivery_partner_exists
+      errors.add(:delivery_partner_ecf_id, "Delivery partner does not exist") unless delivery_partner
+    end
+
+    def lead_provider_delivery_partnership_exists
+      return unless school_partnership && delivery_partner
+
+      errors.add(:delivery_partner_ecf_id, "Lead provider and delivery partner do not have a partnership") unless lead_provider_delivery_partnership
+    end
+
+    def school_partnership_does_not_already_exists
+      return unless school_partnership && lead_provider_delivery_partnership
+
+      existing_school_partnership = school_partnership.school.school_partnerships.exists?(lead_provider_delivery_partnership:)
+
+      errors.add(:school_ecf_id, "School partnership already exists for the lead provider, delivery partner and registration year") if existing_school_partnership
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -197,6 +197,7 @@
   - chosen_lead_provider_id
   - chosen_programme_type
   - id
+  - ecf_id
   - created_at
   - updated_at
   - urn
@@ -279,6 +280,7 @@
   - email
   :lead_providers:
   - id
+  - ecf_id
   - name
   - created_at
   - updated_at
@@ -330,6 +332,7 @@
   - updated_at
   :delivery_partners:
   - id
+  - ecf_id
   - name
   - created_at
   - updated_at

--- a/db/migrate/20250501130805_add_ecf_id_to_models.rb
+++ b/db/migrate/20250501130805_add_ecf_id_to_models.rb
@@ -1,0 +1,7 @@
+class AddECFIdToModels < ActiveRecord::Migration[8.0]
+  def change
+    add_column :schools, :ecf_id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_column :lead_providers, :ecf_id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_column :delivery_partners, :ecf_id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_01_130805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -123,6 +123,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["name"], name: "index_delivery_partners_on_name", unique: true
   end
 
@@ -295,6 +296,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["name"], name: "index_lead_providers_on_name", unique: true
   end
 
@@ -399,6 +401,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_103043) do
     t.bigint "chosen_appropriate_body_id"
     t.bigint "chosen_lead_provider_id"
     t.enum "chosen_programme_type", enum_type: "programme_type"
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["chosen_appropriate_body_id"], name: "index_schools_on_chosen_appropriate_body_id"
     t.index ["chosen_lead_provider_id"], name: "index_schools_on_chosen_lead_provider_id"
     t.index ["urn"], name: "schools_unique_urn", unique: true

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -6,6 +6,7 @@ describe SchoolPartnership do
     it { is_expected.to have_one(:lead_provider).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:delivery_partner).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:registration_period).through(:lead_provider_delivery_partnership) }
+    it { is_expected.to have_one(:lead_provider_active_period).through(:lead_provider_delivery_partnership) }
   end
 
   describe "validations" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -122,4 +122,148 @@ describe School do
       end
     end
   end
+
+  describe "#eligible_establishment_type?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(type_name:) }
+
+    context "when an eligible establishment type" do
+      let(:type_name) { GIAS::Types::ELIGIBLE_TYPES.sample }
+
+      it { is_expected.to be_eligible_establishment_type }
+    end
+
+    context "when not an eligible establishment type" do
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+
+      it { is_expected.not_to be_eligible_establishment_type }
+    end
+  end
+
+  describe "#cip_only_type?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(type_name:) }
+
+    context "when a CIP only type" do
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+
+      it { is_expected.to be_cip_only_type }
+    end
+
+    context "when not a CIP only type" do
+      let(:type_name) { (GIAS::Types::ALL_TYPES - GIAS::Types::CIP_ONLY_TYPES).sample }
+
+      it { is_expected.not_to be_cip_only_type }
+    end
+  end
+
+  describe "#open?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(status:) }
+
+    context "when status is open" do
+      let(:status) { :open }
+
+      it { is_expected.to be_open }
+    end
+
+    context "when status is proposed_to_close" do
+      let(:status) { :proposed_to_close }
+
+      it { is_expected.to be_open }
+    end
+
+    context "when status is closed" do
+      let(:status) { :closed }
+
+      it { is_expected.not_to be_open }
+    end
+  end
+
+  describe "#eligible?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(status:, type_name:, in_england:, section_41_approved:) }
+
+    context "when open, in england and an eligible establishment type" do
+      let(:status) { :open }
+      let(:in_england) { true }
+      let(:type_name) { GIAS::Types::ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.to be_eligible }
+    end
+
+    context "when open, in england and an section 41 approved" do
+      let(:status) { :open }
+      let(:in_england) { true }
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { true }
+
+      it { is_expected.to be_eligible }
+    end
+
+    context "when not open, in engliand and an eligible establishment type" do
+      let(:status) { :closed }
+      let(:in_england) { true }
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.not_to be_eligible }
+    end
+
+    context "when open, not in england and section 41 approved" do
+      let(:status) { :open }
+      let(:in_england) { false }
+      let(:type_name) { GIAS::Types::NOT_ELIGIBLE_TYPES.sample }
+      let(:section_41_approved) { true }
+
+      it { is_expected.not_to be_eligible }
+    end
+  end
+
+  describe "#cip_only?" do
+    subject(:school) { create(:school) }
+
+    before { school.gias_school.update(status:, type_name:, in_england:, section_41_approved:) }
+
+    context "when ineligible, open and a cip only type" do
+      let(:in_england) { false }
+      let(:status) { :open }
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.to be_cip_only }
+    end
+
+    context "when eligible, open and a cip only type" do
+      let(:in_england) { true }
+      let(:status) { :open }
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+      let(:section_41_approved) { true }
+
+      it { is_expected.not_to be_cip_only }
+    end
+
+    context "when ineligible, closed and a cip only type" do
+      let(:in_england) { false }
+      let(:status) { :closed }
+      let(:type_name) { GIAS::Types::CIP_ONLY_TYPES.sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.not_to be_cip_only }
+    end
+
+    context "when ineligible, open and not a cip only type" do
+      let(:in_england) { false }
+      let(:status) { :open }
+      let(:type_name) { (GIAS::Types::ALL_TYPES - GIAS::Types::CIP_ONLY_TYPES).sample }
+      let(:section_41_approved) { false }
+
+      it { is_expected.not_to be_cip_only }
+    end
+  end
 end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -175,6 +175,20 @@ describe TrainingPeriod do
         expect(TrainingPeriod.for_mentor(456).to_sql).to end_with(%(WHERE "training_periods"."mentor_at_school_period_id" = 456))
       end
     end
+
+    describe ".for_school" do
+      it "returns training periods only for the specified school" do
+        ect_at_school_period_1 = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
+        training_period_1 = create(:training_period, ect_at_school_period: ect_at_school_period_1, started_on: 1.month.ago, finished_on: 1.week.ago)
+        ect_at_school_period_2 = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
+        training_period_2 = create(:training_period, ect_at_school_period: ect_at_school_period_2, started_on: 1.month.ago, finished_on: 1.week.ago)
+        mentor_at_school_period = create(:mentor_at_school_period, school: training_period_1.ect_at_school_period.school, started_on: 1.year.ago, finished_on: 1.week.ago)
+        training_period_3 = create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on: 1.month.ago)
+
+        expect(TrainingPeriod.for_school(training_period_1.ect_at_school_period.school)).to contain_exactly(training_period_1, training_period_3)
+        expect(TrainingPeriod.for_school(training_period_2.ect_at_school_period.school)).to contain_exactly(training_period_2)
+      end
+    end
   end
 
   describe "#siblings" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -164,6 +164,16 @@ describe TrainingPeriod do
   end
 
   describe "scopes" do
+    describe ".pending" do
+      subject { described_class.pending }
+
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+      let!(:actioned_expression_of_interest) { create(:training_period, ect_at_school_period:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+      let!(:pending_expression_of_interest) { create(:training_period, ect_at_school_period:, school_partnership: nil, started_on: '2022-06-01', finished_on: '2023-01-01') }
+
+      it { is_expected.to contain_exactly(pending_expression_of_interest) }
+    end
+
     describe ".for_ect" do
       it "returns training periods only for the specified ect at school period" do
         expect(TrainingPeriod.for_ect(123).to_sql).to end_with(%(WHERE "training_periods"."ect_at_school_period_id" = 123))

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -152,6 +152,17 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
       expect(expression_of_interest.reload.school_partnership).to eq(created_school_partnership)
     end
 
+    it "ignores expressions of interest that have already been actioned" do
+      ect_at_school_period = create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      expression_of_interest: lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+
+      expect { create_school_partnership }.not_to(change { expression_of_interest.reload.school_partnership })
+    end
+
     it "ignores expressions of interest for the lead provider active period if the school is different" do
       ect_at_school_period = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
       expression_of_interest = create(:training_period,

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -1,0 +1,187 @@
+RSpec.describe API::SchoolPartnerships::Create, type: :model do
+  let(:service) do
+    described_class.new(
+      registration_year:,
+      school_ecf_id:,
+      lead_provider_ecf_id:,
+      delivery_partner_ecf_id:
+    )
+  end
+
+  let(:registration_period) { create(:registration_period) }
+  let(:registration_year) { registration_period.year }
+
+  let(:gias_school) { create(:gias_school, :eligible_for_fip, :eligible_type) }
+  let(:school) { create(:school, urn: gias_school.urn, gias_school: nil) }
+  let(:school_ecf_id) { school.ecf_id }
+
+  let(:lead_provider) { create(:lead_provider) }
+  let(:lead_provider_ecf_id) { lead_provider.ecf_id }
+
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:delivery_partner_ecf_id) { delivery_partner.ecf_id }
+
+  let!(:lead_provider_active_period) { create(:lead_provider_active_period, lead_provider:, registration_period:) }
+  let!(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, lead_provider_active_period:, delivery_partner:) }
+
+  let(:ect_at_school_period) { create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago) }
+  let!(:fip_participant) { create(:training_period, ect_at_school_period:, started_on: 2.months.ago, finished_on: 1.month.ago) }
+
+  describe "validations" do
+    subject { service }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:registration_year) }
+    it { is_expected.to validate_presence_of(:school_ecf_id) }
+    it { is_expected.to validate_presence_of(:lead_provider_ecf_id) }
+    it { is_expected.to validate_presence_of(:delivery_partner_ecf_id) }
+
+    context "when the registration year does not exist" do
+      let(:registration_year) { registration_period.year - 1 }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:registration_year]).to include("Registration year does not exist")
+      end
+    end
+
+    context "when the lead provider does not exist" do
+      let(:lead_provider_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:lead_provider_ecf_id]).to include("Lead provider does not exist")
+      end
+    end
+
+    context "when the school does not exist" do
+      let(:school_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School does not exist")
+      end
+    end
+
+    context "when the school is CIP only" do
+      let(:gias_school) { create(:gias_school, :cip_only) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School is CIP only")
+      end
+    end
+
+    context "when the school is not eligible" do
+      let(:gias_school) { create(:gias_school, :not_eligible_type) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School is not eligible")
+      end
+    end
+
+    context "when the school partnership already exists" do
+      before { create(:school_partnership, school:, lead_provider_delivery_partnership:) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School partnership already exists for the lead provider, delivery partner and registration year")
+      end
+    end
+
+    context "when a school training period does not exist" do
+      let(:other_school) { create(:school) }
+
+      before { ect_at_school_period.update!(school: other_school) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School does not have any FIP participants")
+      end
+    end
+
+    context "when a mentor at school period exists" do
+      let(:mentor_at_school_period) { create(:mentor_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago) }
+      let!(:fip_participant) { create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on: 1.month.ago) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the delivery partner does not exist" do
+      let(:delivery_partner_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Delivery partner does not exist")
+      end
+    end
+
+    context "when a lead provider delivery partnership does not exist" do
+      let(:lead_provider_delivery_partnership) { nil }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Lead provider and delivery partner do not have a partnership")
+      end
+    end
+  end
+
+  describe "#create" do
+    subject(:create_school_partnership) { service.create }
+
+    it "creates a school partnership" do
+      created_school_partnership = nil
+
+      expect { created_school_partnership = create_school_partnership }.to change(SchoolPartnership, :count).by(1)
+
+      expect(created_school_partnership).to have_attributes(school:, lead_provider_delivery_partnership:)
+    end
+
+    it "accepts expressions of interest for the lead provider active period providing the school is consistent" do
+      ect_at_school_period = create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      school_partnership: nil,
+                                      expression_of_interest: lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+      created_school_partnership = create_school_partnership
+
+      expect(expression_of_interest.reload.school_partnership).to eq(created_school_partnership)
+    end
+
+    it "ignores expressions of interest for the lead provider active period if the school is different" do
+      ect_at_school_period = create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      school_partnership: nil,
+                                      expression_of_interest: lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+
+      expect { create_school_partnership }.not_to(change { expression_of_interest.reload.school_partnership })
+    end
+
+    it "ignores expressions of interest for other lead provider active periods" do
+      other_lead_provider_active_period = create(:lead_provider_active_period, registration_period:)
+      ect_at_school_period = create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 1.week.ago)
+      expression_of_interest = create(:training_period,
+                                      school_partnership: nil,
+                                      expression_of_interest: other_lead_provider_active_period,
+                                      ect_at_school_period:,
+                                      started_on: 2.months.ago,
+                                      finished_on: 1.month.ago)
+
+      expect { create_school_partnership }.not_to(change { expression_of_interest.reload.school_partnership })
+    end
+
+    context "when invalid" do
+      let(:school_ecf_id) { SecureRandom.uuid }
+
+      it { is_expected.to be(false) }
+      it { expect { create_school_partnership }.not_to change(SchoolPartnership, :count) }
+    end
+  end
+end

--- a/spec/services/api/school_partnerships/update_spec.rb
+++ b/spec/services/api/school_partnerships/update_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe API::SchoolPartnerships::Update, type: :model do
+  let(:service) do
+    described_class.new(
+      school_partnership:,
+      delivery_partner_ecf_id:
+    )
+  end
+
+  let(:school_partnership) { create(:school_partnership) }
+
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:delivery_partner_ecf_id) { delivery_partner.ecf_id }
+
+  let!(:lead_provider_active_period) { school_partnership.lead_provider_active_period }
+  let!(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, lead_provider_active_period:, delivery_partner:) }
+
+  describe "validations" do
+    subject { service }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:school_partnership) }
+    it { is_expected.to validate_presence_of(:delivery_partner_ecf_id) }
+
+    context "when the delivery partner does not exist" do
+      let(:delivery_partner_ecf_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Delivery partner does not exist")
+      end
+    end
+
+    context "when a lead provider delivery partnership does not exist" do
+      let(:lead_provider_delivery_partnership) { nil }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_ecf_id]).to include("Lead provider and delivery partner do not have a partnership")
+      end
+    end
+
+    context "when the school partnership already exists" do
+      before { create(:school_partnership, school: school_partnership.school, lead_provider_delivery_partnership:) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_ecf_id]).to include("School partnership already exists for the lead provider, delivery partner and registration year")
+      end
+    end
+  end
+
+  describe "#update" do
+    subject(:update_school_partnership) { service.update }
+
+    it "update the school partnership" do
+      expect { update_school_partnership }.to change(school_partnership, :delivery_partner).to(delivery_partner)
+    end
+
+    context "when invalid" do
+      let(:delivery_partner_ecf_id) { SecureRandom.uuid }
+
+      it { is_expected.to be(false) }
+      it { expect { update_school_partnership }.not_to change(school_partnership, :delivery_partner) }
+    end
+  end
+end


### PR DESCRIPTION
[Jira-4222](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4222)

### Support creating/updating partnerships

Add support for creating and updating partnerships by replicating the service behaviour in ECF.

Add `ecf_id` to `School`, `DeliveryPartner` and `LeadProvider` models.

Add convenience methods to `School` for eligibility checks.

Add `Create` and `Update` services.

Accept expressions of interest for the same school when creating a `SchoolPartnership`.

### Notes on implementation

There's going to be some difficulty with keeping parity with ECF and also adopting the RECT modelling/terminology. I've opted to keep the service request/attribute naming consistent with RECT, however we'll need to translate the attributes back into what we currently return in ECF (along with any error messages - replacing `registration year` with `cohort`, for example). We may be able to do something around custom I18n backends/middleware to achieve this globally (not quite the same, but similar to [this in NPQ reg](https://github.com/DFE-Digital/npq-registration/blob/main/lib/i18n/backend/npq.rb)).

In general the mix of terminology is going to be confusing; we may want to look into seeing if we can reference the RECT terminology instead of the ECF terms for 'cohort/registration year', 'partnership/school partnership' for example.

In RECT we can't tell which school is intending to offer DfE funding for which registration period as there is no notion of a `SchoolCohort`. Instead, we have dropped the validation for this as well as the restriction on a single LP/School/Registration Year partnership (off the back of Nathan's suggestion). To determine if we should allow a partnership at all we are now checking if there are any `TrainingPeriod` records with the school relationship, which implies a FIP participant as CIP don't get training periods in RECT.

I have not gone as far as implementing partnership reminders/notifications in this spike.

Relationships and challenged partnerships are not going to be supported in RECT.

The behaviour of expressions of interests is still TBC, but for the sake of this spike we will accept expressions of interests for a given school if they have the same LP/registration year combination and we ignore any others.

A couple of pain points I ran into with this spike:

- Training period factories are a bit iffy; you can't just `create(:training_period)` as often the date ranges don't align with the associated ECT/mentor at school periods. I found it would sometimes work locally but then fail in CI, so I have had to manually create the at school periods with started on/finished on dates and set the training period dates manually as well to ensure they will align.
- Creating schools in a certain state is hard because of how the school/GIAS school factory is setup. To create a school with a custom GIAS school you need to `nil` it in the factory and assciate it with the `urn` which is confusing, for example: `build(:school, gias_school: nil, urn: gias_school.urn)
- The randomness in the school factory made lots of my seed data flakey until I made them explicit - I think we should get rid of the `[true false].sample` stuff in the seeds, personally.