### PR TITLE
Remove regeneration steps from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,3 @@ We still aim to work as openly as possible and will respond to any issues or pul
 ## Entity Relationships
 
 ![Entity Relationship Diagram](documentation/domain-model.png)
-
-You can regenerate this diagram with:
-
-```sh
-bundle exec erd
-```


### PR DESCRIPTION
### Context

It feels like unnecessary clutter to have this in the README, the diagram will autogenerate when a migration is run and this should be committed with the migration.

Therefore the diagram should always be up to date and there should be no need for someone to manually regenerate.