### PR TITLE
Add example env vars for GIAS import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ DFE_ANALYTICS_ENABLED=false
 ENCRYPTION_PRIMARY_KEY=local_primary_key
 ENCRYPTION_DETERMINISTIC_KEY=local_deterministic_key
 ENCRYPTION_DERIVATION_SALT=local_derivation_salt
+GIAS_API_SCHEMA=https://ea-edubase-api-prod.azurewebsites.net/edubase/schema/service.wsdl
+GIAS_API_PASSWORD=
+GIAS_API_USER=
+GIAS_EXTRACT_ID=


### PR DESCRIPTION
These environment variables need to be populated in order for the GIAS school import rake task to run.