### PR TITLE
Spike partnerships data compatibility

### DIFF
--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -2,5 +2,15 @@ module Migration
   class School < Migration::Base
     has_many :school_cohorts
     has_many :partnerships
+
+    def in_england?
+      english_district_code?(administrative_district_code)
+    end
+
+    def english_district_code?(district_code)
+      # expanded to include the 9999 code which seems to have crept in and is preventing a couple of schools onboarding
+      # the establishment codes should filter out any that should not come in that are 9999 district
+      district_code.to_s.match?(/^([Ee]|9999)/)
+    end
   end
 end

--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -19,7 +19,7 @@ module API::SchoolPartnerships
     validate :delivery_partner_exists
     validate :lead_provider_delivery_partnership_exists
     validate :school_partnership_does_not_already_exists
-    validate :school_training_period_exists
+    validate :school_training_period_exists # NOTE: disable before running partnership migration script
 
     def create
       return false unless valid?
@@ -72,6 +72,8 @@ module API::SchoolPartnerships
     end
 
     def school_is_eligible
+      return unless school
+
       errors.add(:school_ecf_id, "School is not eligible") unless school&.eligible?
     end
 

--- a/app/services/gias/types.rb
+++ b/app/services/gias/types.rb
@@ -40,6 +40,8 @@ module GIAS
       "Voluntary aided school",
       "Voluntary controlled school",
       "Welsh establishment",
+      "Children's centre linked site",
+      "Children's centre",
     ].freeze
 
     CIP_ONLY_TYPES = [

--- a/partnerships_data_script.temp
+++ b/partnerships_data_script.temp
@@ -13,7 +13,7 @@ end
 schools_not_found = {}
 Migration::School.find_each do |ecf_school|
   gias_school = GIAS::School.find_by(urn: ecf_school.urn)
-  
+
   if gias_school.nil?
     school_status = {
       "Open" => :open,
@@ -37,7 +37,7 @@ Migration::School.find_each do |ecf_school|
     )
 
     unless gias_school.save
-      schools_not_found[ecf_school.id] << ecf_school.errors.full_messages
+      schools_not_found[ecf_school.school_type_name] = gias_school.errors
       next
     end
   end
@@ -47,7 +47,10 @@ Migration::School.find_each do |ecf_school|
 end
 
 schools_not_found.count
-=> 3007 (out of 54796 total)
+=> 5 (out of 54796 total)
+
+schools_not_found.values.map(&:full_messages).flatten.tally
+=> {"Ukprn has already been taken"=>5}
 
 invalid_school_partnerships = {}
 Migration::Partnership.includes(:cohort).find_each do |partnership|
@@ -65,7 +68,7 @@ Migration::Partnership.includes(:cohort).find_each do |partnership|
     delivery_partner_ecf_id: partnership.delivery_partner_id,
   )
 
-  unless service.create
+  unless service.valid?
     invalid_school_partnerships[partnership.id] = service.errors
   end
 end

--- a/partnerships_data_script.temp
+++ b/partnerships_data_script.temp
@@ -1,0 +1,80 @@
+Migration::Cohort.find_each do |cohort|
+  RegistrationPeriod.create!(year: cohort.start_year, started_on: "#{cohort.start_year}-06-01", finished_on: "#{cohort.start_year + 1}-05-31") unless RegistrationPeriod.exists?(year: cohort.start_year) 
+end
+
+Migration::LeadProvider.find_each do |lead_provider|
+  LeadProvider.find_or_create_by!(name: lead_provider.name, ecf_id: lead_provider.id)
+end
+
+Migration::DeliveryPartner.find_each do |delivery_partner|
+  DeliveryPartner.find_or_create_by!(name: delivery_partner.name, ecf_id: delivery_partner.id)
+end
+
+schools_not_found = {}
+Migration::School.find_each do |ecf_school|
+  gias_school = GIAS::School.find_by(urn: ecf_school.urn)
+  
+  if gias_school.nil?
+    school_status = {
+      "Open" => :open,
+      "Closed" => :closed,
+      "Open, but proposed to close" => :proposed_to_close,
+      "Proposed to open" => :proposed_to_open,
+    }.freeze
+
+    gias_school = GIAS::School.new(
+      urn: ecf_school.urn,
+      name: ecf_school.name,
+      status: school_status[ecf_school.school_status_name],
+      funding_eligibility: :eligible_for_fip, # not used
+      section_41_approved: ecf_school.section_41_approved,
+      type_name: ecf_school.school_type_name,
+      local_authority_code: rand(20), # not used
+      establishment_number: ecf_school.urn, # not used
+      induction_eligibility: true, # not used
+      ukprn: ecf_school.ukprn, # not used
+      in_england: ecf_school.in_england?,
+    )
+
+    unless gias_school.save
+      schools_not_found[ecf_school.id] << ecf_school.errors.full_messages
+      next
+    end
+  end
+
+  school = School.find_or_create_by!(urn: ecf_school.urn)
+  school.update!(ecf_id: ecf_school.id)
+end
+
+schools_not_found.count
+=> 3007 (out of 54796 total)
+
+invalid_school_partnerships = {}
+Migration::Partnership.includes(:cohort).find_each do |partnership|
+  lead_provider = LeadProvider.find_by(ecf_id: partnership.lead_provider_id)
+  registration_period = RegistrationPeriod.find_by(year: partnership.cohort.start_year)
+  delivery_partner = DeliveryPartner.find_by(ecf_id: partnership.delivery_partner_id)
+
+  lead_provider_active_period = LeadProviderActivePeriod.find_or_create_by!(lead_provider:, registration_period:)
+  LeadProviderDeliveryPartnership.find_or_create_by!(lead_provider_active_period:, delivery_partner:)
+
+  service = API::SchoolPartnerships::Create.new(
+    registration_year: partnership.cohort.start_year,
+    school_ecf_id: partnership.school_id,
+    lead_provider_ecf_id: partnership.lead_provider_id,
+    delivery_partner_ecf_id: partnership.delivery_partner_id,
+  )
+
+  unless service.create
+    invalid_school_partnerships[partnership.id] = service.errors
+  end
+end
+
+invalid_school_partnerships.values.map(&:full_messages).flatten.tally
+
+=> 
+{"School ECF School is not eligible"=>399,
+ "School ECF School is CIP only"=>69,
+ "School ECF School does not exist"=>14}
+
+ # 63879 total


### PR DESCRIPTION
[Jira-4221](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4221)

Leaving this as draft as we probably don't want to merge this one down.

- Minor updates to validation

Disable the training period validation as we haven't brought this across from ECF yet.

- Add partnerships data migration script

A spike for migrating partnerships data.

Migrates delivery partners, lead providers and cohorts.

Expects GIAS import to have been ran locally, then imports schools from ECF.

Creates partnerships.

#### Notes

Most of the partnerships pull across fine, there are a handful with school-related errors that we will need to dig into further when we investigate the schools data:

```
schools_not_found.count
=> 5 (out of 54796 total)

schools_not_found.values.map(&:full_messages).flatten.tally
=> {"Ukprn has already been taken"=>5}

invalid_school_partnerships.values.map(&:full_messages).flatten.tally
=> 
{"School ECF School is not eligible"=>399,
 "School ECF School is CIP only"=>69,
 "School ECF School does not exist"=>14}
```

If we omit the school validation we only get errors for schools that don't exist:

```
=> {"School ECF School does not exist"=>15}
```