### PR TITLE
Participants endpoint investigation

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -29,7 +29,7 @@ module API
       end
 
       def to_json(obj)
-        ParticipantSerializer.render(obj, root: "data", lead_provider: current_lead_provider)
+        ParticipantSerializer.render(obj, view: :v3, root: "data")
       end
     end
   end

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,12 +1,36 @@
 module API
   module V3
     class ParticipantsController < BaseController
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
+      include Pagination
+
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
+      def show
+        render json: to_json(participants_query.participant(id: participant_params[:id]))
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
+
+    private
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider }
+
+        Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(:id)
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,0 +1,50 @@
+module API
+  class ParticipantSerializer < Blueprinter::Base
+    class AttributesSerializer < Blueprinter::Base
+      exclude :id
+
+      field(:full_name) { |p, _| [p.trainee.teacher.trs_first_name, p.trainee.teacher.trs_last_name].join(' ') }
+      field(:trn) { |p, _| p.trainee.teacher.trn }
+
+      field(:ecf_enrolments) do |object, options|
+        object.trainee.training_periods.map do |training_period|
+          next unless training_period.lead_provider == options[:lead_provider]
+
+          {
+            training_record_id: training_period.id,
+            email: training_period.trainee.email,
+            mentor_id: training_period.for_ect? ? training_period.trainee&.mentors&.map(&:id) : nil,
+            school_urn: training_period.school_partnership&.school&.urn,
+            participant_type: training_period.for_ect? ? :ect : :mentor,
+            cohort: training_period.school_partnership&.registration_period&.year.to_s,
+            training_status: training_period.trainee.teacher.trs_induction_status,
+            participant_status: nil,
+            teacher_reference_number_validated: nil,
+            eligible_for_funding: nil,
+            pupil_premium_uplift: nil,
+            sparsity_uplift: nil,
+            schedule_identifier: nil,
+            delivery_partner_id: training_period.delivery_partner&.id,
+            withdrawal: [],
+            deferral: [],
+            created_at: training_period.created_at.rfc3339,
+            induction_end_date: training_period.finished_on&.strftime("%Y-%m-%d"),
+            mentor_funding_end_date: nil,
+            cohort_changed_after_payments_frozen: nil,
+            mentor_ineligible_for_funding_reason: training_period.for_mentor? ? training_period.trainee.teacher.mentor_became_ineligible_for_funding_reason : nil,
+          }
+        end
+      end
+
+      field :created_at
+      field :updated_at
+    end
+
+    identifier :id
+    field(:type) { "participant" }
+
+    association :attributes, blueprint: AttributesSerializer do |participant|
+      participant
+    end
+  end
+end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,50 +1,63 @@
 module API
   class ParticipantSerializer < Blueprinter::Base
+    identifier :ecf_user_id, name: :id
+    field(:type) { "participant" }
+
     class AttributesSerializer < Blueprinter::Base
       exclude :id
 
-      field(:full_name) { |p, _| [p.trainee.teacher.trs_first_name, p.trainee.teacher.trs_last_name].join(' ') }
-      field(:trn) { |p, _| p.trainee.teacher.trn }
+      view :v3 do
+        field(:full_name) { |t, _| Teachers::Name.new(t).full_name }
+        field(:trn) { |t, _| t.trn }
 
-      field(:ecf_enrolments) do |object, options|
-        object.trainee.training_periods.map do |training_period|
-          next unless training_period.lead_provider == options[:lead_provider]
+        field(:ecf_enrolments) do |teacher, _options|
+          (teacher.ect_at_school_periods + teacher.mentor_at_school_periods).map do |school_period|
+            # Better using uuids instead as we don't know whether latest_training_period is an id from ect_at_school_periods or mentor_at_school_periods
+            training_period = school_period.training_periods.find { |training_period| teacher.latest_training_period.include?(training_period.id) }
 
-          {
-            training_record_id: training_period.id,
-            email: training_period.trainee.email,
-            mentor_id: training_period.for_ect? ? training_period.trainee&.mentors&.map(&:id) : nil,
-            school_urn: training_period.school_partnership&.school&.urn,
-            participant_type: training_period.for_ect? ? :ect : :mentor,
-            cohort: training_period.school_partnership&.registration_period&.year.to_s,
-            training_status: training_period.trainee.teacher.trs_induction_status,
-            participant_status: nil,
-            teacher_reference_number_validated: nil,
-            eligible_for_funding: nil,
-            pupil_premium_uplift: nil,
-            sparsity_uplift: nil,
-            schedule_identifier: nil,
-            delivery_partner_id: training_period.delivery_partner&.id,
-            withdrawal: [],
-            deferral: [],
-            created_at: training_period.created_at.rfc3339,
-            induction_end_date: training_period.finished_on&.strftime("%Y-%m-%d"),
-            mentor_funding_end_date: nil,
-            cohort_changed_after_payments_frozen: nil,
-            mentor_ineligible_for_funding_reason: training_period.for_mentor? ? training_period.trainee.teacher.mentor_became_ineligible_for_funding_reason : nil,
-          }
+            next if training_period.blank?
+
+            {
+              training_record_id: school_period.id,
+              email: school_period.email,
+              mentor_id: training_period.for_ect? ? school_period&.mentors&.map(&:id) : nil,
+              school_urn: training_period.school_partnership&.school&.urn,
+              participant_type: training_period.for_ect? ? :ect : :mentor,
+              cohort: training_period.school_partnership&.registration_period&.year.to_s,
+              training_status: nil,
+              participant_status: teacher.trs_induction_status,
+              teacher_reference_number_validated: nil,
+              eligible_for_funding: nil,
+              pupil_premium_uplift: nil,
+              sparsity_uplift: nil,
+              schedule_identifier: nil,
+              delivery_partner_id: training_period.delivery_partner&.id,
+              withdrawal: [],
+              deferral: [],
+              created_at: training_period.created_at.rfc3339,
+              induction_end_date: training_period.finished_on&.strftime("%Y-%m-%d"),
+              mentor_funding_end_date: nil,
+              cohort_changed_after_payments_frozen: nil,
+              mentor_ineligible_for_funding_reason: training_period.for_mentor? ? teacher.mentor_became_ineligible_for_funding_reason : nil,
+            }
+          end
         end
+
+        field :created_at
+        field :updated_at
       end
-
-      field :created_at
-      field :updated_at
     end
-
-    identifier :id
-    field(:type) { "participant" }
 
     association :attributes, blueprint: AttributesSerializer do |participant|
       participant
+    end
+
+    %i[v1 v2 v3].each do |version|
+      view version do
+        association :attributes, blueprint: AttributesSerializer, view: version do |participant|
+          participant
+        end
+      end
     end
   end
 end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -1,0 +1,74 @@
+module Participants
+  class Query
+    attr_reader :scope, :lead_provider
+
+    def initialize(lead_provider:)
+      @lead_provider = lead_provider
+      @scope = all_participants
+    end
+
+    def participants
+      scope.order(created_at: :asc)
+    end
+
+    def participant(id: nil)
+      scope.where(id:)
+    end
+
+  private
+
+    def all_participants
+      TrainingPeriod.from("(#{ect_participants.to_sql} UNION #{mentor_participants.to_sql}) as training_periods")
+    end
+
+    def ect_participants
+      TrainingPeriod
+        .joins("JOIN (#{latest_ect_training_periods_join.to_sql}) AS latest_ect_training_periods_join ON latest_ect_training_periods_join.latest_id = training_periods.id")
+    end
+
+    def mentor_participants
+      TrainingPeriod
+        .joins("JOIN (#{latest_mentor_training_periods_join.to_sql}) AS latest_mentor_training_periods_join ON latest_mentor_training_periods_join.latest_id = training_periods.id")
+    end
+
+    def latest_ect_training_periods_join
+      TrainingPeriod
+      .select(Arel.sql("DISTINCT FIRST_VALUE(training_periods.id) OVER (#{latest_ect_training_period_order}) AS latest_id"))
+      .joins(:school_partnership)
+      .merge!(SchoolPartnership.for_lead_provider(lead_provider.id))
+    end
+
+    def latest_mentor_training_periods_join
+      TrainingPeriod
+      .select(Arel.sql("DISTINCT FIRST_VALUE(training_periods.id) OVER (#{latest_mentor_training_period_order}) AS latest_id"))
+      .joins(:school_partnership)
+      .merge!(SchoolPartnership.for_lead_provider(lead_provider.id))
+    end
+
+    def latest_ect_training_period_order
+      <<~SQL
+        PARTITION BY(training_periods.ect_at_school_period_id) ORDER BY
+          CASE
+            WHEN training_periods.finished_on IS NULL
+              THEN 1
+            ELSE 2
+          END,
+          training_periods.started_on DESC,
+          training_periods.created_at DESC
+      SQL
+    end
+
+    def latest_mentor_training_period_order
+      <<~SQL
+        PARTITION BY(training_periods.mentor_at_school_period_id) ORDER BY
+          CASE
+            WHEN training_periods.finished_on IS NULL
+              THEN 1
+            ELSE 2
+          END,
+          training_periods.started_on DESC,
+          training_periods.created_at DESC
+      SQL
+    end
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -18,30 +18,38 @@ module Participants
   private
 
     def all_participants
-      TrainingPeriod.from("(#{ect_participants.to_sql} UNION #{mentor_participants.to_sql}) as training_periods")
+      Teacher.select("teachers.*").from("(#{ect_participants.to_sql} UNION #{mentor_participants.to_sql}) as teachers")
     end
 
     def ect_participants
-      TrainingPeriod
-        .joins("JOIN (#{latest_ect_training_periods_join.to_sql}) AS latest_ect_training_periods_join ON latest_ect_training_periods_join.latest_id = training_periods.id")
+      Teacher
+        .select("teachers.*", "COALESCE(jsonb_agg(DISTINCT latest_ect_teachers.latest_id), '[]') AS latest_training_period")
+        .joins(ect_at_school_periods: [training_periods: :school_partnership])
+        .joins("JOIN (#{latest_ect_teachers_join.to_sql}) AS latest_ect_teachers ON latest_ect_teachers.latest_id = training_periods_ect_at_school_periods.id")
+        .group("teachers.id")
+        .distinct
     end
 
     def mentor_participants
-      TrainingPeriod
-        .joins("JOIN (#{latest_mentor_training_periods_join.to_sql}) AS latest_mentor_training_periods_join ON latest_mentor_training_periods_join.latest_id = training_periods.id")
+      Teacher
+        .select("teachers.*", "COALESCE(jsonb_agg(DISTINCT latest_mentor_teachers.latest_id), '[]') AS latest_training_period")
+        .joins(mentor_at_school_periods: [training_periods: :school_partnership])
+        .joins("JOIN (#{latest_mentor_teachers_join.to_sql}) AS latest_mentor_teachers ON latest_mentor_teachers.latest_id = training_periods_mentor_at_school_periods.id")
+        .group("teachers.id")
+        .distinct
     end
 
-    def latest_ect_training_periods_join
-      TrainingPeriod
-      .select(Arel.sql("DISTINCT FIRST_VALUE(training_periods.id) OVER (#{latest_ect_training_period_order}) AS latest_id"))
-      .joins(:school_partnership)
+    def latest_ect_teachers_join
+      Teacher
+      .select(Arel.sql("DISTINCT FIRST_VALUE(training_periods.id) OVER (#{latest_ect_training_period_order}) AS latest_id, teachers.id as teacher_id"))
+      .joins(ect_at_school_periods: [training_periods: :school_partnership])
       .merge!(SchoolPartnership.for_lead_provider(lead_provider.id))
     end
 
-    def latest_mentor_training_periods_join
-      TrainingPeriod
-      .select(Arel.sql("DISTINCT FIRST_VALUE(training_periods.id) OVER (#{latest_mentor_training_period_order}) AS latest_id"))
-      .joins(:school_partnership)
+    def latest_mentor_teachers_join
+      Teacher
+      .select(Arel.sql("DISTINCT FIRST_VALUE(training_periods.id) OVER (#{latest_mentor_training_period_order}) AS latest_id, teachers.id as teacher_id"))
+      .joins(mentor_at_school_periods: [training_periods: :school_partnership])
       .merge!(SchoolPartnership.for_lead_provider(lead_provider.id))
     end
 

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -2,16 +2,20 @@ RSpec.describe "Participants API", type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
 
   describe "#index" do
-    it "returns method not allowed" do
+    it "returns a successful response" do
       api_get(api_v3_participants_path)
-      expect(response).to be_method_not_allowed
+
+      expect(response).to be_successful
+      expect(parsed_response["data"]).to be_empty
     end
   end
 
   describe "#show" do
-    it "returns method not allowed" do
+    it "returns a successful response" do
       api_get(api_v3_participant_path(123))
-      expect(response).to be_method_not_allowed
+
+      expect(response).to be_successful
+      expect(parsed_response["data"]).to be_empty
     end
   end
 

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Partnerships API", type: :request do
   end
 
   describe "#index" do
-    it "returns method not allowed" do
+    it "returns a successful response" do
       api_get(api_v3_partnerships_path)
 
       expect(response).to be_successful
@@ -18,7 +18,7 @@ RSpec.describe "Partnerships API", type: :request do
   end
 
   describe "#show" do
-    it "returns method not allowed" do
+    it "returns a successful response" do
       api_get(api_v3_partnership_path(123))
 
       expect(response).to be_successful


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4223](https://dfedigital.atlassian.net/browse/CPDLP-4223)

We're investigating how the participants endpoints would look like with the new models.

### Changes proposed in this pull request

- This is just a spike and for discussion
- Create `GET /api/v3/participants` and `GET /api/v3/participants/{id}`
- Add query for multiple partnerships
- Add query for single partnership
- Check performance of query
  - ~90ms in comparison to ~300ms in ECF1
- Basic serialiser to surface data - we’ll build the proper one later