### PR TITLE
Make FactoryBot calls explicit

### DIFF
--- a/spec/components/schools/mentors/details_component_spec.rb
+++ b/spec/components/schools/mentors/details_component_spec.rb
@@ -1,41 +1,41 @@
 RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  let(:school) { create(:school) }
-  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:school) { FactoryBot.create(:school) }
+  let(:mentor_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
   let(:started_on) { Date.new(2023, 9, 1) }
 
   let(:mentor) do
-    create(:mentor_at_school_period,
-           teacher: mentor_teacher,
-           school:,
-           started_on:,
-           finished_on: nil)
+    FactoryBot.create(:mentor_at_school_period,
+                      teacher: mentor_teacher,
+                      school:,
+                      started_on:,
+                      finished_on: nil)
   end
 
-  let(:ect_teacher_1) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
-  let(:ect_teacher_2) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
+  let(:ect_teacher_1) { FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+  let(:ect_teacher_2) { FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
 
   let(:ect_period_1) do
-    create(:ect_at_school_period,
-           teacher: ect_teacher_1,
-           school:,
-           started_on:,
-           finished_on: nil)
+    FactoryBot.create(:ect_at_school_period,
+                      teacher: ect_teacher_1,
+                      school:,
+                      started_on:,
+                      finished_on: nil)
   end
 
   let(:ect_period_2) do
-    create(:ect_at_school_period,
-           teacher: ect_teacher_2,
-           school:,
-           started_on:,
-           finished_on: nil)
+    FactoryBot.create(:ect_at_school_period,
+                      teacher: ect_teacher_2,
+                      school:,
+                      started_on:,
+                      finished_on: nil)
   end
 
   context 'when there are ECTs assigned to the mentor' do
     before do
-      create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
-      create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
 
       render_inline(described_class.new(teacher: mentor_teacher, mentor:))
     end
@@ -68,17 +68,17 @@ RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
   end
 
   context 'when there are ECTs not assigned to this mentor' do
-    let(:other_teacher) { create(:teacher, trs_first_name: 'Kakashi', trs_last_name: 'Hatake') }
+    let(:other_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Kakashi', trs_last_name: 'Hatake') }
     let(:other_mentor) do
-      create(:mentor_at_school_period, teacher: other_teacher, school:, started_on:, finished_on: nil)
+      FactoryBot.create(:mentor_at_school_period, teacher: other_teacher, school:, started_on:, finished_on: nil)
     end
-    let(:unrelated_ect_teacher) { create(:teacher, trs_first_name: 'Sauske', trs_last_name: 'Uchiha') }
+    let(:unrelated_ect_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Sauske', trs_last_name: 'Uchiha') }
     let(:unrelated_ect) do
-      create(:ect_at_school_period, teacher: unrelated_ect_teacher, school:, started_on:, finished_on: nil)
+      FactoryBot.create(:ect_at_school_period, teacher: unrelated_ect_teacher, school:, started_on:, finished_on: nil)
     end
 
     before do
-      create(:mentorship_period, mentor: other_mentor, mentee: unrelated_ect, started_on:, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor: other_mentor, mentee: unrelated_ect, started_on:, finished_on: nil)
       render_inline(described_class.new(teacher: mentor_teacher, mentor:))
     end
 

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -1,25 +1,25 @@
 RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :component do
-  let(:school) { create(:school) }
+  let(:school) { FactoryBot.create(:school) }
   let(:mentor_start_date) { Date.new(2023, 1, 1) }
-  let(:mentor) { create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date, finished_on: nil) }
-  let(:teacher) { create(:teacher, mentor_became_ineligible_for_funding_on: nil) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date, finished_on: nil) }
+  let(:teacher) { FactoryBot.create(:teacher, mentor_became_ineligible_for_funding_on: nil) }
 
   context 'when teacher is eligible and there is a provider-led ECT with a lead provider' do
-    let(:lead_provider) { create(:lead_provider, name: 'Hidden leaf village') }
-    let(:ect_teacher) { create(:teacher) }
+    let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Hidden leaf village') }
+    let(:ect_teacher) { FactoryBot.create(:teacher) }
     let(:ect_start_date) { mentor_start_date + 1.month }
     let(:ect) do
-      create(:ect_at_school_period,
-             teacher: ect_teacher,
-             school:,
-             programme_type: 'provider_led',
-             lead_provider:,
-             started_on: ect_start_date,
-             finished_on: nil)
+      FactoryBot.create(:ect_at_school_period,
+                        teacher: ect_teacher,
+                        school:,
+                        programme_type: 'provider_led',
+                        lead_provider:,
+                        started_on: ect_start_date,
+                        finished_on: nil)
     end
 
     before do
-      create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
     end
 
     it 'renders the summary cards' do
@@ -36,20 +36,20 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
   end
 
   context 'when teacher is not eligible' do
-    let(:teacher) { create(:teacher, mentor_became_ineligible_for_funding_on: Date.new(2024, 1, 1)) }
-    let(:ect_teacher) { create(:teacher) }
+    let(:teacher) { FactoryBot.create(:teacher, mentor_became_ineligible_for_funding_on: Date.new(2024, 1, 1)) }
+    let(:ect_teacher) { FactoryBot.create(:teacher) }
     let(:ect_start_date) { mentor_start_date + 1.month }
     let(:ect) do
-      create(:ect_at_school_period,
-             teacher: ect_teacher,
-             school:,
-             programme_type: 'provider_led',
-             started_on: ect_start_date,
-             finished_on: nil)
+      FactoryBot.create(:ect_at_school_period,
+                        teacher: ect_teacher,
+                        school:,
+                        programme_type: 'provider_led',
+                        started_on: ect_start_date,
+                        finished_on: nil)
     end
 
     before do
-      create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
     end
 
     it 'renders the ineligible message' do
@@ -59,19 +59,19 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
   end
 
   context 'when all ECTs are school-led' do
-    let(:ect_teacher) { create(:teacher) }
+    let(:ect_teacher) { FactoryBot.create(:teacher) }
     let(:school_led_ect) do
-      create(:ect_at_school_period,
-             teacher: ect_teacher,
-             school:,
-             programme_type: 'school_led',
-             lead_provider: nil,
-             started_on: mentor_start_date + 1.month,
-             finished_on: nil)
+      FactoryBot.create(:ect_at_school_period,
+                        teacher: ect_teacher,
+                        school:,
+                        programme_type: 'school_led',
+                        lead_provider: nil,
+                        started_on: mentor_start_date + 1.month,
+                        finished_on: nil)
     end
 
     before do
-      create(:mentorship_period, mentor:, mentee: school_led_ect, started_on: school_led_ect.started_on, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor:, mentee: school_led_ect, started_on: school_led_ect.started_on, finished_on: nil)
     end
 
     it 'does not render' do

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
-  let(:school) { create(:school) }
-  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:school) { FactoryBot.create(:school) }
+  let(:mentor_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
   let(:started_on) { Date.new(2023, 9, 1) }
-  let(:mentor) { create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on:, finished_on: nil) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on:, finished_on: nil) }
 
   context 'with no ECTs' do
     it 'shows No ECTs assigned' do
@@ -14,9 +14,9 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'with less than or equal to 5 ECTs' do
     let!(:ects) do
-      create_list(:teacher, 5).map do |teacher|
-        ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
-        create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
+      FactoryBot.create_list(:teacher, 5).map do |teacher|
+        ect = FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
+        FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
         teacher
       end
     end
@@ -32,9 +32,9 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'with more than 5 ECTs' do
     before do
-      create_list(:teacher, 6).each do |teacher|
-        ect = create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
-        create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
+      FactoryBot.create_list(:teacher, 6).each do |teacher|
+        ect = FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil)
+        FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on:, finished_on: nil)
       end
     end
 
@@ -45,18 +45,18 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
   end
 
   context 'when there are multiple mentors' do
-    let(:mentor2_teacher) { create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
-    let(:mentor2) { create(:mentor_at_school_period, :active, teacher: mentor2_teacher, school:, started_on:) }
+    let(:mentor2_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
+    let(:mentor2) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor2_teacher, school:, started_on:) }
 
-    let(:ect1_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
-    let(:ect2_teacher) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
+    let(:ect1_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+    let(:ect2_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
 
-    let(:ect1) { create(:ect_at_school_period, teacher: ect1_teacher, school:, started_on:, finished_on: nil) }
-    let(:ect2) { create(:ect_at_school_period, teacher: ect2_teacher, school:, started_on:, finished_on: nil) }
+    let(:ect1) { FactoryBot.create(:ect_at_school_period, teacher: ect1_teacher, school:, started_on:, finished_on: nil) }
+    let(:ect2) { FactoryBot.create(:ect_at_school_period, teacher: ect2_teacher, school:, started_on:, finished_on: nil) }
 
     before do
-      create(:mentorship_period, mentor:, mentee: ect1, started_on:, finished_on: nil)
-      create(:mentorship_period, mentor: mentor2, mentee: ect2, started_on:, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor:, mentee: ect1, started_on:, finished_on: nil)
+      FactoryBot.create(:mentorship_period, mentor: mentor2, mentee: ect2, started_on:, finished_on: nil)
     end
 
     it 'only shows ECTs assigned to the specific mentor' do

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -20,12 +20,12 @@ private
   def given_that_i_have_an_active_mentor_with_an_ect
     start_date = Date.new(2023, 9, 1)
 
-    @school = create(:school, urn: '1234567')
-    @mentor_teacher = create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki')
-    @mentor = create(:mentor_at_school_period, teacher: @mentor_teacher, school: @school, started_on: start_date, finished_on: nil, id: 1)
+    @school = FactoryBot.create(:school, urn: '1234567')
+    @mentor_teacher = FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki')
+    @mentor = FactoryBot.create(:mentor_at_school_period, teacher: @mentor_teacher, school: @school, started_on: start_date, finished_on: nil, id: 1)
 
-    @ect_teacher = create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki')
-    @ect = create(
+    @ect_teacher = FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki')
+    @ect = FactoryBot.create(
       :ect_at_school_period,
       :provider_led,
       teacher: @ect_teacher,
@@ -34,7 +34,7 @@ private
       finished_on: nil
     )
 
-    create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
+    FactoryBot.create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
   end
 
   def given_i_click_on_an_assigned_ect

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,6 @@ RSpec.configure do |config|
   ]
 
   config.include ActiveSupport::Testing::TimeHelpers
-  config.include FactoryBot::Syntax::Methods
   config.include Features::ViewHelpers, type: :feature
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
     end
 
     context 'with extensions and teacher' do
-      let!(:extension) { create(:induction_extension, teacher:) }
+      let!(:extension) { FactoryBot.create(:induction_extension, teacher:) }
 
       it 'displays the row' do
         render

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -1,25 +1,25 @@
 RSpec.describe 'schools/mentors/show.html.erb' do
-  let(:school) { create(:school) }
+  let(:school) { FactoryBot.create(:school) }
   let(:start_date) { Date.new(2023, 9, 1) }
 
   let(:mentor_teacher) do
-    create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki', mentor_became_ineligible_for_funding_on:)
+    FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki', mentor_became_ineligible_for_funding_on:)
   end
 
   let(:mentor_became_ineligible_for_funding_on) { nil }
 
   let(:mentor_period) do
-    create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: nil)
+    FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: nil)
   end
 
-  let(:lead_provider) { create(:lead_provider, name: 'Hidden leaf village') }
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Hidden leaf village') }
 
   let(:ect_teacher) do
-    create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi')
+    FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi')
   end
 
   let(:ect_period) do
-    create(
+    FactoryBot.create(
       :ect_at_school_period,
       teacher: ect_teacher,
       school:,
@@ -31,7 +31,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
   end
 
   let!(:mentorship_period) do
-    create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: nil)
+    FactoryBot.create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: nil)
   end
 
   before do
@@ -97,7 +97,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
 
   context 'when all ECTs are school-led' do
     let(:ect_period) do
-      create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
+      FactoryBot.create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
     end
 
     before do

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -137,7 +137,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     end
 
     context 'when the mentor is prohibited from teaching' do
-      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -111,7 +111,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
 
     context 'when the mentor is prohibited from teaching' do
-      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new


### PR DESCRIPTION
Including modules at a high level makes it hard to see where methods are coming from, and when they overlap with Rails methods (create, build) it's confusing for people new to the codebase. Instead let's be explicit when we're using FactoryBot.
