### PR TITLE
Use `freeze_time` instead of approximation

### DIFF
--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -70,11 +70,11 @@ describe Teachers::RefreshTRSAttributes do
       end
 
       it "marks the teacher as deactivated when the TRS reports the teacher as 'gone'" do
-        Teachers::RefreshTRSAttributes.new(teacher).refresh!
+        freeze_time do
+          Teachers::RefreshTRSAttributes.new(teacher).refresh!
 
-        expect(fake_manage).to have_received(:mark_teacher_as_deactivated!).once.with(
-          trs_data_last_refreshed_at: within(0.001.seconds).of(Time.zone.now)
-        )
+          expect(fake_manage).to have_received(:mark_teacher_as_deactivated!).once.with(trs_data_last_refreshed_at: Time.zone.now)
+        end
       end
     end
   end


### PR DESCRIPTION
I introduced this flaky spec, it appears the tests run much slower in CI than on my computer. Switching over to `freeze_time` is clearly a better idea.
