### PR TITLE
Run migrations before trying to boot the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,7 @@ RUN apk add --no-cache libpq
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-ENV PORT=8080
-EXPOSE ${PORT}
+EXPOSE 8080
 
-CMD bundle exec rails db:prepare && \
-    bundle exec rails server -b 0.0.0.0 -p ${PORT}
+ENTRYPOINT ["./bin/rails", "server"]
+CMD ["-p", "8080"]

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-
-# If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
-  ./bin/rails db:prepare
-fi
-
-exec "${@}"

--- a/config/terraform/application/application.tf
+++ b/config/terraform/application/application.tf
@@ -33,8 +33,87 @@ module "application_configuration" {
   )
 }
 
+# Run database migrations
+# https://guides.rubyonrails.org/active_record_migrations.html#preparing-the-database
+# Terraform waits for this to complete before starting web_application and worker_application
+resource "kubernetes_job" "migrations" {
+  metadata {
+    name      = "${var.service_name}-${var.environment}-migrations"
+    namespace = var.namespace
+  }
+
+  spec {
+    template {
+      metadata {
+        labels = { app = "${var.service_name}-${var.environment}-migrations" }
+        annotations = {
+          "logit.io/send"        = "true"
+          "fluentbit.io/exclude" = "true"
+        }
+      }
+
+      spec {
+        container {
+          name    = "migrate"
+          image   = var.docker_image
+          command = ["bundle"]
+          args    = ["exec", "rails", "db:prepare"]
+
+          env_from {
+            config_map_ref {
+              name = module.application_configuration.kubernetes_config_map_name
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = module.application_configuration.kubernetes_secret_name
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = module.cluster_data.configuration_map.cpu_min
+              memory = "1Gi"
+            }
+            limits = {
+              cpu    = 1
+              memory = "1Gi"
+            }
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+
+            capabilities {
+              drop = ["ALL"]
+              add  = ["NET_BIND_SERVICE"]
+            }
+          }
+        }
+
+        restart_policy = "Never"
+      }
+    }
+
+    backoff_limit = 1
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "11m"
+    update = "11m"
+  }
+}
+
 module "web_application" {
-  source = "./vendor/modules/aks//aks/application"
+  source     = "./vendor/modules/aks//aks/application"
+  depends_on = [kubernetes_job.migrations]
 
   is_web = true
 
@@ -63,7 +142,8 @@ module "web_application" {
 }
 
 module "worker_application" {
-  source = "./vendor/modules/aks//aks/application"
+  source     = "./vendor/modules/aks//aks/application"
+  depends_on = [kubernetes_job.migrations]
 
   is_web = false
 

--- a/config/terraform/application/variables.tf
+++ b/config/terraform/application/variables.tf
@@ -127,3 +127,21 @@ locals {
     GOOGLE_CLOUD_CREDENTIALS = module.dfe_analytics[0].google_cloud_credentials
   } : {}
 }
+
+variable "commands" {
+  description = "list of required docker image commands for k8s job to run"
+  type        = list(string)
+  default     = ["bundle"]
+}
+
+variable "arguments" {
+  description = "list of required docker image arguments for k8s job to run"
+  type        = list(string)
+  default     = ["exec", "rails", "db:prepare"]
+}
+
+variable "job_name" {
+  description = "name of the k8s job to run"
+  type        = string
+  default     = "migrations"
+}


### PR DESCRIPTION
This is wholesale lifted from https://github.com/DFE-Digital/itt-mentor-services/.

There it was intended to ensure there are no problems caused by multiple containers trying to run the same migrations simultaneously. Here we'll benefit from that too, but also it will simplify our Dockerfile and mean we only need to worry about starting the app, not doing database migration stuff too.