### PR TITLE
Spike statement/item/adjustment models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'rubypants'
 gem "blueprinter"
 gem "oj"
 
+gem "state_machines-activerecord"
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -646,6 +646,13 @@ GEM
       rbtree
       set (~> 1.0)
     stackprof (0.2.27)
+    state_machines (0.6.0)
+    state_machines-activemodel (0.9.0)
+      activemodel (>= 6.0)
+      state_machines (>= 0.6.0)
+    state_machines-activerecord (0.9.0)
+      activerecord (>= 6.0)
+      state_machines-activemodel (>= 0.9.0)
     stringio (3.1.7)
     super_diff (0.15.0)
       attr_extras (>= 6.2.4)
@@ -762,6 +769,7 @@ DEPENDENCIES
   shoulda-matchers
   solid_queue
   stackprof
+  state_machines-activerecord
   super_diff
   tzinfo-data
   webrick

--- a/app/models/lead_provider_active_period.rb
+++ b/app/models/lead_provider_active_period.rb
@@ -3,6 +3,7 @@ class LeadProviderActivePeriod < ApplicationRecord
   belongs_to :registration_period
   has_many :delivery_partnerships, class_name: "LeadProviderDeliveryPartnership"
   has_many :expressions_of_interest, class_name: "TrainingPeriod", inverse_of: :expression_of_interest
+  has_many :statements
 
   validates :lead_provider, presence: true
   validates :registration_period, presence: true

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -1,0 +1,19 @@
+class Statement < ApplicationRecord
+  belongs_to :lead_provider_active_period
+  has_many :items
+  has_many :adjustments
+
+  state_machine :state, initial: :open do
+    state :open
+    state :payable
+    state :paid
+
+    event :mark_as_payable do
+      transition [:open] => :payable
+    end
+
+    event :mark_as_paid do
+      transition [:payable] => :paid
+    end
+  end
+end

--- a/app/models/statement/adjustment.rb
+++ b/app/models/statement/adjustment.rb
@@ -1,0 +1,3 @@
+class Statement::Adjustment < ApplicationRecord
+  belongs_to :statement
+end

--- a/app/models/statement/item.rb
+++ b/app/models/statement/item.rb
@@ -1,0 +1,41 @@
+class Statement::Item < ApplicationRecord
+  belongs_to :statement
+
+  state_machine :state, initial: :eligible do
+    state :eligible
+    state :payable
+    state :paid
+    state :voided
+    state :ineligible
+    state :awaiting_clawback
+    state :clawed_back
+
+    event :mark_as_payable do
+      transition [:eligible] => :payable
+    end
+
+    event :mark_as_paid do
+      transition [:payable] => :paid
+    end
+
+    event :mark_as_voided do
+      transition %i[eligible payable] => :voided
+    end
+
+    event :mark_as_awaiting_clawback do
+      transition [:paid] => :awaiting_clawback
+    end
+
+    event :mark_as_clawed_back do
+      transition [:awaiting_clawback] => :clawed_back
+    end
+
+    event :mark_as_ineligible do
+      transition [:eligible] => :ineligible
+    end
+
+    event :revert_to_eligible do
+      transition [:payable] => :eligible
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -386,3 +386,31 @@
   - registration_period_id
   - created_at
   - updated_at
+  :statement_items:
+  - id
+  - statement_id
+  - ecf_id
+  - state
+  - created_at
+  - updated_at
+  :statement_adjustments:
+  - id
+  - statement_id
+  - ecf_id
+  - payment_type
+  - amount
+  - created_at
+  - updated_at
+  :statements:
+  - id
+  - lead_provider_active_period_id
+  - ecf_id
+  - month
+  - year
+  - deadline_date
+  - payment_date
+  - marked_as_paid_at
+  - output_fee
+  - state
+  - created_at
+  - updated_at

--- a/db/migrate/20250514102421_create_statements.rb
+++ b/db/migrate/20250514102421_create_statements.rb
@@ -1,0 +1,20 @@
+class CreateStatements < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :statement_states, %w[open payable paid]
+
+    create_table :statements do |t|
+      t.references :lead_provider_active_period, null: false, foreign_key: true
+
+      t.uuid :ecf_id, null: false, default: -> { "gen_random_uuid()" }
+      t.integer :month, null: false
+      t.integer :year, null: false
+      t.date :deadline_date, null: false
+      t.date :payment_date, null: false
+      t.datetime :marked_as_paid_at
+      t.boolean :output_fee, default: true, null: false
+      t.enum :state, enum_type: "statement_states", default: "open", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250514103030_create_statement_items.rb
+++ b/db/migrate/20250514103030_create_statement_items.rb
@@ -1,0 +1,14 @@
+class CreateStatementItems < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :statement_item_states, %w[eligible payable paid voided ineligible awaiting_clawback clawed_back]
+
+    create_table :statement_items do |t|
+      t.references :statement, null: false, foreign_key: true
+
+      t.uuid :ecf_id, null: false, default: -> { "gen_random_uuid()" }
+      t.enum :state, enum_type: "statement_item_states", default: "eligible", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250514103518_create_statement_adjustments.rb
+++ b/db/migrate/20250514103518_create_statement_adjustments.rb
@@ -1,0 +1,13 @@
+class CreateStatementAdjustments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :statement_adjustments do |t|
+      t.references :statement, null: false, foreign_key: true
+
+      t.uuid :ecf_id, null: false, default: -> { "gen_random_uuid()" }
+      t.string :payment_type, null: false
+      t.decimal :amount, default: 0.0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/statement/item_factory.rb
+++ b/spec/factories/statement/item_factory.rb
@@ -1,0 +1,37 @@
+FactoryBot.define do
+  factory(:statement_item, class: "Statement::Item") do
+    association :statement
+
+    trait :eligible do
+      state { :eligible }
+    end
+
+    trait :ineligible do
+      state { :ineligible }
+    end
+
+    trait :voided do
+      state { :voided }
+    end
+
+    trait :payable do
+      state { :payable }
+    end
+
+    trait :paid do
+      state { :paid }
+    end
+
+    trait :awaiting_clawback do
+      state { :awaiting_clawback }
+    end
+
+    trait :clawed_back do
+      state { :clawed_back }
+    end
+
+    trait :voided do
+      state { :voided }
+    end
+  end
+end

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory(:statement) do
+    association :lead_provider_active_period
+
+    ecf_id { SecureRandom.uuid }
+    month { Faker::Number.between(from: 1, to: 12) }
+    year { Faker::Number.between(from: 2021, to: 2024) }
+    deadline_date { Faker::Date.forward(days: 30) }
+    payment_date { Faker::Date.forward(days: 30) }
+    output_fee { true }
+
+    trait :open do
+      state { :open }
+    end
+
+    trait :payable do
+      state { :payable }
+    end
+
+    trait :paid do
+      state { :paid }
+    end
+  end
+end

--- a/spec/models/lead_provider_active_period_spec.rb
+++ b/spec/models/lead_provider_active_period_spec.rb
@@ -4,6 +4,7 @@ describe LeadProviderActivePeriod do
     it { is_expected.to belong_to(:registration_period) }
     it { is_expected.to have_many(:delivery_partnerships).class_name("LeadProviderDeliveryPartnership") }
     it { is_expected.to have_many(:expressions_of_interest).class_name("TrainingPeriod").inverse_of(:expression_of_interest) }
+    it { is_expected.to have_many(:statements) }
   end
 
   describe "validations" do

--- a/spec/models/statement/adjustment_spec.rb
+++ b/spec/models/statement/adjustment_spec.rb
@@ -1,0 +1,5 @@
+describe Statement::Adjustment do
+  describe "associations" do
+    it { is_expected.to belong_to(:statement) }
+  end
+end

--- a/spec/models/statement/item_spec.rb
+++ b/spec/models/statement/item_spec.rb
@@ -1,0 +1,61 @@
+describe Statement::Item do
+  describe "associations" do
+    it { is_expected.to belong_to(:statement) }
+
+    describe "state transitions" do
+      context "when transitioning from eligible to payable" do
+        let(:item) { build(:statement_item, :eligible) }
+
+        it { expect { item.mark_as_payable! }.to change(item, :state).from("eligible").to("payable") }
+      end
+
+      context "when transitioning from payable to paid" do
+        let(:item) { build(:statement_item, :payable) }
+
+        it { expect { item.mark_as_paid! }.to change(item, :state).from("payable").to("paid") }
+      end
+
+      context "when transitioning from eligible to voided" do
+        let(:item) { build(:statement_item, :eligible) }
+
+        it { expect { item.mark_as_voided! }.to change(item, :state).from("eligible").to("voided") }
+      end
+
+      context "when transitioning from payable to voided" do
+        let(:item) { build(:statement_item, :payable) }
+
+        it { expect { item.mark_as_voided! }.to change(item, :state).from("payable").to("voided") }
+      end
+
+      context "when transitioning from paid to awaiting_clawback" do
+        let(:item) { build(:statement_item, :paid) }
+
+        it { expect { item.mark_as_awaiting_clawback! }.to change(item, :state).from("paid").to("awaiting_clawback") }
+      end
+
+      context "when transitioning from awaiting_clawback to clawed_back" do
+        let(:item) { build(:statement_item, :awaiting_clawback) }
+
+        it { expect { item.mark_as_clawed_back! }.to change(item, :state).from("awaiting_clawback").to("clawed_back") }
+      end
+
+      context "when transitioning from eligible to ineligible" do
+        let(:item) { build(:statement_item, :eligible) }
+
+        it { expect { item.mark_as_ineligible! }.to change(item, :state).from("eligible").to("ineligible") }
+      end
+
+      context "when transitioning from payable to eligible" do
+        let(:item) { build(:statement_item, :payable) }
+
+        it { expect { item.revert_to_eligible! }.to change(item, :state).from("payable").to("eligible") }
+      end
+
+      context "when transitioning to an invalid state" do
+        let(:item) { build(:statement_item, :awaiting_clawback) }
+
+        it { expect { item.mark_as_paid! }.to raise_error(StateMachines::InvalidTransition) }
+      end
+    end
+  end
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -1,0 +1,27 @@
+describe Statement do
+  describe "associations" do
+    it { is_expected.to belong_to(:lead_provider_active_period) }
+    it { is_expected.to have_many(:adjustments) }
+    it { is_expected.to have_many(:items) }
+  end
+
+  describe "state transitions" do
+    context "when transitioning from open to payable" do
+      let(:statement) { build(:statement, :open) }
+
+      it { expect { statement.mark_as_payable! }.to change(statement, :state).from("open").to("payable") }
+    end
+
+    context "when transitioning from payable to paid" do
+      let(:statement) { build(:statement, :payable) }
+
+      it { expect { statement.mark_as_paid! }.to change(statement, :state).from("payable").to("paid") }
+    end
+
+    context "when transitioning to an invalid state" do
+      let(:statement) { build(:statement, :paid) }
+
+      it { expect { statement.mark_as_payable! }.to raise_error(StateMachines::InvalidTransition) }
+    end
+  end
+end


### PR DESCRIPTION
[Issue #1603](https://github.com/DFE-Digital/register-ects-project-board/issues/1603)

Spike to add the `Statement`, `Statement::Item` and `Statement::Adjustment` models from ECF to RECT.

Adds state machine and transitions for `Statement` and `Statement::Item`.

```mermaid
stateDiagram-v2
  [*] --> open
  open --> payable : mark_as_payable
  payable --> paid : mark_as_paid
```

```mermaid
stateDiagram-v2
  [*] --> eligible

  eligible --> payable : mark_as_payable
  payable --> paid : mark_as_paid
  paid --> awaiting_clawback : mark_as_awaiting_clawback
  awaiting_clawback --> clawed_back : mark_as_clawed_back

  eligible --> voided : mark_as_voided
  payable --> voided : mark_as_voided

  eligible --> ineligible : mark_as_ineligible
  payable --> eligible : revert_to_eligible
```

### Statement models/fields

- The `Statement#original_value` attribute does not appear to be referenced anywhere in ECF. It was introduced [here](https://github.com/DFE-Digital/early-careers-framework/pull/1711).
- The `Statement#contract_version` is out of scope for this spike.
- The `StatementLineItem#participant_
declaration_id` is out of scope for this spike.
- The `Statement#reconcile_amount` appears to be an early adjustments implementation. We plan on moving these to manual adjustments instead of porting over the field. It only effects a small number of statements:

```
Finance::Statement.where.not(reconcile_amount: 0).map { |s| [s.id, s.name, s.cohort.start_year,
 s.reconcile_amount.to_f, s.cpd_lead_provider.name] }
=> 
[["640e79a7-b1e0-4f58-ac57-7d548b546aab", "May 2022", 2021, 579.6],
 ["3ac32912-457e-434c-a4c0-d5cded031ffa", "May 2022", 2021, 2766.661],
 ["973e6200-1f90-46c5-b37c-2bdbd65bc962", "January 2022", 2021, 1196.076],
 ["2261b73d-2aa8-40f7-ab77-ffc578bcb165", "May 2022", 2021, 1762.74],
 ["6b42113a-bbcd-4fa2-a989-06e64d30f206", "January 2022", 2021, 251.82],
 ["74d754be-7049-4164-bc9c-429feeeea1ef", "May 2022", 2021, 907.3513],
 ["619e3a65-b712-4ca1-9584-dc369be17a95", "May 2022", 2021, 1691.5],
 ["9449cf3a-c5d1-43e8-9d46-8dfb8cf48647", "May 2022", 2021, 600.0]]
 ```

 I've opted to structure the namespacing slightly differently to ECF and NPQ reg. Open to discussions:

 - `Statement`
 - `Statement::Item`
 - `Statement::Adjustment`

### Adding `api_id`

We will add an `api_id` (named `ecf_id` in this model for consistency with the base branch) to support the API and data migrations. This is straight-forward as the models have a one-to-one mapping with ECF.

### Lead provider/registration period

There's nothing additional we need to bring across to support statements as far as I can see.

