### PR TITLE
[1438] - Back link from the start of register mentor journey depends on the referer page

### DIFF
--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -34,6 +34,10 @@ module ECTHelper
     end
   end
 
+  def assign_mentor_or_home_ects_path(ect)
+    eligible_mentors_for_ect?(ect) ? new_schools_ect_mentorship_path(ect) : schools_ects_home_path
+  end
+
 private
 
   def assign_or_create_mentor_link(ect)

--- a/app/views/schools/register_mentor_wizard/start.html.erb
+++ b/app/views/schools/register_mentor_wizard/start.html.erb
@@ -1,5 +1,5 @@
 <% page_data(title: "What you'll need to add a new mentor for #{@ect_name}",
-             backlink_href: schools_ects_home_path) %>
+             backlink_href: assign_mentor_or_home_ects_path(@ect)) %>
 
 <p class="govuk-body">You must provide the mentor's:</p>
 <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/1438)

When a school user clicks 'Assign mentor...' to one of their ECTs listed, they can be redirected either to (1) an intermediate page (if there are potential mentors already registered at the school) listing potential mentors + add a new one or (2) straight to the start of the journey to add a new mentor (if there are no potential mentors already registered at the school).

The back link in the view of the start of the journey to add a new mentor (What you will need to register a new mentor) is always linking back to the list of ECTs of the school. 

This ticket will amend that behavior so that in (1) it will redirect the user back to the intermediate view listing the potential mentors of the ECT and in (2) back to the list of ECTs of the school. 

Video:

https://github.com/user-attachments/assets/c6b1bdfb-4aff-4f7c-82bb-1eb8260dda87


