### PR TITLE
Add optional pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+### Context
+
+### Changes proposed in this pull request
+
+### Guidance to review


### PR DESCRIPTION
As discussed in slack, add an optional simple PR template. This is based off the [ECF template](https://github.com/DFE-Digital/early-careers-framework/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

Format from [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template)