### PR TITLE
Add admin timeline link

### DIFF
--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -19,4 +19,8 @@
   component.with_past_induction_periods(enable_edit: true)
 end %>
 
+<p class='govuk-body'>
+  <%= govuk_link_to('View change history', admin_teacher_timeline_path(@teacher)) %>
+</p>
+
 <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") if @teacher.has_migration_failures? %>

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe "Admin::Teachers#show", type: :request do
         expect(response.body).to include(CGI.escape_html(Teachers::Name.new(teacher).full_name))
       end
 
+      it "links to teacher timeline" do
+        get admin_teacher_path(teacher)
+        expect(response.body).to include(admin_teacher_timeline_path(teacher))
+      end
+
       context "when teacher has migration failures" do
         before do
           MigrationFailure.create!(parent_type: "Teacher", parent_id: teacher.id, failure_message: "foo", item: { foo: :bar }, data_migration_id: 1)

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -27,17 +27,6 @@ RSpec.describe "Admin::Teachers#show", type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      it "displays teacher information" do
-        get admin_teacher_path(teacher)
-        expect(response.body).to include(teacher.trn)
-        expect(response.body).to include(CGI.escape_html(Teachers::Name.new(teacher).full_name))
-      end
-
-      it "links to teacher timeline" do
-        get admin_teacher_path(teacher)
-        expect(response.body).to include(admin_teacher_timeline_path(teacher))
-      end
-
       context "when teacher has migration failures" do
         before do
           MigrationFailure.create!(parent_type: "Teacher", parent_id: teacher.id, failure_message: "foo", item: { foo: :bar }, data_migration_id: 1)

--- a/spec/views/admin/teachers/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/show.html.erb_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'admin/teachers/show.html.erb' do
+  let(:teacher) { FactoryBot.create(:teacher, trn: '1234567', trs_first_name: 'Floella', trs_last_name: 'Benjamin') }
+
+  before do
+    FactoryBot.create(:induction_period, :active, teacher:)
+    assign(:teacher, Admin::TeacherPresenter.new(teacher))
+    render
+  end
+
+  it 'includes a back link to admin teachers list' do
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link('Back', href: admin_teachers_path)
+  end
+
+  it 'displays teacher information' do
+    expect(view.content_for(:page_title)).to eql('Floella Benjamin')
+    expect(view.content_for(:page_header)).to have_css('h1', text: 'Floella Benjamin')
+    expect(view.content_for(:page_caption)).to have_text('TRN: 1234567')
+  end
+
+  it 'displays induction information' do
+    expect(rendered).to have_text('Current induction period')
+  end
+
+  it 'links to teacher timeline' do
+    expect(rendered).to have_link('View change history', href: admin_teacher_timeline_path(teacher))
+  end
+
+  context 'when there are no migration failures' do
+    it 'does not report migration failures' do
+      expect(rendered).not_to have_text("Some of this teacher's records could not be migrated")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ready to surface the admin event timeline 

### Changes proposed in this pull request

Add link to ECT's timeline on their admin page

### Guidance to review

Login as admin and navigate to an ECT and click `View change history`

![cpd-ec2-review-618-web test teacherservices cloud_admin_teachers_27](https://github.com/user-attachments/assets/92d0f190-b7d0-436a-b2e8-396d51d19a40)


Fixes #619 