### PR TITLE
Use `allow_value` instead of shoulda matcher `validate_inclusion_of`

### DIFF
--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -7,7 +7,8 @@ describe Statement do
   describe "validations" do
     subject { FactoryBot.create(:statement) }
 
-    it { is_expected.to validate_inclusion_of(:output_fee).in_array([true, false]).with_message("Output fee must be true or false") }
+    it { is_expected.to allow_values(true, false).for(:output_fee).with_message("Output fee must be true or false") }
+    it { is_expected.not_to allow_value(nil).for(:output_fee).with_message("Output fee must be true or false") }
     it { is_expected.to validate_numericality_of(:month).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(12).with_message("Month must be a number between 1 and 12") }
     it { is_expected.to validate_numericality_of(:year).only_integer.is_greater_than_or_equal_to(2020).with_message("Year must be on or after 2020 and on or before #{described_class.maximum_year}") }
     it { is_expected.to validate_uniqueness_of(:active_lead_provider_id).scoped_to(:year, :month).with_message("Statement with the same month and year already exists for the lead provider") }


### PR DESCRIPTION
### Context

We are getting a warning from using `validate_inclusion_of` on a boolean value in the model


### Changes proposed in this pull request

Change spec to `allow_value` instead and add a test for when the value is `nil` as well 

### Guidance to review
Rerun test `spec/models/statement_spec.rb` and there should be no warning