### PR TITLE
Bulk upload outcomes: post-party snag list

### DIFF
--- a/app/presenters/pending_induction_submission_batch_presenter.rb
+++ b/app/presenters/pending_induction_submission_batch_presenter.rb
@@ -14,7 +14,7 @@ class PendingInductionSubmissionBatchPresenter < SimpleDelegator
 
   # @return [String] downloadable CSV of failed submissions and their errors
   def to_csv
-    CSV.generate do |csv|
+    CSV.generate(force_quotes: true) do |csv|
       csv << row_headings.values
       failed_submissions.each { |row| csv << row }
     end

--- a/app/presenters/pending_induction_submission_batch_presenter.rb
+++ b/app/presenters/pending_induction_submission_batch_presenter.rb
@@ -14,8 +14,7 @@ class PendingInductionSubmissionBatchPresenter < SimpleDelegator
 
   # @return [String] downloadable CSV of failed submissions and their errors
   def to_csv
-    CSV.generate(force_quotes: true) do |csv|
-      csv << row_headings.values
+    CSV.generate(headers: row_headings.values, write_headers: true, force_quotes: true) do |csv|
       failed_submissions.each { |row| csv << row }
     end
   end

--- a/public/bulk-actions-template.csv
+++ b/public/bulk-actions-template.csv
@@ -1,1 +1,1 @@
-TRN,Date of birth,Induction period end date,Number of terms,Outcome
+"TRN","Date of birth","Induction period end date","Number of terms","Outcome"

--- a/spec/features/appropriate_bodies/process_batch_action_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_action_spec.rb
@@ -84,8 +84,24 @@ RSpec.describe 'Process bulk actions' do
         end
       end
 
-      context 'when file is not a CSV' do
+      context 'when template is empty' do
+        let(:file_path) { Rails.root.join('public/bulk-actions-template.csv').to_s }
+
+        scenario 'fails immediately' do
+          then_i_should_see_the_error('The selected file is empty')
+        end
+      end
+
+      context 'when file is not a CSV (text)' do
         let(:file_name) { 'invalid_not_a_csv_file.txt' }
+
+        scenario 'fails immediately' do
+          then_i_should_see_the_error('The selected file must be a CSV')
+        end
+      end
+
+      context 'when file is not a CSV (image)' do
+        let(:file_path) { Rails.root.join('documentation/domain-model.png').to_s }
 
         scenario 'fails immediately' do
           then_i_should_see_the_error('The selected file must be a CSV')

--- a/spec/fixtures/invalid_duplicate_trns_action.csv
+++ b/spec/fixtures/invalid_duplicate_trns_action.csv
@@ -1,3 +1,3 @@
-TRN,Date of birth,Induction period end date,Number of terms,Outcome
+"TRN","Date of birth","Induction period end date","Number of terms","Outcome"
 1234567,1981-06-30,,,
 1234567,1981-06-30,,,

--- a/spec/fixtures/invalid_duplicate_trns_claim.csv
+++ b/spec/fixtures/invalid_duplicate_trns_claim.csv
@@ -1,3 +1,3 @@
-TRN,Date of birth,Induction programme,Induction period start date,Error message
+"TRN","Date of birth","Induction programme","Induction period start date","Error message"
 1234567,1981-06-30,fip,,
 1234567,1981-06-30,CIP,,

--- a/spec/fixtures/invalid_missing_columns.csv
+++ b/spec/fixtures/invalid_missing_columns.csv
@@ -1,1 +1,1 @@
-TRN,Date of birth
+"TRN","Date of birth"

--- a/spec/fixtures/seeds_action.csv
+++ b/spec/fixtures/seeds_action.csv
@@ -1,4 +1,4 @@
-TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message
+"TRN","Date of birth","Induction period end date","Number of terms","Outcome","Error message"
 1000890,1997-01-15,2025-04-01,1,pass,
 3002564,1991-07-05,2025-04-01,2,fail,
 3002586,1977-02-03,2025-04-01,3,release,

--- a/spec/fixtures/seeds_claim.csv
+++ b/spec/fixtures/seeds_claim.csv
@@ -1,4 +1,4 @@
-TRN,Date of birth,Induction programme,Induction period start date,Error message
+"TRN","Date of birth","Induction programme","Induction period start date","Error message"
 1000890,1997-01-15,FIP,2025-01-04,
 3002564,1991-07-05,CIP,2025-02-20,
 3002586,1977-02-03,FIP,2025-01-15,

--- a/spec/fixtures/valid_complete_action.csv
+++ b/spec/fixtures/valid_complete_action.csv
@@ -1,3 +1,3 @@
-TRN,Date of birth,Induction period end date,Number of terms,Outcome
+"TRN","Date of birth","Induction period end date","Number of terms","Outcome"
 1234567,1981-06-30,2025-01-30,0.5,pass
 7654321,1981-06-30,2025-01-30,7.2,fail

--- a/spec/fixtures/valid_complete_claim.csv
+++ b/spec/fixtures/valid_complete_claim.csv
@@ -1,3 +1,3 @@
-TRN,Date of birth,Induction programme,Induction period start date
+"TRN","Date of birth","Induction programme","Induction period start date"
 1234567,1981-06-30,fip,2025-01-30
 7654321,1981-06-30,CIP,2025-01-30

--- a/spec/forms/appropriate_bodies/process_batch_form_spec.rb
+++ b/spec/forms/appropriate_bodies/process_batch_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
       end
     end
 
-    describe 'contains some empty rows' do
+    describe 'contains some empty rows (at the end)' do
       let(:csv_content) do
         <<~CSV
           TRN,Date of birth,Induction period end date,Number of terms,Outcome
@@ -68,6 +68,26 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
           2345678,2001-02-02,2024-12-31,2,Fail
           ,,,,
           ,,,,
+        CSV
+      end
+
+      specify do
+        expect(form).to be_valid
+        expect(form.to_a).to eq([
+          { trn: '1234567', date_of_birth: '2000-01-01', finished_on: '2023-12-31', number_of_terms: '1', outcome: 'Pass', },
+          { trn: '2345678', date_of_birth: '2001-02-02', finished_on: '2024-12-31', number_of_terms: '2', outcome: 'Fail' }
+        ])
+      end
+    end
+
+    describe 'contains some empty rows (in the middle)' do
+      let(:csv_content) do
+        <<~CSV
+          TRN,Date of birth,Induction period end date,Number of terms,Outcome
+          ,,,,
+          1234567,2000-01-01,2023-12-31,1,Pass
+          ,,,,
+          2345678,2001-02-02,2024-12-31,2,Fail
         CSV
       end
 

--- a/spec/forms/appropriate_bodies/process_batch_form_spec.rb
+++ b/spec/forms/appropriate_bodies/process_batch_form_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
 
   let(:content_type) { 'text/csv' }
   let(:csv_file_size) { 50.kilobytes }
+  let(:csv_file_name) { 'test.csv' }
 
   let(:csv_file) do
     instance_double(ActionDispatch::Http::UploadedFile,
                     content_type:,
                     size: csv_file_size,
                     read: csv_content,
-                    original_filename: 'test.csv')
+                    original_filename: csv_file_name)
   end
 
   describe '#metadata' do
@@ -39,6 +40,44 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
         { trn: '1234567', date_of_birth: '2000-01-01', finished_on: '2023-12-31', number_of_terms: '1', outcome: 'Pass', },
         { trn: '2345678', date_of_birth: '2001-02-02', finished_on: '2024-12-31', number_of_terms: '2', outcome: 'Fail' }
       ])
+    end
+
+    describe 'has reordered columns' do
+      let(:csv_content) do
+        <<~CSV
+          Outcome,TRN,Date of birth,Induction period end date,Number of terms
+          PASS,1234567,2000-01-01,2023-12-31,1
+          FAIL,2345678,2001-02-02,2024-12-31,2
+        CSV
+      end
+
+      specify do
+        expect(form).to be_valid
+        expect(form.to_a).to eq([
+          { outcome: 'PASS', trn: '1234567', date_of_birth: '2000-01-01', finished_on: '2023-12-31', number_of_terms: '1' },
+          { outcome: 'FAIL', trn: '2345678', date_of_birth: '2001-02-02', finished_on: '2024-12-31', number_of_terms: '2' }
+        ])
+      end
+    end
+
+    describe 'contains some empty rows' do
+      let(:csv_content) do
+        <<~CSV
+          TRN,Date of birth,Induction period end date,Number of terms,Outcome
+          1234567,2000-01-01,2023-12-31,1,Pass
+          2345678,2001-02-02,2024-12-31,2,Fail
+          ,,,,
+          ,,,,
+        CSV
+      end
+
+      specify do
+        expect(form).to be_valid
+        expect(form.to_a).to eq([
+          { trn: '1234567', date_of_birth: '2000-01-01', finished_on: '2023-12-31', number_of_terms: '1', outcome: 'Pass', },
+          { trn: '2345678', date_of_birth: '2001-02-02', finished_on: '2024-12-31', number_of_terms: '2', outcome: 'Fail' }
+        ])
+      end
     end
 
     describe 'contains cell padding' do
@@ -111,25 +150,36 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
   end
 
   context 'when the attached file is invalid' do
-    describe '#csv_mime_type' do
-      let(:content_type) { 'text/plain' }
+    describe '#csv_file' do
+      context 'when mime type is not supported' do
+        let(:content_type) { 'text/plain' }
 
-      specify do
-        expect(form).not_to be_valid
-        expect(form.errors[:csv_file]).to include('The selected file must be a CSV')
+        specify do
+          expect(form).not_to be_valid
+          expect(form.errors[:csv_file]).to eq(['The selected file must be a CSV'])
+        end
+      end
+
+      context 'when file extension is not .csv' do
+        let(:csv_file_name) { 'test.xls' }
+
+        specify do
+          expect(form).not_to be_valid
+          expect(form.errors[:csv_file]).to eq(['The selected file must be a CSV'])
+        end
       end
     end
 
-    describe '#csv_file_size' do
+    describe '#file_size' do
       let(:csv_file_size) { 101.kilobytes }
 
       specify do
         expect(form).not_to be_valid
-        expect(form.errors[:csv_file]).to include('File size must be less than 100KB')
+        expect(form.errors[:csv_file]).to eq(['File size must be less than 100KB'])
       end
     end
 
-    describe '#wrong_headers' do
+    describe '#template' do
       let(:headers) do
         {
           trn: 'TRN',
@@ -139,7 +189,7 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
 
       specify do
         expect(form).not_to be_valid
-        expect(form.errors[:csv_file]).to include('The selected file must follow the template')
+        expect(form.errors[:csv_file]).to eq(['The selected file must follow the template'])
       end
     end
 
@@ -149,12 +199,14 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
           TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message
           1234567,2000-01-01,2023-12-31,1,pass
           1234567,2001-02-02,2024-12-31,2,pass
+          ,,,,
+          ,,,,
         CSV
       end
 
       specify do
         expect(form).not_to be_valid
-        expect(form.errors[:csv_file]).to include('The selected file has duplicate ECTs')
+        expect(form.errors[:csv_file]).to eq(['The selected file has duplicate ECTs'])
       end
     end
 
@@ -163,35 +215,66 @@ RSpec.describe AppropriateBodies::ProcessBatchForm, type: :model do
         let(:csv_content) do
           <<~CSV
             TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message
-              1234567,2001-02-02,2024-12-31,1,pass
-              2345678,2001-02-02,2024-12-31,2,pass
-              3456789,2001-02-02,2024-12-31,2,pass
-              4567890,2001-02-02,2024-12-31,2,pass
-              0987654,2001-02-02,2024-12-31,2,pass
-              9876543,2001-02-02,2024-12-31,2,pass
-              8765432,2001-02-02,2024-12-31,2,pass
-              7654321,2001-02-02,2024-12-31,2,pass
+            1234567,2001-02-02,2024-12-31,1,pass
+            2345678,2001-02-02,2024-12-31,2,pass
+            3456789,2001-02-02,2024-12-31,2,pass
+            4567890,2001-02-02,2024-12-31,2,pass
+            0987654,2001-02-02,2024-12-31,2,pass
+            9876543,2001-02-02,2024-12-31,2,pass
+            8765432,2001-02-02,2024-12-31,2,pass
+            7654321,2001-02-02,2024-12-31,2,pass
+            ,,,,
+            ,,,,
           CSV
         end
 
         specify do
           stub_const('AppropriateBodies::ProcessBatchForm::MAX_ROW_SIZE', 5)
           expect(form).not_to be_valid
-          expect(form.errors[:csv_file]).to include('The selected file must have fewer than 5 rows')
+          expect(form.errors[:csv_file]).to eq(['The selected file must have fewer than 5 rows'])
+        end
+      end
+
+      context 'with too few rows (template)' do
+        let(:csv_content) do
+          <<~CSV
+            TRN,Date of birth,Induction period end date,Number of terms,Outcome
+          CSV
+        end
+
+        specify do
+          expect(form).not_to be_valid
+          expect(form.errors[:csv_file]).to eq(['The selected file is empty'])
+        end
+      end
+
+      context 'with too few rows (template with empty rows)' do
+        let(:csv_content) do
+          <<~CSV
+            TRN,Date of birth,Induction period end date,Number of terms,Outcome
+            ,,,,
+            ,,,,
+          CSV
+        end
+
+        specify do
+          expect(form).not_to be_valid
+          expect(form.errors[:csv_file]).to eq(['The selected file is empty'])
         end
       end
     end
 
-    context 'with too few rows' do
-      let(:csv_content) do
-        <<~CSV
-          TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message
-        CSV
-      end
+    describe 'Large invalid file' do
+      let(:csv_file_size) { 101.kilobytes }
+      let(:content_type) { 'text/plain' }
+      let(:csv_file_name) { 'test.xls' }
 
       specify do
         expect(form).not_to be_valid
-        expect(form.errors[:csv_file]).to include('The selected file is empty')
+        expect(form.errors[:csv_file]).to eq([
+          'The selected file must be a CSV',
+          'File size must be less than 100KB'
+        ])
       end
     end
   end

--- a/spec/presenters/pending_induction_submission_batch_presenter_spec.rb
+++ b/spec/presenters/pending_induction_submission_batch_presenter_spec.rb
@@ -57,7 +57,11 @@ RSpec.describe PendingInductionSubmissionBatchPresenter do
       end
 
       it 'returns a CSV string with the correct headers and no rows' do
-        expect(presenter.to_csv).to eq("TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message\n")
+        expect(presenter.to_csv).to eq(
+          <<~CSV_DATA
+            "TRN","Date of birth","Induction period end date","Number of terms","Outcome","Error message"
+          CSV_DATA
+        )
       end
 
       context 'and there are failed_submissions' do
@@ -82,8 +86,8 @@ RSpec.describe PendingInductionSubmissionBatchPresenter do
         it 'returns only failed submissions with their errors as a sentence' do
           expect(presenter.to_csv).to eq(
             <<~CSV_DATA
-              TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message
-              1234567,1990-01-01,2023-12-31,2.0,pass,"error one, error two, error three, and error four"
+              "TRN","Date of birth","Induction period end date","Number of terms","Outcome","Error message"
+              "1234567","1990-01-01","2023-12-31","2.0","pass","error one, error two, error three, and error four"
             CSV_DATA
           )
         end

--- a/spec/requests/appropriate_bodies/process_batch/actions/show_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/show_spec.rb
@@ -42,8 +42,11 @@ RSpec.describe "Appropriate Body bulk actions show page", type: :request do
         get("/appropriate-body/bulk/actions/#{batch.id}.csv")
         expect(response).to be_successful
         expect(response.headers['Content-Disposition']).to include('filename="Errors for 3 valid actions.csv"')
-
-        expect(response.body).to eq "TRN,Date of birth,Induction period end date,Number of terms,Outcome,Error message\n"
+        expect(response.body).to eq(
+          <<~CSV_DATA
+            "TRN","Date of birth","Induction period end date","Number of terms","Outcome","Error message"
+          CSV_DATA
+        )
       end
     end
   end


### PR DESCRIPTION
### Context

Bulk upload bug party snags

### Changes proposed in this pull request

Testers saw errors due to:

1. Non-CSV data being parsed and treated as if it were CSV data rather than being told the file was not a CSV (https://github.com/DFE-Digital/register-early-career-teachers-public/pull/603 stops exposing these internal errors now we are done with testing)
2. After having edited and exported from XLS files, testers had created files with many additional blank rows
3. Using software that delimited headers by spaces

### Guidance to review

1. Upload images, Excel spreadsheets, anything 
![octocat](https://github.com/user-attachments/assets/ac474a5b-96ac-40fb-beb6-564973ad0b77)

2. Upload a valid file with completely empty rows anywhere, either at the end, in the middle of the data or at the start `,,,,,,,`
[test 3.csv](https://github.com/user-attachments/files/20406375/test.3.csv)

3. Using capable software like LibreOffice, by default the template CSV, or any subsequent downloaded failures, should be opened correctly