### PR TITLE
Add `APIToken` functionality/seeds

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,5 @@
 module API
   class BaseController < ActionController::Base
-    include API::TokenAuthenticatable
+    include TokenAuthenticatable
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,5 @@
 module API
   class BaseController < ActionController::Base
+    include API::TokenAuthenticatable
   end
 end

--- a/app/controllers/concerns/api/token_authenticatable.rb
+++ b/app/controllers/concerns/api/token_authenticatable.rb
@@ -15,7 +15,7 @@ module API
 
     def authenticate_token
       authenticate_with_http_token do |token|
-        API::TokenManager.find_lead_provider_api_token(token:)
+        TokenManager.find_lead_provider_api_token(token:)
       end
     end
 

--- a/app/controllers/concerns/api/token_authenticatable.rb
+++ b/app/controllers/concerns/api/token_authenticatable.rb
@@ -15,7 +15,7 @@ module API
 
     def authenticate_token
       authenticate_with_http_token do |token|
-        APIToken.find_lead_provider_api_token(token:)
+        API::TokenManager.find_lead_provider_api_token(token:)
       end
     end
 

--- a/app/controllers/concerns/api/token_authenticatable.rb
+++ b/app/controllers/concerns/api/token_authenticatable.rb
@@ -1,0 +1,26 @@
+module API
+  module TokenAuthenticatable
+    extend ActiveSupport::Concern
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+
+    included do
+      before_action :authenticate
+    end
+
+  private
+
+    def authenticate
+      authenticate_token || render_unauthorized
+    end
+
+    def authenticate_token
+      authenticate_with_http_token do |token|
+        APIToken.find_lead_provider_api_token(token:)
+      end
+    end
+
+    def render_unauthorized
+      render json: { error: "HTTP Token: Access denied" }.to_json, status: :unauthorized
+    end
+  end
+end

--- a/app/models/api/token.rb
+++ b/app/models/api/token.rb
@@ -1,4 +1,6 @@
-class APIToken < ApplicationRecord
+class API::Token < ApplicationRecord
+  self.table_name = :api_tokens
+
   has_secure_token :token, length: 32
   encrypts :token, deterministic: true
 

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -9,20 +9,4 @@ class APIToken < ApplicationRecord
   validates :token, uniqueness: { message: "Hashed token must be unique" }
 
   scope :lead_provider_tokens, -> { where.not(lead_provider: nil) }
-
-  class << self
-    def create_lead_provider_api_token!(lead_provider:, token: nil, description: nil)
-      description = "A lead provider token for #{lead_provider.name}" if description.nil?
-
-      create!(
-        lead_provider:,
-        token:,
-        description:
-      )
-    end
-
-    def find_lead_provider_api_token(token:)
-      find_by(token:).tap { |api_token| api_token&.touch(:last_used_at) }
-    end
-  end
 end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -7,4 +7,22 @@ class APIToken < ApplicationRecord
   validates :lead_provider, presence: { message: "Lead provider must be specified" }
   validates :token, presence: { message: "Hashed token must be specified" }
   validates :token, uniqueness: { message: "Hashed token must be unique" }
+
+  scope :lead_provider_tokens, -> { where.not(lead_provider: nil) }
+
+  class << self
+    def create_lead_provider_api_token!(lead_provider:, token: nil, description: nil)
+      description = "A lead provider token for #{lead_provider.name}" if description.nil?
+
+      create!(
+        lead_provider:,
+        token:,
+        description:
+      )
+    end
+
+    def find_lead_provider_api_token(token:)
+      find_by(token:).tap { |api_token| api_token&.touch(:last_used_at) }
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,8 @@ class Event < ApplicationRecord
     teacher_trs_deactivated
     teacher_trs_induction_start_date_updated
     teacher_trs_induction_status_updated
+    lead_provider_api_token_created
+    lead_provider_api_token_revoked
   ].freeze
 
   belongs_to :teacher

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -3,7 +3,7 @@ class LeadProvider < ApplicationRecord
   has_many :school_partnerships, inverse_of: :lead_provider
   has_many :active_lead_providers, inverse_of: :lead_provider
   has_many :events
-  has_many :api_tokens
+  has_many :api_tokens, class_name: "API::Token"
 
   # Validations
   validates :name,

--- a/app/services/api/token_manager.rb
+++ b/app/services/api/token_manager.rb
@@ -4,7 +4,7 @@ module API
       def create_lead_provider_api_token!(lead_provider:, token: nil, description: nil)
         description = "A lead provider token for #{lead_provider.name}" if description.nil?
 
-        APIToken.create!(
+        Token.create!(
           lead_provider:,
           token:,
           description:
@@ -19,7 +19,7 @@ module API
       end
 
       def find_lead_provider_api_token(token:)
-        APIToken.find_by(token:).tap { |api_token| api_token&.touch(:last_used_at) }
+        Token.lead_provider_tokens.find_by(token:).tap { |api_token| api_token&.touch(:last_used_at) }
       end
     end
   end

--- a/app/services/api/token_manager.rb
+++ b/app/services/api/token_manager.rb
@@ -1,0 +1,26 @@
+module API
+  class TokenManager
+    class << self
+      def create_lead_provider_api_token!(lead_provider:, token: nil, description: nil)
+        description = "A lead provider token for #{lead_provider.name}" if description.nil?
+
+        APIToken.create!(
+          lead_provider:,
+          token:,
+          description:
+        ).tap do |api_token|
+          Events::Record.record_lead_provider_api_token_created_event!(author: Events::SystemAuthor.new, api_token:)
+        end
+      end
+
+      def revoke_lead_provider_api_token!(api_token:)
+        api_token.destroy!
+        Events::Record.record_lead_provider_api_token_revoked_event!(author: Events::SystemAuthor.new, api_token:)
+      end
+
+      def find_lead_provider_api_token(token:)
+        APIToken.find_by(token:).tap { |api_token| api_token&.touch(:last_used_at) }
+      end
+    end
+  end
+end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -307,6 +307,26 @@ module Events
       new(event_type:, author:, appropriate_body: batch.appropriate_body, heading:, happened_at: Time.zone.now, metadata:).record_event!
     end
 
+    # API Token Events
+
+    def self.record_lead_provider_api_token_created_event!(author:, api_token:)
+      event_type = :lead_provider_api_token_created
+      lead_provider = api_token.lead_provider
+      heading = "An API token was created for lead provider: #{lead_provider.name}"
+      metadata = { description: api_token.description }
+
+      new(event_type:, author:, heading:, lead_provider:, happened_at: Time.zone.now, metadata:).record_event!
+    end
+
+    def self.record_lead_provider_api_token_revoked_event!(author:, api_token:)
+      event_type = :lead_provider_api_token_revoked
+      lead_provider = api_token.lead_provider
+      heading = "An API token was revoked for lead provider: #{lead_provider.name}"
+      metadata = { description: api_token.description }
+
+      new(event_type:, author:, heading:, lead_provider:, happened_at: Time.zone.now, metadata:).record_event!
+    end
+
   private
 
     def attributes

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,3 +28,15 @@ seed_files.each do |seed_file|
 
   ApplicationRecord.transaction { load(seed_file) }
 end
+
+print_seed_info("Adding API tokens for lead providers:")
+
+maximum_lead_provider_name_length = LeadProvider.maximum("LENGTH(name)")
+
+LeadProvider.find_each do |lead_provider|
+  token = lead_provider.name.parameterize
+  APIToken.create_lead_provider_api_token!(lead_provider:, token:)
+
+  lead_provider_name = lead_provider.name.ljust(maximum_lead_provider_name_length)
+  print_seed_info("#{lead_provider_name} \t '#{token}'", indent: 2)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,7 @@ maximum_lead_provider_name_length = LeadProvider.maximum("LENGTH(name)")
 
 LeadProvider.find_each do |lead_provider|
   token = lead_provider.name.parameterize
-  APIToken.create_lead_provider_api_token!(lead_provider:, token:)
+  API::TokenManager.create_lead_provider_api_token!(lead_provider:, token:)
 
   lead_provider_name = lead_provider.name.ljust(maximum_lead_provider_name_length)
   print_seed_info("#{lead_provider_name} \t '#{token}'", indent: 2)

--- a/spec/factories/api_token_factory.rb
+++ b/spec/factories/api_token_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory(:api_token) do
+  factory(:api_token, class: "API::Token") do
     association :lead_provider
     description { "A token used for test purposes" }
     last_used_at { Faker::Time.between(from: 1.month.ago, to: 1.day.ago) }

--- a/spec/models/api/token_spec.rb
+++ b/spec/models/api/token_spec.rb
@@ -1,4 +1,4 @@
-describe APIToken do
+describe API::Token do
   describe "associations" do
     it { is_expected.to belong_to(:lead_provider) }
   end
@@ -20,7 +20,7 @@ describe APIToken do
       before do
         # Contrived example as we only support lead provider tokens at
         # the moment, but provides a safety net for future changes.
-        described_class.new(lead_provider: nil, description: "Non-lead provider token").save(validate: false)
+        described_class.new(lead_provider: nil, description: "Non-lead provider token").save!(validate: false)
       end
 
       it { is_expected.to contain_exactly(lead_provider_token) }

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -11,6 +11,22 @@ describe APIToken do
     it { is_expected.to validate_uniqueness_of(:token).with_message("Hashed token must be unique") }
   end
 
+  describe "scopes" do
+    describe ".lead_provider_tokens" do
+      subject { described_class.lead_provider_tokens }
+
+      let!(:lead_provider_token) { FactoryBot.create(:api_token) }
+
+      before do
+        # Contrived example as we only support lead provider tokens at
+        # the moment, but provides a safety net for future changes.
+        described_class.new(lead_provider: nil, description: "Non-lead provider token").save(validate: false)
+      end
+
+      it { is_expected.to contain_exactly(lead_provider_token) }
+    end
+  end
+
   describe "has_secure_token" do
     it "generates a 32 character token on create" do
       lead_provider = FactoryBot.create(:lead_provider)
@@ -26,6 +42,45 @@ describe APIToken do
       encrypted_token = api_token.token_before_type_cast
 
       expect(api_token.token).not_to eq(encrypted_token)
+    end
+  end
+
+  describe ".create_lead_provider_api_token!" do
+    subject(:create_token) { described_class.create_lead_provider_api_token!(lead_provider:, token:, description:) }
+
+    let(:description) { "A token used for test purposes" }
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:token) { "a-token" }
+
+    it { expect { create_token }.to change(described_class, :count).by(1) }
+    it { is_expected.to be_a(described_class) }
+    it { is_expected.to have_attributes(lead_provider:, token:, description:) }
+
+    context "when the description is nil" do
+      let(:description) { nil }
+
+      it { is_expected.to have_attributes(description: "A lead provider token for #{lead_provider.name}") }
+    end
+
+    context "when the token is nil" do
+      let(:token) { nil }
+
+      it { is_expected.to have_attributes(token: be_present) }
+    end
+  end
+
+  describe ".find_lead_provider_api_token" do
+    subject(:find_token) { described_class.find_lead_provider_api_token(token: api_token.token) }
+
+    let(:api_token) { FactoryBot.create(:api_token) }
+
+    it { expect { find_token }.to change { api_token.reload.last_used_at }.to be_within(5.seconds).of(Time.current) }
+    it { is_expected.to eq(api_token) }
+
+    context "when the API token does not exist" do
+      let(:api_token) { FactoryBot.build(:api_token, token: "does-not-exist-yet") }
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -44,43 +44,4 @@ describe APIToken do
       expect(api_token.token).not_to eq(encrypted_token)
     end
   end
-
-  describe ".create_lead_provider_api_token!" do
-    subject(:create_token) { described_class.create_lead_provider_api_token!(lead_provider:, token:, description:) }
-
-    let(:description) { "A token used for test purposes" }
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
-    let(:token) { "a-token" }
-
-    it { expect { create_token }.to change(described_class, :count).by(1) }
-    it { is_expected.to be_a(described_class) }
-    it { is_expected.to have_attributes(lead_provider:, token:, description:) }
-
-    context "when the description is nil" do
-      let(:description) { nil }
-
-      it { is_expected.to have_attributes(description: "A lead provider token for #{lead_provider.name}") }
-    end
-
-    context "when the token is nil" do
-      let(:token) { nil }
-
-      it { is_expected.to have_attributes(token: be_present) }
-    end
-  end
-
-  describe ".find_lead_provider_api_token" do
-    subject(:find_token) { described_class.find_lead_provider_api_token(token: api_token.token) }
-
-    let(:api_token) { FactoryBot.create(:api_token) }
-
-    it { expect { find_token }.to change { api_token.reload.last_used_at }.to be_within(5.seconds).of(Time.current) }
-    it { is_expected.to eq(api_token) }
-
-    context "when the API token does not exist" do
-      let(:api_token) { FactoryBot.build(:api_token, token: "does-not-exist-yet") }
-
-      it { is_expected.to be_nil }
-    end
-  end
 end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -3,7 +3,7 @@ describe LeadProvider do
     it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:active_lead_providers).inverse_of(:lead_provider) }
-    it { is_expected.to have_many(:api_tokens) }
+    it { is_expected.to have_many(:api_tokens).class_name("API::Token") }
   end
 
   describe "validations" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
 
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Features::ViewHelpers, type: :feature
+  config.include APIHelper, type: :request
 
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,28 +1,44 @@
 RSpec.describe "Participant declarations API", type: :request do
   describe "#create" do
+    let(:path) { api_v3_declarations_path }
+
+    it_behaves_like "a token authenticated endpoint", :post
+
     it "returns method not allowed" do
-      post api_v3_declarations_path
+      authenticated_api_post path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#index" do
+    let(:path) { api_v3_declarations_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_declarations_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_declaration_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_declaration_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#void" do
+    let(:path) { api_v3_declaration_void_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :put
+
     it "returns method not allowed" do
-      put api_v3_declaration_void_path(123)
+      authenticated_api_put path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe "Delivery partners API", type: :request do
   describe "#index" do
+    let(:path) { api_v3_delivery_partners_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_delivery_partners_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_delivery_partner_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_delivery_partner_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/participant_transfers_spec.rb
+++ b/spec/requests/api/v3/participant_transfers_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe "Participant transfers API", type: :request do
   describe "#index" do
+    let(:path) { api_v3_transfers_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_transfers_path
+      authenticated_api_get api_v3_transfers_path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_participant_transfers_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_participant_transfers_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,42 +1,66 @@
 RSpec.describe "Participants API", type: :request do
   describe "#index" do
+    let(:path) { api_v3_participants_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_participants_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_participant_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_participant_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#change_schedule" do
+    let(:path) { api_v3_participant_change_schedule_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :put
+
     it "returns method not allowed" do
-      put api_v3_participant_change_schedule_path(123)
+      authenticated_api_put path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#defer" do
+    let(:path) { api_v3_participant_defer_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :put
+
     it "returns method not allowed" do
-      put api_v3_participant_defer_path(123)
+      authenticated_api_put path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#resume" do
+    let(:path) { api_v3_participant_resume_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :put
+
     it "returns method not allowed" do
-      put api_v3_participant_resume_path(123)
+      authenticated_api_put path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#withdraw" do
+    let(:path) { api_v3_participant_withdraw_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :put
+
     it "returns method not allowed" do
-      put api_v3_participant_withdraw_path(123)
+      authenticated_api_put path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -1,28 +1,44 @@
 RSpec.describe "Partnerships API", type: :request do
   describe "#create" do
+    let(:path) { api_v3_partnerships_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      post api_v3_partnerships_path
+      authenticated_api_post path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#index" do
+    let(:path) { api_v3_partnerships_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_partnerships_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_partnership_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_partnership_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#update" do
+    let(:path) { api_v3_partnership_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :put
+
     it "returns method not allowed" do
-      put api_v3_partnership_path(123)
+      authenticated_api_put path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe "Schools API", type: :request do
   describe "#index" do
+    let(:path) { api_v3_schools_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_schools_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_school_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_school_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe "Statements API", type: :request do
   describe "#index" do
+    let(:path) { api_v3_statements_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_statements_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_statement_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_statement_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe "Unfunded mentors API", type: :request do
   describe "#index" do
+    let(:path) { api_v3_unfunded_mentors_path }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_unfunded_mentors_path
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end
 
   describe "#show" do
+    let(:path) { api_v3_unfunded_mentor_path(123) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+
     it "returns method not allowed" do
-      get api_v3_unfunded_mentor_path(123)
+      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/services/api/token_manager_spec.rb
+++ b/spec/services/api/token_manager_spec.rb
@@ -6,8 +6,8 @@ describe API::TokenManager do
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
     let(:token) { "a-token" }
 
-    it { expect { create_token }.to change(APIToken, :count).by(1) }
-    it { is_expected.to be_a(APIToken) }
+    it { expect { create_token }.to change(API::Token, :count).by(1) }
+    it { is_expected.to be_a(API::Token) }
     it { is_expected.to have_attributes(lead_provider:, token:, description:) }
 
     it "records an event" do
@@ -40,7 +40,7 @@ describe API::TokenManager do
     let!(:api_token) { FactoryBot.create(:api_token) }
 
     it "destroys the API token" do
-      expect { revoke_token }.to change(APIToken, :count).by(-1)
+      expect { revoke_token }.to change(API::Token, :count).by(-1)
       expect { api_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -66,6 +66,17 @@ describe API::TokenManager do
 
     context "when the API token does not exist" do
       let(:api_token) { FactoryBot.build(:api_token, token: "does-not-exist-yet") }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when a matching, non-lead provider token exists" do
+      let(:api_token) do
+        API::Token.new(
+          lead_provider: nil,
+          description: "Non-lead provider token"
+        ).tap { |token| token.save!(validate: false) }
+      end
 
       it { is_expected.to be_nil }
     end

--- a/spec/services/api/token_manager_spec.rb
+++ b/spec/services/api/token_manager_spec.rb
@@ -1,0 +1,73 @@
+describe API::TokenManager do
+  describe ".create_lead_provider_api_token!" do
+    subject(:create_token) { described_class.create_lead_provider_api_token!(lead_provider:, token:, description:) }
+
+    let(:description) { "A token used for test purposes" }
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:token) { "a-token" }
+
+    it { expect { create_token }.to change(APIToken, :count).by(1) }
+    it { is_expected.to be_a(APIToken) }
+    it { is_expected.to have_attributes(lead_provider:, token:, description:) }
+
+    it "records an event" do
+      allow(Events::Record).to receive(:record_lead_provider_api_token_created_event!).once.and_call_original
+
+      api_token = create_token
+
+      expect(Events::Record).to have_received(:record_lead_provider_api_token_created_event!).with(
+        author: an_instance_of(Events::SystemAuthor),
+        api_token:
+      )
+    end
+
+    context "when the description is nil" do
+      let(:description) { nil }
+
+      it { is_expected.to have_attributes(description: "A lead provider token for #{lead_provider.name}") }
+    end
+
+    context "when the token is nil" do
+      let(:token) { nil }
+
+      it { is_expected.to have_attributes(token: be_present) }
+    end
+  end
+
+  describe ".revoke_lead_provider_api_token!" do
+    subject(:revoke_token) { described_class.revoke_lead_provider_api_token!(api_token:) }
+
+    let!(:api_token) { FactoryBot.create(:api_token) }
+
+    it "destroys the API token" do
+      expect { revoke_token }.to change(APIToken, :count).by(-1)
+      expect { api_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "records an event" do
+      allow(Events::Record).to receive(:record_lead_provider_api_token_revoked_event!).once.and_call_original
+
+      revoke_token
+
+      expect(Events::Record).to have_received(:record_lead_provider_api_token_revoked_event!).with(
+        author: an_instance_of(Events::SystemAuthor),
+        api_token:
+      )
+    end
+  end
+
+  describe ".find_lead_provider_api_token" do
+    subject(:find_token) { described_class.find_lead_provider_api_token(token: api_token.token) }
+
+    let(:api_token) { FactoryBot.create(:api_token) }
+
+    it { expect { find_token }.to change { api_token.reload.last_used_at }.to be_within(5.seconds).of(Time.current) }
+    it { is_expected.to eq(api_token) }
+
+    context "when the API token does not exist" do
+      let(:api_token) { FactoryBot.build(:api_token, token: "does-not-exist-yet") }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -748,4 +748,42 @@ RSpec.describe Events::Record do
       end
     end
   end
+
+  describe '.record_lead_provider_api_token_created_event!' do
+    let(:api_token) { FactoryBot.create(:api_token) }
+
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        Events::Record.record_lead_provider_api_token_created_event!(author:, api_token:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          heading: "An API token was created for lead provider: #{api_token.lead_provider.name}",
+          lead_provider: api_token.lead_provider,
+          event_type: :lead_provider_api_token_created,
+          happened_at: Time.zone.now,
+          metadata: { description: api_token.description },
+          **author_params
+        )
+      end
+    end
+  end
+
+  describe '.record_lead_provider_api_token_revoked_event!' do
+    let(:api_token) { FactoryBot.create(:api_token) }
+
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        Events::Record.record_lead_provider_api_token_revoked_event!(author:, api_token:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          heading: "An API token was revoked for lead provider: #{api_token.lead_provider.name}",
+          lead_provider: api_token.lead_provider,
+          event_type: :lead_provider_api_token_revoked,
+          happened_at: Time.zone.now,
+          metadata: { description: api_token.description },
+          **author_params
+        )
+      end
+    end
+  end
 end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Events::Record do
+  include ActiveJob::TestHelper
+
   let(:user) { FactoryBot.create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Rhys', trs_last_name: 'Ifans') }
   let(:induction_period) { FactoryBot.create(:induction_period) }
@@ -11,7 +13,11 @@ RSpec.describe Events::Record do
   let(:body) { 'A very important event' }
   let(:happened_at) { 2.minutes.ago }
 
-  before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+  before { allow(RecordEventJob).to receive(:perform_later).and_call_original }
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
 
   describe '#initialize' do
     context "when the user isn't a Sessions::User" do

--- a/spec/support/requests/api_helper.rb
+++ b/spec/support/requests/api_helper.rb
@@ -1,0 +1,24 @@
+module APIHelper
+  def authenticated_api_get(path, token: nil)
+    get path, headers: api_headers(token:)
+  end
+
+  def authenticated_api_post(path, token: nil)
+    post path, headers: api_headers(token:)
+  end
+
+  def authenticated_api_put(path, token: nil)
+    put path, headers: api_headers(token:)
+  end
+
+  def api_headers(token: nil)
+    {
+      Authorization: "Bearer #{token || generate_api_token.token}"
+    }
+  end
+
+  def generate_api_token
+    lead_provider = FactoryBot.create(:lead_provider)
+    APIToken.create_lead_provider_api_token!(lead_provider:)
+  end
+end

--- a/spec/support/requests/api_helper.rb
+++ b/spec/support/requests/api_helper.rb
@@ -19,6 +19,6 @@ module APIHelper
 
   def generate_api_token
     lead_provider = FactoryBot.create(:lead_provider)
-    APIToken.create_lead_provider_api_token!(lead_provider:)
+    API::TokenManager.create_lead_provider_api_token!(lead_provider:)
   end
 end

--- a/spec/support/shared_contexts/api/token_authenticated_endpoint.rb
+++ b/spec/support/shared_contexts/api/token_authenticated_endpoint.rb
@@ -1,0 +1,16 @@
+shared_examples "a token authenticated endpoint" do |request_method|
+  it "returns unauthorized when no token is provided" do
+    send(request_method, path)
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns unauthorized when an invalid token is provided" do
+    send("authenticated_api_#{request_method}", path, token: "invalid")
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "does not return unauthorized when a valid token is provided" do
+    send("authenticated_api_#{request_method}", path)
+    expect(response).not_to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
### Context

We want to use the new `APIToken` model in order to authenticate API requests. We also want to include known tokens for seeded lead providers so that we can easily test in development.

### Changes proposed in this pull request

- Add methods to create/find API tokens

Add a method to create a new `APIToken` for a `LeadProvider`. It will default to a randomly generated `token` if not specified and a predefined `description`.

Add method to retrieve an `APIToken` for a given `token`. It will touch the `last_used_at` timestamp when doing so.

- Add APIToken seeds for each LeadProvider

Generate a known token for each lead provider in the seeds.

- Authenticate API controllers

Add `API::TokenAuthenticatable` concern and include it in the `API::BaseController`.

Add `ApiHelper` to easily make authenticated requests in the specs.

Add shared context to easily test authentication for each type of endpoint (get, post, put).

- Add events for creating/revoking access tokens

Add events to `Event::Record` for creating and revoking lead provider access tokens.

- Extract APIToken methods into API::TokenManager service

Pulls the `APIToken` methods for creating, revoking and retrieving a token into a new `API::TokenManager` service.

Integrates the actions into the newly added events.

- Namespace APIToken as API::Token

Unlike other models this is purely for the API and to mimic the `API::TokenManager` namespacing it should live under `API::`