### PR TITLE
Implement block ECT registration logic

### DIFF
--- a/app/helpers/register_ect_helper.rb
+++ b/app/helpers/register_ect_helper.rb
@@ -5,4 +5,8 @@ module RegisterECTHelper
 
     schools_register_ect_wizard_change_state_school_appropriate_body_path
   end
+
+  def formatted_academic_year_range(year)
+    "#{year} to #{year + 1}"
+  end
 end

--- a/app/views/schools/register_ect_wizard/cannot_register_ect_yet.html.erb
+++ b/app/views/schools/register_ect_wizard/cannot_register_ect_yet.html.erb
@@ -1,0 +1,6 @@
+<% page_data(title: "You cannot register #{@ect.full_name} yet", error: false) %>
+
+<p class="govuk-body">Registration for the <%= formatted_academic_year_range(@ect.start_date.to_date.year) %> academic year is not open.</p>
+<p class="govuk-body">We'll email you to let you know when registration will open. This is usually in June.</p>
+
+<p class="govuk-body"><%= govuk_link_to("Back to ECTs", schools_ects_home_path) %></p>

--- a/app/wizards/schools/register_ect_wizard/cannot_register_ect_yet_step.rb
+++ b/app/wizards/schools/register_ect_wizard/cannot_register_ect_yet_step.rb
@@ -1,0 +1,6 @@
+module Schools
+  module RegisterECTWizard
+    class CannotRegisterECTYetStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -10,6 +10,8 @@ module Schools
       end
 
       def next_step
+        return :cannot_register_ect_yet if start_date_in_disabled_registration_period? && start_date_is_today_or_in_future?
+
         :working_pattern
       end
 
@@ -28,7 +30,22 @@ module Schools
       end
 
       def start_date_formatted
-        Schools::Validation::ECTStartDate.new(date_as_hash: start_date).formatted_date
+        ect_start_date_obj.formatted_date
+      end
+
+      def start_date_in_disabled_registration_period?
+        date = ect_start_date_obj.value_as_date
+
+        period = RegistrationPeriod.where('? BETWEEN started_on AND finished_on', date).first
+        period.nil? || !period.enabled
+      end
+
+      def start_date_is_today_or_in_future?
+        ect_start_date_obj.value_as_date >= Date.current
+      end
+
+      def ect_start_date_obj
+        @ect_start_date_obj ||= Schools::Validation::ECTStartDate.new(date_as_hash: start_date)
       end
     end
   end

--- a/app/wizards/schools/register_ect_wizard/wizard.rb
+++ b/app/wizards/schools/register_ect_wizard/wizard.rb
@@ -10,6 +10,7 @@ module Schools
           {
             already_active_at_school: AlreadyActiveAtSchoolStep,
             cannot_register_ect: CannotRegisterECTStep,
+            cannot_register_ect_yet: CannotRegisterECTYetStep,
             cant_use_email: CantUseEmailStep,
             change_email_address: ChangeEmailAddressStep,
             change_independent_school_appropriate_body: ChangeIndependentSchoolAppropriateBodyStep,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
       get "trn-not-found", action: :new
       get "not-found", action: :new
       get "cannot-register-ect", action: :new
+      get "cannot-register-ect-yet", action: :new
 
       get "already_active_at_school", action: :new
       get "induction-completed", action: :new

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -15,6 +15,10 @@ module Schools
         value_as_date.strftime(Date::DATE_FORMATS[:govuk])
       end
 
+      def value_as_date
+        @value_as_date ||= Time.zone.local(*date_as_hash.values_at(1, 2, 3).map(&:to_i))
+      end
+
     private
 
       attr_reader :current_date
@@ -39,10 +43,6 @@ module Schools
 
       def date_missing?
         super || date_as_hash.values_at(1, 2, 3).all?(&:nil?)
-      end
-
-      def value_as_date
-        @value_as_date ||= Time.zone.local(*date_as_hash.values_at(1, 2, 3).map(&:to_i))
       end
     end
   end

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -3,7 +3,6 @@ module Schools
     class ECTStartDate < HashDate
       DATE_MISSING_MESSAGE = "Enter the date the ECT started or will start teaching at your school".freeze
       INVALID_FORMAT_MESSAGE = "Enter the start date using the correct format, for example, 17 09 1999".freeze
-      OUT_OF_RANGE_MESSAGE = "The start date must be from within either the current academic year or one of the last 2 academic years".freeze
 
       def initialize(date_as_hash:, current_date: nil)
         super(date_as_hash)
@@ -22,24 +21,6 @@ module Schools
     private
 
       attr_reader :current_date
-
-      def extra_validation_error_message
-        OUT_OF_RANGE_MESSAGE if out_of_range?
-      end
-
-      # The date must be in the current academic year or within the previous two academic years.
-      # i.e. if user was registering an ECT in 2024 the start date could be in any of these academic years:
-      # - August 22 - July 23
-      # - August 23 - July 24
-      # - August 24 - July 25
-      def out_of_range?
-        before_august = current_date.month < 8
-        start_of_current_academic_year = Time.zone.local(current_date.year - (before_august ? 1 : 0), 8, 1)
-        first_allowed_date = start_of_current_academic_year.prev_year(2)
-        last_allowed_date = start_of_current_academic_year.next_year(1)
-
-        !(first_allowed_date...last_allowed_date).cover?(value_as_date)
-      end
 
       def date_missing?
         super || date_as_hash.values_at(1, 2, 3).all?(&:nil?)

--- a/lib/schools/validation/hash_date.rb
+++ b/lib/schools/validation/hash_date.rb
@@ -8,7 +8,7 @@ module Schools
 
       # Expects value with the format { 1 => year, 2 => month, 3 => day } or a date string or a Date instance
       def initialize(value)
-        @date_as_hash = value.is_a?(Hash) ? value : convert_to_hash(value&.to_date)
+        @date_as_hash = value.is_a?(Hash) ? integerize_keys!(value) : convert_to_hash(value&.to_date)
       end
 
       def valid?
@@ -17,6 +17,10 @@ module Schools
       end
 
     private
+
+      def integerize_keys!(hash)
+        hash.transform_keys(&:to_i)
+      end
 
       def convert_to_hash(date)
         { 3 => date.day, 2 => date.month, 1 => date.year } if date

--- a/lib/schools/validation/hash_date.rb
+++ b/lib/schools/validation/hash_date.rb
@@ -37,6 +37,8 @@ module Schools
       def extra_validation_error_message = nil
 
       def invalid_date?
+        return true if year_zero?
+
         value_as_date
         false
       rescue ArgumentError
@@ -48,6 +50,10 @@ module Schools
         return self.class::INVALID_FORMAT_MESSAGE if invalid_date?
 
         extra_validation_error_message
+      end
+
+      def year_zero?
+        date_as_hash[1].to_i.zero?
       end
     end
   end

--- a/spec/helpers/register_ect_helper_spec.rb
+++ b/spec/helpers/register_ect_helper_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe RegisterECTHelper, type: :helper do
+  describe '#formatted_academic_year_range' do
+    it 'returns the correct formatted academic year string' do
+      expect(formatted_academic_year_range(2024)).to eq('2024 to 2025')
+    end
+  end
+end

--- a/spec/validators/ect_start_date_validator_spec.rb
+++ b/spec/validators/ect_start_date_validator_spec.rb
@@ -18,126 +18,6 @@ RSpec.describe ECTStartDateValidator, type: :model do
     end
   end
 
-  context "when the current date is July 31st 2024" do
-    subject { test_class.new(start_date:) }
-
-    let(:error_message) { "The start date must be from within either the current academic year or one of the last 2 academic years" }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
-
-        # Academic year begins in August 2023
-        validates :start_date, ect_start_date: { current_date: Time.zone.local(2024, 7, 31) }
-      end
-    end
-
-    context "and the start date is before the earliest possible start date" do
-      # July 2021, ie more than 2 academic years ago
-      let(:start_date) { { 1 => "2021", 2 => "07", 3 => "31" } }
-
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
-    end
-
-    context "and the start date is after the latest possible start date" do
-      # August 2025, ie the next academic year
-      let(:start_date) { { 1 => "2024", 2 => "08", 3 => "1" } }
-
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
-    end
-
-    context "and the start_date is within the accepted range" do
-      let(:start_date) { { 1 => "2024", 2 => "07", 3 => "31" } }
-
-      it "does not add any errors" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to be_empty
-      end
-    end
-  end
-
-  context "when the current date is August 1st 2024" do
-    subject { test_class.new(start_date:) }
-
-    let(:error_message) { "The start date must be from within either the current academic year or one of the last 2 academic years" }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
-
-        # Academic year begins in August 2024
-        validates :start_date, ect_start_date: { current_date: Time.zone.local(2024, 8, 1) }
-      end
-    end
-
-    context "and the start date is one day before the earliest possible start date" do
-      # July 2022, ie more than 2 academic years ago
-      let(:start_date) { { 1 => "2022", 2 => "07", 3 => "31" } }
-
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
-    end
-
-    context "and the start date is one day after the latest possible start date" do
-      # August 2025, ie the next academic year
-      let(:start_date) { { 1 => "2025", 2 => "08", 3 => "1" } }
-
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
-    end
-
-    context "and the start_date is within the accepted range" do
-      let(:start_date) { { 1 => "2025", 2 => "07", 3 => "31" } }
-
-      it "does not add any errors" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to be_empty
-      end
-    end
-  end
-
-  context "when the start date is at the boundary of the accepted academic year range" do
-    subject { test_class.new(start_date:) }
-
-    let(:error_message) { "The start date must be from within either the current academic year or one of the last 2 academic years" }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
-
-        validates :start_date, ect_start_date: { current_date: Time.zone.local(2024, 8, 1) }
-      end
-    end
-
-    context "when the start date is the day of the earliest academic year" do
-      let(:start_date) { { 1 => "2022", 2 => "08", 3 => "1" } }
-
-      it "does not add any errors" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to be_empty
-      end
-    end
-
-    context "when the start date is the last day of the latest academic year" do
-      let(:start_date) { { 1 => "2025", 2 => "07", 3 => "31" } }
-
-      it "does not add any errors" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to be_empty
-      end
-    end
-  end
-
   context "when the start date has invalid values" do
     subject { test_class.new(start_date:) }
 
@@ -163,7 +43,6 @@ RSpec.describe ECTStartDateValidator, type: :model do
     context "when the year is non-integer" do
       # "abcd".to_i == 0 and and therefore a valid date year but it is out of range
       let(:start_date) { { 1 => "abcd", 2 => "07", 3 => "1" } }
-      let("error_message") { "The start date must be from within either the current academic year or one of the last 2 academic years" }
 
       it "adds an error" do
         subject.valid?

--- a/spec/validators/ect_start_date_validator_spec.rb
+++ b/spec/validators/ect_start_date_validator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ECTStartDateValidator, type: :model do
     end
 
     context "when the year is non-integer" do
-      # "abcd".to_i == 0 and and therefore a valid date year but it is out of range
+      # "abcd".to_i == 0 and and therefore a valid date year but it is not valid
       let(:start_date) { { 1 => "abcd", 2 => "07", 3 => "1" } }
 
       it "adds an error" do

--- a/spec/views/schools/register_ect_wizard/cannot_register_ect_yet.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/cannot_register_ect_yet.html.erb_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "schools/register_ect_wizard/cannot_register_ect_yet" do
+  let(:ect) { double('ECT', full_name: 'John Doe', start_date: '15 May 2025') }
+
+  before do
+    assign(:ect, ect)
+    render
+  end
+
+  it "sets the page title" do
+    expect(sanitize(view.content_for(:page_title))).to eql('You cannot register John Doe yet')
+  end
+
+  it "displays the cannot register ECT message" do
+    expect(rendered).to have_content("Registration for the 2025 to 2026 academic year is not open")
+    expect(rendered).to have_content("We'll email you to let you know when registration will open. This is usually in June.")
+  end
+
+  it "includes a link back to ECTs" do
+    expect(rendered).to have_link("Back to ECTs", href: schools_ects_home_path)
+  end
+end

--- a/spec/wizards/schools/register_ect_wizard/cannot_register_ect_yet_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/cannot_register_ect_yet_step_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Schools::RegisterECTWizard::CannotRegisterECTYetStep, type: :model do
+  describe "inheritance" do
+    it "inherits from Step" do
+      expect(subject).to be_a(Schools::RegisterECTWizard::Step)
+    end
+  end
+end

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -50,8 +50,94 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
   end
 
   describe '#next_step' do
-    it 'returns the next step' do
-      expect(subject.next_step).to eq(:working_pattern)
+    subject { described_class.new(start_date:) }
+
+    around do |example|
+      travel_to(today) { example.run }
+    end
+
+    let(:today) { Date.new(2024, 4, 15) }
+    let(:period_2023) { FactoryBot.create(:registration_period, year: 2023, enabled: enabled_2023) }
+    let(:enabled_2023) { true }
+
+    let(:period_2024) { FactoryBot.create(:registration_period, year: 2024, enabled: enabled_2024) }
+    let(:enabled_2024) { true }
+
+    let(:period_2025) { FactoryBot.create(:registration_period, year: 2025, enabled: enabled_2025) }
+    let(:enabled_2025) { true }
+
+    before do
+      period_2023
+      period_2024
+      period_2025
+    end
+
+    context "when the start date does not fall in any registration period" do
+      let(:start_date) { { 1 => "2030", 2 => "01", 3 => "01" } }
+
+      it "returns the cannot register ect yet step" do
+        expect(subject.next_step).to eq(:cannot_register_ect_yet)
+      end
+    end
+
+    context 'when the start date is in the past' do
+      let(:start_date) { { 1 => period_2023.year, 2 => "07", 3 => "01" } }
+
+      context 'when the past registration period is disabled' do
+        let(:enabled_2023) { false }
+
+        it 'returns the working pattern step' do
+          expect(subject.next_step).to eq(:working_pattern)
+        end
+      end
+
+      context 'when the past registration period is enabled' do
+        let(:enabled_2023) { true }
+
+        it 'returns the working pattern step' do
+          expect(subject.next_step).to eq(:working_pattern)
+        end
+      end
+    end
+
+    context 'when the start date is in the present' do
+      let(:start_date) { { 1 => period_2024.year, 2 => "07", 3 => "01" } }
+
+      context 'when the past registration period is disabled' do
+        let(:enabled_2024) { false }
+
+        it 'returns the cannot register ect yet step' do
+          expect(subject.next_step).to eq(:cannot_register_ect_yet)
+        end
+      end
+
+      context 'when the past registration period is enabled' do
+        let(:enabled_2024) { true }
+
+        it 'returns the working pattern step' do
+          expect(subject.next_step).to eq(:working_pattern)
+        end
+      end
+    end
+
+    context 'when the start date is in the future' do
+      let(:start_date) { { 1 => period_2025.year, 2 => "07", 3 => "01" } }
+
+      context 'when the past registration period is disabled' do
+        let(:enabled_2025) { false }
+
+        it 'returns the cannot register ect yet step' do
+          expect(subject.next_step).to eq(:cannot_register_ect_yet)
+        end
+      end
+
+      context 'when the past registration period is enabled' do
+        let(:enabled_2025) { true }
+
+        it 'returns the working pattern step' do
+          expect(subject.next_step).to eq(:working_pattern)
+        end
+      end
     end
   end
 

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
   subject { wizard.current_step }
 
-  let(:prepopulated_start_date) { { "1" => "2025", "2" => "01" } }
-  let(:provided_start_date) { { "1" => "2024", "2" => "12" } }
+  let(:prepopulated_start_date) { { 1 => "2025", 2 => "01", 3 => '01' } }
+  let(:provided_start_date) { { 1 => "2024", 2 => "12", 3 => '01' } }
   let(:school) { FactoryBot.build(:school) }
   let(:step_params) { {} }
   let(:store) { FactoryBot.build(:session_repository, start_date: prepopulated_start_date) }


### PR DESCRIPTION
### Context

We want to block the ECT journey when a school user enters a start date for the ECT that does not fall within an enabled registration period. The only exception is when the start date is in the past. In that case, the user will be allowed to register the ECT.

We also don't need the ECTStartDate's `out of range` validation.

Changes proposed in this pull request
- Add a new block page
- Update the  StartDateStep to return the block page if the block criteria is met
- Remove the ECTStartDate out of range validation
- Update the HashDate to gracefully handle hash date with string numerics as keys, 
- Update the HashDate to raise invalid date when non-numerical years like "abcd" is entered by the user