### PR TITLE
Add pagination support to API controllers

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,7 @@
 module API
   class BaseController < ActionController::API
     include TokenAuthenticatable
+    include Paginatable
     include ErrorRescuable
   end
 end

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -1,7 +1,11 @@
 module API
   module V3
     class StatementsController < BaseController
-      def index = head(:method_not_allowed)
+      def index
+        # Temp to demonstrate pagination.
+        render json: { data: paginate(Statement.all) }.to_json
+      end
+
       def show = head(:method_not_allowed)
     end
   end

--- a/app/controllers/concerns/api/paginatable.rb
+++ b/app/controllers/concerns/api/paginatable.rb
@@ -1,0 +1,32 @@
+module API
+  module Paginatable
+    extend ActiveSupport::Concern
+    include Pagy::Backend
+
+  private
+
+    def paginate(scope)
+      _pagy, paginated_records = pagy_countless(scope, limit: per_page, page:)
+
+      paginated_records
+    rescue Pagy::VariableError
+      raise_as_bad_request!
+    end
+
+    def per_page
+      [page_params.dig(:page, :per_page).to_i.nonzero? || Pagy::DEFAULT[:api_per_page], Pagy::DEFAULT[:api_max_per_page]].min
+    end
+
+    def page
+      page_params.dig(:page, :page).to_i.nonzero? || 1
+    end
+
+    def page_params
+      params.permit(page: %i[per_page page])
+    end
+
+    def raise_as_bad_request!
+      raise ActionController::BadRequest, "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number"
+    end
+  end
+end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,8 +1,11 @@
+require 'pagy/extras/countless'
 require 'pagy/extras/array'
 require 'pagy/extras/overflow'
 require 'pagy/extras/size'
 
 Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
-Pagy::DEFAULT[:size] = [1, 1, 1, 1].freeze
-Pagy::DEFAULT[:limit] = 20
+Pagy::DEFAULT[:size] = [1, 1, 1, 1].freeze # nav bar links
+Pagy::DEFAULT[:limit] = 20 # items per page
+Pagy::DEFAULT[:api_per_page] = 100 # items per page (API)
+Pagy::DEFAULT[:api_max_per_page] = 3_000 # max items per page (API)
 Pagy::DEFAULT.freeze

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -3,8 +3,11 @@ FactoryBot.define do
     active_lead_provider
 
     api_id { SecureRandom.uuid }
-    month { Faker::Number.between(from: 1, to: 12) }
-    year { Faker::Number.between(from: 2021, to: Date.current.year) }
+    sequence(:month) { |n| ((n - 1) % 12) + 1 }
+    sequence(:year) do |n|
+      available_years = (2021..Date.current.year).to_a
+      available_years[(n - 1) % available_years.size]
+    end
     deadline_date { Faker::Date.forward(days: 30) }
     payment_date { Faker::Date.forward(days: 30) }
     output_fee { true }

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,21 +1,28 @@
 RSpec.describe "Statements API", type: :request do
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+
   describe "#index" do
     let(:path) { api_v3_statements_path }
 
-    it_behaves_like "a token authenticated endpoint", :get
-    it_behaves_like "an error rescuable endpoint"
+    def create_resource(active_lead_provider:)
+      FactoryBot.create(:statement, active_lead_provider:)
+    end
 
-    it "returns method not allowed" do
+    it_behaves_like "an error rescuable endpoint"
+    it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "a paginated endpoint"
+
+    it "returns success" do
       authenticated_api_get path
-      expect(response).to be_method_not_allowed
+      expect(response).to be_successful
     end
   end
 
   describe "#show" do
     let(:path) { api_v3_statement_path(123) }
 
-    it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "an error rescuable endpoint"
+    it_behaves_like "a token authenticated endpoint", :get
 
     it "returns method not allowed" do
       authenticated_api_get path

--- a/spec/support/shared_contexts/api/paginated_endpoint.rb
+++ b/spec/support/shared_contexts/api/paginated_endpoint.rb
@@ -1,0 +1,34 @@
+shared_examples "a paginated endpoint" do
+  before do
+    8.times { create_resource(active_lead_provider:) }
+  end
+
+  it "returns 5 resources on page 1" do
+    authenticated_api_get(path, params: { page: { per_page: 5, page: 1 } })
+
+    expect(response).to have_http_status(:success)
+    expect(parsed_response_data.size).to eq(5)
+  end
+
+  it "returns 3 resources on page 2" do
+    authenticated_api_get(path, params: { page: { per_page: 5, page: 2 } })
+
+    expect(response).to have_http_status(:success)
+    expect(parsed_response_data.size).to eq(3)
+  end
+
+  it "returns empty for page 3" do
+    authenticated_api_get(path, params: { page: { per_page: 5, page: 3 } })
+
+    expect(response).to have_http_status(:success)
+    expect(parsed_response_data).to be_empty
+  end
+
+  it "returns error when requesting page -1" do
+    authenticated_api_get(path, params: { page: { per_page: 5, page: -1 } })
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number" }] }.to_json)
+  end
+end


### PR DESCRIPTION
### Context

We want to add pagination support to the API controllers so that we can serve back results in pages, as per the behaviour in ECF.

### Changes proposed in this pull request

- Add pagination support to API controllers

Add `API::Paginatable` concern to easily support pagination in controller actions.

Update the `StatementsController#index` action to demonstrate pagination and testing.

Add shared context to support easily testing pagination.

Update `pagy` initializer with defaults for the API pagination.

### Guidance to review

I think arguably the pagination logic may be better in a service as its only a subset of actions, but I've left it as a concern for now as that's what we agreed originally I believe.

I've updated the statement factory to generate statements sequentially as I was finding I would get random duplicate statement errors when creating them with random months/years.