### PR TITLE
[1652] Add API base and error handling

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,35 @@
 module API
-  class BaseController < ActionController::Base
+  class BaseController < ActionController::API
+    before_action :set_cache_headers
+    before_action :remove_charset
+
+    include ActionController::MimeResponds
+
+    rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response
+    rescue_from ActionController::BadRequest, with: :bad_request_response
+    rescue_from ArgumentError, with: :bad_request_response
+    rescue_from API::Errors::FilterValidationError, with: :filter_validation_error_response
+
+  private
+
+    def remove_charset
+      ActionDispatch::Response.default_charset = nil
+    end
+
+    def unpermitted_parameter_response(exception)
+      render json: { errors: API::Errors::Response.new(error: "Unpermitted parameters", params: exception.params).call }, status: :unprocessable_entity
+    end
+
+    def bad_request_response(exception)
+      render json: { errors: API::Errors::Response.new(error: "Bad request", params: exception.message).call }, status: :bad_request
+    end
+
+    def filter_validation_error_response(exception)
+      render json: { errors: API::Errors::Response.new(error: "Unpermitted parameters", params: exception.message).call }, status: :unprocessable_entity
+    end
+
+    def set_cache_headers
+      no_store
+    end
   end
 end

--- a/app/services/api/errors/filter_validation_error.rb
+++ b/app/services/api/errors/filter_validation_error.rb
@@ -1,0 +1,5 @@
+module API
+  module Errors
+    class FilterValidationError < StandardError; end
+  end
+end

--- a/app/services/api/errors/response.rb
+++ b/app/services/api/errors/response.rb
@@ -1,0 +1,26 @@
+module API
+  module Errors
+    class Response
+      attr_reader :error, :params
+
+      def initialize(error:, params:)
+        @params = params
+        @error = error
+      end
+
+      def call
+        params.map do |param|
+          {
+            title: error,
+            detail: param,
+          }
+        end
+      rescue StandardError
+        [{
+          title: error,
+          detail: params,
+        }]
+      end
+    end
+  end
+end

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe API::BaseController, type: :controller do
+  describe "handling `UnpermittedParameters` exceptions" do
+    controller do
+      def index
+        raise ActionController::UnpermittedParameters.new(params: { foo: "bar" })
+      end
+    end
+
+    before { get :index }
+
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    it "renders correct error message" do
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => ["params", { "foo" => "bar" }],
+          "title" => "Unpermitted parameters",
+        },
+      ])
+    end
+
+    it "returns 422" do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "handling `BadRequest` exceptions" do
+    controller do
+      def index
+        raise ActionController::BadRequest, "testing"
+      end
+    end
+
+    before { get :index }
+
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    it "renders correct error message" do
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => "testing",
+          "title" => "Bad request",
+        },
+      ])
+    end
+
+    it "returns 400" do
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe "handling `ArgumentError` exceptions" do
+    controller do
+      def index
+        raise ArgumentError, "testing"
+      end
+    end
+
+    before { get :index }
+
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    it "renders correct error message" do
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => "testing",
+          "title" => "Bad request",
+        },
+      ])
+    end
+
+    it "returns 400" do
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe "handling `FilterValidationError` exceptions" do
+    controller do
+      def index
+        raise API::Errors::FilterValidationError, "testing"
+      end
+    end
+
+    before { get :index }
+
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    it "renders correct error message" do
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => "testing",
+          "title" => "Unpermitted parameters",
+        },
+      ])
+    end
+
+    it "returns 422" do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/services/api/errors/response_spec.rb
+++ b/spec/services/api/errors/response_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe API::Errors::Response do
+  subject { described_class.new(error:, params:) }
+
+  let(:error) { "StandardError" }
+  let(:params) do
+    [
+      "Error 1",
+      "Error 2",
+    ]
+  end
+
+  describe "#call" do
+    it "returns formatted errors" do
+      result = subject.call
+      expect(result.size).to be(2)
+
+      expect(result[0][:title]).to eql("StandardError")
+      expect(result[0][:detail]).to eql("Error 1")
+
+      expect(result[1][:title]).to eql("StandardError")
+      expect(result[1][:detail]).to eql("Error 2")
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Issue #1652](https://github.com/DFE-Digital/register-ects-project-board/issues/1652)

In order to create API endpoints, the API::BaseController will need to be set up to handle API errors and responses.

### Changes proposed in this pull request

- Add API::BaseController
- Add error responses for various status codes
- Add exception handling

### Guidance to review

Review app
