### PR TITLE
Fix display bug in lead provider seed output

### DIFF
--- a/db/seeds/lead_providers.rb
+++ b/db/seeds/lead_providers.rb
@@ -1,6 +1,6 @@
 def describe_lead_provider(lead_provider, years)
   years_description = if years.any?
-                        Colourize.text(years.map(&:year).join(', '), :green)
+                        Colourize.text(years.join(', '), :green)
                       else
                         Colourize.text('inactive', :red)
                       end


### PR DESCRIPTION
We were calling #year on the year number so getting much higher than expected values!

```ruby
> 2021.year.to_i
=> 63776599992
```
