### PR TITLE
[1655] Rate limiting for /api/ with rack attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,19 @@
 class Rack::Attack
+  class Request < ::Rack::Request
+    def remote_ip
+      # This will always be present because the ActionDispatch::RemoteIp
+      # middleware runs long before this middleware. Use #fetch here
+      # so that we bail quickly if that middleware goes away or changes
+      # the field name. Have preferred this to instantiating a whole
+      # ActionDispatch::Request as that's a whole lot of work and this happens
+      # on every request.
+      #
+      # Favour the X-Real-IP header if set by Azure, if not fallback to
+      # ActionDispatch#remote_ip which is more reliable than Rack's ip method.
+      @remote_ip ||= env.fetch("x-real-ip", nil).presence || env.fetch("action_dispatch.remote_ip").to_s
+    end
+  end
+
   PROTECTED_ROUTES = %w[
     /otp-sign-in
     /otp-sign-in/code
@@ -21,17 +36,22 @@ class Rack::Attack
   end
 
   throttle("protected routes (OTP)", limit: 5, period: 20.seconds) do |request|
-    request.ip if protected_path?(request)
+    request.remote_ip if protected_path?(request)
   end
 
   # Throttle /api requests by auth token (1000 requests per 5 minutes)
   throttle("API requests by auth token", limit: 1000, period: 5.minutes) do |request|
-    auth_token(request) if api_request?(request)
+    if api_request?(request)
+      auth_token(request)
+    end
   end
+
+  # Fallback throttling for all other paths
+  throttle("All other requests by ip", limit: 1000, period: 5.minutes, &:remote_ip)
 end
 
 ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, request_id, payload|
-  ip = payload.fetch(:request).ip
+  ip = payload.fetch(:request).remote_ip
   path = payload.fetch(:request).fullpath
 
   Rails.logger.warn("[rack-attack] Throttled request #{request_id} from #{ip} to '#{path}'")

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -26,7 +26,7 @@ class Rack::Attack
 
   # Throttle /api requests by auth token (1000 requests per 5 minutes)
   throttle("API requests by auth token", limit: 1000, period: 5.minutes) do |request|
-    auth_token(request) if api_request?(request) && !protected_path?(request)
+    auth_token(request) if api_request?(request)
   end
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -47,7 +47,7 @@ class Rack::Attack
   end
 
   # Fallback throttling for all other paths
-  throttle("All other requests by ip", limit: 1000, period: 5.minutes, &:remote_ip)
+  throttle("All other requests by ip", limit: 1500, period: 5.minutes, &:remote_ip)
 end
 
 ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, request_id, payload|

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe "Rack::Attack" do
     end
   end
 
+  # TODO: enable when we have guidance and api docs
+  # [
+  #   "/api/guidance",
+  #   "/api/docs/v3",
+  # ].each do |public_api_path|
+  #   context "when requesting the public API path #{public_api_path}" do
+  #     let(:path) { public_api_path }
+  #
+  #     it_behaves_like "a rate limited endpoint", "public API requests by ip" do
+  #       def perform_request
+  #         get path
+  #       end
+  #
+  #       def change_condition
+  #         set_request_ip(other_ip)
+  #       end
+  #     end
+  #   end
+  # end
+
   context "rate limit all other requests by ip" do
     it_behaves_like "a rate limited endpoint", "All other requests by ip" do
       def perform_request

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -57,4 +57,28 @@ RSpec.describe "Rack::Attack" do
       end
     end
   end
+
+  context "rate limit all other requests by ip" do
+    it "throttles over 1000 requests within 5 minutes" do
+      freeze_time do
+        1000.times do
+          authenticated_api_get(ab_landing_path)
+          expect(response).to have_http_status(:ok)
+        end
+
+        5.times do
+          authenticated_api_get(ab_landing_path)
+          expect(response).to have_http_status(:too_many_requests)
+        end
+      end
+
+      # After 5 minutes
+      travel(5.minutes) do
+        5.times do
+          authenticated_api_get(ab_landing_path)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -35,17 +35,15 @@ RSpec.describe "Rack::Attack" do
   end
 
   context "rate limit /api/ endpoints by auth token" do
-    let(:headers) { { Authorization: "Bearer TEST_TOKEN" } }
-
     it "throttles over 1000 requests within 5 minutes" do
       freeze_time do
         1000.times do
-          get(api_v3_statements_path, headers:)
+          authenticated_api_get(api_v3_statements_path)
           expect(response).to have_http_status(:method_not_allowed) # change to :ok when /api/v3/statements is ready
         end
 
         5.times do
-          get(api_v3_statements_path, headers:)
+          authenticated_api_get(api_v3_statements_path)
           expect(response).to have_http_status(:too_many_requests)
         end
       end
@@ -53,7 +51,7 @@ RSpec.describe "Rack::Attack" do
       # After 5 minutes
       travel(5.minutes) do
         5.times do
-          get(api_v3_statements_path, headers:)
+          authenticated_api_get(api_v3_statements_path)
           expect(response).to have_http_status(:method_not_allowed) # change to :ok when /api/v3/statements is ready
         end
       end

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -34,6 +34,29 @@ RSpec.describe "Rack::Attack" do
     end
   end
 
-  xit 'POST /otp-sign-in'
-  xit 'POST /otp-sign-in/verify'
+  context "rate limit /api/ endpoints by auth token" do
+    let(:headers) { { Authorization: "Bearer TEST_TOKEN" } }
+
+    it "throttles over 1000 requests within 5 minutes" do
+      freeze_time do
+        1000.times do
+          get(api_v3_statements_path, headers:)
+          expect(response).to have_http_status(:method_not_allowed) # change to :ok when /api/v3/statements is ready
+        end
+
+        5.times do
+          get(api_v3_statements_path, headers:)
+          expect(response).to have_http_status(:too_many_requests)
+        end
+      end
+
+      # After 5 minutes
+      travel(5.minutes) do
+        5.times do
+          get(api_v3_statements_path, headers:)
+          expect(response).to have_http_status(:method_not_allowed) # change to :ok when /api/v3/statements is ready
+        end
+      end
+    end
+  end
 end

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Rack::Attack.enabled = false
+
+RSpec.configure do |config|
+  config.around do |example|
+    if example.metadata[:rack_attack] == true
+      begin
+        Rack::Attack.enabled = true
+        Rack::Attack.reset!
+
+        example.run
+      ensure
+        Rack::Attack.enabled = false
+      end
+    else
+      example.run
+    end
+  end
+end

--- a/spec/support/requests/api_helper.rb
+++ b/spec/support/requests/api_helper.rb
@@ -1,14 +1,14 @@
 module APIHelper
-  def authenticated_api_get(path, params: {}, token: nil)
-    get path, headers: api_headers(token:), params:
+  def authenticated_api_get(path, params: {}, token: nil, headers: {})
+    get path, headers: api_headers(token:).merge(headers), params:
   end
 
-  def authenticated_api_post(path, params: {}, token: nil)
-    post path, headers: api_headers(token:), params:
+  def authenticated_api_post(path, params: {}, token: nil, headers: {})
+    post path, headers: api_headers(token:).merge(headers), params:
   end
 
-  def authenticated_api_put(path, params: {}, token: nil)
-    put path, headers: api_headers(token:), params:
+  def authenticated_api_put(path, params: {}, token: nil, headers: {})
+    put path, headers: api_headers(token:).merge(headers), params:
   end
 
   def api_headers(token: nil)

--- a/spec/support/shared_examples/rate_limiting_support.rb
+++ b/spec/support/shared_examples/rate_limiting_support.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a rate limited endpoint", :rack_attack do |desc|
+  describe desc do
+    subject { response }
+
+    let(:limit) { 2 }
+    let(:throttle) { Rack::Attack.throttles[desc] }
+
+    before do
+      memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
+      allow(Rack::Attack.cache).to receive(:store) { memory_store }
+
+      allow(throttle).to receive(:limit) { limit }
+
+      allow(Rails.logger).to receive(:warn)
+
+      freeze_time
+
+      request_count.times { perform_request }
+    end
+
+    context "when fewer than rate limit" do
+      let(:request_count) { limit - 1 }
+
+      it { is_expected.to have_http_status(:success) }
+    end
+
+    context "when more than rate limit" do
+      let(:request_count) { limit + 1 }
+
+      it { is_expected.to have_http_status(:too_many_requests) }
+
+      it "logs a warning" do
+        expect(Rails.logger).to have_received(:warn).with(
+          %r{\[rack-attack\] Throttled request [a-zA-Z0-9]{20} from #{Regexp.escape(request.remote_ip)} to '#{request.path}'}
+        )
+      end
+
+      it "allows another request when the time restriction has passed" do
+        travel(throttle.period + 10.seconds)
+        perform_request
+        expect(subject).to have_http_status(:success)
+      end
+
+      it "allows another request if the condition changes" do
+        change_condition
+        perform_request
+        expect(subject).to have_http_status(:success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1655

### Changes proposed in this pull request

* Updated rack attack config to throttle `/api/` requests, 1000 requests per 5 minutes
* Added fall back throttle for 1000 requests per 5 minutes
* Added `remote_ip` changes from https://github.com/DFE-Digital/early-careers-framework/pull/4085
* Added rspec tests

### Guidance to review
