### PR TITLE
Update navigation links for 'ECTs' and 'mentors' for schools to match prototype

### DIFF
--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -43,8 +43,8 @@ module Navigation
           { text: "Organisations", href: admin_organisations_path, active_when: '/admin/organisations' },
         ],
         school_user: [
-          { text: "Your ECTs", href: schools_ects_home_path },
-          { text: "Your Mentors", href: schools_mentors_home_path },
+          { text: "ECTs", href: schools_ects_home_path },
+          { text: "Mentors", href: schools_mentors_home_path },
         ],
         api_guidance: [
           { text: "Home", href: '/api/guidance' },


### PR DESCRIPTION

I noticed these were different from the prototype (and also the capitalisation was driving me bonkers).

### Changes proposed in this pull request
Fix the name of links in the main school nav.

### Guidance to review
Make sure I didn't break any tests or devvy things please!