### PR TITLE
[1651] Add API filtering

### DIFF
--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -1,6 +1,9 @@
 module API
   module V3
     class StatementsController < BaseController
+      include FilterByDate
+      include FilterByRegistrationPeriod
+
       def index = head(:method_not_allowed)
       def show = head(:method_not_allowed)
     end

--- a/app/controllers/concerns/api/filter_by_date.rb
+++ b/app/controllers/concerns/api/filter_by_date.rb
@@ -1,0 +1,21 @@
+module API
+  module FilterByDate
+    extend ActiveSupport::Concern
+
+  protected
+
+    def updated_since
+      date_filter(filter_name: :updated_since)
+    end
+
+    def date_filter(filter_name:)
+      date_param = params.dig(:filter, filter_name)
+
+      return if date_param.blank?
+
+      Time.iso8601(URI.decode_www_form_component(date_param))
+    rescue ArgumentError
+      raise ActionController::BadRequest, I18n.t(:invalid_date_filter, attribute: filter_name)
+    end
+  end
+end

--- a/app/controllers/concerns/api/filter_by_registration_period.rb
+++ b/app/controllers/concerns/api/filter_by_registration_period.rb
@@ -1,0 +1,11 @@
+module API
+  module FilterByRegistrationPeriod
+    extend ActiveSupport::Concern
+
+  protected
+
+    def registration_period_start_years
+      params.dig(:filter, :cohort)
+    end
+  end
+end

--- a/spec/concerns/api/filter_by_date_spec.rb
+++ b/spec/concerns/api/filter_by_date_spec.rb
@@ -1,0 +1,45 @@
+class ControllerWithFilterByDate
+  include API::FilterByDate
+
+  public :updated_since
+
+  def initialize(updated_since_param:)
+    @updated_since_param = updated_since_param
+  end
+
+private
+
+  def params
+    {
+      filter: {
+        updated_since: @updated_since_param,
+      },
+    }
+  end
+end
+
+RSpec.describe API::FilterByDate do
+  let(:expected_updated_since) { Time.zone.local(2022, 2, 1, 10, 30) }
+
+  let(:updated_since_param) { expected_updated_since.rfc3339 }
+
+  let(:instance) { ControllerWithFilterByDate.new(updated_since_param:) }
+
+  describe "#updated_since" do
+    subject { instance.updated_since }
+
+    it { is_expected.to eq(expected_updated_since) }
+
+    context "when the updated_since filter is not present" do
+      let(:updated_since_param) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the updated_since filter is not an ISO8601 date" do
+      let(:updated_since_param) { "invalid-date" }
+
+      it { expect { subject }.to raise_error(ActionController::BadRequest).with_message(I18n.t(:invalid_date_filter, attribute: :updated_since)) }
+    end
+  end
+end

--- a/spec/concerns/api/filter_by_registration_period_spec.rb
+++ b/spec/concerns/api/filter_by_registration_period_spec.rb
@@ -1,0 +1,39 @@
+class ControllerWithFilterByRegistrationPeriod
+  include API::FilterByRegistrationPeriod
+
+  public :registration_period_start_years
+
+  def initialize(registration_period_param:)
+    @registration_period_param = registration_period_param
+  end
+
+private
+
+  def params
+    {
+      filter: {
+        cohort: @registration_period_param,
+      },
+    }
+  end
+end
+
+RSpec.describe API::FilterByRegistrationPeriod do
+  let(:expected_registration_period_start_years) { "2022,2025" }
+
+  let(:registration_period_param) { "2022,2025" }
+
+  let(:instance) { ControllerWithFilterByRegistrationPeriod.new(registration_period_param:) }
+
+  describe "#registration_period_start_years" do
+    subject { instance.registration_period_start_years }
+
+    it { is_expected.to eq(expected_registration_period_start_years) }
+
+    context "when the registration_period filter is not present" do
+      let(:registration_period_param) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe "Statements API", type: :request do
+  let(:current_lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:query) { Statements::Query }
+  let(:serializer) { API::StatementSerializer }
+
   describe "#index" do
     let(:path) { api_v3_statements_path }
 
+    def create_resource(**attrs)
+      FactoryBot.create(:statement, **attrs)
+    end
+
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "an error rescuable endpoint"
+    it_behaves_like "an index endpoint with filter by registration_period"
+    it_behaves_like "an index endpoint with filter by updated_since"
 
     it "returns method not allowed" do
       authenticated_api_get path

--- a/spec/support/requests/api_helper.rb
+++ b/spec/support/requests/api_helper.rb
@@ -1,14 +1,14 @@
 module APIHelper
-  def authenticated_api_get(path, params: {}, token: nil)
-    get path, headers: api_headers(token:), params:
+  def authenticated_api_get(path, token: nil, headers: {}, params: {})
+    get path, headers: api_headers(token:).merge(headers), params:
   end
 
-  def authenticated_api_post(path, params: {}, token: nil)
-    post path, headers: api_headers(token:), params:
+  def authenticated_api_post(path, token: nil, headers: {}, params: {})
+    post path, headers: api_headers(token:).merge(headers), params:
   end
 
-  def authenticated_api_put(path, params: {}, token: nil)
-    put path, headers: api_headers(token:), params:
+  def authenticated_api_put(path, token: nil, headers: {}, params: {})
+    put path, headers: api_headers(token:).merge(headers), params:
   end
 
   def api_headers(token: nil)

--- a/spec/support/shared_contexts/api/index_endpoint.rb
+++ b/spec/support/shared_contexts/api/index_endpoint.rb
@@ -1,0 +1,59 @@
+RSpec.shared_examples "an index endpoint with filter by registration_period", skip: "endpoint not ready" do
+  context "when fitlering by cohort" do
+    let(:registration_period_2023) { FactoryBot.create(:registration_period, year: 2023) }
+    let(:registration_period_2024) { FactoryBot.create(:registration_period, year: 2024) }
+    let(:registration_period_2025) { FactoryBot.create(:registration_period, year: 2025) }
+
+    it "returns resources for the specified cohorts" do
+      create_resource(lead_provider: current_lead_provider, registration_period: registration_period_2023)
+      create_resource(lead_provider: current_lead_provider, registration_period: registration_period_2024)
+      create_resource(lead_provider: current_lead_provider, registration_period: registration_period_2025)
+
+      authenticated_api_get(path, params: { filter: { cohort: "2023,2024" } })
+
+      expect(parsed_response_data.size).to eq(2)
+    end
+
+    it "calls the correct query" do
+      expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, registration_period_start_years: "2023,2024")).and_call_original
+
+      authenticated_api_get(path, params: { filter: { cohort: "2023,2024" } })
+    end
+  end
+end
+
+RSpec.shared_examples "an index endpoint with filter by updated_since", skip: "endpoint not ready" do
+  context "when fitlering by updated_since" do
+    it "returns resources updated since the specified date" do
+      travel_to(2.hours.ago) do
+        create_resource(lead_provider: current_lead_provider)
+      end
+      travel_to(1.minute.ago) do
+        create_resource(lead_provider: current_lead_provider)
+      end
+
+      authenticated_api_get(path, params: { filter: { updated_since: 1.hour.ago.iso8601 } })
+
+      expect(parsed_response_data.size).to eq(1)
+    end
+
+    it "calls the correct query" do
+      updated_since = 1.hour.ago.iso8601
+      expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, updated_since: Time.iso8601(updated_since))).and_call_original
+
+      authenticated_api_get(path, params: { filter: { updated_since: } })
+    end
+
+    it "returns 400 - bad request for invalid updated_since" do
+      authenticated_api_get(path, params: { filter: { updated_since: "invalid" } })
+
+      expect(response.status).to eq 400
+      expect(parsed_response_errors).to eq([
+        {
+          "detail" => "The filter '#/updated_since' must be a valid ISO 8601 date",
+          "title" => "Bad request",
+        },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Issue #1651](https://github.com/DFE-Digital/register-ects-project-board/issues/1651)

As a Lead Provider
I want to limit the number of statements which are returned to me using cohort and updated since filters
So that I can efficiently view the latest updated statements or the statements limited to a filter

### Changes proposed in this pull request

- Add a cohort filter - this can accept a single or list of cohorts;
- Add an updated since filter;
- Requests shared_examples specs are being skipped for now till endpoint/controller is ready;