### PR TITLE
Only enable request spec timeouts in CI

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,7 @@ module RegisterEarlyCareerTeachers
     config.enable_bulk_upload = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_BULK_UPLOAD', false))
     config.enable_api = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_API', false))
     config.sentry_dsn = ENV['SENTRY_DSN']
+    config.enable_request_specs_timeout = ActiveModel::Type::Boolean.new.cast(ENV.fetch('CI', false))
 
     config.dfe_sign_in_issuer = ENV.fetch('DFE_SIGN_IN_ISSUER', 'https://dev-oidc.signin.education.gov.uk')
     config.dfe_sign_in_client_id = ENV['DFE_SIGN_IN_CLIENT_ID']

--- a/spec/support/testing_request_specs.rb
+++ b/spec/support/testing_request_specs.rb
@@ -1,5 +1,7 @@
 require 'timeout'
 
+return unless Rails.application.config.enable_request_specs_timeout
+
 RSpec.configure do |config|
   # Set a timeout for request specs
   config.add_setting :request_timeout, default: 3


### PR DESCRIPTION
### Context

We want our request specs to fail fast in CI (rather than hang for long periods).

When running the tests locally, however, this causes a timeout in the console when using breakpoints.

### Changes proposed in this pull request

- Only timeout request specs in CI.

