### PR TITLE
Add lead provider migrator specs

### DIFF
--- a/app/migration/migrators/lead_provider.rb
+++ b/app/migration/migrators/lead_provider.rb
@@ -20,7 +20,12 @@ module Migrators
 
     def migrate!
       migrate(self.class.lead_providers) do |lead_provider|
-        ::LeadProvider.create!(name: lead_provider.name, api_id: lead_provider.id)
+        lp = ::LeadProvider.find_or_initialize_by(api_id: lead_provider.id)
+
+        lp.name = lead_provider.name
+        lp.created_at = lead_provider.created_at
+        lp.updated_at = lead_provider.updated_at
+        lp.save!
       end
     end
   end

--- a/spec/factories/migration/ecf_lead_provider_factory.rb
+++ b/spec/factories/migration/ecf_lead_provider_factory.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :ecf_lead_provider, class: "Migration::LeadProvider" do
-    name { "ABC Provider" }
-  end
-end

--- a/spec/factories/migration/ecf_lead_provider_factory.rb
+++ b/spec/factories/migration/ecf_lead_provider_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :ecf_lead_provider, class: "Migration::LeadProvider" do
+    name { "ABC Provider" }
+  end
+end

--- a/spec/migration/migrators/lead_provider_spec.rb
+++ b/spec/migration/migrators/lead_provider_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Migrators::LeadProvider do
+  subject(:migrator) { described_class.new(worker: 0) }
+
+  let!(:ecf_lead_provider) { FactoryBot.create(:ecf_lead_provider) }
+
+  describe ".record_count" do
+    it "returns the number of LeadProvider records in the ECF database" do
+      expect(described_class.record_count).to eq 1
+    end
+  end
+
+  describe ".model" do
+    it "returns :lead_provider" do
+      expect(described_class.model).to eq :lead_provider
+    end
+  end
+
+  describe ".lead_providers" do
+    it "returns all LeadProvider records in the ECF database" do
+      expect(described_class.lead_providers).to eq [ecf_lead_provider]
+    end
+  end
+
+  describe ".records_per_worker" do
+    it "returns the worker batch size for lead_providers" do
+      expect(described_class.records_per_worker).to eq 5_000
+    end
+  end
+
+  describe ".dependencies" do
+    it "returns a list of migrators that must be run before this one" do
+      expect(described_class.dependencies).to eq []
+    end
+  end
+
+  describe "#migrate!" do
+    let!(:data_migration) { FactoryBot.create(:data_migration, model: :lead_provider) }
+
+    it 'creates a record in the ecf2 database' do
+      expect {
+        migrator.migrate!
+      }.to change(::LeadProvider, :count).by(1)
+    end
+
+    it "populates the ecf2 model correctly" do
+      migrator.migrate!
+      expect(::LeadProvider.first.name).to eq ecf_lead_provider.name
+    end
+  end
+end


### PR DESCRIPTION
### Context

Part of the task to bring the migrators up to date: adding missing specs for the `LeadProvider` migrator.
This migrates `LeadProvider` records from the ECF1 database and creates matching `LeadProvider` records in the RECT database.  These records are basically a 1 to 1 match.

### Changes proposed in this pull request
Adds specs for the lead provider migrator

### Guidance to review
