### PR TITLE
Update sandbox phase banner to say it is for lead provider testing

### DIFF
--- a/config/terraform/application/config/sandbox.yml
+++ b/config/terraform/application/config/sandbox.yml
@@ -1,6 +1,6 @@
 ---
 ENVIRONMENT_COLOUR: yellow
-ENVIRONMENT_PHASE_BANNER_TAG: Sandbox 🏖️
+ENVIRONMENT_PHASE_BANNER_TAG: Lead provider sandbox 🏖️
 ENVIRONMENT_PHASE_BANNER_CONTENT: This sandbox environment is for lead provider testing.
 ENABLE_SENTRY: true
 SENTRY_ENVIRONMENT: sandbox


### PR DESCRIPTION
### Context

We want to make clearer that the sandbox testing environment is for lead providers only.

### Changes proposed in this pull request

Change the banner guidance to say it's for lead providers.

### Guidance to review

Make sure I've not broken anything.
