### PR TITLE
Add admin finance page and statements list

### DIFF
--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -41,6 +41,7 @@ module Navigation
         dfe_staff_user: [
           { text: "Teachers", href: admin_teachers_path, active_when: '/admin/teachers' },
           { text: "Organisations", href: admin_organisations_path, active_when: '/admin/organisations' },
+          { text: "Finance", href: admin_finance_path, active_when: '/admin/finance' },
         ],
         school_user: [
           { text: "ECTs", href: schools_ects_home_path },

--- a/app/controllers/admin/finance/statements_controller.rb
+++ b/app/controllers/admin/finance/statements_controller.rb
@@ -1,0 +1,22 @@
+module Admin::Finance
+  class StatementsController < AdminController
+    layout 'full'
+
+    def index
+      @pagy, statements = pagy(
+        Statements::Query.new.statements.eager_load(active_lead_provider: %i[
+          lead_provider
+          registration_period
+        ])
+      )
+
+      @statements = Admin::StatementPresenter.wrap(statements)
+    end
+
+    def show
+      statement = Statement.eager_load(active_lead_provider: :lead_provider).find(params[:id])
+
+      @statement = Admin::StatementPresenter.new(statement)
+    end
+  end
+end

--- a/app/controllers/admin/finance_controller.rb
+++ b/app/controllers/admin/finance_controller.rb
@@ -1,0 +1,6 @@
+module Admin
+  class FinanceController < AdminController
+    def show
+    end
+  end
+end

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,7 +1,5 @@
 module Admin
   class OrganisationsController < AdminController
-    layout 'full'
-
     def index
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,4 +49,8 @@ module ApplicationHelper
 
     RubyPants.new(string, %i[quotes], ruby_pants_options).to_html
   end
+
+  def boolean_to_yes_or_no(value)
+    value ? "Yes" : "No"
+  end
 end

--- a/app/presenters/admin/statement_presenter.rb
+++ b/app/presenters/admin/statement_presenter.rb
@@ -1,0 +1,47 @@
+module Admin
+  class StatementPresenter < SimpleDelegator
+    def self.wrap(collection)
+      collection.map { |teacher| new(teacher) }
+    end
+
+    def month_and_year
+      month_name = Date::MONTHNAMES.fetch(statement.month)
+
+      "#{month_name} #{statement.year}"
+    end
+
+    def status_tag_kwargs
+      colour = { 'open' => 'blue', 'payable' => 'yellow', 'paid' => 'green' }.fetch(statement.state)
+
+      { text: statement.state.capitalize, colour: }
+    end
+
+    def page_title
+      lead_provider_name = statement.active_lead_provider.lead_provider.name
+
+      "#{lead_provider_name} - #{month_and_year}"
+    end
+
+    def registration_period_year
+      statement.active_lead_provider.registration_period.year.to_s
+    end
+
+    def lead_provider_name
+      statement.active_lead_provider.lead_provider.name
+    end
+
+    def formatted_deadline_date
+      statement.deadline_date.to_fs(:govuk)
+    end
+
+    def formatted_payment_date
+      statement.payment_date.to_fs(:govuk)
+    end
+
+  private
+
+    def statement
+      __getobj__
+    end
+  end
+end

--- a/app/presenters/admin/statement_presenter.rb
+++ b/app/presenters/admin/statement_presenter.rb
@@ -1,7 +1,7 @@
 module Admin
   class StatementPresenter < SimpleDelegator
     def self.wrap(collection)
-      collection.map { |teacher| new(teacher) }
+      collection.map { |statement| new(statement) }
     end
 
     def month_and_year

--- a/app/views/admin/finance/show.html.erb
+++ b/app/views/admin/finance/show.html.erb
@@ -1,0 +1,9 @@
+<% page_data(title: "Finance") %>
+
+<h2 class="govuk-heading-m">
+  <%= govuk_link_to('Statements', admin_finance_statements_path, no_visited_state: true, no_underline: true) %>
+</h2>
+
+<p class="govuk-body">
+  Monthly record of payments made to lead providers.
+</p>

--- a/app/views/admin/finance/statements/index.html.erb
+++ b/app/views/admin/finance/statements/index.html.erb
@@ -8,7 +8,7 @@
       head: ["ID", "Lead provider", "Contract year", "Statement", "Status"],
       rows: @statements.map { |s| [
         govuk_link_to(s.id, admin_finance_statement_path(s)),
-        govuk_link_to(s.lead_provider_name, '#', text_colour: true),
+        s.lead_provider_name,
         s.registration_period_year,
         s.month_and_year,
         govuk_tag(**s.status_tag_kwargs)

--- a/app/views/admin/finance/statements/index.html.erb
+++ b/app/views/admin/finance/statements/index.html.erb
@@ -5,13 +5,13 @@
 <% else %>
   <%=
     govuk_table(
-      head: ["ID", "Lead provider", "Contract year", "Statement", "Status"],
+      head: ["Lead provider", "Contract year", "Statement", "Status", govuk_visually_hidden("Actions")],
       rows: @statements.map { |s| [
-        govuk_link_to(s.id, admin_finance_statement_path(s)),
         s.lead_provider_name,
         s.registration_period_year,
         s.month_and_year,
-        govuk_tag(**s.status_tag_kwargs)
+        govuk_tag(**s.status_tag_kwargs),
+        govuk_link_to("View", admin_finance_statement_path(s)),
       ] }
     )
   %>

--- a/app/views/admin/finance/statements/index.html.erb
+++ b/app/views/admin/finance/statements/index.html.erb
@@ -1,0 +1,20 @@
+<% page_data(title: "Statements") %>
+
+<% if @statements.none? %>
+  <p class='govuk-body'>There are no statements</p>
+<% else %>
+  <%=
+    govuk_table(
+      head: ["ID", "Lead provider", "Contract year", "Statement", "Status"],
+      rows: @statements.map { |s| [
+        govuk_link_to(s.id, admin_finance_statement_path(s)),
+        govuk_link_to(s.lead_provider_name, '#', text_colour: true),
+        s.registration_period_year,
+        s.month_and_year,
+        govuk_tag(**s.status_tag_kwargs)
+      ] }
+    )
+  %>
+<% end %>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -1,0 +1,46 @@
+<% page_data(title: @statement.page_title) %>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: govuk_link_to(@statement.lead_provider_name, '#', text_colour: true))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Status")
+      row.with_value(text: govuk_tag(**@statement.status_tag_kwargs))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Contract year")
+      row.with_value(text: @statement.registration_period_year)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Month")
+      row.with_value(text: @statement.month_and_year)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Deadline date")
+      row.with_value(text: @statement.formatted_deadline_date)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Payment date")
+      row.with_value(text: @statement.formatted_payment_date)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "API ID")
+      row.with_value { tag.code(@statement.api_id) }
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Output fee")
+      row.with_value { boolean_to_yes_or_no(@statement.output_fee) }
+    end
+  end
+%>
+

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -1,21 +1,15 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% page_data(title: "Organisations") %>
-  </div>
+<% page_data(title: "Organisations") %>
 
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">
-      <%= govuk_link_to('Schools', admin_schools_path, no_visited_state: true, no_underline: true) %>
-    </h2>
-    <p class="govuk-body">
-      The schools who have teachers or mentors undertaking ECF training
-    </p>
-    <hr class="govuk-section-break--l govuk-section-break--visible">
-    <h2 class="govuk-heading-m">
-      <%= govuk_link_to('Appropriate bodies', admin_appropriate_bodies_path, no_visited_state: true, no_underline: true) %>
-    </h2>
-    <p class="govuk-body">
-      Appropriate bodies are responsible for assuring the quality of the statutory induction of ECTs
-    </p>
-  </div>
-</div>
+<h2 class="govuk-heading-m">
+  <%= govuk_link_to('Schools', admin_schools_path, no_visited_state: true, no_underline: true) %>
+</h2>
+<p class="govuk-body">
+  The schools who have teachers or mentors undertaking ECF training
+</p>
+<hr class="govuk-section-break--l govuk-section-break--visible">
+<h2 class="govuk-heading-m">
+  <%= govuk_link_to('Appropriate bodies', admin_appropriate_bodies_path, no_visited_state: true, no_underline: true) %>
+</h2>
+<p class="govuk-body">
+  Appropriate bodies are responsible for assuring the quality of the statutory induction of ECTs
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,12 @@ Rails.application.routes.draw do
       resource :record_failed_outcome, only: %i[new create show], path: 'record-failed-outcome', controller: 'teachers/record_failed_outcome'
       resource :reopen_induction, only: %i[update], path: 'reopen-induction', controller: 'teachers/reopen_induction'
     end
+
+    resource :finance, only: %i[show], controller: 'finance' do
+      collection do
+        resources :statements, as: 'finance_statements', controller: 'finance/statements', only: %i[index show]
+      end
+    end
   end
 
   resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab_landing', controller: 'appropriate_bodies/landing'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -120,4 +120,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.smart_quotes("")).to eq("")
     end
   end
+
+  describe '#boolean_to_yes_or_no' do
+    subject { boolean_to_yes_or_no(value) }
+
+    context 'when value is true' do
+      let(:value) { true }
+
+      it { is_expected.to eql('Yes') }
+    end
+
+    context 'when value is false' do
+      let(:value) { false }
+
+      it { is_expected.to eql('No') }
+    end
+  end
 end

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -1,0 +1,99 @@
+describe Admin::StatementPresenter do
+  subject { Admin::StatementPresenter.new(statement) }
+
+  describe '#month_and_year' do
+    let(:statement) { FactoryBot.build(:statement, month: 6, year: 2023) }
+
+    it 'returns the month name and year in a string' do
+      expect(subject.month_and_year).to eql('June 2023')
+    end
+
+    context 'when the month is invalid' do
+      let(:statement) { FactoryBot.build(:statement, month: 13, year: 2023) }
+
+      it 'raises an IndexError' do
+        expect { subject.month_and_year }.to raise_error(IndexError)
+      end
+    end
+  end
+
+  describe '#status_tag_kwargs' do
+    context 'when open' do
+      let(:statement) { FactoryBot.build(:statement, state: 'open') }
+
+      it 'is blue and Open' do
+        expect(subject.status_tag_kwargs).to eql({ colour: 'blue', text: 'Open' })
+      end
+    end
+
+    context 'when payable' do
+      let(:statement) { FactoryBot.build(:statement, state: 'payable') }
+
+      it 'is yellow and Payable' do
+        expect(subject.status_tag_kwargs).to eql({ colour: 'yellow', text: 'Payable' })
+      end
+    end
+
+    context 'when paid' do
+      let(:statement) { FactoryBot.build(:statement, state: 'paid') }
+
+      it 'is green and Paid' do
+        expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Paid' })
+      end
+    end
+
+    context 'when unrecognised' do
+      let(:statement) { FactoryBot.build(:statement, state: 'bad_state') }
+
+      it 'raises an IndexError' do
+        expect { subject.status_tag_kwargs }.to raise_error(IndexError)
+      end
+    end
+  end
+
+  describe '#page_title' do
+    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
+    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
+    let(:statement) { FactoryBot.build(:statement, active_lead_provider:, month: 5, year: 2023) }
+
+    it 'returns the lead provider, month and year in a string' do
+      expect(subject.page_title).to eql('Some LP - May 2023')
+    end
+  end
+
+  describe '#lead_provider_name' do
+    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
+    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
+    let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+
+    it 'returns the lead provider name' do
+      expect(subject.lead_provider_name).to eql('Some LP')
+    end
+  end
+
+  describe '#registration_period_year' do
+    let(:registration_period) { FactoryBot.build(:registration_period, year: 2022) }
+    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, registration_period:) }
+    let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+
+    it 'returns the lead provider name' do
+      expect(subject.registration_period_year).to eql('2022')
+    end
+  end
+
+  describe '#formatted_deadline_date' do
+    let(:statement) { FactoryBot.build(:statement, deadline_date: Date.new(2024, 1, 1)) }
+
+    it 'formats the deadline date in the GOV.UK style' do
+      expect(subject.formatted_deadline_date).to eq('1 January 2024')
+    end
+  end
+
+  describe '#formatted_payment_date' do
+    let(:statement) { FactoryBot.build(:statement, deadline_date: Date.new(2025, 2, 2)) }
+
+    it 'formats the payment date in the GOV.UK style' do
+      expect(subject.formatted_deadline_date).to eq('2 February 2025')
+    end
+  end
+end

--- a/spec/requests/admin/finance/finance_spec.rb
+++ b/spec/requests/admin/finance/finance_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "Admin finance page", type: :request do
+  describe "GET /admin/finance" do
+    it "redirects to sign in path" do
+      get "/admin/finance"
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "requires authorisation" do
+        get "/admin/finance"
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when signed in as a DfE user' do
+      include_context 'sign in as DfE user'
+
+      it 'displays the finance page' do
+        get "/admin/finance"
+
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/finance/statements/statements_spec.rb
+++ b/spec/requests/admin/finance/statements/statements_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe "Admin finance statements index", type: :request do
+  describe "GET /admin/finance/statements" do
+    it "redirects to sign in path" do
+      get "/admin/finance/statements"
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "requires authorisation" do
+        get "/admin/finance/statements"
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when signed in as a DfE user' do
+      include_context 'sign in as DfE user'
+
+      it 'displays the finance page' do
+        get "/admin/finance/statements"
+
+        expect(response.status).to eq(200)
+      end
+
+      it 'retrieves a list of statements' do
+        allow(Statements::Query).to receive(:new).and_call_original
+
+        get "/admin/finance/statements"
+
+        expect(Statements::Query).to have_received(:new).once
+      end
+    end
+  end
+
+  describe "GET /admin/finance/statements/:statement_id" do
+    it "redirects to sign in path" do
+      get "/admin/finance/statements/1"
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "requires authorisation" do
+        get "/admin/finance/statements/1"
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when signed in as a DfE user' do
+      let!(:statement) { FactoryBot.create(:statement) }
+
+      include_context 'sign in as DfE user'
+
+      it 'displays the finance page' do
+        get "/admin/finance/statements/#{statement.id}"
+
+        expect(response.status).to eq(200)
+      end
+
+      it 'uses the presenter to display the statement' do
+        allow(Admin::StatementPresenter).to receive(:new).with(statement).and_call_original
+
+        get "/admin/finance/statements/#{statement.id}"
+
+        expect(Admin::StatementPresenter).to have_received(:new).with(statement).once
+      end
+    end
+  end
+end

--- a/spec/views/admin/finance/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/show.html.erb_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe 'admin/finance/show.html.erb' do
+  it 'has a link to the statements page' do
+    render
+
+    expect(rendered).to have_link('Statements', href: admin_finance_statements_path)
+  end
+end

--- a/spec/views/admin/finance/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/index.html.erb_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe 'admin/finance/statements/index.html.erb' do
+  let(:raw_statements) { FactoryBot.create_list(:statement, 3) }
+  let(:pagy) { pagy_array(raw_statements, items: 10, page: 1) }
+  let(:statements) { Admin::StatementPresenter.wrap(raw_statements) }
+
+  before do
+    assign(:statements, statements)
+  end
+
+  it 'has title Statements' do
+    render
+
+    expect(view.content_for(:page_title)).to eq('Statements')
+  end
+
+  it 'shows a table of statements' do
+    render
+
+    expect(rendered).to have_css('.govuk-table')
+  end
+
+  it 'has the right number of rows' do
+    render
+
+    expect(rendered).to have_css('.govuk-table > .govuk-table__body > tr', count: 3)
+  end
+
+  context 'when there are no statements' do
+    let(:raw_statements) { [] }
+
+    it 'displays a message informing me there are no statements to display' do
+      render
+
+      expect(rendered).to have_content('There are no statements')
+    end
+  end
+end

--- a/spec/views/admin/finance/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/index.html.erb_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe 'admin/finance/statements/index.html.erb' do
     expect(rendered).to have_css('.govuk-table')
   end
 
+  it 'has a link to each statement' do
+    render
+
+    raw_statements.each { |s| expect(rendered).to have_link('View', href: admin_finance_statement_path(s)) }
+  end
+
   it 'has the right number of rows' do
     render
 

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'admin/finance/statements/show.html.erb' do
+  let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
+  let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
+  let(:raw_statement) { FactoryBot.build(:statement, active_lead_provider:, month: 5, year: 2023) }
+  let(:statement) { Admin::StatementPresenter.new(raw_statement) }
+
+  before do
+    assign(:statement, statement)
+  end
+
+  it 'has title with lead provider name and statement month and year' do
+    render
+
+    expect(view.content_for(:page_title)).to eq('Some LP - May 2023')
+  end
+
+  it 'displays the statement information in a summary list' do
+    render
+
+    expect(rendered).to have_css('.govuk-summary-list')
+  end
+
+  it 'contains values relevant to the statement'
+end


### PR DESCRIPTION
### Context

This is a rough draft containing statements pages.

The design will be iterated but for now they just list the statements as per the prototype and add a finance page that has a link to the statements index.

It's intended to be a starting off point and to allow us to review data in the app.

### Differences to the prototype

* no filters - we need to decide how they're going to work, hopefully avoiding the current broken state where you can select incompatible years/statements and get no results
* no secondary horizontal nav - this is in the prototype but for now I've reused the extra nav page style from organisations. It keeps the hierarchy in tact and doesn't require new code/styles.

### Changes proposed in this pull request

- **Fix the organisations layout**
- **Add routes for finance and statements**
- **Add boolean to yes or no helper**
- **Add statement presenter and associated tests**
- **Add finance/statements controllers, views and specs**

### Preview

| Finance page | Statements list | Statement view |
| ---- |---- | ---- |
| ![image](https://github.com/user-attachments/assets/a21abc9c-a30a-48ec-9258-bd0f909ccfc7) | ![Screenshot From 2025-05-30 14-42-57](https://github.com/user-attachments/assets/c54927cf-e462-4149-ac73-f72093a4f707) | ![image](https://github.com/user-attachments/assets/9cb22d93-91c2-4592-b8b4-6d8a4f668e45) |


Fixes DFE-Digital/register-ects-project-board#1697