### PR TITLE
Add specs for the registration period migrators

### DIFF
--- a/app/migration/migrators/registration_period.rb
+++ b/app/migration/migrators/registration_period.rb
@@ -20,7 +20,11 @@ module Migrators
 
     def migrate!
       migrate(self.class.cohorts) do |cohort|
-        ::RegistrationPeriod.create!(id: cohort.start_year)
+        ::RegistrationPeriod.create!(
+          id: cohort.start_year,
+          started_on: cohort.registration_start_date,
+          finished_on: cohort.registration_start_date.next_year.prev_day
+        )
       end
     end
   end

--- a/spec/factories/migration/cohort_factory.rb
+++ b/spec/factories/migration/cohort_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :migration_cohort, class: "Migration::Cohort" do
+    start_year { Date.current.year - (Date.current.month < 9 ? 1 : 0) }
+    registration_start_date { Date.new(start_year.to_i, 6, 5) }
+    academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
+    automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
+
+    initialize_with do
+      Migration::Cohort.find_by(start_year:) || new(**attributes)
+    end
+
+    trait :with_sequential_start_year do
+      sequence(:start_year) { |n| 2021 + (n % 9) }
+    end
+  end
+end

--- a/spec/migration/migrators/registration_period_spec.rb
+++ b/spec/migration/migrators/registration_period_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe Migrators::RegistrationPeriod do
+  describe '.record_count' do
+    it 'returns the count of cohorts' do
+      FactoryBot.create_list(:migration_cohort, 2, :with_sequential_start_year)
+      expect(described_class.record_count).to eq(2)
+    end
+  end
+
+  describe '.model' do
+    it 'returns :registration_period' do
+      expect(described_class.model).to eq(:registration_period)
+    end
+  end
+
+  describe '.cohorts' do
+    it 'returns all cohorts' do
+      cohort = FactoryBot.create(:migration_cohort)
+      expect(described_class.cohorts).to include(cohort)
+    end
+  end
+
+  describe '.reset!' do
+    before { allow(::RegistrationPeriod).to receive_message_chain(:connection, :execute) }
+
+    context 'when migration testing is enabled' do
+      it 'truncates the registration periods table' do
+        allow(Rails.application.config).to receive(:enable_migration_testing).and_return(true)
+        expect(::RegistrationPeriod.connection).to receive(:execute) do |sql|
+          expect(sql).to include('TRUNCATE')
+          expect(sql).to include(::RegistrationPeriod.table_name)
+        end
+        described_class.reset!
+      end
+    end
+
+    context 'when migration testing is disabled' do
+      it 'does not truncate the table' do
+        allow(Rails.application.config).to receive(:enable_migration_testing).and_return(false)
+        expect(::RegistrationPeriod.connection).not_to receive(:execute)
+        described_class.reset!
+      end
+    end
+  end
+
+  describe '#migrate!' do
+    let!(:cohort1) { FactoryBot.create(:migration_cohort, start_year: 2021) }
+    let!(:cohort2) { FactoryBot.create(:migration_cohort, start_year: 2022) }
+    let!(:data_migration) { DataMigration.create!(model: :registration_period, worker: 0) }
+
+    it 'creates registration periods with cohort start years as IDs' do
+      expect {
+        described_class.new(worker: 0).migrate!
+      }.to change { RegistrationPeriod.count }.by(2)
+      expect(RegistrationPeriod.pluck(:id)).to contain_exactly(2021, 2022)
+    end
+  end
+end

--- a/spec/migration/migrators/registration_period_spec.rb
+++ b/spec/migration/migrators/registration_period_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Migrators::RegistrationPeriod do
   describe '#migrate!' do
     let!(:cohort1) { FactoryBot.create(:migration_cohort, start_year: 2021) }
     let!(:cohort2) { FactoryBot.create(:migration_cohort, start_year: 2022) }
-    let!(:data_migration) { DataMigration.create!(model: :registration_period, worker: 0) }
+    let!(:data_migration) { FactoryBot.create(:data_migration, model: :registration_period) }
 
     it 'creates registration periods with cohort start years as IDs' do
       expect {

--- a/spec/migration/migrators/registration_period_spec.rb
+++ b/spec/migration/migrators/registration_period_spec.rb
@@ -20,24 +20,24 @@ RSpec.describe Migrators::RegistrationPeriod do
   end
 
   describe '.reset!' do
-    before { allow(::RegistrationPeriod).to receive_message_chain(:connection, :execute) }
+    before do
+      FactoryBot.create(:registration_period)
+      allow(Rails.application.config).to receive(:enable_migration_testing).and_return(enabled_migration_testing)
+    end
 
     context 'when migration testing is enabled' do
-      it 'truncates the registration periods table' do
-        allow(Rails.application.config).to receive(:enable_migration_testing).and_return(true)
-        expect(::RegistrationPeriod.connection).to receive(:execute) do |sql|
-          expect(sql).to include('TRUNCATE')
-          expect(sql).to include(::RegistrationPeriod.table_name)
-        end
-        described_class.reset!
+      let(:enabled_migration_testing) { true }
+
+      it 'removes all records from the registration_periods table' do
+        expect { described_class.reset! }.to change(RegistrationPeriod, :count).from(1).to(0)
       end
     end
 
     context 'when migration testing is disabled' do
-      it 'does not truncate the table' do
-        allow(Rails.application.config).to receive(:enable_migration_testing).and_return(false)
-        expect(::RegistrationPeriod.connection).not_to receive(:execute)
-        described_class.reset!
+      let(:enabled_migration_testing) { false }
+
+      it 'does not remove records from the registration_periods table' do
+        expect { described_class.reset! }.not_to(change(RegistrationPeriod, :count))
       end
     end
   end

--- a/spec/migration/migrators/registration_period_spec.rb
+++ b/spec/migration/migrators/registration_period_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Migrators::RegistrationPeriod do
       expect {
         described_class.new(worker: 0).migrate!
       }.to change(RegistrationPeriod, :count).by(2)
-      expect(RegistrationPeriod.pluck(:id)).to contain_exactly(2021, 2022)
+      expect(RegistrationPeriod.pluck(:year)).to contain_exactly(2021, 2022)
     end
   end
 end

--- a/spec/migration/migrators/registration_period_spec.rb
+++ b/spec/migration/migrators/registration_period_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Migrators::RegistrationPeriod do
   describe '.reset!' do
     before do
       FactoryBot.create(:registration_period)
-      allow(Rails.application.config).to receive(:enable_migration_testing).and_return(enabled_migration_testing)
+      allow(Rails.application.config).to receive(:enable_migration_testing).and_return(enable_migration_testing)
     end
 
     context 'when migration testing is enabled' do
-      let(:enabled_migration_testing) { true }
+      let(:enable_migration_testing) { true }
 
       it 'removes all records from the registration_periods table' do
         expect { described_class.reset! }.to change(RegistrationPeriod, :count).from(1).to(0)
@@ -34,7 +34,7 @@ RSpec.describe Migrators::RegistrationPeriod do
     end
 
     context 'when migration testing is disabled' do
-      let(:enabled_migration_testing) { false }
+      let(:enable_migration_testing) { false }
 
       it 'does not remove records from the registration_periods table' do
         expect { described_class.reset! }.not_to(change(RegistrationPeriod, :count))

--- a/spec/migration/migrators/registration_period_spec.rb
+++ b/spec/migration/migrators/registration_period_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Migrators::RegistrationPeriod do
     it 'creates registration periods with cohort start years as IDs' do
       expect {
         described_class.new(worker: 0).migrate!
-      }.to change { RegistrationPeriod.count }.by(2)
+      }.to change(RegistrationPeriod, :count).by(2)
       expect(RegistrationPeriod.pluck(:id)).to contain_exactly(2021, 2022)
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1669

This PR primarily adds specs for the registration period migrator.

It also updates the migrator to include the `started_on` and `finished_on` values when creating RegistrationPeriod records. The started_on is set to the cohort’s registration_start_date, and the finished_on is calculated as one year later, minus one day.

### Changes proposed in this pull request
- Add factory to create ecf cohorts
- Add specs for the registration period migrator
- Update the migrator to include the missing started_on and finished_on fields


