### PR TITLE
Move API tokens into file for seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,15 +28,3 @@ seed_files.each do |seed_file|
 
   ApplicationRecord.transaction { load(seed_file) }
 end
-
-print_seed_info("Adding API tokens for lead providers:")
-
-maximum_lead_provider_name_length = LeadProvider.maximum("LENGTH(name)")
-
-LeadProvider.find_each do |lead_provider|
-  token = lead_provider.name.parameterize
-  API::TokenManager.create_lead_provider_api_token!(lead_provider:, token:)
-
-  lead_provider_name = lead_provider.name.ljust(maximum_lead_provider_name_length)
-  print_seed_info("#{lead_provider_name} \t '#{token}'", indent: 2)
-end

--- a/db/seeds/api_tokens.rb
+++ b/db/seeds/api_tokens.rb
@@ -1,0 +1,13 @@
+def describe_api_token(lead_provider_name, token)
+  print_seed_info("#{lead_provider_name} \t '#{token}'", indent: 2)
+end
+
+maximum_lead_provider_name_length = LeadProvider.maximum("LENGTH(name)")
+
+LeadProvider.find_each do |lead_provider|
+  token = lead_provider.name.parameterize
+  API::TokenManager.create_lead_provider_api_token!(lead_provider:, token:)
+
+  lead_provider_name = lead_provider.name.ljust(maximum_lead_provider_name_length)
+  describe_api_token(lead_provider_name, token)
+end


### PR DESCRIPTION
### Context
Seeds have been broken up into small files to make them more readable. It seems tokens wasn't moved

### Changes proposed in this pull request
- Move API tokens into its own file
- Add a describe method for the output to follow the same pattern

### Guidance to review
```
be rake db:seed:replant
```
🌱 
