### PR TITLE
Fix Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "libpq-dev, libvips, libglib2.0-0, libnss3, libnspr4, libdbus-1-3, libatk1.0-0, libatk-bridge2.0-0, libcups2, libdrm2, libxcb1, libxkbcommon0, libatspi2.0-0, libx11-6, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxrandr2, libgbm1, libpango-1.0-0, libcairo2, libasound2t64"
+      "packages": "libpq-dev, libvips, libglib2.0-0, libnss3, libnspr4, libdbus-1-3, libatk1.0-0, libatk-bridge2.0-0, libcups2, libdrm2, libxcb1, libxkbcommon0, libatspi2.0-0, libx11-6, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxrandr2, libgbm1, libpango-1.0-0, libcairo2, libasound2t64",
+      "upgradePackages": true
     },
     "ghcr.io/devcontainers/features/git:1": {
       "version": "latest"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,6 @@
     "vscode": {
       "extensions": [
         "esbenp.prettier-vscode",
-        "ms-vscode.vscode-typescript-tslint-plugin",
         "ms-vscode.vscode-types"
       ],
       "settings": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     environment:
       ENABLE_PERSONAS: true
       ENABLE_BULK_UPLOAD: true
+      ECF_DATABASE_URL: 'postgresql://postgres:postgres@postgres/ecf_development'
+      ENCRYPTION_PRIMARY_KEY: local_primary_key
+      ENCRYPTION_DETERMINISTIC_KEY: local_deterministic_key
+      ENCRYPTION_DERIVATION_SALT: local_derivation_salt
   postgres:
     image: postgres:15-alpine
     restart: unless-stopped


### PR DESCRIPTION
This appeared to have broken because of two recent changes:

* adding database encryption for API token fields #627
* adding a secondary ECF database connection #646

It also gets rid of the [VSCode tslint plugin](https://github.com/microsoft/vscode-tslint) which is deprecated.


## Preview


| Seeded Codespace | Running Codespace |
| -------- | ----------|
| ![Screenshot From 2025-06-02 17-12-40](https://github.com/user-attachments/assets/5b669590-e17b-46a4-a4d2-1131e8ae2d74) | ![Screenshot From 2025-06-02 17-13-26](https://github.com/user-attachments/assets/140e9b1a-dce9-4e80-9388-a8111bef7eca) |

## Notes

Sometimes when building it failed because repos weren't reachable etc. Not really sure what the cause is, but it worked on a retry.