### PR TITLE
Enable monitoring in staging and sandbox

### DIFF
--- a/config/terraform/application/config/sandbox.tfvars.json
+++ b/config/terraform/application/config/sandbox.tfvars.json
@@ -3,5 +3,7 @@
     "namespace": "cpd-production",
     "environment": "sandbox",
     "azure_enable_backup_storage": true,
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_monitoring": true,
+    "external_url": "https://sandbox.register-early-career-teachers.education.gov.uk/healthcheck"
 }

--- a/config/terraform/application/config/staging.tfvars.json
+++ b/config/terraform/application/config/staging.tfvars.json
@@ -3,5 +3,7 @@
     "namespace": "cpd-development",
     "environment": "staging",
     "enable_logit": true,
-    "postgres_flexible_server_sku": "B_Standard_B2s"
+    "postgres_flexible_server_sku": "B_Standard_B2s",
+    "enable_monitoring": true,
+    "external_url": "https://staging.register-early-career-teachers.education.gov.uk/healthcheck"
 }


### PR DESCRIPTION
We currently don't receive alerts when staging or sandbox go down. This change enables monitoring and sets the healthcheck endpoint and statuscake contact group up so those in the 'CPD' group will be notified if one of these environments goes down.