### PR TITLE
Disable reading from TRS in sandbox environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,4 @@ GIAS_API_SCHEMA=https://ea-edubase-api-prod.azurewebsites.net/edubase/schema/ser
 GIAS_API_PASSWORD=
 GIAS_API_USER=
 GIAS_EXTRACT_ID=
+ENABLE_TRS_TEACHER_REFRESH=true

--- a/app/services/teachers/refresh_trs_attributes.rb
+++ b/app/services/teachers/refresh_trs_attributes.rb
@@ -7,6 +7,10 @@ module Teachers
     end
 
     def refresh!
+      # In some environments (e.g. sandbox) we don't want to allow data in TRS to
+      # overwrite existing teacher data, so we skip the refresh.
+      return unless Rails.application.config.enable_trs_teacher_refresh
+
       trs_teacher = TRS::APIClient.build.find_teacher(trn: teacher.trn)
 
       Teacher.transaction do

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ module RegisterEarlyCareerTeachers
     config.enable_api = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_API', false))
     config.sentry_dsn = ENV['SENTRY_DSN']
     config.enable_request_specs_timeout = ActiveModel::Type::Boolean.new.cast(ENV.fetch('CI', false))
+    config.enable_trs_teacher_refresh = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_TRS_TEACHER_REFRESH', true))
 
     config.dfe_sign_in_issuer = ENV.fetch('DFE_SIGN_IN_ISSUER', 'https://dev-oidc.signin.education.gov.uk')
     config.dfe_sign_in_client_id = ENV['DFE_SIGN_IN_CLIENT_ID']

--- a/config/terraform/application/config/sandbox.yml
+++ b/config/terraform/application/config/sandbox.yml
@@ -20,3 +20,4 @@ DFE_ANALYTICS_ENABLED: true
 TRS_API_BASE_URL: 'https://preprod.teacher-qualifications-api.education.gov.uk'
 TRS_API_VERSION: '20250203'
 RAILS_ENV: sandbox
+ENABLE_TRS_TEACHER_REFRESH: false

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -5,6 +5,9 @@ describe Teachers::RefreshTRSAttributes do
     include_context 'fake trs api client that finds teacher that has passed their induction'
 
     let(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Kermit", trs_last_name: "Van Bouten") }
+    let(:enable_trs_teacher_refresh) { true }
+
+    before { allow(Rails.application.config).to receive(:enable_trs_teacher_refresh).and_return(enable_trs_teacher_refresh) }
 
     it 'updates the relevant TRS attributes' do
       freeze_time do
@@ -75,6 +78,16 @@ describe Teachers::RefreshTRSAttributes do
 
           expect(fake_manage).to have_received(:mark_teacher_as_deactivated!).once.with(trs_data_last_refreshed_at: Time.zone.now)
         end
+      end
+    end
+
+    context "when enable_trs_teacher_refresh is false" do
+      let(:enable_trs_teacher_refresh) { false }
+
+      it "does not refresh the teacher's TRS attributes" do
+        service = Teachers::RefreshTRSAttributes.new(teacher)
+
+        expect { service.refresh! }.not_to(change { teacher.reload.attributes })
       end
     end
   end


### PR DESCRIPTION
### Context

We do not want to allow syncs/data pulls from TRS in the sandbox environment to overwrite data in the database (as this may end up confusing lead providers).

### Changes proposed in this pull request

- Disable reading from TRS in sandbox environment

Introduce a `trs_write_only` config variable which is `false` by default and `true` in sandbox to prevent the `Teachers::RefreshTRSAttributes` service from making any changes.

### Guidance to review

The main source of TRS overwriting our local teacher data is in the recurring jobs which are only enabled in production. There are, however, two jobs `FailECTInductionJob` and `PassECTInductionJob` which both write data to TRS and then read it back via the `Teachers::RefreshTRSAttributes` service.
