### PR TITLE
[1688] Add task to set up API tokens

### DIFF
--- a/app/services/api/add_api_token_to_lead_provider.rb
+++ b/app/services/api/add_api_token_to_lead_provider.rb
@@ -1,0 +1,42 @@
+module API
+  class AddAPITokenToLeadProvider
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :lead_provider_name_or_id, :string
+    attribute :logger, default: -> { Rails.logger }
+
+    def add
+      check_params!
+
+      logger.info "AddAPITokenToLeadProvider: Started!"
+
+      ActiveRecord::Base.transaction do
+        Array.wrap(lead_provider || LeadProvider.all).each do |lp|
+          add_api_token_to_lead_provider(lp)
+        end
+      end
+
+      logger.info "AddAPITokenToLeadProvider: Finished!"
+    end
+
+    def lead_provider
+      @lead_provider ||= LeadProvider.find_by(id: lead_provider_name_or_id) ||
+        LeadProvider.find_by(name: lead_provider_name_or_id)
+    end
+
+  private
+
+    def add_api_token_to_lead_provider(lead_provider)
+      logger.info "AddAPITokenToLeadProvider: Adding API Token for Lead provider #{lead_provider.name}"
+
+      api_token = API::TokenManager.create_lead_provider_api_token!(lead_provider:)
+
+      logger.info "AddAPITokenToLeadProvider: API Token #{api_token.token} successfully added to Lead provider #{lead_provider.name}"
+    end
+
+    def check_params!
+      raise("LeadProvider not found") if lead_provider_name_or_id && !lead_provider
+    end
+  end
+end

--- a/lib/tasks/api_token.rake
+++ b/lib/tasks/api_token.rake
@@ -4,14 +4,11 @@ namespace :api_token do
     task :generate_token, %i[lead_provider_name_or_id] => :environment do |_t, args|
       logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
 
-      lead_provider_name_or_id = args.lead_provider_name_or_id
+      API::AddAPITokenToLeadProvider.new(
+        lead_provider_name_or_id: args.lead_provider_name_or_id,
+        logger:
+      ).add
 
-      lead_provider = LeadProvider.find_by(id: lead_provider_name_or_id) || LeadProvider.find_by(name: lead_provider_name_or_id)
-      raise("LeadProvider not found") unless lead_provider
-
-      api_token = API::TokenManager.create_lead_provider_api_token!(lead_provider:)
-
-      logger.info "API Token created: #{api_token.token} for Lead provider: #{lead_provider.name}"
       logger.info "** Important: API Tokens should only be transferred via Galaxkey **"
     end
   end

--- a/lib/tasks/api_token.rake
+++ b/lib/tasks/api_token.rake
@@ -1,15 +1,13 @@
-namespace :api_token do
-  namespace :lead_provider do
-    desc "Generate a new API token for the Lead Providers API"
-    task :generate_token, %i[lead_provider_name_or_id] => :environment do |_t, args|
-      logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
+namespace :lead_provider do
+  desc "Generate a new API token for the Lead Providers API"
+  task :generate_api_token, %i[lead_provider_name_or_id] => :environment do |_t, args|
+    logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
 
-      API::AddAPITokenToLeadProvider.new(
-        lead_provider_name_or_id: args.lead_provider_name_or_id,
-        logger:
-      ).add
+    API::AddAPITokenToLeadProvider.new(
+      lead_provider_name_or_id: args.lead_provider_name_or_id,
+      logger:
+    ).add
 
-      logger.info "** Important: API Tokens should only be transferred via Galaxkey **"
-    end
+    logger.info "** Important: API Tokens should only be transferred via Galaxkey **"
   end
 end

--- a/lib/tasks/api_token.rake
+++ b/lib/tasks/api_token.rake
@@ -1,0 +1,18 @@
+namespace :api_token do
+  namespace :lead_provider do
+    desc "Generate a new API token for the Lead Providers API"
+    task :generate_token, %i[lead_provider_name_or_id] => :environment do |_t, args|
+      logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
+
+      lead_provider_name_or_id = args.lead_provider_name_or_id
+
+      lead_provider = LeadProvider.find_by(id: lead_provider_name_or_id) || LeadProvider.find_by(name: lead_provider_name_or_id)
+      raise("LeadProvider not found") unless lead_provider
+
+      api_token = API::TokenManager.create_lead_provider_api_token!(lead_provider:)
+
+      logger.info "API Token created: #{api_token.token} for Lead provider: #{lead_provider.name}"
+      logger.info "** Important: API Tokens should only be transferred via Galaxkey **"
+    end
+  end
+end

--- a/spec/lib/tasks/api_token_spec.rb
+++ b/spec/lib/tasks/api_token_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe "API Token tasks" do
+  before { allow(Rails.logger).to receive(:info).and_call_original }
+
+  describe "api_token:lead_provider:generate_token" do
+    subject :run_task do
+      Rake::Task["api_token:lead_provider:generate_token"].invoke(lead_provider_name_or_id)
+    end
+
+    after do
+      Rake::Task["api_token:lead_provider:generate_token"].reenable
+    end
+
+    context "with no params" do
+      let(:lead_provider_name_or_id) { nil }
+
+      it "errors and does not create token" do
+        expect { run_task }
+          .to raise_exception(RuntimeError, "LeadProvider not found")
+                .and(not_change(API::Token, :count))
+      end
+    end
+
+    describe "using lead provider id in the params" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
+
+      context "with known lead provider id" do
+        let(:lead_provider_name_or_id) { lead_provider.id }
+
+        it "creates a new API Token for the lead provider" do
+          expect { run_task }.to change(api_tokens, :count).by(1)
+        end
+
+        it "outputs the unhashed version of the new API Token" do
+          run_task
+
+          expect(Rails.logger).to have_received(:info).with(/\AAPI Token created: \w+ for Lead provider: #{lead_provider.name}\z/)
+        end
+      end
+
+      context "with unknown lead provider id" do
+        let(:lead_provider_name_or_id) { 99 }
+
+        it "errors and does not create token" do
+          expect { run_task }
+            .to raise_exception(RuntimeError, "LeadProvider not found")
+                  .and(not_change(API::Token, :count))
+        end
+      end
+    end
+
+    describe "using lead provider name in the params" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
+
+      context "with known lead provider name" do
+        let(:lead_provider_name_or_id) { lead_provider.name }
+
+        it "creates a new API Token for the lead provider" do
+          expect { run_task }.to change(api_tokens, :count).by(1)
+        end
+
+        it "outputs the unhashed version of the new API Token" do
+          run_task
+
+          expect(Rails.logger).to have_received(:info).with(/\AAPI Token created: \w+ for Lead provider: #{lead_provider.name}\z/)
+        end
+      end
+
+      context "with unknown lead provider name" do
+        let(:lead_provider_name_or_id) { "Any" }
+
+        it "errors and does not create token" do
+          expect { run_task }
+            .to raise_exception(RuntimeError, "LeadProvider not found")
+                  .and(not_change(API::Token, :count))
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/api_token_spec.rb
+++ b/spec/lib/tasks/api_token_spec.rb
@@ -1,81 +1,28 @@
-RSpec.describe "API Token tasks" do
-  before { allow(Rails.logger).to receive(:info).and_call_original }
-
+describe "API Token tasks" do
   describe "api_token:lead_provider:generate_token" do
     subject :run_task do
       Rake::Task["api_token:lead_provider:generate_token"].invoke(lead_provider_name_or_id)
+    end
+
+    let(:lead_provider_name_or_id) {}
+    let(:service) { instance_double(API::AddAPITokenToLeadProvider) }
+
+    before do
+      allow(API::AddAPITokenToLeadProvider).to receive(:new).and_return(service)
     end
 
     after do
       Rake::Task["api_token:lead_provider:generate_token"].reenable
     end
 
-    context "with no params" do
-      let(:lead_provider_name_or_id) { nil }
+    it "calls the correct service class" do
+      expect(API::AddAPITokenToLeadProvider).to receive(:new).with(
+        lead_provider_name_or_id:,
+        logger: Rails.logger
+      )
+      expect(service).to receive(:add)
 
-      it "errors and does not create token" do
-        expect { run_task }
-          .to raise_exception(RuntimeError, "LeadProvider not found")
-                .and(not_change(API::Token, :count))
-      end
-    end
-
-    describe "using lead provider id in the params" do
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
-      let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
-
-      context "with known lead provider id" do
-        let(:lead_provider_name_or_id) { lead_provider.id }
-
-        it "creates a new API Token for the lead provider" do
-          expect { run_task }.to change(api_tokens, :count).by(1)
-        end
-
-        it "outputs the unhashed version of the new API Token" do
-          run_task
-
-          expect(Rails.logger).to have_received(:info).with(/\AAPI Token created: \w+ for Lead provider: #{lead_provider.name}\z/)
-        end
-      end
-
-      context "with unknown lead provider id" do
-        let(:lead_provider_name_or_id) { 99 }
-
-        it "errors and does not create token" do
-          expect { run_task }
-            .to raise_exception(RuntimeError, "LeadProvider not found")
-                  .and(not_change(API::Token, :count))
-        end
-      end
-    end
-
-    describe "using lead provider name in the params" do
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
-      let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
-
-      context "with known lead provider name" do
-        let(:lead_provider_name_or_id) { lead_provider.name }
-
-        it "creates a new API Token for the lead provider" do
-          expect { run_task }.to change(api_tokens, :count).by(1)
-        end
-
-        it "outputs the unhashed version of the new API Token" do
-          run_task
-
-          expect(Rails.logger).to have_received(:info).with(/\AAPI Token created: \w+ for Lead provider: #{lead_provider.name}\z/)
-        end
-      end
-
-      context "with unknown lead provider name" do
-        let(:lead_provider_name_or_id) { "Any" }
-
-        it "errors and does not create token" do
-          expect { run_task }
-            .to raise_exception(RuntimeError, "LeadProvider not found")
-                  .and(not_change(API::Token, :count))
-        end
-      end
+      run_task
     end
   end
 end

--- a/spec/lib/tasks/api_token_spec.rb
+++ b/spec/lib/tasks/api_token_spec.rb
@@ -1,7 +1,7 @@
 describe "API Token tasks" do
-  describe "api_token:lead_provider:generate_token" do
+  describe "lead_provider:generate_api_token" do
     subject :run_task do
-      Rake::Task["api_token:lead_provider:generate_token"].invoke(lead_provider_name_or_id)
+      Rake::Task["lead_provider:generate_api_token"].invoke(lead_provider_name_or_id)
     end
 
     let(:lead_provider_name_or_id) {}
@@ -12,7 +12,7 @@ describe "API Token tasks" do
     end
 
     after do
-      Rake::Task["api_token:lead_provider:generate_token"].reenable
+      Rake::Task["lead_provider:generate_api_token"].reenable
     end
 
     it "calls the correct service class" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 
 Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Rails.application.load_tasks
 
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/spec/services/api/add_api_token_to_lead_provider_spec.rb
+++ b/spec/services/api/add_api_token_to_lead_provider_spec.rb
@@ -1,0 +1,89 @@
+describe API::AddAPITokenToLeadProvider do
+  subject { described_class.new(params) }
+
+  let(:params) do
+    {
+      lead_provider_name_or_id:,
+    }
+  end
+
+  before { allow(Rails.logger).to receive(:info).and_call_original }
+
+  describe "#add" do
+    context "with no params" do
+      let(:lead_provider_name_or_id) { nil }
+
+      before do
+        FactoryBot.create_list(:lead_provider, 4)
+      end
+
+      it "creates new API Tokens for all Lead providers" do
+        expect { subject.add }.to change(API::Token, :count).by(4)
+      end
+    end
+
+    describe "using lead provider id in the params" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
+
+      context "with known lead provider id" do
+        let(:lead_provider_name_or_id) { lead_provider.id }
+
+        it "creates a new API Token for the lead provider" do
+          expect { subject.add }.to change(api_tokens, :count).by(1)
+        end
+
+        it "outputs the unhashed version of the new API Token" do
+          subject.add
+
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: Started!/)
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: Adding API Token for Lead provider #{lead_provider.name}/)
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: API Token \w+ successfully added to Lead provider #{lead_provider.name}\z/)
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: Finished/)
+        end
+      end
+
+      context "with unknown lead provider id" do
+        let(:lead_provider_name_or_id) { 99 }
+
+        it "errors and does not create token" do
+          expect { subject.add }
+            .to raise_exception(RuntimeError, "LeadProvider not found")
+                  .and(not_change(API::Token, :count))
+        end
+      end
+    end
+
+    describe "using lead provider name in the params" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
+
+      context "with known lead provider name" do
+        let(:lead_provider_name_or_id) { lead_provider.name }
+
+        it "creates a new API Token for the lead provider" do
+          expect { subject.add }.to change(api_tokens, :count).by(1)
+        end
+
+        it "outputs the unhashed version of the new API Token" do
+          subject.add
+
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: Started!/)
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: Adding API Token for Lead provider #{lead_provider.name}/)
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: API Token \w+ successfully added to Lead provider #{lead_provider.name}\z/)
+          expect(Rails.logger).to have_received(:info).with(/AddAPITokenToLeadProvider: Finished/)
+        end
+      end
+
+      context "with unknown lead provider name" do
+        let(:lead_provider_name_or_id) { "Any" }
+
+        it "errors and does not create token" do
+          expect { subject.add }
+            .to raise_exception(RuntimeError, "LeadProvider not found")
+                  .and(not_change(API::Token, :count))
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,5 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
 end
+
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
### Context

[Issue #1688](https://github.com/DFE-Digital/register-ects-project-board/issues/1688)

We need to setup API tokens for providers to test the API in sandbox.

### Changes proposed in this pull request

- Create a task to generate API tokens for providers;

### Guidance to review


- Generates tokens for all lead providers: `rake 'lead_provider:generate_api_token'`
- Generates token for a specific lead provider by name: `rake 'lead_provider:generate_api_token[Ambitious Institute]'`
- Generates token for a specific lead provider by id: `rake 'lead_provider:generate_api_token[1]'`