### PR TITLE
Updates to service rules

### DIFF
--- a/documentation/service-rules/school-admins.md
+++ b/documentation/service-rules/school-admins.md
@@ -131,7 +131,7 @@ In addition, it prevents us sending privacy notes or other communication intende
 
 We also make sure the email follows a correct format.
 
-### Giving the school start date for an ECT and assigning the registration_period
+### Giving the school start date for an ECT and assigning the `registration_period`
 
 The school user is asked for the date when the ECT will start or started as an early career teacher.
 


### PR DESCRIPTION
### Context

We forgot to add that ECTs can't be registered if they're prohibited from teaching.

We also need to add the bits around registration_periods.

### Changes proposed in this pull request
1. Add bits on prohibited from teaching
2. Add details on logic for registering an ECT and how that links to registration_period

### Guidance to review
I don't really like registration_period as a term.

It doesn't feel quite right.