### PR TITLE
Add seed data to the sandbox environment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,16 @@ Style/HashSyntax:
 Style/Lambda:
   EnforcedStyle: literal
 
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - staging
+    - development
+    - test
+    - sandbox
+    - review
+    - migration
+
 Rails/UniqueValidationWithoutIndex:
   Enabled: false
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -28,4 +28,17 @@ class Statement < ApplicationRecord
       transition [:payable] => :paid
     end
   end
+
+  def shorthand_state
+    case state
+    when "open"
+      "OP"
+    when "payable"
+      "PB"
+    when "paid"
+      "PD"
+    else
+      raise ArgumentError, "Unknown state: #{state}"
+    end
+  end
 end

--- a/app/services/sandbox_seed_data/base.rb
+++ b/app/services/sandbox_seed_data/base.rb
@@ -1,0 +1,32 @@
+module SandboxSeedData
+  class Base
+  protected
+
+    def log_plant_info(name)
+      logger.info("\r\n🪴  Planting #{name}...\r\n")
+    end
+
+    def log_seed_info(message, indent: 2, colour: nil, blank_lines_before: 0)
+      blank_lines_before.times { logger.info("🌱") }
+
+      if colour
+        logger.info("🌱 " + (" " * indent) + Colourize.text(message, colour))
+      else
+        logger.info("🌱" + (" " * indent) + message)
+      end
+    end
+
+    def plantable?
+      Rails.env.sandbox? || Rails.env.development?
+    end
+
+  private
+
+    def logger
+      @logger ||= Logger.new($stdout).tap do |stdout_logger|
+        stdout_logger.level = Logger::INFO
+        stdout_logger.formatter = Rails.logger.formatter
+      end
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/lead_providers.rb
+++ b/app/services/sandbox_seed_data/lead_providers.rb
@@ -1,0 +1,36 @@
+module SandboxSeedData
+  class LeadProviders < Base
+    DATA = {
+      "Ambition Institute" => 2021..2025,
+      "Best Practice Network" => 2021..2024,
+      "Capita" => 2021..2022,
+      "Teach First" => 2021..2025,
+      "National Institute of Teaching" => 2021..2025,
+      "Education Development Trust" => 2021..2025,
+      "UCL Institute of Education" => 2021..2025,
+    }.freeze
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("lead providers")
+
+      DATA.each.with_index do |(name, active_years), index|
+        lead_provider = LeadProvider.find_or_create_by!(name:)
+
+        active_years.each do |year|
+          registration_period = RegistrationPeriod.find_by!(year:)
+          ActiveLeadProvider.find_or_create_by!(registration_period:, lead_provider:)
+        end
+
+        log_seed_info("#{Colourize.text(name, colour(index))} (#{active_years.to_a.join(', ')})")
+      end
+    end
+
+  private
+
+    def colour(index)
+      Colourize::COLOURS.keys[index % Colourize::COLOURS.size]
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/registration_periods.rb
+++ b/app/services/sandbox_seed_data/registration_periods.rb
@@ -1,0 +1,28 @@
+module SandboxSeedData
+  class RegistrationPeriods < Base
+    DATA = {
+      2021 => false,
+      2022 => false,
+      2023 => true,
+      2024 => true,
+      2025 => true
+    }.freeze
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("registration periods")
+
+      DATA.each do |year, enabled|
+        RegistrationPeriod.find_or_create_by!(
+          year:,
+          enabled:,
+          started_on: Date.new(year, 6, 1),
+          finished_on: Date.new(year + 1, 5, 31)
+        ).tap do |registration_period|
+          log_seed_info("#{registration_period.year} (running from #{registration_period.started_on} until #{registration_period.finished_on})")
+        end
+      end
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/statements.rb
+++ b/app/services/sandbox_seed_data/statements.rb
@@ -1,0 +1,122 @@
+module SandboxSeedData
+  class Statements < Base
+    YEARS_TO_CREATE = 4
+    MONTHS = (1..12).to_a.freeze
+    STATE_COLOURS = {
+      OP: :blue,
+      PB: :cyan,
+      PD: :green,
+    }.freeze
+    COL_WIDTHS = {
+      month: 10,
+      year: 18,
+    }.freeze
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("statements")
+
+      active_lead_providers_by_lead_provider.each do |lead_provider, active_lead_providers|
+        statements = []
+
+        active_lead_providers.each do |active_lead_provider|
+          years = years(active_lead_provider.registration_period.year)
+
+          statements += years.product(MONTHS).map do |year, month|
+            deadline_date = deadline_date(year, month)
+
+            Statement.find_or_create_by!(
+              active_lead_provider:,
+              month:,
+              year:,
+              deadline_date:
+            ) do |statement|
+              statement.payment_date = payment_date(deadline_date)
+              statement.state = state(statement.payment_date, deadline_date)
+              statement.output_fee = output_fee
+            end
+          end
+        end
+
+        log_statement_seed_info(lead_provider, statements)
+      end
+    end
+
+  private
+
+    def active_lead_providers_by_lead_provider
+      ActiveLeadProvider.includes(:lead_provider).group_by(&:lead_provider)
+    end
+
+    def years(registration_year)
+      (registration_year...(registration_year + YEARS_TO_CREATE)).to_a
+    end
+
+    def output_fee
+      [true, false].sample
+    end
+
+    def payment_date(deadline_date)
+      Time.zone.at(rand(deadline_date.to_i..(deadline_date + 2.months).to_i))
+    end
+
+    def deadline_date(year, month)
+      Time.zone.local(year, month).end_of_month
+    end
+
+    def state(payment_date, deadline_date)
+      if payment_date < Date.current
+        :paid
+      elsif Date.current.between?(deadline_date, payment_date)
+        :payable
+      else
+        :open
+      end
+    end
+
+    def group_statements_by_year_and_month(statements)
+      statements.group_by(&:year).transform_values { |v| v.group_by(&:month) }
+    end
+
+    def log_header_info(lead_provider, years)
+      log_seed_info(lead_provider.name, indent: 2, blank_lines_before: 1)
+
+      header = " " * COL_WIDTHS[:month] + years.map { |y| y.to_s.rjust(COL_WIDTHS[:year]) }.join
+      log_seed_info(header, indent: 2)
+    end
+
+    def format_month(month)
+      Date::MONTHNAMES[month].rjust(COL_WIDTHS[:month])
+    end
+
+    def shorthand_states(statements_by_year_and_month, month, year)
+      statements_by_year_and_month.dig(year, month)&.map(&:shorthand_state) || []
+    end
+
+    def format_states(shorthand_states)
+      return 'none'.rjust(COL_WIDTHS[:year]) unless shorthand_states
+
+      coloured_states = shorthand_states.map { |state| Colourize.text(state, STATE_COLOURS[state.to_sym]) }
+      # The colourizing characters affect the length so offset the rjust.
+      offset = coloured_states.sum(&:length) - shorthand_states.sum(&:length)
+      coloured_states.join(", ").rjust(COL_WIDTHS[:year] + offset)
+    end
+
+    def build_month_row(month, years, statements_by_year_and_month)
+      [format_month(month)] + years.map { |year| format_states(shorthand_states(statements_by_year_and_month, month, year)) }
+    end
+
+    def log_statement_seed_info(lead_provider, statements)
+      statements_by_year_and_month = group_statements_by_year_and_month(statements)
+      years = statements_by_year_and_month.keys.sort
+
+      log_header_info(lead_provider, years)
+
+      MONTHS.each do |month|
+        row = build_month_row(month, years, statements_by_year_and_month)
+        log_seed_info(row.join, indent: 2)
+      end
+    end
+  end
+end

--- a/lib/tasks/sandbox_seed_data.rake
+++ b/lib/tasks/sandbox_seed_data.rake
@@ -1,0 +1,15 @@
+namespace :sandbox_seed_data do
+  desc "Generate seed data for the sandbox environment"
+  task generate: :environment do
+    seeds = [
+      SandboxSeedData::RegistrationPeriods,
+      SandboxSeedData::LeadProviders,
+      SandboxSeedData::Statements
+    ]
+
+    seeds.each do |seed_class|
+      seed = seed_class.new
+      seed.plant
+    end
+  end
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -67,4 +67,34 @@ describe Statement do
       it { expect { statement.mark_as_payable! }.to raise_error(StateMachines::InvalidTransition) }
     end
   end
+
+  describe "#shorthand_state" do
+    subject(:shorthand_state) { statement.shorthand_state }
+
+    let(:statement) { FactoryBot.build(:statement, state:) }
+
+    context "when state is open" do
+      let(:state) { :open }
+
+      it { is_expected.to eq("OP") }
+    end
+
+    context "when state is payable" do
+      let(:state) { :payable }
+
+      it { is_expected.to eq("PB") }
+    end
+
+    context "when state is paid" do
+      let(:state) { :paid }
+
+      it { is_expected.to eq("PD") }
+    end
+
+    context "when state is unknown" do
+      let(:state) { :unknown_state }
+
+      it { expect { shorthand_state }.to raise_error(ArgumentError, "Unknown state: unknown_state") }
+    end
+  end
 end

--- a/spec/services/sandbox_seed_data/lead_providers_spec.rb
+++ b/spec/services/sandbox_seed_data/lead_providers_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe SandboxSeedData::LeadProviders do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+  let(:all_registration_years) { described_class::DATA.values.map(&:to_a).flatten }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+  end
+
+  describe "#plant" do
+    before do
+      all_registration_years.uniq.each { |year| FactoryBot.create(:registration_period, year:) }
+    end
+
+    it "creates lead providers and active lead providers with correct attributes" do
+      instance.plant
+
+      described_class::DATA.each do |name, active_years|
+        lead_provider = LeadProvider.find_by(name:)
+        expect(lead_provider).to be_present
+
+        active_years.each do |year|
+          active_lead_provider = ActiveLeadProvider.find_by(
+            lead_provider:,
+            registration_period: RegistrationPeriod.find_by!(year:)
+          )
+          expect(active_lead_provider).to be_present
+        end
+      end
+    end
+
+    it "does not create data when already present" do
+      expect { instance.plant }.to change(LeadProvider, :count).by(described_class::DATA.count)
+        .and change(ActiveLeadProvider, :count).by(all_registration_years.count)
+
+      expect { instance.plant }.not_to change(LeadProvider, :count)
+      expect { instance.plant }.not_to change(ActiveLeadProvider, :count)
+    end
+
+    it "logs the creation of lead providers" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting lead providers/).once
+      expect(logger).to have_received(:info).with(/#{described_class::DATA.keys.sample}/).once
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any lead providers" do
+        expect { instance.plant }.not_to change(LeadProvider, :count)
+      end
+    end
+  end
+end

--- a/spec/services/sandbox_seed_data/registration_periods_spec.rb
+++ b/spec/services/sandbox_seed_data/registration_periods_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe SandboxSeedData::RegistrationPeriods do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+  end
+
+  describe "#plant" do
+    it "creates registration periods with correct attributes" do
+      instance.plant
+
+      described_class::DATA.each do |year, enabled|
+        expect(RegistrationPeriod.find_by!(year:)).to have_attributes(
+          enabled:,
+          started_on: Date.new(year, 6, 1),
+          finished_on: Date.new(year + 1, 5, 31)
+        )
+      end
+    end
+
+    it "does not create data when already present" do
+      expect { instance.plant }.to change(RegistrationPeriod, :count).by(described_class::DATA.count)
+      expect { instance.plant }.not_to change(RegistrationPeriod, :count)
+    end
+
+    it "logs the creation of registration periods" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting registration periods/).once
+      expect(logger).to have_received(:info).with(/#{described_class::DATA.keys.sample}/).at_least(:once)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any registration periods" do
+        expect { instance.plant }.not_to change(RegistrationPeriod, :count)
+      end
+    end
+  end
+end

--- a/spec/services/sandbox_seed_data/statements_spec.rb
+++ b/spec/services/sandbox_seed_data/statements_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe SandboxSeedData::Statements do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+  end
+
+  describe "#plant" do
+    let(:registration_period) { FactoryBot.create(:registration_period, year: Time.zone.now.year - 1) }
+    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, registration_period:) }
+
+    it "creates statements for active lead providers with the correct attributes" do
+      instance.plant
+
+      registration_year = registration_period.year
+      years = (registration_year...(registration_year + described_class::YEARS_TO_CREATE)).to_a
+      months = described_class::MONTHS.to_a
+
+      years.product(months).each do |year, month|
+        statement = Statement.find_by(year:, month:)
+        expected_deadline_date = Date.new(year, month).end_of_month
+
+        expect(statement).to have_attributes(
+          active_lead_provider:,
+          deadline_date: expected_deadline_date,
+          payment_date: be_between(expected_deadline_date, expected_deadline_date + 2.months),
+          state: be_in(%w[open payable paid])
+        )
+      end
+    end
+
+    it "creates statements with all states" do
+      instance.plant
+
+      expect(Statement.distinct.pluck(:state)).to match_array(%w[open payable paid])
+    end
+
+    it "logs the creation of statements" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting statements/).once
+
+      expect(logger).to have_received(:info).with(/#{active_lead_provider.lead_provider.name}/).once
+
+      expect(logger).to have_received(:info).with(/#{registration_period.year}/).once
+      expect(logger).to have_received(:info).with(/#{registration_period.year + described_class::YEARS_TO_CREATE - 1}/).once
+
+      described_class::MONTHS.each do |month|
+        expect(logger).to have_received(:info).with(/#{Date::MONTHNAMES[month]}/).at_least(:once)
+      end
+
+      %i[OP PB PD].each do |state|
+        expect(logger).to have_received(:info).with(/#{state}/).at_least(:once)
+      end
+    end
+
+    it "does not create data when already present" do
+      number_of_statements_created = described_class::YEARS_TO_CREATE * described_class::MONTHS.count
+      expect { instance.plant }.to change(Statement, :count).by(number_of_statements_created)
+
+      expect { instance.plant }.not_to change(Statement, :count)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any statements" do
+        expect { instance.plant }.not_to change(Statement, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to be able to generate seed data in sandbox.

The seed data initially will be registration periods, lead providers and statements. The statements data should be close to what we have in production.

We want the data to remain consistent if we run the seeds multiple times (we should end up with the same registration periods, lead providers and statements).

### Changes proposed in this pull request

- Add seed data to the sandbox environment

Add sandbox seed data services. A `Base` service is used to centralise logging and environment checks.

Add a rake task for convenience; `bundle exec rake sandbox_seed_data:generate`.

### Guidance to review

<img width="1121" alt="Screenshot 2025-06-05 at 11 20 10" src="https://github.com/user-attachments/assets/a95ebb83-a48a-41f8-8ee0-c8ebbe49e33c" />

