### PR TITLE
Use TRS API version 20250203 instead of Next in Review

### DIFF
--- a/config/terraform/application/config/review.yml
+++ b/config/terraform/application/config/review.yml
@@ -13,7 +13,7 @@ SENTRY_ENVIRONMENT: review
 ENABLE_BLAZER: true
 DFE_ANALYTICS_ENABLED: false
 TRS_API_BASE_URL: 'https://preprod.teacher-qualifications-api.education.gov.uk'
-TRS_API_VERSION: 'Next'
+TRS_API_VERSION: '20250203'
 ENCRYPTION_PRIMARY_KEY: review_primary_key
 ENCRYPTION_DETERMINISTIC_KEY: review_deterministic_key
 ENCRYPTION_DERIVATION_SALT: review_derivation_salt


### PR DESCRIPTION
We had this set to Next for API testing early on when releasing RIAB but now there's something causing it to crash, so for now push this back to the stable verison.

Fixes DFE-Digital/register-ects-project-board#1723
