### PR TITLE
Fix flakey statements sandbox seed spec

### DIFF
--- a/app/services/sandbox_seed_data/statements.rb
+++ b/app/services/sandbox_seed_data/statements.rb
@@ -58,7 +58,15 @@ module SandboxSeedData
     end
 
     def payment_date(deadline_date)
-      Time.zone.at(rand(deadline_date.to_i..(deadline_date + 2.months).to_i))
+      payment_date_range = deadline_date..(deadline_date + 2.months)
+
+      # If the range includes the current date, adjust the window
+      # to ensure we always get a payable statement.
+      if Date.current.in?(payment_date_range)
+        payment_date_range = Date.current..payment_date_range.end
+      end
+
+      Time.zone.at(rand(payment_date_range.begin.to_time.to_i..payment_date_range.end.to_time.to_i))
     end
 
     def deadline_date(year, month)


### PR DESCRIPTION
When generating seed data for statements in sandbox we only get a `payable` statement if the random payment date includes the current date.

This has a chance of happening for a number of statements in the seeds, but isn't guaranteed to and so it causes the test that ensures we generate statements with all states to be flakey.

Instead, we adjust the window for statements with dates near the current date to ensure they will always end up as `payable`.
