### PR TITLE
Remove `enable_tracing` config from sentry initialiser as it is deprecated

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,8 +5,6 @@ if Rails.application.config.enable_sentry
     config.dsn = Rails.application.config.sentry_dsn
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.release = ENV["COMMIT_SHA"]
-
-    config.enable_tracing = true
     config.traces_sample_rate = 0.1
     config.profiles_sample_rate = 0.1
   end


### PR DESCRIPTION
### Context

Seeing deprecation message when logging into envs console.

```W, [2025-06-06T11:35:55.094119 #409]  WARN -- sentry: `enable_tracing` is now deprecated in favor of `traces_sample_rate = 1.0`.```

### Changes proposed in this pull request

- Remove `enable_tracing` config from sentry initialiser as it is deprecated 

### Guidance to review
