### PR TITLE
Enable Dependabot's Docker package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,8 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - Dependencies
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This will help us keep our docker images up to date and running the latest versions.
