### PR TITLE
Make the email page more accessible

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,5 +1,0 @@
-module ContentHelper
-  def generic_email_label
-    "Do not use a generic email like headteacher@school.com"
-  end
-end

--- a/app/views/schools/register_ect_wizard/_email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/_email_address.html.erb
@@ -1,17 +1,25 @@
 <% page_data(
     title: "What is #{@ect.full_name}’s email address?",
+    header: false,
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
 
-<p class="govuk-body">We ask for an email so we can share their details if needed for training.</p>
-
-<p class="govuk-body">Make sure you use an email the ECT can access. You can update it later if they haven’t got a school email set up yet.</p>
-
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_email_field(:email, label: { text: generic_email_label, class: 'govuk-!-margin-bottom-4' }) %>
+  <%=
+    f.govuk_email_field(
+      :email,
+      label: { text: "What is #{@ect.full_name}’s email address?",
+               tag: 'h1',
+               size: 'l' },
+      hint: { text: 'Do not use a generic email like headteacher@school.com' }
+    ) do %>
+    <p class="govuk-body">We ask for an email so we can share their details if needed for training.</p>
+
+    <p class="govuk-body">Make sure you use an email the ECT can access. You can update it later if they haven’t got a school email set up yet.</p>
+  <% end %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_enter_the_ect_email_address
-    page.fill('#email-address-email-field', 'example@example.com')
+    page.get_by_label('What is Kirk Van Damme’s email address?').fill('example@example.com')
   end
 
   def then_i_should_be_taken_to_the_programme_type_page
@@ -253,7 +253,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_enter_a_new_ect_email_address
-    page.fill('#change-email-address-email-field', 'new@example.com')
+    page.get_by_label('What is Kirk Van Damme’s email address?').fill('new@example.com')
   end
 
   def and_i_should_see_the_new_email

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe ContentHelper, type: :helper do
-  describe "#generic_email_label" do
-    let(:label) { helper.generic_email_label }
-
-    it 'returns the label' do
-      expect(label).to eql('Do not use a generic email like headteacher@school.com')
-    end
-  end
-end


### PR DESCRIPTION
On the ECT registration flow the label wasn't really describing the question, it was more of a hint.

I've made the page heading the label and set the old label text as the hint.

With this being fixed we can also change the features to use the label text when selecting the input.
