### PR TITLE
Update failed batch action view content

### DIFF
--- a/app/views/appropriate_bodies/process_batch/actions/_failed.html.erb
+++ b/app/views/appropriate_bodies/process_batch/actions/_failed.html.erb
@@ -1,15 +1,16 @@
 <%
   page_data(
-    title: "Batch failed",
-    header: false,
+    title: 'Something went wrong',
     backlink_href: ab_batch_actions_path
   )
 %>
 
 <p class='govuk-body'>
-  This upload has failed
+  You'll need to try again
 </p>
-
+<p class='govuk-body'>
+  We have not saved or uploaded your CSV.
+</p>
 <p class='govuk-body'>
   <%= govuk_link_to 'Go back to your overview', ab_batch_actions_path %>
 </p>

--- a/spec/views/appropriate_bodies/process_batch/actions/failed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/failed.html.erb_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "appropriate_bodies/process_batch/actions/_failed.html.erb" do
+  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :action, :failed) }
+
+  before do
+    assign(:pending_induction_submission_batch, pending_induction_submission_batch)
+
+    render
+  end
+
+  it 'links back to bulk actions overview' do
+    expect(rendered).to have_text("You'll need to try again")
+    expect(rendered).to have_link('Go back to your overview', href: ab_batch_actions_path)
+  end
+end


### PR DESCRIPTION
### Context

Bulk outcomes has a `failed` state that should never be needed but if an upload suffers an internal error this is the view partial that the user will see.

### Changes proposed in this pull request

![cpd-ec2-review-699-web test teacherservices cloud_appropriate-body_bulk_actions_1](https://github.com/user-attachments/assets/70da352e-d8aa-405f-aa45-bee19939bcd7)


### Guidance to review

https://cpd-ec2-review-699-web.test.teacherservices.cloud/appropriate-body/bulk/actions/1
