### PR TITLE
Bulk outcomes content changes

### DIFF
--- a/app/views/appropriate_bodies/process_batch/actions/_processed.html.erb
+++ b/app/views/appropriate_bodies/process_batch/actions/_processed.html.erb
@@ -23,7 +23,8 @@
 
   <% if batch.pending_induction_submissions.with_errors.any? %>
     <p class='govuk-body'>
-      You had <%= batch.pending_induction_submissions.with_errors.count %> ECTs with errors which were not included.
+      You had <%= batch.pending_induction_submissions.with_errors.count %> ECTs with errors. 
+      You can download a CSV with error messages included after you record your outcomes.
     </p>
   <% end %>
 

--- a/app/views/appropriate_bodies/process_batch/actions/new.html.erb
+++ b/app/views/appropriate_bodies/process_batch/actions/new.html.erb
@@ -18,8 +18,8 @@
 
   <%= 
     govuk_list([
-      'their date of birth in YYYY-MM-DD format',
       'their teacher reference number (TRN) - must be 7 digits',
+      'their date of birth in YYYY-MM-DD format',
       'their induction period end date in YYYY-MM-DD format',
       "the number of terms they've completed with you - must be between 0 and 16 and you can use up to one decimal place if the term is not a whole number",
       'their outcome - must be either a pass, a fail, or release'


### PR DESCRIPTION
### Context

Minor content changes following feature pre-release testing

### Changes proposed in this pull request

- change upload guidance bulletpoint order to match template column order
- inform user that a CSV download of failed rows is available on the next screen

### Guidance to review

