### PR TITLE
Add toggle to enable/disable parity check

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,9 @@ module RegisterEarlyCareerTeachers
     config.sentry_dsn = ENV['SENTRY_DSN']
     config.enable_request_specs_timeout = ActiveModel::Type::Boolean.new.cast(ENV.fetch('CI', false))
     config.enable_trs_teacher_refresh = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_TRS_TEACHER_REFRESH', true))
+    config.parity_check = {
+      enabled: ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_PARITY_CHECK', false)),
+    }
 
     config.dfe_sign_in_issuer = ENV.fetch('DFE_SIGN_IN_ISSUER', 'https://dev-oidc.signin.education.gov.uk')
     config.dfe_sign_in_client_id = ENV['DFE_SIGN_IN_CLIENT_ID']

--- a/config/terraform/application/config/migration.yml
+++ b/config/terraform/application/config/migration.yml
@@ -10,6 +10,7 @@ ENABLE_FAKE_TRS_API: false
 SENTRY_ENVIRONMENT: migration
 ENABLE_PERSONAS: false
 ENABLE_BULK_UPLOAD: false
+ENABLE_PARITY_CHECK: true
 SERVICE_URL: 'https://cpd-ec2-migration-web.teacherservices.cloud'
 DFE_ANALYTICS_ENABLED: false
 TRS_API_BASE_URL: 'https://preprod.teacher-qualifications-api.education.gov.uk'


### PR DESCRIPTION
We want to be able to enable the parity check functionality only on the migration environment.

Add config option to enable the parity check. This is nested as we will end up with other options under the parity check config (for tokens and environment URLs).
