### PR TITLE
Remove content on if you're not sure on who is providing training for mentors and add content to LP description on learning platform

### DIFF
--- a/app/views/schools/register_ect_wizard/_lead_provider.html.erb
+++ b/app/views/schools/register_ect_wizard/_lead_provider.html.erb
@@ -5,7 +5,7 @@
 ) %>
 
 <p class="govuk-body">
-Lead providers are responsible for creating the materials used for training ECTs and mentors.
+Lead providers are responsible for creating the materials and learning platforms used for training ECTs and mentors.
 </p>
 
 <p class="govuk-body">

--- a/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
@@ -9,10 +9,6 @@
 
 <p class="govuk-body">We'll pass on their details to <%= @wizard.ect.lead_provider.name %> who will contact them to arrange the training.</p>
 
-<p class="govuk-body">If you don't know who will be providing training you can continue and update this later.</p>
-
-
-
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -16,7 +16,7 @@ For clarity, avoid referring to ‘induction training’ which could be misconst
 
 ## Lead provider
 
-Lead providers are responsible for creating the materials used for training ECTs and mentors.
+Lead providers are responsible for creating the materials and learning platforms used for training ECTs and mentors.
 
 ## Providers of the ECTP
 


### PR DESCRIPTION
### Context
We agreed in UR to remove this content.

We also agreed to add the bits on learning platforms

### Changes proposed in this pull request
1. Remove the content on if you're not sure who is providing training for mentors
2. Add content on learning platform to the lead provider question

### Guidance to review
