### PR TITLE
Add `ParityCheck::Client`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,5 @@ GIAS_API_USER=
 GIAS_EXTRACT_ID=
 ENABLE_TRS_TEACHER_REFRESH=true
 PARITY_CHECK_KEYS='{"lead_provider_api_id":"token"}'
+PARITY_CHECK_ECF_URL=https://cpd-ecf-migration-web.teacherservices.cloud
+PARITY_CHECK_RECT_URL=https://cpd-ec2-migration-web.teacherservices.cloud

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :test do
   gem "rspec-rails"
   gem "shoulda-matchers"
   gem "super_diff"
+  gem "webmock"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cri (2.15.12)
     cssbundling-rails (1.4.3)
@@ -240,6 +243,7 @@ GEM
     gyoku (1.4.0)
       builder (>= 2.1.2)
       rexml (~> 3.0)
+    hashdiff (1.2.0)
     hashie (5.0.0)
     hotwire-rails (0.1.3)
       rails (>= 6.0.0)
@@ -702,6 +706,10 @@ GEM
       activesupport
       faraday (~> 2.0)
       faraday-follow_redirects
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
     websocket-driver (0.7.7)
       base64
@@ -783,6 +791,7 @@ DEPENDENCIES
   super_diff
   turbo-rails
   tzinfo-data
+  webmock
   webrick
 
 RUBY VERSION

--- a/app/migration/parity_check/client.rb
+++ b/app/migration/parity_check/client.rb
@@ -1,0 +1,32 @@
+module ParityCheck
+  class Client
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :endpoint
+
+    def perform_requests
+      ecf_result = timed_response { send("#{request_builder.method}_request", app: :ecf) }
+      rect_result = timed_response { send("#{request_builder.method}_request", app: :rect) }
+
+      yield(ecf_result, rect_result)
+    end
+
+  private
+
+    def timed_response
+      response = nil
+      response_time_ms = Benchmark.realtime { response = yield } * 1_000
+
+      { response:, response_time_ms: }
+    end
+
+    def get_request(app:)
+      HTTParty.get(request_builder.url(app:), headers: request_builder.headers)
+    end
+
+    def request_builder
+      @request_builder ||= RequestBuilder.new(endpoint:)
+    end
+  end
+end

--- a/app/migration/parity_check/endpoint.rb
+++ b/app/migration/parity_check/endpoint.rb
@@ -1,0 +1,19 @@
+module ParityCheck
+  class Endpoint
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :lead_provider
+    attribute :method
+    attribute :path
+    attribute :options, default: {}
+
+    def options=(value)
+      super(value || {})
+    end
+
+    def method=(value)
+      super(value&.to_sym)
+    end
+  end
+end

--- a/app/migration/parity_check/request_builder.rb
+++ b/app/migration/parity_check/request_builder.rb
@@ -1,0 +1,29 @@
+module ParityCheck
+  class RequestBuilder
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :endpoint
+
+    delegate :lead_provider, :method, :path, :options, to: :endpoint
+
+    def url(app:)
+      config_key = "#{app}_url".to_sym
+      Rails.application.config.parity_check[config_key] + path
+    end
+
+    def headers
+      {
+        "Authorization" => "Bearer #{token_provider.token(lead_provider:)}",
+        "Accept" => "application/json",
+        "Content-Type" => "application/json",
+      }
+    end
+
+  private
+
+    def token_provider
+      @token_provider ||= TokenProvider.new
+    end
+  end
+end

--- a/app/migration/parity_check/token_provider.rb
+++ b/app/migration/parity_check/token_provider.rb
@@ -3,12 +3,18 @@ module ParityCheck
     class UnsupportedEnvironmentError < RuntimeError; end
 
     def generate!
-      raise UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment" unless enabled?
+      ensure_enabled!
 
       known_tokens_by_lead_provider_api_id.each do |api_id, token|
         lead_provider = LeadProvider.find_by(api_id:)
         API::TokenManager.create_lead_provider_api_token!(lead_provider:, token:) if lead_provider
       end
+    end
+
+    def token(lead_provider:)
+      ensure_enabled!
+
+      known_tokens_by_lead_provider_api_id[lead_provider.api_id]
     end
 
   private
@@ -21,6 +27,10 @@ module ParityCheck
 
     def raw_tokens
       Rails.application.config.parity_check[:tokens]
+    end
+
+    def ensure_enabled!
+      raise UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment" unless enabled?
     end
 
     def enabled?

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,9 @@ module RegisterEarlyCareerTeachers
     config.enable_trs_teacher_refresh = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_TRS_TEACHER_REFRESH', true))
     config.parity_check = {
       enabled: ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_PARITY_CHECK', false)),
-      tokens: ENV.fetch('PARITY_CHECK_KEYS', "{}")
+      tokens: ENV.fetch('PARITY_CHECK_KEYS', "{}"),
+      ecf_url: ENV['PARITY_CHECK_ECF_URL'],
+      rect_url: ENV['PARITY_CHECK_RECT_URL'],
     }
 
     config.dfe_sign_in_issuer = ENV.fetch('DFE_SIGN_IN_ISSUER', 'https://dev-oidc.signin.education.gov.uk')

--- a/config/terraform/application/config/migration.yml
+++ b/config/terraform/application/config/migration.yml
@@ -19,3 +19,5 @@ ENCRYPTION_PRIMARY_KEY: migration_primary_key
 ENCRYPTION_DETERMINISTIC_KEY: migration_deterministic_key
 ENCRYPTION_DERIVATION_SALT: migration_derivation_salt
 RAILS_ENV: migration
+PARITY_CHECK_ECF_URL: https://cpd-ecf-migration-web.teacherservices.cloud
+PARITY_CHECK_RECT_URL: https://cpd-ec2-migration-web.teacherservices.cloud

--- a/spec/migration/parity_check/client_spec.rb
+++ b/spec/migration/parity_check/client_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe ParityCheck::Client do
+  let(:ecf_url) { "https://ecf.example.com:443/test-path" }
+  let(:rect_url) { "https://rect.example.com:443/test-path" }
+  let(:method) { :get }
+  let(:headers) { { "Accept" => "application/json" } }
+  let(:endpoint) { double(ParityCheck::Endpoint) }
+  let(:request_builder) { instance_double(ParityCheck::RequestBuilder, headers:, method:) }
+  let(:instance) { described_class.new(endpoint:) }
+
+  before do
+    allow(ParityCheck::RequestBuilder).to receive(:new).with(endpoint:).and_return(request_builder)
+    allow(request_builder).to receive(:url).with(app: :ecf).and_return(ecf_url)
+    allow(request_builder).to receive(:url).with(app: :rect).and_return(rect_url)
+  end
+
+  it "has the correct attributes" do
+    expect(instance).to have_attributes(endpoint:)
+  end
+
+  describe "#perform_requests" do
+    let(:requests) { WebMock::RequestRegistry.instance.requested_signatures.hash.keys }
+    let(:ecf_requests) { requests.select { |r| r.uri.to_s.include?(ecf_url) } }
+    let(:rect_requests) { requests.select { |r| r.uri.to_s.include?(rect_url) } }
+
+    before do
+      stub_request(method, ecf_url).to_return(status: 200, body: "ecf_body")
+      stub_request(method, rect_url).to_return(status: 201, body: "rect_body")
+    end
+
+    it "makes requests to the correct URL for each app" do
+      instance.perform_requests {}
+
+      expect(ecf_requests.count).to eq(1)
+      expect(rect_requests.count).to eq(1)
+    end
+
+    it "makes requests with the correct headers" do
+      instance.perform_requests {}
+
+      expect(requests.map(&:headers)).to all include(headers)
+    end
+
+    it "yields the result of each request to the block" do
+      instance.perform_requests do |ecf_result, rect_result|
+        expect(ecf_result[:response].code).to eq(200)
+        expect(ecf_result[:response].body).to eq("ecf_body")
+        expect(ecf_result[:response_time_ms]).to be >= 0
+
+        expect(rect_result[:response].code).to eq(201)
+        expect(rect_result[:response].body).to eq("rect_body")
+        expect(rect_result[:response_time_ms]).to be >= 0
+      end
+    end
+  end
+end

--- a/spec/migration/parity_check/endpoint_spec.rb
+++ b/spec/migration/parity_check/endpoint_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe ParityCheck::Endpoint do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:method) { :get }
+  let(:path) { "/test-path" }
+  let(:options) { { foo: :bar } }
+  let(:instance) { described_class.new(lead_provider:, method:, path:, options:) }
+
+  it "has the correct attributes" do
+    expect(instance).to have_attributes(
+      lead_provider:,
+      method:,
+      path:,
+      options:
+    )
+  end
+
+  describe "#options=" do
+    it "sets options to an empty hash if nil is provided" do
+      instance.options = nil
+      expect(instance.options).to eq({})
+    end
+  end
+
+  describe "#method=" do
+    it "converts the method to a symbol" do
+      instance.method = "get"
+      expect(instance.method).to eq(:get)
+    end
+  end
+end

--- a/spec/migration/parity_check/request_builder_spec.rb
+++ b/spec/migration/parity_check/request_builder_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe ParityCheck::RequestBuilder do
+  let(:lead_provider) { FactoryBot.build(:lead_provider) }
+  let(:path) { "/test-path" }
+  let(:method) { :get }
+  let(:options) { { foo: :bar } }
+  let(:endpoint) { ParityCheck::Endpoint.new(method:, path:, lead_provider:, options:) }
+  let(:instance) { described_class.new(endpoint:) }
+
+  it "has the correct attributes" do
+    expect(instance).to have_attributes(endpoint:)
+  end
+
+  describe "delegate methods" do
+    it { is_expected.to delegate_method(:lead_provider).to(:endpoint) }
+    it { is_expected.to delegate_method(:method).to(:endpoint) }
+    it { is_expected.to delegate_method(:path).to(:endpoint) }
+    it { is_expected.to delegate_method(:options).to(:endpoint) }
+  end
+
+  describe "instance methods" do
+    let(:tokens) { { lead_provider.api_id => "test_token" } }
+    let(:ecf_url) { "https://ecf.example.com" }
+    let(:rect_url) { "https://rect.example.com" }
+
+    before do
+      allow(Rails.application.config).to receive(:parity_check) do
+        {
+          enabled: true,
+          tokens: tokens.to_json,
+          ecf_url:,
+          rect_url:,
+        }
+      end
+    end
+
+    describe "#url" do
+      subject { instance.url(app:) }
+
+      let(:app) { :ecf }
+
+      it { is_expected.to eq("#{ecf_url}#{endpoint.path}") }
+    end
+
+    describe "#headers" do
+      subject { instance.headers }
+
+      it "returns the correct headers" do
+        expect(instance.headers).to eq(
+          "Authorization" => "Bearer test_token",
+          "Accept" => "application/json",
+          "Content-Type" => "application/json"
+        )
+      end
+    end
+  end
+end

--- a/spec/migration/parity_check/token_provider_spec.rb
+++ b/spec/migration/parity_check/token_provider_spec.rb
@@ -55,4 +55,33 @@ RSpec.describe ParityCheck::TokenProvider do
       it { expect { generate }.to raise_error(described_class::UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment") }
     end
   end
+
+  describe "#token" do
+    subject(:token) { instance.token(lead_provider:) }
+
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+
+    context "when parity check is enabled" do
+      let(:enabled) { true }
+
+      context "when the keys are not present" do
+        let(:tokens) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the keys are present" do
+        let(:tokens) { { lead_provider.api_id => "token" } }
+
+        it { is_expected.to eq("token") }
+      end
+    end
+
+    context "when parity check is disabled" do
+      let(:enabled) { false }
+      let(:tokens) { nil }
+
+      it { expect { token }.to raise_error(described_class::UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment") }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "view_component/test_helpers"
 require "view_component/system_test_helpers"
 require 'playwright'
 require 'playwright/test'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
@@ -23,3 +24,4 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
### Context

The parity check service will need to make calls to both ECF and RECT migration environments. This PR adds the `Client` and associated models/services to be able to build and make requests for the various endpoints we will want to test. It only supports a basic GET request to begin with; follow up PRs will add POST/PUT and complex GET (path ids/pagination/etc).

### Changes proposed in this pull request

- Add WebMock

We need `webmock` in order to stub out and test the external calls the `ParityCheck::Client` will make to ECF and RECT.

- Add parity check URLs to migration env

The parity check will call out to the ECF and RECT migration environments.

Add the URLs to the migration environment config and load into the Rails config.

- Add token method to TokenProvider

We need to be able to retrieve a token for a given lead provider as part of the parity check in order to make valid API calls.

We could have encapsulated this in the `TokenManager` service, but as we will want to cleanly remove the parity check related code after we are finished migrating across it makes sense to house it in the `ParityCheck::TokenProvider`.

- Add ParityCheck::Client and associated models/services

We want to abstract the complexities involved with making parity check requests into a `Client`. The client will be responsible for taking an endpoint definition, constructing valid requests, making the requests and returning the
results along with request duration information.

Add `Endpoint` model to describe a callable endpoint.

Add `RequestBuilder` service to take an `Endpoint` and construct the different aspects of a request (path, headers, etc).

Add `Client` to perform the requests with `HTTParty`. To begin with we will only support basic GET endpoints.

### Guidance to review

As there is quite a lot of verbose setup for testing this I've opted to test each aspect in isolation to reduce the test complexity. We will also have end to end tests when the rest of the parity check service is finished to make sure it all hangs together as expected.