### PR TITLE
[1749] Adjustments for statements

### DIFF
--- a/app/components/admin/statements/adjustments.html.erb
+++ b/app/components/admin/statements/adjustments.html.erb
@@ -1,0 +1,24 @@
+<%=
+  govuk_summary_card(title: "Additional adjustments") do |card|
+    card.with_action { govuk_link_to("Add", "#", visually_hidden_suffix: "adjustment") if adjustment_editable? }
+    card.with_summary_list do |sl|
+      adjustments.each do |adjustment|
+        sl.with_row do |row|
+          row.with_key(text: adjustment.payment_type)
+          row.with_value(text: number_to_pounds(adjustment.amount))
+          if adjustment_editable?
+            row.with_action(text: "Change", href: '#', visually_hidden_text: "adjustment")
+            row.with_action(text: "Remove", href: '#', visually_hidden_text: "adjustment")
+          end
+        end
+      end
+
+      if adjustments.any?
+        sl.with_row do |row|
+          row.with_key(text: "Total")
+          row.with_value(text: number_to_pounds(total_amount))
+        end
+      end
+    end
+  end
+%>

--- a/app/components/admin/statements/adjustments.html.erb
+++ b/app/components/admin/statements/adjustments.html.erb
@@ -5,22 +5,26 @@
     end
 
     card.with_summary_list do |sl|
-      adjustments.each do |adjustment|
-        sl.with_row do |row|
-          row.with_key(text: adjustment.payment_type)
-          row.with_value(text: number_to_pounds(adjustment.amount))
+      if adjustments.any?
+        adjustments.each do |adjustment|
+          sl.with_row do |row|
+            row.with_key(text: adjustment.payment_type)
+            row.with_value(text: number_to_pounds(adjustment.amount))
 
-          if adjustment_editable?
-            row.with_action(text: "Change", href: edit_admin_finance_statement_adjustment_path(statement, adjustment), visually_hidden_text: "adjustment")
-            row.with_action(text: "Remove", href: delete_admin_finance_statement_adjustment_path(statement, adjustment), visually_hidden_text: "adjustment")
+            if adjustment_editable?
+              row.with_action(text: "Change", href: edit_admin_finance_statement_adjustment_path(statement, adjustment), visually_hidden_text: "adjustment")
+              row.with_action(text: "Remove", href: delete_admin_finance_statement_adjustment_path(statement, adjustment), visually_hidden_text: "adjustment")
+            end
           end
         end
-      end
 
-      if adjustments.any?
         sl.with_row do |row|
           row.with_key(text: "Total")
           row.with_value(text: number_to_pounds(total_amount))
+        end
+      else
+        sl.with_row do |row|
+          row.with_value(text: "No adjustments")
         end
       end
     end

--- a/app/components/admin/statements/adjustments.html.erb
+++ b/app/components/admin/statements/adjustments.html.erb
@@ -1,14 +1,18 @@
 <%=
-  govuk_summary_card(title: "Additional adjustments") do |card|
-    card.with_action { govuk_link_to("Add", "#", visually_hidden_suffix: "adjustment") if adjustment_editable? }
+  govuk_summary_card(title: "Additional adjustments", html_attributes: { id: "adjustments" }) do |card|
+    if adjustment_editable?
+      card.with_action { govuk_link_to("Add", new_admin_finance_statement_adjustment_path(statement), visually_hidden_suffix: "adjustment") }
+    end
+
     card.with_summary_list do |sl|
       adjustments.each do |adjustment|
         sl.with_row do |row|
           row.with_key(text: adjustment.payment_type)
           row.with_value(text: number_to_pounds(adjustment.amount))
+
           if adjustment_editable?
-            row.with_action(text: "Change", href: '#', visually_hidden_text: "adjustment")
-            row.with_action(text: "Remove", href: '#', visually_hidden_text: "adjustment")
+            row.with_action(text: "Change", href: edit_admin_finance_statement_adjustment_path(statement, adjustment), visually_hidden_text: "adjustment")
+            row.with_action(text: "Remove", href: delete_admin_finance_statement_adjustment_path(statement, adjustment), visually_hidden_text: "adjustment")
           end
         end
       end

--- a/app/components/admin/statements/adjustments.rb
+++ b/app/components/admin/statements/adjustments.rb
@@ -1,0 +1,20 @@
+module Admin
+  module Statements
+    class Adjustments < ViewComponent::Base
+      delegate :number_to_pounds, to: :helpers
+
+      delegate :adjustments, :adjustment_editable?,
+               to: :statement
+
+      attr_accessor :statement
+
+      def initialize(statement:)
+        @statement = statement
+      end
+
+      def total_amount
+        adjustments.sum(&:amount)
+      end
+    end
+  end
+end

--- a/app/components/admin/statements/adjustments.rb
+++ b/app/components/admin/statements/adjustments.rb
@@ -3,7 +3,7 @@ module Admin
     class Adjustments < ViewComponent::Base
       delegate :number_to_pounds, to: :helpers
 
-      delegate :adjustments, :adjustment_editable?,
+      delegate :adjustment_editable?,
                to: :statement
 
       attr_accessor :statement
@@ -14,6 +14,10 @@ module Admin
 
       def total_amount
         adjustments.sum(&:amount)
+      end
+
+      def adjustments
+        statement.adjustments.order(created_at: :asc)
       end
     end
   end

--- a/app/controllers/admin/finance/adjustments_controller.rb
+++ b/app/controllers/admin/finance/adjustments_controller.rb
@@ -1,0 +1,68 @@
+module Admin::Finance
+  class AdjustmentsController < AdminController
+    before_action :set_statement
+    before_action :redirect_if_adjustment_not_editable
+    before_action :set_adjustment, only: %i[edit update delete destroy]
+
+    def new
+      @adjustment = @statement.adjustments.new
+    end
+
+    def create
+      @adjustment = @statement.adjustments.new(adjustment_params)
+
+      if @adjustment.save
+        redirect_to statement_path, alert: "Adjustment added"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @adjustment.update(adjustment_params)
+        redirect_to statement_path, alert: "Adjustment changed"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def delete
+    end
+
+    def destroy
+      @adjustment.destroy!
+      redirect_to statement_path, alert: "Adjustment removed"
+    end
+
+  private
+
+    def adjustment_params
+      params.permit(
+        statement_adjustment: %i[payment_type amount form_step]
+      )[:statement_adjustment] || {}
+    end
+
+    def set_statement
+      @statement = Statement.find(params[:finance_statement_id])
+    end
+
+    def set_adjustment
+      @adjustment = @statement.adjustments.find(params[:id])
+    end
+
+    def redirect_if_adjustment_not_editable
+      return if @statement.adjustment_editable?
+
+      redirect_to statement_path
+    end
+
+    def statement_path
+      admin_finance_statement_path(@statement)
+    end
+
+    helper_method :statement_path
+  end
+end

--- a/app/helpers/number_helper.rb
+++ b/app/helpers/number_helper.rb
@@ -1,0 +1,9 @@
+module NumberHelper
+  include ActionView::Helpers::NumberHelper
+
+  def number_to_pounds(number)
+    number = 0 if number.zero?
+
+    number_to_currency number, precision: 2, unit: "£"
+  end
+end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -41,4 +41,8 @@ class Statement < ApplicationRecord
       raise ArgumentError, "Unknown state: #{state}"
     end
   end
+
+  def adjustment_editable?
+    output_fee && !paid?
+  end
 end

--- a/app/models/statement/adjustment.rb
+++ b/app/models/statement/adjustment.rb
@@ -4,6 +4,22 @@ class Statement::Adjustment < ApplicationRecord
   validates :payment_type, presence: { message: "Payment type is required" }
   validates :amount, presence: { message: "Amount is required" }
   validates :amount, numericality: { other_than: 0, message: "Amount must be greater than 0" }
+  validate :amount_min_and_max_values
+
   # Only needed for migrating data from ECF; can be removed later.
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement adjustment" }
+
+private
+
+  def amount_min_and_max_values
+    return if errors.any?
+
+    if amount < -1_000_000.0
+      errors.add(:amount, "Amount must be greater than or equal to -1,000,000")
+    end
+
+    if amount > 1_000_000.0
+      errors.add(:amount, "Amount must be less than or equal to 1,000,000")
+    end
+  end
 end

--- a/app/views/admin/finance/adjustments/_fields.html.erb
+++ b/app/views/admin/finance/adjustments/_fields.html.erb
@@ -1,0 +1,19 @@
+<%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+<%=
+  form.govuk_text_field(
+    :payment_type,
+    label: { text: "Adjustment name", size: "m" },
+    hint: { text: "Describe what the adjustment is for"},
+  )
+%>
+
+<%=
+  form.govuk_text_field(
+    :amount,
+    prefix_text: '£',
+    width: 'one-quarter',
+    label: { text: "Adjustment amount", size: "m" },
+    hint: { text: "Add a minus symbol before the amount if you need to make a negative adjustment. For example, -45" },
+  )
+%>

--- a/app/views/admin/finance/adjustments/delete.html.erb
+++ b/app/views/admin/finance/adjustments/delete.html.erb
@@ -1,0 +1,8 @@
+<% page_data(title: "Are you sure you want to remove the '#{@adjustment.payment_type}' adjustment?") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_button_to "Remove adjustment", admin_finance_statement_adjustment_path(@statement, @adjustment), method: :delete %>
+    <%= govuk_link_to "Cancel and return to statement", statement_path %>
+  </div>
+</div>

--- a/app/views/admin/finance/adjustments/edit.html.erb
+++ b/app/views/admin/finance/adjustments/edit.html.erb
@@ -1,0 +1,12 @@
+<% page_data(title: "Change adjustment") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with model: @adjustment, url: admin_finance_statement_adjustment_path(@statement, @adjustment) do |form| %>
+      <%= render "fields", form: %>
+      <%= form.submit "Save changes", class: "govuk-button" %>
+    <% end %>
+
+    <%= govuk_link_to "Cancel and return to statement", statement_path %>
+  </div>
+</div>

--- a/app/views/admin/finance/adjustments/new.html.erb
+++ b/app/views/admin/finance/adjustments/new.html.erb
@@ -1,0 +1,12 @@
+<% page_data(title: "Make adjustment") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with model: @adjustment, url: admin_finance_statement_adjustments_path(@statement) do |form| %>
+      <%= render "fields", form: %>
+      <%= form.submit "Add adjustment", class: "govuk-button" %>
+    <% end %>
+
+    <%= govuk_link_to "Cancel and return to statement", statement_path %>
+  </div>
+</div>

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -44,3 +44,4 @@
   end
 %>
 
+<%= render Admin::Statements::Adjustments.new(statement: @statement) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,13 @@ Rails.application.routes.draw do
 
     resource :finance, only: %i[show], controller: 'finance' do
       collection do
-        resources :statements, as: 'finance_statements', controller: 'finance/statements', only: %i[index show]
+        resources :statements, as: 'finance_statements', controller: 'finance/statements', only: %i[index show] do
+          resources :adjustments, controller: 'finance/adjustments', only: %i[new create edit update destroy] do
+            member do
+              get :delete
+            end
+          end
+        end
       end
     end
   end

--- a/spec/components/admin/statements/adjustments_spec.rb
+++ b/spec/components/admin/statements/adjustments_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe Admin::Statements::Adjustments, type: :component do
+  subject { render_inline(component) }
+
+  let(:statement) { FactoryBot.create(:statement) }
+  let(:component) { described_class.new statement: }
+
+  let(:summary_list_values) do
+    subject.css(".govuk-summary-card .govuk-summary-list .govuk-summary-list__row").map do |row|
+      row.css(".govuk-summary-list__key, .govuk-summary-list__value").map { |v| v.text.strip }
+    end
+  end
+
+  context "no adjustments" do
+    it "renders correctly" do
+      expect(statement.adjustments.count).to eq(0)
+      expect(summary_list_values.count).to eq(0)
+
+      expect(subject).to have_link("Add adjustment")
+      expect(subject).not_to have_link("Change adjustment")
+    end
+  end
+
+  context "one adjustment" do
+    let!(:adjustment) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
+
+    it "renders correctly" do
+      expect(statement.adjustments.count).to eq(1)
+      expect(component.total_amount.to_s).to eq("999.99")
+
+      expect(summary_list_values.count).to eq(2)
+
+      expect(summary_list_values[0][0]).to eq("Big amount")
+      expect(summary_list_values[0][1]).to eq("£999.99")
+
+      expect(summary_list_values[1][0]).to eq("Total")
+      expect(summary_list_values[1][1]).to eq("£999.99")
+
+      expect(subject).to have_link("Add adjustment")
+      expect(subject).to have_link("Change adjustment")
+    end
+  end
+
+  context "multiple adjustments" do
+    let!(:adjustment1) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
+    let!(:adjustment2) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Negative amount", amount: -500.0 }
+    let!(:adjustment3) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Another amount", amount: 300.0 }
+
+    it "renders correctly" do
+      expect(statement.adjustments.count).to eq(3)
+      expect(component.total_amount.to_s).to eq("799.99")
+
+      expect(summary_list_values.count).to eq(4)
+
+      expect(summary_list_values[0][0]).to eq("Big amount")
+      expect(summary_list_values[0][1]).to eq("£999.99")
+
+      expect(summary_list_values[1][0]).to eq("Negative amount")
+      expect(summary_list_values[1][1]).to eq("-£500.00")
+
+      expect(summary_list_values[2][0]).to eq("Another amount")
+      expect(summary_list_values[2][1]).to eq("£300.00")
+
+      expect(summary_list_values[3][0]).to eq("Total")
+      expect(summary_list_values[3][1]).to eq("£799.99")
+
+      expect(subject).to have_link("Add adjustment")
+      expect(subject).to have_link("Change adjustment")
+    end
+  end
+
+  context ".adjustment_editable?" do
+    let!(:adjustment1) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
+
+    context "non-paid statement" do
+      it "renders links" do
+        expect(subject).to have_link("Add adjustment")
+      end
+    end
+
+    context "paid statement" do
+      let(:statement) { FactoryBot.create :statement, :paid }
+
+      it "does not render links" do
+        expect(subject).not_to have_link("Add adjustment")
+      end
+    end
+
+    context "statement with output_fee=fase" do
+      let(:statement) { FactoryBot.create :statement, output_fee: false }
+
+      it "does not render links" do
+        expect(subject).not_to have_link("Add adjustment")
+      end
+    end
+  end
+end

--- a/spec/components/admin/statements/adjustments_spec.rb
+++ b/spec/components/admin/statements/adjustments_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Admin::Statements::Adjustments, type: :component do
   context "no adjustments" do
     it "renders correctly" do
       expect(statement.adjustments.count).to eq(0)
-      expect(summary_list_values.count).to eq(0)
+      expect(summary_list_values.count).to eq(1)
+      expect(summary_list_values[0][0]).to eq("No adjustments")
 
       expect(subject).to have_link("Add adjustment")
       expect(subject).not_to have_link("Change adjustment")

--- a/spec/features/admin/finance/adjustments/create_adjustment_spec.rb
+++ b/spec/features/admin/finance/adjustments/create_adjustment_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe "Create adjustment for statement" do
+  before { sign_in_as_dfe_user(role: :admin) }
+
+  scenario "Add new adjustment" do
+    given_a_finance_statement_exists
+    when_i_visit_the_finance_statement_page
+    then_i_see_adjustments_section
+
+    when_i_click_link("Add adjustment")
+
+    then_i_see("Make adjustment")
+
+    when_i_fill_in(label: "Adjustment name", value: "Test Payment")
+    and_i_fill_in(label: "Adjustment amount", value: "999.99")
+    and_i_click_button("Add adjustment")
+
+    then_i_see_adjustments_section
+    and_i_see_adjustment_values
+    and_i_see_adjustment_total
+    and_an_adjustment_is_created
+  end
+
+  def given_a_finance_statement_exists
+    @statement = FactoryBot.create(:statement)
+  end
+
+  def when_i_visit_the_finance_statement_page
+    page.goto(admin_finance_statement_path(@statement))
+  end
+
+  def then_i_see_adjustments_section
+    expect(page.locator('#adjustments.govuk-summary-card h2').text_content).to eq("Additional adjustments")
+  end
+
+  def when_i_click_link(name)
+    page.get_by_role('link', name:).click
+  end
+
+  def then_i_see(string)
+    expect(page.get_by_text(string)).to be_visible
+  end
+
+  def when_i_fill_in(label:, value:)
+    page.get_by_label(label, exact: true).fill(value.to_s)
+  end
+
+  alias_method :and_i_fill_in, :when_i_fill_in
+
+  def and_i_click_button(name)
+    page.get_by_role('button', name:).click
+  end
+
+  def and_i_see_adjustment_values
+    expect(summary_list_values[0][0]).to eq("Test Payment")
+    expect(summary_list_values[0][1]).to eq("£999.99")
+  end
+
+  def and_i_see_adjustment_total
+    expect(summary_list_values.last[0]).to eq("Total")
+    expect(summary_list_values.last[1]).to eq("£999.99")
+  end
+
+  def and_an_adjustment_is_created
+    adjustment = Statement::Adjustment.first
+    expect(adjustment.statement).to eq(@statement)
+    expect(adjustment.payment_type).to eq("Test Payment")
+    expect(adjustment.amount).to eq(999.99)
+  end
+
+  def summary_list_values
+    @summary_list_values ||=
+      page.query_selector_all("#adjustments.govuk-summary-card .govuk-summary-list .govuk-summary-list__row").map do |row|
+        row.query_selector_all(".govuk-summary-list__key, .govuk-summary-list__value").map { |v| v.text_content.strip }
+      end
+  end
+end

--- a/spec/features/admin/finance/adjustments/delete_adjustment_spec.rb
+++ b/spec/features/admin/finance/adjustments/delete_adjustment_spec.rb
@@ -1,0 +1,99 @@
+RSpec.describe "Delete adjustment from statement" do
+  before { sign_in_as_dfe_user(role: :admin) }
+
+  scenario "Delete adjustment" do
+    given_a_finance_statement_exists
+    and_the_statement_has_adjustments
+
+    when_i_visit_the_finance_statement_page
+    then_i_see_adjustments_section
+    and_i_see_adjustment_values
+    and_i_see_adjustment_total
+
+    when_i_click_delete_adjustment_link
+
+    then_i_see("Are you sure you want to remove the '#{@deleted_adjustment.payment_type}' adjustment?")
+    and_i_click_button("Remove adjustment")
+
+    then_i_see_adjustments_section
+    and_i_see_new_adjustment_values
+    and_i_see_new_adjustment_total
+    and_deleted_adjustment_should_not_exist
+  end
+
+  def given_a_finance_statement_exists
+    @statement = FactoryBot.create(:statement)
+  end
+
+  def when_i_visit_the_finance_statement_page
+    page.goto(admin_finance_statement_path(@statement))
+  end
+
+  def and_the_statement_has_adjustments
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
+    @deleted_adjustment = FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
+  end
+
+  def and_i_see_adjustment_values
+    values = summary_list_values
+    expect(values[0][0]).to eq("Amount 1")
+    expect(values[0][1]).to eq("£100.00")
+
+    expect(values[1][0]).to eq("Amount 2")
+    expect(values[1][1]).to eq("-£150.00")
+
+    expect(values[2][0]).to eq("Amount 3")
+    expect(values[2][1]).to eq("£500.00")
+  end
+
+  def and_i_see_adjustment_total
+    values = summary_list_values
+    expect(values.last[0]).to eq("Total")
+    expect(values.last[1]).to eq("£450.00")
+  end
+
+  def and_i_see_new_adjustment_values
+    values = summary_list_values
+    expect(values[0][0]).to eq("Amount 1")
+    expect(values[0][1]).to eq("£100.00")
+
+    expect(values[1][0]).to eq("Amount 3")
+    expect(values[1][1]).to eq("£500.00")
+  end
+
+  def and_i_see_new_adjustment_total
+    values = summary_list_values
+    expect(values.last[0]).to eq("Total")
+    expect(values.last[1]).to eq("£600.00")
+  end
+
+  def then_i_see_adjustments_section
+    expect(page.locator('#adjustments.govuk-summary-card h2').text_content).to eq("Additional adjustments")
+  end
+
+  def when_i_click_delete_adjustment_link
+    # second adjustment
+    page.locator('#adjustments.govuk-summary-card .govuk-summary-list .govuk-summary-list__row:nth-child(2)').get_by_role('link', name: "Remove adjustment").click
+  end
+
+  def and_deleted_adjustment_should_not_exist
+    expect(page.get_by_text(@deleted_adjustment.payment_type)).not_to be_visible
+    expect(Statement::Adjustment.count).to be(2)
+    expect(Statement::Adjustment.where(id: @deleted_adjustment.id).count).to be(0)
+  end
+
+  def summary_list_values
+    page.query_selector_all("#adjustments.govuk-summary-card .govuk-summary-list .govuk-summary-list__row").map do |row|
+      row.query_selector_all(".govuk-summary-list__key, .govuk-summary-list__value").map { |v| v.text_content.strip }
+    end
+  end
+
+  def then_i_see(string)
+    expect(page.get_by_text(string)).to be_visible
+  end
+
+  def and_i_click_button(name)
+    page.get_by_role('button', name:).click
+  end
+end

--- a/spec/features/admin/finance/adjustments/list_adjustments_spec.rb
+++ b/spec/features/admin/finance/adjustments/list_adjustments_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe "List adjustments for statement" do
+  before { sign_in_as_dfe_user(role: :admin) }
+
+  scenario "Statement with adjustments" do
+    given_a_finance_statement_exists
+    and_the_statement_has_adjustments
+
+    when_i_visit_the_finance_statement_page
+
+    then_i_see_adjustments_section
+    and_i_see_adjustment_values
+    and_i_see_adjustment_total
+  end
+
+  scenario "Statement is payable or paid" do
+    given_a_closed_finance_statement_exists
+    when_i_visit_the_finance_statement_page
+
+    then_i_see_adjustments_section
+    and_i_should_not_see_add_adjustment_link
+
+    when_i_visit_new_adjustment_page_directly
+    then_i_am_redirected_back_to_finance_statement_page
+  end
+
+  scenario "Statement has false output_fee" do
+    given_a_finance_statement_with_false_output_fees_exists
+    when_i_visit_the_finance_statement_page
+
+    then_i_see_adjustments_section
+    and_i_should_not_see_add_adjustment_link
+
+    when_i_visit_new_adjustment_page_directly
+    then_i_am_redirected_back_to_finance_statement_page
+  end
+
+  def given_a_finance_statement_exists
+    @statement = FactoryBot.create(:statement)
+  end
+
+  def given_a_closed_finance_statement_exists
+    @statement = FactoryBot.create(:statement, :paid)
+  end
+
+  def given_a_finance_statement_with_false_output_fees_exists
+    @statement = FactoryBot.create(:statement, output_fee: false)
+  end
+
+  def when_i_visit_the_finance_statement_page
+    page.goto(admin_finance_statement_path(@statement))
+  end
+
+  def and_the_statement_has_adjustments
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
+  end
+
+  def then_i_see_adjustments_section
+    expect(page.locator('#adjustments.govuk-summary-card h2').text_content).to eq("Additional adjustments")
+  end
+
+  def and_i_see_adjustment_values
+    expect(summary_list_values[0][0]).to eq("Amount 1")
+    expect(summary_list_values[0][1]).to eq("£100.00")
+
+    expect(summary_list_values[1][0]).to eq("Amount 2")
+    expect(summary_list_values[1][1]).to eq("-£150.00")
+
+    expect(summary_list_values[2][0]).to eq("Amount 3")
+    expect(summary_list_values[2][1]).to eq("£500.00")
+  end
+
+  def and_i_see_adjustment_total
+    expect(summary_list_values.last[0]).to eq("Total")
+    expect(summary_list_values.last[1]).to eq("£450.00")
+  end
+
+  def and_i_should_not_see_add_adjustment_link
+    expect(page.get_by_role('link', name: "Add adjustment")).not_to be_visible
+  end
+
+  def when_i_visit_new_adjustment_page_directly
+    page.goto(new_admin_finance_statement_adjustment_path(@statement))
+  end
+
+  def then_i_am_redirected_back_to_finance_statement_page
+    expect(page.url).to end_with(admin_finance_statement_path(@statement))
+  end
+
+  def summary_list_values
+    @summary_list_values ||=
+      page.query_selector_all("#adjustments.govuk-summary-card .govuk-summary-list .govuk-summary-list__row").map do |row|
+        row.query_selector_all(".govuk-summary-list__key, .govuk-summary-list__value").map { |v| v.text_content.strip }
+      end
+  end
+end

--- a/spec/features/admin/finance/adjustments/update_adjustment_spec.rb
+++ b/spec/features/admin/finance/adjustments/update_adjustment_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe "Update adjustment for statement" do
+  before { sign_in_as_dfe_user(role: :admin) }
+
+  scenario "Update adjustment" do
+    given_a_finance_statement_exists
+    and_the_statement_has_adjustments
+
+    when_i_visit_the_finance_statement_page
+    then_i_see_adjustments_section
+    and_i_see_adjustment_values
+    and_i_see_adjustment_total
+
+    when_i_click_change_adjustment_link
+
+    then_i_see("Change adjustment")
+
+    when_i_fill_in(label: "Adjustment name", value: "Big amount")
+    and_i_fill_in(label: "Adjustment amount", value: "10000")
+    and_i_click_button("Save changes")
+
+    then_i_see_adjustments_section
+    and_i_see_new_adjustment_values
+    and_i_see_new_adjustment_total
+    and_adjustment_should_have_been_updated
+  end
+
+  def given_a_finance_statement_exists
+    @statement = FactoryBot.create(:statement)
+  end
+
+  def when_i_visit_the_finance_statement_page
+    page.goto(admin_finance_statement_path(@statement))
+  end
+
+  def and_the_statement_has_adjustments
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
+    @changed_adjustment = FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
+    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
+  end
+
+  def and_i_see_adjustment_values
+    values = summary_list_values
+    expect(values[0][0]).to eq("Amount 1")
+    expect(values[0][1]).to eq("£100.00")
+
+    expect(values[1][0]).to eq("Amount 2")
+    expect(values[1][1]).to eq("-£150.00")
+
+    expect(values[2][0]).to eq("Amount 3")
+    expect(values[2][1]).to eq("£500.00")
+  end
+
+  def and_i_see_adjustment_total
+    values = summary_list_values
+    expect(values.last[0]).to eq("Total")
+    expect(values.last[1]).to eq("£450.00")
+  end
+
+  def and_i_see_new_adjustment_values
+    values = summary_list_values
+    expect(values[0][0]).to eq("Amount 1")
+    expect(values[0][1]).to eq("£100.00")
+
+    expect(values[1][0]).to eq("Big amount")
+    expect(values[1][1]).to eq("£10,000.00")
+
+    expect(values[2][0]).to eq("Amount 3")
+    expect(values[2][1]).to eq("£500.00")
+  end
+
+  def and_i_see_new_adjustment_total
+    values = summary_list_values
+    expect(values.last[0]).to eq("Total")
+    expect(values.last[1]).to eq("£10,600.00")
+  end
+
+  def then_i_see_adjustments_section
+    expect(page.locator('#adjustments.govuk-summary-card h2').text_content).to eq("Additional adjustments")
+  end
+
+  def when_i_click_change_adjustment_link
+    # second adjustment
+    page.locator('#adjustments.govuk-summary-card .govuk-summary-list .govuk-summary-list__row:nth-child(2)').get_by_role('link', name: "Change adjustment").click
+  end
+
+  def and_adjustment_should_have_been_updated
+    @changed_adjustment.reload
+    expect(@changed_adjustment.payment_type).to eq("Big amount")
+    expect(@changed_adjustment.amount).to eq(10_000.0)
+    expect(Statement::Adjustment.count).to eq(3)
+  end
+
+  def summary_list_values
+    page.query_selector_all("#adjustments.govuk-summary-card .govuk-summary-list .govuk-summary-list__row").map do |row|
+      row.query_selector_all(".govuk-summary-list__key, .govuk-summary-list__value").map { |v| v.text_content.strip }
+    end
+  end
+
+  def then_i_see(string)
+    expect(page.get_by_text(string)).to be_visible
+  end
+
+  def when_i_fill_in(label:, value:)
+    page.get_by_label(label, exact: true).fill(value.to_s)
+  end
+
+  alias_method :and_i_fill_in, :when_i_fill_in
+
+  def and_i_click_button(name)
+    page.get_by_role('button', name:).click
+  end
+end

--- a/spec/helpers/number_helper_spec.rb
+++ b/spec/helpers/number_helper_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe NumberHelper, type: :helper do
+  describe "#number_to_pounds" do
+    context "when positive number" do
+      it "returns pounds" do
+        expect(helper.number_to_pounds(BigDecimal("100.0"))).to eql("£100.00")
+      end
+    end
+
+    context "when negative number" do
+      it "returns pounds" do
+        expect(helper.number_to_pounds(BigDecimal("-100.0"))).to eql("-£100.00")
+      end
+    end
+
+    context "when negative zero" do
+      it "returns unsigned zero" do
+        expect(helper.number_to_pounds(BigDecimal("-0"))).to eql("£0.00")
+      end
+    end
+  end
+end

--- a/spec/models/statement/adjustment_spec.rb
+++ b/spec/models/statement/adjustment_spec.rb
@@ -10,5 +10,17 @@ describe Statement::Adjustment do
     it { is_expected.to validate_presence_of(:amount).with_message("Amount is required") }
     it { is_expected.to validate_numericality_of(:amount).is_other_than(0).with_message("Amount must be greater than 0") }
     it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another statement adjustment") }
+
+    it "returns validation error when amount is less than -1,000,000" do
+      subject.amount = -1_000_001.0
+      subject.valid?
+      expect(subject.errors[:amount]).to include("Amount must be greater than or equal to -1,000,000")
+    end
+
+    it "returns validation error when amount is greater than 1,000,000" do
+      subject.amount = 1_000_001.0
+      subject.valid?
+      expect(subject.errors[:amount]).to include("Amount must be less than or equal to 1,000,000")
+    end
   end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -97,4 +97,36 @@ describe Statement do
       it { expect { shorthand_state }.to raise_error(ArgumentError, "Unknown state: unknown_state") }
     end
   end
+
+  context ".adjustment_editable?" do
+    context "paid statement" do
+      subject { FactoryBot.build(:statement, :paid) }
+
+      it "returns false" do
+        subject.output_fee = true
+        expect(subject.adjustment_editable?).to be(false)
+
+        subject.output_fee = false
+        expect(subject.adjustment_editable?).to be(false)
+      end
+    end
+
+    context "non-paid statement" do
+      context "output_fee is true" do
+        subject { FactoryBot.build(:statement, :open, output_fee: true) }
+
+        it "returns true" do
+          expect(subject.adjustment_editable?).to be(true)
+        end
+      end
+
+      context "output_fee is false" do
+        subject { FactoryBot.build(:statement, :open, output_fee: false) }
+
+        it "returns false" do
+          expect(subject.adjustment_editable?).to be(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'admin/finance/statements/show.html.erb' do
-  let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
-  let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
-  let(:raw_statement) { FactoryBot.build(:statement, active_lead_provider:, month: 5, year: 2023) }
-  let(:statement) { Admin::StatementPresenter.new(raw_statement) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+  let(:statement_rec) { FactoryBot.create(:statement, active_lead_provider:, month: 5, year: 2023) }
+  let(:statement) { Admin::StatementPresenter.new(statement_rec) }
 
   before do
     assign(:statement, statement)


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1749

### Changes proposed in this pull request

* New component `Admin::Statements::Adjustments`
  * Using summary card instead of table (ecf1)
* Add/change/remove adjustments for statements
* `NumberHelper` added for £

### Guidance to review

* Login as admin
* Go to an open statement