### PR TITLE
[1596] Add active lead providers migrator

### DIFF
--- a/app/migration/migrators/active_lead_provider.rb
+++ b/app/migration/migrators/active_lead_provider.rb
@@ -1,0 +1,36 @@
+module Migrators
+  class ActiveLeadProvider < Migrators::Base
+    def self.record_count
+      active_lead_providers.size
+    end
+
+    def self.model
+      :active_lead_provider
+    end
+
+    def self.active_lead_providers
+      ::Migration::LeadProvider.select("lead_providers.id, cohorts.start_year").joins(:cohorts).order(:start_year)
+    end
+
+    def self.dependencies
+      %i[lead_provider registration_period]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::ActiveLeadProvider.connection.execute("TRUNCATE #{::ActiveLeadProvider.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.active_lead_providers) do |ecf_active_lead_provider|
+        lead_provider_id = find_lead_provider_id!(api_id: ecf_active_lead_provider.id)
+
+        ::ActiveLeadProvider.find_or_create_by!(
+          lead_provider_id:,
+          registration_period_id: ecf_active_lead_provider.start_year
+        )
+      end
+    end
+  end
+end

--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -13,8 +13,7 @@ module Migrators
     end
 
     def self.dependencies
-      # TODO: add :active_lead_provider to the array when migrator is implemented
-      %i[lead_provider registration_period]
+      %i[lead_provider registration_period active_lead_provider]
     end
 
     def self.reset!

--- a/app/models/migration/lead_provider.rb
+++ b/app/models/migration/lead_provider.rb
@@ -1,5 +1,6 @@
 module Migration
   class LeadProvider < Migration::Base
     has_many :partnerships
+    has_and_belongs_to_many :cohorts
   end
 end

--- a/spec/factories/migration/lead_provider_factory.rb
+++ b/spec/factories/migration/lead_provider_factory.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :migration_lead_provider, class: "Migration::LeadProvider" do
     name  { Faker::Company.name }
+
+    trait :active do
+      after(:create) do |lead_provider|
+        lead_provider.cohorts << FactoryBot.create(:migration_cohort)
+      end
+    end
   end
 end

--- a/spec/migration/migrators/active_lead_provider_spec.rb
+++ b/spec/migration/migrators/active_lead_provider_spec.rb
@@ -1,0 +1,34 @@
+describe Migrators::ActiveLeadProvider do
+  it_behaves_like "a migrator", :active_lead_provider, %i[lead_provider registration_period] do
+    def create_migration_resource
+      FactoryBot.create(:migration_lead_provider, :active)
+    end
+
+    def create_resource(migration_resource)
+      # creating dependencies resources
+      FactoryBot.create(:lead_provider, name: migration_resource.name, api_id: migration_resource.id)
+      FactoryBot.create(:registration_period, year: migration_resource.cohorts.first.start_year)
+
+      FactoryBot.create(:active_lead_provider)
+    end
+
+    def setup_failure_state
+      # Record to be migrated with unmet dependencies in the destination db
+      lead_provider = FactoryBot.create(:migration_lead_provider)
+      lead_provider.cohorts << FactoryBot.create(:migration_cohort)
+      lead_provider
+    end
+
+    describe "#migrate!" do
+      it "sets the created record attributes correctly" do
+        instance.migrate!
+
+        active_lead_provider = ActiveLeadProvider.find_by(
+          lead_provider_id: LeadProvider.find_by_api_id(migration_resource1.id).id,
+          registration_period_id: migration_resource1.cohorts.first.start_year
+        )
+        expect(active_lead_provider).to be_present
+      end
+    end
+  end
+end

--- a/spec/migration/migrators/statement_spec.rb
+++ b/spec/migration/migrators/statement_spec.rb
@@ -1,5 +1,5 @@
 describe Migrators::Statement do
-  it_behaves_like "a migrator", :statement, %i[lead_provider registration_period] do
+  it_behaves_like "a migrator", :statement, %i[lead_provider registration_period active_lead_provider] do
     def create_migration_resource
       FactoryBot.create(:migration_statement, name: "February 2025")
     end
@@ -14,8 +14,8 @@ describe Migrators::Statement do
     end
 
     def setup_failure_state
-      # Record to be migrated with no output_fee.
-      FactoryBot.create(:migration_statement, output_fee: nil)
+      # Record to be migrated with unmet dependencies in the destination db
+      FactoryBot.create(:migration_statement)
     end
 
     describe "#migrate!" do


### PR DESCRIPTION
### Context

[Issue #1596](https://github.com/DFE-Digital/register-ects-project-board/issues/1596)

We need a migrator for active lead providers from ECF1 to ECF2.

### Changes proposed in this pull request

Create a new migrator that creates and populates a new ActiveLeadProvider record in ECF2 for only the years every lead provider was active in ECF1.