### PR TITLE
Add migrator for statement adjustments

### DIFF
--- a/app/migration/migrators/reconcile_adjustment.rb
+++ b/app/migration/migrators/reconcile_adjustment.rb
@@ -19,7 +19,7 @@ module Migrators
 
     def self.reset!
       if Rails.application.config.enable_migration_testing
-        ::StatementAdjustment.connection.execute("TRUNCATE #{::StatementAdjustment.table_name} RESTART IDENTITY CASCADE")
+        ::Statement::Adjustment.connection.execute("TRUNCATE #{::Statement::Adjustment.table_name} RESTART IDENTITY CASCADE")
       end
     end
 

--- a/app/migration/migrators/reconcile_adjustment.rb
+++ b/app/migration/migrators/reconcile_adjustment.rb
@@ -1,0 +1,41 @@
+module Migrators
+  class ReconcileAdjustment < Migrators::Base
+    def self.record_count
+      statements_with_adjustments.count
+    end
+
+    def self.model
+      # this is really :statement_adjustment but if we use that it won't queue both
+      :reconcile_adjustment
+    end
+
+    def self.statements_with_adjustments
+      Migration::Statement.where.not(reconcile_amount: 0.0)
+    end
+
+    def self.dependencies
+      %i[statement]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::StatementAdjustment.connection.execute("TRUNCATE #{::StatementAdjustment.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.statements_with_adjustments) do |statement|
+        statement_adjustment = ::Statement::Adjustment.find_or_initialize_by(api_id: statement.id)
+
+        statement_adjustment.statement = ::Statement.find_by!(api_id: statement.id)
+        statement_adjustment.payment_type = "Reconcile amounts pre-adjustments feature"
+        statement_adjustment.amount = statement.reconcile_amount
+
+        statement_adjustment.created_at = statement.created_at
+        statement_adjustment.updated_at = statement.updated_at
+
+        statement_adjustment.save!
+      end
+    end
+  end
+end

--- a/app/migration/migrators/statement_adjustment.rb
+++ b/app/migration/migrators/statement_adjustment.rb
@@ -1,0 +1,39 @@
+module Migrators
+  class StatementAdjustment < Migrators::Base
+    def self.record_count
+      statement_adjustments.count
+    end
+
+    def self.model
+      :statement_adjustment
+    end
+
+    def self.statement_adjustments
+      Migration::FinanceAdjustment.all
+    end
+
+    def self.dependencies
+      %i[statement]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::Statement::Adjustment.connection.execute("TRUNCATE #{::Statement::Adjustment.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.statement_adjustments) do |adjustment|
+        statement_adjustment = ::Statement::Adjustment.find_or_initialize_by(api_id: adjustment.id)
+
+        statement_adjustment.statement = ::Statement.find_by!(api_id: adjustment.statement_id)
+        statement_adjustment.payment_type = adjustment.payment_type
+        statement_adjustment.amount = adjustment.amount
+        statement_adjustment.created_at = adjustment.created_at
+        statement_adjustment.updated_at = adjustment.updated_at
+
+        statement_adjustment.save!
+      end
+    end
+  end
+end

--- a/app/models/migration/finance_adjustment.rb
+++ b/app/models/migration/finance_adjustment.rb
@@ -1,0 +1,5 @@
+module Migration
+  class FinanceAdjustment < Migration::Base
+    belongs_to :statement
+  end
+end

--- a/spec/factories/migration/finance_adjustment_factory.rb
+++ b/spec/factories/migration/finance_adjustment_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :migration_finance_adjustment, class: "Migration::FinanceAdjustment" do
+    statement { FactoryBot.create(:migration_statement) }
+    sequence(:payment_type) { |n| "Custom payment #{n}" }
+    amount { 9.99 }
+  end
+end

--- a/spec/migration/migrators/reconcile_adjustment_spec.rb
+++ b/spec/migration/migrators/reconcile_adjustment_spec.rb
@@ -1,5 +1,5 @@
 describe Migrators::ReconcileAdjustment do
-  it_behaves_like "a migrator", :statement_adjustment, %i[statement] do
+  it_behaves_like "a migrator", :reconcile_adjustment, %i[statement] do
     def create_migration_resource
       FactoryBot.create(:migration_statement, reconcile_amount: 100.77)
     end

--- a/spec/migration/migrators/reconcile_adjustment_spec.rb
+++ b/spec/migration/migrators/reconcile_adjustment_spec.rb
@@ -1,0 +1,40 @@
+describe Migrators::ReconcileAdjustment do
+  it_behaves_like "a migrator", :statement_adjustment, %i[statement] do
+    def create_migration_resource
+      FactoryBot.create(:migration_statement, reconcile_amount: 100.77)
+    end
+
+    def create_resource(migration_resource)
+      # creating dependencies resources
+
+      ecf_lp = migration_resource.lead_provider
+      ecf_cohort = migration_resource.cohort
+
+      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, api_id: ecf_lp.id)
+      registration_period = FactoryBot.create(:registration_period, year: ecf_cohort.start_year)
+      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
+      FactoryBot.create(:statement, api_id: migration_resource.id, lead_provider:, registration_period:, active_lead_provider:)
+    end
+
+    def setup_failure_state
+      # add a resource to migrate but don't create migrated dependencies
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it "sets the created statement adjustment attributes correctly" do
+        instance.migrate!
+
+        described_class.statements_with_adjustments.find_each do |statement|
+          adjustment = ::Statement::Adjustment.find_by!(api_id: statement.id)
+
+          expect(adjustment.api_id).to eq statement.id
+          expect(adjustment.payment_type).to eq "Reconcile amounts pre-adjustments feature"
+          expect(adjustment.amount).to eq statement.reconcile_amount
+          expect(adjustment.created_at).to eq statement.created_at
+          expect(adjustment.updated_at).to eq statement.updated_at
+        end
+      end
+    end
+  end
+end

--- a/spec/migration/migrators/statement_adjustment_spec.rb
+++ b/spec/migration/migrators/statement_adjustment_spec.rb
@@ -1,0 +1,41 @@
+describe Migrators::StatementAdjustment do
+  it_behaves_like "a migrator", :statement_adjustment, %i[statement] do
+    def create_migration_resource
+      FactoryBot.create(:migration_finance_adjustment)
+    end
+
+    def create_resource(migration_resource)
+      # creating dependencies resources
+
+      ecf_lp = migration_resource.statement.lead_provider
+      ecf_cohort = migration_resource.statement.cohort
+
+      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, api_id: ecf_lp.id)
+      registration_period = FactoryBot.create(:registration_period, year: ecf_cohort.start_year)
+      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
+      FactoryBot.create(:statement, api_id: migration_resource.statement_id, lead_provider:, registration_period:, active_lead_provider:)
+    end
+
+    def setup_failure_state
+      # add a resource to migrate but don't create migrated dependencies
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it "sets the created statement adjustment attributes correctly" do
+        instance.migrate!
+
+        Migration::FinanceAdjustment.find_each do |finance_adjustment|
+          adjustment = ::Statement::Adjustment.find_by!(api_id: finance_adjustment.id)
+          adjustment.statement
+
+          expect(adjustment.api_id).to eq finance_adjustment.id
+          expect(adjustment.payment_type).to eq finance_adjustment.payment_type
+          expect(adjustment.amount).to eq finance_adjustment.amount
+          expect(adjustment.created_at).to eq finance_adjustment.created_at
+          expect(adjustment.updated_at).to eq finance_adjustment.updated_at
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Add a migrator for ECF `Finance::Adjustment` records. These are attached to a `Statement` and so are dependent on the statement migrator being run beforehand.

There are 2 migrators for this:
1. a migrator that migrates the existing `Finance::Adjustment` records from ECF and creates `Statement::Adjustment` records in RECT
2. a migrator that creates `Statement::Adjustment` records for ECF `Finance::Statement` records that have a non-zero `reconcile_amount`

Statements with a `reconcile_amount` value was how an adjustment was performed prior to the introduction of the adjustment record functionality in ECF. There are only 8 statements with a non-zero `reconcile_amount` value in ECF

I split this into 2 migrators because they are performing different queries against different tables so more difficult to get record counts for the migrator jobs and to combine into 1 migrator without adding a lot of conditional logic and complexity.

If we wanted to combine, it makes more sense to incorporate the "reconcile_amount" migrator into the `Statement` migrator.

### Changes proposed in this pull request

Adds 2 migrators:
* one to migrate statement adjustments from ECF to RECT
* one to create new statement adjustments in RECT for ECF statements with reconcile amounts.

