### PR TITLE
Fix token generation during migration DB refresh

### DIFF
--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Generate known keys
         shell: bash
         run: |
-          kubectl -n cpd-production exec -ti --tty deployment/cpd-ec2-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner \"ParityCheck::TokenProvider.new.generate!\"
+          kubectl -n cpd-production exec -ti --tty deployment/cpd-ec2-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner ParityCheck::TokenProvider.new.generate!"


### PR DESCRIPTION
There was a missing closing quote causing the refresh to fail.

[Successful run](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/15683544563)