### PR TITLE
Fix issue with TRS API in event spec

### DIFF
--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -735,11 +735,11 @@ RSpec.describe Events::Record do
   describe '.record_bulk_upload_completed_event!' do
     let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body:) }
 
+    include_context 'fake trs api client'
+
     before do
       ProcessBatchClaimJob.perform_now(batch, author.email, author.name)
     end
-
-    include_context 'fake trs api client'
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do


### PR DESCRIPTION
### Context

Webmock is now being used, one spec calls TRS via a background job prior to the fake API being included

### Changes proposed in this pull request

Reorder the spec

### Guidance to review
