### PR TITLE
Support POST/PUT and query parameters

### DIFF
--- a/app/migration/parity_check/client.rb
+++ b/app/migration/parity_check/client.rb
@@ -31,7 +31,13 @@ module ParityCheck
     end
 
     def perform_request(app:)
-      HTTParty.send(request_builder.method, request_builder.url(app:), headers: request_builder.headers)
+      HTTParty.send(
+        request_builder.method,
+        request_builder.url(app:),
+        headers: request_builder.headers,
+        query: request_builder.query,
+        body: request_builder.body
+      )
     end
 
     def request_builder

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -1,4 +1,12 @@
 get:
   "/api/v3/statements":
+  "/api/v3/statements":
+    query:
+      filter:
+        cohort: 2021
   "/api/v3/statements/:id":
     id: statement_id
+post:
+  "/api/v3/statements":
+    body: example_statement_body
+

--- a/spec/factories/parity_check/endpoint_factory.rb
+++ b/spec/factories/parity_check/endpoint_factory.rb
@@ -3,5 +3,23 @@ FactoryBot.define do
     add_attribute(:method) { :get }
     path { "/test-path" }
     options { { foo: :bar } }
+
+    trait :get do
+      add_attribute(:method) { :get }
+    end
+
+    trait :post do
+      add_attribute(:method) { :post }
+      options { { body: :example_statement_body } }
+    end
+
+    trait :put do
+      add_attribute(:method) { :post }
+      options { { body: :example_statement_body } }
+    end
+
+    trait :with_query_parameters do
+      options { { query: { filter: "value" } } }
+    end
   end
 end

--- a/spec/migration/parity_check/request_builder_spec.rb
+++ b/spec/migration/parity_check/request_builder_spec.rb
@@ -79,5 +79,52 @@ RSpec.describe ParityCheck::RequestBuilder do
         )
       end
     end
+
+    describe "#body" do
+      subject(:body) { instance.body }
+
+      context "when the body contains an example_statement_body" do
+        let(:options) { { body: :example_statement_body } }
+
+        it "returns the example statement body JSON encoded" do
+          expect(body).to eq({
+            data: {
+              type: "statements",
+              attributes: {
+                content: "This is an example request body.",
+              },
+            },
+          }.to_json)
+        end
+      end
+
+      context "when the options do not specify a body" do
+        let(:options) { {} }
+
+        it { expect(body).to be_nil }
+      end
+
+      context "when the options[:body] method is missing" do
+        let(:options) { { body: :unrecognized_body } }
+
+        it { expect { body }.to raise_error(described_class::UnrecognizedRequestBodyError, "Method missing for body: unrecognized_body") }
+      end
+    end
+
+    describe "#query" do
+      subject(:query) { instance.query }
+
+      context "when the query is a hash" do
+        let(:options) { { query: { filter: { cohort: 2022 } } } }
+
+        it { is_expected.to eq(options[:query]) }
+      end
+
+      context "when the query is not a hash" do
+        let(:options) { { query: "filter=test" } }
+
+        it { expect { query }.to raise_error(described_class::UnrecognizedQueryError, "Query must be a Hash: filter=test") }
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/parity_check_support.rb
+++ b/spec/support/shared_examples/parity_check_support.rb
@@ -38,3 +38,78 @@ RSpec.shared_examples "completable validations" do
     end
   end
 end
+
+RSpec.shared_examples "client performs requests" do
+  let(:requests) { WebMock::RequestRegistry.instance.requested_signatures.hash.keys }
+  let(:ecf_requests) { requests.select { |r| r.uri.to_s.include?(ecf_url) } }
+  let(:rect_requests) { requests.select { |r| r.uri.to_s.include?(rect_url) } }
+
+  before do
+    # In case the endpoint path has parameters directly in it
+    # we strip them out (as we test explicitly for them elsewhere).
+    path_without_query_parameters = endpoint.path.split("?").first
+
+    stub_request(endpoint.method, %r{#{ecf_url + path_without_query_parameters}.*}).to_return(status: 200, body: "ecf_body")
+    stub_request(endpoint.method, %r{#{rect_url + path_without_query_parameters}.*}).to_return(status: 201, body: "rect_body")
+  end
+
+  it "makes requests to the correct URL for each app" do
+    instance.perform_requests {}
+
+    expect(ecf_requests.count).to eq(1)
+    expect(rect_requests.count).to eq(1)
+  end
+
+  it "makes requests with the correct headers" do
+    instance.perform_requests {}
+
+    expect(requests.map(&:headers)).to all include({
+      "Content-Type" => "application/json",
+      "Accept" => "application/json",
+      "Authorization" => "Bearer #{token}",
+    })
+  end
+
+  it "makes requests with the correct query parameters" do
+    options_query_parameters = endpoint.options[:query] || {}
+    path_query_parameters = Addressable::URI.parse(endpoint.path).query_values || {}
+    all_query_parameters = path_query_parameters.merge(options_query_parameters).to_query.presence
+
+    if all_query_parameters
+      instance.perform_requests {}
+
+      expect(ecf_requests.first.uri.query).to eq(all_query_parameters)
+      expect(rect_requests.first.uri.query).to eq(all_query_parameters)
+    end
+  end
+
+  it "makes requests with the correct body" do
+    body = endpoint.options[:body]
+
+    if body
+      instance.perform_requests {}
+
+      ecf_body = ecf_requests.first.body
+      rect_body = rect_requests.first.body
+
+      expect(ecf_body).to be_present
+      expect(rect_body).to be_present
+
+      expect { JSON.parse(ecf_body) }.not_to raise_error
+      expect { JSON.parse(rect_body) }.not_to raise_error
+    end
+  end
+
+  it "yields the response of request to the block" do
+    instance.perform_requests do |response|
+      expect(response).to have_attributes({
+        ecf_body: "ecf_body",
+        ecf_status_code: 200,
+        ecf_time_ms: be >= 0,
+        rect_body: "rect_body",
+        rect_status_code: 201,
+        rect_time_ms: be >= 0
+      })
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to update the parity check to support POST and PUT endpoints, as well as endpoints that contain query parameters.

### Changes proposed in this pull request

- Support POST/PUT and query parameters

Update `RequestBuilder` to to extract query parameters and the request body from the request options.

Pass the body and query parameters through to `HTTParty` in the parity check `Client`.

### Guidance to review

Contains an example request body for now for the tests; we can change this when we add the first set of POST/PUT endpoints.