### PR TITLE
Rename Lead Provider `api_id` to `ecf_id`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,6 @@ GIAS_API_PASSWORD=
 GIAS_API_USER=
 GIAS_EXTRACT_ID=
 ENABLE_TRS_TEACHER_REFRESH=true
-PARITY_CHECK_KEYS='{"lead_provider_api_id":"token"}'
+PARITY_CHECK_KEYS='{"lead_provider_ecf_id":"token"}'
 PARITY_CHECK_ECF_URL=https://cpd-ecf-migration-web.teacherservices.cloud
 PARITY_CHECK_RECT_URL=https://cpd-ec2-migration-web.teacherservices.cloud

--- a/app/migration/migrators/active_lead_provider.rb
+++ b/app/migration/migrators/active_lead_provider.rb
@@ -24,7 +24,7 @@ module Migrators
 
     def migrate!
       migrate(self.class.active_lead_providers) do |ecf_active_lead_provider|
-        lead_provider_id = find_lead_provider_id!(api_id: ecf_active_lead_provider.id)
+        lead_provider_id = find_lead_provider_id!(ecf_id: ecf_active_lead_provider.id)
 
         ::ActiveLeadProvider.find_or_create_by!(
           lead_provider_id:,

--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -117,8 +117,8 @@ module Migrators
       @data_migration ||= DataMigration.find_by(model: self.class.model, worker:)
     end
 
-    def find_lead_provider_id!(api_id:)
-      lead_provider_ids_by_api_id[api_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find LeadProvider")
+    def find_lead_provider_id!(ecf_id:)
+      lead_provider_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find LeadProvider")
     end
 
     def find_active_lead_provider_id!(lead_provider_id:, registration_period_id:)
@@ -169,8 +169,8 @@ module Migrators
       MigrationJob.set(wait: 10.seconds).perform_later
     end
 
-    def lead_provider_ids_by_api_id
-      @lead_provider_ids_by_api_id ||= ::LeadProvider.pluck(:api_id, :id).to_h
+    def lead_provider_ids_by_ecf_id
+      @lead_provider_ids_by_ecf_id ||= ::LeadProvider.pluck(:ecf_id, :id).to_h
     end
 
     def active_lead_provider_ids_by_lead_provider_and_registration_period

--- a/app/migration/migrators/lead_provider.rb
+++ b/app/migration/migrators/lead_provider.rb
@@ -20,7 +20,7 @@ module Migrators
 
     def migrate!
       migrate(self.class.lead_providers) do |lead_provider|
-        lp = ::LeadProvider.find_or_initialize_by(api_id: lead_provider.id)
+        lp = ::LeadProvider.find_or_initialize_by(ecf_id: lead_provider.id)
 
         lp.name = lead_provider.name
         lp.created_at = lead_provider.created_at

--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -26,7 +26,7 @@ module Migrators
       migrate(self.class.statements) do |ecf_statement|
         statement = ::Statement.find_or_initialize_by(api_id: ecf_statement.id)
 
-        lead_provider_id = find_lead_provider_id!(api_id: ecf_statement.lead_provider.id)
+        lead_provider_id = find_lead_provider_id!(ecf_id: ecf_statement.lead_provider.id)
         registration_period_id = ecf_statement.cohort.start_year
 
         statement.update!(

--- a/app/migration/parity_check/token_provider.rb
+++ b/app/migration/parity_check/token_provider.rb
@@ -5,8 +5,8 @@ module ParityCheck
     def generate!
       ensure_parity_check_enabled!
 
-      known_tokens_by_lead_provider_api_id.each do |api_id, token|
-        lead_provider = LeadProvider.find_by(api_id:)
+      known_tokens_by_lead_provider_ecf_id.each do |ecf_id, token|
+        lead_provider = LeadProvider.find_by(ecf_id:)
         API::TokenManager.create_lead_provider_api_token!(lead_provider:, token:) if lead_provider
       end
     end
@@ -14,12 +14,12 @@ module ParityCheck
     def token(lead_provider:)
       ensure_parity_check_enabled!
 
-      known_tokens_by_lead_provider_api_id[lead_provider.api_id]
+      known_tokens_by_lead_provider_ecf_id[lead_provider.ecf_id]
     end
 
   private
 
-    def known_tokens_by_lead_provider_api_id
+    def known_tokens_by_lead_provider_ecf_id
       JSON.parse(parity_check_tokens) || {}
     rescue JSON::ParserError
       {}

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -7,5 +7,5 @@ class LeadProvider < ApplicationRecord
 
   # Validations
   validates :name, presence: true, uniqueness: true
-  validates :api_id, uniqueness: { case_sensitive: false }, allow_nil: true
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -293,7 +293,7 @@
   - email
   :lead_providers:
   - id
-  - api_id
+  - ecf_id
   - name
   - created_at
   - updated_at

--- a/db/migrate/20250617185849_rename_api_id_to_ecf_id_in_lead_providers.rb
+++ b/db/migrate/20250617185849_rename_api_id_to_ecf_id_in_lead_providers.rb
@@ -1,0 +1,5 @@
+class RenameAPIIdToECFIdInLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :lead_providers, :api_id, :ecf_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_16_160837) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_17_185849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -308,8 +308,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_16_160837) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "api_id"
-    t.index ["api_id"], name: "index_lead_providers_on_api_id", unique: true
+    t.uuid "ecf_id"
+    t.index ["ecf_id"], name: "index_lead_providers_on_ecf_id", unique: true
     t.index ["name"], name: "index_lead_providers_on_name", unique: true
   end
 

--- a/spec/factories/lead_provider_factory.rb
+++ b/spec/factories/lead_provider_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:lead_provider) do
     sequence(:name) { |n| "Lead Provider #{n}" }
-    api_id { SecureRandom.uuid }
+    ecf_id { SecureRandom.uuid }
   end
 end

--- a/spec/migration/migrators/active_lead_provider_spec.rb
+++ b/spec/migration/migrators/active_lead_provider_spec.rb
@@ -6,7 +6,7 @@ describe Migrators::ActiveLeadProvider do
 
     def create_resource(migration_resource)
       # creating dependencies resources
-      FactoryBot.create(:lead_provider, name: migration_resource.name, api_id: migration_resource.id)
+      FactoryBot.create(:lead_provider, name: migration_resource.name, ecf_id: migration_resource.id)
       FactoryBot.create(:registration_period, year: migration_resource.cohorts.first.start_year)
 
       FactoryBot.create(:active_lead_provider)
@@ -24,7 +24,7 @@ describe Migrators::ActiveLeadProvider do
         instance.migrate!
 
         active_lead_provider = ActiveLeadProvider.find_by(
-          lead_provider_id: LeadProvider.find_by_api_id(migration_resource1.id).id,
+          lead_provider_id: LeadProvider.find_by_ecf_id(migration_resource1.id).id,
           registration_period_id: migration_resource1.cohorts.first.start_year
         )
         expect(active_lead_provider).to be_present

--- a/spec/migration/migrators/lead_provider_spec.rb
+++ b/spec/migration/migrators/lead_provider_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Migrators::LeadProvider do
 
     def setup_failure_state
       lp = FactoryBot.create(:migration_lead_provider)
-      FactoryBot.create(:lead_provider, name: lp.name, api_id: SecureRandom.uuid)
+      FactoryBot.create(:lead_provider, name: lp.name, ecf_id: SecureRandom.uuid)
     end
 
     describe "#migrate!" do
@@ -23,7 +23,7 @@ RSpec.describe Migrators::LeadProvider do
         instance.migrate!
 
         ::LeadProvider.find_each do |lead_provider|
-          source_record = Migration::LeadProvider.find(lead_provider.api_id)
+          source_record = Migration::LeadProvider.find(lead_provider.ecf_id)
           expect(lead_provider.name).to eq source_record.name
           expect(lead_provider.created_at).to eq source_record.created_at
           expect(lead_provider.updated_at).to eq source_record.updated_at

--- a/spec/migration/migrators/reconcile_adjustment_spec.rb
+++ b/spec/migration/migrators/reconcile_adjustment_spec.rb
@@ -10,7 +10,7 @@ describe Migrators::ReconcileAdjustment do
       ecf_lp = migration_resource.lead_provider
       ecf_cohort = migration_resource.cohort
 
-      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, api_id: ecf_lp.id)
+      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
       registration_period = FactoryBot.create(:registration_period, year: ecf_cohort.start_year)
       active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
       FactoryBot.create(:statement, api_id: migration_resource.id, lead_provider:, registration_period:, active_lead_provider:)

--- a/spec/migration/migrators/statement_adjustment_spec.rb
+++ b/spec/migration/migrators/statement_adjustment_spec.rb
@@ -10,7 +10,7 @@ describe Migrators::StatementAdjustment do
       ecf_lp = migration_resource.statement.lead_provider
       ecf_cohort = migration_resource.statement.cohort
 
-      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, api_id: ecf_lp.id)
+      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
       registration_period = FactoryBot.create(:registration_period, year: ecf_cohort.start_year)
       active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
       FactoryBot.create(:statement, api_id: migration_resource.statement_id, lead_provider:, registration_period:, active_lead_provider:)

--- a/spec/migration/migrators/statement_spec.rb
+++ b/spec/migration/migrators/statement_spec.rb
@@ -6,7 +6,7 @@ describe Migrators::Statement do
 
     def create_resource(migration_resource)
       # creating dependencies resources
-      lead_provider = FactoryBot.create(:lead_provider, name: migration_resource.lead_provider.name, api_id: migration_resource.lead_provider.id)
+      lead_provider = FactoryBot.create(:lead_provider, name: migration_resource.lead_provider.name, ecf_id: migration_resource.lead_provider.id)
       registration_period = FactoryBot.create(:registration_period, year: migration_resource.cohort.start_year)
       FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
 

--- a/spec/migration/parity_check/client_spec.rb
+++ b/spec/migration/parity_check/client_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ParityCheck::Client do
       enabled: true,
       ecf_url:,
       rect_url:,
-      tokens: { request.lead_provider.api_id => token }.to_json,
+      tokens: { request.lead_provider.ecf_id => token }.to_json,
     })
   end
 

--- a/spec/migration/parity_check/configuration_spec.rb
+++ b/spec/migration/parity_check/configuration_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ParityCheck::Configuration do
   let(:enabled) { true }
-  let(:tokens) { { "lead_provider_api_id" => "test_token" } }
+  let(:tokens) { { "lead_provider_ecf_id" => "test_token" } }
   let(:ecf_url) { "https://ecf.example.com" }
   let(:rect_url) { "https://rect.example.com" }
   let(:instance) { Class.new { include ParityCheck::Configuration }.new }

--- a/spec/migration/parity_check/request_builder_spec.rb
+++ b/spec/migration/parity_check/request_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ParityCheck::RequestBuilder do
   end
 
   describe "instance methods" do
-    let(:tokens) { { lead_provider.api_id => "test_token" } }
+    let(:tokens) { { lead_provider.ecf_id => "test_token" } }
     let(:ecf_url) { "https://ecf.example.com" }
     let(:rect_url) { "https://rect.example.com" }
 

--- a/spec/migration/parity_check/token_provider_spec.rb
+++ b/spec/migration/parity_check/token_provider_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ParityCheck::TokenProvider do
     context "when the tokens are present" do
       let(:tokens) do
         LeadProvider.all.each_with_object({}) do |lead_provider, hash|
-          hash[lead_provider.api_id] = SecureRandom.uuid
+          hash[lead_provider.ecf_id] = SecureRandom.uuid
         end
       end
 
@@ -33,13 +33,13 @@ RSpec.describe ParityCheck::TokenProvider do
         generate
 
         LeadProvider.find_each do |lead_provider|
-          token = tokens[lead_provider.api_id]
+          token = tokens[lead_provider.ecf_id]
           expect(API::TokenManager.find_lead_provider_api_token(token:).lead_provider).to eq(lead_provider)
         end
       end
 
       context "when the tokens don't match the lead providers" do
-        let(:tokens) { { "non_existent_api_id" => SecureRandom.uuid } }
+        let(:tokens) { { "non_existent_ecf_id" => SecureRandom.uuid } }
 
         it { expect { generate }.not_to change(API::Token, :count) }
       end
@@ -65,7 +65,7 @@ RSpec.describe ParityCheck::TokenProvider do
     end
 
     context "when the keys are present" do
-      let(:tokens) { { lead_provider.api_id => "token" } }
+      let(:tokens) { { lead_provider.ecf_id => "token" } }
 
       it { is_expected.to eq("token") }
     end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -11,6 +11,6 @@ describe LeadProvider do
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
-    it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.allow_nil }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.allow_nil }
   end
 end


### PR DESCRIPTION
### Context

We will be importing the `uuid` from ECF1 into RECT. IDs required for the API will be stored in columns called `api_id` Those values will autogenerate when not set and will never be `null`. 

IDs required for the migration and to make moving data easier, however not needed for the API and likely to be removed after will be called `ecf_id`. Those IDs are not auto generated and can be `null`

Lead provider ids are not surfaced in the API so can be renamed to `ecf_id`

### Changes proposed in this pull request
- Rename the column `api_id` to `ecf_id` in Lead providers
- Rename all occurrences of this column name in migrators and parity check to `ecf_id`

