### PR TITLE
Rework `ECTAtSchoolPeriods::Training` and uncomment the disabled specs

### DIFF
--- a/app/services/ect_at_school_periods/training.rb
+++ b/app/services/ect_at_school_periods/training.rb
@@ -1,44 +1,74 @@
 module ECTAtSchoolPeriods
   class Training
-    attr_reader :ect_at_school_period
+    attr_reader :ect_at_school_period, :latest_training_period
 
     def initialize(ect_at_school_period)
       @ect_at_school_period = ect_at_school_period
+
+      @latest_training_period ||= ect_at_school_period.training_periods
+                                                      .eager_load(**eager_load_confirmed_partnership_tables)
+                                                      .started_before(Date.tomorrow)
+                                                      .latest_first
+                                                      .first
     end
 
     def current_training_period
       latest_training_period if latest_training_period&.ongoing?
     end
 
-    # current_delivery_partner
-    delegate :delivery_partner, to: :current_training_period, allow_nil: true, prefix: :current
+    def current_lead_provider
+      current_training_period
+        &.school_partnership
+        &.lead_provider_delivery_partnership
+        &.active_lead_provider
+        &.lead_provider
+    end
+
+    def current_delivery_partner
+      current_training_period
+        &.school_partnership
+        &.lead_provider_delivery_partnership
+        &.delivery_partner
+    end
 
     # current_delivery_partner_name
     delegate :name, to: :current_delivery_partner, allow_nil: true, prefix: true
 
-    # current_lead_provider
-    delegate :lead_provider, to: :current_training_period, allow_nil: true, prefix: :current
-
     # current_lead_provider_name
     delegate :name, to: :current_lead_provider, allow_nil: true, prefix: true
 
-    def latest_training_period
-      @latest_training_period ||= ect_at_school_period.training_periods
-                                                      .started_before(Date.tomorrow)
-                                                      .latest_first
-                                                      .first
+    def latest_lead_provider
+      latest_training_period
+        &.school_partnership
+        &.lead_provider_delivery_partnership
+        &.active_lead_provider
+        &.lead_provider
     end
 
-    # latest_delivery_partner
-    delegate :delivery_partner, to: :latest_training_period, allow_nil: true, prefix: :latest
+    def latest_delivery_partner
+      latest_training_period
+        &.school_partnership
+        &.lead_provider_delivery_partnership
+        &.delivery_partner
+    end
 
     # latest_delivery_partner_name
     delegate :name, to: :latest_delivery_partner, allow_nil: true, prefix: true
 
-    # latest_lead_provider
-    delegate :lead_provider, to: :latest_training_period, allow_nil: true, prefix: :latest
-
     # latest_lead_provider_name
     delegate :name, to: :latest_lead_provider, allow_nil: true, prefix: true
+
+  private
+
+    def eager_load_confirmed_partnership_tables
+      {
+        school_partnership: {
+          lead_provider_delivery_partnership: [
+            :delivery_partner,
+            { active_lead_provider: %i[lead_provider registration_period] }
+          ]
+        }
+      }
+    end
   end
 end

--- a/app/services/ect_at_school_periods/training.rb
+++ b/app/services/ect_at_school_periods/training.rb
@@ -21,10 +21,10 @@ module ECTAtSchoolPeriods
     delegate :school_partnership, to: :current_training_period, allow_nil: true, prefix: :current
 
     # current_lead_provider_delivery_partnership
-    delegate :lead_provider_delivery_partnership, to: :current_school_partnership, allow_nil: true, prefix: :current
+    delegate :lead_provider_delivery_partnership, to: :current_school_partnership, allow_nil: true, prefix: :current, private: true
 
     # current_active_lead_provider
-    delegate :active_lead_provider, to: :current_lead_provider_delivery_partnership, allow_nil: true, prefix: :current
+    delegate :active_lead_provider, to: :current_lead_provider_delivery_partnership, allow_nil: true, prefix: :current, private: true
 
     # current_lead_provider
     delegate :lead_provider, to: :current_active_lead_provider, allow_nil: true, prefix: :current
@@ -44,10 +44,10 @@ module ECTAtSchoolPeriods
     delegate :school_partnership, to: :latest_training_period, allow_nil: true, prefix: :latest
 
     # latest_lead_provider_delivery_partnership
-    delegate :lead_provider_delivery_partnership, to: :latest_school_partnership, allow_nil: true, prefix: :latest
+    delegate :lead_provider_delivery_partnership, to: :latest_school_partnership, allow_nil: true, prefix: :latest, private: true
 
     # latest_active_lead_provider
-    delegate :active_lead_provider, to: :latest_lead_provider_delivery_partnership, allow_nil: true, prefix: :latest
+    delegate :active_lead_provider, to: :latest_lead_provider_delivery_partnership, allow_nil: true, prefix: :latest, private: true
 
     # latest_lead_provider
     delegate :lead_provider, to: :latest_active_lead_provider, allow_nil: true, prefix: :latest

--- a/spec/services/ect_at_school_periods/training_spec.rb
+++ b/spec/services/ect_at_school_periods/training_spec.rb
@@ -1,4 +1,4 @@
-xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, needs adjustment" do
+describe ECTAtSchoolPeriods::Training do
   describe "#current_training_period" do
     subject { described_class.new(ect_at_school_period).current_training_period }
 
@@ -45,7 +45,7 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.delivery_partner) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
   end
 
@@ -70,7 +70,7 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.delivery_partner.name) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
   end
 
@@ -95,7 +95,7 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.lead_provider) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
   end
 
@@ -120,7 +120,7 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.lead_provider.name) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
   end
 
@@ -159,14 +159,14 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
     context "when the ect has had past training periods" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
-      it { is_expected.to eq(old_training.delivery_partner) }
+      it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.delivery_partner) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
   end
 
@@ -182,14 +182,14 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
     context "when the ect has had past training periods" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
-      it { is_expected.to eq(old_training.delivery_partner.name) }
+      it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.delivery_partner.name) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
   end
 
@@ -205,14 +205,14 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
     context "when the ect has had past training periods" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
-      it { is_expected.to eq(old_training.lead_provider) }
+      it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.lead_provider) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
   end
 
@@ -228,14 +228,14 @@ xdescribe ECTAtSchoolPeriods::Training, pending: "written before the EOI model, 
     context "when the ect has had past training periods" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
-      it { is_expected.to eq(old_training.lead_provider.name) }
+      it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
       let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
-      it { is_expected.to eq(ongoing_training.lead_provider.name) }
+      it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
   end
 end


### PR DESCRIPTION
### Context

These specs were commented out as part of #507.

Now it's done they are being reinstated.

I rejigged the service class so it adheres to the new schema.

It also now eager loads the whole set of training data up front so we're not firing query after query while traversing.

Fixes #767
