### PR TITLE
Create a module for range query helpers

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -2,11 +2,11 @@ module Interval
   extend ActiveSupport::Concern
 
   included do
+    include Queries::RangeQueries
     # Validations
     validate :period_dates_validation
 
     # Scopes
-    scope :overlapping_with, ->(period) { where("range && daterange(?, ?)", period.started_on, period.finished_on) }
     scope :ongoing, -> { where(finished_on: nil) }
     scope :finished, -> { where.not(finished_on: nil) }
     scope :earliest_first, -> { order(started_on: 'asc') }
@@ -15,8 +15,9 @@ module Interval
     scope :started_on_or_after, ->(date) { where(started_on: date..) }
     scope :finished_before, ->(date) { where(finished_on: ...date) }
     scope :finished_on_or_after, ->(date) { where(finished_on: date..) }
-    scope :containing_period, ->(period) { where("range @> daterange(?, ?)", period.started_on, period.finished_on) }
-    scope :ongoing_on, ->(date) { where("range @> ?::date", date) }
+    scope :overlapping_with, ->(period) { where(*overlapping_with_range(period.started_on, period.finished_on)) }
+    scope :containing_period, ->(period) { where(*containing_range(period.started_on, period.finished_on)) }
+    scope :ongoing_on, ->(date) { where(*date_in_range(date)) }
   end
 
   # Validations

--- a/app/services/queries/range_queries.rb
+++ b/app/services/queries/range_queries.rb
@@ -1,0 +1,19 @@
+module Queries
+  module RangeQueries
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def date_in_range(date, range_column: 'range')
+        [%("#{table_name}"."#{range_column}" @> date(?)), date]
+      end
+
+      def containing_range(start, finish, range_column: 'range')
+        [%("#{table_name}"."#{range_column}" @> daterange(?, ?)), start, finish]
+      end
+
+      def overlapping_with_range(start, finish, range_column: 'range')
+        [%("#{table_name}"."#{range_column}" && daterange(?, ?)), start, finish]
+      end
+    end
+  end
+end

--- a/spec/services/queries/range_queries_spec.rb
+++ b/spec/services/queries/range_queries_spec.rb
@@ -1,0 +1,34 @@
+class FakeRangeQueryClass
+  include Queries::RangeQueries
+
+  def self.table_name = 'a_fake_table'
+end
+
+describe Queries::RangeQueries do
+  let(:start) { Date.new(2001, 1, 1) }
+  let(:finish) { Date.new(2001, 2, 2) }
+
+  describe '.date_in_range' do
+    subject { FakeRangeQueryClass.date_in_range(start) }
+
+    let(:clause) { %{"a_fake_table"."range" @> date(?)} }
+
+    it { is_expected.to eql([clause, start]) }
+  end
+
+  describe '.containing_range' do
+    subject { FakeRangeQueryClass.containing_range(start, finish) }
+
+    let(:clause) { %{"a_fake_table"."range" @> daterange(?, ?)} }
+
+    it { is_expected.to eql([clause, start, finish]) }
+  end
+
+  describe '.overlapping_with_range' do
+    subject { FakeRangeQueryClass.overlapping_with_range(start, finish) }
+
+    let(:clause) { %{"a_fake_table"."range" && daterange(?, ?)} }
+
+    it { is_expected.to eql([clause, start, finish]) }
+  end
+end


### PR DESCRIPTION
The reasons for moving this logic to a module are:

* the [PostgreSQL range query](https://www.postgresql.org/docs/current/functions-range.html) syntax is a little terse and the method names are (hopefully) easier to understand
* there will soon be methods that make use of this syntax outside of a scope, i.e., when finding the current `RegistrationPeriod` (where we'd want a `.find_by` rather than a `.where`)

The scopes which use these methods are already tested so here we're just confirming that they produce the right args that can be passed into `where`.

This functionality will soon be used as part of DFE-Digital/register-ects-project-board#1499