### PR TITLE
Switch parity check from HTTParty to Faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "govuk_markdown"
 
 gem "mail-notify"
 
-gem "httparty"
 gem "sentry-rails"
 gem "sentry-ruby"
 gem "solid_queue"
@@ -55,6 +54,8 @@ gem 'turbo-rails'
 # JSON Serializer
 gem "blueprinter"
 gem "oj"
+
+gem "async-http-faraday"
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,27 @@ GEM
       nokogiri
     asciidoctor (2.0.23)
     ast (2.4.3)
+    async (2.25.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.15)
+    async-http (0.89.0)
+      async (>= 2.10.2)
+      async-pool (~> 0.9)
+      io-endpoint (~> 0.14)
+      io-stream (~> 0.6)
+      metrics (~> 0.12)
+      protocol-http (~> 0.49)
+      protocol-http1 (~> 0.30)
+      protocol-http2 (~> 0.22)
+      traces (~> 0.10)
+    async-http-faraday (0.21.0)
+      async-http (~> 0.42)
+      faraday
+    async-pool (0.10.3)
+      async (>= 1.25)
     attr_extras (7.1.0)
     attr_required (1.0.2)
     base32 (0.3.4)
@@ -147,6 +168,10 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    console (1.31.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     crack (1.0.0)
       bigdecimal
       rexml
@@ -191,6 +216,10 @@ GEM
     faraday-net_http (3.3.0)
       net-http
     ffi (1.17.0)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -269,6 +298,9 @@ GEM
       concurrent-ruby (~> 1.1)
       sorted_set (~> 1.0)
     io-console (0.8.0)
+    io-endpoint (0.15.2)
+    io-event (1.11.0)
+    io-stream (0.6.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
@@ -314,6 +346,7 @@ GEM
     matrix (0.4.2)
     memo_wise (1.11.0)
     method_source (1.1.0)
+    metrics (0.12.2)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
@@ -451,6 +484,13 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
+    protocol-hpack (1.5.1)
+    protocol-http (0.50.1)
+    protocol-http1 (0.34.0)
+      protocol-http (~> 0.22)
+    protocol-http2 (0.22.1)
+      protocol-hpack (~> 1.4)
+      protocol-http (~> 0.47)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -676,6 +716,7 @@ GEM
       faraday-follow_redirects
     thor (1.3.2)
     timeout (0.4.3)
+    traces (0.15.2)
     trailblazer-option (0.1.2)
     tty-color (0.6.0)
     tty-command (0.10.1)
@@ -739,6 +780,7 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor
+  async-http-faraday
   base32
   better_errors
   binding_of_caller
@@ -759,7 +801,6 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   govuk_markdown
   hotwire-rails
-  httparty
   jsbundling-rails
   mail-notify
   nanoc

--- a/app/migration/parity_check/request_benchmark.rb
+++ b/app/migration/parity_check/request_benchmark.rb
@@ -1,0 +1,15 @@
+module ParityCheck
+  class RequestBenchmark < Faraday::Middleware
+    def on_request(env)
+      env[:request_start_time] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def on_complete(env)
+      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      start_time = env[:request_start_time]
+      duration_ms = (end_time - start_time) * 1_000
+
+      env[:request_duration_ms] = duration_ms
+    end
+  end
+end

--- a/spec/migration/parity_check/client_spec.rb
+++ b/spec/migration/parity_check/client_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ParityCheck::Client do
     it "raises an UnsupportedRequestMethodError" do
       expect {
         instance.perform_requests {}
-      }.to raise_error(NoMethodError, "undefined method 'fetch' for module HTTParty")
+      }.to raise_error(NoMethodError, "undefined method 'fetch' for an instance of Faraday::Connection")
     end
   end
 end

--- a/spec/migration/parity_check/request_benchmark_spec.rb
+++ b/spec/migration/parity_check/request_benchmark_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe ParityCheck::RequestBenchmark do
+  it "attaches the request duration in milliseconds to the response env" do
+    allow(Process).to receive(:clock_gettime).and_return(1.0, 1.25)
+
+    connection = Faraday::Connection.new { it.use described_class }
+    url = "http://example.com"
+    stub_request(:get, url).to_return(status: 200, body: "OK")
+    response = connection.get(url)
+
+    expect(response.env[:request_duration_ms].to_i).to eq(250)
+  end
+end


### PR DESCRIPTION
We are switching the parity check to use Faraday to be consistent with other areas of the app.

It makes sense to take advantage of the in_parallel support Faraday offers to make the parity check requests in parallel (to both services at the same time). This should make the overall parity check run quicker.

Extracts the response benchmarking to a Faraday middleware to make the client cleaner.