### PR TITLE
Rename `statements.state` to `status`

### DIFF
--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -37,7 +37,7 @@ module Migrators
           payment_date: ecf_statement.payment_date,
           marked_as_paid_at: ecf_statement.marked_as_paid_at,
           output_fee: ecf_statement.output_fee,
-          state: state(ecf_statement),
+          status: status(ecf_statement),
           created_at: ecf_statement.created_at,
           updated_at: ecf_statement.updated_at
         )
@@ -46,7 +46,7 @@ module Migrators
 
   private
 
-    def state(ecf_statement)
+    def status(ecf_statement)
       case ecf_statement.type
       when "Finance::Statement::ECF::Payable"
         :payable

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -13,9 +13,9 @@ class Statement < ApplicationRecord
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement" }
 
   scope :with_output_fee, ->(output_fee: true) { where(output_fee:) }
-  scope :with_state, ->(*state) { where(state:) }
+  scope :with_state, ->(*status) { where(status:) }
 
-  state_machine :state, initial: :open do
+  state_machine :status, initial: :open do
     state :open
     state :payable
     state :paid
@@ -29,8 +29,8 @@ class Statement < ApplicationRecord
     end
   end
 
-  def shorthand_state
-    case state
+  def shorthand_status
+    case status
     when "open"
       "OP"
     when "payable"
@@ -38,7 +38,7 @@ class Statement < ApplicationRecord
     when "paid"
       "PD"
     else
-      raise ArgumentError, "Unknown state: #{state}"
+      raise ArgumentError, "Unknown status: #{status}"
     end
   end
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -13,7 +13,7 @@ class Statement < ApplicationRecord
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement" }
 
   scope :with_output_fee, ->(output_fee: true) { where(output_fee:) }
-  scope :with_state, ->(*status) { where(status:) }
+  scope :with_status, ->(*status) { where(status:) }
 
   state_machine :status, initial: :open do
     state :open

--- a/app/presenters/admin/statement_presenter.rb
+++ b/app/presenters/admin/statement_presenter.rb
@@ -11,9 +11,9 @@ module Admin
     end
 
     def status_tag_kwargs
-      colour = { 'open' => 'blue', 'payable' => 'yellow', 'paid' => 'green' }.fetch(statement.state)
+      colour = { 'open' => 'blue', 'payable' => 'yellow', 'paid' => 'green' }.fetch(statement.status)
 
-      { text: statement.state.capitalize, colour: }
+      { text: statement.status.capitalize, colour: }
     end
 
     def page_title

--- a/app/services/sandbox_seed_data/statements.rb
+++ b/app/services/sandbox_seed_data/statements.rb
@@ -33,7 +33,7 @@ module SandboxSeedData
               deadline_date:
             ) do |statement|
               statement.payment_date = payment_date(deadline_date)
-              statement.state = state(statement.payment_date, deadline_date)
+              statement.status = status(statement.payment_date, deadline_date)
               statement.output_fee = output_fee
             end
           end
@@ -73,7 +73,7 @@ module SandboxSeedData
       Time.zone.local(year, month).end_of_month
     end
 
-    def state(payment_date, deadline_date)
+    def status(payment_date, deadline_date)
       if payment_date < Date.current
         :paid
       elsif Date.current.between?(deadline_date, payment_date)
@@ -98,21 +98,21 @@ module SandboxSeedData
       Date::MONTHNAMES[month].rjust(COL_WIDTHS[:month])
     end
 
-    def shorthand_states(statements_by_year_and_month, month, year)
-      statements_by_year_and_month.dig(year, month)&.map(&:shorthand_state) || []
+    def shorthand_statuses(statements_by_year_and_month, month, year)
+      statements_by_year_and_month.dig(year, month)&.map(&:shorthand_status) || []
     end
 
-    def format_states(shorthand_states)
-      return 'none'.rjust(COL_WIDTHS[:year]) unless shorthand_states
+    def format_statuses(shorthand_statuses)
+      return 'none'.rjust(COL_WIDTHS[:year]) unless shorthand_statuses
 
-      coloured_states = shorthand_states.map { |state| Colourize.text(state, STATE_COLOURS[state.to_sym]) }
+      coloured_statuses = shorthand_statuses.map { |status| Colourize.text(status, STATE_COLOURS[status.to_sym]) }
       # The colourizing characters affect the length so offset the rjust.
-      offset = coloured_states.sum(&:length) - shorthand_states.sum(&:length)
-      coloured_states.join(", ").rjust(COL_WIDTHS[:year] + offset)
+      offset = coloured_statuses.sum(&:length) - shorthand_statuses.sum(&:length)
+      coloured_statuses.join(", ").rjust(COL_WIDTHS[:year] + offset)
     end
 
     def build_month_row(month, years, statements_by_year_and_month)
-      [format_month(month)] + years.map { |year| format_states(shorthand_states(statements_by_year_and_month, month, year)) }
+      [format_month(month)] + years.map { |year| format_statuses(shorthand_statuses(statements_by_year_and_month, month, year)) }
     end
 
     def log_statement_seed_info(lead_provider, statements)

--- a/app/services/statements/query.rb
+++ b/app/services/statements/query.rb
@@ -5,13 +5,13 @@ module Statements
 
     attr_reader :scope
 
-    def initialize(lead_provider: :ignore, registration_period_years: :ignore, updated_since: :ignore, state: :ignore, output_fee: true)
+    def initialize(lead_provider: :ignore, registration_period_years: :ignore, updated_since: :ignore, status: :ignore, output_fee: true)
       @scope = Statement.distinct.includes(active_lead_provider: %i[lead_provider registration_period])
 
       where_lead_provider_is(lead_provider)
       where_registration_period_year_in(registration_period_years)
       where_updated_since(updated_since)
-      where_state_is(state)
+      where_status_is(status)
       where_output_fee_is(output_fee)
     end
 
@@ -51,10 +51,10 @@ module Statements
       scope.merge!(Statement.where(updated_at: updated_since..))
     end
 
-    def where_state_is(state)
+    def where_status_is(state)
       return if ignore?(filter: state)
 
-      scope.merge!(Statement.with_state(extract_conditions(state)))
+      scope.merge!(Statement.with_status(extract_conditions(state)))
     end
 
     def where_output_fee_is(output_fee)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -401,7 +401,7 @@
   - payment_date
   - marked_as_paid_at
   - output_fee
-  - state
+  - status
   - created_at
   - updated_at
   :api_tokens:

--- a/db/migrate/20250620092940_rename_statements_state_to_status.rb
+++ b/db/migrate/20250620092940_rename_statements_state_to_status.rb
@@ -1,0 +1,6 @@
+class RenameStatementsStateToStatus < ActiveRecord::Migration[8.0]
+  def change
+    rename_enum :statement_states, :statement_statuses
+    rename_column :statements, :state, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_19_092538) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_20_092940) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_092538) do
   create_enum "induction_programme", ["cip", "fip", "diy", "unknown", "pre_september_2021"]
   create_enum "mentor_became_ineligible_for_funding_reason", ["completed_declaration_received", "completed_during_early_roll_out", "started_not_completed"]
   create_enum "request_method_types", ["get", "post", "put"]
-  create_enum "statement_states", ["open", "payable", "paid"]
+  create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
@@ -621,7 +621,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_092538) do
     t.date "payment_date", null: false
     t.datetime "marked_as_paid_at"
     t.boolean "output_fee", default: true, null: false
-    t.enum "state", default: "open", null: false, enum_type: "statement_states"
+    t.enum "status", default: "open", null: false, enum_type: "statement_statuses"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["active_lead_provider_id"], name: "index_statements_on_active_lead_provider_id"

--- a/db/seeds/statements.rb
+++ b/db/seeds/statements.rb
@@ -19,12 +19,12 @@ def describe_group_of_statements(lead_provider, statements, month_col_width: 15,
     row = [Date::MONTHNAMES[month].rjust(month_col_width)]
 
     years.each do |year|
-      states = statements_by_year_and_month.dig(year, month)&.map(&:state) || []
-      if states.any?
-        coloured_states = states.map { |state| Colourize.text(state, STATEMENT_STATE_COLOURS[state.to_sym]) }
+      statuses = statements_by_year_and_month.dig(year, month)&.map(&:status) || []
+      if statuses.any?
+        coloured_statuses = statuses.map { |state| Colourize.text(state, STATEMENT_STATE_COLOURS[state.to_sym]) }
         # the colourizing characters affect the length so offset the rjust
-        offset = coloured_states.sum(&:length) - states.sum(&:length)
-        row << coloured_states.join(", ").rjust(year_col_width + offset)
+        offset = coloured_statuses.sum(&:length) - statuses.sum(&:length)
+        row << coloured_statuses.join(", ").rjust(year_col_width + offset)
       else
         row << 'none'.rjust(year_col_width)
       end
@@ -47,13 +47,13 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
     years.product(months).map do |year, month|
       deadline_date = Time.zone.local(year, month).end_of_month
       payment_date = Time.zone.at(rand(deadline_date.to_i..(deadline_date + 2.months).to_i))
-      state = if payment_date < Date.current
-                :paid
-              elsif Date.current.between?(deadline_date, payment_date)
-                :payable
-              else
-                :open
-              end
+      status = if payment_date < Date.current
+                 :paid
+               elsif Date.current.between?(deadline_date, payment_date)
+                 :payable
+               else
+                 :open
+               end
 
       Statement.create!(
         active_lead_provider: alp,
@@ -62,7 +62,7 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
         deadline_date:,
         payment_date:,
         output_fee: [true, false].sample,
-        state:
+        status:
       )
     end
   end

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -14,15 +14,15 @@ FactoryBot.define do
     open
 
     trait :open do
-      state { :open }
+      status { :open }
     end
 
     trait :payable do
-      state { :payable }
+      status { :payable }
     end
 
     trait :paid do
-      state { :paid }
+      status { :paid }
     end
   end
 end

--- a/spec/migration/migrators/statement_spec.rb
+++ b/spec/migration/migrators/statement_spec.rb
@@ -28,7 +28,7 @@ describe Migrators::Statement do
         expect(statement.year).to eq(2025)
         expect(statement.registration_period.year).to eq(migration_resource1.cohort.start_year)
         expect(statement.lead_provider.name).to eq(migration_resource1.cpd_lead_provider.lead_provider.name)
-        expect(statement.state).to eq("open")
+        expect(statement.status).to eq("open")
       end
     end
   end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -18,17 +18,17 @@ describe Statement do
   end
 
   describe "scopes" do
-    describe ".with_state" do
+    describe ".with_status" do
       let!(:statement1) { FactoryBot.create(:statement, :open) }
       let!(:statement2) { FactoryBot.create(:statement, :payable) }
       let!(:statement3) { FactoryBot.create(:statement, :paid) }
 
-      it "selects only statements with states matching the provided name" do
-        expect(described_class.with_state("open")).to contain_exactly(statement1)
+      it "selects only statements with statuses matching the provided name" do
+        expect(described_class.with_status("open")).to contain_exactly(statement1)
       end
 
-      it "selects only multiple statements with states matching the provided names" do
-        expect(described_class.with_state("payable", "paid")).to contain_exactly(statement2, statement3)
+      it "selects only multiple statements with statuses matching the provided names" do
+        expect(described_class.with_status("payable", "paid")).to contain_exactly(statement2, statement3)
       end
     end
 
@@ -52,13 +52,13 @@ describe Statement do
     context "when transitioning from open to payable" do
       let(:statement) { FactoryBot.create(:statement, :open) }
 
-      it { expect { statement.mark_as_payable! }.to change(statement, :state).from("open").to("payable") }
+      it { expect { statement.mark_as_payable! }.to change(statement, :status).from("open").to("payable") }
     end
 
     context "when transitioning from payable to paid" do
       let(:statement) { FactoryBot.create(:statement, :payable) }
 
-      it { expect { statement.mark_as_paid! }.to change(statement, :state).from("payable").to("paid") }
+      it { expect { statement.mark_as_paid! }.to change(statement, :status).from("payable").to("paid") }
     end
 
     context "when transitioning to an invalid state" do
@@ -68,33 +68,33 @@ describe Statement do
     end
   end
 
-  describe "#shorthand_state" do
-    subject(:shorthand_state) { statement.shorthand_state }
+  describe "#shorthand_status" do
+    subject(:shorthand_status) { statement.shorthand_status }
 
-    let(:statement) { FactoryBot.build(:statement, state:) }
+    let(:statement) { FactoryBot.build(:statement, status:) }
 
-    context "when state is open" do
-      let(:state) { :open }
+    context "when status is open" do
+      let(:status) { :open }
 
       it { is_expected.to eq("OP") }
     end
 
-    context "when state is payable" do
-      let(:state) { :payable }
+    context "when status is payable" do
+      let(:status) { :payable }
 
       it { is_expected.to eq("PB") }
     end
 
-    context "when state is paid" do
-      let(:state) { :paid }
+    context "when status is paid" do
+      let(:status) { :paid }
 
       it { is_expected.to eq("PD") }
     end
 
-    context "when state is unknown" do
-      let(:state) { :unknown_state }
+    context "when status is unknown" do
+      let(:status) { :unknown_status }
 
-      it { expect { shorthand_state }.to raise_error(ArgumentError, "Unknown state: unknown_state") }
+      it { expect { shorthand_status }.to raise_error(ArgumentError, "Unknown status: unknown_status") }
     end
   end
 

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -19,7 +19,7 @@ describe Admin::StatementPresenter do
 
   describe '#status_tag_kwargs' do
     context 'when open' do
-      let(:statement) { FactoryBot.build(:statement, state: 'open') }
+      let(:statement) { FactoryBot.build(:statement, :open) }
 
       it 'is blue and Open' do
         expect(subject.status_tag_kwargs).to eql({ colour: 'blue', text: 'Open' })
@@ -27,7 +27,7 @@ describe Admin::StatementPresenter do
     end
 
     context 'when payable' do
-      let(:statement) { FactoryBot.build(:statement, state: 'payable') }
+      let(:statement) { FactoryBot.build(:statement, :payable) }
 
       it 'is yellow and Payable' do
         expect(subject.status_tag_kwargs).to eql({ colour: 'yellow', text: 'Payable' })
@@ -35,7 +35,7 @@ describe Admin::StatementPresenter do
     end
 
     context 'when paid' do
-      let(:statement) { FactoryBot.build(:statement, state: 'paid') }
+      let(:statement) { FactoryBot.build(:statement, :paid) }
 
       it 'is green and Paid' do
         expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Paid' })
@@ -43,7 +43,7 @@ describe Admin::StatementPresenter do
     end
 
     context 'when unrecognised' do
-      let(:statement) { FactoryBot.build(:statement, state: 'bad_state') }
+      let(:statement) { FactoryBot.build(:statement, status: 'bad_state') }
 
       it 'raises an IndexError' do
         expect { subject.status_tag_kwargs }.to raise_error(IndexError)

--- a/spec/serializers/statement_serializer_spec.rb
+++ b/spec/serializers/statement_serializer_spec.rb
@@ -52,14 +52,14 @@ describe StatementSerializer, type: :serializer do
     end
 
     describe "`paid` status" do
-      it "returns `true` when state is `paid`" do
-        statement.state = :paid
+      it "returns `true` when status is `paid`" do
+        statement.status = :paid
 
         expect(attributes["paid"]).to be(true)
       end
 
       it "returns `false` when `state` is not `paid`" do
-        statement.state = :open
+        statement.status = :open
 
         expect(attributes["paid"]).to be(false)
       end

--- a/spec/services/sandbox_seed_data/statements_spec.rb
+++ b/spec/services/sandbox_seed_data/statements_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SandboxSeedData::Statements do
           active_lead_provider:,
           deadline_date: expected_deadline_date,
           payment_date: be_between(expected_deadline_date, expected_deadline_date + 2.months),
-          state: be_in(%w[open payable paid])
+          status: be_in(%w[open payable paid])
         )
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe SandboxSeedData::Statements do
     it "creates statements with all states" do
       instance.plant
 
-      expect(Statement.distinct.pluck(:state)).to match_array(%w[open payable paid])
+      expect(Statement.distinct.pluck(:status)).to match_array(%w[open payable paid])
     end
 
     it "logs the creation of statements" do
@@ -55,8 +55,8 @@ RSpec.describe SandboxSeedData::Statements do
         expect(logger).to have_received(:info).with(/#{Date::MONTHNAMES[month]}/).at_least(:once)
       end
 
-      %i[OP PB PD].each do |state|
-        expect(logger).to have_received(:info).with(/#{state}/).at_least(:once)
+      %i[OP PB PD].each do |status|
+        expect(logger).to have_received(:info).with(/#{status}/).at_least(:once)
       end
     end
 

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -138,17 +138,17 @@ RSpec.describe Statements::Query do
         let!(:paid_statement) { FactoryBot.create(:statement, :paid) }
 
         it "filters by `state`" do
-          expect(described_class.new(state: "open").statements).to eq([open_statement])
-          expect(described_class.new(state: "payable").statements).to eq([payable_statement])
-          expect(described_class.new(state: "paid").statements).to eq([paid_statement])
+          expect(described_class.new(status: "open").statements).to eq([open_statement])
+          expect(described_class.new(status: "payable").statements).to eq([payable_statement])
+          expect(described_class.new(status: "paid").statements).to eq([paid_statement])
         end
 
         it "filters by multiple states with a comma separated list" do
-          expect(described_class.new(state: "open,paid").statements).to contain_exactly(open_statement, paid_statement)
+          expect(described_class.new(status: "open,paid").statements).to contain_exactly(open_statement, paid_statement)
         end
 
         it "filters by multiple states with an array" do
-          expect(described_class.new(state: %w[open paid]).statements).to contain_exactly(open_statement, paid_statement)
+          expect(described_class.new(status: %w[open paid]).statements).to contain_exactly(open_statement, paid_statement)
         end
 
         context "when `state` param is omitted" do
@@ -158,7 +158,7 @@ RSpec.describe Statements::Query do
         end
 
         it "does not filter by `state` if blank" do
-          query = described_class.new(state: " ")
+          query = described_class.new(status: " ")
 
           expect(query.statements).to contain_exactly(open_statement, payable_statement, paid_statement)
         end


### PR DESCRIPTION
We have lots of status columns in the app already and having one called 'state' (as it is in ECF1) will likely be confusing.

This change renames the column, enumerated type and all refences to 'state' to 'status'

Fixes #715

## Review notes

Did I miss anywhere? It's hard to search for with `state` being the first half of `statement` and a common general term :grimacing: 