### PR TITLE
Rebrand

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (5.10.1)
+    govuk-components (5.11.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
       view_component (>= 3.18, < 3.24)

--- a/app/assets/stylesheets/header/colour-overrides.scss
+++ b/app/assets/stylesheets/header/colour-overrides.scss
@@ -3,7 +3,7 @@ $colours: ("pink", "orange", "red", "purple", "yellow");
 @each $colour in $colours {
   .govuk-header {
     &.app-header--#{$colour} {
-      border-color: govuk-colour($colour);
+      outline: 5px solid govuk-colour($colour);
     }
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,4 +55,8 @@ module ApplicationHelper
   def boolean_to_yes_or_no(value)
     value ? "Yes" : "No"
   end
+
+  def govuk_html_element(&block)
+    tag.html(lang: 'en', class: %w[govuk-template govuk-template--rebranded], &block)
+  end
 end

--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -3,7 +3,7 @@
   <%= stylesheet_link_tag "swagger", media: "all" %>
 <% end %>
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
   <body class="govuk-template__body" data-turbo="false">
@@ -35,4 +35,4 @@
 
     <%= render partial: "layouts/shared/footer" %>
   </body>
-</html>
+<% end %>

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
   <body class="govuk-template__body">
@@ -53,4 +53,4 @@
 
     <%= render partial: "layouts/shared/footer" %>
   </body>
-</html>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
   <body class="govuk-template__body" data-turbo="false">
@@ -41,4 +41,4 @@
 
     <%= render partial: "layouts/shared/footer" %>
   </body>
-</html>
+<% end %>

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
   <body class="govuk-template__body" data-turbo="false">
@@ -36,4 +36,4 @@
 
     <%= render partial: "layouts/shared/footer" %>
   </body>
-</html>
+<% end %>

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -6,11 +6,11 @@
   <%= csp_meta_tag %>
 
   <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-  <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
-  <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-  <%= favicon_link_tag asset_path('images/favicon.ico') %>
-  <%= favicon_link_tag asset_path('images/govuk-icon-mask.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b1c0c" %>
-  <%= favicon_link_tag asset_path('images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+  <%= tag :meta, property: 'og:image', content: asset_path('rebrand/images/govuk-opengraph-image.png') %>
+  <%= tag :meta, name: 'theme-color', content: '#1d70b8' %>
+  <%= favicon_link_tag asset_path('rebrand/images/favicon.ico') %>
+  <%= favicon_link_tag asset_path('rebrand/images/govuk-icon-mask.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b1c0c" %>
+  <%= favicon_link_tag asset_path('rebrand/images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
   <%= turbo_include_tags %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -220,4 +220,22 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to eql('No') }
     end
   end
+
+  describe '#govuk_html_element' do
+    subject { govuk_html_element { content } }
+
+    let(:content) { 'what a nice page' }
+
+    it 'renders the provided content in a HTML element' do
+      expect(subject).to match(%r{<html.*#{content}</html>})
+    end
+
+    it 'includes both the govuk-template and govuk-template--rebranded classes' do
+      expect(subject).to include('govuk-template govuk-template--rebranded')
+    end
+
+    it 'defaults to english' do
+      expect(subject).to include('lang="en"')
+    end
+  end
 end


### PR DESCRIPTION
[GOV.UK is launching the rebranded styles on the 25th June 2025](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0).

This PR brings these services up to date.

| Before | After |
| ---- | ---- |
| ![Screenshot From 2025-06-20 14-00-12](https://github.com/user-attachments/assets/3ab4ab60-87e2-43cb-9a72-9622bea0c255) | ![Screenshot From 2025-06-20 14-00-08](https://github.com/user-attachments/assets/fc93b9c5-52ed-4fe7-aaa4-0237d5009db6) |

> [!IMPORTANT]  
> Don't merge this before the 25 June 2025.


## Final tasks

* [x] remove the commit that brings in govuk-components 5.10.2b2 and replace it with the actual version that contains x-govuk/govuk-components#586