### PR TITLE
Add a migrator for `LeadProviderDeliveryPartnerships` and update `DeliveryPartner` migrator

### DIFF
--- a/app/migration/migrators/delivery_partner.rb
+++ b/app/migration/migrators/delivery_partner.rb
@@ -20,7 +20,11 @@ module Migrators
 
     def migrate!
       migrate(self.class.delivery_partners) do |delivery_partner|
-        ::DeliveryPartner.create!(name: delivery_partner.name)
+        dp = ::DeliveryPartner.find_or_initialize_by(api_id: delivery_partner.id)
+        dp.name = delivery_partner.name
+        dp.created_at = delivery_partner.created_at
+        dp.updated_at = delivery_partner.updated_at
+        dp.save!
       end
     end
   end

--- a/app/migration/migrators/lead_provider_delivery_partnership.rb
+++ b/app/migration/migrators/lead_provider_delivery_partnership.rb
@@ -27,7 +27,8 @@ module Migrators
         partnership = ::LeadProviderDeliveryPartnership.find_or_initialize_by(ecf_id: provider_relationship.id)
         partnership.active_lead_provider = ::ActiveLeadProvider.find_by!(
           lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
-          registration_period_id: ::RegistrationPeriod.find(provider_relationship.cohort.start_year))
+          registration_period_id: ::RegistrationPeriod.find(provider_relationship.cohort.start_year)
+        )
         partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
         partnership.created_at = provider_relationship.created_at
         partnership.updated_at = provider_relationship.updated_at

--- a/app/migration/migrators/lead_provider_delivery_partnership.rb
+++ b/app/migration/migrators/lead_provider_delivery_partnership.rb
@@ -27,7 +27,7 @@ module Migrators
         partnership = ::LeadProviderDeliveryPartnership.find_or_initialize_by(ecf_id: provider_relationship.id)
         partnership.active_lead_provider = ::ActiveLeadProvider.find_by!(
           lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
-          registration_period_id: ::RegistratonPeriod.find(provider_relationship.cohort.start_year))
+          registration_period_id: ::RegistrationPeriod.find(provider_relationship.cohort.start_year))
         partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
         partnership.created_at = provider_relationship.created_at
         partnership.updated_at = provider_relationship.updated_at

--- a/app/migration/migrators/lead_provider_delivery_partnership.rb
+++ b/app/migration/migrators/lead_provider_delivery_partnership.rb
@@ -5,7 +5,7 @@ module Migrators
     end
 
     def self.model
-      :school_partnership
+      :lead_provider_delivery_partnership
     end
 
     def self.provider_relationships
@@ -18,7 +18,7 @@ module Migrators
 
     def self.reset!
       if Rails.application.config.enable_migration_testing
-        ::SchoolPartnership.connection.execute("TRUNCATE #{::SchoolPartnership.table_name} RESTART IDENTITY CASCADE")
+        ::LeadProviderDeliveryPartnership.connection.execute("TRUNCATE #{::LeadProviderDeliveryPartnership.table_name} RESTART IDENTITY CASCADE")
       end
     end
 
@@ -29,6 +29,9 @@ module Migrators
           lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
           registration_period_id: ::RegistratonPeriod.find(provider_relationship.cohort.start_year))
         partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
+        partnership.created_at = provider_relationship.created_at
+        partnership.updated_at = provider_relationship.updated_at
+
         partnership.save!
       end
     end

--- a/app/migration/migrators/lead_provider_delivery_partnership.rb
+++ b/app/migration/migrators/lead_provider_delivery_partnership.rb
@@ -1,0 +1,36 @@
+module Migrators
+  class LeadProviderDeliveryPartnership < Migrators::Base
+    def self.record_count
+      provider_relationships.count
+    end
+
+    def self.model
+      :school_partnership
+    end
+
+    def self.provider_relationships
+      ::Migration::ProviderRelationship.all
+    end
+
+    def self.dependencies
+      %i[registration_period active_lead_provider delivery_partner]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::SchoolPartnership.connection.execute("TRUNCATE #{::SchoolPartnership.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.provider_relationships.includes(:lead_provider, :delivery_partner, :cohort)) do |provider_relationship|
+        partnership = ::LeadProviderDeliveryPartnership.find_or_initialize_by(ecf_id: provider_relationship.id)
+        partnership.active_lead_provider = ::ActiveLeadProvider.find_by!(
+          lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
+          registration_period_id: ::RegistratonPeriod.find(provider_relationship.cohort.start_year))
+        partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
+        partnership.save!
+      end
+    end
+  end
+end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -8,4 +8,5 @@ class DeliveryPartner < ApplicationRecord
   validates :name,
             presence: true,
             uniqueness: true
+  validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another delivery partner" }
 end

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -8,6 +8,7 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
   validates :delivery_partner_id,
             presence: { message: 'Select a delivery partner' },
             uniqueness: { scope: :active_lead_provider_id, message: 'Delivery partner and active lead provider pairing must be unique' }
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   scope :with_delivery_partner, ->(delivery_partner_id) { where(delivery_partner_id:) }
   scope :with_active_lead_provider, ->(active_lead_provider_id) { where(active_lead_provider_id:) }

--- a/spec/factories/migration/provider_relationship_factory.rb
+++ b/spec/factories/migration/provider_relationship_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :migration_provider_relationship, class: "Migration::ProviderRelationship" do
+    lead_provider { FactoryBot.create(:migration_lead_provider) }
+    delivery_partner { FactoryBot.create(:migration_delivery_partner) }
+    cohort { FactoryBot.create(:migration_cohort) }
+  end
+end

--- a/spec/migration/migrators/delivery_partner_spec.rb
+++ b/spec/migration/migrators/delivery_partner_spec.rb
@@ -1,4 +1,7 @@
 RSpec.describe Migrators::DeliveryPartner do
+  # TODO: would be nice to use the 'it_behaves_like "a migrator"' shared_example but this one is difficult to make fail
+  # so the failure handling specs fail
+
   describe '.record_count' do
     it 'returns the count of delivery partners' do
       FactoryBot.create_list(:migration_delivery_partner, 2)
@@ -52,8 +55,12 @@ RSpec.describe Migrators::DeliveryPartner do
     before { subject.migrate! }
 
     it 'creates a delivery partner for each ecf delivery partner' do
-      expect(DeliveryPartner.count).to eq(2)
-      expect(DeliveryPartner.pluck(:name)).to contain_exactly(delivery_partner1.name, delivery_partner2.name)
+      described_class.delivery_partners.find_each do |delivery_partner|
+        dp = DeliveryPartner.find_by(api_id: delivery_partner.id)
+        expect(dp.name).to eq delivery_partner.name
+        expect(dp.created_at).to eq delivery_partner.created_at
+        expect(dp.updated_at).to eq delivery_partner.updated_at
+      end
     end
   end
 end

--- a/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
+++ b/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
@@ -34,6 +34,8 @@ describe Migrators::LeadProviderDeliveryPartnership do
           lpdp = LeadProviderDeliveryPartnership.find_by!(ecf_id: provider_relationship.id)
           expect(lpdp.active_lead_provider).to eq(active_lead_provider)
           expect(lpdp.delivery_partner).to eq(delivery_partner)
+          expect(lpdp.created_at).to eq provider_relationship.created_at
+          expect(lpdp.updated_at).to eq provider_relationship.updated_at
         end
       end
     end

--- a/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
+++ b/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
@@ -25,7 +25,6 @@ describe Migrators::LeadProviderDeliveryPartnership do
         instance.migrate!
 
         described_class.provider_relationships.find_each do |provider_relationship|
-
           lead_provider = LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id)
           delivery_partner = DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
           registration_period = RegistrationPeriod.find(provider_relationship.cohort.start_year)

--- a/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
+++ b/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
@@ -6,12 +6,13 @@ describe Migrators::LeadProviderDeliveryPartnership do
 
     def create_resource(migration_resource)
       cohort = migration_resource.cohort
-      lead_provider = migration_resource.lead_provider
-      delivery_partner = migration_resource.delivery_partner
+      lp = migration_resource.lead_provider
+      dp = migration_resource.delivery_partner
 
-      FactoryBot.create(:registration_period, year: migration_resource.cohort.start_year)
-      FactoryBot.create(:lead_provider, name: lead_provider.name, ecf_id: lead_provider.id)
-      FactoryBot.create(:delivery_partner, name: delivery_partner.name, api_id: delivery_partner.id)
+      registration_period = FactoryBot.create(:registration_period, year: cohort.start_year)
+      lead_provider = FactoryBot.create(:lead_provider, name: lp.name, ecf_id: lp.id)
+      FactoryBot.create(:delivery_partner, name: dp.name, api_id: dp.id)
+      FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
     end
 
     def setup_failure_state
@@ -26,7 +27,7 @@ describe Migrators::LeadProviderDeliveryPartnership do
         described_class.provider_relationships.find_each do |provider_relationship|
 
           lead_provider = LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id)
-          delivery_partner = DeliveryPartner.find_by!(ecf_id: provider_relationship.delivery_partner_id)
+          delivery_partner = DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
           registration_period = RegistrationPeriod.find(provider_relationship.cohort.start_year)
 
           active_lead_provider = ActiveLeadProvider.find_by!(lead_provider:, registration_period:)

--- a/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
+++ b/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
@@ -1,0 +1,41 @@
+describe Migrators::LeadProviderDeliveryPartnership do
+  it_behaves_like "a migrator", :lead_provider_delivery_partnership, %i[registration_period active_lead_provider delivery_partner] do
+    def create_migration_resource
+      FactoryBot.create(:migration_provider_relationship)
+    end
+
+    def create_resource(migration_resource)
+      cohort = migration_resource.cohort
+      lead_provider = migration_resource.lead_provider
+      delivery_partner = migration_resource.delivery_partner
+
+      FactoryBot.create(:registration_period, year: migration_resource.cohort.start_year)
+      FactoryBot.create(:lead_provider, name: lead_provider.name, ecf_id: lead_provider.id)
+      FactoryBot.create(:delivery_partner, name: delivery_partner.name, api_id: delivery_partner.id)
+    end
+
+    def setup_failure_state
+      # create object without migrated dependencies
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it "sets the created attributes correctly" do
+        instance.migrate!
+
+        described_class.provider_relationships.find_each do |provider_relationship|
+
+          lead_provider = LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id)
+          delivery_partner = DeliveryPartner.find_by!(ecf_id: provider_relationship.delivery_partner_id)
+          registration_period = RegistrationPeriod.find(provider_relationship.cohort.start_year)
+
+          active_lead_provider = ActiveLeadProvider.find_by!(lead_provider:, registration_period:)
+
+          lpdp = LeadProviderDeliveryPartnership.find_by!(ecf_id: provider_relationship.id)
+          expect(lpdp.active_lead_provider).to eq(active_lead_provider)
+          expect(lpdp.delivery_partner).to eq(delivery_partner)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We were missing a migrator for `LeadProviderDeliveryPartner` so this adds one to migrate `ProviderRelationship` records in ECF to `LeadProviderDeliveryPartner` in RECT.
This also required `DeliveryPartner` which was in-place but wasn't using/storing `api_id` from ECF so have updated that migrator too.
