### PR TITLE
Extract dynamic request content from RequestBuilder

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -1,0 +1,40 @@
+module ParityCheck
+  class DynamicRequestContent
+    class UnrecognizedIdentifierError < RuntimeError; end
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :lead_provider
+
+    def fetch(identifier)
+      raise UnrecognizedIdentifierError, "Identifier not recognized: #{identifier}" unless respond_to?(identifier, true)
+
+      send(identifier)
+    end
+
+  private
+
+    # Path ID methods
+
+    def statement_id
+      Statement
+        .joins(:active_lead_provider)
+        .where(active_lead_provider: lead_provider.active_lead_providers)
+        .order("RANDOM()")
+        .pick(:api_id)
+    end
+
+    # Request body methods
+
+    def example_statement_body
+      {
+        data: {
+          type: "statements",
+          attributes: {
+            content: "This is an example request body.",
+          },
+        },
+      }
+    end
+  end
+end

--- a/documentation/parity-check.md
+++ b/documentation/parity-check.md
@@ -42,8 +42,8 @@ In the above example, we have `get` and `post` endpoints:
 
 - The `/api/v3/statements` endpoint will be paginated (so all pages are requested in the parity check). 
 - The other request to `/api/v3/statements` will append query parameters, so the request will be to `/api/v3/statements?filter[cohort]=2021`. 
-- The final `get` endpoint has a dynamic path ID; there must be a method `statement_id` in the `RequestBuilder` service that will be called and interpolated into the path as the `:id` parameter.
-- The `post` endpoint defines a dynamic body for the request; there must be a method `example_statement_body` in the `RequestBuilder` that will be called and passed as request body.
+- The final `get` endpoint has a dynamic path ID; there must be a method `statement_id` in the `DynamicRequestContent` that will be called and interpolated into the path as the `:id` parameter.
+- The `post` endpoint defines a dynamic body for the request; there must be a method `example_statement_body` in the `DynamicRequestContent` that will be called and passed as request body.
 
 ### Tokens
 
@@ -134,6 +134,7 @@ At a high-level, the process is as follows:
 
 - The `RequestHandler` asks the `Client` to perform the `Request`.
 - The `Client` calls a `RequestBuilder` to interpolate the `Endpoint` into valid request components (url, method, body, headers etc).
+- The `RequestBuilder` will call `DynamicRequestContent` to build any dynamic content for the request (such as the path ID or the request body).
 - The `RequestBuilder` will also call out to the `TokenProvider` to get a valid token for the authentication header.
 - The `Client` runs the request through `Faraday` using an parallel adapter, so we call RECT and ECF at the same time.
 - The `Client` returns the `Response` to the `RequestHandler`, which then attaches it to the `Request`.
@@ -149,6 +150,7 @@ flowchart TD
   Client["Client"]
   RequestBuilder["RequestBuilder"]
   Endpoint["Endpoint"]
+  DynamicRequestContent["DynamicRequestContent"]
   TokenProvider["TokenProvider"]
   Faraday["Faraday"]
   RECTAPI["RECT API"]
@@ -160,6 +162,7 @@ flowchart TD
   RequestBuilder -->|request details| Client
   Endpoint -->|endpoint details| RequestBuilder
   TokenProvider -->|token| RequestBuilder
+  DynamicRequestContent -->|content| RequestBuilder
 
   Client -->|request| Faraday
   Faraday -->|response| Client

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe ParityCheck::DynamicRequestContent do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:instance) { described_class.new(lead_provider:) }
+
+  describe "#fetch" do
+    subject(:fetch) { instance.fetch(identifier) }
+
+    context "when fetching an unrecognized identifier" do
+      let(:identifier) { :unrecognized_identifier }
+
+      it { expect { fetch }.to raise_error(described_class::UnrecognizedIdentifierError, "Identifier not recognized: unrecognized_identifier") }
+    end
+
+    context "when fetching statement_id" do
+      let(:identifier) { :statement_id }
+      let!(:statement) { FactoryBot.create(:statement, lead_provider:) }
+
+      # Statement for different lead provider should not be used.
+      before { FactoryBot.create(:statement) }
+
+      it { is_expected.to eq(statement.api_id) }
+    end
+
+    context "when fetching example_statement_body" do
+      let(:identifier) { :example_statement_body }
+
+      it "returns the example statement body" do
+        expect(fetch).to eq({
+          data: {
+            type: "statements",
+            attributes: {
+              content: "This is an example request body.",
+            },
+          },
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
To avoid the `RequestBuilder` bloating with all the dynamic request content we will be adding as we add new endpoints, it makes sense to extract them to their own class to keep things cleaner.