### PR TITLE
Add parity check start page

### DIFF
--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -1,0 +1,28 @@
+class Migration::ParityChecksController < ::AdminController
+  before_action :load_endpoints, only: %i[new create]
+
+  def new
+    @runner = ParityCheck::Runner.new
+  end
+
+  def create
+    @runner = ParityCheck::Runner.new(runner_params)
+    if @runner.valid?
+      @runner.run!
+      flash[:notice] = "Parity check has been started."
+      redirect_to new_migration_parity_check_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def load_endpoints
+    @endpoints = ParityCheck::Endpoint.all
+  end
+
+  def runner_params
+    params.require(:parity_check_runner).permit(:mode, endpoint_ids: [])
+  end
+end

--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -1,0 +1,14 @@
+module ParityCheckHelper
+  def grouped_endpoints(endpoints)
+    endpoints.group_by(&:group_name)
+  end
+
+  def run_mode_options
+    mode = Struct.new(:value, :name, :description, keyword_init: true)
+
+    [
+      mode.new(value: :concurrent, name: "Concurrent", description: "Send requests in parallel for a faster run."),
+      mode.new(value: :sequential, name: "Sequential", description: "Send requests one at a time for accurate performance benchmarking."),
+    ]
+  end
+end

--- a/app/migration/parity_check/runner.rb
+++ b/app/migration/parity_check/runner.rb
@@ -1,17 +1,22 @@
 module ParityCheck
   class Runner
+    include ActiveModel::Model
+    include ActiveModel::Attributes
     include ParityCheck::Configuration
 
-    attr_reader :endpoints
+    attribute :endpoint_ids
+    attribute :mode, default: -> { :concurrent }
 
-    def initialize(endpoints)
-      @endpoints = endpoints
-    end
+    validates :mode, presence: true, inclusion: { in: %w[concurrent sequential] }
+    validates :endpoint_ids, presence: { message: "Select at least one endpoint." }
+    validate :endpoints_exist
 
-    def run
+    def run!
+      return unless valid?
+
       ensure_parity_check_enabled!
 
-      Run.create!.tap do |run|
+      Run.create!(mode:).tap do |run|
         lead_providers.to_a.product(endpoints).each do |lead_provider, endpoint|
           run.requests.create!(lead_provider:, endpoint:)
         end
@@ -20,7 +25,21 @@ module ParityCheck
       end
     end
 
+    def endpoint_ids=(ids)
+      super(ids&.compact_blank)
+    end
+
   private
+
+    def endpoints
+      @endpoints ||= Endpoint.where(id: endpoint_ids)
+    end
+
+    def endpoints_exist
+      return if endpoints.none? || endpoints.count == endpoint_ids.uniq.count
+
+      errors.add(:endpoint_ids, "One or more selected endpoints do not exist.")
+    end
 
     def lead_providers
       @lead_providers ||= LeadProvider.all

--- a/app/migration/parity_check/seed_endpoints.rb
+++ b/app/migration/parity_check/seed_endpoints.rb
@@ -6,7 +6,6 @@ module ParityCheck
 
     def plant!
       ensure_parity_check_enabled!
-
       clear_endpoints!
       seed_endpoints!
     end
@@ -19,8 +18,8 @@ module ParityCheck
 
     def seed_endpoints!
       yaml_file
-        .flat_map { |method, paths| paths.map { [method, it] } }
-        .map { |method, (path, options)| ParityCheck::Endpoint.create!(method:, path:, options:) }
+        .flat_map { |method, paths| paths.map { [method, it.to_a].flatten } }
+        .map { |method, path, options| ParityCheck::Endpoint.create!(method:, path:, options:) }
     end
 
     def yaml_file

--- a/app/models/parity_check/endpoint.rb
+++ b/app/models/parity_check/endpoint.rb
@@ -7,6 +7,7 @@ module ParityCheck
     validates :path, presence: true
     validates :method, presence: true, inclusion: { in: %i[get post put] }
     validate :options_is_a_hash
+    validate :path_does_not_contain_query_params
 
     def method
       super&.to_sym
@@ -21,10 +22,27 @@ module ParityCheck
       value.deep_symbolize_keys if value.respond_to?(:deep_symbolize_keys)
     end
 
+    def group_name
+      match = path.match(%r{/api/v\d+/(?<group>[^/?]+)})
+      match ? match[:group]&.to_sym : :miscellaneous
+    end
+
+    def description
+      pagination_note = options[:paginate] ? " (all pages)" : ""
+      query_string = options[:query].present? ? "?#{CGI.unescape(options[:query].to_query)}" : ""
+      "#{method.to_s.upcase} #{path}#{query_string}#{pagination_note}"
+    end
+
   private
 
     def options_is_a_hash
       errors.add(:options, "Options must be a hash") unless options.is_a?(Hash)
+    end
+
+    def path_does_not_contain_query_params
+      return unless path&.include?("?")
+
+      errors.add(:path, "Path should not contain query parameters; use options[:query] instead.")
     end
   end
 end

--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -5,7 +5,7 @@ module ParityCheck
     belongs_to :run
     belongs_to :lead_provider
     belongs_to :endpoint
-    has_many :responses
+    has_many :responses, dependent: :destroy
 
     validates :lead_provider, presence: true
     validates :run, presence: true

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -9,8 +9,6 @@ module ParityCheck
     validates :request, presence: true
     validates :ecf_status_code, inclusion: { in: 100..599 }
     validates :rect_status_code, inclusion: { in: 100..599 }
-    validates :ecf_body, presence: true, if: :different?
-    validates :rect_body, presence: true, if: :different?
     validates :ecf_time_ms, numericality: { greater_than: 0 }
     validates :rect_time_ms, numericality: { greater_than: 0 }
     validates :page, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true, uniqueness: { scope: :request_id }

--- a/app/models/parity_check/run.rb
+++ b/app/models/parity_check/run.rb
@@ -2,7 +2,7 @@ module ParityCheck
   class Run < ApplicationRecord
     self.table_name = "parity_check_runs"
 
-    has_many :requests
+    has_many :requests, dependent: :destroy
 
     attribute :mode, default: -> { :concurrent }
 

--- a/app/views/migration/parity_checks/_form.html.erb
+++ b/app/views/migration/parity_checks/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_for @runner, url: migration_parity_checks_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <% grouped_endpoints(@endpoints).each do |group, endpoints| %>
+    <%= f.govuk_collection_check_boxes :endpoint_ids, endpoints, :id, :description, legend: { text: group.capitalize } %>
+  <% end %>
+
+  <%= f.govuk_collection_radio_buttons(:mode, run_mode_options, :value, :name, :description, legend: { text: "Mode" }) %>
+
+  <%= f.govuk_submit "Run" %>
+<% end %>

--- a/app/views/migration/parity_checks/new.html.erb
+++ b/app/views/migration/parity_checks/new.html.erb
@@ -1,0 +1,13 @@
+<% page_data(title: "Run a parity check") %>
+
+<p>
+  Select endpoints you would like to run a parity check against.
+</p>
+
+<% if @endpoints.any? %>
+  <%= render partial: "form" %>
+<% else %>
+  <p>
+    No endpoints available for parity checks.
+  </p>
+<% end %>

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -1,13 +1,15 @@
 get:
-  "/api/v3/statements":
+  - "/api/v3/statements":
+      paginate: true
+  - "/api/v3/statements":
+      query:
+        filter:
+          cohort: 2021
+  - "/api/v3/statements/:id":
+      id: statement_id
+  - "/api/v3/schools":
     paginate: true
-  "/api/v3/statements":
-    query:
-      filter:
-        cohort: 2021
-  "/api/v3/statements/:id":
-    id: statement_id
 post:
-  "/api/v3/statements":
-    body: example_statement_body
+  - "/api/v3/statements":
+      body: example_statement_body
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,10 @@ Rails.application.routes.draw do
     resources :failures, only: %i[index]
     resources :teacher_failures, path: "teacher-failures", only: %i[index]
     resources :teachers, only: %i[index show]
+
+    constraints -> { Rails.application.config.parity_check[:enabled] } do
+      resources :parity_checks, only: %i[new create]
+    end
   end
 
   namespace :schools do

--- a/spec/features/migration/run_parity_check_spec.rb
+++ b/spec/features/migration/run_parity_check_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe "Run parity check" do
+  before do
+    sign_in_as_dfe_user(role: :admin)
+    allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: true })
+  end
+
+  let!(:get_endpoint) { FactoryBot.create(:parity_check_endpoint, :get, path: "/api/v1/statements") }
+  let!(:post_endpoint) { FactoryBot.create(:parity_check_endpoint, :post, path: "/api/v1/statement/:id") }
+  let!(:put_endpoint) { FactoryBot.create(:parity_check_endpoint, :put, path: "/api/v3/users/:id") }
+
+  scenario "Running a parity check with endpoints selected" do
+    page.goto(new_migration_parity_check_path)
+
+    expect(page.get_by_role("heading", name: "Run a parity check")).to be_visible
+    expect(page.get_by_text("Select endpoints you would like to run a parity check against.")).to be_visible
+
+    expect(page.locator("legend").and(page.get_by_text("Statements"))).to be_visible
+    expect(page.get_by_label(get_endpoint.description)).to be_visible
+    page.get_by_label(post_endpoint.description).click
+
+    expect(page.locator("legend").and(page.get_by_text("Users"))).to be_visible
+    page.get_by_label(put_endpoint.description).click
+
+    page.get_by_role("button", name: "Run").click
+
+    expect(page.get_by_text("Parity check has been started.")).to be_visible
+  end
+
+  scenario "Running a parity check with no endpoints selected" do
+    page.goto(new_migration_parity_check_path)
+
+    page.get_by_role("button", name: "Run").click
+
+    expect(page.get_by_role("heading", name: "There is a problem")).to be_visible
+    expect(page.locator(".govuk-error-summary a").and(page.get_by_text("Select at least one endpoint."))).to be_visible
+  end
+
+  scenario "Running a parity check when there are no endpoints" do
+    ParityCheck::Endpoint.destroy_all
+
+    page.goto(new_migration_parity_check_path)
+
+    expect(page.get_by_text("No endpoints available for parity checks.")).to be_visible
+    expect(page.get_by_role("form")).not_to be_visible
+  end
+end

--- a/spec/fixtures/files/parity_check_endpoints.yml
+++ b/spec/fixtures/files/parity_check_endpoints.yml
@@ -1,7 +1,9 @@
 get:
-  "/a-path":
-    foo: bar
-  "/another-path":
+  - "/a-path":
+      foo: bar
+  - "/another-path":
+  - "/another-path":
+      corge: grault
 post:
-  "/yet-another-path":
-    baz: qux
+  - "/yet-another-path":
+      baz: qux

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe ParityCheckHelper, type: :helper do
+  describe "#grouped_endpoints" do
+    subject(:grouping) { grouped_endpoints(endpoints) }
+
+    let(:endpoints) do
+      [
+        FactoryBot.build(:parity_check_endpoint, path: "/api/v1/users"),
+        FactoryBot.build(:parity_check_endpoint, path: "/api/v3/users/create"),
+        FactoryBot.build(:parity_check_endpoint, path: "/api/v2/statements"),
+        FactoryBot.build(:parity_check_endpoint, path: "/login"),
+      ]
+    end
+
+    it "groups endpoints by their group name" do
+      expect(grouping).to eq({
+        users: endpoints[0..1],
+        statements: [endpoints[2]],
+        miscellaneous: [endpoints[3]]
+      })
+    end
+  end
+
+  describe "#run_mode_options" do
+    subject(:options) { run_mode_options }
+
+    it "returns an array of mode options with value, name, and description" do
+      expect(options).to contain_exactly(
+        have_attributes(value: :concurrent, name: "Concurrent", description: "Send requests in parallel for a faster run."),
+        have_attributes(value: :sequential, name: "Sequential", description: "Send requests one at a time for accurate performance benchmarking.")
+      )
+    end
+  end
+end

--- a/spec/migration/parity_check/runner_spec.rb
+++ b/spec/migration/parity_check/runner_spec.rb
@@ -1,27 +1,49 @@
-RSpec.describe ParityCheck::Runner do
+RSpec.describe ParityCheck::Runner, type: :model do
   let(:endpoints) do
     [
-      ParityCheck::Endpoint.new(method: :get, path: "/test-path"),
-      ParityCheck::Endpoint.new(method: :post, path: "/test-other-path"),
+      FactoryBot.create(:parity_check_endpoint, method: :get, path: "/test-path"),
+      FactoryBot.create(:parity_check_endpoint, method: :post, path: "/test-other-path"),
     ]
   end
-
-  let(:instance) { described_class.new(endpoints) }
+  let(:mode) { "sequential" }
+  let(:endpoint_ids) { endpoints.map(&:id) }
   let(:enabled) { true }
+  let(:instance) { described_class.new(endpoint_ids:, mode:) }
 
   before { allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: }) }
 
   it "has the correct attributes" do
-    expect(instance).to have_attributes(endpoints:)
+    expect(instance).to have_attributes(endpoint_ids:)
+    expect(instance).to have_attributes(mode:)
   end
 
-  describe "#run" do
-    subject(:run) { instance.run }
+  describe "defaults" do
+    it { is_expected.to have_attributes(mode: :concurrent) }
+  end
 
-    it "creates a pending run" do
+  describe "validations" do
+    subject { instance }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:endpoint_ids).with_message("Select at least one endpoint.") }
+    it { is_expected.to validate_presence_of(:mode) }
+    it { is_expected.to validate_inclusion_of(:mode).in_array(%w[concurrent sequential]) }
+
+    it "validates that all endpoints exist" do
+      endpoints.first.destroy!
+      expect(instance).not_to be_valid
+      expect(instance.errors[:endpoint_ids]).to include("One or more selected endpoints do not exist.")
+    end
+  end
+
+  describe "#run!" do
+    subject(:run) { instance.run! }
+
+    it "creates a pending run of the correct mode" do
       created_run = nil
       expect { created_run = run }.to change(ParityCheck::Run, :count).by(1)
       expect(created_run).to be_pending
+      expect(created_run.mode).to eq(mode)
     end
 
     it "creates a request for each lead provider and endpoint" do
@@ -54,5 +76,13 @@ RSpec.describe ParityCheck::Runner do
 
       it { expect { run }.to raise_error(described_class::UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment") }
     end
+  end
+
+  describe "#endpoint_ids=" do
+    subject { instance.endpoint_ids }
+
+    let(:endpoint_ids) { ["", "123", nil, "456"] }
+
+    it { is_expected.to contain_exactly("123", "456") }
   end
 end

--- a/spec/migration/parity_check/seed_endpoints_spec.rb
+++ b/spec/migration/parity_check/seed_endpoints_spec.rb
@@ -20,11 +20,12 @@ RSpec.describe ParityCheck::SeedEndpoints do
     end
 
     it "seeds endpoints from the YAML file" do
-      expect { plant }.to change(ParityCheck::Endpoint, :count).by(3)
+      expect { plant }.to change(ParityCheck::Endpoint, :count).by(4)
 
       expect(ParityCheck::Endpoint.all).to include(
         have_attributes(method: :get, path: "/a-path", options: { foo: "bar" }),
         have_attributes(method: :get, path: "/another-path", options: {}),
+        have_attributes(method: :get, path: "/another-path", options: { corge: "grault" }),
         have_attributes(method: :post, path: "/yet-another-path", options: { baz: "qux" })
       )
     end

--- a/spec/models/parity_check/endpoint_spec.rb
+++ b/spec/models/parity_check/endpoint_spec.rb
@@ -10,7 +10,13 @@ describe ParityCheck::Endpoint do
     it { is_expected.to validate_presence_of(:method) }
     it { is_expected.to validate_inclusion_of(:method).in_array(%w[get post put]) }
     it { is_expected.to allow_values({}, { foo: "bar" }).for(:options) }
-    it { is_expected.not_to allow_values([], [{ foo: :bar }]).for(:options) }
+    it { is_expected.not_to allow_values([], [{ foo: :bar }]).for(:options).with_message("Options must be a hash") }
+
+    it "validates that the path does not contain query parameters" do
+      instance = FactoryBot.build(:parity_check_endpoint, path: "/a/path?with=query")
+      expect(instance).not_to be_valid
+      expect(instance.errors[:path]).to include("Path should not contain query parameters; use options[:query] instead.")
+    end
   end
 
   describe "#method" do
@@ -32,6 +38,61 @@ describe ParityCheck::Endpoint do
       endpoint = described_class.new
       endpoint.options = nil
       expect(endpoint.options).to eq({})
+    end
+  end
+
+  describe "#description" do
+    subject { instance.description }
+
+    let(:options) { {} }
+    let(:instance) { FactoryBot.build(:parity_check_endpoint, method: :get, path: "/a/path", options:) }
+
+    it { is_expected.to eq("GET /a/path") }
+
+    context "when pagination is enabled" do
+      let(:options) { { paginate: true, } }
+
+      it { is_expected.to eq("GET /a/path (all pages)") }
+    end
+
+    context "when query parameters are specified" do
+      let(:options) { { query: { filter: { cohort: 2022, active: true } }, } }
+
+      it { is_expected.to eq("GET /a/path?filter[active]=true&filter[cohort]=2022") }
+    end
+
+    context "when pagination is enabled and query parameters are specified" do
+      let(:options) { { paginate: true, query: { filter: { cohort: 2022, active: true } }, } }
+
+      it { is_expected.to eq("GET /a/path?filter[active]=true&filter[cohort]=2022 (all pages)") }
+    end
+  end
+
+  describe "#group_name" do
+    subject { described_class.new(path:).group_name }
+
+    context "when the path matches the expected format" do
+      let(:path) { "/api/v3/statements" }
+
+      it { is_expected.to eq(:statements) }
+    end
+
+    context "when the path matches the expected format (with query parameters)" do
+      let(:path) { "/api/v3/users?query=param" }
+
+      it { is_expected.to eq(:users) }
+    end
+
+    context "when the path matches the expected format (nested path)" do
+      let(:path) { "/api/v3/users/create" }
+
+      it { is_expected.to eq(:users) }
+    end
+
+    context "when the path does not match the expected format" do
+      let(:path) { "/some/other/path" }
+
+      it { is_expected.to eq(:miscellaneous) }
     end
   end
 end

--- a/spec/models/parity_check/request_spec.rb
+++ b/spec/models/parity_check/request_spec.rb
@@ -5,7 +5,7 @@ describe ParityCheck::Request do
     it { is_expected.to belong_to(:run) }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:endpoint) }
-    it { is_expected.to have_many(:responses) }
+    it { is_expected.to have_many(:responses).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -22,19 +22,5 @@ describe ParityCheck::Response do
     it { is_expected.to validate_numericality_of(:rect_time_ms).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:page).is_greater_than(0).only_integer.allow_nil }
     it { is_expected.to validate_uniqueness_of(:page).scoped_to(:request_id) }
-
-    context "when the response comparison is equal" do
-      subject { described_class.new(ecf_status_code: 200, rect_status_code: 200) }
-
-      it { is_expected.not_to validate_presence_of(:ecf_body) }
-      it { is_expected.not_to validate_presence_of(:rect_body) }
-    end
-
-    context "when the response comparison is different" do
-      subject { described_class.new(ecf_status_code: 404, rect_status_code: 200) }
-
-      it { is_expected.to validate_presence_of(:ecf_body) }
-      it { is_expected.to validate_presence_of(:rect_body) }
-    end
   end
 end

--- a/spec/models/parity_check/run_spec.rb
+++ b/spec/models/parity_check/run_spec.rb
@@ -2,7 +2,7 @@ describe ParityCheck::Run do
   it { expect(described_class).to have_attributes(table_name: "parity_check_runs") }
 
   describe "associations" do
-    it { is_expected.to have_many(:requests) }
+    it { is_expected.to have_many(:requests).dependent(:destroy) }
   end
 
   describe "defaults" do


### PR DESCRIPTION
### Context

We want to add a page available to DfE users that allows us to kick off a parity check. It should only be accessible if you are a DfE user and the parity check is enabled on the environment. We want to list and allow the user to select endpoints for the run.

### Changes proposed in this pull request

- Support multiple endpoints with the same method/path

At the moment if we define two endpoints with the same path under the same request method in the YAML file we only get one after parsing the file due to it being structured in a hash.

To avoid this, we can change the endpoints to be array items; this will allow duplicates. The use case for this is when testing, for example, an index action once with pagination and a separate time with filters.

- Add group_name and description to Endpoint

When we come to render an endpoint in a view we want to be able to describe the endpoint and group them.

Add `description` which will be used for the checkbox labels.

Add `group_name` which will allow us to group endpoints sensibly in the UI.

Add validation to ensure endpoint paths do not contain query parameters (these should be specified under the `options[:query]` in the YAML file.

- Add dependent: destroy to parity check to_many relationships

This is just for convenience, so we can clear a run with `run.destroy!` and it will take care of the related run data.

- Add admin page to start a parity check

Add the initial page to start a parity check; this is only accessible to administrators and only if the environment supports parity checks.

The `Runner` has been updated so we can use it as a form object.

If no endpoints are selected the user will see an error message.

On submitting a run we show a flash notice to inform the user it has been started.

Endpoints are grouped to make selection easier.

### Guidance to review

| Run - no endpoints    | Run - endpoints | Run - after submit |
| -------- | ------- | ------- |
| <img width="1312" alt="Screenshot 2025-06-23 at 14 09 27" src="https://github.com/user-attachments/assets/8d741e53-281e-43b1-bb73-16606dd1bb39" />  | <img width="1260" alt="Screenshot 2025-06-25 at 14 47 03" src="https://github.com/user-attachments/assets/a9e9dcd5-1aaa-4f96-9d5e-dfb82ebb93e4" />  | <img width="1304" alt="Screenshot 2025-06-25 at 14 47 36" src="https://github.com/user-attachments/assets/db62037e-b386-4aa4-bcf8-c73affff7e97" /> |


