### PR TITLE
Remove redundant SolidQueue rake task from bin/dev script

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -9,5 +9,3 @@ fi
 export PORT="${PORT:-3000}"
 
 exec foreman start -f Procfile.dev "$@"
-
-bundle exec rake solid_queue:start


### PR DESCRIPTION
### Context

I started to notice job worker crashes with `Process memory map` when I was working on a new laptop.
Whilst investigating, I spotted a potential cause, or at least something that could be changed.

### Changes proposed in this pull request

SolidQueue is started via foreman and also via rake.

### Guidance to review
