### PR TITLE
Fix author_params which caused event record jobs to stay queued

### DIFF
--- a/app/services/events/appropriate_body_background_job_author.rb
+++ b/app/services/events/appropriate_body_background_job_author.rb
@@ -9,10 +9,10 @@ class Events::AppropriateBodyBackgroundJobAuthor
 
   def author_params
     {
-      email:,
-      name:,
+      author_email: email,
+      author_name: name,
       appropriate_body_id:,
-      author_type: 'appropriate_body_user',
+      author_type: :appropriate_body_user,
     }
   end
 end

--- a/spec/services/events/appropriate_body_background_job_author_spec.rb
+++ b/spec/services/events/appropriate_body_background_job_author_spec.rb
@@ -1,14 +1,20 @@
-describe Events::AppropriateBodyBackgroundJobAuthor do
-  describe 'initialization' do
-    it 'is initialized with an email, name and appropriate body id' do
-      author = Events::AppropriateBodyBackgroundJobAuthor.new(email: 'test@test.org', name: 'Mr Test', appropriate_body_id: 123)
+RSpec.describe Events::AppropriateBodyBackgroundJobAuthor do
+  subject(:author) do
+    Events::AppropriateBodyBackgroundJobAuthor.new(
+      email: 'test@test.org',
+      name: 'Mr Test',
+      appropriate_body_id: 123
+    )
+  end
 
+  describe '#author_params' do
+    it 'returns author name, email, type and associated appropriate body id' do
       expect(author.author_params).to eql(
         {
-          email: 'test@test.org',
-          name: 'Mr Test',
-          appropriate_body_id: 123,
-          author_type: 'appropriate_body_user'
+          author_name: 'Mr Test',
+          author_email: 'test@test.org',
+          author_type: :appropriate_body_user,
+          appropriate_body_id: 123
         }
       )
     end


### PR DESCRIPTION
### Context

The event record jobs enqueued with the new `Events::AppropriateBodyBackgroundJobAuthor` class were not being completed. This was identified by missing pass/fail/release events in the admin timeline. So far only 5 have become stuck.

```ruby
SolidQueue::Job.where(class_name: "RecordEventJob", finished_at: nil).count
```

### Changes proposed in this pull request

Fix the `author_params` keys adding a missing `author_` prefix

### Guidance to review

- All jobs should complete with a `finished_at` timestamp.
- AB bulk claims and actions should result in no missing events for an ECT in an Admin users teacher timeline.

