### PR TITLE
Show completed parity checks

### DIFF
--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -1,7 +1,8 @@
 class Migration::ParityChecksController < ::AdminController
   layout "full"
 
-  before_action :load_endpoints, :load_runs, only: %i[new create]
+  before_action :load_endpoints, :load_pending_and_in_progress_runs, only: %i[new create]
+  before_action :load_completed_runs, only: %i[new create completed]
 
   def new
     @runner = ParityCheck::Runner.new
@@ -18,15 +19,25 @@ class Migration::ParityChecksController < ::AdminController
     end
   end
 
+  def completed
+    @breadcrumbs = {
+      "Run a parity check" => new_migration_parity_check_path,
+    }
+  end
+
 private
 
   def load_endpoints
     @endpoints = ParityCheck::Endpoint.all
   end
 
-  def load_runs
+  def load_pending_and_in_progress_runs
     @in_progress_run = ParityCheck::Run.in_progress.first
     @pending_runs = ParityCheck::Run.pending
+  end
+
+  def load_completed_runs
+    @pagy, @completed_runs = pagy(ParityCheck::Run.completed)
   end
 
   def runner_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,15 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-  def page_data(title:, header: :use_title, header_size: "l", error: false, backlink_href: nil, caption: nil, caption_size: 'm', header_classes: [])
+  def page_data(title:, header: :use_title, header_size: "l", error: false, backlink_href: nil, breadcrumbs: nil, caption: nil, caption_size: 'm', header_classes: [])
     page_title = title_with_error_prefix(title, error:)
     content_for(:page_title) { page_title }
 
-    backlink_or_breadcrumb = govuk_back_link(href: backlink_href) unless backlink_href.nil?
+    backlink_or_breadcrumb = if breadcrumbs
+                               govuk_breadcrumbs(breadcrumbs:)
+                             elsif backlink_href
+                               govuk_back_link(href: backlink_href) unless backlink_href.nil?
+                             end
     content_for(:backlink_or_breadcrumb) { backlink_or_breadcrumb }
 
     if (page_header_text = (header == :use_title) ? title : header)

--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -11,4 +11,39 @@ module ParityCheckHelper
       mode.new(value: :sequential, name: "Sequential", description: "Send requests one at a time for accurate performance benchmarking."),
     ]
   end
+
+  def formatted_endpoint_group_name(group_name)
+    group_name.to_s.tr("-", " ").humanize
+  end
+
+  def formatted_endpoint_group_names(run)
+    formatted_group_names = run.request_group_names.map(&method(:formatted_endpoint_group_name))
+    govuk_list(formatted_group_names)
+  end
+
+  def match_rate_tag(run)
+    colour = case run.match_rate
+             when 0..49
+               "red"
+             when 50..74
+               "orange"
+             when 75..99
+               "yellow"
+             else
+               "green"
+             end
+
+    govuk_tag(text: "#{run.match_rate}%", colour:)
+  end
+
+  def performance_gain(run)
+    ratio = run.rect_performance_gain_ratio
+
+    return if ratio.nil?
+
+    return "⚖️ equal" if ratio == 1
+    return "🚀 #{ratio}x faster" if ratio > 1
+
+    "🐌 #{ratio}x slower"
+  end
 end

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -13,6 +13,8 @@ module ParityCheck
     validates :rect_time_ms, numericality: { greater_than: 0 }
     validates :page, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true, uniqueness: { scope: :request_id }
 
+    scope :different, -> { where("ecf_status_code != rect_status_code OR ecf_body != rect_body") }
+
   private
 
     def different?

--- a/app/views/migration/parity_checks/_form.html.erb
+++ b/app/views/migration/parity_checks/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.govuk_error_summary %>
 
   <% grouped_endpoints(@endpoints).each do |group, endpoints| %>
-    <%= f.govuk_collection_check_boxes :endpoint_ids, endpoints, :id, :description, legend: { text: group.capitalize } %>
+    <%= f.govuk_collection_check_boxes :endpoint_ids, endpoints, :id, :description, legend: { text: formatted_endpoint_group_name(group) } %>
   <% end %>
 
   <%= f.govuk_collection_radio_buttons(:mode, run_mode_options, :value, :name, :description, legend: { text: "Mode" }) %>

--- a/app/views/migration/parity_checks/completed.html.erb
+++ b/app/views/migration/parity_checks/completed.html.erb
@@ -1,0 +1,45 @@
+<% page_data(title: "Completed parity checks", breadcrumbs: @breadcrumbs) %>
+
+<% if @completed_runs.none? %>
+  <p>
+    There are no completed parity checks.
+  </p>
+<% else %>
+  <%= govuk_details(summary_text: "How the run mode affects performance") do %>
+    <p>
+      In concurrent mode we send multiple requests to the same application at once, resulting in varying loads that randomly impact performance.
+    </p>
+    <p>
+      In sequential mode we send one request at a time, ensuring a like-for-like performance comparison.
+    </p>
+  <% end %>
+
+  <%= govuk_table do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Run #")
+        row.with_cell(text: "Endpoints")
+        row.with_cell(text: "Runtime")
+        row.with_cell(text: "Mode")
+        row.with_cell(text: "Match rate")
+        row.with_cell(text: "Performance")
+      end
+    end
+
+    table.with_body do |body|
+      @completed_runs.each do |run|
+        body.with_row do |row|
+          row.with_cell(text: run.id)
+          row.with_cell(text: formatted_endpoint_group_names(run))
+          row.with_cell(text: distance_of_time_in_words(run.started_at, run.completed_at))
+          row.with_cell(text: run.mode.capitalize)
+          row.with_cell(text: match_rate_tag(run))
+          row.with_cell(text: performance_gain(run))
+        end
+      end
+    end
+  end
+  %>
+
+  <%= govuk_pagination(pagy: @pagy) %>
+<% end %>

--- a/app/views/migration/parity_checks/new.html.erb
+++ b/app/views/migration/parity_checks/new.html.erb
@@ -15,6 +15,7 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">
+    <%= tag.p(link_to("View completed runs", completed_migration_parity_checks_path)) if @completed_runs.any? %>
     <%= render partial: "in_progress_run" if @in_progress_run %>
     <%= render partial: "pending_runs" if @pending_runs.any? %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,11 @@ Rails.application.routes.draw do
     resources :teachers, only: %i[index show]
 
     constraints -> { Rails.application.config.parity_check[:enabled] } do
-      resources :parity_checks, only: %i[new create]
+      resources :parity_checks, only: %i[new create] do
+        collection do
+          get :completed
+        end
+      end
     end
   end
 

--- a/db/seeds/parity_checks.rb
+++ b/db/seeds/parity_checks.rb
@@ -1,0 +1,75 @@
+def describe_endpoint(endpoint)
+  print_seed_info(endpoint.description, indent: 4)
+end
+
+def describe_run(run)
+  print_seed_info("#{run.mode.capitalize}, #{run.requests.size} requests, #{run.rect_performance_gain_ratio}x performance gain, #{run.match_rate}% match rate", indent: 4)
+end
+
+def random_time(from, max_distance)
+  Time.zone.at(rand(from.to_f..(from + max_distance).to_f))
+end
+
+def create_in_progress_run
+  mode = %i[concurrent sequential].sample
+  started_at = random_time(1.month.ago, 1.month)
+
+  ParityCheck::Run.create!(state: :in_progress, mode:, started_at:)
+end
+
+def create_in_progress_request(run:)
+  lead_provider = LeadProvider.order("RANDOM()").first
+  endpoint = ParityCheck::Endpoint.order("RANDOM()").first
+  started_at = random_time(run.started_at, 10.minutes)
+
+  ParityCheck::Request.create!(state: :in_progress, started_at:, run:, lead_provider:, endpoint:)
+end
+
+def create_response(request, response_type, page)
+  ecf_body = %({ "some": { "random": "json" } })
+  rect_body = response_type == :matching ? ecf_body : %({ "some": { "different": "json" } })
+
+  ParityCheck::Response.create!(
+    request:,
+    ecf_status_code: 200,
+    ecf_time_ms: rand(100..2000),
+    ecf_body:,
+    rect_status_code: 200,
+    rect_body:,
+    rect_time_ms: rand(100..2000),
+    page:
+  )
+end
+
+def random_response_types
+  # 20% change of all matching response types, otherwise weight towards most matching.
+  response_type_options = rand < 0.8 ? %i[matching matching different] : %i[matching]
+  Array.new(rand(1..3)) { response_type_options.sample }.flatten
+end
+
+print_seed_info("Endpoints:", colour: :blue)
+
+ParityCheck::SeedEndpoints.new.plant!
+ParityCheck::Endpoint.find_each(&method(:describe_endpoint))
+
+print_seed_info("Completed runs:", colour: :green, blank_lines_before: 1)
+
+5.times do
+  in_progress_run = create_in_progress_run
+
+  rand(3..10).times do
+    in_progress_request = create_in_progress_request(run: in_progress_run)
+
+    random_response_types.each.with_index(1) do |response_type, page|
+      create_response(in_progress_request, response_type, page)
+    end
+
+    request_completed_at = random_time(in_progress_request.started_at, 10.seconds)
+    in_progress_request.update!(state: :completed, completed_at: request_completed_at)
+  end
+
+  run_completed_at = random_time(in_progress_run.started_at, 2.hours)
+  in_progress_run.update!(state: :completed, completed_at: run_completed_at)
+
+  describe_run(in_progress_run)
+end

--- a/spec/factories/parity_check/request_factory.rb
+++ b/spec/factories/parity_check/request_factory.rb
@@ -4,6 +4,14 @@ FactoryBot.define do
     association(:run, factory: :parity_check_run)
     association(:endpoint, factory: :parity_check_endpoint)
 
+    transient do
+      response_types { [] }
+    end
+
+    after(:build) do |request, evaluator|
+      request.responses = evaluator.response_types.map { build(:parity_check_response, it, request:) } if evaluator.response_types.any?
+    end
+
     trait :get do
       endpoint { association(:parity_check_endpoint, :get) }
     end
@@ -33,6 +41,7 @@ FactoryBot.define do
       state { :completed }
       started_at { Time.current }
       completed_at { Time.current + 3.minutes }
+      response_types { %i[different] }
     end
   end
 end

--- a/spec/factories/parity_check/response_factory.rb
+++ b/spec/factories/parity_check/response_factory.rb
@@ -3,16 +3,23 @@ FactoryBot.define do
     association(:request, factory: :parity_check_request)
     ecf_body { "ECF response body" }
     ecf_status_code { 200 }
-    ecf_time_ms { 100 }
+    ecf_time_ms { Faker::Number.between(from: 10, to: 2000) }
     rect_body { "RECT response body" }
     rect_status_code { 201 }
-    rect_time_ms { 150 }
+    rect_time_ms { Faker::Number.between(from: 10, to: 2000) }
 
-    trait :equal do
+    trait :matching do
       ecf_status_code { 200 }
       rect_status_code { 200 }
       ecf_body { "Same response body" }
       rect_body { "Same response body" }
+    end
+
+    trait :different do
+      ecf_status_code { 200 }
+      rect_status_code { 201 }
+      ecf_body { "ECF response body" }
+      rect_body { "RECT response body" }
     end
   end
 end

--- a/spec/factories/parity_check/run_factory.rb
+++ b/spec/factories/parity_check/run_factory.rb
@@ -1,5 +1,13 @@
 FactoryBot.define do
   factory(:parity_check_run, class: "ParityCheck::Run") do
+    transient do
+      request_states { [] }
+    end
+
+    after(:build) do |run, evaluator|
+      run.requests = evaluator.request_states.map { build(:parity_check_request, it, run:) } if evaluator.request_states.any?
+    end
+
     trait :concurrent do
       mode { :concurrent }
     end

--- a/spec/features/migration/completed_parity_checks_spec.rb
+++ b/spec/features/migration/completed_parity_checks_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe "Completed parity checks" do
+  include ActionView::Helpers::DateHelper
+
+  before do
+    FactoryBot.create(:lead_provider)
+    sign_in_as_dfe_user(role: :admin)
+    allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: true })
+  end
+
+  scenario "Viewing completed parity checks" do
+    completed_run = FactoryBot.create(:parity_check_run, :completed)
+
+    statements_endpoint = FactoryBot.create(:parity_check_endpoint, path: "/api/v1/statements")
+    user_endpoint = FactoryBot.create(:parity_check_endpoint, path: "/api/v1/users/:id")
+
+    FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching different], run: completed_run, endpoint: statements_endpoint)
+    FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching matching], run: completed_run, endpoint: user_endpoint)
+
+    page.goto(new_migration_parity_check_path)
+    page.get_by_role("link", name: "View completed runs").click
+
+    expect(page.get_by_role("heading", name: "Completed parity checks")).to be_visible
+
+    expect(page.get_by_text(/In concurrent mode/)).not_to be_visible
+    page.get_by_text("How the run mode affects performance").click
+    expect(page.get_by_text(/In concurrent mode/)).to be_visible
+
+    page.screenshot(path: "completed_parity_checks.png")
+
+    completed_run_details = page.locator("table tbody")
+    expect(completed_run_details.get_by_text(completed_run.id.to_s)).to be_visible
+    expect(completed_run_details.get_by_text("Statements")).to be_visible
+    expect(completed_run_details.get_by_text("Users")).to be_visible
+    expect(completed_run_details.get_by_text("3 minutes")).to be_visible
+    expect(completed_run_details.get_by_text("Concurrent")).to be_visible
+    expect(completed_run_details.get_by_text("50%")).to be_visible
+    expect(completed_run_details.get_by_text(/faster|slower|equal/)).to be_visible
+
+    expect(page.locator(".govuk-pagination")).not_to be_visible
+  end
+
+  scenario "Paginating the completed parity checks when there are many" do
+    FactoryBot.create_list(:parity_check_run, Pagy::DEFAULT[:limit] + 1, :completed)
+
+    page.goto(completed_migration_parity_checks_path)
+
+    expect(page.locator("tbody tr")).to have_count(Pagy::DEFAULT[:limit])
+
+    pagination = page.locator(".govuk-pagination")
+    expect(pagination).to be_visible
+
+    expect(pagination.get_by_role("link", name: "1")).to be_visible
+    expect(pagination.get_by_role("link", name: "2")).to be_visible
+
+    pagination.get_by_role("link", name: "Next").click
+    expect(page.locator("tbody tr")).to have_count(1)
+  end
+
+  scenario "Viewing completed parity checks when there are none" do
+    page.goto(new_migration_parity_check_path)
+
+    expect(page.get_by_role("link", name: "View completed runs")).not_to be_visible
+
+    page.goto(completed_migration_parity_checks_path)
+
+    expect(page.get_by_role("heading", name: "Completed parity checks")).to be_visible
+    expect(page.get_by_text("There are no completed parity checks.")).to be_visible
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Run a parity check").click
+    expect(page.url).to end_with(new_migration_parity_check_path)
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,7 +24,20 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(content_for(:backlink_or_breadcrumb)).to eq(%(<a class="govuk-back-link" href="/retreat">Back</a>))
       end
 
-      it "adds provided breadcrumbs"
+      it "adds provided breadcrumbs" do
+        page_data(title: "Breadcrumb test", breadcrumbs: { "Home" => "/", "Detail" => "/detail" })
+
+        expect(content_for(:backlink_or_breadcrumb)).to eq(
+          <<~HTML.chomp
+            <div class="govuk-breadcrumbs">
+              <ol class="govuk-breadcrumbs__list">
+                  <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/">Home</a></li>
+                  <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/detail">Detail</a></li>
+              </ol>
+            </div>
+          HTML
+        )
+      end
     end
 
     describe "page_header" do

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -1,22 +1,60 @@
 RSpec.describe ParityCheckHelper, type: :helper do
   describe "#grouped_endpoints" do
-    subject(:grouping) { grouped_endpoints(endpoints) }
+    subject(:grouping) { helper.grouped_endpoints(endpoints) }
 
     let(:endpoints) do
       [
         FactoryBot.build(:parity_check_endpoint, path: "/api/v1/users"),
         FactoryBot.build(:parity_check_endpoint, path: "/api/v3/users/create"),
-        FactoryBot.build(:parity_check_endpoint, path: "/api/v2/statements"),
+        FactoryBot.build(:parity_check_endpoint, path: "/api/v2/participant-declarations"),
         FactoryBot.build(:parity_check_endpoint, path: "/login"),
       ]
     end
 
     it "groups endpoints by their group name" do
-      expect(grouping).to eq({
+      expect(grouping).to eq(
         users: endpoints[0..1],
-        statements: [endpoints[2]],
+        "participant-declarations": [endpoints[2]],
         miscellaneous: [endpoints[3]]
-      })
+      )
+    end
+  end
+
+  describe "#formatted_endpoint_group_name" do
+    subject { helper.formatted_endpoint_group_name(:"participant-declarations") }
+
+    it { is_expected.to eq("Participant declarations") }
+  end
+
+  describe "#formatted_endpoint_group_names" do
+    subject { helper.formatted_endpoint_group_names(run) }
+
+    let(:run) { FactoryBot.build(:parity_check_run) }
+
+    before { allow(run).to receive(:request_group_names).and_return(%i[participant-declarations users]) }
+
+    it { is_expected.to eq(%(<ul class=\"govuk-list\"><li>Participant declarations</li><li>Users</li></ul>)) }
+  end
+
+  describe "#match_rate_tag" do
+    subject { helper.match_rate_tag(run) }
+
+    let(:run) { FactoryBot.build(:parity_check_run, :completed) }
+
+    {
+      0 => "red",
+      49 => "red",
+      50 => "orange",
+      74 => "orange",
+      75 => "yellow",
+      99 => "yellow",
+      100 => "green"
+    }.each do |match_rate, colour|
+      context "when match rate is #{match_rate}%" do
+        before { allow(run).to receive(:match_rate).and_return(match_rate) }
+
+        it { is_expected.to eq(%(<strong class=\"govuk-tag govuk-tag--#{colour}\">#{match_rate}%</strong>)) }
+      end
     end
   end
 

--- a/spec/migration/parity_check/request_dispatcher_spec.rb
+++ b/spec/migration/parity_check/request_dispatcher_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe ParityCheck::RequestDispatcher do
 
       it "dispatches the post requests when all get requests are completed" do
         %i[queue! start! complete!].each do
+          pending_get_request.responses << FactoryBot.create(:parity_check_response, :matching)
           pending_get_request.send(it)
           # We complete the put request as it has the same priority and
           # we want to isolate the post request in this test.
+          pending_put_request.responses << FactoryBot.create(:parity_check_response, :matching)
           pending_put_request.send(it)
         end
 
@@ -43,8 +45,10 @@ RSpec.describe ParityCheck::RequestDispatcher do
       it "dispatches the put requests when all get requests are completed" do
         %i[queue! start! complete!].each do
           pending_get_request.send(it)
+          pending_get_request.responses << FactoryBot.create(:parity_check_response, :matching)
           # We complete the post request as it has the same priority and
           # we want to isolate the put request in this test.
+          pending_post_request.responses << FactoryBot.create(:parity_check_response, :matching)
           pending_post_request.send(it)
         end
 

--- a/spec/models/parity_check/endpoint_spec.rb
+++ b/spec/models/parity_check/endpoint_spec.rb
@@ -78,9 +78,9 @@ describe ParityCheck::Endpoint do
     end
 
     context "when the path matches the expected format (with query parameters)" do
-      let(:path) { "/api/v3/users?query=param" }
+      let(:path) { "/api/v3/participant-declarations?query=param" }
 
-      it { is_expected.to eq(:users) }
+      it { is_expected.to eq(:"participant-declarations") }
     end
 
     context "when the path matches the expected format (nested path)" do

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -6,8 +6,8 @@ describe ParityCheck::Response do
   end
 
   describe "before_validation" do
-    it "clears bodies if the responses are the same" do
-      response = FactoryBot.build(:parity_check_response, :equal)
+    it "clears bodies if the responses match" do
+      response = FactoryBot.build(:parity_check_response, :matching)
       expect { response.save! }.to change { response.ecf_body }.to(nil).and change { response.rect_body }.to(nil)
     end
   end
@@ -22,5 +22,16 @@ describe ParityCheck::Response do
     it { is_expected.to validate_numericality_of(:rect_time_ms).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:page).is_greater_than(0).only_integer.allow_nil }
     it { is_expected.to validate_uniqueness_of(:page).scoped_to(:request_id) }
+  end
+
+  describe "scopes" do
+    let!(:matching_response) { FactoryBot.create(:parity_check_response, :matching) }
+    let!(:different_response) { FactoryBot.create(:parity_check_response, :different) }
+
+    describe ".different" do
+      subject { described_class.different }
+
+      it { expect(subject).to contain_exactly(different_response) }
+    end
   end
 end

--- a/spec/requests/migration/parity_check_spec.rb
+++ b/spec/requests/migration/parity_check_spec.rb
@@ -80,4 +80,35 @@ RSpec.describe "Parity check", type: :request do
       end
     end
   end
+
+  describe "GET /migration/parity_checks/completed" do
+    context "when signed in as a DfE user" do
+      include_context 'sign in as DfE user'
+
+      it "renders the completed parity checks page" do
+        get completed_migration_parity_checks_path
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Completed parity checks")
+      end
+
+      context "when parity check is disabled" do
+        let(:enabled) { false }
+
+        it "renders 404 not found" do
+          get completed_migration_parity_checks_path
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "when not signed in as a DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "renders the unauthorized page" do
+        get completed_migration_parity_checks_path
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include("You are not authorised to access this page")
+      end
+    end
+  end
 end


### PR DESCRIPTION
> ⚠️ WIP

### Context

We want to be able to view all the completed parity check runs, so that we can later drill down into the run details.

### Changes proposed in this pull request

- Support breadcrumbs in `page_data`

It looks like support for this was intended/started but not finished.

Add `breadcrumbs` option to `page_data` which will render out the GOV UK style breadcrumbs.

This is going to be useful for the parity check navigation.

- Add completed parity checks to seed data

This makes developing the parity check locally easier if we can have completed parity checks planted.

I've not planted any pending/in-progress runs as the would just be instantly picked up by the job workers and become completed when the app boots anyway - we can easily kick these off manually.

- Add convenience methods/extra validation to `Run`/`Request`/`Response`

Add convenience methods for metrics and data we will want to surface as part of the completed parity checks page, namely:

- Completed parity checks
- Request groups
- Performance gain ratio
- Match rate

Update `Request` to validate responses are present when moving to a `completed`
state.

Update `Run` to validate all requests have been completed when moving to a `completed` state.

- Add completed parity checks page

Add a new route/page to show completed parity check runs.

Link to the new page from the start page when there are completed runs present.

Display key/high-level information about each run.

Paginate the results in case we end up with a lot of retained runs.

Add breadcrumbs to make navigation easier (eventually the parity check views will become quite nested when we drill down a run -> requests -> responses -> diffs).

### Guidance to review

| Seed output    | Start page (with completed runs link) | Completed page | Completed page (no runs yet) |
| -------- | ------- | ------- | ------- | 
| <img width="495" alt="Screenshot 2025-06-25 at 14 43 28" src="https://github.com/user-attachments/assets/85a0e853-1fd5-4617-9d3d-e1d42e90953f" /> | <img width="1183" alt="Screenshot 2025-06-25 at 14 43 56" src="https://github.com/user-attachments/assets/fa15d072-54e1-4b25-b27e-7e3aeab989ad" /> | <img width="1184" alt="Screenshot 2025-06-25 at 14 44 44" src="https://github.com/user-attachments/assets/29861743-99c9-4577-b839-d107d68eb620" /> | <img width="1179" alt="Screenshot 2025-06-25 at 14 45 15" src="https://github.com/user-attachments/assets/18f52787-eeea-4b80-b1f7-e62eec2cc91b" /> |