### PR TITLE
[1781] Authorise for payment action on statement

### DIFF
--- a/app/components/admin/statements/payment_authorisation_component.html.erb
+++ b/app/components/admin/statements/payment_authorisation_component.html.erb
@@ -1,0 +1,5 @@
+<% if can_authorise_payment? %>
+  <%= govuk_button_to "Authorise for payment", authorise_payment_admin_finance_statement_path(statement) %>
+<% elsif marked_as_paid? %>
+  <%= tag.p(marked_as_paid_text) %>
+<% end %>

--- a/app/components/admin/statements/payment_authorisation_component.rb
+++ b/app/components/admin/statements/payment_authorisation_component.rb
@@ -23,7 +23,7 @@ module Admin
       end
 
       def marked_as_paid_at
-        statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y")
+        statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %B %Y")
       end
     end
   end

--- a/app/components/admin/statements/payment_authorisation_component.rb
+++ b/app/components/admin/statements/payment_authorisation_component.rb
@@ -11,7 +11,7 @@ module Admin
       end
 
       def render?
-        statement.output_fee
+        statement.output_fee?
       end
 
       def marked_as_paid?

--- a/app/components/admin/statements/payment_authorisation_component.rb
+++ b/app/components/admin/statements/payment_authorisation_component.rb
@@ -1,0 +1,30 @@
+module Admin
+  module Statements
+    class PaymentAuthorisationComponent < ViewComponent::Base
+      delegate :can_authorise_payment?,
+               to: :statement
+
+      attr_accessor :statement
+
+      def initialize(statement:)
+        @statement = statement
+      end
+
+      def render?
+        statement.output_fee
+      end
+
+      def marked_as_paid?
+        statement.marked_as_paid_at.present?
+      end
+
+      def marked_as_paid_text
+        "Authorised for payment at #{marked_as_paid_at}"
+      end
+
+      def marked_as_paid_at
+        statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y")
+      end
+    end
+  end
+end

--- a/app/controllers/admin/finance/statements_controller.rb
+++ b/app/controllers/admin/finance/statements_controller.rb
@@ -27,6 +27,17 @@ module Admin::Finance
       end
     end
 
+    def authorise_payment
+      @statement = Statement.find(params[:id])
+
+      # TODO: run in a background job
+      if Statements::AuthorisePayment.new(@statement).authorise
+        redirect_to admin_finance_statement_path(@statement), alert: "Statement authorised"
+      else
+        redirect_to admin_finance_statement_path(@statement), alert: "Unable to authorise statement"
+      end
+    end
+
   private
 
     def statements_query

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,14 @@ module ApplicationHelper
     end
   end
 
+  def backlink_with_fallback(fallback:)
+    if request.referer.present? && request.referer != request.url
+      request.referer
+    else
+      fallback
+    end
+  end
+
   def page_data_from_front_matter(yaml)
     parsed_yaml = YAML.load(yaml)&.symbolize_keys
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -52,4 +52,9 @@ class Statement < ApplicationRecord
   def adjustment_editable?
     output_fee? && !paid?
   end
+
+  def can_authorise_payment?
+    # TODO: will also need to include: `participant_declarations.any?`
+    output_fee && payable? && !marked_as_paid_at? && deadline_date < Date.current
+  end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -55,6 +55,6 @@ class Statement < ApplicationRecord
 
   def can_authorise_payment?
     # TODO: will also need to include: `participant_declarations.any?`
-    output_fee && payable? && !marked_as_paid_at? && deadline_date < Date.current
+    output_fee? && payable? && !marked_as_paid_at? && deadline_date < Date.current
   end
 end

--- a/app/presenters/admin/statement_presenter.rb
+++ b/app/presenters/admin/statement_presenter.rb
@@ -13,7 +13,13 @@ module Admin
     def status_tag_kwargs
       colour = { 'open' => 'blue', 'payable' => 'yellow', 'paid' => 'green' }.fetch(statement.status)
 
-      { text: statement.status.capitalize, colour: }
+      text = if statement.output_fee? && statement.paid?
+               "Authorised for payment"
+             else
+               statement.status.capitalize
+             end
+
+      { text:, colour: }
     end
 
     def page_title

--- a/app/services/statements/authorise_payment.rb
+++ b/app/services/statements/authorise_payment.rb
@@ -1,0 +1,16 @@
+module Statements
+  class AuthorisePayment
+    attr_reader :statement
+
+    def initialize(statement)
+      @statement = statement
+    end
+
+    def authorise
+      return false unless statement.can_authorise_payment?
+
+      statement.marked_as_paid_at = Time.zone.now
+      statement.mark_as_paid
+    end
+  end
+end

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -46,4 +46,5 @@
   end
 %>
 
+<%= render Admin::Statements::PaymentAuthorisationComponent.new(statement: @statement) %>
 <%= render Admin::Statements::AdjustmentsComponent.new(statement: @statement) %>

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: @statement.page_title, backlink_href: (request.referer || admin_finance_statements_path)) %>
+<% page_data(title: @statement.page_title, backlink_href: backlink_with_fallback(fallback: admin_finance_statements_path)) %>
 
 <%= render Admin::Statements::SelectorComponent.new(statement: @statement) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,9 @@ Rails.application.routes.draw do
           collection do
             post :choose
           end
-
+          member do
+            post :authorise_payment
+          end
           resources :adjustments, controller: 'finance/adjustments', only: %i[new create edit update destroy] do
             member do
               get :delete

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -75,10 +75,9 @@ paths:
 components:
   securitySchemes:
     api_key:
+      type: http
+      scheme: bearer
       description: Bearer token
-      type: apiKey
-      name: Authorization
-      in: header
   schemas:
     IDAttribute:
       description: The unique ID of the resource.

--- a/spec/components/admin/statements/payment_authorisation_component_spec.rb
+++ b/spec/components/admin/statements/payment_authorisation_component_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe Admin::Statements::PaymentAuthorisationComponent, type: :component do
+  subject { render_inline(component) }
+
+  let(:statement) { FactoryBot.create(:statement, :payable, output_fee: true, marked_as_paid_at:) }
+  let(:marked_as_paid_at) { nil }
+  let(:component) { described_class.new statement: }
+
+  context "service_fee statement" do
+    let(:statement) { FactoryBot.create(:statement, :payable, output_fee: false) }
+
+    it "does not render" do
+      expect(subject.text).to be_blank
+    end
+  end
+
+  context "output_fee statement" do
+    context "can authorise payment" do
+      before { allow(statement).to receive(:can_authorise_payment?).and_return(true) }
+
+      it "renders correctly" do
+        expect(subject).to have_button("Authorise for payment")
+      end
+    end
+
+    context "marked as paid" do
+      let(:marked_as_paid_at) { Time.zone.now }
+
+      before { allow(statement).to receive(:can_authorise_payment?).and_return(false) }
+
+      it "renders correctly" do
+        expect(subject).not_to have_button("Authorise for payment")
+        marked_as_paid_at = statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y")
+        expect(subject).to have_content("Authorised for payment at #{marked_as_paid_at}")
+      end
+    end
+  end
+end

--- a/spec/components/admin/statements/payment_authorisation_component_spec.rb
+++ b/spec/components/admin/statements/payment_authorisation_component_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Admin::Statements::PaymentAuthorisationComponent, type: :component do
   subject { render_inline(component) }
 
-  let(:statement) { FactoryBot.create(:statement, :payable, output_fee: true, marked_as_paid_at:) }
+  let(:statement) { FactoryBot.create(:statement, :payable, :output_fee, marked_as_paid_at:) }
   let(:marked_as_paid_at) { nil }
   let(:component) { described_class.new statement: }
 
   context "service_fee statement" do
-    let(:statement) { FactoryBot.create(:statement, :payable, output_fee: false) }
+    let(:statement) { FactoryBot.create(:statement, :payable, :service_fee) }
 
     it "does not render" do
       expect(subject.text).to be_blank

--- a/spec/components/admin/statements/payment_authorisation_component_spec.rb
+++ b/spec/components/admin/statements/payment_authorisation_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::Statements::PaymentAuthorisationComponent, type: :componen
 
       it "renders correctly" do
         expect(subject).not_to have_button("Authorise for payment")
-        marked_as_paid_at = statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y")
+        marked_as_paid_at = statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %B %Y")
         expect(subject).to have_content("Authorised for payment at #{marked_as_paid_at}")
       end
     end

--- a/spec/features/admin/finance/statements/payment_authorisation_spec.rb
+++ b/spec/features/admin/finance/statements/payment_authorisation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Payment authorisation for statement" do
   end
 
   def and_i_see_payment_authorised_text
-    marked_as_paid_at = @statement.reload.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y")
+    marked_as_paid_at = @statement.reload.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %B %Y")
     expect(page.get_by_text("Authorised for payment at #{marked_as_paid_at}")).to be_visible
   end
 

--- a/spec/features/admin/finance/statements/payment_authorisation_spec.rb
+++ b/spec/features/admin/finance/statements/payment_authorisation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Payment authorisation for statement" do
   end
 
   def given_a_payable_finance_statement_exists
-    @statement = FactoryBot.create(:statement, :payable, output_fee: true, marked_as_paid_at: nil, deadline_date: 3.days.ago.to_date)
+    @statement = FactoryBot.create(:statement, :payable, :output_fee, marked_as_paid_at: nil, deadline_date: 3.days.ago.to_date)
   end
 
   def when_i_visit_the_finance_statement_page

--- a/spec/features/admin/finance/statements/payment_authorisation_spec.rb
+++ b/spec/features/admin/finance/statements/payment_authorisation_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe "Payment authorisation for statement" do
+  before { sign_in_as_dfe_user(role: :admin) }
+
+  scenario "Statement can be authorised for payment" do
+    given_a_payable_finance_statement_exists
+
+    when_i_visit_the_finance_statement_page
+    and_i_click_authorise_for_payment_button
+
+    then_i_see_payment_authorised_notice
+    and_i_see_payment_authorised_text
+    and_statement_is_payment_authorised
+  end
+
+  def given_a_payable_finance_statement_exists
+    @statement = FactoryBot.create(:statement, :payable, output_fee: true, marked_as_paid_at: nil, deadline_date: 3.days.ago.to_date)
+  end
+
+  def when_i_visit_the_finance_statement_page
+    page.goto(admin_finance_statement_path(@statement))
+  end
+
+  def and_i_click_authorise_for_payment_button
+    page.get_by_role('button', name: "Authorise for payment").click
+  end
+
+  def then_i_see_payment_authorised_notice
+    expect(page.get_by_text('Statement authorised')).to be_visible
+  end
+
+  def and_i_see_payment_authorised_text
+    marked_as_paid_at = @statement.reload.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y")
+    expect(page.get_by_text("Authorised for payment at #{marked_as_paid_at}")).to be_visible
+  end
+
+  def and_statement_is_payment_authorised
+    expect(@statement.marked_as_paid_at).to be_present
+    expect(@statement.status).to eq("paid")
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -92,6 +92,41 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#backlink_with_fallback" do
+    let(:mock_referer) { "http://example.com/referer" }
+    let(:mock_url) { "http://example.com/url" }
+
+    before do
+      mock_request = instance_double(ActionDispatch::Request, referer: mock_referer, url: mock_url)
+      allow(self).to receive(:request).and_return(mock_request)
+    end
+
+    context "request with referer" do
+      it "returns referer url" do
+        url = backlink_with_fallback(fallback: "/statements")
+        expect(url).to eq(mock_referer)
+      end
+
+      context "when referer url is same as page url" do
+        let(:mock_referer) { mock_url }
+
+        it "returns fallback url" do
+          url = backlink_with_fallback(fallback: "/statements")
+          expect(url).to eq("/statements")
+        end
+      end
+    end
+
+    context "request without referer" do
+      let(:mock_referer) { nil }
+
+      it "returns fallback url" do
+        url = backlink_with_fallback(fallback: "/statements")
+        expect(url).to eq("/statements")
+      end
+    end
+  end
+
   describe "#page_data_from_front_matter" do
     context "with yaml content" do
       let(:front_matter) do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -152,4 +152,53 @@ describe Statement do
       end
     end
   end
+
+  context ".can_authorise_payment?" do
+    context "open statement" do
+      subject { FactoryBot.build(:statement, :open) }
+
+      it { expect(subject.can_authorise_payment?).to be(false) }
+    end
+
+    context "paid statement" do
+      subject { FactoryBot.build(:statement, :paid) }
+
+      it { expect(subject.can_authorise_payment?).to be(false) }
+    end
+
+    # output_fee && payable? && !marked_as_paid_at? && deadline_date < Date.current
+    context "payable statement" do
+      context "service_fee statement" do
+        subject { FactoryBot.build(:statement, :payable, output_fee: false) }
+
+        it { expect(subject.can_authorise_payment?).to be(false) }
+      end
+
+      context "output_fee statement" do
+        let(:output_fee) { true }
+
+        context "with deadline_date in future" do
+          subject { FactoryBot.build(:statement, :payable, output_fee:, deadline_date: 3.days.from_now.to_date) }
+
+          it { expect(subject.can_authorise_payment?).to be(false) }
+        end
+
+        context "with deadline_date in past" do
+          let(:deadline_date) { 3.days.ago.to_date }
+
+          context "marked as payable" do
+            subject { FactoryBot.build(:statement, :payable, output_fee:, deadline_date:, marked_as_paid_at: Time.zone.now) }
+
+            it { expect(subject.can_authorise_payment?).to be(false) }
+          end
+
+          context "is not marked as payable" do
+            subject { FactoryBot.build(:statement, :payable, output_fee:, deadline_date:, marked_as_paid_at: nil) }
+
+            it { expect(subject.can_authorise_payment?).to be(true) }
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -166,19 +166,16 @@ describe Statement do
       it { expect(subject.can_authorise_payment?).to be(false) }
     end
 
-    # output_fee && payable? && !marked_as_paid_at? && deadline_date < Date.current
     context "payable statement" do
       context "service_fee statement" do
-        subject { FactoryBot.build(:statement, :payable, output_fee: false) }
+        subject { FactoryBot.build(:statement, :payable, :service_fee) }
 
         it { expect(subject.can_authorise_payment?).to be(false) }
       end
 
       context "output_fee statement" do
-        let(:output_fee) { true }
-
         context "with deadline_date in future" do
-          subject { FactoryBot.build(:statement, :payable, output_fee:, deadline_date: 3.days.from_now.to_date) }
+          subject { FactoryBot.build(:statement, :payable, :output_fee, deadline_date: 3.days.from_now.to_date) }
 
           it { expect(subject.can_authorise_payment?).to be(false) }
         end
@@ -187,13 +184,13 @@ describe Statement do
           let(:deadline_date) { 3.days.ago.to_date }
 
           context "marked as payable" do
-            subject { FactoryBot.build(:statement, :payable, output_fee:, deadline_date:, marked_as_paid_at: Time.zone.now) }
+            subject { FactoryBot.build(:statement, :payable, :output_fee, deadline_date:, marked_as_paid_at: Time.zone.now) }
 
             it { expect(subject.can_authorise_payment?).to be(false) }
           end
 
           context "is not marked as payable" do
-            subject { FactoryBot.build(:statement, :payable, output_fee:, deadline_date:, marked_as_paid_at: nil) }
+            subject { FactoryBot.build(:statement, :payable, :output_fee, deadline_date:, marked_as_paid_at: nil) }
 
             it { expect(subject.can_authorise_payment?).to be(true) }
           end

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -35,10 +35,20 @@ describe Admin::StatementPresenter do
     end
 
     context 'when paid' do
-      let(:statement) { FactoryBot.build(:statement, :paid) }
+      context 'when service fee statement' do
+        let(:statement) { FactoryBot.build(:statement, :paid, output_fee: false) }
 
-      it 'is green and Paid' do
-        expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Paid' })
+        it 'is green and Paid' do
+          expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Paid' })
+        end
+      end
+
+      context 'when output fee statement' do
+        let(:statement) { FactoryBot.build(:statement, :paid, output_fee: true) }
+
+        it 'is green and Paid' do
+          expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Authorised for payment' })
+        end
       end
     end
 

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -36,7 +36,7 @@ describe Admin::StatementPresenter do
 
     context 'when paid' do
       context 'when service fee statement' do
-        let(:statement) { FactoryBot.build(:statement, :paid, output_fee: false) }
+        let(:statement) { FactoryBot.build(:statement, :paid, :service_fee) }
 
         it 'is green and Paid' do
           expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Paid' })
@@ -44,7 +44,7 @@ describe Admin::StatementPresenter do
       end
 
       context 'when output fee statement' do
-        let(:statement) { FactoryBot.build(:statement, :paid, output_fee: true) }
+        let(:statement) { FactoryBot.build(:statement, :paid, :output_fee) }
 
         it 'is green and Paid' do
           expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Authorised for payment' })

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Statements::AuthorisePayment do
+  subject { described_class.new(statement) }
+
+  let(:statement) { FactoryBot.create(:statement, :payable, marked_as_paid_at: nil) }
+
+  describe "#authorise" do
+    context "can authorise payment" do
+      before { allow(statement).to receive(:can_authorise_payment?).and_return(true) }
+
+      it "sets marked_as_paid_at and status to paid" do
+        expect(subject.authorise).to be(true)
+        statement.reload
+        expect(statement.marked_as_paid_at).to be_present
+        expect(statement.status).to eq("paid")
+      end
+    end
+
+    context "cannot authorise payment" do
+      before { allow(statement).to receive(:can_authorise_payment?).and_return(false) }
+
+      it "return false" do
+        expect(subject.authorise).to be(false)
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -30,10 +30,9 @@ RSpec.configure do |config|
       components: {
         securitySchemes: {
           api_key: {
+            type: :http,
+            scheme: :bearer,
             description: "Bearer token",
-            type: :apiKey,
-            name: "Authorization",
-            in: :header,
           },
         },
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1781

### Changes proposed in this pull request

* Created `Admin::Statements::PaymentAuthorisationComponent` component
* Created `Statements::AuthorisePayment` service class
* Controller action to authorise payment

### Guidance to review

* In DfE admin, go to statements
* Select a `payable` statement