### PR TITLE
[1705] Use inline Active Job adapter in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,7 +83,8 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  config.active_job.queue_adapter = :solid_queue
+  # Use inline job execution in development to simplify debugging. Jobs run immediately in the same process (no queue required).
+  config.active_job.queue_adapter = :inline
+
   # config.active_job.queue_name_prefix = "ecf2_development"
 end


### PR DESCRIPTION
### Context

In development, we were using the `:solid_queue` Active Job adapter, which runs jobs asynchronously. This made it harder to debug jobs or confirm side effects like event creation in real time.

### Changes proposed in this pull request

- Switches the Active Job adapter to `:inline` in development so jobs run immediately and synchronously
- Makes it easier to debug and test features involving background jobs (e.g. event recording)

### Why this matters

Running jobs inline in development improves feedback loops and avoids needing to run a job processor or check a queue when developing or debugging.