### PR TITLE
Refresh parity check runs with turbo streams

### DIFF
--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -49,6 +49,10 @@ module ParityCheck
       before_transition any => :completed do |instance|
         instance.touch(:completed_at)
       end
+
+      after_transition any => :completed do |instance|
+        instance.run.broadcast_run_states
+      end
     end
 
     def average_ecf_response_time_ms

--- a/app/views/migration/parity_checks/_in_progress_run.html.erb
+++ b/app/views/migration/parity_checks/_in_progress_run.html.erb
@@ -1,11 +1,13 @@
 <h2 class="govuk-heading-m">In-progress run</h2>
 
 <%= govuk_list classes: "parity-check-in-progress" do
-  tag.li do
-    govuk_list do
-      tag.li(tag.label(tag.strong("Run ##{@in_progress_run.id}")) + " " + govuk_tag(text: "#{@in_progress_run.progress}%", colour: "blue")) +
-      tag.li(tag.progress(value: @in_progress_run.progress, max: 100)) +
-      tag.li(tag.small("Started #{time_ago_in_words(@in_progress_run.started_at)} ago"))
+    tag.li do
+      govuk_list do
+        tag.li(tag.label(tag.strong("Run ##{in_progress_run.id}")) + " " + govuk_tag(text: "#{in_progress_run.progress}%", colour: "blue")) +
+        tag.li(tag.progress(value: in_progress_run.progress, max: 100)) +
+        tag.li(tag.small("Started #{time_ago_in_words(in_progress_run.started_at)} ago"))
+      end
     end
-  end
-end %>
+  end 
+%>
+

--- a/app/views/migration/parity_checks/_pending_runs.html.erb
+++ b/app/views/migration/parity_checks/_pending_runs.html.erb
@@ -1,16 +1,16 @@
 <h2 class="govuk-heading-m">
   Pending runs
-  <% if @in_progress_run&.estimated_completion_at %>
+  <% if in_progress_run&.estimated_completion_at %>
   <p>
     <small class="govuk-caption-xs">
-      ⏱️ The next run will start in <%= distance_of_time_in_words(@in_progress_run.started_at, @in_progress_run.estimated_completion_at) %>
+      ⏱️ The next run will start in <%= distance_of_time_in_words(in_progress_run.started_at, in_progress_run.estimated_completion_at) %>
     </small>
   </p>
   <% end %>  
 </h2>
 
 <%= govuk_list do
-  safe_join(@pending_runs.map do |run|
+  safe_join(pending_runs.map do |run|
     tag.li do
       govuk_list do
         tag.li(tag.label(tag.strong("Run ##{run.id}"))) +

--- a/app/views/migration/parity_checks/_runs_sidebar.html.erb
+++ b/app/views/migration/parity_checks/_runs_sidebar.html.erb
@@ -1,0 +1,5 @@
+<div id="run_states">
+  <%= tag.p(link_to("View completed runs", completed_migration_parity_checks_path)) if completed_runs.any? %>
+  <%= render partial: "in_progress_run", locals: { in_progress_run: } if in_progress_run %>
+  <%= render partial: "pending_runs", locals: { pending_runs:, in_progress_run: } if pending_runs.any? %>
+</div>

--- a/app/views/migration/parity_checks/new.html.erb
+++ b/app/views/migration/parity_checks/new.html.erb
@@ -15,9 +15,9 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= tag.p(link_to("View completed runs", completed_migration_parity_checks_path)) if @completed_runs.any? %>
-    <%= render partial: "in_progress_run" if @in_progress_run %>
-    <%= render partial: "pending_runs" if @pending_runs.any? %>
+    <%= turbo_stream_from :run_states %>
+
+    <%= render partial: "runs_sidebar", locals: { in_progress_run: @in_progress_run, completed_runs: @completed_runs, pending_runs: @pending_runs } %>
   </div>
 </div>
 

--- a/spec/models/parity_check/request_spec.rb
+++ b/spec/models/parity_check/request_spec.rb
@@ -125,6 +125,12 @@ describe ParityCheck::Request do
 
       it { expect { request.complete! }.to change(request, :state).from("in_progress").to("completed") }
       it { expect { request.complete! }.to change(request, :completed_at).from(nil).to(be_within(1.second).of(Time.zone.now)) }
+
+      it "broadcasts the run states" do
+        expect(request.run).to receive(:broadcast_run_states).once
+
+        request.complete!
+      end
     end
 
     context "when attempting an unsupported transition" do


### PR DESCRIPTION
### Context

When we submit a run the run appears in the sidebar, but the state doesn't update unless you refresh the page. I've been looking for an excuse to try turbo streams, so I knocked this together in my own time 🙂 

![Turbo time](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHBpcWoycnJ4ZHoxZHI3ZGdweDNsYzJrbmpwcXl5ZDZzaXdkYmFhMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6wrnKTAc3ZFu6EcE/giphy.gif)

### Changes proposed in this pull request

- Update runs sidebar in place with turbo streams

Use turbo streams to broadcast run updates and refresh the sidebar.

### Guidance to review

It looks like you should be able to pass a partial to `broadcast_update_to` directly, but it always rendered empty for me so I gave up and called the renderer directly. I may pull the broadcasting out into its own service if we introduce it in other places.


https://github.com/user-attachments/assets/8846c740-0a37-4f86-9089-a3ac6afbb531

