### PR TITLE
Show a parity check request in detail

### DIFF
--- a/app/assets/stylesheets/migration/parity_check.scss
+++ b/app/assets/stylesheets/migration/parity_check.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.parity-check-table {
+.parity-check-requests-table {
   tbody:nth-child(odd) {
     tr:last-child .govuk-table__cell {
       border: none;
@@ -31,5 +31,23 @@
     tr:last-child td {
       border-bottom: 3px solid #b1b4b6; 
     }
+  }
+}
+
+.parity-check-responses-table {
+  .border-left {
+    border-left: 1px solid #b1b4b6;
+  }
+
+  thead {
+    tr:first-child th {
+      text-align: center;
+      border-bottom: 0;
+    }
+  }
+  
+
+  tbody .center {
+    text-align: center;
   }
 }

--- a/app/controllers/migration/parity_checks/requests_controller.rb
+++ b/app/controllers/migration/parity_checks/requests_controller.rb
@@ -1,0 +1,17 @@
+module Migration::ParityChecks
+  class RequestsController < ::AdminController
+    layout "full"
+
+    def show
+      @request = ParityCheck::Run.completed.find(params[:parity_check_run_id]).requests.find(params[:id])
+      @pagy, @responses = pagy(@request.responses)
+
+      @multiple_pages = @responses.any?(&:page)
+      @breadcrumbs = {
+        "Run a parity check" => new_migration_parity_check_path,
+        "Completed parity checks" => completed_migration_parity_checks_path,
+        "Parity check run ##{@request.run_id}" => migration_parity_check_path(@request.run),
+      }
+    end
+  end
+end

--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -26,7 +26,7 @@ class Migration::ParityChecksController < ::AdminController
   end
 
   def show
-    @run = ParityCheck::Run.completed.find(params[:id])
+    @run = ParityCheck::Run.completed.find(params[:run_id])
     @breadcrumbs = {
       "Run a parity check" => new_migration_parity_check_path,
       "Completed parity checks" => completed_migration_parity_checks_path,

--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -40,6 +40,23 @@ module ParityCheckHelper
     govuk_tag(text: "#{match_rate}%", colour:)
   end
 
+  def status_code_tag(status_code)
+    colour = case status_code
+             when 0...300
+               "green"
+             when 300...400
+               "yellow"
+             else
+               "red"
+             end
+
+    govuk_tag(text: status_code, colour:)
+  end
+
+  def comparison_emoji(matching)
+    matching ? "✅" : "❌"
+  end
+
   def performance_gain(ratio)
     return if ratio.nil?
 

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -36,14 +36,14 @@ module ParityCheck
       !different?
     end
 
+    def different?
+      [ecf_status_code, ecf_body] != [rect_status_code, rect_body]
+    end
+
   private
 
     def bodies_matching?
       ecf_body == rect_body
-    end
-
-    def different?
-      [ecf_status_code, ecf_body] != [rect_status_code, rect_body]
     end
 
     def clear_bodies

--- a/app/views/migration/parity_checks/completed.html.erb
+++ b/app/views/migration/parity_checks/completed.html.erb
@@ -36,7 +36,7 @@
           row.with_cell(text: run.mode.capitalize)
           row.with_cell(text: match_rate_tag(run.match_rate))
           row.with_cell(text: performance_gain(run.rect_performance_gain_ratio))
-          row.with_cell(text: govuk_link_to("View", migration_parity_check_path(run)))
+          row.with_cell(text: govuk_link_to("Run details", migration_parity_check_path(run)))
         end
       end
     end

--- a/app/views/migration/parity_checks/requests/show.html.erb
+++ b/app/views/migration/parity_checks/requests/show.html.erb
@@ -1,0 +1,73 @@
+<% page_data(title: @request.endpoint.description, caption: @request.lead_provider.name, breadcrumbs: @breadcrumbs) %>
+
+<p>
+  The request resulted in <strong><%= number_with_delimiter(@responses.size) %> <%= "response".pluralize(@responses.size) %></strong> 
+  that took <strong><%= distance_of_time_in_words(@request.started_at, @request.completed_at) %></strong> to complete.
+</p>
+
+<p>
+  Overall the request was <%= match_rate_tag(@request.match_rate) %> successful and had on average 
+  <strong><%= performance_gain(@request.rect_performance_gain_ratio) %></strong> performance when compared to ECF.
+</p>
+
+<hr class="govuk-section-break govuk-section-break--l">
+
+<%= govuk_table(classes: %w[parity-check-responses-table]) do |table|
+  table.with_caption(size: "m", text: "Responses")
+
+  table.with_colgroup do |colgroup|
+    colgroup.with_col(span: 1)
+    colgroup.with_col(span: 2, html_attributes: { class: "rect" })
+    colgroup.with_col(span: 2, html_attributes: { class: "ecf" })
+  end
+
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell if @multiple_pages
+
+      row.with_cell(text: "RECT", colspan: 2, scope: "colgroup", html_attributes: { class: @multiple_pages ? "border-left" : "" })
+      row.with_cell(text: "ECF", colspan: 2, scope: "colgroup", html_attributes: { class: "border-left" })
+      row.with_cell(colspan: 2, scope: "colgroup", html_attributes: { class: "border-left" })
+    end
+
+    head.with_row do |row|
+      row.with_cell(text: "Page") if @multiple_pages
+
+      row.with_cell(text: "Status", numeric: true, html_attributes: { class: @multiple_pages ? "border-left" : "" })
+      row.with_cell(text: "Time", numeric: true)
+
+      row.with_cell(text: "Status", numeric: true, html_attributes: { class: "border-left" })
+      row.with_cell(text: "Time", numeric: true)
+
+      row.with_cell(text: "Performance", numeric: true, html_attributes: { class: "border-left" })
+      row.with_cell(text: "Matching", html_attributes: { class: "center" })
+
+      row.with_cell if @responses.any?(&:different?)
+    end
+  end
+
+  table.with_body do |body|
+    @responses.each do |response|
+      body.with_row do |row|
+        row.with_cell(text: response.page) if @multiple_pages
+
+        row.with_cell(text: status_code_tag(response.rect_status_code), numeric: true, html_attributes: { class: @multiple_pages ? "border-left" : "" })
+        row.with_cell(text: "#{number_with_delimiter(response.rect_time_ms)}ms", numeric: true)
+
+        row.with_cell(text: status_code_tag(response.ecf_status_code), numeric: true, html_attributes: { class: "border-left" })
+        row.with_cell(text: "#{number_with_delimiter(response.ecf_time_ms)}ms", numeric: true)
+
+        row.with_cell(text: performance_gain(response.rect_performance_gain_ratio), numeric: true, html_attributes: { class: "border-left" })
+        row.with_cell(text: comparison_emoji(response.matching?), html_attributes: { class: "center" })
+
+        if response.different?
+          row.with_cell(text: govuk_link_to("Response details", "#"), html_attributes: { class: "center" })     
+        elsif @responses.any?(&:different?)
+          row.with_cell
+        end
+      end
+    end
+  end
+end %>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/migration/parity_checks/show.html.erb
+++ b/app/views/migration/parity_checks/show.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Overall the run was <%= match_rate_tag(@run.match_rate) %> successful and had 
+  Overall the run was <%= match_rate_tag(@run.match_rate) %> successful and had on average 
   <strong><%= performance_gain(@run.rect_performance_gain_ratio) %></strong> performance when compared to ECF.
 </p>
 
@@ -24,7 +24,7 @@
   </p>
 <% else %>
   <% @run.lead_providers.each do |lead_provider| %>
-    <%= govuk_table(classes: %w[parity-check-table]) do |table|
+    <%= govuk_table(classes: %w[parity-check-requests-table]) do |table|
       table.with_caption(size: "m", text: lead_provider.name)
 
       table.with_head do |head|
@@ -32,6 +32,7 @@
           row.with_cell(text: "Endpoint", width: "one-half")
           row.with_cell(text: "Match rate", width: "one-quater")
           row.with_cell(text: "Performance", width: "one-quater")
+          row.with_cell
         end
       end
 
@@ -42,6 +43,7 @@
               row.with_cell(text: request.endpoint.description)
               row.with_cell(text: match_rate_tag(request.match_rate))
               row.with_cell(text: performance_gain(request.rect_performance_gain_ratio))
+              row.with_cell(text: govuk_link_to("Request details", migration_parity_check_request_path(@run, request)))
             end
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,10 +134,12 @@ Rails.application.routes.draw do
     resources :teachers, only: %i[index show]
 
     constraints -> { Rails.application.config.parity_check[:enabled] } do
-      resources :parity_checks, only: %i[new create show] do
+      resources :parity_checks, only: %i[new create show], param: :run_id do
         collection do
           get :completed
         end
+
+        resources :requests, only: :show, module: :parity_checks
       end
     end
   end

--- a/db/seeds/parity_checks.rb
+++ b/db/seeds/parity_checks.rb
@@ -67,7 +67,9 @@ if Rails.application.config.parity_check[:enabled]
       LeadProvider.find_each do |lead_provider|
         in_progress_request = create_in_progress_request(run: in_progress_run, lead_provider:, endpoint:)
 
-        random_response_types.each.with_index(1) do |response_type, page|
+        response_types = random_response_types
+        response_types.each.with_index(1) do |response_type, page|
+          page = nil if response_types.size == 1
           create_response(in_progress_request, response_type, page)
         end
 

--- a/spec/factories/parity_check/request_factory.rb
+++ b/spec/factories/parity_check/request_factory.rb
@@ -29,29 +29,32 @@ FactoryBot.define do
     end
 
     trait :queued do
+      association(:run, factory: %i[parity_check_run in_progress])
       state { :queued }
     end
 
     trait :in_progress do
+      association(:run, factory: %i[parity_check_run in_progress])
       state { :in_progress }
       started_at { Time.current }
     end
 
     trait :completed do
+      association(:run, factory: %i[parity_check_run completed])
       state { :completed }
       started_at { Time.current }
       completed_at { Time.current + 3.minutes }
-      response_types { %i[different] }
+      response_types { responses.any? ? [] : [:different] }
     end
 
     trait :completed_different do
       completed
-      response_types { %i[different] }
+      response_types { responses.any? ? [] : [:different] }
     end
 
     trait :completed_matching do
       completed
-      response_types { %i[matching] }
+      response_types { responses.any? ? [] : [:matching] }
     end
   end
 end

--- a/spec/features/migration/view_completed_parity_checks_spec.rb
+++ b/spec/features/migration/view_completed_parity_checks_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe "View completed parity checks" do
   before do
-    FactoryBot.create(:lead_provider)
     sign_in_as_dfe_user(role: :admin)
     allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: true })
   end
@@ -23,15 +22,15 @@ RSpec.describe "View completed parity checks" do
     page.get_by_text("How the run mode affects performance").click
     expect(page.get_by_text(/In concurrent mode/)).to be_visible
 
-    tbody = page.locator("table tbody")
-    expect(tbody.locator("td:nth-child(1)").get_by_text(completed_run.id.to_s)).to be_visible
-    expect(tbody.get_by_text("Statements")).to be_visible
-    expect(tbody.get_by_text("Users")).to be_visible
-    expect(tbody.get_by_text("3 minutes")).to be_visible
-    expect(tbody.get_by_text("Concurrent")).to be_visible
-    expect(tbody.get_by_text("75%")).to be_visible
-    expect(tbody.get_by_text(/faster|slower|equal/)).to be_visible
-    expect(tbody.get_by_role("link", name: "View")).to be_visible
+    completed_run_details = page.locator("table tbody")
+    expect(completed_run_details.get_by_text(completed_run.id.to_s)).to be_visible
+    expect(completed_run_details.get_by_text("Statements")).to be_visible
+    expect(completed_run_details.get_by_text("Users")).to be_visible
+    expect(completed_run_details.get_by_text("3 minutes")).to be_visible
+    expect(completed_run_details.get_by_text("Concurrent")).to be_visible
+    expect(completed_run_details.get_by_text("75%")).to be_visible
+    expect(completed_run_details.get_by_text(/faster|slower|equal/)).to be_visible
+    expect(completed_run_details.get_by_role("link", name: "Run details")).to be_visible
 
     expect(page.locator(".govuk-pagination")).not_to be_visible
   end

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -1,0 +1,98 @@
+RSpec.describe "View parity check request" do
+  include ActionView::Helpers::NumberHelper
+
+  before do
+    sign_in_as_dfe_user(role: :admin)
+    allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: true })
+  end
+
+  scenario "Viewing a parity check request" do
+    run = FactoryBot.create(:parity_check_run, :completed)
+    responses = [
+      FactoryBot.create(:parity_check_response, :matching, page: 1),
+      FactoryBot.create(:parity_check_response, :different, page: 2),
+    ]
+    request = FactoryBot.create(:parity_check_request, :completed, run:, responses:)
+
+    page.goto(migration_parity_check_path(run))
+    page.get_by_role("link", name: "Request details").click
+
+    expect(page.get_by_text(request.lead_provider.name)).to be_visible
+    expect(page.get_by_role("heading", name: request.endpoint.description)).to be_visible
+
+    expect(page.get_by_text("The request resulted in 2 responses that took 3 minutes to complete.")).to be_visible
+    expect(page.get_by_text("Overall the request was 50% successful")).to be_visible
+    expect(page.get_by_text(/(equal|faster|slower) performance when compared to ECF/)).to be_visible
+
+    table = page.locator("table")
+    expect(table.get_by_text("Responses")).to be_visible
+
+    responses.each.with_index(1) do |response, row_number|
+      row = table.locator("tbody tr:nth-child(#{row_number})")
+
+      expect(row.locator("td:nth-child(1)").get_by_text(response.page.to_s)).to be_visible
+
+      expect(row.locator("td:nth-child(2)").get_by_text(response.rect_status_code.to_s)).to be_visible
+      expect(row.locator("td:nth-child(3)").get_by_text(number_with_delimiter(response.rect_time_ms))).to be_visible
+
+      expect(row.locator("td:nth-child(4)").get_by_text(response.ecf_status_code.to_s)).to be_visible
+      expect(row.locator("td:nth-child(5)").get_by_text(number_with_delimiter(response.ecf_time_ms))).to be_visible
+
+      expect(row.get_by_text(/faster|slower|equal/)).to be_visible
+      expect(row.get_by_text(response.matching? ? "✅" : "❌")).to be_visible
+
+      expect(row.get_by_role("link", name: "Response details").visible?).to eq(response.different?)
+    end
+
+    expect(page.locator(".govuk-pagination")).not_to be_visible
+  end
+
+  scenario "Paginating the parity check responses when there are many" do
+    run = FactoryBot.create(:parity_check_run, :completed)
+    responses = FactoryBot.create_list(:parity_check_response, Pagy::DEFAULT[:limit] + 1, :matching)
+    request = FactoryBot.create(:parity_check_request, :completed, run:, responses:)
+
+    page.goto(migration_parity_check_request_path(run, request))
+
+    expect(page.locator("tbody tr")).to have_count(Pagy::DEFAULT[:limit])
+
+    pagination = page.locator(".govuk-pagination")
+    expect(pagination).to be_visible
+
+    expect(pagination.get_by_role("link", name: "1")).to be_visible
+    expect(pagination.get_by_role("link", name: "2")).to be_visible
+
+    pagination.get_by_role("link", name: "Next").click
+    expect(page.locator("tbody tr")).to have_count(1)
+  end
+
+  scenario "Navigating back to the parity check run" do
+    request = FactoryBot.create(:parity_check_request, :completed)
+
+    page.goto(migration_parity_check_request_path(request.run, request))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Parity check run ##{request.run.id}").click
+    expect(page.url).to end_with(migration_parity_check_path(request.run))
+  end
+
+  scenario "Navigating back to completed parity checks" do
+    request = FactoryBot.create(:parity_check_request, :completed)
+
+    page.goto(migration_parity_check_request_path(request.run, request))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Completed parity checks").click
+    expect(page.url).to end_with(completed_migration_parity_checks_path)
+  end
+
+  scenario "Navigating back to run a parity check" do
+    request = FactoryBot.create(:parity_check_request, :completed)
+
+    page.goto(migration_parity_check_request_path(request.run, request))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Run a parity check").click
+    expect(page.url).to end_with(new_migration_parity_check_path)
+  end
+end

--- a/spec/features/migration/view_parity_check_spec.rb
+++ b/spec/features/migration/view_parity_check_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe "View parity check" do
   before do
-    FactoryBot.create(:lead_provider)
     sign_in_as_dfe_user(role: :admin)
     allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: true })
   end
@@ -9,7 +8,7 @@ RSpec.describe "View parity check" do
     run = FactoryBot.create(:parity_check_run, :completed, request_states: %i[completed_different completed_matching])
 
     page.goto(completed_migration_parity_checks_path)
-    page.get_by_role("link", name: "View").click
+    page.get_by_role("link", name: "Run details").click
 
     expect(page.get_by_role("heading", name: "Parity check run ##{run.id}")).to be_visible
 
@@ -31,6 +30,7 @@ RSpec.describe "View parity check" do
         expect(table.get_by_text(request.endpoint.description)).to be_visible
         expect(table.get_by_text("#{request.match_rate}%")).to be_visible
         expect(table.get_by_text(/faster|slower|equal/)).to be_visible
+        expect(table.get_by_role("link", name: "Request details")).to be_visible
       end
     end
   end

--- a/spec/features/migration/view_pending_and_in_progress_parity_checks_spec.rb
+++ b/spec/features/migration/view_pending_and_in_progress_parity_checks_spec.rb
@@ -7,13 +7,11 @@ RSpec.describe "View pending and in-progress parity checks" do
   end
 
   scenario "Viewing the in-progress parity check" do
-    requests = [
-      FactoryBot.create(:parity_check_request, :pending),
-      FactoryBot.create(:parity_check_request, :queued),
-      FactoryBot.create(:parity_check_request, :in_progress),
-      FactoryBot.create(:parity_check_request, :completed),
-    ]
-    run = FactoryBot.create(:parity_check_run, :in_progress, requests:)
+    run = FactoryBot.create(:parity_check_run, :in_progress, requests: [])
+    FactoryBot.create(:parity_check_request, :pending, run:)
+    FactoryBot.create(:parity_check_request, :queued, run:)
+    FactoryBot.create(:parity_check_request, :in_progress, run:)
+    FactoryBot.create(:parity_check_request, :completed, run:)
 
     page.goto(new_migration_parity_check_path)
 
@@ -24,11 +22,9 @@ RSpec.describe "View pending and in-progress parity checks" do
   end
 
   scenario "Viewing the pending parity checks" do
-    requests = [
-      FactoryBot.create(:parity_check_request, :in_progress),
-      FactoryBot.create(:parity_check_request, :completed),
-    ]
-    FactoryBot.create(:parity_check_run, :in_progress, started_at: 1.hour.ago, requests:)
+    run = FactoryBot.create(:parity_check_run, :in_progress, started_at: 1.hour.ago, requests: [])
+    FactoryBot.create(:parity_check_request, :in_progress, run:)
+    FactoryBot.create(:parity_check_request, :completed, run:)
 
     pending_run_1 = travel_to(1.hour.ago) { FactoryBot.create(:parity_check_run, :pending) }
     pending_run_2 = travel_to(25.minutes.ago) { FactoryBot.create(:parity_check_run, :pending) }

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -75,6 +75,38 @@ RSpec.describe ParityCheckHelper, type: :helper do
     end
   end
 
+  describe "#status_code_tag" do
+    {
+      0 => "green",
+      299 => "green",
+      300 => "yellow",
+      399 => "yellow",
+      400 => "red",
+    }.each do |status_code, colour|
+      context "when status code is #{status_code}%" do
+        subject { helper.status_code_tag(status_code) }
+
+        it { is_expected.to eq(%(<strong class=\"govuk-tag govuk-tag--#{colour}\">#{status_code}</strong>)) }
+      end
+    end
+  end
+
+  describe "#comparison_emoji" do
+    subject { helper.comparison_emoji(matching) }
+
+    context "when matching" do
+      let(:matching) { true }
+
+      it { is_expected.to eq("✅") }
+    end
+
+    context "when different" do
+      let(:matching) { false }
+
+      it { is_expected.to eq("❌") }
+    end
+  end
+
   describe "#performance_gain" do
     subject { helper.performance_gain(ratio) }
 

--- a/spec/models/parity_check/request_spec.rb
+++ b/spec/models/parity_check/request_spec.rb
@@ -35,10 +35,11 @@ describe ParityCheck::Request do
   end
 
   describe "scopes" do
-    let!(:pending_get_request) { FactoryBot.create(:parity_check_request, :pending, :get) }
-    let!(:queued_get_request) { FactoryBot.create(:parity_check_request, :queued, :get) }
-    let!(:in_progress_post_request) { FactoryBot.create(:parity_check_request, :in_progress, :post) }
-    let!(:completed_put_request) { FactoryBot.create(:parity_check_request, :completed, :put) }
+    let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+    let!(:pending_get_request) { FactoryBot.create(:parity_check_request, :pending, :get, run:) }
+    let!(:queued_get_request) { FactoryBot.create(:parity_check_request, :queued, :get, run:) }
+    let!(:in_progress_post_request) { FactoryBot.create(:parity_check_request, :in_progress, :post, run:) }
+    let!(:completed_put_request) { FactoryBot.create(:parity_check_request, :completed, :put, run:) }
 
     describe ".pending" do
       subject { described_class.pending }
@@ -103,10 +104,11 @@ describe ParityCheck::Request do
     describe ".with_all_responses_matching" do
       subject { described_class.with_all_responses_matching }
 
-      let!(:request_with_no_responses) { FactoryBot.create(:parity_check_request, :in_progress, response_types: []) }
-      let!(:request_with_matching_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching matching]) }
-      let!(:request_with_different_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[different]) }
-      let!(:request_with_matching_and_different_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching different]) }
+      let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+      let!(:request_with_no_responses) { FactoryBot.create(:parity_check_request, :in_progress, response_types: [], run:) }
+      let!(:request_with_matching_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching matching], run:) }
+      let!(:request_with_different_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[different], run:) }
+      let!(:request_with_matching_and_different_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching different], run:) }
 
       it { expect(subject).to contain_exactly(request_with_matching_responses) }
     end

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -132,4 +132,20 @@ describe ParityCheck::Response do
       it { is_expected.not_to be_matching }
     end
   end
+
+  describe ".different?" do
+    subject { response }
+
+    context "when the response is different" do
+      let(:response) { FactoryBot.build(:parity_check_response, :different) }
+
+      it { is_expected.to be_different }
+    end
+
+    context "when the response is matching" do
+      let(:response) { FactoryBot.build(:parity_check_response, :matching) }
+
+      it { is_expected.not_to be_different }
+    end
+  end
 end

--- a/spec/requests/migration/parity_check_spec.rb
+++ b/spec/requests/migration/parity_check_spec.rb
@@ -133,6 +133,13 @@ RSpec.describe "Parity check", type: :request do
         end
       end
 
+      context "when the parity check does not exist" do
+        it "renders 404 not found" do
+          get migration_parity_check_path(99)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
       context "when parity check is disabled" do
         let(:enabled) { false }
 
@@ -148,6 +155,63 @@ RSpec.describe "Parity check", type: :request do
 
       it "renders the unauthorized page" do
         get migration_parity_check_path(run)
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include("You are not authorised to access this page")
+      end
+    end
+  end
+
+  describe "GET /migration/parity_checks/:run_id/requests/:id" do
+    let(:run) { FactoryBot.create(:parity_check_run, :completed) }
+    let(:request) { FactoryBot.create(:parity_check_request, :completed, run:) }
+
+    context "when signed in as a DfE user" do
+      include_context 'sign in as DfE user'
+
+      it "renders the parity check request page" do
+        get migration_parity_check_request_path(run, request)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(request.endpoint.description)
+      end
+
+      context "when the parity check is not completed" do
+        let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+
+        it "renders 404 not found" do
+          get migration_parity_check_request_path(run, request)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the request does not exist" do
+        it "renders 404 not found" do
+          get migration_parity_check_request_path(run, 99)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the run does not exist" do
+        it "renders 404 not found" do
+          get migration_parity_check_request_path(99, request)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when parity check is disabled" do
+        let(:enabled) { false }
+
+        it "renders 404 not found" do
+          get migration_parity_check_request_path(run, request)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "when not signed in as a DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "renders the unauthorized page" do
+        get migration_parity_check_request_path(run, request)
         expect(response).to have_http_status(:unauthorized)
         expect(response.body).to include("You are not authorised to access this page")
       end


### PR DESCRIPTION
### Context

We want to add a page that shows the details of a parity check request and links in to each of the responses.

### Changes proposed in this pull request

- Add view helpers for parity check responses

Add view helpers to render out details of a parity check response; we want to show the status code as a colour-coded tag and the comparison emoji for matching/different responses.

- Expose different? method on parity check response

To avoid `unless matching?` in various places its going to be helpful to have `different?` exposed publicly.

- Don't set page on single responses

When a request only has a single response its most likely not a paginated result; seed single responses with a `nil` page for more realistic data.

- Improve parity check request factory

When generating a completed request we should make sure the run is also in a relevant state (defaulting to completed as well).

If the caller passes `responses` we should ignore `response_types`.

- Add view to show a parity check request

We want to allow users to drill into a particular request; here we can describe the request at a high-level and list the responses associated with the request and some key metrics of those.

### Guidance to review

| Single successful response    | Multiple successful responses | Multiple mix of responses | Paginated responses |
| -------- | ------- | ------- | ------- | 
| <img width="1142" alt="Screenshot 2025-06-30 at 08 52 14" src="https://github.com/user-attachments/assets/37b352d1-3333-4c22-a2ec-da4f350378c3" />  | <img width="1142" alt="Screenshot 2025-06-30 at 08 52 43" src="https://github.com/user-attachments/assets/8f897403-84ee-4f57-a9b2-56f5d35c8a8d" />   | <img width="1142" alt="Screenshot 2025-06-30 at 08 53 00" src="https://github.com/user-attachments/assets/34fa0442-8d29-48d2-ae5e-c9dfaefdf363" /> | ![screencapture-0-0-0-0-3000-migration-parity-checks-2-requests-26-2025-06-30-08_53_24](https://github.com/user-attachments/assets/82d1d51f-f64e-4659-b6be-44db1c086dbf) |


