### PR TITLE
Add future date and predating ECF rollout checks to bulk journeys

### DIFF
--- a/app/models/concerns/batch_rows.rb
+++ b/app/models/concerns/batch_rows.rb
@@ -1,4 +1,3 @@
-# TODO: move outcome, terms and programme out into Action service
 module BatchRows
   extend ActiveSupport::Concern
 
@@ -35,16 +34,6 @@ module BatchRows
         members[0..-2].any? { |key| public_send(key).blank? }
       end
 
-      # @return [Boolean] pass, FAIL, Release (case-insensitive)
-      def invalid_outcome?
-        outcome !~ /\A(pass|fail|release)\z/i
-      end
-
-      # @return [Boolean] 0-16 upto one decimal place
-      def invalid_terms?
-        number_of_terms !~ /\A\d+(\.\d{1})?\z/ || !number_of_terms.to_f.between?(0, 16)
-      end
-
       # @return [Boolean] formatted as YYYY-MM-DD
       def invalid_date?
         members.grep(/date_of_birth|started_on|finished_on/).any? do |key|
@@ -54,14 +43,12 @@ module BatchRows
         end
       end
 
-      # @return [Boolean]
+      # @return [Boolean] induction dates must be in the past
       def future_dates?
         members.grep(/started_on|finished_on/).any? do |key|
           Date.parse(public_send(key).to_s).future?
         rescue Date::Error
           true
-        rescue NameError
-          false
         end
       end
 
@@ -70,12 +57,6 @@ module BatchRows
         !(Time.zone.today.year - Date.parse(date_of_birth.to_s).year).between?(18, 99)
       rescue Date::Error
         true
-      end
-
-      # @return [Boolean] school-led, provider-led (case-insensitive) new style
-      # @return [Boolean] diy, cip, fip (case-insensitive) old style
-      def invalid_training_programme?
-        induction_programme !~ /\A(diy|cip|fip)\z/i
       end
 
       # @param errors [Array<String>]

--- a/app/models/concerns/batch_rows.rb
+++ b/app/models/concerns/batch_rows.rb
@@ -1,3 +1,4 @@
+# TODO: move outcome, terms and programme out into Action service
 module BatchRows
   extend ActiveSupport::Concern
 
@@ -50,6 +51,17 @@ module BatchRows
           !Date.iso8601(public_send(key))
         rescue Date::Error
           true
+        end
+      end
+
+      # @return [Boolean]
+      def future_dates?
+        members.grep(/started_on|finished_on/).any? do |key|
+          Date.parse(public_send(key).to_s).future?
+        rescue Date::Error
+          true
+        rescue NameError
+          false
         end
       end
 

--- a/app/services/appropriate_bodies/process_batch/action.rb
+++ b/app/services/appropriate_bodies/process_batch/action.rb
@@ -75,10 +75,20 @@ module AppropriateBodies
       def incorrectly_formatted?
         super
 
-        pending_induction_submission.errors.add(:base, 'Outcome must be either pass, fail or release') if row.invalid_outcome?
-        pending_induction_submission.errors.add(:base, 'Enter number of terms between 0 and 16 using up to one decimal place') if row.invalid_terms?
+        pending_induction_submission.errors.add(:base, 'Outcome must be either pass, fail or release') if invalid_outcome?
+        pending_induction_submission.errors.add(:base, 'Enter number of terms between 0 and 16 using up to one decimal place') if invalid_terms?
 
         pending_induction_submission.errors.any? ? pending_induction_submission.playback_errors : false
+      end
+
+      # @return [Boolean] pass, FAIL, Release (case-insensitive)
+      def invalid_outcome?
+        row.outcome !~ /\A(pass|fail|release)\z/i
+      end
+
+      # @return [Boolean] 0-16 upto one decimal place
+      def invalid_terms?
+        row.number_of_terms !~ /\A\d+(\.\d{1})?\z/ || !row.number_of_terms.to_f.between?(0, 16)
       end
 
       # @return [Boolean]

--- a/app/services/appropriate_bodies/process_batch/base.rb
+++ b/app/services/appropriate_bodies/process_batch/base.rb
@@ -48,9 +48,10 @@ module AppropriateBodies
       # @return [Boolean] common pre-checks for all submissions
       def incorrectly_formatted?
         pending_induction_submission.errors.add(:base, 'Fill in the blanks on this row') if row.blank_cell?
+        pending_induction_submission.errors.add(:base, 'Enter a valid TRN using 7 digits') if row.invalid_trn?
         pending_induction_submission.errors.add(:base, 'Dates must be in the format YYYY-MM-DD') if row.invalid_date?
         pending_induction_submission.errors.add(:base, 'Date of birth must be a real date and the teacher must be between 18 and 100 years old') if row.invalid_age?
-        pending_induction_submission.errors.add(:base, 'Enter a valid TRN using 7 digits') if row.invalid_trn?
+        pending_induction_submission.errors.add(:base, 'Dates cannot be in the future') if row.future_dates?
       end
 
       # @param message [String]

--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -109,10 +109,16 @@ module AppropriateBodies
 
         pending_induction_submission.errors.add(:base, 'Induction start date must be after 1 September 2021') if predates_ecf_rollout?
         # TODO: ready for training programme types update
-        # pending_induction_submission.errors.add(:base, 'Induction programme type must be school-led or provider-led') if row.invalid_training_programme?
-        pending_induction_submission.errors.add(:base, 'Induction programme type must be DIY, FIP or CIP') if row.invalid_training_programme?
+        # pending_induction_submission.errors.add(:base, 'Induction programme type must be school-led or provider-led') if invalid_training_programme?
+        pending_induction_submission.errors.add(:base, 'Induction programme type must be DIY, FIP or CIP') if invalid_training_programme?
 
         pending_induction_submission.errors.any? ? pending_induction_submission.playback_errors : false
+      end
+
+      # @return [Boolean] school-led, provider-led (case-insensitive) new style
+      # @return [Boolean] diy, cip, fip (case-insensitive) old style
+      def invalid_training_programme?
+        row.induction_programme !~ /\A(diy|cip|fip)\z/i
       end
 
       # @return [AppropriateBodies::ClaimAnECT::FindECT]

--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -85,7 +85,16 @@ module AppropriateBodies
 
       # @return [Boolean]
       def predates_qts_award?
-        Date.parse(row.started_on) < pending_induction_submission.trs_qts_awarded_on
+        Date.parse(row.started_on.to_s) < pending_induction_submission.trs_qts_awarded_on
+      rescue Date::Error
+        true
+      end
+
+      # @return [Boolean] started_on before 1 September 2021
+      def predates_ecf_rollout?
+        Date.parse(row.started_on.to_s) <= ::ECF_ROLLOUT_DATE
+      rescue Date::Error
+        true
       end
 
       # @see TRS::Teacher#prohibited_from_teaching?
@@ -97,6 +106,8 @@ module AppropriateBodies
       # @return [Boolean]
       def incorrectly_formatted?
         super
+
+        pending_induction_submission.errors.add(:base, 'Induction start date must be after 1 September 2021') if predates_ecf_rollout?
         # TODO: ready for training programme types update
         # pending_induction_submission.errors.add(:base, 'Induction programme type must be school-led or provider-led') if row.invalid_training_programme?
         pending_induction_submission.errors.add(:base, 'Induction programme type must be DIY, FIP or CIP') if row.invalid_training_programme?

--- a/spec/models/concerns/batch_rows_spec.rb
+++ b/spec/models/concerns/batch_rows_spec.rb
@@ -116,41 +116,27 @@ RSpec.describe BatchRows do
       end
     end
 
-    describe '#invalid_outcome?' do
-      it 'returns false for valid outcomes' do
-        allow(dummy_action).to receive(:data).and_return([{ outcome: 'pass' }])
-        expect(dummy_action.rows.first).not_to be_invalid_outcome
-        allow(dummy_action).to receive(:data).and_return([{ outcome: 'FAIL' }])
-        expect(dummy_action.rows.first).not_to be_invalid_outcome
+    describe '#future_dates?' do
+      let(:future_date) { 1.week.from_now.to_date.to_s }
+
+      it 'returns false for past induction dates' do
+        allow(dummy_claim).to receive(:data).and_return([{ started_on: '2020-09-01' }])
+        expect(dummy_claim.rows.first).not_to be_future_dates
+
+        allow(dummy_action).to receive(:data).and_return([{ finished_on: '2020-09-01' }])
+        expect(dummy_action.rows.first).not_to be_future_dates
       end
 
-      it 'returns true for invalid outcomes' do
-        allow(dummy_action).to receive(:data).and_return([{ outcome: 'passed' }])
-        expect(dummy_action.rows.first).to be_invalid_outcome
-        allow(dummy_action).to receive(:data).and_return([{ outcome: 'Released' }])
-        expect(dummy_action.rows.first).to be_invalid_outcome
-        allow(dummy_action).to receive(:data).and_return([{ outcome: '' }])
-        expect(dummy_action.rows.first).to be_invalid_outcome
-      end
-    end
+      it 'returns true for invalid or future induction dates' do
+        allow(dummy_claim).to receive(:data).and_return([{ started_on: nil }])
+        expect(dummy_claim.rows.first).to be_future_dates
+        allow(dummy_claim).to receive(:data).and_return([{ started_on: future_date }])
+        expect(dummy_claim.rows.first).to be_future_dates
 
-    describe '#invalid_terms?' do
-      it 'returns false for valid terms' do
-        allow(dummy_action).to receive(:data).and_return([{ number_of_terms: '1.1' }])
-        expect(dummy_action.rows.first).not_to be_invalid_terms
-        allow(dummy_action).to receive(:data).and_return([{ number_of_terms: '16.0' }])
-        expect(dummy_action.rows.first).not_to be_invalid_terms
-      end
-
-      it 'returns true for invalid terms' do
-        allow(dummy_action).to receive(:data).and_return([{ number_of_terms: '1.11' }])
-        expect(dummy_action.rows.first).to be_invalid_terms
-        allow(dummy_action).to receive(:data).and_return([{ number_of_terms: '16.1' }])
-        expect(dummy_action.rows.first).to be_invalid_terms
-        allow(dummy_action).to receive(:data).and_return([{ number_of_terms: 'foo' }])
-        expect(dummy_action.rows.first).to be_invalid_terms
-        allow(dummy_action).to receive(:data).and_return([{ number_of_terms: '' }])
-        expect(dummy_action.rows.first).to be_invalid_terms
+        allow(dummy_action).to receive(:data).and_return([{ finished_on: 'foo' }])
+        expect(dummy_action.rows.first).to be_future_dates
+        allow(dummy_action).to receive(:data).and_return([{ finished_on: future_date }])
+        expect(dummy_action.rows.first).to be_future_dates
       end
     end
 
@@ -194,22 +180,6 @@ RSpec.describe BatchRows do
         expect(dummy_claim.rows.first).to be_invalid_age
         allow(dummy_claim).to receive(:data).and_return([{ date_of_birth: '' }])
         expect(dummy_claim.rows.first).to be_invalid_age
-      end
-    end
-
-    describe '#invalid_training_programme?' do
-      it 'returns false for valid training programmes' do
-        allow(dummy_claim).to receive(:data).and_return([{ induction_programme: 'DiY' }])
-        expect(dummy_claim.rows.first).not_to be_invalid_training_programme
-      end
-
-      it 'returns true for invalid training programmes' do
-        allow(dummy_claim).to receive(:data).and_return([{ induction_programme: 'DIYI' }])
-        expect(dummy_claim.rows.first).to be_invalid_training_programme
-        allow(dummy_claim).to receive(:data).and_return([{ induction_programme: 'foo' }])
-        expect(dummy_claim.rows.first).to be_invalid_training_programme
-        allow(dummy_claim).to receive(:data).and_return([{ induction_programme: '' }])
-        expect(dummy_claim.rows.first).to be_invalid_training_programme
       end
     end
   end

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
             'Fill in the blanks on this row',
-            'Dates must be in the format YYYY-MM-DD'
+            'Dates must be in the format YYYY-MM-DD',
+            'Dates cannot be in the future'
           ]
         end
       end
@@ -213,6 +214,14 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         end
       end
 
+      context 'when the end date is in the future' do
+        let(:finished_on) { 1.year.from_now.to_date.to_s }
+
+        it 'captures an error message' do
+          expect(submission.error_messages).to eq ['Dates cannot be in the future']
+        end
+      end
+
       context 'when the outcome is not recognised' do
         let(:outcome) { 'foo' }
 
@@ -264,8 +273,9 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
             'Fill in the blanks on this row',
-            'Dates must be in the format YYYY-MM-DD',
             'Enter a valid TRN using 7 digits',
+            'Dates must be in the format YYYY-MM-DD',
+            'Dates cannot be in the future',
             'Outcome must be either pass, fail or release',
             'Enter number of terms between 0 and 16 using up to one decimal place'
           ]
@@ -340,7 +350,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         let(:finished_on) { 1.year.from_now.to_date.to_s }
 
         it 'captures an error message' do
-          expect(submission.error_messages).to eq ['End date cannot be in the future']
+          expect(submission.error_messages).to eq ['Dates cannot be in the future']
         end
       end
 

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -114,7 +114,19 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
               'Fill in the blanks on this row',
-              'Dates must be in the format YYYY-MM-DD'
+              'Dates must be in the format YYYY-MM-DD',
+              'Dates cannot be in the future',
+              'Induction start date must be after 1 September 2021'
+            ]
+          end
+        end
+
+        context 'when the start date predates the service rollout' do
+          let(:started_on) { 7.years.ago.to_date.to_s }
+
+          it 'captures an error message' do
+            expect(submission.error_messages).to eq [
+              'Induction start date must be after 1 September 2021'
             ]
           end
         end
@@ -191,7 +203,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         end
 
         context 'when the start date is not ISO8601' do
-          let(:started_on) { '30/06/1981' }
+          let(:started_on) { '30/06/2022' }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq ['Dates must be in the format YYYY-MM-DD']
@@ -224,8 +236,10 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
               'Fill in the blanks on this row',
-              'Dates must be in the format YYYY-MM-DD',
               'Enter a valid TRN using 7 digits',
+              'Dates must be in the format YYYY-MM-DD',
+              'Dates cannot be in the future',
+              'Induction start date must be after 1 September 2021',
               'Induction programme type must be DIY, FIP or CIP'
             ]
           end
@@ -382,8 +396,8 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     context 'start date before QTS' do
       include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
 
-      let(:started_on) { 4.years.ago.to_date.to_s }
       let(:qts_date) { 3.years.ago.to_date }
+      let(:started_on) { (qts_date - 1.day).to_s }
 
       before do
         service.process!
@@ -507,7 +521,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
       describe 'submission error messages' do
         subject { submission.error_messages }
 
-        it { is_expected.to eq ['Start date cannot be in the future'] }
+        it { is_expected.to eq ['Dates cannot be in the future'] }
       end
     end
   end


### PR DESCRIPTION
### Context

Prevalidate rows using logic from `SharedInductionPeriodValidation`

### Changes proposed in this pull request

- no future dates
- no start dates before Sept 2021

### Guidance to review
