### PR TITLE
Splitting up teacher migrator

### DIFF
--- a/app/migration/builders/ect/school_periods.rb
+++ b/app/migration/builders/ect/school_periods.rb
@@ -12,14 +12,14 @@ module Builders
         success = true
         school_periods.each do |period|
           school = School.find_by!(urn: period.urn)
-          ::ECTAtSchoolPeriod.create!(teacher:,
-                                      school:,
-                                      training_programme: period.training_programme,
-                                      lead_provider_id: period.lead_provider_id,
-                                      started_on: period.start_date,
-                                      finished_on: period.end_date,
-                                      ecf_start_induction_record_id: period.start_source_id,
-                                      ecf_end_induction_record_id: period.end_source_id)
+          school_period = ::ECTAtSchoolPeriod.find_or_initialize_by(teacher:, school:, started_on: period.start_date)
+          school_period.training_programme = period.training_programme
+          school_period.lead_provider_id = period.lead_provider_id
+          school_period.finished_on = period.end_date
+          school_period.ecf_start_induction_record_id = period.start_source_id
+          school_period.ecf_end_induction_record_id = period.end_source_id
+          school_period.save!
+
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/ect/school_periods.rb
+++ b/app/migration/builders/ect/school_periods.rb
@@ -19,7 +19,6 @@ module Builders
           school_period.ecf_start_induction_record_id = period.start_source_id
           school_period.ecf_end_induction_record_id = period.end_source_id
           school_period.save!
-
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -15,19 +15,23 @@ module Builders
         training_period_data.each do |period|
           next unless period.training_programme == "full_induction_programme"
 
-          school_partnership = ::SchoolPartnership.where(lead_provider: ::LeadProvider.find_by!(name: period.lead_provider),
-                                                         delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
-                                                         registration_period_id: period.cohort_year).first
+          lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
+          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, registration_period_id: period.cohort_year)
+          delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
+          lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first
 
-          ::TrainingPeriod.create!(school_partnership:,
-                                   ect_at_school_period:,
-                                   started_on: period.start_date,
-                                   finished_on: period.end_date,
-                                   ecf_start_induction_record_id: period.start_source_id,
-                                   ecf_end_induction_record_id: period.end_source_id)
+          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school: ect_at_school_period.school)
+
+          training_period = ::TrainingPeriod.find_or_initialize_by(ecf_start_induction_record_id: period.start_source_id)
+          training_period.ect_at_school_period = ect_at_school_period
+          training_period.school_partnership = school_partnership
+          training_period.started_on = period.start_date
+          training_period.finished_on = period.end_date
+          training_period.ecf_end_induction_record_id = period.end_source_id
+          training_period.save!
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentor/school_periods.rb
+++ b/app/migration/builders/mentor/school_periods.rb
@@ -12,12 +12,12 @@ module Builders
         success = true
         school_periods.each do |period|
           school = School.find_by!(urn: period.urn)
-          ::MentorAtSchoolPeriod.create!(teacher:,
-                                         school:,
-                                         started_on: period.start_date,
-                                         finished_on: period.end_date,
-                                         ecf_start_induction_record_id: period.start_source_id,
-                                         ecf_end_induction_record_id: period.end_source_id)
+          school_period = ::MentorAtSchoolPeriod.find_or_initialize_by(teacher:, school:, started_on: period.start_date)
+          school_period.finished_on = period.end_date
+          school_period.ecf_start_induction_record_id = period.start_source_id
+          school_period.ecf_end_induction_record_id = period.end_source_id
+          school_period.save!
+
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentor/school_periods.rb
+++ b/app/migration/builders/mentor/school_periods.rb
@@ -17,7 +17,6 @@ module Builders
           school_period.ecf_start_induction_record_id = period.start_source_id
           school_period.ecf_end_induction_record_id = period.end_source_id
           school_period.save!
-
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -15,19 +15,23 @@ module Builders
         training_period_data.each do |period|
           next unless period.training_programme == "full_induction_programme"
 
-          school_partnership = ::SchoolPartnership.where(lead_provider: ::LeadProvider.find_by!(name: period.lead_provider),
-                                                         delivery_partner: ::DeliveryPartner.find_by!(name: period.delivery_partner),
-                                                         registration_period_id: period.cohort_year).first
+          lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
+          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, registration_period_id: period.cohort_year)
+          delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
+          lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first
 
-          ::TrainingPeriod.create!(school_partnership:,
-                                   mentor_at_school_period:,
-                                   started_on: period.start_date,
-                                   finished_on: period.end_date,
-                                   ecf_start_induction_record_id: period.start_source_id,
-                                   ecf_end_induction_record_id: period.end_source_id)
+          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school: mentor_at_school_period.school)
+
+          training_period = ::TrainingPeriod.find_or_initialize_by(ecf_start_induction_record_id: period.start_source_id)
+          training_period.mentor_at_school_period = mentor_at_school_period
+          training_period.school_partnership = school_partnership
+          training_period.started_on = period.start_date
+          training_period.finished_on = period.end_date
+          training_period.ecf_end_induction_record_id = period.end_source_id
+          training_period.save!
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -1,0 +1,56 @@
+module Migrators
+  class ECTAtSchoolPeriod < Migrators::Base
+    def self.record_count
+      ect_teachers.count
+    end
+
+    def self.model
+      :ect_at_school_period
+    end
+
+    def self.ect_teachers
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect).distinct
+    end
+
+    def self.dependencies
+      %i[teacher school]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::ECTAtSchoolPeriod.connection.execute("TRUNCATE #{::ECTAtSchoolPeriod.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.ect_teachers.eager_load(:user)) do |teacher_profile|
+        teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+
+        result = true
+
+        teacher_profile
+          .participant_profiles
+          .ect
+          .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
+          .find_each do |participant_profile|
+            induction_records = InductionRecordSanitizer.new(participant_profile:)
+
+          if induction_records.valid?
+            school_periods = SchoolPeriodExtractor.new(induction_records:)
+
+            teacher.update!(ecf_ect_profile_id: participant_profile.id)
+            result = Builders::ECT::SchoolPeriods.new(teacher:, school_periods:).build
+          else
+            ::TeacherMigrationFailure.create!(teacher:,
+                                              message: induction_records.error,
+                                              migration_item_id: participant_profile.id,
+                                              migration_item_type: participant_profile.class.name)
+            result = false
+          end
+        end
+
+        result
+      end
+    end
+  end
+end

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -33,7 +33,7 @@ module Migrators
           .mentor
           .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
           .find_each do |participant_profile|
-            induction_records = InductionRecordSanitizer.new(participant_profile:)
+          induction_records = InductionRecordSanitizer.new(participant_profile:)
 
           if induction_records.valid?
             school_periods = SchoolPeriodExtractor.new(induction_records:)

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -1,0 +1,56 @@
+module Migrators
+  class MentorAtSchoolPeriod < Migrators::Base
+    def self.record_count
+      mentor_teachers.count
+    end
+
+    def self.model
+      :mentor_at_school_period
+    end
+
+    def self.mentor_teachers
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.mentor).distinct
+    end
+
+    def self.dependencies
+      %i[teacher school]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::MentorAtSchoolPeriod.connection.execute("TRUNCATE #{::MentorAtSchoolPeriod.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.mentor_teachers.eager_load(:user)) do |teacher_profile|
+        teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+
+        result = true
+
+        teacher_profile
+          .participant_profiles
+          .mentor
+          .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
+          .find_each do |participant_profile|
+            induction_records = InductionRecordSanitizer.new(participant_profile:)
+
+          if induction_records.valid?
+            school_periods = SchoolPeriodExtractor.new(induction_records:)
+
+            teacher.update!(ecf_mentor_profile_id: participant_profile.id)
+            result = Builders::Mentor::SchoolPeriods.new(teacher:, school_periods:).build
+          else
+            ::TeacherMigrationFailure.create!(teacher:,
+                                              message: induction_records.error,
+                                              migration_item_id: participant_profile.id,
+                                              migration_item_type: participant_profile.class.name)
+            result = false
+          end
+        end
+
+        result
+      end
+    end
+  end
+end

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -4,6 +4,8 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
   has_many :school_partnerships
   has_many :events
 
+  delegate :lead_provider, to: :active_lead_provider
+
   validates :active_lead_provider_id, presence: { message: 'Select an active lead provider' }
   validates :delivery_partner_id,
             presence: { message: 'Select a delivery partner' },

--- a/app/models/migration/induction_record.rb
+++ b/app/models/migration/induction_record.rb
@@ -5,5 +5,6 @@ module Migration
     belongs_to :appropriate_body
     belongs_to :mentor_profile, class_name: "Migration::ParticipantProfile"
     belongs_to :schedule
+    belongs_to :preferred_identity, class_name: "Migration::ParticipantIdentity"
   end
 end

--- a/app/models/migration/participant_identity.rb
+++ b/app/models/migration/participant_identity.rb
@@ -1,0 +1,6 @@
+module Migration
+  class ParticipantIdentity < Migration::Base
+    belongs_to :user
+    has_many :participant_profiles
+  end
+end

--- a/app/models/migration/participant_profile.rb
+++ b/app/models/migration/participant_profile.rb
@@ -3,7 +3,9 @@ module Migration
     self.inheritance_column = nil
 
     belongs_to :teacher_profile
+    belongs_to :participant_identity
     belongs_to :school_cohort
+    belongs_to :schedule
     has_many :induction_records
     has_many :school_mentors # only ParticipantProfile::Mentor
 

--- a/app/models/migration/school_cohort.rb
+++ b/app/models/migration/school_cohort.rb
@@ -4,5 +4,6 @@ module Migration
     belongs_to :cohort
     has_many :induction_programmes
     belongs_to :appropriate_body
+    belongs_to :default_induction_programme, class_name: "Migration::InductionProgramme", optional: true
   end
 end

--- a/app/models/migration/user.rb
+++ b/app/models/migration/user.rb
@@ -1,5 +1,6 @@
 module Migration
   class User < Migration::Base
     has_one :teacher_profile
+    has_many :participant_identities
   end
 end

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -4,6 +4,9 @@ class SchoolPartnership < ApplicationRecord
   belongs_to :school
   has_many :events
 
+  # delegates
+  delegate :lead_provider, :delivery_partner, to: :lead_provider_delivery_partnership
+
   # Validations
   validates :lead_provider_delivery_partnership_id, presence: true
   validates :school_id,

--- a/spec/factories/migration/induction_programme_factory.rb
+++ b/spec/factories/migration/induction_programme_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :migration_induction_programme, class: "Migration::InductionProgramme" do
+    training_programme { :full_induction_programme }
+    school_cohort { FactoryBot.create(:migration_school_cohort, induction_programme_choice: training_programme) }
+  end
+end

--- a/spec/factories/migration/induction_record_factory.rb
+++ b/spec/factories/migration/induction_record_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :migration_induction_record, class: "Migration::InductionRecord" do
+    participant_profile { FactoryBot.create(:migration_participant_profile, :ect) }
+    preferred_identity { participant_profile.participant_identity }
+    induction_programme { participant_profile.school_cohort.default_induction_programme }
+    schedule { participant_profile.schedule }
+    induction_status { :active }
+    training_status { :active }
+    start_date { 1.month.ago }
+    end_date { nil }
+  end
+end

--- a/spec/factories/migration/participant_identity_factory.rb
+++ b/spec/factories/migration/participant_identity_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :migration_participant_identity, class: "Migration::ParticipantIdentity" do
+    user { FactoryBot.create(:migration_user) }
+    email { user.email }
+    external_identifier { user.id }
+    origin { "ecf" }
+  end
+end

--- a/spec/factories/migration/participant_profile_factory.rb
+++ b/spec/factories/migration/participant_profile_factory.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :migration_participant_profile, class: "Migration::ParticipantProfile" do
+    transient do
+      user { FactoryBot.create(:migration_user) }
+    end
+
+    teacher_profile { FactoryBot.create(:migration_teacher_profile, user:) }
+    participant_identity { FactoryBot.create(:migration_participant_identity, user:) }
+    school_cohort { FactoryBot.create(:migration_school_cohort) }
+    schedule { FactoryBot.create(:migration_schedule, cohort: school_cohort.cohort) }
+
+    trait :ect do
+      type { "ParticipantProfile::ECT" }
+    end
+
+    trait :mentor do
+      type { "ParticipantProfile::Mentor" }
+    end
+  end
+end

--- a/spec/factories/migration/schedule_factory.rb
+++ b/spec/factories/migration/schedule_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :migration_schedule, class: "Migration::Schedule" do
+    cohort { FactoryBot.create(:migration_cohort) }
+    schedule_identifier { "#{Faker::Lorem.word} #{Faker::Alphanumeric.alpha(number: 5).upcase}" }
+    name { Faker::Lorem.words(number: 2) }
+  end
+end

--- a/spec/factories/migration/school_cohort_factory.rb
+++ b/spec/factories/migration/school_cohort_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :migration_school_cohort, class: "Migration::SchoolCohort" do
+    school { FactoryBot.create(:ecf_migration_school) }
+    cohort { FactoryBot.create(:migration_cohort) }
+
+    induction_programme_choice { :full_induction_programme }
+
+    default_induction_programme { FactoryBot.create(:migration_induction_programme, training_programme: induction_programme_choice, school_cohort: instance) }
+  end
+end

--- a/spec/factories/migration/teacher_profile_factory.rb
+++ b/spec/factories/migration/teacher_profile_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :migration_teacher_profile, class: "Migration::TeacherProfile" do
+    user { FactoryBot.create(:migration_user) }
+    trn { Faker::Number.unique.number(digits: 7) }
+  end
+end

--- a/spec/factories/migration/user_factory.rb
+++ b/spec/factories/migration/user_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :migration_user, class: "Migration::User" do
+    full_name { Faker::FunnyName.two_word_name }
+    email { Faker::Internet.unique.email(name: full_name) }
+  end
+end

--- a/spec/migration/migrators/ect_at_school_period_spec.rb
+++ b/spec/migration/migrators/ect_at_school_period_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Migrators::ECTAtSchoolPeriod do
+  it_behaves_like "a migrator", :ect_at_school_period, %i[teacher school] do
+    def create_migration_resource
+      ect = FactoryBot.create(:migration_participant_profile, :ect)
+      FactoryBot.create(:migration_induction_record, participant_profile: ect)
+      ect.teacher_profile
+    end
+
+    def create_resource(migration_resource)
+      FactoryBot.create(:teacher, trn: migration_resource.trn)
+      FactoryBot.create(:school, urn: migration_resource.participant_profiles.first.school_cohort.school.urn)
+    end
+
+    def setup_failure_state
+      # add but with no dependencies added
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it 'creates an ECTAtSchoolPeriod records for each school period found in the ECF induction records' do
+        instance.migrate!
+
+        Migration::TeacherProfile.find_each do |teacher_profile|
+          teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+
+          teacher_profile.participant_profiles.first.induction_records.each do |induction_record|
+            expect(teacher.ect_at_school_periods.first.started_on.to_date).to eq induction_record.start_date.to_date
+            expect(teacher.ect_at_school_periods.first.school.urn).to eq induction_record.induction_programme.school_cohort.school.urn.to_i
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/migration/migrators/mentor_at_school_period_spec.rb
+++ b/spec/migration/migrators/mentor_at_school_period_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Migrators::MentorAtSchoolPeriod do
+  it_behaves_like "a migrator", :mentor_at_school_period, %i[teacher school] do
+    def create_migration_resource
+      mentor = FactoryBot.create(:migration_participant_profile, :mentor)
+      FactoryBot.create(:migration_induction_record, participant_profile: mentor)
+      mentor.teacher_profile
+    end
+
+    def create_resource(migration_resource)
+      FactoryBot.create(:teacher, trn: migration_resource.trn)
+      FactoryBot.create(:school, urn: migration_resource.participant_profiles.first.school_cohort.school.urn)
+    end
+
+    def setup_failure_state
+      # add but with no dependencies added
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it 'creates a MentorAtSchoolPeriod records for each school period found in the ECF induction records' do
+        instance.migrate!
+
+        Migration::TeacherProfile.find_each do |teacher_profile|
+          teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+
+          teacher_profile.participant_profiles.first.induction_records.each do |induction_record|
+            expect(teacher.mentor_at_school_periods.first.started_on.to_date).to eq induction_record.start_date.to_date
+            expect(teacher.mentor_at_school_periods.first.school.urn).to eq induction_record.induction_programme.school_cohort.school.urn.to_i
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/migration/migrators/teacher_spec.rb
+++ b/spec/migration/migrators/teacher_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Migrators::Teacher do
+  it_behaves_like "a migrator", :teacher, [] do
+    def create_migration_resource
+      ect = FactoryBot.create(:migration_participant_profile, :ect)
+      ect.teacher_profile
+    end
+
+    def create_resource(migration_resource)
+    end
+
+    def setup_failure_state
+      teacher_profile = FactoryBot.create(:migration_teacher_profile, trn: nil)
+      FactoryBot.create(:migration_participant_profile, :ect, teacher_profile:, user: teacher_profile.user)
+    end
+
+    describe "#migrate!" do
+      it 'creates a Teacher records for each ECF TeacherProfile' do
+        instance.migrate!
+
+        Migration::TeacherProfile.find_each do |teacher_profile|
+          user = teacher_profile.user
+
+          teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+          expect(Teachers::Name.new(teacher).full_name).to eq user.full_name
+          expect(teacher.created_at).to be_within(1.second).of teacher_profile.created_at
+          expect(teacher.updated_at).to be_within(1.second).of teacher_profile.updated_at
+        end
+      end
+    end
+  end
+end

--- a/spec/migration/migrators/training_period_spec.rb
+++ b/spec/migration/migrators/training_period_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe Migrators::TrainingPeriod do
+  it_behaves_like "a migrator", :training_period, %i[ect_at_school_period mentor_at_school_period school_partnership] do
+    def create_migration_resource
+      ect = FactoryBot.create(:migration_participant_profile, :ect)
+      FactoryBot.create(:migration_induction_record, participant_profile: ect)
+      school = ect.school_cohort.school
+      cohort = ect.school_cohort.cohort
+      induction_programme = ect.school_cohort.default_induction_programme
+
+      induction_programme.update!(partnership: FactoryBot.create(:migration_partnership, school:, cohort:))
+      ect.teacher_profile
+    end
+
+    def create_resource(migration_resource)
+      teacher = FactoryBot.create(:teacher, trn: migration_resource.trn)
+      ect = migration_resource.participant_profiles.first
+      school_cohort = ect.school_cohort
+      partnership = school_cohort.school.partnerships.first
+
+      school = FactoryBot.create(:school, urn: school_cohort.school.urn)
+      FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: school_cohort.default_induction_programme.induction_records.first.start_date, finished_on: nil)
+
+      lead_provider = FactoryBot.create(:lead_provider, name: partnership.lead_provider.name, ecf_id: partnership.lead_provider_id)
+      delivery_partner = FactoryBot.create(:delivery_partner, name: partnership.delivery_partner.name, api_id: partnership.delivery_partner_id)
+      registration_period = FactoryBot.create(:registration_period, year: school_cohort.cohort.start_year)
+      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, registration_period:)
+      lpdp = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp)
+    end
+
+    def setup_failure_state
+      # add but with no dependencies added
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it 'creates a TrainingPeriod record for each partnership period found in the ECF induction records' do
+        instance.migrate!
+
+        Migration::TeacherProfile.find_each do |teacher_profile|
+          teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+
+          teacher_profile.participant_profiles.first.induction_records.each do |induction_record|
+            training_period = ::TrainingPeriod.find_by!(ecf_start_induction_record_id: induction_record.id)
+            expect(training_period.ect_at_school_period.teacher).to eq teacher
+            expect(training_period.started_on.to_date).to eq induction_record.start_date.to_date
+            expect(training_period.school_partnership.school.urn).to eq induction_record.induction_programme.school_cohort.school.urn.to_i
+            expect(training_period.school_partnership.lead_provider.name).to eq induction_record.induction_programme.partnership.lead_provider.name
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently there is a "Teacher" migrator that creates `Teacher` records, `ECTAtSchoolPeriod`, `MentorAtSchoolPeriod` and `TrainingPeriod` records from ECF data.
There are lots of data issues to sort out as this is the main part of the participant migration.  If we split these into separate migrators it will allow a clearer view of the issues and where they appear and also make it easier to work on in parallel, at the cost of some duplication at this stage.

### Changes proposed in this pull request

Refactor teacher migrator into migrators for the separate models

### Guidance to review
