### PR TITLE
Show parity check response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem "oj"
 gem "async-http-faraday"
 gem "with_advisory_lock"
 
+gem "diffy"
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     debug_inspector (1.2.0)
     declarative (0.0.20)
     diff-lcs (1.6.2)
+    diffy (3.4.4)
     drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -821,6 +822,7 @@ DEPENDENCIES
   debug
   dfe-analytics!
   dfe-wizard!
+  diffy
   factory_bot_rails
   faker
   faraday

--- a/app/assets/stylesheets/migration/parity_check.scss
+++ b/app/assets/stylesheets/migration/parity_check.scss
@@ -51,3 +51,15 @@
     text-align: center;
   }
 }
+
+.diff {
+  &.red {
+    background-color: rgb(255, 238, 238);
+    color: #b00000;
+  }
+
+  &.green {
+    background-color:rgb(221, 255, 221);
+    color: #080000;
+  }
+}

--- a/app/controllers/migration/parity_checks/responses_controller.rb
+++ b/app/controllers/migration/parity_checks/responses_controller.rb
@@ -1,0 +1,17 @@
+module Migration::ParityChecks
+  class ResponsesController < ::AdminController
+    layout "full"
+
+    def show
+      @run = ParityCheck::Run.completed.find(params[:parity_check_run_id])
+      @response = @run.responses.different.find(params[:id])
+      @request = @response.request
+      @breadcrumbs = {
+        "Run a parity check" => new_migration_parity_check_path,
+        "Completed parity checks" => completed_migration_parity_checks_path,
+        "Parity check run ##{@run.id}" => migration_parity_check_path(@run),
+        @request.description => migration_parity_check_request_path(@run, @request),
+      }
+    end
+  end
+end

--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -67,4 +67,16 @@ module ParityCheckHelper
 
     "🐌 #{formatted_ratio}x slower"
   end
+
+  def comparison_in_words(matching)
+    if matching
+      "the same"
+    else
+      "different"
+    end
+  end
+
+  def sanitize_diff(html)
+    sanitize html, tags: %w[div br ul li strong del ins], attributes: %w[class]
+  end
 end

--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -19,6 +19,8 @@ module ParityCheck
     scope :with_all_responses_matching, -> { joins(:responses).where.not(id: ParityCheck::Response.different.pluck(:request_id)).distinct }
     scope :with_lead_provider, ->(lead_provider) { where(lead_provider:) }
 
+    delegate :description, to: :endpoint
+
     state_machine :state, initial: :pending do
       state :queued
 

--- a/app/models/parity_check/run.rb
+++ b/app/models/parity_check/run.rb
@@ -7,6 +7,7 @@ module ParityCheck
     has_many :requests, dependent: :destroy
     has_many :lead_providers, -> { distinct.order(name: :asc) }, through: :requests
     has_many :endpoints, -> { distinct.order(path: :asc) }, through: :requests
+    has_many :responses, -> { distinct.order(page: :asc) }, through: :requests
 
     attribute :mode, default: -> { "concurrent" }
 

--- a/app/views/migration/parity_checks/requests/show.html.erb
+++ b/app/views/migration/parity_checks/requests/show.html.erb
@@ -1,4 +1,4 @@
-<% page_data(title: @request.endpoint.description, caption: @request.lead_provider.name, breadcrumbs: @breadcrumbs) %>
+<% page_data(title: @request.description, caption: @request.lead_provider.name, breadcrumbs: @breadcrumbs) %>
 
 <p>
   The request resulted in <strong><%= number_with_delimiter(@responses.size) %> <%= "response".pluralize(@responses.size) %></strong> 
@@ -61,7 +61,7 @@
         row.with_cell(text: comparison_emoji(response.matching?), html_attributes: { class: "center" })
 
         if response.different?
-          row.with_cell(text: govuk_link_to("Response details", "#"), html_attributes: { class: "center" })     
+          row.with_cell(text: govuk_link_to("Response details", migration_parity_check_response_path(@request.run, response)), html_attributes: { class: "center" })     
         elsif @responses.any?(&:different?)
           row.with_cell
         end

--- a/app/views/migration/parity_checks/responses/show.html.erb
+++ b/app/views/migration/parity_checks/responses/show.html.erb
@@ -1,0 +1,42 @@
+<% page_data(title: @response.description, caption: @request.description, breadcrumbs: @breadcrumbs) %>
+
+<p>
+  The status code from ECF was <strong><%= status_code_tag(@response.ecf_status_code) %></strong>  
+  and the response took <strong><%= number_with_delimiter(@response.ecf_time_ms) %>ms</strong>.
+</p>
+
+<p>
+  The status code from RECT was <strong><%= status_code_tag(@response.rect_status_code) %></strong>  
+  and the response took <strong><%= number_with_delimiter(@response.rect_time_ms) %>ms</strong>.
+</p>
+
+<p>
+  The response bodies were <strong><%= comparison_in_words(@response.bodies_matching?) %></strong> and RECT had 
+  <strong><%= performance_gain(@response.rect_performance_gain_ratio) %></strong> performance when compared to ECF.
+</p>
+
+<% if @response.bodies_different? %>
+  <% content_for(:head) do %>
+    <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
+  <% end %>
+
+  <hr class="govuk-section-break govuk-section-break--l">
+
+  <%= govuk_details(summary_text: "Understanding the differences") do %>
+    <p>
+      The diff below highlights what has changed between the ECF and RECT response bodies.
+    </p>
+    
+    <p>
+      Sections <span class="diff green">in green</span> show content that exists 
+      in the RECT response but is missing from the ECF response.
+    </p>
+
+    <p>
+      Sections <span class="diff red">in red</span> show content that exists 
+      in the ECF response but is missing from the RECT response.
+    </p>
+  <% end %>
+
+  <%= sanitize_diff(@response.body_diff.to_s(:html)) %>
+<% end %>

--- a/app/views/migration/parity_checks/show.html.erb
+++ b/app/views/migration/parity_checks/show.html.erb
@@ -40,7 +40,7 @@
         table.with_body do |body|
           requests.each do |request|  
             body.with_row do |row|
-              row.with_cell(text: request.endpoint.description)
+              row.with_cell(text: request.description)
               row.with_cell(text: match_rate_tag(request.match_rate))
               row.with_cell(text: performance_gain(request.rect_performance_gain_ratio))
               row.with_cell(text: govuk_link_to("Request details", migration_parity_check_request_path(@run, request)))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
         end
 
         resources :requests, only: :show, module: :parity_checks
+        resources :responses, only: :show, module: :parity_checks
       end
     end
   end

--- a/db/seeds/parity_checks.rb
+++ b/db/seeds/parity_checks.rb
@@ -24,8 +24,8 @@ def create_in_progress_request(run:, lead_provider:, endpoint:)
 end
 
 def create_response(request, response_type, page)
-  ecf_body = %({ "some": { "random": "json" } })
-  rect_body = response_type == :matching ? ecf_body : %({ "some": { "different": "json" } })
+  ecf_body = Faker::Json.shallow_json(width: 3)
+  rect_body = response_type == :matching ? ecf_body : Faker::Json.shallow_json(width: 3)
 
   ParityCheck::Response.create!(
     request:,

--- a/spec/factories/parity_check/response_factory.rb
+++ b/spec/factories/parity_check/response_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:parity_check_response, class: "ParityCheck::Response") do
-    association(:request, factory: :parity_check_request)
+    association(:request, factory: %i[parity_check_request completed])
     ecf_body { "ECF response body" }
     ecf_status_code { 200 }
     ecf_time_ms { Faker::Number.between(from: 10, to: 2000) }
@@ -20,6 +20,13 @@ FactoryBot.define do
       rect_status_code { 201 }
       ecf_body { "ECF response body" }
       rect_body { "RECT response body" }
+    end
+
+    trait :different_status_code_matching_body do
+      ecf_status_code { 200 }
+      rect_status_code { 201 }
+      ecf_body { "Response body" }
+      rect_body { "Response body" }
     end
   end
 end

--- a/spec/features/migration/view_completed_parity_checks_spec.rb
+++ b/spec/features/migration/view_completed_parity_checks_spec.rb
@@ -22,15 +22,15 @@ RSpec.describe "View completed parity checks" do
     page.get_by_text("How the run mode affects performance").click
     expect(page.get_by_text(/In concurrent mode/)).to be_visible
 
-    completed_run_details = page.locator("table tbody")
-    expect(completed_run_details.get_by_text(completed_run.id.to_s)).to be_visible
-    expect(completed_run_details.get_by_text("Statements")).to be_visible
-    expect(completed_run_details.get_by_text("Users")).to be_visible
-    expect(completed_run_details.get_by_text("3 minutes")).to be_visible
-    expect(completed_run_details.get_by_text("Concurrent")).to be_visible
-    expect(completed_run_details.get_by_text("75%")).to be_visible
-    expect(completed_run_details.get_by_text(/faster|slower|equal/)).to be_visible
-    expect(completed_run_details.get_by_role("link", name: "Run details")).to be_visible
+    tbody = page.locator("table tbody")
+    expect(tbody.locator("td:nth-child(1)").get_by_text(completed_run.id.to_s)).to be_visible
+    expect(tbody.get_by_text("Statements")).to be_visible
+    expect(tbody.get_by_text("Users")).to be_visible
+    expect(tbody.get_by_text("3 minutes")).to be_visible
+    expect(tbody.get_by_text("Concurrent")).to be_visible
+    expect(tbody.get_by_text("75%")).to be_visible
+    expect(tbody.get_by_text(/faster|slower|equal/)).to be_visible
+    expect(tbody.get_by_role("link", name: "Run details")).to be_visible
 
     expect(page.locator(".govuk-pagination")).not_to be_visible
   end

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "View parity check request" do
     page.goto(migration_parity_check_path(run))
     page.get_by_role("link", name: "Request details").click
 
-    expect(page.get_by_text(request.lead_provider.name)).to be_visible
-    expect(page.get_by_role("heading", name: request.endpoint.description)).to be_visible
+    expect(page.locator(".govuk-caption-m").get_by_text(request.lead_provider.name)).to be_visible
+    expect(page.get_by_role("heading", name: request.description)).to be_visible
 
     expect(page.get_by_text("The request resulted in 2 responses that took 3 minutes to complete.")).to be_visible
     expect(page.get_by_text("Overall the request was 50% successful")).to be_visible

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe "View parity check response" do
+  include ActionView::Helpers::NumberHelper
+
+  before do
+    sign_in_as_dfe_user(role: :admin)
+    allow(Rails.application.config).to receive(:parity_check).and_return({ enabled: true })
+  end
+
+  scenario "Viewing a parity check response" do
+    run = FactoryBot.create(:parity_check_run, :completed)
+    response = FactoryBot.create(:parity_check_response, :different)
+    request = FactoryBot.create(:parity_check_request, :completed, run:, responses: [response])
+
+    page.goto(migration_parity_check_request_path(run, request))
+    page.get_by_role("link", name: "Response details").click
+
+    expect(page.locator(".govuk-caption-m").get_by_text(request.description)).to be_visible
+    expect(page.get_by_role("heading", name: response.description)).to be_visible
+
+    expect(page.get_by_text("The status code from ECF was 200 and the response took #{number_with_delimiter(response.ecf_time_ms)}ms.")).to be_visible
+    expect(page.get_by_text("The status code from RECT was 201 and the response took #{number_with_delimiter(response.rect_time_ms)}ms.")).to be_visible
+    expect(page.get_by_text("The response bodies were different")).to be_visible
+    expect(page.get_by_text(/(equal|faster|slower) performance when compared to ECF/)).to be_visible
+
+    expect(page.get_by_text(/The diff below highlights/)).not_to be_visible
+    page.get_by_text("Understanding the differences").click
+    expect(page.get_by_text(/The diff below highlights/)).to be_visible
+
+    diff = page.locator(".diff")
+    expect(diff.get_by_text(response.ecf_body)).to be_visible
+    expect(diff.get_by_text(response.rect_body)).to be_visible
+  end
+
+  scenario "Viewing a parity check response where the bodies match" do
+    response = FactoryBot.create(:parity_check_response, :different_status_code_matching_body)
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    expect(page.get_by_text("The response bodies were the same")).to be_visible
+
+    expect(page.get_by_text("Understanding the differences")).not_to be_visible
+    expect(page.get_by_text(response.ecf_body)).not_to be_visible
+    expect(page.get_by_text(response.rect_body)).not_to be_visible
+  end
+
+  scenario "Navigating back to the parity check request" do
+    response = FactoryBot.create(:parity_check_response, :different)
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: response.request.description).click
+    expect(page.url).to end_with(migration_parity_check_request_path(response.run, response.request))
+  end
+
+  scenario "Navigating back to the parity check run" do
+    response = FactoryBot.create(:parity_check_response, :different)
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Parity check run ##{response.run.id}").click
+    expect(page.url).to end_with(migration_parity_check_path(response.run))
+  end
+
+  scenario "Navigating back to completed parity checks" do
+    response = FactoryBot.create(:parity_check_response, :different)
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Completed parity checks").click
+    expect(page.url).to end_with(completed_migration_parity_checks_path)
+  end
+
+  scenario "Navigating back to run a parity check" do
+    response = FactoryBot.create(:parity_check_response, :different)
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    breadcrumbs = page.locator(".govuk-breadcrumbs")
+    breadcrumbs.get_by_role("link", name: "Run a parity check").click
+    expect(page.url).to end_with(new_migration_parity_check_path)
+  end
+end

--- a/spec/features/migration/view_parity_check_spec.rb
+++ b/spec/features/migration/view_parity_check_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "View parity check" do
       expect(table.get_by_text(lead_provider.name)).to be_visible
 
       requests.each do |request|
-        expect(table.get_by_text(request.endpoint.description)).to be_visible
+        expect(table.get_by_text(request.description)).to be_visible
         expect(table.get_by_text("#{request.match_rate}%")).to be_visible
         expect(table.get_by_text(/faster|slower|equal/)).to be_visible
         expect(table.get_by_role("link", name: "Request details")).to be_visible

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -145,4 +145,36 @@ RSpec.describe ParityCheckHelper, type: :helper do
       )
     end
   end
+
+  describe "#comparison_in_words" do
+    subject { helper.comparison_in_words(matching) }
+
+    context "when matching" do
+      let(:matching) { true }
+
+      it { is_expected.to eq("the same") }
+    end
+
+    context "when different" do
+      let(:matching) { false }
+
+      it { is_expected.to eq("different") }
+    end
+  end
+
+  describe "#sanitize_diff" do
+    subject { helper.sanitize_diff(html) }
+
+    let(:html) { response.body_diff.to_s(:html) }
+    let(:response) { FactoryBot.build(:parity_check_response, :different) }
+
+    it { is_expected.to eq(html.html_safe) }
+
+    context "when the diff contains malicious HTML" do
+      let(:html) { "<script>alert('maliciousness');</script>#{response.body_diff.to_s(:html)}" }
+
+      it { is_expected.not_to eq(html.html_safe) }
+      it { is_expected.not_to include("<script>") }
+    end
+  end
 end

--- a/spec/models/parity_check/request_spec.rb
+++ b/spec/models/parity_check/request_spec.rb
@@ -8,6 +8,10 @@ describe ParityCheck::Request do
     it { is_expected.to have_many(:responses).dependent(:destroy) }
   end
 
+  describe "delegate methods" do
+    it { is_expected.to delegate_method(:description).to(:endpoint) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:lead_provider) }
     it { is_expected.to validate_presence_of(:endpoint) }

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -5,10 +5,36 @@ describe ParityCheck::Response do
     it { is_expected.to belong_to(:request) }
   end
 
+  describe "delegate methods" do
+    it { is_expected.to delegate_method(:run).to(:request) }
+  end
+
   describe "before_validation" do
     it "clears bodies if the response bodies match" do
       response = FactoryBot.build(:parity_check_response, :different, ecf_body: "same", rect_body: "same")
       expect { response.save! }.to change { response.ecf_body }.to(nil).and change { response.rect_body }.to(nil)
+    end
+  end
+
+  describe "before_save" do
+    it "formats bodies as pretty JSON if they are valid JSON" do
+      ecf_body = { ecf_key: "ecf_value" }
+      rect_body = { rect_key: "rect_value" }
+      response = FactoryBot.build(:parity_check_response, ecf_body: ecf_body.to_json, rect_body: rect_body.to_json)
+
+      response.save!
+
+      expect(response.ecf_body).to eq(JSON.pretty_generate(ecf_body))
+      expect(response.rect_body).to eq(JSON.pretty_generate(rect_body))
+    end
+
+    it "does not format bodies if they are not valid JSON" do
+      response = FactoryBot.build(:parity_check_response, ecf_body: "not json", rect_body: "also not json")
+
+      response.save!
+
+      expect(response.ecf_body).to eq("not json")
+      expect(response.rect_body).to eq("also not json")
     end
   end
 
@@ -25,10 +51,11 @@ describe ParityCheck::Response do
   end
 
   describe "scopes" do
-    let!(:matching_response) { FactoryBot.create(:parity_check_response, :matching) }
-    let!(:matching_status_codes_response) { FactoryBot.create(:parity_check_response, :matching, ecf_body: "different") }
-    let!(:matching_bodies_response) { FactoryBot.create(:parity_check_response, :matching, ecf_status_code: 404) }
-    let!(:different_response) { FactoryBot.create(:parity_check_response, :different) }
+    let(:request) { FactoryBot.create(:parity_check_request) }
+    let!(:matching_response) { FactoryBot.create(:parity_check_response, :matching, request:) }
+    let!(:matching_status_codes_response) { FactoryBot.create(:parity_check_response, :matching, ecf_body: "different", request:) }
+    let!(:matching_bodies_response) { FactoryBot.create(:parity_check_response, :matching, ecf_status_code: 404, request:) }
+    let!(:different_response) { FactoryBot.create(:parity_check_response, :different, request:) }
 
     describe ".different" do
       subject { described_class.different }
@@ -117,6 +144,22 @@ describe ParityCheck::Response do
     end
   end
 
+  describe "#description" do
+    subject { response.description }
+
+    context "when the response has a page" do
+      let(:response) { FactoryBot.build(:parity_check_response, page: 1) }
+
+      it { is_expected.to eq("Response for page 1") }
+    end
+
+    context "when the response does not have a page" do
+      let(:response) { FactoryBot.build(:parity_check_response, page: nil) }
+
+      it { is_expected.to eq("Response") }
+    end
+  end
+
   describe ".matching?" do
     subject { response }
 
@@ -147,5 +190,56 @@ describe ParityCheck::Response do
 
       it { is_expected.not_to be_different }
     end
+  end
+
+  describe "#bodies_matching?" do
+    subject { response }
+
+    context "when the ECF and RECT bodies are the same" do
+      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "body", rect_body: "body") }
+
+      it { is_expected.to be_bodies_matching }
+    end
+
+    context "when the ECF and RECT bodies are different" do
+      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "ecf body", rect_body: "rect body") }
+
+      it { is_expected.not_to be_bodies_matching }
+    end
+  end
+
+  describe "#bodies_different?" do
+    subject { response }
+
+    context "when the ECF and RECT bodies are the same" do
+      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "body", rect_body: "body") }
+
+      it { is_expected.not_to be_bodies_different }
+    end
+
+    context "when the ECF and RECT bodies are different" do
+      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "ecf body", rect_body: "rect body") }
+
+      it { is_expected.to be_bodies_different }
+    end
+  end
+
+  describe "#body_diff" do
+    subject(:diff) { response.body_diff }
+
+    let(:response) { FactoryBot.create(:parity_check_response, :different) }
+
+    it { is_expected.to be_a(Diffy::Diff) }
+
+    it {
+      expect(diff.to_s(:text)).to eq(
+        <<~DIFF
+          -ECF response body
+          \\ No newline at end of file
+          +RECT response body
+          \\ No newline at end of file
+        DIFF
+      )
+    }
   end
 end

--- a/spec/models/parity_check/run_spec.rb
+++ b/spec/models/parity_check/run_spec.rb
@@ -5,27 +5,37 @@ describe ParityCheck::Run do
     it { is_expected.to have_many(:requests).dependent(:destroy) }
     it { is_expected.to have_many(:lead_providers).through(:requests) }
     it { is_expected.to have_many(:endpoints).through(:requests) }
+    it { is_expected.to have_many(:responses).through(:requests) }
 
     it "returns distinct lead providers, ordered by name in ascending order" do
-      lead_provider_1 = FactoryBot.create(:lead_provider, name: "A lead provider")
-      lead_provider_2 = FactoryBot.create(:lead_provider, name: "B lead provider")
+      lead_provider_1 = FactoryBot.create(:lead_provider, name: "B lead provider")
+      lead_provider_2 = FactoryBot.create(:lead_provider, name: "A lead provider")
       run = FactoryBot.create(:parity_check_run)
       FactoryBot.create(:parity_check_request, run:, lead_provider: lead_provider_1)
       FactoryBot.create(:parity_check_request, run:, lead_provider: lead_provider_1)
       FactoryBot.create(:parity_check_request, run:, lead_provider: lead_provider_2)
 
-      expect(run.lead_providers).to eq([lead_provider_1, lead_provider_2])
+      expect(run.lead_providers).to eq([lead_provider_2, lead_provider_1])
     end
 
     it "returns distinct endpoints, ordered by path in ascending order" do
-      endpoint_1 = FactoryBot.create(:parity_check_endpoint, path: "/a/path")
-      endpoint_2 = FactoryBot.create(:parity_check_endpoint, path: "/b/path")
+      endpoint_1 = FactoryBot.create(:parity_check_endpoint, path: "/b/path")
+      endpoint_2 = FactoryBot.create(:parity_check_endpoint, path: "/a/path")
       run = FactoryBot.create(:parity_check_run)
       FactoryBot.create(:parity_check_request, run:, endpoint: endpoint_1)
       FactoryBot.create(:parity_check_request, run:, endpoint: endpoint_1)
       FactoryBot.create(:parity_check_request, run:, endpoint: endpoint_2)
 
-      expect(run.endpoints).to eq([endpoint_1, endpoint_2])
+      expect(run.endpoints).to eq([endpoint_2, endpoint_1])
+    end
+
+    it "returns responses, ordered by page in ascending order" do
+      run = FactoryBot.create(:parity_check_run, :in_progress, requests: [])
+      request = FactoryBot.create(:parity_check_request, :in_progress, run:)
+      response_1 = FactoryBot.create(:parity_check_response, request:, page: 2)
+      response_2 = FactoryBot.create(:parity_check_response, request:, page: 1)
+
+      expect(run.responses).to eq([response_2, response_1])
     end
   end
 

--- a/spec/requests/migration/parity_check_spec.rb
+++ b/spec/requests/migration/parity_check_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "Parity check", type: :request do
       it "renders the parity check request page" do
         get migration_parity_check_request_path(run, request)
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(request.endpoint.description)
+        expect(response.body).to include(request.description)
       end
 
       context "when the parity check is not completed" do
@@ -212,6 +212,73 @@ RSpec.describe "Parity check", type: :request do
 
       it "renders the unauthorized page" do
         get migration_parity_check_request_path(run, request)
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include("You are not authorised to access this page")
+      end
+    end
+  end
+
+  describe "GET /migration/parity_checks/:run_id/responses/:id" do
+    let(:run) { FactoryBot.create(:parity_check_run, :completed) }
+    let(:request) { FactoryBot.create(:parity_check_request, :completed, run:) }
+    let(:parity_check_response) { FactoryBot.create(:parity_check_response, :different, request:) }
+
+    context "when signed in as a DfE user" do
+      include_context 'sign in as DfE user'
+
+      it "renders the parity check response page" do
+        get migration_parity_check_response_path(run, parity_check_response)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(parity_check_response.description)
+      end
+
+      context "when the parity check is not completed" do
+        let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+
+        it "renders 404 not found" do
+          get migration_parity_check_response_path(run, request)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the response does not exist" do
+        it "renders 404 not found" do
+          get migration_parity_check_response_path(run, 99)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the response is matching" do
+        let(:parity_check_response) { FactoryBot.create(:parity_check_response, :matching, request:) }
+
+        it "renders 404 not found" do
+          get migration_parity_check_response_path(run, 99)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the run does not exist" do
+        it "renders 404 not found" do
+          get migration_parity_check_response_path(99, request)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when parity check is disabled" do
+        let(:enabled) { false }
+
+        it "renders 404 not found" do
+          get migration_parity_check_response_path(run, request)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "when not signed in as a DfE user" do
+      include_context 'sign in as non-DfE user'
+
+      it "renders the unauthorized page" do
+        get migration_parity_check_response_path(run, request)
         expect(response).to have_http_status(:unauthorized)
         expect(response.body).to include("You are not authorised to access this page")
       end


### PR DESCRIPTION
### Context

We want to be able to click into a response that is different in order to see a diff of the response bodies and identify what's changed.

### Changes proposed in this pull request

Add routes/actions for showing a parity check response.

Add `diffy` to generate diffs of the response bodies.

Add more realistic JSON bodies to the seed data.

Add convenience methods to models and view helper methods.

### Guidance to review

| Single response | Page response |
| -- | -- |
| <img width="1142" alt="Screenshot 2025-06-30 at 14 17 24" src="https://github.com/user-attachments/assets/b0830807-4309-4e72-b01d-ace350e9d001" /> | <img width="1142" alt="Screenshot 2025-06-30 at 14 17 50" src="https://github.com/user-attachments/assets/6883a092-414d-4437-a87e-66ecfd3e990e" /> |