### PR TITLE
Remove `super_diff` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ group :test do
   gem "rspec"
   gem "rspec-rails"
   gem "shoulda-matchers"
-  gem "super_diff"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,6 @@ GEM
       faraday
     async-pool (0.10.3)
       async (>= 1.25)
-    attr_extras (7.1.0)
     attr_required (1.0.2)
     base32 (0.3.4)
     base64 (0.3.0)
@@ -461,7 +460,6 @@ GEM
       tzinfo
       validate_url
       webfinger (~> 2.0)
-    optimist (3.2.1)
     os (1.1.4)
     ostruct (0.6.1)
     pagy (9.3.4)
@@ -471,8 +469,6 @@ GEM
       racc
     pastel (0.8.0)
       tty-color (~> 0.5)
-    patience_diff (1.2.0)
-      optimist (~> 3.0)
     pg (1.5.9)
     playwright-ruby-client (1.52.0)
       concurrent-ruby (>= 1.1.6)
@@ -707,10 +703,6 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
-    super_diff (0.16.0)
-      attr_extras (>= 6.2.4)
-      diff-lcs
-      patience_diff
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -838,7 +830,6 @@ DEPENDENCIES
   solid_queue
   stackprof
   state_machines-activerecord
-  super_diff
   turbo-rails
   tzinfo-data
   webmock

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,5 @@
 require 'ostruct'
 require 'spec_helper'
-require "super_diff/rspec-rails"
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 


### PR DESCRIPTION
It's really good for comparing hashes, arrays and strings but it seems to dump a ton of ActiveRecord stuff into the terminal when inspecting records.
