### PR TITLE
Lean on `ActiveSupport::Duration` in tests

### DIFF
--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_enter_a_valid_start_date
-    page.get_by_label('day').fill(one_month_ago_today.day.to_s)
-    page.get_by_label('month').fill(one_month_ago_today.month.to_s)
-    page.get_by_label('year').fill(one_month_ago_today.year.to_s)
+    page.get_by_label('day').fill(1.month.ago.day.to_s)
+    page.get_by_label('month').fill(1.month.ago.month.to_s)
+    page.get_by_label('year').fill(1.month.ago.year.to_s)
     and_i_click_continue
   end
 
@@ -62,9 +62,5 @@ RSpec.describe 'Registering an ECT' do
 
   def and_i_see_the_correct_appropriate_body_on_the_page
     expect(page.get_by_text('ISTIP')).to be_visible
-  end
-
-  def one_month_ago_today
-    @one_month_ago_today ||= Time.zone.today.prev_month
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_enter_a_valid_start_date
-    page.get_by_label('day').fill(one_month_ago_today.day.to_s)
-    page.get_by_label('month').fill(one_month_ago_today.month.to_s)
-    page.get_by_label('year').fill(one_month_ago_today.year.to_s)
+    page.get_by_label('day').fill(1.month.ago.day.to_s)
+    page.get_by_label('month').fill(1.month.ago.month.to_s)
+    page.get_by_label('year').fill(1.month.ago.year.to_s)
   end
 
   def and_i_select_a_teaching_school_hub_as_the_appropriate_body_type
@@ -77,9 +77,5 @@ RSpec.describe 'Registering an ECT' do
 
   def and_i_see_the_correct_appropriate_body_on_the_page
     expect(page.get_by_text('Golden Leaf Teaching Hub')).to be_visible
-  end
-
-  def one_month_ago_today
-    @one_month_ago_today ||= Time.zone.today.prev_month
   end
 end

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe 'Registering an ECT' do
   def create_contract_period_for_start_date
     @contract_period = FactoryBot.create(
       :contract_period,
-      started_on: one_month_ago_today.beginning_of_month - 6.months,
-      finished_on: one_month_ago_today.end_of_month + 6.months
+      started_on: 7.months.ago.beginning_of_month,
+      finished_on: 7.months.from_now.end_of_month
     )
   end
 
@@ -219,9 +219,9 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def when_i_enter_a_valid_start_date
-    page.get_by_label('day').fill(one_month_ago_today.day.to_s)
-    page.get_by_label('month').fill(one_month_ago_today.month.to_s)
-    page.get_by_label('year').fill(one_month_ago_today.year.to_s)
+    page.get_by_label('day').fill(1.month.ago.day.to_s)
+    page.get_by_label('month').fill(1.month.ago.month.to_s)
+    page.get_by_label('year').fill(1.month.ago.year.to_s)
   end
 
   def then_i_should_be_taken_to_the_use_previous_ect_choices_page
@@ -262,7 +262,7 @@ RSpec.describe 'Registering an ECT' do
     expect(page.get_by_text(trn)).to be_visible
     expect(page.get_by_text("Kirk Van Damme")).to be_visible
     expect(page.get_by_text('example@example.com')).to be_visible
-    expect(page.get_by_text("#{Date::MONTHNAMES[one_month_ago_today.month]} #{one_month_ago_today.year}")).to be_visible
+    expect(page.get_by_text("#{Date::MONTHNAMES[1.month.ago.month]} #{1.month.ago.year}")).to be_visible
     expect(page.get_by_text('Golden Leaf Teaching Hub')).to be_visible
   end
 
@@ -370,9 +370,5 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_ects_page
     expect(page.url).to end_with('/schools/home/ects')
-  end
-
-  def one_month_ago_today
-    @one_month_ago_today ||= Time.zone.today.prev_month
   end
 end


### PR DESCRIPTION
### Context

I saw these tests change in a recent PR, and this popped into my head. Keen to hear others thoughts 💚

### Changes proposed in this pull request

Before, we defined a private, memoized method `one_month_ago_today` to refer to the date 1 month ago.

This seemed superfluous, but I'm mindful I might be missing something.

How do we feel about leaning on [`ActiveSupport::Duration`][docs] in these situations?

I find it clear and intuitive, but I wonder what other people think?

There might be other places we could make similar changes, but I figured it's worth discussing before digging any deeper!

[docs]: https://api.rubyonrails.org/classes/ActiveSupport/Duration.html

### Guidance to review

- Run the relevant tests