### PR TITLE
Fix N+1 query on AB teachers page

### DIFF
--- a/app/controllers/appropriate_bodies/teachers_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers_controller.rb
@@ -18,7 +18,13 @@ module AppropriateBodies
         query_string: params[:q],
         appropriate_bodies: @appropriate_body,
         status: @status
-      ).search.includes([:induction_periods])
+      )
+      .search
+      .includes(
+        :induction_periods,
+        :first_induction_period,
+        :last_induction_period
+      )
     end
   end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -13,8 +13,12 @@ class Teacher < ApplicationRecord
   has_many :ect_at_school_periods, inverse_of: :teacher
   has_many :mentor_at_school_periods, inverse_of: :teacher
   has_many :induction_extensions, inverse_of: :teacher
+
   has_many :induction_periods
+  has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"
+  has_one :last_induction_period, -> { order(started_on: :desc) }, class_name: "InductionPeriod"
   has_many :appropriate_bodies, through: :induction_periods
+
   has_many :events
 
   # TODO: remove after migration complete

--- a/app/services/teachers/induction_period.rb
+++ b/app/services/teachers/induction_period.rb
@@ -7,7 +7,7 @@ class Teachers::InductionPeriod
 
   # @return [Date, nil]
   def induction_start_date
-    first_induction_period&.started_on
+    teacher.first_induction_period&.started_on
   end
 
   def formatted_induction_start_date
@@ -34,23 +34,11 @@ class Teachers::InductionPeriod
     teacher.induction_periods.ongoing.first
   end
 
-  def last_induction_period
-    induction_periods.last
-  end
-
   # @param date [Date]
   # @return [Boolean]
   def overlapping_with?(date)
-    induction_periods.ongoing_on(date).exists?
+    teacher.induction_periods.ongoing_on(date).exists?
   end
 
-private
-
-  def first_induction_period
-    induction_periods.first
-  end
-
-  def induction_periods
-    @induction_periods ||= teacher.induction_periods.order(:started_on)
-  end
+  delegate :last_induction_period, to: :teacher
 end


### PR DESCRIPTION
### Context

We saw some [N+1 queries in Sentry](https://dfe-teacher-services.sentry.io/issues/6621363705/?project=4508369974788096&query=is%3Aunresolved&referrer=issue-stream&stream_index=6) on the appropriate bodies teachers index. We fixed one in #849, and this resolves the other.

### Changes proposed in this pull request

Following on from #849 (and in a similar vein to #843), this introduces a couple of associations to the `Teacher` model for their first and last induction periods.

Before, we would retrieve these to return various pieces of information (e.g induction start date) and present them to the User. This worked, but resulted in N+1 queries since we iterate a collection of teachers.

By defining these relationships as associations, we can lean on Active Record's automatic pre-loading to prevent them.

### Guidance to review

**Before**

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/381a161b-f695-4bbf-a96b-574ab00f7d11" />

**After**

<img width="1699" alt="image" src="https://github.com/user-attachments/assets/b20e0608-f6d0-4b30-be5f-f9365202c9bd" />

