### PR TITLE
Fix issue with LP naming in spec

### DIFF
--- a/spec/factories/migration/lead_provider_factory.rb
+++ b/spec/factories/migration/lead_provider_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_lead_provider, class: "Migration::LeadProvider" do
-    name  { Faker::Company.name }
+    sequence(:name) { |n| "Migration Lead Provider #{n}" }
 
     trait :active do
       after(:create) do |lead_provider|


### PR DESCRIPTION
### Context

A failing spec found it's way into production.  This fixes it.

### Changes proposed in this pull request

Make the `LeadProvider` name different in the factories that create them between ECF and RECT

### Guidance to review
