### PR TITLE
Recheck a bulk upload before completing

### DIFF
--- a/app/jobs/process_batch_job.rb
+++ b/app/jobs/process_batch_job.rb
@@ -18,7 +18,19 @@ class ProcessBatchJob < ApplicationJob
     author = event_author(pending_induction_submission_batch, author_email, author_name)
     batch_service = self.class.batch_service.new(pending_induction_submission_batch:, author:)
 
-    batch_service.complete! if pending_induction_submission_batch.processed? || pending_induction_submission_batch.completing?
+    # confirm and complete
+    if pending_induction_submission_batch.processed?
+      if batch_service.revalidated?
+        batch_service.complete!
+      else
+        pending_induction_submission_batch.pending!
+        self.class.perform_later(pending_induction_submission_batch, author_email, author_name)
+      end
+    end
+
+    # resume completing
+    batch_service.complete! if pending_induction_submission_batch.completing?
+    # process or resume processing
     batch_service.process! if pending_induction_submission_batch.pending? || pending_induction_submission_batch.processing?
   rescue StandardError => e
     Rails.logger.debug("Attempt #{executions}: #{e.message}")

--- a/app/models/concerns/batch_rows.rb
+++ b/app/models/concerns/batch_rows.rb
@@ -105,9 +105,15 @@ module BatchRows
     end
   end
 
+  # @param trn [String]
+  # @return [BatchRows::ClaimRow, BatchRows::ActionRow]
+  def row_by(trn:)
+    rows.find { |row| row.trn.eql?(trn) }
+  end
+
 private
 
-  # @return [ActionRow, ClaimRow]
+  # @return [Class]
   def row_class
     return ActionRow if action?
 

--- a/app/services/appropriate_bodies/process_batch/base.rb
+++ b/app/services/appropriate_bodies/process_batch/base.rb
@@ -32,6 +32,18 @@ module AppropriateBodies
         pending_induction_submission_batch.processed!
       end
 
+      # @return [Boolean] valid submissions are still valid
+      def revalidated?
+        pending_induction_submission_batch.pending_induction_submissions.without_errors.all? do |pending_induction_submission|
+          @row = pending_induction_submission_batch.row_by(trn: pending_induction_submission.trn)
+          @pending_induction_submission = pending_induction_submission
+
+          next(false) if fails_pre_checks?
+
+          validate_submission!.nil?
+        end
+      end
+
     private
 
       # Formatting validation of TRN and DOB happens after creation so a safe version of the TRN is used
@@ -111,6 +123,10 @@ module AppropriateBodies
         "#{name} does not have their qualified teacher status (QTS)"
       rescue StandardError
         "Something went wrong. You’ll need to try again later"
+      end
+
+      def fails_pre_checks?
+        raise(NotImplementedError)
       end
     end
   end

--- a/spec/features/appropriate_bodies/process_batch_retry_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_retry_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe 'Process bulk claims then actions which have become invalidated' do
+  include ActiveJob::TestHelper
+
+  include_context 'test trs api client'
+
+  let(:appropriate_body) do
+    FactoryBot.create(:appropriate_body, name: 'The Appropriate Body')
+  end
+
+  before do
+    sign_in_as_appropriate_body_user(appropriate_body:)
+  end
+
+  scenario 'redo processing' do
+    page.goto(new_ab_batch_claim_path)
+    expect(page.url).to end_with('/appropriate-body/bulk/claims/new')
+    when_i_upload_a_file('valid_complete_claim.csv')
+
+    expect(PendingInductionSubmissionBatch.last).to be_pending
+    expect(perform_enqueued_jobs).to be(2)
+    expect(PendingInductionSubmissionBatch.last).to be_processed
+    expect(Event.all.map(&:heading)).to eq(["The Appropriate Body started a bulk claim"])
+
+    page.reload
+    expect(page.get_by_text('CSV file summary')).to be_visible
+    expect(page.get_by_text("Your CSV named 'valid_complete_claim.csv' has 2 ECT records that you can claim.")).to be_visible
+    page.get_by_role('button', name: 'Claim ECTs').click
+
+    expect(perform_enqueued_jobs).to be(2)
+    expect(PendingInductionSubmissionBatch.last).to be_completed
+    expect(perform_enqueued_jobs).to be(8)
+
+    page.reload
+    expect(page.get_by_text("You claimed 2 ECT records.")).to be_visible
+    page.get_by_role('link', name: 'Go back to your overview').click
+    expect(page.get_by_text('valid_complete_claim.csv')).to be_visible
+
+    page.goto(new_ab_batch_action_path)
+    expect(page.url).to end_with('/appropriate-body/bulk/actions/new')
+    when_i_upload_a_file('valid_complete_action.csv')
+
+    expect(PendingInductionSubmissionBatch.last).to be_pending
+    expect(perform_enqueued_jobs).to be(2)
+    expect(PendingInductionSubmissionBatch.last).to be_processed
+
+    page.reload
+    expect(page.get_by_text('CSV file summary')).to be_visible
+    expect(page.get_by_text("Your CSV named 'valid_complete_action.csv' has 2 ECT records")).to be_visible
+    expect(page.get_by_text("1 ECT with a passed induction")).to be_visible
+    expect(page.get_by_text("1 ECT with a failed induction")).to be_visible
+    expect(page.get_by_text("0 ECTs with a released outcome")).to be_visible
+
+    expect(PendingInductionSubmissionBatch.last.pending_induction_submissions.map(&:error_messages)).to contain_exactly([], [])
+
+    # Delete the induction we wanted to fail and invalidate the row
+    Teacher.find_by(trn: '7654321').induction_periods.delete_all
+
+    page.get_by_role('button', name: 'Record outcomes').click
+    expect(perform_enqueued_jobs).to be(2)
+    expect(PendingInductionSubmissionBatch.last).to be_processed # rechecked
+    expect(PendingInductionSubmissionBatch.last.pending_induction_submissions.map(&:error_messages)).to contain_exactly(
+      [],
+      [/does not have an open induction/]
+    )
+
+    page.reload
+    # Updated expectation
+    expect(page.get_by_text('CSV file summary')).to be_visible
+    expect(page.get_by_text("Your CSV named 'valid_complete_action.csv' has 1 ECT record")).to be_visible
+    expect(page.get_by_text("1 ECT with a passed induction")).to be_visible
+    expect(page.get_by_text("0 ECTs with a failed induction")).to be_visible
+    expect(page.get_by_text("0 ECTs with a released outcome")).to be_visible
+    expect(page.get_by_text("You had 1 ECT with errors")).to be_visible
+  end
+
+private
+
+  def when_i_upload_a_file(file_name)
+    file_path = Rails.root.join("spec/fixtures/#{file_name}").to_s
+    page.locator('input[type="file"]').set_input_files(file_path)
+    page.get_by_role('button', name: 'Continue').click
+  end
+end


### PR DESCRIPTION
### Context

If a bulk upload were to sit in a processed state and not progress to completion promptly, and any of these happens before the batch is completed:

1. the user manually processes the same TRNs
2. another user at the same AB alters ECT records
3. an admin or automation altered records
4. another AB altered records
5. an update to TRS for the TRNs

Then the promised outcomes may no longer be achievable, and unexpected validation error messages may be seen, when the batch CTA completes the previously valid submissions.

### Changes proposed in this pull request

Before completing a batch, revalidate previously valid submissions, and render changes to the user

### Guidance to review

Invalidate a previously valid submission somehow, before the CTA, then when proceeding to complete the change should be caught by a second round of validation
