### PR TITLE
Allow filtering out attributes from the parity check response diffs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 import { initAll } from 'govuk-frontend'
 import './autocomplete'
+import '../../../app/javascript/controllers'
 
 initAll()

--- a/app/assets/stylesheets/migration/parity_check.scss
+++ b/app/assets/stylesheets/migration/parity_check.scss
@@ -52,6 +52,12 @@
   }
 }
 
+.diff-container {
+  > div:first-child {
+    border-right: 1px solid #b1b4b6;
+  }
+}
+
 .diff {
   &.red {
     background-color: rgb(255, 238, 238);
@@ -62,4 +68,62 @@
     background-color:rgb(221, 255, 221);
     color: #080000;
   }
+}
+
+.diff-filter {
+  overflow-x: scroll;
+
+  ul {
+    padding-left: 20px;
+  }
+
+  .govuk-checkboxes {
+    padding-top: 8px;
+  }
+
+  label {
+    font-size: 0.8em;
+  }
+
+  .govuk-checkboxes > ul {
+    padding-left: 10px;
+    margin-top: 20px;
+
+    li {
+      position: relative;
+      margin-top: -20px;
+      margin-left: -9px;
+      padding-left: 10px;
+      border-left: 1px solid #b1b4b6;
+    }
+
+    li:last-child {
+      border-left-color: transparent;
+    }
+
+    li::before {
+      content: "";
+      position: absolute;
+      top: 20px;
+      left: 0;
+      width: 11px;
+      height: 1px;
+      background-color: #b1b4b6;
+    }
+
+    li:last-child::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: -1px;
+      width: 1px;
+      height: 20px;
+      background-color: #b1b4b6;
+    }
+  }
+}
+
+.no-differences {
+  margin-top: 100px;
+  text-align: center;
 }

--- a/app/controllers/migration/parity_checks/responses_controller.rb
+++ b/app/controllers/migration/parity_checks/responses_controller.rb
@@ -6,12 +6,21 @@ module Migration::ParityChecks
       @run = ParityCheck::Run.completed.find(params[:parity_check_run_id])
       @response = @run.responses.different.find(params[:id])
       @request = @response.request
+      @filter = ParityCheck::Filter::ResponseBody.new(response: @response, **selected_key_path_params)
       @breadcrumbs = {
         "Run a parity check" => new_migration_parity_check_path,
         "Completed parity checks" => completed_migration_parity_checks_path,
         "Parity check run ##{@run.id}" => migration_parity_check_path(@run),
         @request.description => migration_parity_check_request_path(@run, @request),
       }
+    end
+
+  private
+
+    def selected_key_path_params
+      return { selected_key_paths: nil } unless params[:parity_check_filter_response_body]
+
+      params.require(:parity_check_filter_response_body).permit(selected_key_paths: [])
     end
   end
 end

--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -77,7 +77,7 @@ module ParityCheckHelper
   end
 
   def sanitize_diff(html)
-    sanitize html, tags: %w[div br ul li strong del ins], attributes: %w[class]
+    sanitize html, tags: %w[div ul li strong del ins span], attributes: %w[class]
   end
 
   def render_filterable_key_hash(hash, key_path: [], &block)

--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -79,4 +79,19 @@ module ParityCheckHelper
   def sanitize_diff(html)
     sanitize html, tags: %w[div br ul li strong del ins], attributes: %w[class]
   end
+
+  def render_filterable_key_hash(hash, key_path: [], &block)
+    govuk_list(
+      hash.map do |key, nested_hash|
+        new_key_path = key_path + [key]
+        nested_keys_exist = nested_hash.is_a?(Hash) && nested_hash.any?
+        nested_list = render_filterable_key_hash(nested_hash, key_path: new_key_path, &block) if nested_keys_exist
+
+        safe_join([
+          yield(new_key_path),
+          nested_list
+        ])
+      end
+    )
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,3 +3,6 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application"
+
+import ResponseBodyFilterController from "./parity_check/response_body_filter_controller"
+application.register("parity-check-response-body-filter", ResponseBodyFilterController)

--- a/app/javascript/controllers/parity_check/response_body_filter_controller.js
+++ b/app/javascript/controllers/parity_check/response_body_filter_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "checkbox", "form" ]
+
+  clickedCheckbox(event) {
+    this.updateCheckboxStates(event.currentTarget)
+    this.formTarget.submit()
+  }
+
+  updateCheckboxStates(clickedCheckbox) {
+    const checked = clickedCheckbox.checked
+
+    this.checkboxTargets.forEach(checkbox => {
+      if (checkbox === clickedCheckbox) return
+
+      if (!checked && clickedCheckbox.closest("li").contains(checkbox)) {
+        checkbox.checked = false
+      } else if (checked && checkbox.closest("li").contains(clickedCheckbox)) {
+        checkbox.checked = true
+      }
+    })
+  }
+}

--- a/app/migration/parity_check/runner.rb
+++ b/app/migration/parity_check/runner.rb
@@ -10,6 +10,7 @@ module ParityCheck
     validates :mode, presence: true, inclusion: { in: %w[concurrent sequential] }
     validates :endpoint_ids, presence: { message: "Select at least one endpoint." }
     validate :endpoints_exist
+    validate :lead_providers_exist
 
     def run!
       return unless valid?
@@ -39,6 +40,12 @@ module ParityCheck
       return if endpoints.none? || endpoints.count == endpoint_ids.uniq.count
 
       errors.add(:endpoint_ids, "One or more selected endpoints do not exist.")
+    end
+
+    def lead_providers_exist
+      return if lead_providers.any?
+
+      errors.add(:base, "There are no lead providers available; create at least one lead provider to run a parity check.")
     end
 
     def lead_providers

--- a/app/models/parity_check/filter/response_body.rb
+++ b/app/models/parity_check/filter/response_body.rb
@@ -1,0 +1,120 @@
+module ParityCheck::Filter
+  class ResponseBody
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :response
+    attribute :selected_key_paths
+
+    delegate :ecf_body_hash, :rect_body_hash, to: :response
+
+    # Not all response bodies are JSON.
+    def filterable?
+      filterable_key_hash.any?
+    end
+
+    # Sorted key structure of the response bodies, for example:
+    #
+    # {
+    #  key1: {}
+    #  key2: {
+    #   subkey1: {},
+    #   subkey2: {}
+    #  }
+    # }
+    def filterable_key_hash
+      rect_key_hash.merge(ecf_key_hash)
+    end
+
+    # Checks if a key path has been selected for filtering, for example:
+    #
+    # [:key, :subkey]
+    def selected?(key_path)
+      return true if selected_key_paths.nil?
+
+      selected_key_paths.include?(key_path.map(&:to_sym))
+    end
+
+    # Sets the selected key paths for filtering as an array of strings
+    # for convenience with how forms represent array values. For example:
+    #
+    # ["key subkey", "another_key"]
+    def selected_key_paths=(value)
+      super(value.nil? ? value : Array.wrap(value).map { it.to_s.split.map(&:to_sym) })
+
+      verify_selected_key_paths!
+    end
+
+    # Applies the selected filters to the response bodies.
+    def filtered_response
+      return response unless filterable? && !selected_key_paths.nil?
+
+      response.tap do
+        it.ecf_body = apply_filter(it.ecf_body_hash).to_json if it.ecf_body.present?
+        it.rect_body = apply_filter(it.rect_body_hash).to_json if it.rect_body.present?
+      end
+    end
+
+  private
+
+    def verify_selected_key_paths!
+      return if selected_key_paths.blank?
+
+      selected_key_paths.each do |key_path|
+        next if key_path.size == 1
+
+        parent_key_path = key_path[...-1]
+        next if parent_key_path.in?(selected_key_paths)
+
+        raise ArgumentError, "Parent key path #{parent_key_path} for key path #{key_path} must also be selected."
+      end
+    end
+
+    def apply_filter(body, parent_path = [])
+      return body unless body.is_a?(Hash)
+
+      body.each_with_object({}) do |(key, value), filtered|
+        current_path = parent_path + [key.to_sym]
+
+        next unless selected?(current_path)
+
+        filtered[key] = if value.is_a?(Hash)
+                          apply_filter(value, current_path)
+                        elsif value.is_a?(Array)
+                          value.map { |item| apply_filter(item, current_path) }
+                        else
+                          value
+                        end
+      end
+    end
+
+    def rect_key_hash
+      return {} unless rect_body_hash
+
+      @rect_key_hash ||= nested_key_hash(rect_body_hash)
+    end
+
+    def ecf_key_hash
+      return {} unless ecf_body_hash
+
+      @ecf_key_hash ||= nested_key_hash(ecf_body_hash)
+    end
+
+    def nested_key_hash(hash)
+      result = {}
+
+      hash.keys.sort.each do |key|
+        value = hash[key]
+        result[key] = if value.is_a?(Hash) && value.any?
+                        nested_key_hash(value)
+                      elsif value.is_a?(Array) && value.any?
+                        value.map { nested_key_hash(it) }.reduce(:merge)
+                      else
+                        {}
+                      end
+      end
+
+      result
+    end
+  end
+end

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -86,7 +86,7 @@ module ParityCheck
     end
 
     def parse_json_body(body)
-      JSON.parse(body).deep_symbolize_keys if body
+      JSON.parse(body)&.deep_symbolize_keys if body
     rescue JSON::ParserError
       nil
     end

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -7,7 +7,6 @@ module ParityCheck
     delegate :run, to: :request
 
     before_validation :clear_bodies, if: :bodies_matching?
-    before_save :format_bodies
 
     validates :request, presence: true
     validates :ecf_status_code, inclusion: { in: 100..599 }
@@ -60,21 +59,34 @@ module ParityCheck
     end
 
     def body_diff
-      Diffy::Diff.new(ecf_body, rect_body, context: 3)
+      @body_diff ||= Diffy::Diff.new(ecf_body, rect_body, context: 3)
+    end
+
+    def ecf_body_hash
+      @ecf_body_hash ||= parse_json_body(ecf_body)
+    end
+
+    def rect_body_hash
+      @rect_body_hash ||= parse_json_body(rect_body)
+    end
+
+    def ecf_body=(value)
+      super(pretty_json(value))
+    end
+
+    def rect_body=(value)
+      super(pretty_json(value))
     end
 
   private
 
-    def format_bodies
-      ecf_body_hash = parse_json_body(ecf_body)
-      self.ecf_body = JSON.pretty_generate(ecf_body_hash) if ecf_body_hash
-
-      rect_body_hash = parse_json_body(rect_body)
-      self.rect_body = JSON.pretty_generate(rect_body_hash) if rect_body_hash
+    def pretty_json(value)
+      parsed_json = parse_json_body(value)
+      parsed_json ? JSON.pretty_generate(parsed_json) : value
     end
 
     def parse_json_body(body)
-      JSON.parse(body) if body
+      JSON.parse(body).deep_symbolize_keys if body
     rescue JSON::ParserError
       nil
     end

--- a/app/views/migration/parity_checks/responses/_diff.html.erb
+++ b/app/views/migration/parity_checks/responses/_diff.html.erb
@@ -1,0 +1,6 @@
+<% if response.bodies_different? %>
+  <%= sanitize_diff(response.body_diff.to_s(:html)) %>
+<% else %>
+  <p class="no-differences govuk-!-font-size-27">No differences found 🙌</p>
+<% end %>
+

--- a/app/views/migration/parity_checks/responses/_filter.html.erb
+++ b/app/views/migration/parity_checks/responses/_filter.html.erb
@@ -1,0 +1,9 @@
+<div class="diff-filter" data-controller="parity-check-response-body-filter">
+  <%= form_for(filter, url: migration_parity_check_response_path(filter.response.run, filter.response), method: :get, html: { data: { "parity-check-response-body-filter-target": "form" } }) do |f| %>
+    <%= f.govuk_check_boxes_fieldset :selected_key_paths, legend: { text: "What do you want to compare?"}, hint: { text: "Only selected attributes will appear in the diff." }, small: true do %>
+      <%= render_filterable_key_hash(filter.filterable_key_hash) do |key_path| %>
+        <% f.govuk_check_box :selected_key_paths, key_path, label: { text: key_path.last }, checked: filter.selected?(key_path), data: { "parity-check-response-body-filter-target": "checkbox", action: "click->parity-check-response-body-filter#clickedCheckbox" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/migration/parity_checks/responses/show.html.erb
+++ b/app/views/migration/parity_checks/responses/show.html.erb
@@ -20,8 +20,6 @@
     <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
   <% end %>
 
-  <hr class="govuk-section-break govuk-section-break--l">
-
   <%= govuk_details(summary_text: "Understanding the differences") do %>
     <p>
       The diff below highlights what has changed between the ECF and RECT response bodies.
@@ -38,5 +36,14 @@
     </p>
   <% end %>
 
-  <%= sanitize_diff(@response.body_diff.to_s(:html)) %>
+  <hr class="govuk-section-break govuk-section-break--l">
+
+  <div class="govuk-grid-row diff-container">
+    <div class="govuk-grid-column-one-third">
+      <%= render partial: "filter", locals: { filter: @filter } if @filter.filterable? %>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render partial: "diff", locals: { response: @filter.filtered_response } %>
+    </div>
+  </div>
 <% end %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -13,3 +13,5 @@ review: *redis
 staging: *redis
 
 production: *redis
+
+migration: *redis

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -13,7 +13,7 @@ get:
       id: example_id
   - "/api/v3/partnerships/ecf":
   - "/api/v3/partnerships/ecf/:id":
-    id: example_id
+      id: example_id
 post:
   - "/api/v3/statements":
       body: example_body
@@ -21,5 +21,6 @@ post:
       body: example_body
 put:
   - "/api/v3/participant-declarations/:id":
+      id: example_id
       body: example_body
 

--- a/db/seeds/parity_checks.rb
+++ b/db/seeds/parity_checks.rb
@@ -24,8 +24,10 @@ def create_in_progress_request(run:, lead_provider:, endpoint:)
 end
 
 def create_response(request, response_type, page)
-  ecf_body = Faker::Json.shallow_json(width: 3)
-  rect_body = response_type == :matching ? ecf_body : Faker::Json.shallow_json(width: 3)
+  options = { key: "Name.first_name", value: "Name.last_name" }
+  ecf_body = Faker::Json.shallow_json(width: 3, options:)
+  different_json = { data: { attributes: { name: Faker::Name.name, address: Faker::Address.full_address }, another: "test" } }.to_json
+  rect_body = response_type == :matching ? ecf_body : different_json
 
   ParityCheck::Response.create!(
     request:,

--- a/spec/features/migration/run_parity_check_spec.rb
+++ b/spec/features/migration/run_parity_check_spec.rb
@@ -67,6 +67,20 @@ RSpec.describe "Run parity check" do
     expect(page.locator(".govuk-error-summary a").and(page.get_by_text("Select at least one endpoint."))).to be_visible
   end
 
+  scenario "Running a parity check when there are no lead providers" do
+    LeadProvider.destroy_all
+
+    page.goto(new_migration_parity_check_path)
+
+    page.get_by_label(post_endpoint.description).click
+
+    page.get_by_role("button", name: "Run").click
+    page.screenshot(path: "tmp.png")
+
+    expect(page.get_by_role("heading", name: "There is a problem")).to be_visible
+    expect(page.locator(".govuk-error-summary a").and(page.get_by_text("There are no lead providers available; create at least one lead provider to run a parity check."))).to be_visible
+  end
+
   scenario "Running a parity check when there are no endpoints" do
     ParityCheck::Endpoint.destroy_all
 

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -29,6 +29,42 @@ RSpec.describe "View parity check response" do
     diff = page.locator(".diff")
     expect(diff.get_by_text(response.ecf_body)).to be_visible
     expect(diff.get_by_text(response.rect_body)).to be_visible
+
+    expect(page.locator(".diff-filter")).not_to be_visible
+  end
+
+  scenario "Viewing a parity check response where the bodies are filterable", :js do
+    ecf_body = { key: { nested: :value, additional_nested: :nested_data } }.to_json
+    rect_body = { key: { nested: :different_value }, additional: :data }.to_json
+    response = FactoryBot.create(:parity_check_response, ecf_body:, rect_body:)
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    diff = page.locator(".diff")
+    expect(diff.locator(".del").get_by_text(%("nested": "value"))).to be_visible
+    expect(diff.locator(".ins").get_by_text(%("nested": "different_value"))).to be_visible
+    expect(diff.locator(".ins").get_by_text(%("additional": "data"))).to be_visible
+
+    filter = page.locator(".diff-filter")
+    expect(filter).to be_visible
+
+    filter.locator("input[type='checkbox'][value='key']").uncheck
+    expect(filter.locator("input[type='checkbox'][value='key nested']")).not_to be_checked
+    expect(filter.locator("input[type='checkbox'][value='key additional_nested']")).not_to be_checked
+    expect(filter.locator("input[type='checkbox'][value='additional']")).to be_checked
+
+    expect(diff.get_by_text(%("nested": "value"))).not_to be_visible
+    expect(diff.get_by_text(%("nested": "different_value"))).not_to be_visible
+    expect(diff.locator(".ins").get_by_text(%("additional": "data"))).to be_visible
+
+    filter.locator("input[type='checkbox'][value='additional']").uncheck
+
+    expect(page.get_by_text("No differences found 🙌")).to be_visible
+
+    filter.locator("input[type='checkbox'][value='key nested']").check
+    expect(filter.locator("input[type='checkbox'][value='key']")).to be_checked
+    expect(filter.locator("input[type='checkbox'][value='key additional_nested']")).not_to be_checked
+    expect(filter.locator("input[type='checkbox'][value='additional']")).not_to be_checked
   end
 
   scenario "Viewing a parity check response where the bodies match" do

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -177,4 +177,36 @@ RSpec.describe ParityCheckHelper, type: :helper do
       it { is_expected.not_to include("<script>") }
     end
   end
+
+  describe "#render_filterable_key_hash" do
+    let(:key_hash) do
+      {
+        key1: {
+          key2: {}
+        },
+        key3: {}
+      }
+    end
+
+    it "renders a nested list of the key hash, yielding the key name and keypath of each" do
+      rendered_list = helper.render_filterable_key_hash(key_hash) do |key_path|
+        key_path.join(".")
+      end
+
+      # Embedding the nested ul inside the li for the parent key
+      # makes the CSS for rendering the 'tree' connections much simpler.
+      expected_html = <<~HTML
+        <ul class="govuk-list">
+          <li>key1
+            <ul class="govuk-list">
+              <li>key1.key2</li>
+            </ul>
+          </li>
+          <li>key3</li>
+        </ul>
+      HTML
+
+      expect(rendered_list).to eq(expected_html.squish.gsub(/\s+</, "<"))
+    end
+  end
 end

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -166,14 +166,15 @@ RSpec.describe ParityCheckHelper, type: :helper do
     subject { helper.sanitize_diff(html) }
 
     let(:html) { response.body_diff.to_s(:html) }
-    let(:response) { FactoryBot.build(:parity_check_response, :different) }
+    let(:ecf_body) { { key1: { subkey: "value1" } }.to_json }
+    let(:rect_body) { { key1: { subkey: "value2" } }.to_json }
+    let(:response) { FactoryBot.build(:parity_check_response, rect_body:, ecf_body:) }
 
-    it { is_expected.to eq(html.html_safe) }
+    it { is_expected.to eq(CGI.unescapeHTML(html.html_safe)) }
 
     context "when the diff contains malicious HTML" do
       let(:html) { "<script>alert('maliciousness');</script>#{response.body_diff.to_s(:html)}" }
 
-      it { is_expected.not_to eq(html.html_safe) }
       it { is_expected.not_to include("<script>") }
     end
   end

--- a/spec/models/parity_check/filter/response_body_spec.rb
+++ b/spec/models/parity_check/filter/response_body_spec.rb
@@ -1,0 +1,185 @@
+describe ParityCheck::Filter::ResponseBody do
+  let(:response) { FactoryBot.create(:parity_check_response) }
+  let(:selected_key_paths) { [] }
+  let(:instance) { described_class.new(response:, selected_key_paths:) }
+
+  describe "attributes" do
+    subject { instance }
+
+    it { is_expected.to have_attributes(response:) }
+    it { is_expected.to have_attributes(selected_key_paths:) }
+  end
+
+  describe "delegate methods" do
+    it { is_expected.to delegate_method(:ecf_body_hash).to(:response) }
+    it { is_expected.to delegate_method(:rect_body_hash).to(:response) }
+  end
+
+  describe "#filterable?" do
+    subject { instance }
+
+    context "when the response body is not JSON" do
+      let(:response) { FactoryBot.create(:parity_check_response, ecf_body: "some text", rect_body: "some text") }
+
+      it { is_expected.not_to be_filterable }
+    end
+
+    context "when at least one response body is JSON" do
+      let(:response) { FactoryBot.create(:parity_check_response, ecf_body: { some: :json }.to_json, rect_body: "some text") }
+
+      it { is_expected.to be_filterable }
+    end
+  end
+
+  describe "#filterable_key_hash" do
+    subject(:key_hash) { instance.filterable_key_hash }
+
+    context "when the bodies are nil" do
+      let(:response) { FactoryBot.create(:parity_check_response, ecf_body: nil, rect_body: nil) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the bodies are not JSON" do
+      let(:response) { FactoryBot.create(:parity_check_response, ecf_body: "some text", rect_body: "some text") }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the bodies are JSON" do
+      let(:ecf_body) { { key1: { subkey: "value" } }.to_json }
+      let(:rect_body) { { key2: "value" }.to_json }
+      let(:response) { FactoryBot.create(:parity_check_response, ecf_body:, rect_body:) }
+
+      it "returns a hash of the key structure" do
+        expect(key_hash).to eq(
+          key1: {
+            subkey: {},
+          },
+          key2: {}
+        )
+      end
+
+      context "when the JSON contains arrays of objects" do
+        let(:ecf_body) { { key1: [{ subkey: "value1", other_subkey: [{ subsubkey: "value4" }] }, { subkey: "value2" }] }.to_json }
+        let(:rect_body) { { key2: "value" }.to_json }
+
+        it "returns a hash of the key structure with arrays" do
+          expect(key_hash).to eq(
+            key1: {
+              subkey: {},
+              other_subkey: {
+                subsubkey: {}
+              }
+            },
+            key2: {}
+          )
+        end
+      end
+    end
+  end
+
+  describe "#selected_key_paths=" do
+    subject(:set_selected_key_paths) do
+      instance.selected_key_paths = value
+      instance.selected_key_paths
+    end
+
+    context "when the value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the value is an array of strings" do
+      let(:value) { ["key", "key subkey", "other_key"] }
+
+      it { is_expected.to eq([%i[key], %i[key subkey], %i[other_key]]) }
+    end
+
+    context "when intermediate keys are not selected" do
+      let(:value) { ["key subkey"] }
+
+      it { expect { set_selected_key_paths }.to raise_error(ArgumentError, "Parent key path [:key] for key path [:key, :subkey] must also be selected.") }
+    end
+
+    context "when the value is a string" do
+      let(:value) { "key" }
+
+      it { is_expected.to eq([%i[key]]) }
+    end
+
+    context "when the values are not strings" do
+      let(:value) { [123, 456] }
+
+      it { is_expected.to eq([%i[123], %i[456]]) }
+    end
+  end
+
+  describe "#selected?" do
+    subject { instance.selected?(key_path) }
+
+    let(:selected_key_paths) { ["key", "key subkey", "other", "other key"] }
+    let(:key_path) { %i[key subkey] }
+
+    context "when the key_path is selected (symbols)" do
+      let(:key_path) { %i[key subkey] }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the key_path is selected (strings)" do
+      let(:key_path) { %w[key subkey] }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the key_path is not selected" do
+      let(:key_path) { %i[another_key] }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the selected_key_paths are nil" do
+      let(:selected_key_paths) { nil }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the selected_key_paths are empty" do
+      let(:selected_key_paths) { [] }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#filtered_response" do
+    subject(:filtered_response) { instance.filtered_response }
+
+    let(:rect_body) { { key1: { subkey: [{ subsubkey: "value1" }] }, key2: "value2" }.to_json }
+    let(:ecf_body) { { key3: { subkey: "value3" }, key4: "value4" }.to_json }
+    let(:response) { FactoryBot.create(:parity_check_response, rect_body:, ecf_body:) }
+    let(:selected_key_paths) { ["key1", "key1 subkey", "key1 subkey subsubkey", "key4"] }
+
+    it "returns a response with filtered response bodies" do
+      expect(filtered_response.rect_body).to eq(JSON.pretty_generate({ key1: { subkey: [{ subsubkey: "value1" }] } }))
+      expect(filtered_response.ecf_body).to eq(JSON.pretty_generate({ key4: "value4" }))
+    end
+
+    context "when not filterable" do
+      let(:response) { FactoryBot.create(:parity_check_response, ecf_body: "some text", rect_body: "some text") }
+
+      it "does not change the response" do
+        expect { filtered_response }.not_to(change(response, :attributes))
+      end
+    end
+
+    context "when selected_key_paths is nil" do
+      let(:selected_key_paths) { nil }
+
+      it "does not change the response" do
+        expect { filtered_response }.not_to(change(response, :attributes))
+      end
+    end
+  end
+end

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -17,17 +17,6 @@ describe ParityCheck::Response do
   end
 
   describe "before_save" do
-    it "formats bodies as pretty JSON if they are valid JSON" do
-      ecf_body = { ecf_key: "ecf_value" }
-      rect_body = { rect_key: "rect_value" }
-      response = FactoryBot.build(:parity_check_response, ecf_body: ecf_body.to_json, rect_body: rect_body.to_json)
-
-      response.save!
-
-      expect(response.ecf_body).to eq(JSON.pretty_generate(ecf_body))
-      expect(response.rect_body).to eq(JSON.pretty_generate(rect_body))
-    end
-
     it "does not format bodies if they are not valid JSON" do
       response = FactoryBot.build(:parity_check_response, ecf_body: "not json", rect_body: "also not json")
 
@@ -51,7 +40,7 @@ describe ParityCheck::Response do
   end
 
   describe "scopes" do
-    let(:request) { FactoryBot.create(:parity_check_request) }
+    let(:request) { FactoryBot.create(:parity_check_request, :in_progress) }
     let!(:matching_response) { FactoryBot.create(:parity_check_response, :matching, request:) }
     let!(:matching_status_codes_response) { FactoryBot.create(:parity_check_response, :matching, ecf_body: "different", request:) }
     let!(:matching_bodies_response) { FactoryBot.create(:parity_check_response, :matching, ecf_status_code: 404, request:) }
@@ -92,6 +81,20 @@ describe ParityCheck::Response do
 
       it { is_expected.to contain_exactly(matching_response, matching_bodies_response) }
     end
+  end
+
+  describe "#ecf_body=" do
+    let(:ecf_body) { { key: "value" } }
+    let(:response) { FactoryBot.build(:parity_check_response, ecf_body: ecf_body.to_json) }
+
+    it { expect(response.ecf_body).to eq(JSON.pretty_generate(ecf_body)) }
+  end
+
+  describe "#rect_body=" do
+    let(:rect_body) { { key: "value" } }
+    let(:response) { FactoryBot.build(:parity_check_response, rect_body: rect_body.to_json) }
+
+    it { expect(response.rect_body).to eq(JSON.pretty_generate(rect_body)) }
   end
 
   describe "#rect_performance_gain_ratio" do
@@ -241,5 +244,53 @@ describe ParityCheck::Response do
         DIFF
       )
     }
+  end
+
+  describe "#ecf_body_hash" do
+    subject { response.ecf_body_hash }
+
+    let(:response) { FactoryBot.build(:parity_check_response, ecf_body:) }
+
+    context "when the ECF body is valid JSON" do
+      let(:ecf_body) { { key: { "value" => :nested } }.to_json }
+
+      it { is_expected.to eq(key: { value: "nested" }) }
+    end
+
+    context "when the ECF body is not valid JSON" do
+      let(:ecf_body) { "not json" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the ECF body is nil" do
+      let(:ecf_body) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#rect_body_hash" do
+    subject { response.rect_body_hash }
+
+    let(:response) { FactoryBot.build(:parity_check_response, rect_body:) }
+
+    context "when the RECT body is valid JSON" do
+      let(:rect_body) { { key: { "value" => :nested } }.to_json }
+
+      it { is_expected.to eq(key: { value: "nested" }) }
+    end
+
+    context "when the RECT body is not valid JSON" do
+      let(:rect_body) { "not json" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the RECT body is nil" do
+      let(:rect_body) { nil }
+
+      it { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
### Context

When we are reviewing diffs in the parity check responses it would be helpful to be able to add/remove fields from the diff in order to better understand the changes.

### Changes proposed in this pull request

- Pretty format JSON bodies in Response setters

At the moment, we pretty-format the JSON before saving a `Response`. Going forward, we are going to be updating the response bodies as part of the filter, so its better to format them in the setters.

- Add nested JSON bodies to parity check response seeds

This will allow us to check the diff filtering more easily.

- Add ParityCheck::Filter::ResponseBody model

This model will be used in the form to filter a response body diff by the available JSON keys.

It will accept a `response` and `selected_key_paths` submitted from the form (via checkboxes).

It exposes a `filterable_key_hash` which will be used to generate the checkboxes in a tree structure.

It accepts `selected_key_paths` in the format that they will natively be submitted by the browser; for an array set as an `input` value this is a space-separated list, for example the key path `[:key, :nested]` it would submit as `key nested`.

The `filtered_response` method applies the selected filter to the response bodies (excluding fields that are not selected). By default all fields will be treated as selected (if `selected_key_paths` is `nil`).

- Add helper to render checkboxes for a filterable_key_hash

This helper will accept a `filterable_key_hash` from a `ResponseBody` filter and output it as a nested HTML list of checkboxes.

Note the structure of the list nesting is slightly different to what you might expected; the nested `ul` is contained with the parent `li`, so :

```
<ul>
  <li>Parent
    <ul>
      <li>Child</li>
    </ul>
  </li>
<ul>
```

Instead of:

```
<ul>
  <li>Parent</li>
  <li>
    <ul>
      <li>Child</li>
    </ul>
  </li>
</ul>
```

It is like this to make the subsequent styling more straight forward (get show
connections between the keys).

- Add Stimulus controller for response body filtering

When filtering the response body the user will be interacting with checkboxes in a tree structure matching the JSON keys.

If they check a deeply nested checkbox, we want to also check all checkboxes that preceed it in the tree.

If they uncheck a top-level checkbox we want to uncheck all its direct children.

Add `ResponseBodyFilterController` and register it with Stimulus.

Import controllers into `application.js`.

- date parity check response page to support JSON body filtering

We want to be able to include/exclude keys from a JSON response when performing a diff, so we can more easily explore the differences.

Add filter partial that renders a tree structure of checkboxes matching the union of JSON keys from both payloads.

On checking/unchecking a checkbox the diff will refresh and include/omit the appropriate keys.

- Fix parity check endpoints

The indentation was a bit off and some of the URLs that had an `id` in the path didn't contain the method to retrieve the `id` in the `options`.

- Add migration to action cable to fix Redis connection

- Prevent running a parity check if there are no lead providers

This is the current case in the migration environment; to avoid odd runs with no requests we should prevent it.

### Guidance to review

Do we want to test Stimulus controllers directly with jest or just rely on the feature specs?

It would be nice to only show the keys that are different in the filter, but it doesn't look like I can easily extract that information from diffy.

| No filtering | Filtering a range of attributes | Filtering only different attributes |
| -- | -- | -- |
| <img width="1366" alt="Screenshot 2025-07-03 at 08 19 42" src="https://github.com/user-attachments/assets/4f85fa84-b246-4edf-9e5f-f4c44db4e345" /> | <img width="1366" alt="Screenshot 2025-07-03 at 08 19 55" src="https://github.com/user-attachments/assets/707607da-b417-47d9-8b7b-76fdde2b2b61" /> | <img width="1366" alt="Screenshot 2025-07-03 at 08 20 21" src="https://github.com/user-attachments/assets/4982efa5-500e-48e8-a390-a4515958cf26" /> |
