### PR TITLE
Make links to statements more accessible

### DIFF
--- a/app/views/admin/finance/statements/index.html.erb
+++ b/app/views/admin/finance/statements/index.html.erb
@@ -13,7 +13,11 @@
         s.contract_period_year,
         s.month_and_year,
         govuk_tag(**s.status_tag_kwargs),
-        govuk_link_to("View", admin_finance_statement_path(s)),
+        govuk_link_to(
+          "View",
+          admin_finance_statement_path(s),
+          visually_hidden_suffix: "statement for #{s.lead_provider_name} in #{s.month_and_year}"
+        ),
       ] }
     )
   %>

--- a/spec/views/admin/finance/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/index.html.erb_spec.rb
@@ -24,7 +24,11 @@ RSpec.describe 'admin/finance/statements/index.html.erb' do
   it 'has a link to each statement' do
     render(locals:)
 
-    raw_statements.each { |s| expect(rendered).to have_link('View', href: admin_finance_statement_path(s)) }
+    presented_statements = Admin::StatementPresenter.wrap(raw_statements)
+    presented_statements.each do |s|
+      link_text = "View statement for #{s.lead_provider_name} in #{s.month_and_year}"
+      expect(rendered).to have_link(link_text, href: admin_finance_statement_path(s))
+    end
   end
 
   it 'has the right number of rows' do


### PR DESCRIPTION
### Context

#713 

### Changes proposed in this pull request

Before, the links to statements in the admin finance dashboard weren't helpful for users using assistive technologies (i.e they all said "View").

This updates the links to include some visually hidden content that more clearly communicates the intent of each link to these users.

I've followed the approach suggested in #713.

Closes #713.

### Guidance to review

Inspect the links to statements on the admin finance page.

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/a7c97fda-9577-413a-ba12-753152abcbba" />

