### PR TITLE
[1705] Remove `lead_provider_id` from `ECTAtSchoolPeriod` (db change)

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -11,7 +11,6 @@ shared:
     - dqt_id
   :ect_at_school_periods:
     - school_reported_appropriate_body_id
-    - lead_provider_id
     - training_programme
   :induction_extensions:
     - id

--- a/db/migrate/20250714101747_remove_lead_provider_id_from_ect_at_school_periods.rb
+++ b/db/migrate/20250714101747_remove_lead_provider_id_from_ect_at_school_periods.rb
@@ -1,0 +1,5 @@
+class RemoveLeadProviderIdFromECTAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    remove_reference :ect_at_school_periods, :lead_provider, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_08_153449) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_14_101747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -188,10 +188,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_08_153449) do
     t.enum "working_pattern", enum_type: "working_pattern"
     t.citext "email"
     t.bigint "school_reported_appropriate_body_id"
-    t.bigint "lead_provider_id"
     t.enum "training_programme", enum_type: "training_programme"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
-    t.index ["lead_provider_id"], name: "index_ect_at_school_periods_on_lead_provider_id"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
@@ -727,7 +725,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_08_153449) do
   add_foreign_key "active_lead_providers", "lead_providers"
   add_foreign_key "dfe_roles", "users"
   add_foreign_key "ect_at_school_periods", "appropriate_bodies", column: "school_reported_appropriate_body_id"
-  add_foreign_key "ect_at_school_periods", "lead_providers"
   add_foreign_key "ect_at_school_periods", "schools"
   add_foreign_key "ect_at_school_periods", "teachers"
   add_foreign_key "events", "active_lead_providers", on_delete: :nullify


### PR DESCRIPTION
### Context

 Following on from #852, here we make the database changes to drop `lead_provider_id` from `ECTAtSchoolPeriod`.

### Guidance to review

- Check that everything that references the `lead_provider_id` on `ECTAtSchoolPeriod` been removed from the codebase.

- Check that everything still works as it did before.