### PR TITLE
Fix InductionRecordSanitizer to handle multiple blank end dates

### DIFF
--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -16,6 +16,7 @@ class InductionRecordSanitizer
 
   def valid?
     @error = nil
+    sanitize!
     validate!
     true
   rescue InductionRecordError => e
@@ -23,10 +24,13 @@ class InductionRecordSanitizer
     false
   end
 
+  def sanitize!
+    interpolate_blank_end_dates!
+  end
+
   def validate!
     # TODO: add more validation checks here as we discover them
     has_induction_records!
-    fix_multiple_blank_end_dates!
     does_not_have_multiple_active_induction_statuses!
     induction_record_dates_are_sequential!
   end
@@ -69,11 +73,11 @@ private
     raise(NoInductionRecordsError) if induction_records.empty?
   end
 
-  def fix_multiple_blank_end_dates!
+  def interpolate_blank_end_dates!
     return unless induction_records.where(end_date: nil).count > 1
 
-    # Set end_date to the next record's start_date for all but the last record
-    # Fixes only the in-memory records, as we don't want to modify the records in the ECF1 database
+    # Interpolate blank end_dates using the next record's start_date
+    # Works only in-memory to avoid modifying the source ECF1 database
     induction_records.each_cons(2) do |current_record, next_record|
       next if current_record.end_date.present?
 

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -2,6 +2,7 @@ class InductionRecordSanitizer
   include Enumerable
 
   class InductionRecordError < StandardError; end
+  class MultipleBlankEndDateError < InductionRecordError; end
   class MultipleActiveStatesError < InductionRecordError; end
   class StartDateAfterEndDateError < InductionRecordError; end
   class InvalidDateSequenceError < InductionRecordError; end
@@ -31,6 +32,7 @@ class InductionRecordSanitizer
   def validate!
     # TODO: add more validation checks here as we discover them
     has_induction_records!
+    does_not_have_multiple_blank_end_dates!
     does_not_have_multiple_active_induction_statuses!
     induction_record_dates_are_sequential!
   end
@@ -71,6 +73,10 @@ private
 
   def has_induction_records!
     raise(NoInductionRecordsError) if induction_records.empty?
+  end
+
+  def does_not_have_multiple_blank_end_dates!
+    raise(MultipleBlankEndDateError) if induction_records.count { |ir| ir.end_date.nil? } > 1
   end
 
   def interpolate_blank_end_dates!

--- a/app/presenters/migration/migration_failure_presenter.rb
+++ b/app/presenters/migration/migration_failure_presenter.rb
@@ -54,8 +54,6 @@ module Migration
 
     def friendly_error_type(error_class)
       case error_class
-      when "InductionRecordSanitizer::MultipleBlankEndDateError"
-        "More than 1 end date is blank in the Induction records"
       when "InductionRecordSanitizer::MultipleActiveStatesError"
         "More that 1 induction record with an active induction status"
       when "InductionRecordSanitizer::StartDateAfterEndDateError"

--- a/app/presenters/migration/migration_failure_presenter.rb
+++ b/app/presenters/migration/migration_failure_presenter.rb
@@ -54,6 +54,8 @@ module Migration
 
     def friendly_error_type(error_class)
       case error_class
+      when "InductionRecordSanitizer::MultipleBlankEndDateError"
+        "More than 1 end date is blank in the Induction records"
       when "InductionRecordSanitizer::MultipleActiveStatesError"
         "More that 1 induction record with an active induction status"
       when "InductionRecordSanitizer::StartDateAfterEndDateError"

--- a/spec/migration/induction_record_sanitizer_spec.rb
+++ b/spec/migration/induction_record_sanitizer_spec.rb
@@ -3,16 +3,15 @@ RSpec.describe InductionRecordSanitizer do
 
   let(:participant_profile) { FactoryBot.create(:migration_participant_profile, :ect) }
 
-  describe "#validate!" do
+  describe "#sanitize!" do
     context "when there is only one record with blank end_date" do
       before do
         FactoryBot.create(:migration_induction_record, participant_profile:, start_date: Time.zone.parse("2023-01-01 09:00:00"), end_date: nil, induction_status: :active)
+        subject.sanitize!
       end
 
-      it "does not modify the record and validates successfully" do
+      it "does not interpolate when only one record has blank end_date" do
         original_end_date = participant_profile.induction_records.first.end_date
-
-        expect { subject.validate! }.not_to raise_error
         expect(subject.first.end_date).to eq(original_end_date)
       end
     end
@@ -30,18 +29,22 @@ RSpec.describe InductionRecordSanitizer do
         FactoryBot.create(:migration_induction_record, participant_profile:, start_date: Time.zone.parse("2023-09-01 09:00:00"), end_date: nil, induction_status: :active)
       end
 
-      it "automatically fixes multiple blank end dates during validation" do
-        expect { subject.validate! }.not_to raise_error
+      before { subject.sanitize! }
 
+      it "interpolates blank end_dates using next record's start_date" do
         in_memory_induction_records = subject.to_a
 
-        expect(in_memory_induction_records[0].end_date).to eq(first_record.end_date)
         expect(in_memory_induction_records[1].end_date).to eq(third_record.start_date)
         expect(in_memory_induction_records[2].end_date).to be_nil
       end
 
-      it "does not persists fixes to database" do
-        subject.validate!
+      it "leaves existing end_dates unchanged" do
+        in_memory_induction_records = subject.to_a
+
+        expect(in_memory_induction_records[0].end_date).to eq(first_record.end_date)
+      end
+
+      it "does not persist interpolated values to database" do
         expect(second_record.reload.end_date).to be_nil
       end
     end

--- a/spec/migration/induction_record_sanitizer_spec.rb
+++ b/spec/migration/induction_record_sanitizer_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe InductionRecordSanitizer do
+  subject { described_class.new(participant_profile:) }
+
+  let(:participant_profile) { FactoryBot.create(:migration_participant_profile, :ect) }
+
+  describe "#validate!" do
+    context "when there is only one record with blank end_date" do
+      before do
+        FactoryBot.create(:migration_induction_record, participant_profile:, start_date: Time.zone.parse("2023-01-01 09:00:00"), end_date: nil, induction_status: :active)
+      end
+
+      it "does not modify the record and validates successfully" do
+        original_end_date = participant_profile.induction_records.first.end_date
+
+        expect { subject.validate! }.not_to raise_error
+        expect(subject.first.end_date).to eq(original_end_date)
+      end
+    end
+
+    context "when there are multiple records with mixed blank and set end_dates" do
+      let!(:first_record) do
+        FactoryBot.create(:migration_induction_record, participant_profile:, start_date: Time.zone.parse("2023-01-01 09:00:00"), end_date: Time.zone.parse("2023-05-01 09:00:00"), induction_status: :changed)
+      end
+
+      let!(:second_record) do
+        FactoryBot.create(:migration_induction_record, participant_profile:, start_date: Time.zone.parse("2023-05-01 09:00:00"), end_date: nil, induction_status: :changed)
+      end
+
+      let!(:third_record) do
+        FactoryBot.create(:migration_induction_record, participant_profile:, start_date: Time.zone.parse("2023-09-01 09:00:00"), end_date: nil, induction_status: :active)
+      end
+
+      it "automatically fixes multiple blank end dates during validation" do
+        expect { subject.validate! }.not_to raise_error
+
+        in_memory_induction_records = subject.to_a
+
+        expect(in_memory_induction_records[0].end_date).to eq(first_record.end_date)
+        expect(in_memory_induction_records[1].end_date).to eq(third_record.start_date)
+        expect(in_memory_induction_records[2].end_date).to be_nil
+      end
+
+      it "does not persists fixes to database" do
+        subject.validate!
+        expect(second_record.reload.end_date).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1269

The InductionRecordSanitizer is currently throwing MultipleBlankEndDateError when it encounters induction records with multiple blank end_date values. However, we want to keep the records in the database intact and fix them on the fly during migration.


### Changes proposed in this pull request

- Add sanitize method that automatically resolves the blank end dates issue
- Run the validations after sanitizing the records
- Update the multiple blank end dates validation to run on the sanitized records

