### PR TITLE
Attempt to fix bug caused by unaccent config

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,7 +1,7 @@
 def run_commands_in_database(database)
   ActiveRecord::Base.establish_connection(database.to_sym)
   yield
-  ActiveRecord::Base.establish_connection(ENV.fetch('RAILS_ENV', :development).to_sym)
+  ActiveRecord::Base.establish_connection(Rails.env.to_sym)
 end
 
 def create_extension
@@ -47,7 +47,7 @@ namespace :db do
       Rake::Task['db:create'].invoke
     end
 
-    run_commands_in_database(ENV['RAILS_ENV']) do
+    run_commands_in_database(Rails.env) do
       create_extension
       add_configuration
     end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,3 +1,38 @@
+def run_commands_in_database(database)
+  ActiveRecord::Base.establish_connection(database)
+  yield
+  ActiveRecord::Base.establish_connection(ENV['RAILS_ENV'])
+end
+
+def create_extension
+  Rails.logger.info("Adding unaccent extension")
+  command = %(create extension if not exists unaccent;)
+
+  ActiveRecord::Base.connection.execute(command)
+end
+
+def configuration_already_exists?
+  query = %(select cfgname from pg_ts_config where cfgname = 'unaccented';)
+
+  ActiveRecord::Base.connection.execute(query).num_tuples == 1
+end
+
+def add_configuration
+  return if configuration_already_exists?
+
+  Rails.logger.info("Adding full text search configuration")
+
+  command = <<~SQL
+    create text search configuration unaccented ( copy = simple );
+
+    alter text search configuration unaccented
+      alter mapping for hword, hword_part, word
+      with unaccent, simple;
+  SQL
+
+  ActiveRecord::Base.connection.execute(command)
+end
+
 namespace :db do
   desc 'Add search config'
   task setup_search_configuration: :environment do
@@ -12,40 +47,28 @@ namespace :db do
       Rake::Task['db:create'].invoke
     end
 
-    Rails.logger.info("Checking if full text search unaccented configuration exists")
-    result = ActiveRecord::Base.connection.execute("select count(*) FROM pg_ts_config where cfgname = 'unaccented';")
-
-    if result[0]["count"] == 1
-      Rails.logger.info("Full text search unaccented configuration exists, skipping...")
-
-      next
+    run_commands_in_database(:development) do
+      create_extension
+      add_configuration
     end
-
-    Rails.logger.info("Setting up full text search unaccented configuration")
-    command = <<~SQL
-      create extension if not exists unaccent;
-
-      create text search configuration unaccented ( copy = simple );
-
-      alter text search configuration unaccented
-        alter mapping for hword, hword_part, word
-        with unaccent, simple;
-    SQL
-
-    Rails.logger.info("Adding full text search unaccented config to current env")
-    ActiveRecord::Base.connection.execute(command)
 
     # NOTE: when we run this in the development env Rails automatically
     #       creates the test database too, but not via `db:create` so
     #       we need to ensure the text search config is applied there too
     if Rails.env.development?
       Rails.logger.info("Adding full text search unaccented config to test env")
-      ActiveRecord::Base.establish_connection(:test)
-      ActiveRecord::Base.connection.execute(command)
-      ActiveRecord::Base.establish_connection(:development)
+
+      run_commands_in_database(:test) do
+        create_extension
+        add_configuration
+      end
     end
   end
 end
 
+# enhance before running the task
 Rake::Task['db:schema:load'].enhance(['db:setup_search_configuration'])
 Rake::Task['db:prepare'].enhance(['db:setup_search_configuration'])
+Rake::Task['db:test:prepare'].enhance(['db:setup_search_configuration'])
+# enhance after running the task
+Rake::Task['db:create'].enhance { Rake::Task['db:setup_search_configuration'].execute }

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,7 +1,7 @@
 def run_commands_in_database(database)
-  ActiveRecord::Base.establish_connection(database)
+  ActiveRecord::Base.establish_connection(database.to_sym)
   yield
-  ActiveRecord::Base.establish_connection(ENV['RAILS_ENV'])
+  ActiveRecord::Base.establish_connection(ENV.fetch('RAILS_ENV', :development).to_sym)
 end
 
 def create_extension
@@ -47,7 +47,7 @@ namespace :db do
       Rake::Task['db:create'].invoke
     end
 
-    run_commands_in_database(:development) do
+    run_commands_in_database(ENV['RAILS_ENV']) do
       create_extension
       add_configuration
     end


### PR DESCRIPTION
This hopefully fixes the bug we've all encountered where attempting to run the specs after doing a `rails db:migrate` or `rails db:rollback` caused errors.

The key line that makes the difference is:

```ruby
Rake::Task['db:test:prepare'].enhance(['db:setup_search_configuration'])
```

The rest of the PR makes the rake task easier to follow by separating the steps into methods.

The `add_configuration` can now be run repeatedly as it will return early if the `configuration_already_exists?`