### PR TITLE
Introduce Mission Control

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,12 @@ gem "mail-notify"
 
 gem "sentry-rails"
 gem "sentry-ruby"
-gem "solid_queue"
 gem "stackprof"
 gem "state_machines-activerecord"
+
+# Background jobs
+gem "mission_control-jobs"
+gem "solid_queue"
 
 # DfE Sign-In
 gem "omniauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,10 @@ GEM
     immutable-ruby (0.2.0)
       concurrent-ruby (~> 1.1)
       sorted_set (~> 1.0)
+    importmap-rails (2.1.0)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.8.0)
     io-endpoint (0.15.2)
     io-event (1.11.0)
@@ -383,6 +387,16 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
+    mission_control-jobs (1.0.2)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.8.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -832,6 +846,7 @@ DEPENDENCIES
   hotwire-rails
   jsbundling-rails
   mail-notify
+  mission_control-jobs
   nanoc
   nanoc-live
   oj

--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  MissionControl::Jobs.base_controller_class = "AdminController"
+  MissionControl::Jobs.http_basic_auth_enabled = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,9 @@ Rails.application.routes.draw do
       mount Blazer::Engine, at: "blazer"
     end
 
+    # Background jobs dashboard
+    mount MissionControl::Jobs::Engine, at: "jobs"
+
     resources :users, only: %i[index]
 
     resources :organisations, only: %i[index] do


### PR DESCRIPTION
### Context

We want to know more about our background jobs easily. When someone asked "what's happening with OTP", my instinct was to reach for Sidekiq UI (or similar), but we didn't have anything setup.

Mission Control looks to be Rails' take on a basic jobs dashboard, and it supports Solid Queue.

### Changes proposed in this pull request

This introduces the [mission control] gem from Rails so that we can use the lightweight dashboard to see more about the status of our background jobs.

I tried to keep the setup straight-forward, so the dashboard is enabled in all environments.

Admins are the only users who can access the dashboard, and they should authenticate in the usual way. This adds some complexity (the default is HTTP basic auth), but I think it's worthwhile in the interests of security.

Closes #1929.

[mission control]: https://github.com/rails/mission_control-jobs

### Guidance to review

- Get the dashboard running locally, play around with it etc
- Use the dashboard in a review app

<img width="1701" alt="image" src="https://github.com/user-attachments/assets/49a769f1-027b-4f3a-9ecf-f25d35671713" />
