### PR TITLE
Introduce `Statements::Period` class

### DIFF
--- a/app/components/admin/statements/filter_component.rb
+++ b/app/components/admin/statements/filter_component.rb
@@ -29,7 +29,7 @@ module Admin
 
         dates.map do |date|
           statement_date.new(
-            name: "#{month_name(date[1])} #{date[0]}", # January 2025
+            name: ::Statements::Period.from_year_and_month(date.first, date.second), # January 2025
             id: date.join("-") # 2025-01
           )
         end
@@ -50,12 +50,6 @@ module Admin
 
       def statement_type
         params[:statement_type].presence || "output_fee"
-      end
-
-    private
-
-      def month_name(month)
-        Date::MONTHNAMES.fetch(month)
       end
     end
   end

--- a/app/components/admin/statements/selector_component.rb
+++ b/app/components/admin/statements/selector_component.rb
@@ -27,7 +27,7 @@ module Admin
 
         dates.map do |date|
           statement_date.new(
-            name: "#{month_name(date[1])} #{date[0]}", # January 2025
+            name: ::Statements::Period.from_year_and_month(date.first, date.second), # January 2025
             id: date.join("-") # 2025-01
           )
         end
@@ -35,12 +35,6 @@ module Admin
 
       def statement_date
         [@statement.year, @statement.month].join("-")
-      end
-
-    private
-
-      def month_name(month)
-        Date::MONTHNAMES.fetch(month)
       end
     end
   end

--- a/app/presenters/admin/statement_presenter.rb
+++ b/app/presenters/admin/statement_presenter.rb
@@ -4,10 +4,8 @@ module Admin
       collection.map { |statement| new(statement) }
     end
 
-    def month_and_year
-      month_name = Date::MONTHNAMES.fetch(statement.month)
-
-      "#{month_name} #{statement.year}"
+    def period
+      ::Statements::Period.for(statement)
     end
 
     def status_tag_kwargs
@@ -25,7 +23,7 @@ module Admin
     def page_title
       lead_provider_name = statement.active_lead_provider.lead_provider.name
 
-      "#{lead_provider_name} - #{month_and_year}"
+      "#{lead_provider_name} - #{period}"
     end
 
     def contract_period_year

--- a/app/services/statements/period.rb
+++ b/app/services/statements/period.rb
@@ -1,0 +1,19 @@
+class Statements::Period
+  def self.for(statement)
+    new(statement.year, statement.month).to_s
+  end
+
+  def self.from_year_and_month(year, month)
+    new(year, month).to_s
+  end
+
+  def initialize(year, month)
+    @year = year
+    @month = month
+  end
+
+  def to_s
+    month_name = Date::MONTHNAMES.fetch(@month)
+    "#{month_name} #{@year}"
+  end
+end

--- a/app/views/admin/finance/statements/index.html.erb
+++ b/app/views/admin/finance/statements/index.html.erb
@@ -11,12 +11,12 @@
       rows: @statements.map { |s| [
         s.lead_provider_name,
         s.contract_period_year,
-        s.month_and_year,
+        s.period,
         govuk_tag(**s.status_tag_kwargs),
         govuk_link_to(
           "View",
           admin_finance_statement_path(s),
-          visually_hidden_suffix: "statement for #{s.lead_provider_name} in #{s.month_and_year}"
+          visually_hidden_suffix: "statement for #{s.lead_provider_name} in #{s.period}"
         ),
       ] }
     )

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -21,7 +21,7 @@
 
     sl.with_row do |row|
       row.with_key(text: "Month")
-      row.with_value(text: @statement.month_and_year)
+      row.with_value(text: @statement.period)
     end
 
     sl.with_row do |row|

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -5,14 +5,14 @@ describe Admin::StatementPresenter do
     let(:statement) { FactoryBot.build(:statement, month: 6, year: 2023) }
 
     it 'returns the month name and year in a string' do
-      expect(subject.month_and_year).to eql('June 2023')
+      expect(subject.period).to eql('June 2023')
     end
 
     context 'when the month is invalid' do
       let(:statement) { FactoryBot.build(:statement, month: 13, year: 2023) }
 
       it 'raises an IndexError' do
-        expect { subject.month_and_year }.to raise_error(IndexError)
+        expect { subject.period }.to raise_error(IndexError)
       end
     end
   end

--- a/spec/views/admin/finance/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/index.html.erb_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe 'admin/finance/statements/index.html.erb' do
   it 'has a link to each statement' do
     render(locals:)
 
-    presented_statements = Admin::StatementPresenter.wrap(raw_statements)
-    presented_statements.each do |s|
-      link_text = "View statement for #{s.lead_provider_name} in #{s.month_and_year}"
-      expect(rendered).to have_link(link_text, href: admin_finance_statement_path(s))
+    raw_statements.each do |statement|
+      period = Statements::Period.for(statement)
+      link_text = "View statement for #{statement.lead_provider.name} in #{period}"
+      expect(rendered).to have_link(link_text, href: admin_finance_statement_path(statement))
     end
   end
 


### PR DESCRIPTION
### Context

Following on from #864 and based on this [discussion]

### Changes proposed in this pull request

This introduces a small `Statements::Period` class that returns a statement period.

I'm not completely convinced this is the best approach, so keen to hear people's thoughts.

Some decisions worth discussing:

- `Statements::Period` as a name: "Period" makes sense to me, but maybe the verbosity of "YearMonth" is more explicit and clearer
- The API: `.for(statement)` feels ergonomic to me, but perhaps we'd prefer to initialise the object and call `to_s` explicitly
- `.to_s`: I feel like this captures the intention, but maybe it's confusing. I also *vaguely* remember this being bad practice, but I can't remember *why*

Also, are there any other places this might be useful?

[discussion]: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/864#discussion_r2182402696

### Guidance to review

- [ ] Take a look at the statement filter
- [ ] Take a look at the statement selector
- [ ] Take a look at the statements page
