### PR TITLE
Make db test prepare work properly

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -36,21 +36,8 @@ end
 namespace :db do
   desc 'Add search config'
   task setup_search_configuration: :environment do
-    database_exists = ::ActiveRecord::Base.connection_pool.with_connection do |connection|
-      connection.active?
-    rescue ActiveRecord::ConnectionNotEstablished
-      false
-    end
-
-    unless database_exists
-      Rails.logger.info("Database does not exist, creating it...")
-      Rake::Task['db:create'].invoke
-    end
-
-    run_commands_in_database(Rails.env) do
-      create_extension
-      add_configuration
-    end
+    create_extension
+    add_configuration
 
     # NOTE: when we run this in the development env Rails automatically
     #       creates the test database too, but not via `db:create` so

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -56,6 +56,6 @@ end
 # enhance before running the task
 Rake::Task['db:schema:load'].enhance(['db:setup_search_configuration'])
 Rake::Task['db:prepare'].enhance(['db:setup_search_configuration'])
-Rake::Task['db:test:prepare'].enhance(['db:setup_search_configuration'])
 # enhance after running the task
 Rake::Task['db:create'].enhance { Rake::Task['db:setup_search_configuration'].execute }
+Rake::Task['db:test:purge'].enhance { Rake::Task['db:setup_search_configuration'].execute }


### PR DESCRIPTION
The changes in #871 made things better but not perfect.

This change does the following:

* switch enhancing from `db:test:prepare` to `db:test:purge` - `db:test:prepare` always throws the database away and recreates it, so if the enhancement happens before it's disregarded. `db:test:purge` happens within `db:test:prepare`, before the schema is loaded or migrations run
* simplifies the job by removing the checks for database presence, we're hooking on to events that happen when the database exists so it's unnecessary
