### PR TITLE
Include `FactoryBot::Syntax::Methods`

### DIFF
--- a/spec/components/admin/statements/adjustments_component_spec.rb
+++ b/spec/components/admin/statements/adjustments_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
   subject { render_inline(component) }
 
-  let(:statement) { FactoryBot.create(:statement) }
+  let(:statement) { create(:statement) }
   let(:component) { described_class.new statement: }
 
   let(:summary_list_values) do
@@ -22,7 +22,7 @@ RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
   end
 
   context "one adjustment" do
-    let!(:adjustment) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
+    let!(:adjustment) { create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
 
     it "renders correctly" do
       expect(statement.adjustments.count).to eq(1)
@@ -42,9 +42,9 @@ RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
   end
 
   context "multiple adjustments" do
-    let!(:adjustment1) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
-    let!(:adjustment2) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Negative amount", amount: -500.0 }
-    let!(:adjustment3) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Another amount", amount: 300.0 }
+    let!(:adjustment1) { create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
+    let!(:adjustment2) { create :statement_adjustment, statement:, payment_type: "Negative amount", amount: -500.0 }
+    let!(:adjustment3) { create :statement_adjustment, statement:, payment_type: "Another amount", amount: 300.0 }
 
     it "renders correctly" do
       expect(statement.adjustments.count).to eq(3)
@@ -70,7 +70,7 @@ RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
   end
 
   context ".adjustment_editable?" do
-    let!(:adjustment1) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
+    let!(:adjustment1) { create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
 
     context "non-paid statement" do
       it "renders links" do
@@ -79,7 +79,7 @@ RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
     end
 
     context "paid statement" do
-      let(:statement) { FactoryBot.create :statement, :paid }
+      let(:statement) { create :statement, :paid }
 
       it "does not render links" do
         expect(subject).not_to have_link("Add adjustment")
@@ -87,7 +87,7 @@ RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
     end
 
     context "service fee statement" do
-      let(:statement) { FactoryBot.create :statement, :service_fee }
+      let(:statement) { create :statement, :service_fee }
 
       it "does not render links" do
         expect(subject).not_to have_link("Add adjustment")

--- a/spec/components/admin/statements/filter_component_spec.rb
+++ b/spec/components/admin/statements/filter_component_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
   let(:component) { described_class.new filter_params: }
 
   context ".lead_providers" do
-    let!(:lead_provider1) { FactoryBot.create(:lead_provider, name: "C") }
-    let!(:lead_provider2) { FactoryBot.create(:lead_provider, name: "A") }
-    let!(:lead_provider3) { FactoryBot.create(:lead_provider, name: "B") }
+    let!(:lead_provider1) { create(:lead_provider, name: "C") }
+    let!(:lead_provider2) { create(:lead_provider, name: "A") }
+    let!(:lead_provider3) { create(:lead_provider, name: "B") }
 
     it "returns lead providers in alphabetical order" do
       expect(component.lead_providers).to contain_exactly(lead_provider2, lead_provider3, lead_provider1)
@@ -21,9 +21,9 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
   end
 
   context ".contract_periods" do
-    let!(:contract_period1) { FactoryBot.create(:contract_period, year: 2025) }
-    let!(:contract_period2) { FactoryBot.create(:contract_period, year: 2021) }
-    let!(:contract_period3) { FactoryBot.create(:contract_period, year: 2022) }
+    let!(:contract_period1) { create(:contract_period, year: 2025) }
+    let!(:contract_period2) { create(:contract_period, year: 2021) }
+    let!(:contract_period3) { create(:contract_period, year: 2022) }
 
     it "returns contract_period in year order" do
       expect(component.contract_periods).to contain_exactly(contract_period2, contract_period3, contract_period1)
@@ -39,9 +39,9 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
   end
 
   context ".statement_dates" do
-    let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 5) }
-    let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 5) }
-    let!(:statement3) { FactoryBot.create(:statement, year: 2023, month: 5) }
+    let!(:statement1) { create(:statement, year: 2025, month: 5) }
+    let!(:statement2) { create(:statement, year: 2024, month: 5) }
+    let!(:statement3) { create(:statement, year: 2023, month: 5) }
 
     it "returns statement dates in ascending order" do
       dates = component.statement_dates

--- a/spec/components/admin/statements/payment_authorisation_component_spec.rb
+++ b/spec/components/admin/statements/payment_authorisation_component_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Admin::Statements::PaymentAuthorisationComponent, type: :component do
   subject { render_inline(component) }
 
-  let(:statement) { FactoryBot.create(:statement, :payable, :output_fee, marked_as_paid_at:) }
+  let(:statement) { create(:statement, :payable, :output_fee, marked_as_paid_at:) }
   let(:marked_as_paid_at) { nil }
   let(:component) { described_class.new statement: }
 
   context "service_fee statement" do
-    let(:statement) { FactoryBot.create(:statement, :payable, :service_fee) }
+    let(:statement) { create(:statement, :payable, :service_fee) }
 
     it "does not render" do
       expect(subject.text).to be_blank

--- a/spec/components/admin/statements/selector_component_spec.rb
+++ b/spec/components/admin/statements/selector_component_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Admin::Statements::SelectorComponent, type: :component do
-  let(:statement) { FactoryBot.create(:statement) }
+  let(:statement) { create(:statement) }
   let(:component) { described_class.new statement: }
   let(:statement_lead_provider) { statement.active_lead_provider.lead_provider }
   let(:statement_year) { statement.active_lead_provider.contract_period.year }
 
   context ".lead_providers" do
-    let!(:lead_provider1) { FactoryBot.create(:lead_provider, name: "AAAC") }
-    let!(:lead_provider2) { FactoryBot.create(:lead_provider, name: "AAAA") }
-    let!(:lead_provider3) { FactoryBot.create(:lead_provider, name: "AAAB") }
+    let!(:lead_provider1) { create(:lead_provider, name: "AAAC") }
+    let!(:lead_provider2) { create(:lead_provider, name: "AAAA") }
+    let!(:lead_provider3) { create(:lead_provider, name: "AAAB") }
 
     it "returns lead providers in alphabetical order" do
       expect(component.lead_providers).to contain_exactly(lead_provider2, lead_provider3, lead_provider1, statement_lead_provider)
@@ -21,9 +21,9 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
   end
 
   context ".contract_periods" do
-    let!(:contract_period1) { FactoryBot.create(:contract_period, year: 2035) }
-    let!(:contract_period2) { FactoryBot.create(:contract_period, year: 2031) }
-    let!(:contract_period3) { FactoryBot.create(:contract_period, year: 2032) }
+    let!(:contract_period1) { create(:contract_period, year: 2035) }
+    let!(:contract_period2) { create(:contract_period, year: 2031) }
+    let!(:contract_period3) { create(:contract_period, year: 2032) }
 
     it "returns contract_period in year order" do
       expect(component.contract_periods.map(&:year)).to contain_exactly(
@@ -42,9 +42,9 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
   end
 
   context ".statement_dates" do
-    let!(:statement1) { FactoryBot.create(:statement, year: 2021, month: 3) }
-    let!(:statement2) { FactoryBot.create(:statement, year: 2021, month: 2) }
-    let!(:statement3) { FactoryBot.create(:statement, year: 2021, month: 1) }
+    let!(:statement1) { create(:statement, year: 2021, month: 3) }
+    let!(:statement2) { create(:statement, year: 2021, month: 2) }
+    let!(:statement3) { create(:statement, year: 2021, month: 1) }
 
     it "returns statement dates in ascending order" do
       dates = component.statement_dates

--- a/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
   end
 
   let(:teacher) { nil }
-  let(:current_appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:current_appropriate_body) { create(:appropriate_body) }
   let(:pending_induction_submission) do
-    FactoryBot.create(
+    create(
       :pending_induction_submission,
       trs_first_name: "John",
       trs_last_name: "Doe"
@@ -20,12 +20,12 @@ RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
   end
 
   context "with teacher" do
-    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:teacher) { create(:teacher) }
 
     context "when teacher is registered with another appropriate body" do
-      let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:other_appropriate_body) { create(:appropriate_body) }
       let!(:induction_period) do
-        FactoryBot.create(
+        create(
           :induction_period,
           :active,
           teacher:,
@@ -44,7 +44,7 @@ RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
 
     context "when teacher is exempt" do
       let(:pending_induction_submission) do
-        FactoryBot.create(
+        create(
           :pending_induction_submission,
           trs_first_name: "John",
           trs_last_name: "Doe",

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
   let(:started_on) { Date.new(2023, 9, 1) }
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: nil) }
+  let(:teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:ect) { create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil) }
+  let(:mentor) { create(:mentor_at_school_period, school:, started_on:, finished_on: nil) }
 
   context 'when the ECT has a mentor assigned' do
     before do
-      FactoryBot.create(:mentorship_period, :active, started_on: ect.started_on, mentee: ect, mentor:)
+      create(:mentorship_period, :active, started_on: ect.started_on, mentee: ect, mentor:)
       render_inline(described_class.new(ect:))
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when provider led chosen' do
-    let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: ect, started_on:) }
+    let!(:training_period) { create(:training_period, ect_at_school_period: ect, started_on:) }
 
     it "renders their latest providers" do
       render_inline(described_class.new(ect:))
@@ -62,7 +62,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when school led chosen' do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :school_led, teacher:, school:, started_on:, finished_on: nil) }
+    let(:ect) { create(:ect_at_school_period, :school_led, teacher:, school:, started_on:, finished_on: nil) }
 
     it "don't render providers" do
       render_inline(described_class.new(ect:))

--- a/spec/components/schools/mentors/details_component_spec.rb
+++ b/spec/components/schools/mentors/details_component_spec.rb
@@ -1,41 +1,41 @@
 RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  let(:school) { FactoryBot.create(:school) }
-  let(:mentor_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:school) { create(:school) }
+  let(:mentor_teacher) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
   let(:started_on) { Date.new(2023, 9, 1) }
 
   let(:mentor) do
-    FactoryBot.create(:mentor_at_school_period,
-                      teacher: mentor_teacher,
-                      school:,
-                      started_on:,
-                      finished_on: nil)
+    create(:mentor_at_school_period,
+           teacher: mentor_teacher,
+           school:,
+           started_on:,
+           finished_on: nil)
   end
 
-  let(:ect_teacher_1) { FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
-  let(:ect_teacher_2) { FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
+  let(:ect_teacher_1) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+  let(:ect_teacher_2) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
 
   let(:ect_period_1) do
-    FactoryBot.create(:ect_at_school_period,
-                      teacher: ect_teacher_1,
-                      school:,
-                      started_on:,
-                      finished_on: nil)
+    create(:ect_at_school_period,
+           teacher: ect_teacher_1,
+           school:,
+           started_on:,
+           finished_on: nil)
   end
 
   let(:ect_period_2) do
-    FactoryBot.create(:ect_at_school_period,
-                      teacher: ect_teacher_2,
-                      school:,
-                      started_on:,
-                      finished_on: nil)
+    create(:ect_at_school_period,
+           teacher: ect_teacher_2,
+           school:,
+           started_on:,
+           finished_on: nil)
   end
 
   context 'when there are ECTs assigned to the mentor' do
     before do
-      FactoryBot.create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
-      FactoryBot.create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor:, mentee: ect_period_1, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor:, mentee: ect_period_2, started_on:, finished_on: nil)
 
       render_inline(described_class.new(teacher: mentor_teacher, mentor:))
     end
@@ -68,17 +68,17 @@ RSpec.describe Schools::Mentors::DetailsComponent, type: :component do
   end
 
   context 'when there are ECTs not assigned to this mentor' do
-    let(:other_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Kakashi', trs_last_name: 'Hatake') }
+    let(:other_teacher) { create(:teacher, trs_first_name: 'Kakashi', trs_last_name: 'Hatake') }
     let(:other_mentor) do
-      FactoryBot.create(:mentor_at_school_period, teacher: other_teacher, school:, started_on:, finished_on: nil)
+      create(:mentor_at_school_period, teacher: other_teacher, school:, started_on:, finished_on: nil)
     end
-    let(:unrelated_ect_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Sauske', trs_last_name: 'Uchiha') }
+    let(:unrelated_ect_teacher) { create(:teacher, trs_first_name: 'Sauske', trs_last_name: 'Uchiha') }
     let(:unrelated_ect) do
-      FactoryBot.create(:ect_at_school_period, teacher: unrelated_ect_teacher, school:, started_on:, finished_on: nil)
+      create(:ect_at_school_period, teacher: unrelated_ect_teacher, school:, started_on:, finished_on: nil)
     end
 
     before do
-      FactoryBot.create(:mentorship_period, mentor: other_mentor, mentee: unrelated_ect, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor: other_mentor, mentee: unrelated_ect, started_on:, finished_on: nil)
       render_inline(described_class.new(teacher: mentor_teacher, mentor:))
     end
 

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -1,25 +1,25 @@
 RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :component do
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
   let(:mentor_start_date) { Date.new(2023, 1, 1) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date, finished_on: nil) }
-  let(:teacher) { FactoryBot.create(:teacher, mentor_became_ineligible_for_funding_on: nil) }
+  let(:mentor) { create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date, finished_on: nil) }
+  let(:teacher) { create(:teacher, mentor_became_ineligible_for_funding_on: nil) }
 
   context 'when teacher is eligible and there is a provider-led ECT with a lead provider' do
-    let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Hidden leaf village') }
-    let(:ect_teacher) { FactoryBot.create(:teacher) }
+    let(:lead_provider) { create(:lead_provider, name: 'Hidden leaf village') }
+    let(:ect_teacher) { create(:teacher) }
     let(:ect_start_date) { mentor_start_date + 1.month }
     let(:ect) do
-      FactoryBot.create(:ect_at_school_period,
-                        teacher: ect_teacher,
-                        school:,
-                        training_programme: 'provider_led',
-                        lead_provider:,
-                        started_on: ect_start_date,
-                        finished_on: nil)
+      create(:ect_at_school_period,
+             teacher: ect_teacher,
+             school:,
+             training_programme: 'provider_led',
+             lead_provider:,
+             started_on: ect_start_date,
+             finished_on: nil)
     end
 
     before do
-      FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+      create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
     end
 
     it 'renders the summary cards' do
@@ -36,20 +36,20 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
   end
 
   context 'when teacher is not eligible' do
-    let(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
-    let(:ect_teacher) { FactoryBot.create(:teacher) }
+    let(:teacher) { create(:teacher, :ineligible_for_mentor_funding) }
+    let(:ect_teacher) { create(:teacher) }
     let(:ect_start_date) { mentor_start_date + 1.month }
     let(:ect) do
-      FactoryBot.create(:ect_at_school_period,
-                        teacher: ect_teacher,
-                        school:,
-                        training_programme: 'provider_led',
-                        started_on: ect_start_date,
-                        finished_on: nil)
+      create(:ect_at_school_period,
+             teacher: ect_teacher,
+             school:,
+             training_programme: 'provider_led',
+             started_on: ect_start_date,
+             finished_on: nil)
     end
 
     before do
-      FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+      create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
     end
 
     it 'renders the ineligible message' do
@@ -59,19 +59,19 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
   end
 
   context 'when all ECTs are school-led' do
-    let(:ect_teacher) { FactoryBot.create(:teacher) }
+    let(:ect_teacher) { create(:teacher) }
     let(:school_led_ect) do
-      FactoryBot.create(:ect_at_school_period,
-                        teacher: ect_teacher,
-                        school:,
-                        training_programme: 'school_led',
-                        lead_provider: nil,
-                        started_on: mentor_start_date + 1.month,
-                        finished_on: nil)
+      create(:ect_at_school_period,
+             teacher: ect_teacher,
+             school:,
+             training_programme: 'school_led',
+             lead_provider: nil,
+             started_on: mentor_start_date + 1.month,
+             finished_on: nil)
     end
 
     before do
-      FactoryBot.create(:mentorship_period, mentor:, mentee: school_led_ect, started_on: school_led_ect.started_on, finished_on: nil)
+      create(:mentorship_period, mentor:, mentee: school_led_ect, started_on: school_led_ect.started_on, finished_on: nil)
     end
 
     it 'does not render' do

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
-  let(:school) { FactoryBot.create(:school) }
-  let(:mentor) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
+  let(:school) { create(:school) }
+  let(:mentor) { create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
   let(:started_on) { Date.new(2023, 9, 1) }
   let!(:mentor_at_school_period) do
-    FactoryBot.create(:mentor_at_school_period, teacher: mentor, school:, started_on:, finished_on: nil)
+    create(:mentor_at_school_period, teacher: mentor, school:, started_on:, finished_on: nil)
   end
 
   context 'with no ECTs' do
@@ -16,9 +16,9 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'with less than or equal to 5 ECTs' do
     let!(:ects) do
-      FactoryBot.create_list(:teacher, 5).map do |ect_teacher|
-        ect = FactoryBot.create(:ect_at_school_period, teacher: ect_teacher, school:, started_on:, finished_on: nil)
-        FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: ect, started_on:, finished_on: nil)
+      create_list(:teacher, 5).map do |ect_teacher|
+        ect = create(:ect_at_school_period, teacher: ect_teacher, school:, started_on:, finished_on: nil)
+        create(:mentorship_period, mentor: mentor_at_school_period, mentee: ect, started_on:, finished_on: nil)
         ect_teacher
       end
     end
@@ -34,9 +34,9 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
 
   context 'with more than 5 ECTs' do
     before do
-      FactoryBot.create_list(:teacher, 6).each do |ect_teacher|
-        ect = FactoryBot.create(:ect_at_school_period, teacher: ect_teacher, school:, started_on:, finished_on: nil)
-        FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: ect, started_on:, finished_on: nil)
+      create_list(:teacher, 6).each do |ect_teacher|
+        ect = create(:ect_at_school_period, teacher: ect_teacher, school:, started_on:, finished_on: nil)
+        create(:mentorship_period, mentor: mentor_at_school_period, mentee: ect, started_on:, finished_on: nil)
       end
     end
 
@@ -47,20 +47,20 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
   end
 
   context 'when there are multiple mentors' do
-    let(:second_mentor) { FactoryBot.create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
+    let(:second_mentor) { create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
     let!(:second_mentor_at_school_period) do
-      FactoryBot.create(:mentor_at_school_period, :active, teacher: second_mentor, school:, started_on:)
+      create(:mentor_at_school_period, :active, teacher: second_mentor, school:, started_on:)
     end
 
-    let(:ect1_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
-    let(:ect2_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
+    let(:ect1_teacher) { create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }
+    let(:ect2_teacher) { create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki') }
 
-    let(:ect1) { FactoryBot.create(:ect_at_school_period, teacher: ect1_teacher, school:, started_on:, finished_on: nil) }
-    let(:ect2) { FactoryBot.create(:ect_at_school_period, teacher: ect2_teacher, school:, started_on:, finished_on: nil) }
+    let(:ect1) { create(:ect_at_school_period, teacher: ect1_teacher, school:, started_on:, finished_on: nil) }
+    let(:ect2) { create(:ect_at_school_period, teacher: ect2_teacher, school:, started_on:, finished_on: nil) }
 
     before do
-      FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: ect1, started_on:, finished_on: nil)
-      FactoryBot.create(:mentorship_period, mentor: second_mentor_at_school_period, mentee: ect2, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor: mentor_at_school_period, mentee: ect1, started_on:, finished_on: nil)
+      create(:mentorship_period, mentor: second_mentor_at_school_period, mentee: ect2, started_on:, finished_on: nil)
     end
 
     it 'only shows ECTs assigned to the specific mentor' do

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -1,25 +1,25 @@
 RSpec.describe Schools::SummaryCardComponent, type: :component do
-  let(:school_reported_appropriate_body) { FactoryBot.create(:appropriate_body, name: 'an org that assures the quality of statutory teacher induction') }
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'An org that designs the training') }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-  let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'An org that delivers the training') }
-  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+  let(:school_reported_appropriate_body) { create(:appropriate_body, name: 'an org that assures the quality of statutory teacher induction') }
+  let(:lead_provider) { create(:lead_provider, name: 'An org that designs the training') }
+  let(:active_lead_provider) { create(:active_lead_provider, lead_provider:) }
+  let(:delivery_partner) { create(:delivery_partner, name: 'An org that delivers the training') }
+  let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+  let(:school_partnership) { create(:school_partnership, lead_provider_delivery_partnership:) }
 
   let(:school_led_ect) do
-    FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:)
+    create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:)
   end
 
   let(:provider_led_ect) do
-    FactoryBot.create(:ect_at_school_period,
-                      :active,
-                      :provider_led,
-                      school_reported_appropriate_body:,
-                      lead_provider:,
-                      started_on: '2021-01-01')
+    create(:ect_at_school_period,
+           :active,
+           :provider_led,
+           school_reported_appropriate_body:,
+           lead_provider:,
+           started_on: '2021-01-01')
   end
 
-  let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: provider_led_ect, school_partnership:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+  let!(:training_period) { create(:training_period, ect_at_school_period: provider_led_ect, school_partnership:, started_on: '2022-01-01', finished_on: '2022-06-01') }
 
   context 'when data is reported by the school' do
     before { render_inline(described_class.new(title: 'Reported to us by your school', ect: school_led_ect, data_source: :school)) }
@@ -86,10 +86,10 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   end
 
   context 'when data is reported by the appropriate body' do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:) }
+    let(:ect) { create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:) }
 
     before do
-      FactoryBot.create(:induction_period, teacher: ect.teacher, started_on: '2023-01-01')
+      create(:induction_period, teacher: ect.teacher, started_on: '2023-01-01')
       render_inline(described_class.new(title: 'Reported to us by your appropriate body',
                                         ect:,
                                         data_source: :appropriate_body))
@@ -140,7 +140,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
 
   context 'when no training periods exist for a provider-led ECT' do
     let(:provider_led_ect_without_training_periods) do
-      FactoryBot.create(:ect_at_school_period, :active, :provider_led, school_reported_appropriate_body:, lead_provider:)
+      create(:ect_at_school_period, :active, :provider_led, school_reported_appropriate_body:, lead_provider:)
     end
 
     before { render_inline(described_class.new(title: 'Reported to us by your lead provider', ect: provider_led_ect_without_training_periods, data_source: :lead_provider)) }

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,16 +1,16 @@
 RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
-  let(:mentee_teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
-  let(:mentor_teacher) { FactoryBot.create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }
-  let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher, started_on: 3.years.ago) }
+  let(:mentee_teacher) { create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
+  let(:mentor_teacher) { create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }
+  let(:previous_mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+  let(:current_mentor) { create(:mentor_at_school_period, :active, teacher: mentor_teacher, started_on: 3.years.ago) }
   let(:mentee) do
-    FactoryBot.create(:ect_at_school_period, :active, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
-                                                      email: 'foobarect@madeup.com', working_pattern: 'full_time')
+    create(:ect_at_school_period, :active, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
+                                           email: 'foobarect@madeup.com', working_pattern: 'full_time')
   end
 
   before do
-    FactoryBot.create(:mentorship_period, :active, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago)
-    FactoryBot.create(:mentorship_period, :active, mentee:, mentor: current_mentor, started_on: 2.years.ago)
+    create(:mentorship_period, :active, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago)
+    create(:mentorship_period, :active, mentee:, mentor: current_mentor, started_on: 2.years.ago)
     render_inline(described_class.new(mentee))
   end
 

--- a/spec/components/teachers/details/admin_induction_summary_component_spec.rb
+++ b/spec/components/teachers/details/admin_induction_summary_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Teachers::Details::AdminInductionSummaryComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:component) { described_class.new(teacher:) }
 
   context "when teacher has no induction periods" do
@@ -11,7 +11,7 @@ RSpec.describe Teachers::Details::AdminInductionSummaryComponent, type: :compone
   end
 
   context "when teacher has induction periods" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: 1.year.ago) }
+    let!(:induction_period) { create(:induction_period, teacher:, started_on: 1.year.ago) }
 
     it "renders" do
       expect(component.render?).to be true
@@ -29,7 +29,7 @@ RSpec.describe Teachers::Details::AdminInductionSummaryComponent, type: :compone
 
     context "QTS awarded" do
       context "when the teacher has a QTS award date" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
+        let(:teacher) { create(:teacher, trs_qts_awarded_on: 1.year.ago) }
 
         it "renders QTS awarded" do
           render_inline(component)
@@ -48,7 +48,7 @@ RSpec.describe Teachers::Details::AdminInductionSummaryComponent, type: :compone
 
     context "Initial Teacher Training" do
       context "when teacher has ITT provider name" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_initial_teacher_training_provider_name: "Test University") }
+        let(:teacher) { create(:teacher, trs_initial_teacher_training_provider_name: "Test University") }
 
         it "renders ITT section with provider name" do
           render_inline(component)
@@ -58,7 +58,7 @@ RSpec.describe Teachers::Details::AdminInductionSummaryComponent, type: :compone
       end
 
       context "when teacher has no ITT provider name" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_initial_teacher_training_provider_name: nil) }
+        let(:teacher) { create(:teacher, trs_initial_teacher_training_provider_name: nil) }
 
         it "does not render ITT section" do
           render_inline(component)
@@ -68,7 +68,7 @@ RSpec.describe Teachers::Details::AdminInductionSummaryComponent, type: :compone
     end
 
     context "with extensions" do
-      let!(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+      let!(:extension) { create(:induction_extension, teacher:) }
 
       it "displays extension information and link to admin extensions path" do
         render_inline(component)

--- a/spec/components/teachers/details/appropriate_body_induction_summary_component_spec.rb
+++ b/spec/components/teachers/details/appropriate_body_induction_summary_component_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Teachers::Details::AppropriateBodyInductionSummaryComponent, type
   include AppropriateBodyHelper
   include Rails.application.routes.url_helpers
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:component) { described_class.new(teacher:) }
 
   context "when teacher has no induction periods" do
@@ -12,7 +12,7 @@ RSpec.describe Teachers::Details::AppropriateBodyInductionSummaryComponent, type
   end
 
   context "when teacher has induction periods" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: 1.year.ago) }
+    let!(:induction_period) { create(:induction_period, teacher:, started_on: 1.year.ago) }
 
     it "renders" do
       expect(component.render?).to be true
@@ -30,7 +30,7 @@ RSpec.describe Teachers::Details::AppropriateBodyInductionSummaryComponent, type
 
     context "QTS awarded" do
       context "when the teacher has a QTS award date" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
+        let(:teacher) { create(:teacher, trs_qts_awarded_on: 1.year.ago) }
 
         it "renders QTS awarded" do
           render_inline(component)
@@ -49,7 +49,7 @@ RSpec.describe Teachers::Details::AppropriateBodyInductionSummaryComponent, type
 
     context "Initial Teacher Training" do
       context "when teacher has ITT provider name" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_initial_teacher_training_provider_name: "Test University") }
+        let(:teacher) { create(:teacher, trs_initial_teacher_training_provider_name: "Test University") }
 
         it "renders ITT section with provider name" do
           render_inline(component)
@@ -59,7 +59,7 @@ RSpec.describe Teachers::Details::AppropriateBodyInductionSummaryComponent, type
       end
 
       context "when teacher has no ITT provider name" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_initial_teacher_training_provider_name: nil) }
+        let(:teacher) { create(:teacher, trs_initial_teacher_training_provider_name: nil) }
 
         it "does not render ITT section" do
           render_inline(component)
@@ -69,7 +69,7 @@ RSpec.describe Teachers::Details::AppropriateBodyInductionSummaryComponent, type
     end
 
     context "with extensions" do
-      let!(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+      let!(:extension) { create(:induction_extension, teacher:) }
 
       it "displays extension information and link to AB extensions path" do
         render_inline(component)

--- a/spec/components/teachers/details/current_induction_period_component_spec.rb
+++ b/spec/components/teachers/details/current_induction_period_component_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
   include AppropriateBodyHelper
   include Rails.application.routes.url_helpers
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:component) { described_class.new(teacher:) }
 
   context "when teacher has no current induction period" do
@@ -12,13 +12,13 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
   end
 
   context "when teacher has a current induction period" do
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: "Test AB") }
+    let(:appropriate_body) { create(:appropriate_body, name: "Test AB") }
     let!(:current_period) do
-      FactoryBot.create(:induction_period, :active,
-                        teacher:,
-                        appropriate_body:,
-                        started_on: 6.months.ago,
-                        induction_programme: "cip")
+      create(:induction_period, :active,
+             teacher:,
+             appropriate_body:,
+             started_on: 6.months.ago,
+             induction_programme: "cip")
     end
 
     it "renders" do
@@ -73,12 +73,12 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
 
     context "when the induction period has an outcome" do
       let!(:current_period) do
-        FactoryBot.create(:induction_period, :active,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 6.months.ago,
-                          outcome: "pass",
-                          induction_programme: "cip")
+        create(:induction_period, :active,
+               teacher:,
+               appropriate_body:,
+               started_on: 6.months.ago,
+               outcome: "pass",
+               induction_programme: "cip")
       end
 
       it "includes an edit link when enable_edit is true" do

--- a/spec/components/teachers/details/itt_details_component_spec.rb
+++ b/spec/components/teachers/details/itt_details_component_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Teachers::Details::ITTDetailsComponent, type: :component do
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:component) { described_class.new(teacher:) }
 
   context "when teacher has QTS award date and ITT provider" do
     let(:teacher) do
-      FactoryBot.create(
+      create(
         :teacher,
         trs_qts_awarded_on: 1.year.ago,
         trs_initial_teacher_training_provider_name: "Test University"
@@ -24,7 +24,7 @@ RSpec.describe Teachers::Details::ITTDetailsComponent, type: :component do
 
   context "when teacher has no QTS award date" do
     let(:teacher) do
-      FactoryBot.create(
+      create(
         :teacher,
         trs_qts_awarded_on: nil,
         trs_initial_teacher_training_provider_name: "Test University"
@@ -43,7 +43,7 @@ RSpec.describe Teachers::Details::ITTDetailsComponent, type: :component do
 
   context "when teacher has no ITT provider" do
     let(:teacher) do
-      FactoryBot.create(
+      create(
         :teacher,
         trs_qts_awarded_on: 1.year.ago,
         trs_initial_teacher_training_provider_name: nil
@@ -62,7 +62,7 @@ RSpec.describe Teachers::Details::ITTDetailsComponent, type: :component do
 
   context "when teacher has neither QTS award date nor ITT provider" do
     let(:teacher) do
-      FactoryBot.create(
+      create(
         :teacher,
         trs_qts_awarded_on: nil,
         trs_initial_teacher_training_provider_name: nil

--- a/spec/components/teachers/details/past_induction_periods_component_spec.rb
+++ b/spec/components/teachers/details/past_induction_periods_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Teachers::Details::PastInductionPeriodsComponent, type: :component do
   include AppropriateBodyHelper
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:component) { described_class.new(teacher:) }
 
   context "when teacher has no past induction periods" do
@@ -11,15 +11,15 @@ RSpec.describe Teachers::Details::PastInductionPeriodsComponent, type: :componen
   end
 
   context "when teacher has past induction periods" do
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: "Past AB") }
+    let(:appropriate_body) { create(:appropriate_body, name: "Past AB") }
     let!(:past_period) do
-      FactoryBot.create(:induction_period,
-                        teacher:,
-                        appropriate_body:,
-                        started_on: Date.new(2021, 9, 1),
-                        finished_on: 1.year.ago,
-                        induction_programme: "cip",
-                        number_of_terms: 3)
+      create(:induction_period,
+             teacher:,
+             appropriate_body:,
+             started_on: Date.new(2021, 9, 1),
+             finished_on: 1.year.ago,
+             induction_programme: "cip",
+             number_of_terms: 3)
     end
 
     it "renders" do

--- a/spec/components/teachers/details/personal_details_component_spec.rb
+++ b/spec/components/teachers/details/personal_details_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Teachers::Details::PersonalDetailsComponent, type: :component do
   include TeacherHelper
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:component) { described_class.new(teacher:) }
 
   it "renders the personal details" do

--- a/spec/components/teachers/details_component_spec.rb
+++ b/spec/components/teachers/details_component_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Teachers::DetailsComponent, type: :component do
   include ActionView::Helpers::TagHelper
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:mode) { :appropriate_body }
   let(:component) { described_class.new(teacher:, mode:) }
 

--- a/spec/components/teachers/outcome_form_component_spec.rb
+++ b/spec/components/teachers/outcome_form_component_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Teachers::OutcomeFormComponent, type: :component do
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:appropriate_body) { build(:appropriate_body) }
   let(:form) { double("form", govuk_error_summary: "", govuk_date_field: "", govuk_number_field: "") }
 
   context "when in admin mode" do

--- a/spec/components/teachers/record_outcome_component_spec.rb
+++ b/spec/components/teachers/record_outcome_component_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Teachers::RecordOutcomeComponent, type: :component do
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:appropriate_body) { build(:appropriate_body) }
   let(:pending_induction_submission) { PendingInductionSubmission.new }
   let(:teacher_name) { Teachers::Name.new(teacher).full_name }
 

--- a/spec/components/teachers_index/bulk_upload_links_component_spec.rb
+++ b/spec/components/teachers_index/bulk_upload_links_component_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:component) { described_class.new(appropriate_body:) }
 
   describe 'rendered content' do
@@ -54,7 +54,7 @@ RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
 
       context 'when existing bulk uploads exist' do
         before do
-          FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:)
+          create(:pending_induction_submission_batch, :action, appropriate_body:)
         end
 
         it 'links to batch actions index page' do
@@ -102,7 +102,7 @@ RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
 
       context 'when existing bulk uploads exist' do
         before do
-          FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:)
+          create(:pending_induction_submission_batch, :action, appropriate_body:)
         end
 
         it 'bulk actions link goes to index page' do
@@ -122,7 +122,7 @@ RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
 
     context 'when bulk uploads exist for this appropriate body' do
       before do
-        FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:)
+        create(:pending_induction_submission_batch, :action, appropriate_body:)
       end
 
       it 'returns true' do
@@ -131,10 +131,10 @@ RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
     end
 
     context 'when bulk uploads exist for other appropriate bodies only' do
-      let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:other_appropriate_body) { create(:appropriate_body) }
 
       before do
-        FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body: other_appropriate_body)
+        create(:pending_induction_submission_batch, :action, appropriate_body: other_appropriate_body)
       end
 
       it 'returns false' do
@@ -144,7 +144,7 @@ RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
 
     context 'when bulk claims exist but no bulk actions' do
       before do
-        FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body:)
+        create(:pending_induction_submission_batch, :claim, appropriate_body:)
       end
 
       it 'returns false' do
@@ -168,7 +168,7 @@ RSpec.describe TeachersIndex::BulkUploadLinksComponent, type: :component do
 
     context 'when existing bulk uploads exist' do
       before do
-        FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:)
+        create(:pending_induction_submission_batch, :action, appropriate_body:)
       end
 
       it 'routes to batch actions index page' do

--- a/spec/components/teachers_index/table_section_component_spec.rb
+++ b/spec/components/teachers_index/table_section_component_spec.rb
@@ -21,17 +21,17 @@ RSpec.describe TeachersIndex::TableSectionComponent, type: :component do
       end
     end
 
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:appropriate_body) { create(:appropriate_body) }
 
     let!(:teacher_1) do
-      teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
+      teacher = create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
+      create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
       teacher
     end
 
     let!(:teacher_2) do
-      teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 4, 1))
+      teacher = create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
+      create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 4, 1))
       teacher
     end
 
@@ -248,11 +248,11 @@ RSpec.describe TeachersIndex::TableSectionComponent, type: :component do
       end
     end
 
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:appropriate_body) { create(:appropriate_body) }
 
     let!(:integration_teacher) do
-      teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
+      teacher = create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
+      create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
       teacher
     end
 

--- a/spec/components/teachers_index_component_spec.rb
+++ b/spec/components/teachers_index_component_spec.rb
@@ -9,30 +9,30 @@ RSpec.describe TeachersIndexComponent, type: :component do
     )
   end
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:other_appropriate_body) { create(:appropriate_body) }
 
   let!(:teacher_1) do
-    teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 3.months.ago)
+    teacher = create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
+    create(:induction_period, :active, teacher:, appropriate_body:, started_on: 3.months.ago)
     teacher
   end
 
   let!(:teacher_2) do
-    teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 2.months.ago)
+    teacher = create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
+    create(:induction_period, :active, teacher:, appropriate_body:, started_on: 2.months.ago)
     teacher
   end
 
   let!(:teacher_3_closed) do
-    teacher = FactoryBot.create(:teacher, trs_first_name: "Carol", trs_last_name: "Brown", trn: "3456789")
-    FactoryBot.create(:induction_period, :pass, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 6)
+    teacher = create(:teacher, trs_first_name: "Carol", trs_last_name: "Brown", trn: "3456789")
+    create(:induction_period, :pass, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 6)
     teacher
   end
 
   let!(:teacher_4_other_ab) do
-    teacher = FactoryBot.create(:teacher, trs_first_name: "David", trs_last_name: "Wilson", trn: "4567890")
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_appropriate_body, started_on: 1.month.ago)
+    teacher = create(:teacher, trs_first_name: "David", trs_last_name: "Wilson", trn: "4567890")
+    create(:induction_period, :active, teacher:, appropriate_body: other_appropriate_body, started_on: 1.month.ago)
     teacher
   end
 

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe TimelineComponent, type: :component do
   let(:component) { TimelineComponent.new(events) }
 
-  let(:one_day_ago) { FactoryBot.build(:event, :with_body, created_at: 1.day.ago) }
-  let(:two_days_ago) { FactoryBot.build(:event, :with_body, created_at: 2.days.ago) }
-  let(:three_days_ago) { FactoryBot.build(:event, :with_body, created_at: 3.days.ago) }
+  let(:one_day_ago) { build(:event, :with_body, created_at: 1.day.ago) }
+  let(:two_days_ago) { build(:event, :with_body, created_at: 2.days.ago) }
+  let(:three_days_ago) { build(:event, :with_body, created_at: 3.days.ago) }
   let(:events) { [two_days_ago, one_day_ago, three_days_ago] }
 
   before { render_inline(component) }
@@ -34,7 +34,7 @@ RSpec.describe TimelineComponent, type: :component do
 
   describe 'modifications' do
     context 'when modifications are present' do
-      let(:one_day_ago) { FactoryBot.build(:event, :with_body, :with_modifications, created_at: 3.days.ago) }
+      let(:one_day_ago) { build(:event, :with_body, :with_modifications, created_at: 3.days.ago) }
 
       it "renders a 'Changes' heading" do
         expect(rendered_content).to have_css('h3', text: 'Changes')

--- a/spec/factories/migration/finance_adjustment_factory.rb
+++ b/spec/factories/migration/finance_adjustment_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_finance_adjustment, class: "Migration::FinanceAdjustment" do
-    statement { FactoryBot.create(:migration_statement) }
+    statement { create(:migration_statement) }
     sequence(:payment_type) { |n| "Custom payment #{n}" }
     amount { 9.99 }
   end

--- a/spec/factories/migration/induction_programme_factory.rb
+++ b/spec/factories/migration/induction_programme_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_induction_programme, class: "Migration::InductionProgramme" do
     training_programme { :full_induction_programme }
-    school_cohort { FactoryBot.create(:migration_school_cohort, induction_programme_choice: training_programme) }
+    school_cohort { create(:migration_school_cohort, induction_programme_choice: training_programme) }
   end
 end

--- a/spec/factories/migration/induction_record_factory.rb
+++ b/spec/factories/migration/induction_record_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_induction_record, class: "Migration::InductionRecord" do
-    participant_profile { FactoryBot.create(:migration_participant_profile, :ect) }
+    participant_profile { create(:migration_participant_profile, :ect) }
     preferred_identity { participant_profile.participant_identity }
     induction_programme { participant_profile.school_cohort.default_induction_programme }
     schedule { participant_profile.schedule }

--- a/spec/factories/migration/lead_provider_factory.rb
+++ b/spec/factories/migration/lead_provider_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     trait :active do
       after(:create) do |lead_provider|
-        lead_provider.cohorts << FactoryBot.create(:migration_cohort)
+        lead_provider.cohorts << create(:migration_cohort)
       end
     end
   end

--- a/spec/factories/migration/participant_identity_factory.rb
+++ b/spec/factories/migration/participant_identity_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_participant_identity, class: "Migration::ParticipantIdentity" do
-    user { FactoryBot.create(:migration_user) }
+    user { create(:migration_user) }
     email { user.email }
     external_identifier { user.id }
     origin { "ecf" }

--- a/spec/factories/migration/participant_profile_factory.rb
+++ b/spec/factories/migration/participant_profile_factory.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :migration_participant_profile, class: "Migration::ParticipantProfile" do
     transient do
-      user { FactoryBot.create(:migration_user) }
+      user { create(:migration_user) }
     end
 
-    teacher_profile { FactoryBot.create(:migration_teacher_profile, user:) }
-    participant_identity { FactoryBot.create(:migration_participant_identity, user:) }
-    school_cohort { FactoryBot.create(:migration_school_cohort) }
-    schedule { FactoryBot.create(:migration_schedule, cohort: school_cohort.cohort) }
+    teacher_profile { create(:migration_teacher_profile, user:) }
+    participant_identity { create(:migration_participant_identity, user:) }
+    school_cohort { create(:migration_school_cohort) }
+    schedule { create(:migration_schedule, cohort: school_cohort.cohort) }
 
     trait :ect do
       type { "ParticipantProfile::ECT" }

--- a/spec/factories/migration/partnership_factory.rb
+++ b/spec/factories/migration/partnership_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :migration_partnership, class: "Migration::Partnership" do
-    lead_provider { FactoryBot.create(:migration_lead_provider) }
-    delivery_partner { FactoryBot.create(:migration_delivery_partner) }
-    cohort { FactoryBot.create(:migration_cohort) }
-    school { FactoryBot.create(:ecf_migration_school) }
+    lead_provider { create(:migration_lead_provider) }
+    delivery_partner { create(:migration_delivery_partner) }
+    cohort { create(:migration_cohort) }
+    school { create(:ecf_migration_school) }
   end
 end

--- a/spec/factories/migration/provider_relationship_factory.rb
+++ b/spec/factories/migration/provider_relationship_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :migration_provider_relationship, class: "Migration::ProviderRelationship" do
-    lead_provider { FactoryBot.create(:migration_lead_provider) }
-    delivery_partner { FactoryBot.create(:migration_delivery_partner) }
-    cohort { FactoryBot.create(:migration_cohort) }
+    lead_provider { create(:migration_lead_provider) }
+    delivery_partner { create(:migration_delivery_partner) }
+    cohort { create(:migration_cohort) }
   end
 end

--- a/spec/factories/migration/schedule_factory.rb
+++ b/spec/factories/migration/schedule_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_schedule, class: "Migration::Schedule" do
-    cohort { FactoryBot.create(:migration_cohort) }
+    cohort { create(:migration_cohort) }
     schedule_identifier { "#{Faker::Lorem.word} #{Faker::Alphanumeric.alpha(number: 5).upcase}" }
     name { Faker::Lorem.words(number: 2) }
   end

--- a/spec/factories/migration/school_cohort_factory.rb
+++ b/spec/factories/migration/school_cohort_factory.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :migration_school_cohort, class: "Migration::SchoolCohort" do
-    school { FactoryBot.create(:ecf_migration_school) }
-    cohort { FactoryBot.create(:migration_cohort) }
+    school { create(:ecf_migration_school) }
+    cohort { create(:migration_cohort) }
 
     induction_programme_choice { :full_induction_programme }
 
-    default_induction_programme { FactoryBot.create(:migration_induction_programme, training_programme: induction_programme_choice, school_cohort: instance) }
+    default_induction_programme { create(:migration_induction_programme, training_programme: induction_programme_choice, school_cohort: instance) }
   end
 end

--- a/spec/factories/migration/statement_factory.rb
+++ b/spec/factories/migration/statement_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name          { Time.zone.today.strftime "%B %Y" }
     deadline_date { (Time.zone.today - 1.month).end_of_month }
     payment_date  { Time.zone.today.end_of_month }
-    cohort { FactoryBot.create(:migration_cohort) }
+    cohort { create(:migration_cohort) }
     type { "Finance::Statement::ECF" }
     contract_version { "1.0" }
     cpd_lead_provider_id { create(:migration_cpd_lead_provider).id }

--- a/spec/factories/migration/teacher_profile_factory.rb
+++ b/spec/factories/migration/teacher_profile_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :migration_teacher_profile, class: "Migration::TeacherProfile" do
-    user { FactoryBot.create(:migration_user) }
+    user { create(:migration_user) }
     trn { Faker::Number.unique.number(digits: 7) }
   end
 end

--- a/spec/factories/register_ect_wizard_factory.rb
+++ b/spec/factories/register_ect_wizard_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     current_step { :find_ect }
     step_params { {} }
-    store { FactoryBot.build(:session_repository) }
-    school { FactoryBot.create(:school, :state_funded) }
+    store { build(:session_repository) }
+    school { create(:school, :state_funded) }
   end
 end

--- a/spec/factories/register_mentor_wizard_factory.rb
+++ b/spec/factories/register_mentor_wizard_factory.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     current_step { :find_mentor }
     ect_id { Faker::Number.within(range: 5400..6000) }
     step_params { {} }
-    store { FactoryBot.create(:session_repository) }
+    store { create(:session_repository) }
   end
 end

--- a/spec/factories/sessions/school_user_factory.rb
+++ b/spec/factories/sessions/school_user_factory.rb
@@ -12,6 +12,6 @@ FactoryBot.define do
     # NOTE: school_urn is required, either pass one in or use :at_random_school or this
     #       will fail
     school_urn { nil }
-    trait(:at_random_school) { school_urn { FactoryBot.create(:school).urn } }
+    trait(:at_random_school) { school_urn { create(:school).urn } }
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,19 +5,19 @@ FactoryBot.define do
 
     trait :admin do
       after(:create) do |user|
-        FactoryBot.create(:dfe_role, :admin, user:)
+        create(:dfe_role, :admin, user:)
       end
     end
 
     trait :super_admin do
       after(:create) do |user|
-        FactoryBot.create(:dfe_role, :super_admin, user:)
+        create(:dfe_role, :super_admin, user:)
       end
     end
 
     trait :finance do
       after(:create) do |user|
-        FactoryBot.create(:dfe_role, :finance, user:)
+        create(:dfe_role, :finance, user:)
       end
     end
   end

--- a/spec/features/admin/finance/adjustments/create_adjustment_spec.rb
+++ b/spec/features/admin/finance/adjustments/create_adjustment_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Create adjustment for statement" do
   end
 
   def given_a_finance_statement_exists
-    @statement = FactoryBot.create(:statement)
+    @statement = create(:statement)
   end
 
   def when_i_visit_the_finance_statement_page

--- a/spec/features/admin/finance/adjustments/delete_adjustment_spec.rb
+++ b/spec/features/admin/finance/adjustments/delete_adjustment_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Delete adjustment from statement" do
   end
 
   def given_a_finance_statement_exists
-    @statement = FactoryBot.create(:statement)
+    @statement = create(:statement)
   end
 
   def when_i_visit_the_finance_statement_page
@@ -33,9 +33,9 @@ RSpec.describe "Delete adjustment from statement" do
   end
 
   def and_the_statement_has_adjustments
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
-    @deleted_adjustment = FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
+    @deleted_adjustment = create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
   end
 
   def and_i_see_adjustment_values

--- a/spec/features/admin/finance/adjustments/list_adjustments_spec.rb
+++ b/spec/features/admin/finance/adjustments/list_adjustments_spec.rb
@@ -35,15 +35,15 @@ RSpec.describe "List adjustments for statement" do
   end
 
   def given_a_finance_statement_exists
-    @statement = FactoryBot.create(:statement)
+    @statement = create(:statement)
   end
 
   def given_a_closed_finance_statement_exists
-    @statement = FactoryBot.create(:statement, :paid)
+    @statement = create(:statement, :paid)
   end
 
   def given_a_finance_statement_with_false_output_fees_exists
-    @statement = FactoryBot.create(:statement, :service_fee)
+    @statement = create(:statement, :service_fee)
   end
 
   def when_i_visit_the_finance_statement_page
@@ -51,9 +51,9 @@ RSpec.describe "List adjustments for statement" do
   end
 
   def and_the_statement_has_adjustments
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
   end
 
   def then_i_see_adjustments_section

--- a/spec/features/admin/finance/adjustments/update_adjustment_spec.rb
+++ b/spec/features/admin/finance/adjustments/update_adjustment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Update adjustment for statement" do
   end
 
   def given_a_finance_statement_exists
-    @statement = FactoryBot.create(:statement)
+    @statement = create(:statement)
   end
 
   def when_i_visit_the_finance_statement_page
@@ -36,9 +36,9 @@ RSpec.describe "Update adjustment for statement" do
   end
 
   def and_the_statement_has_adjustments
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
-    @changed_adjustment = FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
-    FactoryBot.create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 1", amount: 100.0)
+    @changed_adjustment = create(:statement_adjustment, statement: @statement, payment_type: "Amount 2", amount: -150.0)
+    create(:statement_adjustment, statement: @statement, payment_type: "Amount 3", amount: 500.0)
   end
 
   def and_i_see_adjustment_values

--- a/spec/features/admin/finance/statements/filter_spec.rb
+++ b/spec/features/admin/finance/statements/filter_spec.rb
@@ -29,24 +29,24 @@ RSpec.describe "Admin finance statement filter" do
   end
 
   def given_statements_exist
-    @lead_provider1 = FactoryBot.create(:lead_provider)
-    @lead_provider2 = FactoryBot.create(:lead_provider)
+    @lead_provider1 = create(:lead_provider)
+    @lead_provider2 = create(:lead_provider)
 
-    @contract_period1 = FactoryBot.create(:contract_period)
-    @contract_period2 = FactoryBot.create(:contract_period)
+    @contract_period1 = create(:contract_period)
+    @contract_period2 = create(:contract_period)
 
-    @active_lead_provider1 = FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider1, contract_period: @contract_period1)
-    @active_lead_provider2 = FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider1, contract_period: @contract_period2)
-    @active_lead_provider3 = FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider2, contract_period: @contract_period2)
+    @active_lead_provider1 = create(:active_lead_provider, lead_provider: @lead_provider1, contract_period: @contract_period1)
+    @active_lead_provider2 = create(:active_lead_provider, lead_provider: @lead_provider1, contract_period: @contract_period2)
+    @active_lead_provider3 = create(:active_lead_provider, lead_provider: @lead_provider2, contract_period: @contract_period2)
 
-    @statement1 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider1, fee_type: 'output', year: 2025, month: 5)
-    @statement2 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider1, fee_type: 'service', year: 2023, month: 5)
+    @statement1 = create(:statement, active_lead_provider: @active_lead_provider1, fee_type: 'output', year: 2025, month: 5)
+    @statement2 = create(:statement, active_lead_provider: @active_lead_provider1, fee_type: 'service', year: 2023, month: 5)
 
-    @statement3 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider2, fee_type: 'output', year: 2022, month: 5)
-    @statement4 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider2, fee_type: 'service', year: 2024, month: 5)
+    @statement3 = create(:statement, active_lead_provider: @active_lead_provider2, fee_type: 'output', year: 2022, month: 5)
+    @statement4 = create(:statement, active_lead_provider: @active_lead_provider2, fee_type: 'service', year: 2024, month: 5)
 
-    @statement5 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider3, fee_type: 'output', year: 2025, month: 8)
-    @statement6 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider3, fee_type: 'service', year: 2026, month: 8)
+    @statement5 = create(:statement, active_lead_provider: @active_lead_provider3, fee_type: 'output', year: 2025, month: 8)
+    @statement6 = create(:statement, active_lead_provider: @active_lead_provider3, fee_type: 'service', year: 2026, month: 8)
   end
 
   def when_i_visit_the_statements_page

--- a/spec/features/admin/finance/statements/payment_authorisation_spec.rb
+++ b/spec/features/admin/finance/statements/payment_authorisation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Payment authorisation for statement" do
   end
 
   def given_a_payable_finance_statement_exists
-    @statement = FactoryBot.create(:statement, :payable, :output_fee, marked_as_paid_at: nil, deadline_date: 3.days.ago.to_date)
+    @statement = create(:statement, :payable, :output_fee, marked_as_paid_at: nil, deadline_date: 3.days.ago.to_date)
   end
 
   def when_i_visit_the_finance_statement_page

--- a/spec/features/admin/finance/statements/selector_spec.rb
+++ b/spec/features/admin/finance/statements/selector_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe "Admin finance statement selector" do
   end
 
   def given_statement_exist_with_dropdown_options
-    @lead_provider1 = FactoryBot.create(:lead_provider)
-    @contract_period1 = FactoryBot.create(:contract_period)
-    @active_lead_provider1 = FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider1, contract_period: @contract_period1)
-    @statement1 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider1, year: 2024, month: 7)
+    @lead_provider1 = create(:lead_provider)
+    @contract_period1 = create(:contract_period)
+    @active_lead_provider1 = create(:active_lead_provider, lead_provider: @lead_provider1, contract_period: @contract_period1)
+    @statement1 = create(:statement, active_lead_provider: @active_lead_provider1, year: 2024, month: 7)
 
-    @lead_provider2 = FactoryBot.create(:lead_provider)
-    @contract_period2 = FactoryBot.create(:contract_period)
-    @active_lead_provider2 = FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider2, contract_period: @contract_period2)
-    @statement2 = FactoryBot.create(:statement, active_lead_provider: @active_lead_provider2, year: 2025, month: 5)
+    @lead_provider2 = create(:lead_provider)
+    @contract_period2 = create(:contract_period)
+    @active_lead_provider2 = create(:active_lead_provider, lead_provider: @lead_provider2, contract_period: @contract_period2)
+    @statement2 = create(:statement, active_lead_provider: @active_lead_provider2, year: 2025, month: 5)
   end
 
   def when_i_visit_the_statement_page

--- a/spec/features/admin/teachers/delete_induction_period_spec.rb
+++ b/spec/features/admin/teachers/delete_induction_period_spec.rb
@@ -2,15 +2,15 @@ RSpec.describe "Admin deletes an induction period" do
   include ActiveJob::TestHelper
   include_context "fake trs api client"
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   before do
     sign_in_as_dfe_user(role: :admin)
   end
 
   context "when it is the only induction period" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
 
     scenario "TRS status is reset" do
       given_i_am_on_the_ect_page(teacher)
@@ -27,8 +27,8 @@ RSpec.describe "Admin deletes an induction period" do
   end
 
   context "when there are multiple induction periods" do
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
+    let!(:induction_period1) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period2) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
 
     scenario "TRS start date is updated to next earliest period" do
       given_i_am_on_the_ect_page(teacher)
@@ -45,8 +45,8 @@ RSpec.describe "Admin deletes an induction period" do
   end
 
   context "when deleting the later induction period" do
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
+    let!(:induction_period1) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period2) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
 
     scenario "TRS start date remains unchanged" do
       given_i_am_on_the_ect_page(teacher)

--- a/spec/features/admin/teachers/edit_induction_period_spec.rb
+++ b/spec/features/admin/teachers/edit_induction_period_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "Admin amending number of terms of an induction period" do
   include ActiveJob::TestHelper
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, number_of_terms: nil) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:, number_of_terms: nil) }
 
   before { sign_in_as_dfe_user(role: :admin) }
 

--- a/spec/features/admin/teachers/record_failed_outcome_spec.rb
+++ b/spec/features/admin/teachers/record_failed_outcome_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Admin recording a failed outcome for an ECT" do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:teacher) { create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }
 

--- a/spec/features/admin/teachers/record_passed_outcome_spec.rb
+++ b/spec/features/admin/teachers/record_passed_outcome_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Admin recording a passed outcome for an ECT" do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:teacher) { create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }
 

--- a/spec/features/admin_manages_ect_extensions_spec.rb
+++ b/spec/features/admin_manages_ect_extensions_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature "Admin manages ECT extensions", type: :feature do
-  let(:admin_user) { FactoryBot.create(:user, :admin) }
-  let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Sarah", trs_last_name: "Connor", trs_qts_awarded_on: 2.years.ago) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, teacher:) }
+  let(:admin_user) { create(:user, :admin) }
+  let!(:teacher) { create(:teacher, trs_first_name: "Sarah", trs_last_name: "Connor", trs_qts_awarded_on: 2.years.ago) }
+  let!(:induction_period) { create(:induction_period, teacher:) }
 
   before do
     sign_in_as_dfe_user(role: :admin, user: admin_user)
@@ -37,7 +37,7 @@ RSpec.feature "Admin manages ECT extensions", type: :feature do
   end
 
   context "when an extension exists" do
-    let!(:existing_extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 1.0) }
+    let!(:existing_extension) { create(:induction_extension, teacher:, number_of_terms: 1.0) }
 
     before do
       page.goto admin_teacher_path(teacher)

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe 'Claiming an ECT' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher, trn: '1234567') }
-  let(:other_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher, trn: '1234567') }
+  let(:other_body) { create(:appropriate_body) }
 
   before { sign_in_as_appropriate_body_user(appropriate_body:) }
 
   describe "when the ECT has not passed the induction" do
     let!(:induction_period) do
-      FactoryBot.create(:induction_period, teacher:, started_on: 14.months.ago, finished_on: 13.months.ago, appropriate_body: other_body)
+      create(:induction_period, teacher:, started_on: 14.months.ago, finished_on: 13.months.ago, appropriate_body: other_body)
     end
 
     include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
@@ -34,7 +34,7 @@ RSpec.describe 'Claiming an ECT' do
     include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
 
     before do
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_body)
+      create(:induction_period, :active, teacher:, appropriate_body: other_body)
     end
 
     scenario 'Button is hidden when induction is ongoing' do

--- a/spec/features/appropriate_bodies/process_batch_action_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_action_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Process bulk actions' do
   include_context 'fake trs api client'
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let(:file_name) { 'valid_complete_action.csv' }
   let(:file_path) { Rails.root.join("spec/fixtures/#{file_name}").to_s }
@@ -14,10 +14,10 @@ RSpec.describe 'Process bulk actions' do
   end
 
   context 'when batch is owned by another appropriate body' do
-    let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:other_appropriate_body) { create(:appropriate_body) }
     let(:batch) do
-      FactoryBot.create(:pending_induction_submission_batch, :claim,
-                        appropriate_body: other_appropriate_body)
+      create(:pending_induction_submission_batch, :claim,
+             appropriate_body: other_appropriate_body)
     end
 
     before { page.goto(ab_batch_claim_path(batch.id)) }
@@ -47,8 +47,8 @@ RSpec.describe 'Process bulk actions' do
         expect(page.get_by_text("We're processing your CSV file, it could take up to 5 minutes.")).to be_visible
         expect(page.get_by_text('0%')).to be_visible
 
-        teacher = FactoryBot.create(:teacher, trn: '1234567')
-        FactoryBot.create(:induction_period, teacher:, appropriate_body:)
+        teacher = create(:teacher, trn: '1234567')
+        create(:induction_period, teacher:, appropriate_body:)
         batch = PendingInductionSubmissionBatch.last
         batch.processing!
         batch.pending_induction_submissions.create!(appropriate_body:,

--- a/spec/features/appropriate_bodies/process_batch_claim_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_claim_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Process bulk claims' do
   include_context 'fake trs api client'
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let(:file_name) { 'valid_complete_claim.csv' }
   let(:file_path) { Rails.root.join("spec/fixtures/#{file_name}").to_s }
@@ -14,8 +14,8 @@ RSpec.describe 'Process bulk claims' do
   end
 
   context 'when batch is owned by another appropriate body' do
-    let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body: other_appropriate_body) }
+    let(:other_appropriate_body) { create(:appropriate_body) }
+    let(:batch) { create(:pending_induction_submission_batch, :claim, appropriate_body: other_appropriate_body) }
 
     before { page.goto(ab_batch_claim_path(batch.id)) }
 

--- a/spec/features/appropriate_bodies/process_batch_combo_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_combo_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Process bulk claims then actions events' do
   include_context 'fake trs api returns a teacher and then a teacher that is exempt from induction'
 
   let(:appropriate_body) do
-    FactoryBot.create(:appropriate_body, name: 'The Appropriate Body')
+    create(:appropriate_body, name: 'The Appropriate Body')
   end
 
   before do

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Recording a failed outcome for an ECT" do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:teacher) { create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }
 

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Recording a passed outcome for an ECT" do
-  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let!(:appropriate_body) { create(:appropriate_body) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:teacher) { create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }
 

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Releasing an ECT' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:teacher) { create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }
 

--- a/spec/features/migration/run_parity_check_spec.rb
+++ b/spec/features/migration/run_parity_check_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe "Run parity check" do
   let(:ecf_url) { "https://ecf.example.com" }
   let(:rect_url) { "https://rect.example.com" }
-  let(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let!(:get_endpoint) { FactoryBot.create(:parity_check_endpoint, :get, path: "/api/v1/statements") }
-  let!(:post_endpoint) { FactoryBot.create(:parity_check_endpoint, :post, path: "/api/v1/statement") }
-  let!(:put_endpoint) { FactoryBot.create(:parity_check_endpoint, :put, path: "/api/v3/users") }
+  let(:lead_provider) { create(:lead_provider) }
+  let!(:get_endpoint) { create(:parity_check_endpoint, :get, path: "/api/v1/statements") }
+  let!(:post_endpoint) { create(:parity_check_endpoint, :post, path: "/api/v1/statement") }
+  let!(:put_endpoint) { create(:parity_check_endpoint, :put, path: "/api/v3/users") }
 
   before do
     sign_in_as_dfe_user(role: :admin)

--- a/spec/features/migration/view_completed_parity_checks_spec.rb
+++ b/spec/features/migration/view_completed_parity_checks_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe "View completed parity checks" do
   end
 
   scenario "Viewing completed parity checks" do
-    completed_run = FactoryBot.create(:parity_check_run, :completed)
+    completed_run = create(:parity_check_run, :completed)
 
-    statements_endpoint = FactoryBot.create(:parity_check_endpoint, path: "/api/v1/statements")
-    user_endpoint = FactoryBot.create(:parity_check_endpoint, path: "/api/v1/users/:id")
+    statements_endpoint = create(:parity_check_endpoint, path: "/api/v1/statements")
+    user_endpoint = create(:parity_check_endpoint, path: "/api/v1/users/:id")
 
-    FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching different], run: completed_run, endpoint: statements_endpoint)
-    FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching matching], run: completed_run, endpoint: user_endpoint)
+    create(:parity_check_request, :completed, response_types: %i[matching different], run: completed_run, endpoint: statements_endpoint)
+    create(:parity_check_request, :completed, response_types: %i[matching matching], run: completed_run, endpoint: user_endpoint)
 
     page.goto(new_migration_parity_check_path)
     page.get_by_role("link", name: "View completed runs").click
@@ -36,7 +36,7 @@ RSpec.describe "View completed parity checks" do
   end
 
   scenario "Paginating the completed parity checks when there are many" do
-    FactoryBot.create_list(:parity_check_run, Pagy::DEFAULT[:limit] + 1, :completed)
+    create_list(:parity_check_run, Pagy::DEFAULT[:limit] + 1, :completed)
 
     page.goto(completed_migration_parity_checks_path)
 

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "View parity check request" do
   end
 
   scenario "Viewing a parity check request" do
-    run = FactoryBot.create(:parity_check_run, :completed)
+    run = create(:parity_check_run, :completed)
     responses = [
-      FactoryBot.create(:parity_check_response, :matching, page: 1),
-      FactoryBot.create(:parity_check_response, :different, page: 2),
+      create(:parity_check_response, :matching, page: 1),
+      create(:parity_check_response, :different, page: 2),
     ]
-    request = FactoryBot.create(:parity_check_request, :completed, run:, responses:)
+    request = create(:parity_check_request, :completed, run:, responses:)
 
     page.goto(migration_parity_check_path(run))
     page.get_by_role("link", name: "Request details").click
@@ -48,9 +48,9 @@ RSpec.describe "View parity check request" do
   end
 
   scenario "Paginating the parity check responses when there are many" do
-    run = FactoryBot.create(:parity_check_run, :completed)
-    responses = FactoryBot.create_list(:parity_check_response, Pagy::DEFAULT[:limit] + 1, :matching)
-    request = FactoryBot.create(:parity_check_request, :completed, run:, responses:)
+    run = create(:parity_check_run, :completed)
+    responses = create_list(:parity_check_response, Pagy::DEFAULT[:limit] + 1, :matching)
+    request = create(:parity_check_request, :completed, run:, responses:)
 
     page.goto(migration_parity_check_request_path(run, request))
 
@@ -67,7 +67,7 @@ RSpec.describe "View parity check request" do
   end
 
   scenario "Navigating back to the parity check run" do
-    request = FactoryBot.create(:parity_check_request, :completed)
+    request = create(:parity_check_request, :completed)
 
     page.goto(migration_parity_check_request_path(request.run, request))
 
@@ -77,7 +77,7 @@ RSpec.describe "View parity check request" do
   end
 
   scenario "Navigating back to completed parity checks" do
-    request = FactoryBot.create(:parity_check_request, :completed)
+    request = create(:parity_check_request, :completed)
 
     page.goto(migration_parity_check_request_path(request.run, request))
 
@@ -87,7 +87,7 @@ RSpec.describe "View parity check request" do
   end
 
   scenario "Navigating back to run a parity check" do
-    request = FactoryBot.create(:parity_check_request, :completed)
+    request = create(:parity_check_request, :completed)
 
     page.goto(migration_parity_check_request_path(request.run, request))
 

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "View parity check response" do
   end
 
   scenario "Viewing a parity check response" do
-    run = FactoryBot.create(:parity_check_run, :completed)
-    response = FactoryBot.create(:parity_check_response, :different)
-    request = FactoryBot.create(:parity_check_request, :completed, run:, responses: [response])
+    run = create(:parity_check_run, :completed)
+    response = create(:parity_check_response, :different)
+    request = create(:parity_check_request, :completed, run:, responses: [response])
 
     page.goto(migration_parity_check_request_path(run, request))
     page.get_by_role("link", name: "Response details").click
@@ -32,7 +32,7 @@ RSpec.describe "View parity check response" do
   end
 
   scenario "Viewing a parity check response where the bodies match" do
-    response = FactoryBot.create(:parity_check_response, :different_status_code_matching_body)
+    response = create(:parity_check_response, :different_status_code_matching_body)
 
     page.goto(migration_parity_check_response_path(response.run, response))
 
@@ -44,7 +44,7 @@ RSpec.describe "View parity check response" do
   end
 
   scenario "Navigating back to the parity check request" do
-    response = FactoryBot.create(:parity_check_response, :different)
+    response = create(:parity_check_response, :different)
 
     page.goto(migration_parity_check_response_path(response.run, response))
 
@@ -54,7 +54,7 @@ RSpec.describe "View parity check response" do
   end
 
   scenario "Navigating back to the parity check run" do
-    response = FactoryBot.create(:parity_check_response, :different)
+    response = create(:parity_check_response, :different)
 
     page.goto(migration_parity_check_response_path(response.run, response))
 
@@ -64,7 +64,7 @@ RSpec.describe "View parity check response" do
   end
 
   scenario "Navigating back to completed parity checks" do
-    response = FactoryBot.create(:parity_check_response, :different)
+    response = create(:parity_check_response, :different)
 
     page.goto(migration_parity_check_response_path(response.run, response))
 
@@ -74,7 +74,7 @@ RSpec.describe "View parity check response" do
   end
 
   scenario "Navigating back to run a parity check" do
-    response = FactoryBot.create(:parity_check_response, :different)
+    response = create(:parity_check_response, :different)
 
     page.goto(migration_parity_check_response_path(response.run, response))
 

--- a/spec/features/migration/view_parity_check_spec.rb
+++ b/spec/features/migration/view_parity_check_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "View parity check" do
   end
 
   scenario "Viewing a parity check" do
-    run = FactoryBot.create(:parity_check_run, :completed, request_states: %i[completed_different completed_matching])
+    run = create(:parity_check_run, :completed, request_states: %i[completed_different completed_matching])
 
     page.goto(completed_migration_parity_checks_path)
     page.get_by_role("link", name: "Run details").click
@@ -36,7 +36,7 @@ RSpec.describe "View parity check" do
   end
 
   scenario "Navigating back to completed parity checks" do
-    run = FactoryBot.create(:parity_check_run, :completed)
+    run = create(:parity_check_run, :completed)
 
     page.goto(migration_parity_check_path(run))
 
@@ -46,7 +46,7 @@ RSpec.describe "View parity check" do
   end
 
   scenario "Navigating back to run a parity check" do
-    run = FactoryBot.create(:parity_check_run, :completed)
+    run = create(:parity_check_run, :completed)
 
     page.goto(migration_parity_check_path(run))
 
@@ -56,7 +56,7 @@ RSpec.describe "View parity check" do
   end
 
   scenario "Viewing a parity check with no requests" do
-    run = FactoryBot.create(:parity_check_run, :completed)
+    run = create(:parity_check_run, :completed)
 
     page.goto(migration_parity_check_path(run))
 

--- a/spec/features/migration/view_pending_and_in_progress_parity_checks_spec.rb
+++ b/spec/features/migration/view_pending_and_in_progress_parity_checks_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe "View pending and in-progress parity checks" do
   end
 
   scenario "Viewing the in-progress parity check" do
-    run = FactoryBot.create(:parity_check_run, :in_progress, requests: [])
-    FactoryBot.create(:parity_check_request, :pending, run:)
-    FactoryBot.create(:parity_check_request, :queued, run:)
-    FactoryBot.create(:parity_check_request, :in_progress, run:)
-    FactoryBot.create(:parity_check_request, :completed, run:)
+    run = create(:parity_check_run, :in_progress, requests: [])
+    create(:parity_check_request, :pending, run:)
+    create(:parity_check_request, :queued, run:)
+    create(:parity_check_request, :in_progress, run:)
+    create(:parity_check_request, :completed, run:)
 
     page.goto(new_migration_parity_check_path)
 
@@ -22,13 +22,13 @@ RSpec.describe "View pending and in-progress parity checks" do
   end
 
   scenario "Viewing the pending parity checks" do
-    run = FactoryBot.create(:parity_check_run, :in_progress, started_at: 1.hour.ago, requests: [])
-    FactoryBot.create(:parity_check_request, :in_progress, run:)
-    FactoryBot.create(:parity_check_request, :completed, run:)
+    run = create(:parity_check_run, :in_progress, started_at: 1.hour.ago, requests: [])
+    create(:parity_check_request, :in_progress, run:)
+    create(:parity_check_request, :completed, run:)
 
-    pending_run_1 = travel_to(1.hour.ago) { FactoryBot.create(:parity_check_run, :pending) }
-    pending_run_2 = travel_to(25.minutes.ago) { FactoryBot.create(:parity_check_run, :pending) }
-    pending_run_3 = travel_to(3.minutes.ago) { FactoryBot.create(:parity_check_run, :pending) }
+    pending_run_1 = travel_to(1.hour.ago) { create(:parity_check_run, :pending) }
+    pending_run_2 = travel_to(25.minutes.ago) { create(:parity_check_run, :pending) }
+    pending_run_3 = travel_to(3.minutes.ago) { create(:parity_check_run, :pending) }
     pending_runs = [pending_run_1, pending_run_2, pending_run_3]
 
     page.goto(new_migration_parity_check_path)

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_an_independent_school_user
-    school = FactoryBot.create(:school, :independent)
-    FactoryBot.create(:appropriate_body, :istip)
+    school = create(:school, :independent)
+    create(:appropriate_body, :istip)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Registering an ECT' do
   before do
-    FactoryBot.create(:appropriate_body, name: 'Golden Leaf Teaching Hub')
+    create(:appropriate_body, name: 'Golden Leaf Teaching Hub')
   end
 
   scenario 'Independent school selects ISTIP as appropriate body' do
@@ -27,7 +27,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_an_independent_school_user
-    school = FactoryBot.create(:school, :independent)
+    school = create(:school, :independent)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_i_sign_in_as_that_school_user
@@ -40,7 +40,7 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def and_an_ongoing_ect_is_assigned_to_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
@@ -83,7 +83,7 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def when_i_enter_an_email_address_of_a_teacher_from_their_finished_school_periods
-    finished_ect = FactoryBot.create(:ect_at_school_period)
+    finished_ect = create(:ect_at_school_period)
     page.get_by_label('email').fill(finished_ect.email)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def school
-    @school ||= FactoryBot.create(:school)
+    @school ||= create(:school)
   end
 
   def given_i_am_logged_in_as_a_school_user
@@ -22,8 +22,8 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def and_an_ect_has_already_registered_at_my_school
-    teacher = FactoryBot.create(:teacher, trn: '9876543')
-    FactoryBot.create(:ect_at_school_period, :active, teacher:, school:)
+    teacher = create(:teacher, trn: '9876543')
+    create(:ect_at_school_period, :active, teacher:, school:)
   end
 
   def when_i_click_continue

--- a/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_school_user
-    school = FactoryBot.create(:school)
+    school = create(:school)
     sign_in_as_school_user(school:)
   end
 

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def create_contract_period_for_start_date
-    @contract_period = FactoryBot.create(
+    @contract_period = create(
       :contract_period,
       started_on: 7.months.ago.beginning_of_month,
       finished_on: 7.months.from_now.end_of_month
@@ -107,8 +107,8 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def create_lead_provider_and_active_lead_provider
-    @lead_provider = FactoryBot.create(:lead_provider, name: 'Orange Institute')
-    FactoryBot.create(
+    @lead_provider = create(:lead_provider, name: 'Orange Institute')
+    create(
       :active_lead_provider,
       lead_provider: @lead_provider,
       contract_period: @contract_period
@@ -116,7 +116,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def create_school_with_previous_choices
-    @school = FactoryBot.create(
+    @school = create(
       :school,
       :state_funded,
       :provider_led_last_chosen,
@@ -126,8 +126,8 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def create_appropriate_bodies
-    FactoryBot.create(:appropriate_body, name: 'Golden Leaf Teaching Hub')
-    FactoryBot.create(:appropriate_body, name: 'Umber Teaching Hub')
+    create(:appropriate_body, name: 'Golden Leaf Teaching Hub')
+    create(:appropriate_body, name: 'Umber Teaching Hub')
   end
 
   def trn

--- a/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
+++ b/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def given_i_am_logged_in_as_a_state_funded_school_user_who_has_previously_registered_an_ect
-    @teacher = FactoryBot.create(:teacher)
-    school = FactoryBot.create(:school)
+    @teacher = create(:teacher)
+    school = create(:school)
 
     ect_at_school_period =
-      FactoryBot.create(
+      create(
         :ect_at_school_period,
         school:,
         teacher: @teacher,
@@ -37,14 +37,14 @@ RSpec.describe 'Registering an ECT' do
         finished_on: Date.new(2024, 7, 31)
       )
 
-    FactoryBot.create(
+    create(
       :training_period,
       ect_at_school_period:,
       started_on: Date.new(2023, 9, 1),
       finished_on: Date.new(2024, 7, 31)
     )
 
-    FactoryBot.create(:induction_period, teacher: @teacher, started_on: Date.new(2023, 9, 1))
+    create(:induction_period, teacher: @teacher, started_on: Date.new(2023, 9, 1))
 
     sign_in_as_school_user(school:)
   end

--- a/spec/features/schools/ects/search_spec.rb
+++ b/spec/features/schools/ects/search_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe 'Searching for an ECT', type: :feature do
   end
 
   def given_there_is_a_school_with_teachers
-    @school = FactoryBot.create(:school)
+    @school = create(:school)
 
-    @matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Jimmy', trs_last_name: 'Searchable')
-    FactoryBot.create(:ect_at_school_period, :active, teacher: @matching_teacher, school: @school)
+    @matching_teacher = create(:teacher, trs_first_name: 'Jimmy', trs_last_name: 'Searchable')
+    create(:ect_at_school_period, :active, teacher: @matching_teacher, school: @school)
 
-    @non_matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Invisible')
-    FactoryBot.create(:ect_at_school_period, :active, teacher: @non_matching_teacher, school: @school)
+    @non_matching_teacher = create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Invisible')
+    create(:ect_at_school_period, :active, teacher: @non_matching_teacher, school: @school)
   end
 
   def and_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -32,18 +32,18 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    @ect = FactoryBot.create(:ect_at_school_period, :active, lead_provider:, school: @school)
+    lead_provider = create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @ect = create(:ect_at_school_period, :active, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
-    teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    teacher = create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @mentor = create(:mentor_at_school_period, :active, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -29,18 +29,18 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    @ect = FactoryBot.create(:ect_at_school_period, :active, lead_provider:, school: @school)
+    lead_provider = create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @ect = create(:ect_at_school_period, :active, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
-    teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    teacher = create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @mentor = create(:mentor_at_school_period, :active, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_i_sign_in_as_that_school_user
@@ -47,7 +47,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -25,17 +25,17 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
-    teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    teacher = create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @mentor = create(:mentor_at_school_period, :active, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_i_sign_in_as_that_school_user
@@ -88,9 +88,9 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :active, lead_provider:, school: @school)
+    lead_provider = create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    create(:active_lead_provider, lead_provider:, contract_period: create(:contract_period, year: Date.current.year))
+    @ect = create(:ect_at_school_period, :active, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/search_spec.rb
+++ b/spec/features/schools/mentors/search_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe 'Searching for a mentor', type: :feature do
   end
 
   def given_there_is_a_school_with_teachers
-    @school = FactoryBot.create(:school)
+    @school = create(:school)
 
-    @matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Jimmy', trs_last_name: 'Searchable')
-    FactoryBot.create(:mentor_at_school_period, :active, teacher: @matching_teacher, school: @school)
+    @matching_teacher = create(:teacher, trs_first_name: 'Jimmy', trs_last_name: 'Searchable')
+    create(:mentor_at_school_period, :active, teacher: @matching_teacher, school: @school)
 
-    @non_matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Invisible')
-    FactoryBot.create(:mentor_at_school_period, :active, teacher: @non_matching_teacher, school: @school)
+    @non_matching_teacher = create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Invisible')
+    create(:mentor_at_school_period, :active, teacher: @non_matching_teacher, school: @school)
   end
 
   def and_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -20,12 +20,12 @@ private
   def given_that_i_have_an_active_mentor_with_an_ect
     start_date = Date.new(2023, 9, 1)
 
-    @school = FactoryBot.create(:school, urn: '1234567')
-    @mentor_teacher = FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki')
-    @mentor = FactoryBot.create(:mentor_at_school_period, teacher: @mentor_teacher, school: @school, started_on: start_date, finished_on: nil, id: 1)
+    @school = create(:school, urn: '1234567')
+    @mentor_teacher = create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki')
+    @mentor = create(:mentor_at_school_period, teacher: @mentor_teacher, school: @school, started_on: start_date, finished_on: nil, id: 1)
 
-    @ect_teacher = FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki')
-    @ect = FactoryBot.create(
+    @ect_teacher = create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki')
+    @ect = create(
       :ect_at_school_period,
       :provider_led,
       teacher: @ect_teacher,
@@ -34,7 +34,7 @@ private
       finished_on: nil
     )
 
-    FactoryBot.create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
+    create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
   end
 
   def given_i_click_on_an_assigned_ect

--- a/spec/features/schools/mentorship/add_a_mentor_to_an_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_an_ect_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Add a mentor to an ECT' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_i_sign_in_as_that_school_user
@@ -25,12 +25,12 @@ RSpec.describe 'Add a mentor to an ECT' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = create(:ect_at_school_period, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, started_on: @ect.started_on)
+    @mentor = create(:mentor_at_school_period, :active, school: @school, started_on: @ect.started_on)
     @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
   end
 

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def given_there_is_a_school_in_the_service
-    @school = FactoryBot.create(:school, urn: "1234567")
+    @school = create(:school, urn: "1234567")
   end
 
   def and_i_sign_in_as_that_school_user
@@ -51,14 +51,14 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :active, lead_provider:, school: @school)
+    lead_provider = create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    create(:active_lead_provider, lead_provider:, contract_period: create(:contract_period, year: Date.current.year))
+    @ect = create(:ect_at_school_period, :active, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school)
+    @mentor = create(:mentor_at_school_period, :active, school: @school)
     @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
   end
 

--- a/spec/forms/sessions/otp_sign_in_form_spec.rb
+++ b/spec/forms/sessions/otp_sign_in_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sessions::OTPSignInForm, type: :model do
     let(:email) { "bob@example.com" }
     let(:code) { "123456" }
     let(:result) { 987_654 }
-    let!(:user) { FactoryBot.create(:user, email:) }
+    let!(:user) { create(:user, email:) }
 
     let(:mock_otp_service) { instance_double(Sessions::OneTimePassword, user: User.new(email:)) }
 

--- a/spec/helpers/appropriate_body_helper_spec.rb
+++ b/spec/helpers/appropriate_body_helper_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
   describe "#summary_card_for_teacher" do
     subject(:summary_card) { summary_card_for_teacher(teacher:) }
 
-    let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White') }
+    let(:teacher) { create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White') }
 
     it "builds a summary card for a teacher" do
       expect(summary_card).to have_selector('.govuk-summary-card__title', text: 'Barry White')
@@ -52,9 +52,9 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
     context "when the teacher has induction periods" do
       let(:expected_date) { "2 October 2022" }
       let!(:induction_period) do
-        FactoryBot.create(
+        create(
           :induction_period,
-          appropriate_body: FactoryBot.create(:appropriate_body),
+          appropriate_body: create(:appropriate_body),
           teacher:,
           started_on: Date.parse(expected_date)
         )
@@ -73,7 +73,7 @@ RSpec.describe AppropriateBodyHelper, type: :helper do
   end
 
   describe "#pending_induction_submission_full_name" do
-    let(:pending_induction_submission) { FactoryBot.build(:pending_induction_submission) }
+    let(:pending_induction_submission) { build(:pending_induction_submission) }
     let(:fake_name) { double(PendingInductionSubmissions::Name, full_name: "Joey") }
 
     before do

--- a/spec/helpers/batch_helper_spec.rb
+++ b/spec/helpers/batch_helper_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe BatchHelper, type: :helper do
 
     let(:batches) do
       [
-        FactoryBot.create(:pending_induction_submission_batch, :claim, :completed),
-        FactoryBot.create(:pending_induction_submission_batch, :claim, :processed),
-        FactoryBot.create(:pending_induction_submission_batch, :claim, :processing)
+        create(:pending_induction_submission_batch, :claim, :completed),
+        create(:pending_induction_submission_batch, :claim, :processed),
+        create(:pending_induction_submission_batch, :claim, :processing)
       ]
     end
 
@@ -57,7 +57,7 @@ RSpec.describe BatchHelper, type: :helper do
   end
 
   context "with a single batch" do
-    let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :action, :completed) }
+    let(:batch) { create(:pending_induction_submission_batch, :action, :completed) }
 
     describe "#batch_status_tag" do
       it do

--- a/spec/helpers/ect_helper_spec.rb
+++ b/spec/helpers/ect_helper_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe ECTHelper, type: :helper do
   describe "#ect_status" do
     let(:started_on) { 10.days.ago }
-    let(:school) { FactoryBot.create(:school) }
-    let(:ect_teacher) { FactoryBot.create(:teacher, trs_induction_status:) }
+    let(:school) { create(:school) }
+    let(:ect_teacher) { create(:teacher, trs_induction_status:) }
     let(:trs_induction_status) { nil }
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, teacher: ect_teacher, school:, started_on:) }
-    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, school:, started_on:) }
+    let!(:ect_at_school_period) { create(:ect_at_school_period, :active, teacher: ect_teacher, school:, started_on:) }
+    let!(:mentor_at_school_period) { create(:mentor_at_school_period, :active, school:, started_on:) }
 
     context "when the ECT has a TRS induction status" do
       context "when the status is Passed" do
@@ -36,7 +36,7 @@ RSpec.describe ECTHelper, type: :helper do
 
     context "when the ECT has an empty TRS induction status" do
       context "when the ECT has a current mentor" do
-        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :active, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+        let!(:mentorship_period) { create(:mentorship_period, :active, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
 
         it "returns a green 'Registered' tag" do
           expect(helper.ect_status(ect_at_school_period)).to have_css('strong.govuk-tag.govuk-tag--green', text: 'Registered')

--- a/spec/helpers/induction_helper_spec.rb
+++ b/spec/helpers/induction_helper_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe InductionHelper, type: :helper do
   describe '#claiming_body?' do
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
-    let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:teacher) { create(:teacher) }
+    let(:induction_period) { create(:induction_period, :active, teacher:) }
+    let(:other_appropriate_body) { create(:appropriate_body) }
 
     it 'returns true when the current induction is with the claiming body' do
       expect(helper.claiming_body?(teacher, induction_period.appropriate_body)).to be true

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe ParityCheckHelper, type: :helper do
 
     let(:endpoints) do
       [
-        FactoryBot.build(:parity_check_endpoint, path: "/api/v1/users"),
-        FactoryBot.build(:parity_check_endpoint, path: "/api/v3/users/create"),
-        FactoryBot.build(:parity_check_endpoint, path: "/api/v2/participant-declarations"),
-        FactoryBot.build(:parity_check_endpoint, path: "/login"),
+        build(:parity_check_endpoint, path: "/api/v1/users"),
+        build(:parity_check_endpoint, path: "/api/v3/users/create"),
+        build(:parity_check_endpoint, path: "/api/v2/participant-declarations"),
+        build(:parity_check_endpoint, path: "/login"),
       ]
     end
 
@@ -25,10 +25,10 @@ RSpec.describe ParityCheckHelper, type: :helper do
 
     let(:requests) do
       [
-        FactoryBot.build(:parity_check_request, endpoint: FactoryBot.build(:parity_check_endpoint, path: "/api/v1/users")),
-        FactoryBot.build(:parity_check_request, endpoint: FactoryBot.build(:parity_check_endpoint, path: "/api/v3/users/create")),
-        FactoryBot.build(:parity_check_request, endpoint: FactoryBot.build(:parity_check_endpoint, path: "/api/v2/participant-declarations")),
-        FactoryBot.build(:parity_check_request, endpoint: FactoryBot.build(:parity_check_endpoint, path: "/login")),
+        build(:parity_check_request, endpoint: build(:parity_check_endpoint, path: "/api/v1/users")),
+        build(:parity_check_request, endpoint: build(:parity_check_endpoint, path: "/api/v3/users/create")),
+        build(:parity_check_request, endpoint: build(:parity_check_endpoint, path: "/api/v2/participant-declarations")),
+        build(:parity_check_request, endpoint: build(:parity_check_endpoint, path: "/login")),
       ]
     end
 
@@ -50,7 +50,7 @@ RSpec.describe ParityCheckHelper, type: :helper do
   describe "#formatted_endpoint_group_names" do
     subject { helper.formatted_endpoint_group_names(run) }
 
-    let(:run) { FactoryBot.build(:parity_check_run) }
+    let(:run) { build(:parity_check_run) }
 
     before { allow(run).to receive(:request_group_names).and_return(%i[participant-declarations users]) }
 
@@ -166,7 +166,7 @@ RSpec.describe ParityCheckHelper, type: :helper do
     subject { helper.sanitize_diff(html) }
 
     let(:html) { response.body_diff.to_s(:html) }
-    let(:response) { FactoryBot.build(:parity_check_response, :different) }
+    let(:response) { build(:parity_check_response, :different) }
 
     it { is_expected.to eq(html.html_safe) }
 

--- a/spec/helpers/teacher_helper_spec.rb
+++ b/spec/helpers/teacher_helper_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe TeacherHelper, type: :helper do
   let(:teacher) do
-    FactoryBot.create(:teacher,
-                      trn: '1234567',
-                      trs_first_name: 'Barry',
-                      trs_last_name: 'White')
+    create(:teacher,
+           trn: '1234567',
+           trs_first_name: 'Barry',
+           trs_last_name: 'White')
   end
 
   describe '#teacher_full_name' do
@@ -26,7 +26,7 @@ RSpec.describe TeacherHelper, type: :helper do
 
   describe '#teacher_induction_start_date' do
     context 'when training' do
-      before { FactoryBot.create(:induction_period, teacher:) }
+      before { create(:induction_period, teacher:) }
 
       it { expect(teacher_induction_start_date(teacher)).to eq(1.year.ago.to_date.to_fs(:govuk)) }
     end
@@ -38,7 +38,7 @@ RSpec.describe TeacherHelper, type: :helper do
 
   describe '#teacher_induction_programme' do
     context 'when training' do
-      before { FactoryBot.create(:induction_period, teacher:) }
+      before { create(:induction_period, teacher:) }
 
       it { expect(teacher_induction_programme(teacher)).to eq('Full induction programme') }
     end
@@ -50,7 +50,7 @@ RSpec.describe TeacherHelper, type: :helper do
 
   describe '#teacher_induction_ab_name' do
     context 'when training' do
-      before { FactoryBot.create(:induction_period, teacher:) }
+      before { create(:induction_period, teacher:) }
 
       it { expect(teacher_induction_ab_name(teacher)).to match(/Appropriate Body \d/) }
     end

--- a/spec/jobs/begin_ect_induction_job_spec.rb
+++ b/spec/jobs/begin_ect_induction_job_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe BeginECTInductionJob, type: :job do
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:trn) { teacher.trn }
   let(:start_date) { "2024-01-13" }
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:pending_induction_submission) { create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
 

--- a/spec/jobs/fail_ect_induction_job_spec.rb
+++ b/spec/jobs/fail_ect_induction_job_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe FailECTInductionJob, type: :job do
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:trn) { teacher.trn }
   let(:start_date) { "2023-11-13" }
   let(:completed_date) { "2024-01-13" }
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:pending_induction_submission) { create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
   let(:refresh_service) { instance_double(Teachers::RefreshTRSAttributes) }

--- a/spec/jobs/parity_check_request_job_spec.rb
+++ b/spec/jobs/parity_check_request_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ParityCheckRequestJob, type: :job do
   describe "#perform" do
     it "calls the ParityCheck::RequestHandler service with the request" do
-      request = FactoryBot.create(:parity_check_request)
+      request = create(:parity_check_request)
       request_handler = instance_double(ParityCheck::RequestHandler)
 
       allow(ParityCheck::RequestHandler).to receive(:new).with(request).and_return(request_handler)

--- a/spec/jobs/pass_ect_induction_job_spec.rb
+++ b/spec/jobs/pass_ect_induction_job_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe PassECTInductionJob, type: :job do
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:trn) { teacher.trn }
   let(:start_date) { "2023-11-13" }
   let(:completed_date) { "2024-01-13" }
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:pending_induction_submission) { create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
   let(:refresh_service) { instance_double(Teachers::RefreshTRSAttributes) }

--- a/spec/jobs/process_batch_action_job_spec.rb
+++ b/spec/jobs/process_batch_action_job_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe ProcessBatchActionJob, type: :job do
   include_context 'fake trs api client'
 
-  let(:author) { FactoryBot.create(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
+  let(:author) { create(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe '#perform' do
     let(:submissions) do
@@ -12,9 +12,9 @@ RSpec.describe ProcessBatchActionJob, type: :job do
 
     context 'with valid complete data' do
       let(:pending_induction_submission_batch) do
-        FactoryBot.create(:pending_induction_submission_batch, :action,
-                          appropriate_body:,
-                          data:)
+        create(:pending_induction_submission_batch, :action,
+               appropriate_body:,
+               data:)
       end
 
       include_context '3 valid actions'

--- a/spec/jobs/process_batch_claim_job_spec.rb
+++ b/spec/jobs/process_batch_claim_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ProcessBatchClaimJob, type: :job do
   include_context 'fake trs api client'
 
-  let(:author) { FactoryBot.create(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
+  let(:author) { create(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
 
   before do
     described_class.perform_now(pending_induction_submission_batch, author.email, author.name)
@@ -13,11 +13,11 @@ RSpec.describe ProcessBatchClaimJob, type: :job do
     end
 
     context 'with valid complete data' do
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:appropriate_body) { create(:appropriate_body) }
       let(:pending_induction_submission_batch) do
-        FactoryBot.create(:pending_induction_submission_batch, :claim,
-                          appropriate_body:,
-                          data:)
+        create(:pending_induction_submission_batch, :claim,
+               appropriate_body:,
+               data:)
       end
 
       include_context '2 valid claims'

--- a/spec/jobs/process_batch_job_spec.rb
+++ b/spec/jobs/process_batch_job_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe ProcessBatchJob, type: :job do
-  let(:author) { FactoryBot.build(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
+  let(:author) { build(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
 
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:appropriate_body) { build(:appropriate_body) }
 
   let(:pending_induction_submission_batch) do
-    FactoryBot.build(:pending_induction_submission_batch, appropriate_body:)
+    build(:pending_induction_submission_batch, appropriate_body:)
   end
 
   describe '#perform' do

--- a/spec/jobs/purge_pending_induction_submissions_job_spec.rb
+++ b/spec/jobs/purge_pending_induction_submissions_job_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe PurgePendingInductionSubmissionsJob, type: :job do
   describe "#perform" do
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:appropriate_body) { create(:appropriate_body) }
 
     it "deletes pending induction submissions with delete_at in the past" do
       # submissions that should be deleted
-      past_submissions = FactoryBot.create_list(
+      past_submissions = create_list(
         :pending_induction_submission,
         3,
         appropriate_body:,
@@ -12,7 +12,7 @@ RSpec.describe PurgePendingInductionSubmissionsJob, type: :job do
       )
 
       # submissions with delete_at in the future
-      FactoryBot.create_list(
+      create_list(
         :pending_induction_submission,
         2,
         appropriate_body:,
@@ -20,7 +20,7 @@ RSpec.describe PurgePendingInductionSubmissionsJob, type: :job do
       )
 
       # submissions with no delete_at
-      FactoryBot.create_list(
+      create_list(
         :pending_induction_submission,
         2,
         appropriate_body:,

--- a/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
+++ b/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Teachers::ScheduleTRSSyncJob, type: :job do
   describe "#perform" do
-    let!(:teacher0) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: nil) }
-    let!(:teacher1) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 5.days.ago) }
-    let!(:teacher2) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 4.days.ago) }
-    let!(:teacher3) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 3.days.ago) }
-    let!(:teacher4) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 2.days.ago) }
-    let!(:teacher5) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 1.day.ago) }
-    let!(:teacher6) { FactoryBot.create(:teacher, :deactivated_in_trs, trs_data_last_refreshed_at: 0.days.ago) }
+    let!(:teacher0) { create(:teacher, trs_data_last_refreshed_at: nil) }
+    let!(:teacher1) { create(:teacher, trs_data_last_refreshed_at: 5.days.ago) }
+    let!(:teacher2) { create(:teacher, trs_data_last_refreshed_at: 4.days.ago) }
+    let!(:teacher3) { create(:teacher, trs_data_last_refreshed_at: 3.days.ago) }
+    let!(:teacher4) { create(:teacher, trs_data_last_refreshed_at: 2.days.ago) }
+    let!(:teacher5) { create(:teacher, trs_data_last_refreshed_at: 1.day.ago) }
+    let!(:teacher6) { create(:teacher, :deactivated_in_trs, trs_data_last_refreshed_at: 0.days.ago) }
 
     it "schedules sync jobs for teachers ordered by trs_data_last_refreshed_at" do
       [

--- a/spec/jobs/teachers/sync_teacher_with_trs_job_spec.rb
+++ b/spec/jobs/teachers/sync_teacher_with_trs_job_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Teachers::SyncTeacherWithTRSJob, type: :job do
   describe "#perform" do
-    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:teacher) { create(:teacher) }
     let(:refresh_service) { instance_double(Teachers::RefreshTRSAttributes) }
 
     it "calls the RefreshTRSAttributes service with the correct teacher" do

--- a/spec/migration/builders/ect/school_periods_spec.rb
+++ b/spec/migration/builders/ect/school_periods_spec.rb
@@ -1,11 +1,11 @@
 describe Builders::ECT::SchoolPeriods do
   subject(:service) { described_class.new(teacher:, school_periods:) }
 
-  let(:school_1) { FactoryBot.create(:school, urn: "123456") }
-  let(:school_2) { FactoryBot.create(:school, urn: "987654") }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:period_1) { FactoryBot.build(:school_period, urn: school_1.urn, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:period_2) { FactoryBot.build(:school_period, urn: school_2.urn, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:school_1) { create(:school, urn: "123456") }
+  let(:school_2) { create(:school, urn: "987654") }
+  let(:teacher) { create(:teacher) }
+  let(:period_1) { build(:school_period, urn: school_1.urn, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+  let(:period_2) { build(:school_period, urn: school_2.urn, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:school_periods) { [period_1, period_2] }
 
   describe "#build" do
@@ -33,7 +33,7 @@ describe Builders::ECT::SchoolPeriods do
     end
 
     context "when the school does not exist" do
-      let(:period_1) { FactoryBot.build(:school_period, urn: "12121", start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+      let(:period_1) { build(:school_period, urn: "12121", start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {
@@ -43,7 +43,7 @@ describe Builders::ECT::SchoolPeriods do
     end
 
     context "when the school period dates cause a validation error " do
-      let(:period_2) { FactoryBot.build(:school_period, urn: school_2.urn, start_date: 2.months.ago.to_date, end_date: nil) }
+      let(:period_2) { build(:school_period, urn: school_2.urn, start_date: 2.months.ago.to_date, end_date: nil) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -1,16 +1,16 @@
 describe Builders::ECT::TrainingPeriods do
   subject(:service) { described_class.new(teacher:, training_period_data:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, contract_period:) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, contract_period:) }
-  let(:school_1) { FactoryBot.create(:school, :independent, urn: "123456") }
-  let(:school_2) { FactoryBot.create(:school, :independent, urn: "987654") }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:school_period_1) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
-  let!(:school_period_2) { FactoryBot.create(:ect_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
-  let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:contract_period) { create(:contract_period) }
+  let(:partnership_1) { create(:school_partnership, contract_period:) }
+  let(:partnership_2) { create(:school_partnership, contract_period:) }
+  let(:school_1) { create(:school, :independent, urn: "123456") }
+  let(:school_2) { create(:school, :independent, urn: "987654") }
+  let(:teacher) { create(:teacher) }
+  let!(:school_period_1) { create(:ect_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
+  let!(:school_period_2) { create(:ect_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
+  let(:training_period_1) { build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+  let(:training_period_2) { build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
   describe "#build", pending: "will be reworked once EOI schema is done" do
@@ -38,7 +38,7 @@ describe Builders::ECT::TrainingPeriods do
     end
 
     context "when there is no ECTAtSchoolPeriod that contains the training dates" do
-      let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 14.months.ago.to_date, end_date: 1.month.ago.to_date) }
+      let(:training_period_1) { build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 14.months.ago.to_date, end_date: 1.month.ago.to_date) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {

--- a/spec/migration/builders/mentor/school_periods_spec.rb
+++ b/spec/migration/builders/mentor/school_periods_spec.rb
@@ -1,11 +1,11 @@
 describe Builders::Mentor::SchoolPeriods do
   subject(:service) { described_class.new(teacher:, school_periods:) }
 
-  let(:school_1) { FactoryBot.create(:school, urn: "123456") }
-  let(:school_2) { FactoryBot.create(:school, urn: "987654") }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:period_1) { FactoryBot.build(:school_period, urn: school_1.urn, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:period_2) { FactoryBot.build(:school_period, urn: school_2.urn, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:school_1) { create(:school, urn: "123456") }
+  let(:school_2) { create(:school, urn: "987654") }
+  let(:teacher) { create(:teacher) }
+  let(:period_1) { build(:school_period, urn: school_1.urn, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+  let(:period_2) { build(:school_period, urn: school_2.urn, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:school_periods) { [period_1, period_2] }
 
   describe "#build" do
@@ -33,7 +33,7 @@ describe Builders::Mentor::SchoolPeriods do
     end
 
     context "when the school does not exist" do
-      let(:period_1) { FactoryBot.build(:school_period, urn: "12121", start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+      let(:period_1) { build(:school_period, urn: "12121", start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {
@@ -43,7 +43,7 @@ describe Builders::Mentor::SchoolPeriods do
     end
 
     context "when the school period dates overlap" do
-      let(:period_2) { FactoryBot.build(:school_period, urn: school_2.urn, start_date: 2.months.ago.to_date, end_date: nil) }
+      let(:period_2) { build(:school_period, urn: school_2.urn, start_date: 2.months.ago.to_date, end_date: nil) }
 
       it "does not create a TeacherMigrationFailure record" do
         expect {

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -1,16 +1,16 @@
 describe Builders::Mentor::TrainingPeriods do
   subject(:service) { described_class.new(teacher:, training_period_data:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, contract_period:) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, contract_period:) }
-  let(:school_1) { FactoryBot.create(:school, urn: "123456") }
-  let(:school_2) { FactoryBot.create(:school, urn: "987654") }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:school_period_1) { FactoryBot.create(:mentor_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
-  let!(:school_period_2) { FactoryBot.create(:mentor_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
-  let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:contract_period) { create(:contract_period) }
+  let(:partnership_1) { create(:school_partnership, contract_period:) }
+  let(:partnership_2) { create(:school_partnership, contract_period:) }
+  let(:school_1) { create(:school, urn: "123456") }
+  let(:school_2) { create(:school, urn: "987654") }
+  let(:teacher) { create(:teacher) }
+  let!(:school_period_1) { create(:mentor_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
+  let!(:school_period_2) { create(:mentor_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
+  let(:training_period_1) { build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+  let(:training_period_2) { build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
   describe "#build", pending: "will be reworked once EOI schema is done" do
@@ -38,7 +38,7 @@ describe Builders::Mentor::TrainingPeriods do
     end
 
     context "when there is no MentorAtSchoolPeriod that contains the training dates" do
-      let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 14.months.ago.to_date, end_date: 1.month.ago.to_date) }
+      let(:training_period_1) { build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 14.months.ago.to_date, end_date: 1.month.ago.to_date) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {

--- a/spec/migration/builders/mentorship_periods_spec.rb
+++ b/spec/migration/builders/mentorship_periods_spec.rb
@@ -1,34 +1,34 @@
 describe Builders::MentorshipPeriods do
   subject(:service) { described_class.new(teacher:, mentorship_period_data:) }
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:started_on) { 2.years.ago.to_date }
   let(:finished_on) { 6.months.ago.to_date }
-  let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :active, teacher:, started_on:, finished_on:) }
+  let!(:ect_period) { create(:ect_at_school_period, :active, teacher:, started_on:, finished_on:) }
   let(:mentor_period_1) do
-    FactoryBot.create(:mentor_at_school_period,
-                      :active,
-                      school: ect_period.school,
-                      started_on: started_on + 1.day)
+    create(:mentor_at_school_period,
+           :active,
+           school: ect_period.school,
+           started_on: started_on + 1.day)
   end
   let(:mentor_period_2) do
-    FactoryBot.create(:mentor_at_school_period,
-                      :active,
-                      school: ect_period.school,
-                      started_on: started_on - 1.week)
+    create(:mentor_at_school_period,
+           :active,
+           school: ect_period.school,
+           started_on: started_on - 1.week)
   end
 
   let(:mentorship_period_1) do
-    FactoryBot.build(:mentorship_period_data,
-                     mentor_teacher: mentor_period_1.teacher,
-                     start_date: started_on + 2.days,
-                     end_date: started_on + 2.weeks)
+    build(:mentorship_period_data,
+          mentor_teacher: mentor_period_1.teacher,
+          start_date: started_on + 2.days,
+          end_date: started_on + 2.weeks)
   end
   let(:mentorship_period_2) do
-    FactoryBot.build(:mentorship_period_data,
-                     mentor_teacher: mentor_period_2.teacher,
-                     start_date: started_on + 1.month,
-                     end_date: started_on + 3.months)
+    build(:mentorship_period_data,
+          mentor_teacher: mentor_period_2.teacher,
+          start_date: started_on + 1.month,
+          end_date: started_on + 3.months)
   end
   let(:mentorship_period_data) { [mentorship_period_1, mentorship_period_2] }
 
@@ -57,7 +57,7 @@ describe Builders::MentorshipPeriods do
     end
 
     context "when there is no ECTAtSchoolPeriod that contains the training dates" do
-      let!(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: started_on + 1.month, finished_on:) }
+      let!(:ect_period) { create(:ect_at_school_period, teacher:, started_on: started_on + 1.month, finished_on:) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {
@@ -72,7 +72,7 @@ describe Builders::MentorshipPeriods do
     end
 
     context "when there is no MentorAtSchoolPeriod that contains the training dates" do
-      let(:mentor_period_2) { FactoryBot.create(:mentor_at_school_period, school: ect_period.school, started_on: 1.month.ago) }
+      let(:mentor_period_2) { create(:mentor_at_school_period, school: ect_period.school, started_on: 1.month.ago) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {
@@ -87,7 +87,7 @@ describe Builders::MentorshipPeriods do
     end
 
     context "when the mentor does not have a MentorAtSchoolPeriod at the same school" do
-      let(:mentor_period_1) { FactoryBot.create(:mentor_at_school_period, :active, started_on: started_on + 1.day) }
+      let(:mentor_period_1) { create(:mentor_at_school_period, :active, started_on: started_on + 1.day) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {

--- a/spec/migration/builders/teacher_spec.rb
+++ b/spec/migration/builders/teacher_spec.rb
@@ -40,7 +40,7 @@ describe Builders::Teacher do
     end
 
     context "when a teacher with the same TRN already exists" do
-      let!(:existing_record) { FactoryBot.create(:teacher, trn:, trs_first_name: "Tucker", trs_last_name: "Jenkins") }
+      let!(:existing_record) { create(:teacher, trn:, trs_first_name: "Tucker", trs_last_name: "Jenkins") }
 
       it "returns the matched teacher record" do
         expect(subject.build.id).to eq existing_record.id
@@ -62,7 +62,7 @@ describe Builders::Teacher do
 
       context "when the corrected_name is already set" do
         let!(:existing_record) do
-          FactoryBot.create(:teacher, trn:, trs_first_name: "Tucker", trs_last_name: "Jenkins", corrected_name: "Bert Ward")
+          create(:teacher, trn:, trs_first_name: "Tucker", trs_last_name: "Jenkins", corrected_name: "Bert Ward")
         end
 
         it "does not change the corrected_name" do

--- a/spec/migration/legacy_data_importer_spec.rb
+++ b/spec/migration/legacy_data_importer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe LegacyDataImporter do
     end
 
     it "destroys any DataMigration records" do
-      FactoryBot.create_list(:data_migration, 2)
+      create_list(:data_migration, 2)
       [migrator1, migrator2].each { |migrator| allow(migrator).to receive(:reset!) }
 
       expect {

--- a/spec/migration/migrators/active_lead_provider_spec.rb
+++ b/spec/migration/migrators/active_lead_provider_spec.rb
@@ -1,21 +1,21 @@
 describe Migrators::ActiveLeadProvider do
   it_behaves_like "a migrator", :active_lead_provider, %i[lead_provider contract_period] do
     def create_migration_resource
-      FactoryBot.create(:migration_lead_provider, :active)
+      create(:migration_lead_provider, :active)
     end
 
     def create_resource(migration_resource)
       # creating dependencies resources
-      FactoryBot.create(:lead_provider, name: migration_resource.name, ecf_id: migration_resource.id)
-      FactoryBot.create(:contract_period, year: migration_resource.cohorts.first.start_year)
+      create(:lead_provider, name: migration_resource.name, ecf_id: migration_resource.id)
+      create(:contract_period, year: migration_resource.cohorts.first.start_year)
 
-      FactoryBot.create(:active_lead_provider)
+      create(:active_lead_provider)
     end
 
     def setup_failure_state
       # Record to be migrated with unmet dependencies in the destination db
-      lead_provider = FactoryBot.create(:migration_lead_provider)
-      lead_provider.cohorts << FactoryBot.create(:migration_cohort)
+      lead_provider = create(:migration_lead_provider)
+      lead_provider.cohorts << create(:migration_cohort)
       lead_provider
     end
 

--- a/spec/migration/migrators/contract_period_spec.rb
+++ b/spec/migration/migrators/contract_period_spec.rb
@@ -1,16 +1,16 @@
 describe Migrators::ContractPeriod do
   it_behaves_like "a migrator", :contract_period, [] do
     def create_migration_resource
-      FactoryBot.create(:migration_cohort, :with_sequential_start_year)
+      create(:migration_cohort, :with_sequential_start_year)
     end
 
     def create_resource(migration_resource)
-      FactoryBot.create(:contract_period, year: migration_resource.start_year)
+      create(:contract_period, year: migration_resource.start_year)
     end
 
     def setup_failure_state
       # Record to be migrated with invalid start year
-      FactoryBot.create(:migration_cohort, start_year: 2010)
+      create(:migration_cohort, start_year: 2010)
     end
 
     describe "#migrate!" do

--- a/spec/migration/migrators/delivery_partner_spec.rb
+++ b/spec/migration/migrators/delivery_partner_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Migrators::DeliveryPartner do
 
   describe '.record_count' do
     it 'returns the count of delivery partners' do
-      FactoryBot.create_list(:migration_delivery_partner, 2)
+      create_list(:migration_delivery_partner, 2)
       expect(described_class.record_count).to eq(2)
     end
   end
@@ -17,14 +17,14 @@ RSpec.describe Migrators::DeliveryPartner do
 
   describe '.delivery_partners' do
     it 'returns all delivery_partners' do
-      delivery_partner = FactoryBot.create(:migration_delivery_partner)
+      delivery_partner = create(:migration_delivery_partner)
       expect(described_class.delivery_partners).to include(delivery_partner)
     end
   end
 
   describe '.reset!' do
     before do
-      FactoryBot.create(:delivery_partner)
+      create(:delivery_partner)
       allow(Rails.application.config).to receive(:enable_migration_testing).and_return(enable_migration_testing)
     end
 
@@ -48,9 +48,9 @@ RSpec.describe Migrators::DeliveryPartner do
   describe '#migrate!' do
     subject { described_class.new(worker: 0) }
 
-    let!(:delivery_partner1) { FactoryBot.create(:migration_delivery_partner) }
-    let!(:delivery_partner2) { FactoryBot.create(:migration_delivery_partner) }
-    let!(:data_migration) { FactoryBot.create(:data_migration, model: :delivery_partner) }
+    let!(:delivery_partner1) { create(:migration_delivery_partner) }
+    let!(:delivery_partner2) { create(:migration_delivery_partner) }
+    let!(:data_migration) { create(:data_migration, model: :delivery_partner) }
 
     before { subject.migrate! }
 

--- a/spec/migration/migrators/ect_at_school_period_spec.rb
+++ b/spec/migration/migrators/ect_at_school_period_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Migrators::ECTAtSchoolPeriod do
   it_behaves_like "a migrator", :ect_at_school_period, %i[teacher school] do
     def create_migration_resource
-      ect = FactoryBot.create(:migration_participant_profile, :ect)
-      FactoryBot.create(:migration_induction_record, participant_profile: ect)
+      ect = create(:migration_participant_profile, :ect)
+      create(:migration_induction_record, participant_profile: ect)
       ect.teacher_profile
     end
 
     def create_resource(migration_resource)
-      FactoryBot.create(:teacher, trn: migration_resource.trn)
-      FactoryBot.create(:school, urn: migration_resource.participant_profiles.first.school_cohort.school.urn)
+      create(:teacher, trn: migration_resource.trn)
+      create(:school, urn: migration_resource.participant_profiles.first.school_cohort.school.urn)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/example_spec.rb
+++ b/spec/migration/migrators/example_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Some Migrator' do
   it 'creates a School record in the ecf2 database' do
-    expect { FactoryBot.create(:school) }.to change(School, :count).by(1)
+    expect { create(:school) }.to change(School, :count).by(1)
   end
 
   it 'create a School record in the ecf database' do
-    expect { FactoryBot.create(:ecf_migration_school) }.to change(Migration::School, :count).by(1)
+    expect { create(:ecf_migration_school) }.to change(Migration::School, :count).by(1)
   end
 end

--- a/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
+++ b/spec/migration/migrators/lead_provider_delivery_partnership_spec.rb
@@ -1,7 +1,7 @@
 describe Migrators::LeadProviderDeliveryPartnership do
   it_behaves_like "a migrator", :lead_provider_delivery_partnership, %i[contract_period active_lead_provider delivery_partner] do
     def create_migration_resource
-      FactoryBot.create(:migration_provider_relationship)
+      create(:migration_provider_relationship)
     end
 
     def create_resource(migration_resource)
@@ -9,10 +9,10 @@ describe Migrators::LeadProviderDeliveryPartnership do
       lp = migration_resource.lead_provider
       dp = migration_resource.delivery_partner
 
-      contract_period = FactoryBot.create(:contract_period, year: cohort.start_year)
-      lead_provider = FactoryBot.create(:lead_provider, name: lp.name, ecf_id: lp.id)
-      FactoryBot.create(:delivery_partner, name: dp.name, api_id: dp.id)
-      FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
+      contract_period = create(:contract_period, year: cohort.start_year)
+      lead_provider = create(:lead_provider, name: lp.name, ecf_id: lp.id)
+      create(:delivery_partner, name: dp.name, api_id: dp.id)
+      create(:active_lead_provider, lead_provider:, contract_period:)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/lead_provider_spec.rb
+++ b/spec/migration/migrators/lead_provider_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe Migrators::LeadProvider do
   it_behaves_like "a migrator", :lead_provider, [] do
     def create_migration_resource
-      FactoryBot.create(:migration_lead_provider)
+      create(:migration_lead_provider)
     end
 
     def create_resource(migration_resource)
     end
 
     def setup_failure_state
-      lp = FactoryBot.create(:migration_lead_provider)
-      FactoryBot.create(:lead_provider, name: lp.name, ecf_id: SecureRandom.uuid)
+      lp = create(:migration_lead_provider)
+      create(:lead_provider, name: lp.name, ecf_id: SecureRandom.uuid)
     end
 
     describe "#migrate!" do

--- a/spec/migration/migrators/mentor_at_school_period_spec.rb
+++ b/spec/migration/migrators/mentor_at_school_period_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Migrators::MentorAtSchoolPeriod do
   it_behaves_like "a migrator", :mentor_at_school_period, %i[teacher school] do
     def create_migration_resource
-      mentor = FactoryBot.create(:migration_participant_profile, :mentor)
-      FactoryBot.create(:migration_induction_record, participant_profile: mentor)
+      mentor = create(:migration_participant_profile, :mentor)
+      create(:migration_induction_record, participant_profile: mentor)
       mentor.teacher_profile
     end
 
     def create_resource(migration_resource)
-      FactoryBot.create(:teacher, trn: migration_resource.trn)
-      FactoryBot.create(:school, urn: migration_resource.participant_profiles.first.school_cohort.school.urn)
+      create(:teacher, trn: migration_resource.trn)
+      create(:school, urn: migration_resource.participant_profiles.first.school_cohort.school.urn)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/reconcile_adjustment_spec.rb
+++ b/spec/migration/migrators/reconcile_adjustment_spec.rb
@@ -1,7 +1,7 @@
 describe Migrators::ReconcileAdjustment do
   it_behaves_like "a migrator", :reconcile_adjustment, %i[statement] do
     def create_migration_resource
-      FactoryBot.create(:migration_statement, reconcile_amount: 100.77)
+      create(:migration_statement, reconcile_amount: 100.77)
     end
 
     def create_resource(migration_resource)
@@ -10,10 +10,10 @@ describe Migrators::ReconcileAdjustment do
       ecf_lp = migration_resource.lead_provider
       ecf_cohort = migration_resource.cohort
 
-      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
-      contract_period = FactoryBot.create(:contract_period, year: ecf_cohort.start_year)
-      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
-      FactoryBot.create(:statement, api_id: migration_resource.id, lead_provider:, contract_period:, active_lead_provider:)
+      lead_provider = create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
+      contract_period = create(:contract_period, year: ecf_cohort.start_year)
+      active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period:)
+      create(:statement, api_id: migration_resource.id, lead_provider:, contract_period:, active_lead_provider:)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/school_partnership_spec.rb
+++ b/spec/migration/migrators/school_partnership_spec.rb
@@ -1,20 +1,20 @@
 describe Migrators::SchoolPartnership do
   it_behaves_like "a migrator", :school_partnership, %i[lead_provider_delivery_partnership] do
     def create_migration_resource
-      FactoryBot.create(:migration_partnership)
+      create(:migration_partnership)
     end
 
     def create_resource(migration_resource)
       # creating dependencies resources
-      lead_provider = FactoryBot.create(:lead_provider, name: migration_resource.lead_provider.name, ecf_id: migration_resource.lead_provider_id)
-      delivery_partner = FactoryBot.create(:delivery_partner, name: migration_resource.delivery_partner.name, api_id: migration_resource.delivery_partner.id)
-      contract_period = FactoryBot.create(:contract_period, year: migration_resource.cohort.start_year)
+      lead_provider = create(:lead_provider, name: migration_resource.lead_provider.name, ecf_id: migration_resource.lead_provider_id)
+      delivery_partner = create(:delivery_partner, name: migration_resource.delivery_partner.name, api_id: migration_resource.delivery_partner.id)
+      contract_period = create(:contract_period, year: migration_resource.cohort.start_year)
 
-      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
+      active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period:)
 
-      FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+      create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
 
-      FactoryBot.create(:school, urn: migration_resource.school.urn)
+      create(:school, urn: migration_resource.school.urn)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -1,33 +1,33 @@
 describe Migrators::School do
   def create_ecf_school
-    FactoryBot.create(:ecf_migration_school,
-                      school_status_code: 1,
-                      administrative_district_name: 'AD1',
-                      administrative_district_code: '9999',
-                      school_type_code: 1,
-                      name: 'School one',
-                      school_phase_name: 'Phase one',
-                      section_41_approved: false,
-                      school_status_name: 'Open',
-                      school_type_name: 'Academy converter').tap do |ecf_school|
-      FactoryBot.create(:ecf_migration_school_local_authority, school: ecf_school)
+    create(:ecf_migration_school,
+           school_status_code: 1,
+           administrative_district_name: 'AD1',
+           administrative_district_code: '9999',
+           school_type_code: 1,
+           name: 'School one',
+           school_phase_name: 'Phase one',
+           section_41_approved: false,
+           school_status_name: 'Open',
+           school_type_name: 'Academy converter').tap do |ecf_school|
+      create(:ecf_migration_school_local_authority, school: ecf_school)
     end
   end
 
   def create_gias_school(ecf_school)
-    FactoryBot.create(:gias_school,
-                      urn: ecf_school.urn,
-                      administrative_district_name: 'AD1',
-                      funding_eligibility: 'eligible_for_fip',
-                      induction_eligibility: true,
-                      in_england: true,
-                      local_authority_code: ecf_school.local_authority.code,
-                      name: 'School one',
-                      phase_name: 'Phase one',
-                      section_41_approved: false,
-                      status: 'open',
-                      type_name: 'Academy converter',
-                      ukprn: ecf_school.ukprn)
+    create(:gias_school,
+           urn: ecf_school.urn,
+           administrative_district_name: 'AD1',
+           funding_eligibility: 'eligible_for_fip',
+           induction_eligibility: true,
+           in_england: true,
+           local_authority_code: ecf_school.local_authority.code,
+           name: 'School one',
+           phase_name: 'Phase one',
+           section_41_approved: false,
+           status: 'open',
+           type_name: 'Academy converter',
+           ukprn: ecf_school.ukprn)
   end
 
   it_behaves_like "a migrator", :school, [] do
@@ -39,10 +39,10 @@ describe Migrators::School do
   end
 
   describe "#migrate!" do
-    let!(:data_migration) { FactoryBot.create(:data_migration, model: :school, worker: 0) }
+    let!(:data_migration) { create(:data_migration, model: :school, worker: 0) }
 
     context "when the ECF school can't be found in RECT" do
-      let!(:ecf_school) { FactoryBot.create(:ecf_migration_school, school_status_code: 1, school_type_code: 10) }
+      let!(:ecf_school) { create(:ecf_migration_school, school_status_code: 1, school_type_code: 10) }
 
       before do
         described_class.new(worker: 0).migrate!
@@ -57,33 +57,33 @@ describe Migrators::School do
 
     context "when fields mismatch" do
       let!(:ecf_school) do
-        FactoryBot.create(:ecf_migration_school,
-                          school_status_code: 1,
-                          administrative_district_name: 'AD1',
-                          administrative_district_code: '9999',
-                          school_type_code: 1,
-                          name: 'School one',
-                          school_phase_name: 'Phase one',
-                          section_41_approved: false,
-                          school_status_name: 'Open',
-                          school_type_name: 'Type one',
-                          ukprn: "12345")
+        create(:ecf_migration_school,
+               school_status_code: 1,
+               administrative_district_name: 'AD1',
+               administrative_district_code: '9999',
+               school_type_code: 1,
+               name: 'School one',
+               school_phase_name: 'Phase one',
+               section_41_approved: false,
+               school_status_name: 'Open',
+               school_type_name: 'Type one',
+               ukprn: "12345")
       end
 
       let!(:gias_school) do
-        FactoryBot.create(:gias_school,
-                          urn: ecf_school.urn,
-                          administrative_district_name: 'AAD1',
-                          funding_eligibility: 'eligible_for_cip',
-                          induction_eligibility: true,
-                          in_england: true,
-                          local_authority_code: 24,
-                          name: 'Another School one',
-                          phase_name: 'Another Phase one',
-                          section_41_approved: true,
-                          status: 'proposed_to_close',
-                          type_name: 'Academy converter',
-                          ukprn: 54_321)
+        create(:gias_school,
+               urn: ecf_school.urn,
+               administrative_district_name: 'AAD1',
+               funding_eligibility: 'eligible_for_cip',
+               induction_eligibility: true,
+               in_england: true,
+               local_authority_code: 24,
+               name: 'Another School one',
+               phase_name: 'Another Phase one',
+               section_41_approved: true,
+               status: 'proposed_to_close',
+               type_name: 'Academy converter',
+               ukprn: 54_321)
       end
 
       before do

--- a/spec/migration/migrators/statement_adjustment_spec.rb
+++ b/spec/migration/migrators/statement_adjustment_spec.rb
@@ -1,7 +1,7 @@
 describe Migrators::StatementAdjustment do
   it_behaves_like "a migrator", :statement_adjustment, %i[statement] do
     def create_migration_resource
-      FactoryBot.create(:migration_finance_adjustment)
+      create(:migration_finance_adjustment)
     end
 
     def create_resource(migration_resource)
@@ -10,10 +10,10 @@ describe Migrators::StatementAdjustment do
       ecf_lp = migration_resource.statement.lead_provider
       ecf_cohort = migration_resource.statement.cohort
 
-      lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
-      contract_period = FactoryBot.create(:contract_period, year: ecf_cohort.start_year)
-      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
-      FactoryBot.create(:statement, api_id: migration_resource.statement_id, lead_provider:, contract_period:, active_lead_provider:)
+      lead_provider = create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
+      contract_period = create(:contract_period, year: ecf_cohort.start_year)
+      active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period:)
+      create(:statement, api_id: migration_resource.statement_id, lead_provider:, contract_period:, active_lead_provider:)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/statement_spec.rb
+++ b/spec/migration/migrators/statement_spec.rb
@@ -1,21 +1,21 @@
 describe Migrators::Statement do
   it_behaves_like "a migrator", :statement, %i[lead_provider contract_period active_lead_provider] do
     def create_migration_resource
-      FactoryBot.create(:migration_statement, name: "February 2025")
+      create(:migration_statement, name: "February 2025")
     end
 
     def create_resource(migration_resource)
       # creating dependencies resources
-      lead_provider = FactoryBot.create(:lead_provider, name: migration_resource.lead_provider.name, ecf_id: migration_resource.lead_provider.id)
-      contract_period = FactoryBot.create(:contract_period, year: migration_resource.cohort.start_year)
-      FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
+      lead_provider = create(:lead_provider, name: migration_resource.lead_provider.name, ecf_id: migration_resource.lead_provider.id)
+      contract_period = create(:contract_period, year: migration_resource.cohort.start_year)
+      create(:active_lead_provider, lead_provider:, contract_period:)
 
-      FactoryBot.create(:statement)
+      create(:statement)
     end
 
     def setup_failure_state
       # Record to be migrated with unmet dependencies in the destination db
-      FactoryBot.create(:migration_statement)
+      create(:migration_statement)
     end
 
     describe "#migrate!" do

--- a/spec/migration/migrators/teacher_spec.rb
+++ b/spec/migration/migrators/teacher_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Migrators::Teacher do
   it_behaves_like "a migrator", :teacher, [] do
     def create_migration_resource
-      ect = FactoryBot.create(:migration_participant_profile, :ect)
+      ect = create(:migration_participant_profile, :ect)
       ect.teacher_profile
     end
 
@@ -9,8 +9,8 @@ RSpec.describe Migrators::Teacher do
     end
 
     def setup_failure_state
-      teacher_profile = FactoryBot.create(:migration_teacher_profile, trn: nil)
-      FactoryBot.create(:migration_participant_profile, :ect, teacher_profile:, user: teacher_profile.user)
+      teacher_profile = create(:migration_teacher_profile, trn: nil)
+      create(:migration_participant_profile, :ect, teacher_profile:, user: teacher_profile.user)
     end
 
     describe "#migrate!" do

--- a/spec/migration/migrators/training_period_spec.rb
+++ b/spec/migration/migrators/training_period_spec.rb
@@ -1,31 +1,31 @@
 RSpec.describe Migrators::TrainingPeriod do
   it_behaves_like "a migrator", :training_period, %i[ect_at_school_period mentor_at_school_period school_partnership] do
     def create_migration_resource
-      ect = FactoryBot.create(:migration_participant_profile, :ect)
-      FactoryBot.create(:migration_induction_record, participant_profile: ect)
+      ect = create(:migration_participant_profile, :ect)
+      create(:migration_induction_record, participant_profile: ect)
       school = ect.school_cohort.school
       cohort = ect.school_cohort.cohort
       induction_programme = ect.school_cohort.default_induction_programme
 
-      induction_programme.update!(partnership: FactoryBot.create(:migration_partnership, school:, cohort:))
+      induction_programme.update!(partnership: create(:migration_partnership, school:, cohort:))
       ect.teacher_profile
     end
 
     def create_resource(migration_resource)
-      teacher = FactoryBot.create(:teacher, trn: migration_resource.trn)
+      teacher = create(:teacher, trn: migration_resource.trn)
       ect = migration_resource.participant_profiles.first
       school_cohort = ect.school_cohort
       partnership = school_cohort.school.partnerships.first
 
-      school = FactoryBot.create(:school, urn: school_cohort.school.urn)
-      FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: school_cohort.default_induction_programme.induction_records.first.start_date, finished_on: nil)
+      school = create(:school, urn: school_cohort.school.urn)
+      create(:ect_at_school_period, teacher:, school:, started_on: school_cohort.default_induction_programme.induction_records.first.start_date, finished_on: nil)
 
-      lead_provider = FactoryBot.create(:lead_provider, name: partnership.lead_provider.name, ecf_id: partnership.lead_provider_id)
-      delivery_partner = FactoryBot.create(:delivery_partner, name: partnership.delivery_partner.name, api_id: partnership.delivery_partner_id)
-      contract_period = FactoryBot.create(:contract_period, year: school_cohort.cohort.start_year)
-      active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
-      lpdp = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
-      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp)
+      lead_provider = create(:lead_provider, name: partnership.lead_provider.name, ecf_id: partnership.lead_provider_id)
+      delivery_partner = create(:delivery_partner, name: partnership.delivery_partner.name, api_id: partnership.delivery_partner_id)
+      contract_period = create(:contract_period, year: school_cohort.cohort.start_year)
+      active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period:)
+      lpdp = create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+      create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp)
     end
 
     def setup_failure_state

--- a/spec/migration/parity_check/client_spec.rb
+++ b/spec/migration/parity_check/client_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe ParityCheck::Client do
   let(:ecf_url) { "https://ecf.example.com" }
   let(:rect_url) { "https://rect.example.com" }
-  let(:endpoint) { FactoryBot.build(:parity_check_endpoint) }
-  let(:request) { FactoryBot.build(:parity_check_request, endpoint:) }
+  let(:endpoint) { build(:parity_check_endpoint) }
+  let(:request) { build(:parity_check_request, endpoint:) }
   let(:token) { "test_token" }
   let(:per_page) { ParityCheck::RequestBuilder::PAGINATION_PER_PAGE }
   let(:instance) { described_class.new(request:) }
@@ -22,13 +22,13 @@ RSpec.describe ParityCheck::Client do
 
   describe "#perform_requests" do
     context "when performing a GET request" do
-      let(:endpoint) { FactoryBot.build(:parity_check_endpoint, :get) }
+      let(:endpoint) { build(:parity_check_endpoint, :get) }
 
       include_examples "client performs requests"
     end
 
     context "when performing a request with query parameters" do
-      let(:endpoint) { FactoryBot.build(:parity_check_endpoint, :with_query_parameters) }
+      let(:endpoint) { build(:parity_check_endpoint, :with_query_parameters) }
 
       include_examples "client performs requests"
 
@@ -42,7 +42,7 @@ RSpec.describe ParityCheck::Client do
     end
 
     context "when the path and options contain query parameters and pagination is enabled" do
-      let(:endpoint) { FactoryBot.build(:parity_check_endpoint, :with_query_parameters_and_pagination, path: "/test-path?path=parameter") }
+      let(:endpoint) { build(:parity_check_endpoint, :with_query_parameters_and_pagination, path: "/test-path?path=parameter") }
 
       include_examples "client performs requests"
 
@@ -60,7 +60,7 @@ RSpec.describe ParityCheck::Client do
     end
 
     context "when performing a request with pagination" do
-      let(:endpoint) { FactoryBot.build(:parity_check_endpoint, :with_pagination) }
+      let(:endpoint) { build(:parity_check_endpoint, :with_pagination) }
 
       include_examples "client performs requests"
 
@@ -97,14 +97,14 @@ RSpec.describe ParityCheck::Client do
     end
 
     context "when performing a POST request" do
-      let(:endpoint) { FactoryBot.build(:parity_check_endpoint, :post) }
+      let(:endpoint) { build(:parity_check_endpoint, :post) }
 
       include_examples "client performs requests"
       include_examples "client performs requests with body"
     end
 
     context "when performing a PUT request" do
-      let(:endpoint) { FactoryBot.build(:parity_check_endpoint, :put) }
+      let(:endpoint) { build(:parity_check_endpoint, :put) }
 
       include_examples "client performs requests"
       include_examples "client performs requests with body"
@@ -112,7 +112,7 @@ RSpec.describe ParityCheck::Client do
   end
 
   context "when an unsupported request method is used" do
-    let(:endpoint) { FactoryBot.build(:parity_check_endpoint, method: :fetch) }
+    let(:endpoint) { build(:parity_check_endpoint, method: :fetch) }
 
     it "raises an UnsupportedRequestMethodError" do
       expect {

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ParityCheck::DynamicRequestContent do
-  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:lead_provider) { create(:lead_provider) }
   let(:instance) { described_class.new(lead_provider:) }
 
   describe "#fetch" do
@@ -13,10 +13,10 @@ RSpec.describe ParityCheck::DynamicRequestContent do
 
     context "when fetching example_id" do
       let(:identifier) { :example_id }
-      let!(:statement) { FactoryBot.create(:statement, lead_provider:) }
+      let!(:statement) { create(:statement, lead_provider:) }
 
       # Statement for different lead provider should not be used.
-      before { FactoryBot.create(:statement) }
+      before { create(:statement) }
 
       it { is_expected.to eq(statement.api_id) }
     end

--- a/spec/migration/parity_check/request_builder_spec.rb
+++ b/spec/migration/parity_check/request_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ParityCheck::RequestBuilder do
   let(:method) { :get }
   let(:options) { { foo: :bar } }
   let(:endpoint) { ParityCheck::Endpoint.new(method:, path:, options:) }
-  let(:request) { FactoryBot.create(:parity_check_request, endpoint:) }
+  let(:request) { create(:parity_check_request, endpoint:) }
   let(:per_page) { described_class::PAGINATION_PER_PAGE }
   let(:instance) { described_class.new(request:) }
 
@@ -143,7 +143,7 @@ RSpec.describe ParityCheck::RequestBuilder do
     describe "#advance_page" do
       subject(:advance_page) { instance.advance_page(previous_response) }
 
-      let(:previous_response) { FactoryBot.build(:parity_check_response) }
+      let(:previous_response) { build(:parity_check_response) }
       let(:partial_page_of_data) { { data: Array.new(per_page / 2, { key: :value }) }.to_json }
       let(:full_page_of_data) { { data: Array.new(per_page, { key: :value }) }.to_json }
 
@@ -151,7 +151,7 @@ RSpec.describe ParityCheck::RequestBuilder do
         let(:options) { { paginate: true } }
 
         context "when there is another page (both APIs return full sets of data)" do
-          let(:previous_response) { FactoryBot.build(:parity_check_response, ecf_body: full_page_of_data, rect_body: full_page_of_data) }
+          let(:previous_response) { build(:parity_check_response, ecf_body: full_page_of_data, rect_body: full_page_of_data) }
 
           it "returns true and increments the page number" do
             expect(advance_page).to be_truthy
@@ -160,7 +160,7 @@ RSpec.describe ParityCheck::RequestBuilder do
         end
 
         context "when there is another page (only one API returns a full set of data)" do
-          let(:previous_response) { FactoryBot.build(:parity_check_response, ecf_body: partial_page_of_data, rect_body: full_page_of_data) }
+          let(:previous_response) { build(:parity_check_response, ecf_body: partial_page_of_data, rect_body: full_page_of_data) }
 
           it "returns true and increments the page number" do
             expect(advance_page).to be_truthy
@@ -169,7 +169,7 @@ RSpec.describe ParityCheck::RequestBuilder do
         end
 
         context "when there are no more pages" do
-          let(:previous_response) { FactoryBot.build(:parity_check_response, ecf_body: partial_page_of_data, rect_body: partial_page_of_data) }
+          let(:previous_response) { build(:parity_check_response, ecf_body: partial_page_of_data, rect_body: partial_page_of_data) }
 
           it "returns false and does not increment the page number" do
             expect(advance_page).to be_falsy

--- a/spec/migration/parity_check/request_handler_spec.rb
+++ b/spec/migration/parity_check/request_handler_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ParityCheck::RequestHandler do
-  let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
-  let(:request) { FactoryBot.create(:parity_check_request, :queued, run:) }
+  let(:run) { create(:parity_check_run, :in_progress) }
+  let(:request) { create(:parity_check_request, :queued, run:) }
   let(:instance) { described_class.new(request) }
   let(:enabled) { true }
 
@@ -19,7 +19,7 @@ RSpec.describe ParityCheck::RequestHandler do
   describe "#process_request" do
     subject(:process_request) { instance.process_request }
 
-    let(:response) { FactoryBot.build(:parity_check_response, request: nil) }
+    let(:response) { build(:parity_check_response, request: nil) }
 
     before do
       client = instance_double(ParityCheck::Client)

--- a/spec/migration/parity_check/run_dispatcher_spec.rb
+++ b/spec/migration/parity_check/run_dispatcher_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ParityCheck::RunDispatcher do
     end
 
     context "when there are pending runs" do
-      let!(:pending_runs) { FactoryBot.create_list(:parity_check_run, 3, :pending) }
+      let!(:pending_runs) { create_list(:parity_check_run, 3, :pending) }
       let(:next_run) { pending_runs.first }
 
       it "dispatches the next run" do
@@ -23,7 +23,7 @@ RSpec.describe ParityCheck::RunDispatcher do
       end
 
       context "when there are in-progress runs" do
-        before { FactoryBot.create(:parity_check_request, :in_progress) }
+        before { create(:parity_check_request, :in_progress) }
 
         it "does not call the request dispatcher" do
           expect { dispatch }.not_to have_enqueued_job(ParityCheckRequestJob)
@@ -32,7 +32,7 @@ RSpec.describe ParityCheck::RunDispatcher do
     end
 
     context "when there are in-progress/pending runs" do
-      before { FactoryBot.create(:parity_check_run, :completed) }
+      before { create(:parity_check_run, :completed) }
 
       it "does not call the request dispatcher" do
         expect { dispatch }.not_to have_enqueued_job(ParityCheckRequestJob)

--- a/spec/migration/parity_check/runner_spec.rb
+++ b/spec/migration/parity_check/runner_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe ParityCheck::Runner, type: :model do
   let(:endpoints) do
     [
-      FactoryBot.create(:parity_check_endpoint, method: :get, path: "/test-path"),
-      FactoryBot.create(:parity_check_endpoint, method: :post, path: "/test-other-path"),
+      create(:parity_check_endpoint, method: :get, path: "/test-path"),
+      create(:parity_check_endpoint, method: :post, path: "/test-other-path"),
     ]
   end
   let(:mode) { "sequential" }
@@ -47,8 +47,8 @@ RSpec.describe ParityCheck::Runner, type: :model do
     end
 
     it "creates a request for each lead provider and endpoint" do
-      lead_provider1 = FactoryBot.create(:lead_provider)
-      lead_provider2 = FactoryBot.create(:lead_provider)
+      lead_provider1 = create(:lead_provider)
+      lead_provider2 = create(:lead_provider)
       lead_providers = [lead_provider1, lead_provider2]
 
       created_run = nil

--- a/spec/migration/parity_check/token_provider_spec.rb
+++ b/spec/migration/parity_check/token_provider_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ParityCheck::TokenProvider do
   before do
-    FactoryBot.create_list(:lead_provider, 3)
+    create_list(:lead_provider, 3)
 
     allow(Rails.application.config).to receive(:parity_check).and_return({
       enabled:,
@@ -56,7 +56,7 @@ RSpec.describe ParityCheck::TokenProvider do
   describe "#token" do
     subject(:token) { instance.token(lead_provider:) }
 
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:lead_provider) { create(:lead_provider) }
 
     context "when the keys are not present" do
       let(:tokens) { nil }

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -10,7 +10,7 @@ describe ActiveLeadProvider do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:active_lead_provider) }
+    subject { create(:active_lead_provider) }
 
     it { is_expected.to validate_presence_of(:lead_provider_id).with_message("Choose a lead provider") }
     it { is_expected.to validate_presence_of(:contract_period_id).with_message("Choose a contract period") }
@@ -18,14 +18,14 @@ describe ActiveLeadProvider do
   end
 
   describe "scopes" do
-    let!(:rp_1) { FactoryBot.create(:contract_period) }
-    let!(:rp_2) { FactoryBot.create(:contract_period) }
-    let!(:lp_1) { FactoryBot.create(:lead_provider) }
-    let!(:lp_2) { FactoryBot.create(:lead_provider) }
-    let!(:active_lead_provider_1) { FactoryBot.create(:active_lead_provider, contract_period: rp_1, lead_provider: lp_1) }
-    let!(:active_lead_provider_2) { FactoryBot.create(:active_lead_provider, contract_period: rp_1, lead_provider: lp_2) }
-    let!(:active_lead_provider_3) { FactoryBot.create(:active_lead_provider, contract_period: rp_2, lead_provider: lp_1) }
-    let!(:active_lead_provider_4) { FactoryBot.create(:active_lead_provider, contract_period: rp_2, lead_provider: lp_2) }
+    let!(:rp_1) { create(:contract_period) }
+    let!(:rp_2) { create(:contract_period) }
+    let!(:lp_1) { create(:lead_provider) }
+    let!(:lp_2) { create(:lead_provider) }
+    let!(:active_lead_provider_1) { create(:active_lead_provider, contract_period: rp_1, lead_provider: lp_1) }
+    let!(:active_lead_provider_2) { create(:active_lead_provider, contract_period: rp_1, lead_provider: lp_2) }
+    let!(:active_lead_provider_3) { create(:active_lead_provider, contract_period: rp_2, lead_provider: lp_1) }
+    let!(:active_lead_provider_4) { create(:active_lead_provider, contract_period: rp_2, lead_provider: lp_2) }
 
     describe ".for_contract_period" do
       it "returns provider partnerships only for the specified academic year" do

--- a/spec/models/api/token_spec.rb
+++ b/spec/models/api/token_spec.rb
@@ -4,7 +4,7 @@ describe API::Token do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:api_token) }
+    subject { build(:api_token) }
 
     it { is_expected.to validate_presence_of(:lead_provider).with_message("Lead provider must be specified") }
     it { is_expected.to validate_presence_of(:token).with_message("Hashed token must be specified") }
@@ -15,7 +15,7 @@ describe API::Token do
     describe ".lead_provider_tokens" do
       subject { described_class.lead_provider_tokens }
 
-      let!(:lead_provider_token) { FactoryBot.create(:api_token) }
+      let!(:lead_provider_token) { create(:api_token) }
 
       before do
         # Contrived example as we only support lead provider tokens at
@@ -29,7 +29,7 @@ describe API::Token do
 
   describe "has_secure_token" do
     it "generates a 32 character token on create" do
-      lead_provider = FactoryBot.create(:lead_provider)
+      lead_provider = create(:lead_provider)
       generated_token = described_class.create!(lead_provider:, description: "Test token").token
       expect(generated_token).to be_present
       expect(generated_token.size).to eq(32)
@@ -38,7 +38,7 @@ describe API::Token do
 
   describe "encrypts" do
     it "encrypts the token" do
-      api_token = FactoryBot.create(:api_token)
+      api_token = create(:api_token)
       encrypted_token = api_token.token_before_type_cast
 
       expect(api_token.token).not_to eq(encrypted_token)

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -17,7 +17,7 @@ describe AppropriateBody do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:appropriate_body) }
+    subject { build(:appropriate_body) }
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
@@ -30,8 +30,8 @@ describe AppropriateBody do
 
     it "ensures local_authority_code and establishment_number are unique in combination" do
       ab_args = { local_authority_code: 123, establishment_number: 4567 }
-      FactoryBot.create(:appropriate_body, name: "AB1", **ab_args)
-      FactoryBot.build(:appropriate_body, name: "AB2", **ab_args).tap do |duplicate_ab|
+      create(:appropriate_body, name: "AB1", **ab_args)
+      build(:appropriate_body, name: "AB2", **ab_args).tap do |duplicate_ab|
         expect(duplicate_ab).to be_invalid
         expect(duplicate_ab.errors.messages.fetch(:local_authority_code)).to include(/local authority code and establishment number already exists/)
       end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -1,8 +1,8 @@
 FakePeriod = Struct.new(:started_on, :finished_on)
 
 describe Interval do
-  let(:school_id) { FactoryBot.create(:school, urn: "1234567").id }
-  let(:teacher_id) { FactoryBot.create(:teacher, trs_first_name: "Teacher", trs_last_name: "One").id }
+  let(:school_id) { create(:school, urn: "1234567").id }
+  let(:teacher_id) { create(:teacher, trs_first_name: "Teacher", trs_last_name: "One").id }
 
   describe "validations" do
     context "period dates" do
@@ -29,7 +29,7 @@ describe Interval do
   end
 
   describe "scopes" do
-    let!(:teacher_2_id) { FactoryBot.create(:teacher, trs_first_name: "Teacher", trs_last_name: "Two").id }
+    let!(:teacher_2_id) { create(:teacher, trs_first_name: "Teacher", trs_last_name: "Two").id }
     let!(:period_1) { DummyMentor.create(teacher_id:, school_id:, started_on: '2023-01-01', finished_on: '2023-06-01') }
     let!(:period_2) { DummyMentor.create(teacher_id:, school_id:, started_on: '2023-07-01', finished_on: '2023-12-01') }
     let!(:period_3) { DummyMentor.create(teacher_id:, school_id:, started_on: '2024-01-01', finished_on: nil) }

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -6,7 +6,7 @@ describe ContractPeriod do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:contract_period) }
+    subject { build(:contract_period) }
 
     it { is_expected.to validate_presence_of(:year) }
     it { is_expected.to validate_uniqueness_of(:year) }
@@ -16,15 +16,15 @@ describe ContractPeriod do
     it { is_expected.to validate_presence_of(:finished_on).with_message('Enter an end date') }
 
     describe '#no_overlaps' do
-      before { FactoryBot.create(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 2, 2)) }
+      before { create(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 2, 2)) }
 
       it 'allows new records that do not overlap' do
-        non_overlapping = FactoryBot.build(:contract_period, started_on: Date.new(2024, 2, 2), finished_on: Date.new(2024, 3, 3))
+        non_overlapping = build(:contract_period, started_on: Date.new(2024, 2, 2), finished_on: Date.new(2024, 3, 3))
         expect(non_overlapping).to be_valid
       end
 
       it 'does not allow overlapping records' do
-        overlapping = FactoryBot.build(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 3, 3))
+        overlapping = build(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 3, 3))
         expect(overlapping).not_to be_valid
         expect(overlapping.errors.messages[:base]).to include(/Contract period overlaps/)
       end
@@ -33,7 +33,7 @@ describe ContractPeriod do
 
   describe '.containing_date' do
     let!(:period) do
-      FactoryBot.create(:contract_period, started_on: Date.new(2024, 9, 1), finished_on: Date.new(2025, 8, 31))
+      create(:contract_period, started_on: Date.new(2024, 9, 1), finished_on: Date.new(2025, 8, 31))
     end
 
     it 'returns the contract_period containing the given date' do

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -6,7 +6,7 @@ describe DeliveryPartner do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:delivery_partner) }
+    subject { build(:delivery_partner) }
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -30,19 +30,19 @@ describe ECTAtSchoolPeriod do
       context ":register_ect context" do
         context "when the school is independent" do
           context "when national ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :national_ab) }
+            subject { create(:ect_at_school_period, :independent_school, :national_ab) }
 
             it { is_expected.to be_valid(:register_ect) }
           end
 
           context "when teaching school hub ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
+            subject { create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
 
             it { is_expected.to be_valid(:register_ect) }
           end
 
           context "when local authority ab chosen" do
-            subject { FactoryBot.build(:ect_at_school_period, :independent_school, :local_authority_ab) }
+            subject { build(:ect_at_school_period, :independent_school, :local_authority_ab) }
 
             before { subject.valid?(:register_ect) }
 
@@ -54,10 +54,10 @@ describe ECTAtSchoolPeriod do
         end
 
         context "when the school is state_funded" do
-          subject { FactoryBot.build(:ect_at_school_period, :state_funded_school) }
+          subject { build(:ect_at_school_period, :state_funded_school) }
 
           context "when national ab chosen" do
-            subject { FactoryBot.build(:ect_at_school_period, :state_funded_school, :national_ab) }
+            subject { build(:ect_at_school_period, :state_funded_school, :national_ab) }
 
             before { subject.valid?(:register_ect) }
 
@@ -68,13 +68,13 @@ describe ECTAtSchoolPeriod do
           end
 
           context "when teaching school hub ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }
+            subject { create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }
 
             it { is_expected.to be_valid(:register_ect) }
           end
 
           context "when local authority ab chosen" do
-            subject { FactoryBot.build(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
+            subject { build(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
 
             before { subject.valid?(:register_ect) }
 
@@ -89,41 +89,41 @@ describe ECTAtSchoolPeriod do
       context "no context" do
         context "when the school is independent" do
           context "when national ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :national_ab) }
+            subject { create(:ect_at_school_period, :independent_school, :national_ab) }
 
             it { is_expected.to be_valid }
           end
 
           context "when teaching school hub ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
+            subject { create(:ect_at_school_period, :independent_school, :teaching_school_hub_ab) }
 
             it { is_expected.to be_valid }
           end
 
           context "when local authority ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :independent_school, :local_authority_ab) }
+            subject { create(:ect_at_school_period, :independent_school, :local_authority_ab) }
 
             it { is_expected.to be_valid }
           end
         end
 
         context "when the school is state_funded" do
-          subject { FactoryBot.build(:ect_at_school_period, :state_funded_school) }
+          subject { build(:ect_at_school_period, :state_funded_school) }
 
           context "when national ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :national_ab) }
+            subject { create(:ect_at_school_period, :state_funded_school, :national_ab) }
 
             it { is_expected.to be_valid }
           end
 
           context "when teaching school hub ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }
+            subject { create(:ect_at_school_period, :state_funded_school, :teaching_school_hub_ab) }
 
             it { is_expected.to be_valid }
           end
 
           context "when local authority ab chosen" do
-            subject { FactoryBot.create(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
+            subject { create(:ect_at_school_period, :state_funded_school, :local_authority_ab) }
 
             it { is_expected.to be_valid }
           end
@@ -138,10 +138,10 @@ describe ECTAtSchoolPeriod do
     end
 
     context "lead_provider_id" do
-      subject { FactoryBot.build(:ect_at_school_period) }
+      subject { build(:ect_at_school_period) }
 
       context "when training_programme is 'school_led'" do
-        subject { FactoryBot.build(:ect_at_school_period, :school_led) }
+        subject { build(:ect_at_school_period, :school_led) }
 
         it { is_expected.to validate_absence_of(:lead_provider_id).with_message('Must be nil') }
       end
@@ -150,22 +150,22 @@ describe ECTAtSchoolPeriod do
     describe 'overlapping periods' do
       let(:started_on_message) { 'Start date cannot overlap another Teacher ECT period' }
       let(:finished_on_message) { 'End date cannot overlap another Teacher ECT period' }
-      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:teacher) { create(:teacher) }
 
       context '#teacher_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             before do
-              FactoryBot.create(:ect_at_school_period, teacher:,
-                                                       started_on: test.existing_period_range.first,
-                                                       finished_on: test.existing_period_range.last)
+              create(:ect_at_school_period, teacher:,
+                                            started_on: test.existing_period_range.first,
+                                            finished_on: test.existing_period_range.last)
               period.valid?
             end
 
             let(:period) do
-              FactoryBot.build(:ect_at_school_period, teacher:,
-                                                      started_on: test.new_period_range.first,
-                                                      finished_on: test.new_period_range.last)
+              build(:ect_at_school_period, teacher:,
+                                           started_on: test.new_period_range.first,
+                                           finished_on: test.new_period_range.last)
             end
 
             let(:messages) { period.errors.messages }
@@ -194,7 +194,7 @@ describe ECTAtSchoolPeriod do
     end
 
     context "training_programme" do
-      subject { FactoryBot.build(:ect_at_school_period) }
+      subject { build(:ect_at_school_period) }
 
       it do
         is_expected.to validate_inclusion_of(:training_programme)
@@ -203,7 +203,7 @@ describe ECTAtSchoolPeriod do
       end
 
       context "when lead_provider has been set" do
-        subject { FactoryBot.create(:ect_at_school_period) }
+        subject { create(:ect_at_school_period) }
 
         it { is_expected.to validate_presence_of(:training_programme).with_message("Must be provider-led") }
       end
@@ -211,12 +211,12 @@ describe ECTAtSchoolPeriod do
   end
 
   describe "scopes" do
-    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:teacher) { create(:teacher) }
     let!(:school) { period_1.school }
-    let!(:period_1) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: period_1.finished_on, finished_on: "2023-12-11") }
-    let!(:period_3) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
-    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let!(:period_1) { create(:ect_at_school_period, :state_funded_school, teacher:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:ect_at_school_period, :state_funded_school, teacher:, started_on: period_1.finished_on, finished_on: "2023-12-11") }
+    let!(:period_3) { create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
+    let!(:teacher_2_period) { create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
 
     describe ".for_teacher" do
       it "returns ect periods only for the specified teacher" do
@@ -226,13 +226,13 @@ describe ECTAtSchoolPeriod do
   end
 
   describe "#siblings" do
-    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:teacher) { create(:teacher) }
     let!(:school) { period_1.school }
-    let!(:period_1) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: '2022-12-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: period_1.finished_on, finished_on: '2024-01-01') }
-    let!(:period_3) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
-    let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: '2022-01-01', finished_on: period_1.started_on) }
+    let!(:period_1) { create(:ect_at_school_period, :state_funded_school, teacher:, started_on: '2022-12-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:ect_at_school_period, :state_funded_school, teacher:, started_on: period_1.finished_on, finished_on: '2024-01-01') }
+    let!(:period_3) { create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
+    let!(:teacher_2_period) { create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: '2022-01-01', finished_on: period_1.started_on) }
 
     it "returns ect periods only for the specified instance's teacher excluding the instance" do
       expect(ect_at_school_period.siblings).to match_array([period_1, period_2, period_3])

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -43,7 +43,7 @@ describe Event do
 
     describe '#check_author_present' do
       context 'when author_id and author_email are missing' do
-        subject { FactoryBot.build(:event, author_email: nil, author_name: nil, author_id: nil) }
+        subject { build(:event, author_email: nil, author_name: nil, author_id: nil) }
 
         it { is_expected.to be_invalid }
 
@@ -59,7 +59,7 @@ describe Event do
     it { is_expected.to validate_presence_of(:happened_at) }
 
     describe '#event_happened_in_the_past' do
-      subject { FactoryBot.build(:event, happened_at:) }
+      subject { build(:event, happened_at:) }
 
       before { subject.valid? }
 

--- a/spec/models/gias/school_link_spec.rb
+++ b/spec/models/gias/school_link_spec.rb
@@ -24,7 +24,7 @@ describe GIAS::SchoolLink do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:gias_school_link) }
+    subject { create(:gias_school_link) }
 
     it { is_expected.to validate_inclusion_of(:link_type).in_array(GIAS::SchoolLink::LINK_TYPES) }
     it { is_expected.to validate_presence_of(:link_urn) }

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -67,7 +67,7 @@ describe GIAS::School do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:gias_school) }
+    subject { create(:gias_school) }
 
     it { is_expected.to validate_numericality_of(:local_authority_code).only_integer }
     it { is_expected.to validate_presence_of(:name) }
@@ -88,19 +88,19 @@ describe GIAS::School do
   describe "instance methods" do
     describe "#open?" do
       context "when the status is :open" do
-        subject { FactoryBot.create(:gias_school, status: :open) }
+        subject { create(:gias_school, status: :open) }
 
         it { is_expected.to be_open }
       end
 
       context "when the status is :proposed_to_close" do
-        subject { FactoryBot.create(:gias_school, status: :proposed_to_close) }
+        subject { create(:gias_school, status: :proposed_to_close) }
 
         it { is_expected.to be_open }
       end
 
       context "when the status is not :open or :proposed_to_close" do
-        subject { FactoryBot.create(:gias_school, :not_open) }
+        subject { create(:gias_school, :not_open) }
 
         it { is_expected.not_to be_open }
       end
@@ -108,19 +108,19 @@ describe GIAS::School do
 
     describe "#closed?" do
       context "when the status is :closed" do
-        subject { FactoryBot.create(:gias_school, status: :closed) }
+        subject { create(:gias_school, status: :closed) }
 
         it { is_expected.to be_closed }
       end
 
       context "when the status is :proposed_to_open" do
-        subject { FactoryBot.create(:gias_school, status: :proposed_to_open) }
+        subject { create(:gias_school, status: :proposed_to_open) }
 
         it { is_expected.to be_closed }
       end
 
       context "when the status is not :closed or :proposed_to_open" do
-        subject { FactoryBot.create(:gias_school, :open) }
+        subject { create(:gias_school, :open) }
 
         it { is_expected.not_to be_closed }
       end

--- a/spec/models/induction_extension_spec.rb
+++ b/spec/models/induction_extension_spec.rb
@@ -9,8 +9,8 @@ describe InductionExtension do
       it 'allows valid values to be saved' do
         # NOTE: we're actually saving them here to ensure PostgreSQL's column accepts the necessary
         #       precision and scale
-        expect(FactoryBot.create(:induction_extension, number_of_terms: 0.1)).to be_valid
-        expect(FactoryBot.create(:induction_extension, number_of_terms: 15.9)).to be_valid
+        expect(create(:induction_extension, number_of_terms: 0.1)).to be_valid
+        expect(create(:induction_extension, number_of_terms: 15.9)).to be_valid
       end
 
       it 'prohibits numbers outside the range 1..16' do
@@ -19,7 +19,7 @@ describe InductionExtension do
       end
 
       context "when number_of_terms has more than 1 decimal place" do
-        subject { FactoryBot.build(:induction_extension, number_of_terms: 3.45) }
+        subject { build(:induction_extension, number_of_terms: 3.45) }
 
         it "is invalid" do
           expect(subject).not_to be_valid
@@ -28,7 +28,7 @@ describe InductionExtension do
       end
 
       context "when number_of_terms has 1 decimal place" do
-        subject { FactoryBot.build(:induction_extension, number_of_terms: 3.5) }
+        subject { build(:induction_extension, number_of_terms: 3.5) }
 
         it "is valid" do
           expect(subject).to be_valid
@@ -36,7 +36,7 @@ describe InductionExtension do
       end
 
       context "when number_of_terms is an integer" do
-        subject { FactoryBot.build(:induction_extension, number_of_terms: 3) }
+        subject { build(:induction_extension, number_of_terms: 3) }
 
         it "is valid" do
           expect(subject).to be_valid

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe InductionPeriod do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:induction_period) }
+    subject { build(:induction_period) }
 
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:appropriate_body) { create(:appropriate_body) }
 
     it { is_expected.to validate_presence_of(:started_on).with_message("Enter a start date") }
     it { is_expected.to validate_presence_of(:appropriate_body_id).with_message("Select an appropriate body") }
@@ -21,22 +21,22 @@ RSpec.describe InductionPeriod do
     describe 'overlapping periods' do
       let(:started_on_message) { 'Start date cannot overlap another induction period' }
       let(:finished_on_message) { 'End date cannot overlap another induction period' }
-      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:teacher) { create(:teacher) }
 
       context '#teacher_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             before do
-              FactoryBot.create(:induction_period, teacher:,
-                                                   started_on: test.existing_period_range.first,
-                                                   finished_on: test.existing_period_range.last)
+              create(:induction_period, teacher:,
+                                        started_on: test.existing_period_range.first,
+                                        finished_on: test.existing_period_range.last)
               period.valid?
             end
 
             let(:period) do
-              FactoryBot.build(:induction_period, teacher:,
-                                                  started_on: test.new_period_range.first,
-                                                  finished_on: test.new_period_range.last)
+              build(:induction_period, teacher:,
+                                       started_on: test.new_period_range.first,
+                                       finished_on: test.new_period_range.last)
             end
 
             let(:messages) { period.errors.messages }
@@ -67,7 +67,7 @@ RSpec.describe InductionPeriod do
     it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy unknown pre_september_2021]).with_message("Choose an induction programme") }
 
     describe "outcome validation" do
-      subject { FactoryBot.build(:induction_period) }
+      subject { build(:induction_period) }
 
       it { is_expected.to allow_value('pass').for(:outcome) }
       it { is_expected.to allow_value('fail').for(:outcome) }
@@ -85,7 +85,7 @@ RSpec.describe InductionPeriod do
     end
 
     describe "started_on_not_in_future" do
-      subject { FactoryBot.build(:induction_period, :active, appropriate_body:, started_on:) }
+      subject { build(:induction_period, :active, appropriate_body:, started_on:) }
 
       context "when started_on is today" do
         let(:started_on) { Date.current }
@@ -110,7 +110,7 @@ RSpec.describe InductionPeriod do
     end
 
     describe "finished_on_not_in_future" do
-      subject { FactoryBot.build(:induction_period, appropriate_body:, finished_on:) }
+      subject { build(:induction_period, appropriate_body:, finished_on:) }
 
       context "when finished_on is today" do
         let(:finished_on) { Date.current }
@@ -136,25 +136,25 @@ RSpec.describe InductionPeriod do
 
     describe "number_of_terms" do
       context "when finished_on is empty" do
-        subject { FactoryBot.build(:induction_period, :active, appropriate_body:) }
+        subject { build(:induction_period, :active, appropriate_body:) }
 
         it { is_expected.not_to validate_presence_of(:number_of_terms) }
       end
 
       context "when finished_on is present" do
-        subject { FactoryBot.build(:induction_period, appropriate_body:) }
+        subject { build(:induction_period, appropriate_body:) }
 
         it { is_expected.to validate_presence_of(:number_of_terms).with_message("Enter a number of terms") }
       end
 
       context "when finished on is empty and number of terms is present" do
-        subject { FactoryBot.build(:induction_period, appropriate_body:, number_of_terms: 3, finished_on: nil) }
+        subject { build(:induction_period, appropriate_body:, number_of_terms: 3, finished_on: nil) }
 
         it { is_expected.to validate_absence_of(:number_of_terms).with_message("Delete the number of terms if the induction has no end date") }
       end
 
       context "when number_of_terms contains non-numeric characters" do
-        subject { FactoryBot.build(:induction_period, appropriate_body:, number_of_terms: "4.r5", finished_on: Date.current) }
+        subject { build(:induction_period, appropriate_body:, number_of_terms: "4.r5", finished_on: Date.current) }
 
         it do
           expect(subject).not_to be_valid
@@ -163,7 +163,7 @@ RSpec.describe InductionPeriod do
       end
 
       context "when number_of_terms has more than 1 decimal place" do
-        subject { FactoryBot.build(:induction_period, appropriate_body:, number_of_terms: 3.45, finished_on: Date.current) }
+        subject { build(:induction_period, appropriate_body:, number_of_terms: 3.45, finished_on: Date.current) }
 
         it do
           expect(subject).not_to be_valid
@@ -172,13 +172,13 @@ RSpec.describe InductionPeriod do
       end
 
       context "when number_of_terms has 1 decimal place" do
-        subject { FactoryBot.build(:induction_period, appropriate_body:, number_of_terms: 3.5, finished_on: Date.current) }
+        subject { build(:induction_period, appropriate_body:, number_of_terms: 3.5, finished_on: Date.current) }
 
         it { is_expected.to be_valid }
       end
 
       context "when number_of_terms is an integer" do
-        subject { FactoryBot.build(:induction_period, appropriate_body:, number_of_terms: 3, finished_on: Date.current) }
+        subject { build(:induction_period, appropriate_body:, number_of_terms: 3, finished_on: Date.current) }
 
         it { is_expected.to be_valid }
       end
@@ -202,10 +202,10 @@ RSpec.describe InductionPeriod do
   describe "#siblings" do
     subject { induction_period_1.siblings }
 
-    let!(:teacher) { FactoryBot.create(:teacher) }
-    let!(:induction_period_1) { FactoryBot.create(:induction_period, teacher:, started_on: '2022-01-01', finished_on: '2022-06-01') }
-    let!(:induction_period_2) { FactoryBot.create(:induction_period, teacher:, started_on: '2022-06-01', finished_on: '2023-01-01') }
-    let!(:unrelated_induction_period) { FactoryBot.create(:induction_period, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:teacher) { create(:teacher) }
+    let!(:induction_period_1) { create(:induction_period, teacher:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+    let!(:induction_period_2) { create(:induction_period, teacher:, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:unrelated_induction_period) { create(:induction_period, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
     it "only returns records that belong to the same mentee" do
       expect(subject).to include(induction_period_2)
@@ -220,30 +220,30 @@ RSpec.describe InductionPeriod do
     end
 
     context "with completed siblings and nil finished_on and inserting after them" do
-      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:teacher) { create(:teacher) }
       let!(:previous_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: "2017-09-11",
-                          finished_on: "2018-03-23",
-                          induction_programme: "pre_september_2021")
+        create(:induction_period,
+               teacher:,
+               started_on: "2017-09-11",
+               finished_on: "2018-03-23",
+               induction_programme: "pre_september_2021")
       end
 
       let!(:next_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: "2019-01-07",
-                          finished_on: "2019-07-16",
-                          induction_programme: "pre_september_2021")
+        create(:induction_period,
+               teacher:,
+               started_on: "2019-01-07",
+               finished_on: "2019-07-16",
+               induction_programme: "pre_september_2021")
       end
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: "2025-01-01",
-                          finished_on: nil,
-                          number_of_terms: nil,
-                          induction_programme: "fip")
+        create(:induction_period,
+               teacher:,
+               started_on: "2025-01-01",
+               finished_on: nil,
+               number_of_terms: nil,
+               induction_programme: "fip")
       end
 
       let(:params) { { started_on: "2025-02-24" } }
@@ -255,30 +255,30 @@ RSpec.describe InductionPeriod do
     end
 
     context "with completed siblings and nil finished_on and inserting between them" do
-      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:teacher) { create(:teacher) }
       let!(:previous_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: "2017-09-01",
-                          finished_on: "2018-03-01",
-                          induction_programme: "pre_september_2021")
+        create(:induction_period,
+               teacher:,
+               started_on: "2017-09-01",
+               finished_on: "2018-03-01",
+               induction_programme: "pre_september_2021")
       end
 
       let!(:next_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: "2019-01-01",
-                          finished_on: "2019-07-01",
-                          induction_programme: "pre_september_2021")
+        create(:induction_period,
+               teacher:,
+               started_on: "2019-01-01",
+               finished_on: "2019-07-01",
+               induction_programme: "pre_september_2021")
       end
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: "2025-01-01",
-                          finished_on: nil,
-                          number_of_terms: nil,
-                          induction_programme: "fip")
+        create(:induction_period,
+               teacher:,
+               started_on: "2025-01-01",
+               finished_on: nil,
+               number_of_terms: nil,
+               induction_programme: "fip")
       end
 
       let(:params) { { started_on: "2019-04-24" } }

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -7,7 +7,7 @@ describe LeadProviderDeliveryPartnership do
   end
 
   describe 'validation' do
-    subject { FactoryBot.create(:lead_provider_delivery_partnership) }
+    subject { create(:lead_provider_delivery_partnership) }
 
     it { is_expected.to validate_presence_of(:active_lead_provider_id).with_message('Select an active lead provider') }
     it { is_expected.to validate_presence_of(:delivery_partner_id).with_message('Select a delivery partner') }
@@ -15,12 +15,12 @@ describe LeadProviderDeliveryPartnership do
   end
 
   describe 'scopes' do
-    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
-    let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-    let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner:, active_lead_provider:) }
+    let(:active_lead_provider) { create(:active_lead_provider) }
+    let(:delivery_partner) { create(:delivery_partner) }
+    let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, delivery_partner:, active_lead_provider:) }
 
     describe '.with_delivery_partner' do
-      let(:other_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership) }
+      let(:other_lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership) }
 
       it 'returns the lead provider delivery partnership belonging to the delivery partner' do
         expect(LeadProviderDeliveryPartnership.with_delivery_partner(delivery_partner)).to include(lead_provider_delivery_partnership)
@@ -32,7 +32,7 @@ describe LeadProviderDeliveryPartnership do
     end
 
     describe '.with_active_lead_provider' do
-      let(:other_active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+      let(:other_active_lead_provider) { create(:active_lead_provider) }
 
       it 'returns the lead provider delivery partnership belonging to the delivery partner' do
         expect(LeadProviderDeliveryPartnership.with_active_lead_provider(active_lead_provider)).to include(lead_provider_delivery_partnership)

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -7,16 +7,16 @@ describe LeadProvider do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:lead_provider) }
+    subject { build(:lead_provider) }
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.allow_nil }
 
     describe ".alphabetical" do
-      let(:lead_provider1) { FactoryBot.create(:lead_provider, name: "C") }
-      let(:lead_provider2) { FactoryBot.create(:lead_provider, name: "A") }
-      let(:lead_provider3) { FactoryBot.create(:lead_provider, name: "B") }
+      let(:lead_provider1) { create(:lead_provider, name: "C") }
+      let(:lead_provider2) { create(:lead_provider, name: "A") }
+      let(:lead_provider3) { create(:lead_provider, name: "B") }
 
       it "returns lead providers in alphabetical order" do
         expect(described_class.alphabetical).to contain_exactly(lead_provider2, lead_provider3, lead_provider1)

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -9,7 +9,7 @@ describe MentorAtSchoolPeriod do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:mentor_at_school_period) }
+    subject { build(:mentor_at_school_period) }
 
     it { is_expected.to validate_presence_of(:started_on) }
     it { is_expected.to validate_presence_of(:school_id) }
@@ -24,23 +24,23 @@ describe MentorAtSchoolPeriod do
     describe 'overlapping periods' do
       let(:started_on_message) { 'Start date cannot overlap another Teacher School Mentor period' }
       let(:finished_on_message) { 'End date cannot overlap another Teacher School Mentor period' }
-      let(:teacher) { FactoryBot.create(:teacher) }
-      let(:school) { FactoryBot.create(:school) }
+      let(:teacher) { create(:teacher) }
+      let(:school) { create(:school) }
 
       context '#teacher_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             before do
-              FactoryBot.create(:mentor_at_school_period, teacher:, school:,
-                                                          started_on: test.existing_period_range.first,
-                                                          finished_on: test.existing_period_range.last)
+              create(:mentor_at_school_period, teacher:, school:,
+                                               started_on: test.existing_period_range.first,
+                                               finished_on: test.existing_period_range.last)
               period.valid?
             end
 
             let(:period) do
-              FactoryBot.build(:mentor_at_school_period, teacher:, school:,
-                                                         started_on: test.new_period_range.first,
-                                                         finished_on: test.new_period_range.last)
+              build(:mentor_at_school_period, teacher:, school:,
+                                              started_on: test.new_period_range.first,
+                                              finished_on: test.new_period_range.last)
             end
 
             let(:messages) { period.errors.messages }
@@ -70,13 +70,13 @@ describe MentorAtSchoolPeriod do
   end
 
   describe "scopes" do
-    let!(:teacher) { FactoryBot.create(:teacher) }
-    let!(:school) { FactoryBot.create(:school) }
-    let!(:school_2) { FactoryBot.create(:school) }
-    let!(:period_1) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:mentor_at_school_period, teacher:, school: school_2, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:period_3) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
-    let!(:teacher_2_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let!(:teacher) { create(:teacher) }
+    let!(:school) { create(:school) }
+    let!(:school_2) { create(:school) }
+    let!(:period_1) { create(:mentor_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:mentor_at_school_period, teacher:, school: school_2, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:mentor_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:teacher_2_period) { create(:mentor_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
 
     describe ".for_school" do
       it "returns mentor periods only for the specified school" do
@@ -92,12 +92,12 @@ describe MentorAtSchoolPeriod do
   end
 
   describe "#siblings" do
-    let!(:teacher) { FactoryBot.create(:teacher) }
-    let!(:school) { FactoryBot.create(:school) }
-    let!(:school_2) { FactoryBot.create(:school) }
-    let!(:period_1) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { FactoryBot.create(:mentor_at_school_period, teacher:, school: school_2, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:mentor_at_school_period) { FactoryBot.build(:mentor_at_school_period, teacher:, school: school_2, started_on: "2022-01-01", finished_on: "2023-01-01") }
+    let!(:teacher) { create(:teacher) }
+    let!(:school) { create(:school) }
+    let!(:school_2) { create(:school) }
+    let!(:period_1) { create(:mentor_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:mentor_at_school_period, teacher:, school: school_2, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:mentor_at_school_period) { build(:mentor_at_school_period, teacher:, school: school_2, started_on: "2022-01-01", finished_on: "2023-01-01") }
 
     it "returns mentor periods for the specified instance's teacher and school excluding the instance" do
       expect(mentor_at_school_period.siblings).to match_array([period_2])

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -7,7 +7,7 @@ describe MentorshipPeriod do
 
   describe "validations" do
     subject do
-      FactoryBot.build(
+      build(
         :mentorship_period,
         started_on:,
         finished_on:,
@@ -16,8 +16,8 @@ describe MentorshipPeriod do
       )
     end
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 2.years.ago) }
-    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 2.years.ago) }
+    let!(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 2.years.ago) }
+    let!(:mentor_at_school_period) { create(:mentor_at_school_period, :active, started_on: 2.years.ago) }
     let(:started_on) { 2.months.ago }
     let(:finished_on) { nil }
 
@@ -33,27 +33,27 @@ describe MentorshipPeriod do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             let(:mentor) do
-              FactoryBot.create(:mentor_at_school_period,
-                                started_on: 5.years.ago,
-                                finished_on: nil)
+              create(:mentor_at_school_period,
+                     started_on: 5.years.ago,
+                     finished_on: nil)
             end
             let(:period) do
-              FactoryBot.build(:mentorship_period, mentee:, mentor:,
-                                                   started_on: test.new_period_range.first,
-                                                   finished_on: test.new_period_range.last)
+              build(:mentorship_period, mentee:, mentor:,
+                                        started_on: test.new_period_range.first,
+                                        finished_on: test.new_period_range.last)
             end
             let(:messages) { period.errors.messages }
 
             let(:mentee) do
-              FactoryBot.create(:ect_at_school_period,
-                                started_on: 5.years.ago,
-                                finished_on: nil)
+              create(:ect_at_school_period,
+                     started_on: 5.years.ago,
+                     finished_on: nil)
             end
 
             before do
-              FactoryBot.create(:mentorship_period, mentee:, mentor:,
-                                                    started_on: test.existing_period_range.first,
-                                                    finished_on: test.existing_period_range.last)
+              create(:mentorship_period, mentee:, mentor:,
+                                         started_on: test.existing_period_range.first,
+                                         finished_on: test.existing_period_range.last)
               period.valid?
             end
 
@@ -83,10 +83,10 @@ describe MentorshipPeriod do
     describe 'period containment' do
       describe '#enveloped_by_ect_at_school_period' do
         context 'when the ECT at school period contains the mentorship period' do
-          subject! { FactoryBot.create(:mentorship_period, started_on: 3.months.ago, finished_on: 2.months.ago, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+          subject! { create(:mentorship_period, started_on: 3.months.ago, finished_on: 2.months.ago, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
-          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+          let!(:ect_at_school_period) { create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+          let!(:mentor_at_school_period) { create(:mentor_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
 
           it 'is valid' do
             expect(subject).to be_valid
@@ -94,10 +94,10 @@ describe MentorshipPeriod do
         end
 
         context 'when the mentorship period extends beyond the teacher and mentor at school periods' do
-          subject { FactoryBot.build(:mentorship_period, started_on: 5.months.ago, finished_on: 1.month.ago, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+          subject { build(:mentorship_period, started_on: 5.months.ago, finished_on: 1.month.ago, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
-          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+          let!(:ect_at_school_period) { create(:ect_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
+          let!(:mentor_at_school_period) { create(:mentor_at_school_period, started_on: 4.months.ago, finished_on: 1.month.ago) }
 
           it 'has an appropriate error message about the ECT at school period' do
             subject.valid?
@@ -116,11 +116,11 @@ describe MentorshipPeriod do
 
     context '#not_self_mentoring' do
       context 'when mentor and mentee are the same teacher' do
-        subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+        subject { build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
         let!(:teacher) { ect_at_school_period.teacher }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+        let!(:ect_at_school_period) { create(:ect_at_school_period, :active) }
+        let!(:mentor_at_school_period) { create(:mentor_at_school_period, :active, teacher:) }
 
         it 'add a base error' do
           subject.valid?
@@ -130,10 +130,10 @@ describe MentorshipPeriod do
       end
 
       context 'when mentor and mentee are different teachers' do
-        subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
+        subject { build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+        let!(:ect_at_school_period) { create(:ect_at_school_period, :active) }
+        let!(:mentor_at_school_period) { create(:mentor_at_school_period, :active) }
 
         it 'do not add an error' do
           subject.valid?
@@ -143,10 +143,10 @@ describe MentorshipPeriod do
       end
 
       context 'when mentor or mentee are not set yet' do
-        subject { FactoryBot.build(:mentorship_period, mentor: mentor_at_school_period) }
+        subject { build(:mentorship_period, mentor: mentor_at_school_period) }
 
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+        let!(:ect_at_school_period) { create(:ect_at_school_period, :active) }
+        let!(:mentor_at_school_period) { create(:mentor_at_school_period, :active) }
 
         it 'do not add an error' do
           subject.valid?
@@ -174,13 +174,13 @@ describe MentorshipPeriod do
   describe "#siblings" do
     subject { period_1.siblings }
 
-    let!(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
-    let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: '2021-01-01') }
-    let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-01-01', finished_on: '2022-06-01') }
-    let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:mentee) { create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:mentor) { create(:mentor_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:period_1) { create(:mentorship_period, mentee:, mentor:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+    let!(:period_2) { create(:mentorship_period, mentee:, mentor:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-    let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
-    let!(:unrelated_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:unrelated_mentee) { create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:unrelated_period) { create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
     it "only returns records that belong to the same mentee" do
       expect(subject).to include(period_2)

--- a/spec/models/migration/cohort_spec.rb
+++ b/spec/models/migration/cohort_spec.rb
@@ -1,8 +1,8 @@
 describe Migration::Cohort, type: :model do
-  subject { FactoryBot.create(:migration_cohort) }
+  subject { create(:migration_cohort) }
 
   describe "#next" do
-    let!(:next_cohort) { FactoryBot.create(:migration_cohort, start_year: subject.start_year + 1) }
+    let!(:next_cohort) { create(:migration_cohort, start_year: subject.start_year + 1) }
 
     it "returns the next cohort of the given cohort" do
       expect(subject.next).to eq(next_cohort)

--- a/spec/models/parity_check/endpoint_spec.rb
+++ b/spec/models/parity_check/endpoint_spec.rb
@@ -13,7 +13,7 @@ describe ParityCheck::Endpoint do
     it { is_expected.not_to allow_values([], [{ foo: :bar }]).for(:options).with_message("Options must be a hash") }
 
     it "validates that the path does not contain query parameters" do
-      instance = FactoryBot.build(:parity_check_endpoint, path: "/a/path?with=query")
+      instance = build(:parity_check_endpoint, path: "/a/path?with=query")
       expect(instance).not_to be_valid
       expect(instance.errors[:path]).to include("Path should not contain query parameters; use options[:query] instead.")
     end
@@ -45,7 +45,7 @@ describe ParityCheck::Endpoint do
     subject { instance.description }
 
     let(:options) { {} }
-    let(:instance) { FactoryBot.build(:parity_check_endpoint, method: :get, path: "/a/path", options:) }
+    let(:instance) { build(:parity_check_endpoint, method: :get, path: "/a/path", options:) }
 
     it { is_expected.to eq("GET /a/path") }
 

--- a/spec/models/parity_check/request_spec.rb
+++ b/spec/models/parity_check/request_spec.rb
@@ -21,13 +21,13 @@ describe ParityCheck::Request do
     it { is_expected.not_to validate_presence_of(:responses) }
 
     context "when in_progress" do
-      subject { FactoryBot.build(:parity_check_request, :in_progress) }
+      subject { build(:parity_check_request, :in_progress) }
 
       it { is_expected.to validate_presence_of(:started_at) }
     end
 
     context "when completed" do
-      subject { FactoryBot.build(:parity_check_request, :completed, started_at:) }
+      subject { build(:parity_check_request, :completed, started_at:) }
 
       let(:started_at) { Time.current }
 
@@ -39,11 +39,11 @@ describe ParityCheck::Request do
   end
 
   describe "scopes" do
-    let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
-    let!(:pending_get_request) { FactoryBot.create(:parity_check_request, :pending, :get, run:) }
-    let!(:queued_get_request) { FactoryBot.create(:parity_check_request, :queued, :get, run:) }
-    let!(:in_progress_post_request) { FactoryBot.create(:parity_check_request, :in_progress, :post, run:) }
-    let!(:completed_put_request) { FactoryBot.create(:parity_check_request, :completed, :put, run:) }
+    let(:run) { create(:parity_check_run, :in_progress) }
+    let!(:pending_get_request) { create(:parity_check_request, :pending, :get, run:) }
+    let!(:queued_get_request) { create(:parity_check_request, :queued, :get, run:) }
+    let!(:in_progress_post_request) { create(:parity_check_request, :in_progress, :post, run:) }
+    let!(:completed_put_request) { create(:parity_check_request, :completed, :put, run:) }
 
     describe ".pending" do
       subject { described_class.pending }
@@ -108,11 +108,11 @@ describe ParityCheck::Request do
     describe ".with_all_responses_matching" do
       subject { described_class.with_all_responses_matching }
 
-      let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
-      let!(:request_with_no_responses) { FactoryBot.create(:parity_check_request, :in_progress, response_types: [], run:) }
-      let!(:request_with_matching_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching matching], run:) }
-      let!(:request_with_different_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[different], run:) }
-      let!(:request_with_matching_and_different_responses) { FactoryBot.create(:parity_check_request, :completed, response_types: %i[matching different], run:) }
+      let(:run) { create(:parity_check_run, :in_progress) }
+      let!(:request_with_no_responses) { create(:parity_check_request, :in_progress, response_types: [], run:) }
+      let!(:request_with_matching_responses) { create(:parity_check_request, :completed, response_types: %i[matching matching], run:) }
+      let!(:request_with_different_responses) { create(:parity_check_request, :completed, response_types: %i[different], run:) }
+      let!(:request_with_matching_and_different_responses) { create(:parity_check_request, :completed, response_types: %i[matching different], run:) }
 
       it { expect(subject).to contain_exactly(request_with_matching_responses) }
     end
@@ -122,20 +122,20 @@ describe ParityCheck::Request do
     it { is_expected.to be_pending }
 
     context "when transitioning from pending to queued" do
-      let(:request) { FactoryBot.create(:parity_check_request, :pending) }
+      let(:request) { create(:parity_check_request, :pending) }
 
       it { expect { request.queue! }.to change(request, :state).from("pending").to("queued") }
     end
 
     context "when transitioning from queued to in_progress" do
-      let(:request) { FactoryBot.create(:parity_check_request, :queued) }
+      let(:request) { create(:parity_check_request, :queued) }
 
       it { expect { request.start! }.to change(request, :state).from("queued").to("in_progress") }
       it { expect { request.start! }.to change(request, :started_at).from(nil).to(be_within(1.second).of(Time.zone.now)) }
     end
 
     context "when transitioning from in_progress to completed" do
-      let(:request) { FactoryBot.create(:parity_check_request, :in_progress, response_types: %i[different]) }
+      let(:request) { create(:parity_check_request, :in_progress, response_types: %i[different]) }
 
       it { expect { request.complete! }.to change(request, :state).from("in_progress").to("completed") }
       it { expect { request.complete! }.to change(request, :completed_at).from(nil).to(be_within(1.second).of(Time.zone.now)) }
@@ -148,7 +148,7 @@ describe ParityCheck::Request do
     end
 
     context "when attempting an unsupported transition" do
-      let(:request) { FactoryBot.create(:parity_check_request, :completed) }
+      let(:request) { create(:parity_check_request, :completed) }
 
       it { expect { request.queue! }.to raise_error(StateMachines::InvalidTransition) }
     end
@@ -157,7 +157,7 @@ describe ParityCheck::Request do
   describe "#rect_performance_gain_ratio" do
     subject { request.rect_performance_gain_ratio }
 
-    let(:request) { FactoryBot.create(:parity_check_request, responses:) }
+    let(:request) { create(:parity_check_request, responses:) }
 
     context "when there are no responses" do
       let(:responses) { [] }
@@ -166,7 +166,7 @@ describe ParityCheck::Request do
     end
 
     context "when there are responses" do
-      let(:responses) { FactoryBot.create_list(:parity_check_response, 2) }
+      let(:responses) { create_list(:parity_check_response, 2) }
 
       context "when the response times are equal" do
         before do
@@ -201,12 +201,12 @@ describe ParityCheck::Request do
     subject { request.match_rate }
 
     let(:response_types) { %i[matching matching different] }
-    let(:request) { FactoryBot.create(:parity_check_request, :completed, response_types:) }
+    let(:request) { create(:parity_check_request, :completed, response_types:) }
 
     it { is_expected.to eq(67) }
 
     context "when there are no responses" do
-      let(:request) { FactoryBot.create(:parity_check_request, :in_progress, response_types: []) }
+      let(:request) { create(:parity_check_request, :in_progress, response_types: []) }
 
       it { is_expected.to be_nil }
     end

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -11,7 +11,7 @@ describe ParityCheck::Response do
 
   describe "before_validation" do
     it "clears bodies if the response bodies match" do
-      response = FactoryBot.build(:parity_check_response, :different, ecf_body: "same", rect_body: "same")
+      response = build(:parity_check_response, :different, ecf_body: "same", rect_body: "same")
       expect { response.save! }.to change { response.ecf_body }.to(nil).and change { response.rect_body }.to(nil)
     end
   end
@@ -20,7 +20,7 @@ describe ParityCheck::Response do
     it "formats bodies as pretty JSON if they are valid JSON" do
       ecf_body = { ecf_key: "ecf_value" }
       rect_body = { rect_key: "rect_value" }
-      response = FactoryBot.build(:parity_check_response, ecf_body: ecf_body.to_json, rect_body: rect_body.to_json)
+      response = build(:parity_check_response, ecf_body: ecf_body.to_json, rect_body: rect_body.to_json)
 
       response.save!
 
@@ -29,7 +29,7 @@ describe ParityCheck::Response do
     end
 
     it "does not format bodies if they are not valid JSON" do
-      response = FactoryBot.build(:parity_check_response, ecf_body: "not json", rect_body: "also not json")
+      response = build(:parity_check_response, ecf_body: "not json", rect_body: "also not json")
 
       response.save!
 
@@ -39,7 +39,7 @@ describe ParityCheck::Response do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:parity_check_response) }
+    subject { build(:parity_check_response) }
 
     it { is_expected.to validate_presence_of(:request) }
     it { is_expected.to validate_inclusion_of(:ecf_status_code).in_range(100..599) }
@@ -51,11 +51,11 @@ describe ParityCheck::Response do
   end
 
   describe "scopes" do
-    let(:request) { FactoryBot.create(:parity_check_request) }
-    let!(:matching_response) { FactoryBot.create(:parity_check_response, :matching, request:) }
-    let!(:matching_status_codes_response) { FactoryBot.create(:parity_check_response, :matching, ecf_body: "different", request:) }
-    let!(:matching_bodies_response) { FactoryBot.create(:parity_check_response, :matching, ecf_status_code: 404, request:) }
-    let!(:different_response) { FactoryBot.create(:parity_check_response, :different, request:) }
+    let(:request) { create(:parity_check_request) }
+    let!(:matching_response) { create(:parity_check_response, :matching, request:) }
+    let!(:matching_status_codes_response) { create(:parity_check_response, :matching, ecf_body: "different", request:) }
+    let!(:matching_bodies_response) { create(:parity_check_response, :matching, ecf_status_code: 404, request:) }
+    let!(:different_response) { create(:parity_check_response, :different, request:) }
 
     describe ".different" do
       subject { described_class.different }
@@ -97,7 +97,7 @@ describe ParityCheck::Response do
   describe "#rect_performance_gain_ratio" do
     subject { response.rect_performance_gain_ratio }
 
-    let(:response) { FactoryBot.build(:parity_check_response, ecf_time_ms:, rect_time_ms:) }
+    let(:response) { build(:parity_check_response, ecf_time_ms:, rect_time_ms:) }
 
     context "when there are no response times" do
       let(:rect_time_ms) { nil }
@@ -132,13 +132,13 @@ describe ParityCheck::Response do
     subject { response.match_rate }
 
     context "when the response is matching" do
-      let(:response) { FactoryBot.build(:parity_check_response, :matching) }
+      let(:response) { build(:parity_check_response, :matching) }
 
       it { is_expected.to eq(100) }
     end
 
     context "when the response is different" do
-      let(:response) { FactoryBot.build(:parity_check_response, :different) }
+      let(:response) { build(:parity_check_response, :different) }
 
       it { is_expected.to eq(0) }
     end
@@ -148,13 +148,13 @@ describe ParityCheck::Response do
     subject { response.description }
 
     context "when the response has a page" do
-      let(:response) { FactoryBot.build(:parity_check_response, page: 1) }
+      let(:response) { build(:parity_check_response, page: 1) }
 
       it { is_expected.to eq("Response for page 1") }
     end
 
     context "when the response does not have a page" do
-      let(:response) { FactoryBot.build(:parity_check_response, page: nil) }
+      let(:response) { build(:parity_check_response, page: nil) }
 
       it { is_expected.to eq("Response") }
     end
@@ -164,13 +164,13 @@ describe ParityCheck::Response do
     subject { response }
 
     context "when the response is matching" do
-      let(:response) { FactoryBot.build(:parity_check_response, :matching) }
+      let(:response) { build(:parity_check_response, :matching) }
 
       it { is_expected.to be_matching }
     end
 
     context "when the response is different" do
-      let(:response) { FactoryBot.build(:parity_check_response, :different) }
+      let(:response) { build(:parity_check_response, :different) }
 
       it { is_expected.not_to be_matching }
     end
@@ -180,13 +180,13 @@ describe ParityCheck::Response do
     subject { response }
 
     context "when the response is different" do
-      let(:response) { FactoryBot.build(:parity_check_response, :different) }
+      let(:response) { build(:parity_check_response, :different) }
 
       it { is_expected.to be_different }
     end
 
     context "when the response is matching" do
-      let(:response) { FactoryBot.build(:parity_check_response, :matching) }
+      let(:response) { build(:parity_check_response, :matching) }
 
       it { is_expected.not_to be_different }
     end
@@ -196,13 +196,13 @@ describe ParityCheck::Response do
     subject { response }
 
     context "when the ECF and RECT bodies are the same" do
-      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "body", rect_body: "body") }
+      let(:response) { build(:parity_check_response, ecf_body: "body", rect_body: "body") }
 
       it { is_expected.to be_bodies_matching }
     end
 
     context "when the ECF and RECT bodies are different" do
-      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "ecf body", rect_body: "rect body") }
+      let(:response) { build(:parity_check_response, ecf_body: "ecf body", rect_body: "rect body") }
 
       it { is_expected.not_to be_bodies_matching }
     end
@@ -212,13 +212,13 @@ describe ParityCheck::Response do
     subject { response }
 
     context "when the ECF and RECT bodies are the same" do
-      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "body", rect_body: "body") }
+      let(:response) { build(:parity_check_response, ecf_body: "body", rect_body: "body") }
 
       it { is_expected.not_to be_bodies_different }
     end
 
     context "when the ECF and RECT bodies are different" do
-      let(:response) { FactoryBot.build(:parity_check_response, ecf_body: "ecf body", rect_body: "rect body") }
+      let(:response) { build(:parity_check_response, ecf_body: "ecf body", rect_body: "rect body") }
 
       it { is_expected.to be_bodies_different }
     end
@@ -227,7 +227,7 @@ describe ParityCheck::Response do
   describe "#body_diff" do
     subject(:diff) { response.body_diff }
 
-    let(:response) { FactoryBot.create(:parity_check_response, :different) }
+    let(:response) { create(:parity_check_response, :different) }
 
     it { is_expected.to be_a(Diffy::Diff) }
 

--- a/spec/models/pending_induction_submission_batch_spec.rb
+++ b/spec/models/pending_induction_submission_batch_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe PendingInductionSubmissionBatch do
-  subject(:batch) { FactoryBot.build(:pending_induction_submission_batch, :claim) }
+  subject(:batch) { build(:pending_induction_submission_batch, :claim) }
 
   describe 'associations' do
     it { is_expected.to belong_to(:appropriate_body) }
@@ -8,11 +8,11 @@ RSpec.describe PendingInductionSubmissionBatch do
 
   describe "scopes" do
     describe ".for_appropriate_body" do
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:appropriate_body) { create(:appropriate_body) }
 
-      let!(:batch1) { FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body:) }
-      let!(:batch2) { FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:) }
-      let!(:batch3) { FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body:) }
+      let!(:batch1) { create(:pending_induction_submission_batch, :claim, appropriate_body:) }
+      let!(:batch2) { create(:pending_induction_submission_batch, :action, appropriate_body:) }
+      let!(:batch3) { create(:pending_induction_submission_batch, :claim, appropriate_body:) }
 
       it "returns batched submissions for the specified appropriate body" do
         expect(described_class.for_appropriate_body(appropriate_body)).to contain_exactly(batch1, batch2, batch3)
@@ -21,7 +21,7 @@ RSpec.describe PendingInductionSubmissionBatch do
   end
 
   describe 'class methods' do
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:appropriate_body) { create(:appropriate_body) }
 
     describe '.new_claim_for' do
       subject(:claim) { described_class.new_claim_for(appropriate_body:) }

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe PendingInductionSubmission do
   end
 
   describe "scopes" do
-    let!(:sub1) { FactoryBot.create(:pending_induction_submission) }
-    let!(:sub2) { FactoryBot.create(:pending_induction_submission) }
-    let!(:sub3) { FactoryBot.create(:pending_induction_submission, error_messages: ['something went wrong']) }
+    let!(:sub1) { create(:pending_induction_submission) }
+    let!(:sub2) { create(:pending_induction_submission) }
+    let!(:sub3) { create(:pending_induction_submission, error_messages: ['something went wrong']) }
 
     describe ".with_errors" do
       it "returns submissions with errors" do
@@ -88,13 +88,13 @@ RSpec.describe PendingInductionSubmission do
     end
 
     describe "number_of_terms" do
-      subject { FactoryBot.build(:pending_induction_submission, finished_on: Date.current) }
+      subject { build(:pending_induction_submission, finished_on: Date.current) }
 
       it { is_expected.to validate_presence_of(:number_of_terms).with_message('Enter a number of terms').on(%i[release_ect record_outcome]) }
       it { is_expected.to validate_inclusion_of(:number_of_terms).in_range(0..16).with_message("Number of terms must be between 0 and 16").on(%i[release_ect record_outcome]) }
 
       context "when finished_on is blank" do
-        subject { FactoryBot.build(:pending_induction_submission, finished_on: nil) }
+        subject { build(:pending_induction_submission, finished_on: nil) }
 
         it "validates absence of number_of_terms" do
           subject.number_of_terms = 5
@@ -104,9 +104,9 @@ RSpec.describe PendingInductionSubmission do
       end
 
       context "when number_of_terms has more than 1 decimal place" do
-        subject { FactoryBot.build(:pending_induction_submission, appropriate_body:, number_of_terms: 3.45, finished_on: Date.current) }
+        subject { build(:pending_induction_submission, appropriate_body:, number_of_terms: 3.45, finished_on: Date.current) }
 
-        let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+        let(:appropriate_body) { create(:appropriate_body) }
 
         it "is invalid on release_ect" do
           expect(subject.valid?(:release_ect)).to be false
@@ -120,9 +120,9 @@ RSpec.describe PendingInductionSubmission do
       end
 
       context "when number_of_terms has 1 decimal place" do
-        subject { FactoryBot.build(:pending_induction_submission, appropriate_body:, number_of_terms: 3.5, finished_on: Date.current) }
+        subject { build(:pending_induction_submission, appropriate_body:, number_of_terms: 3.5, finished_on: Date.current) }
 
-        let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+        let(:appropriate_body) { create(:appropriate_body) }
 
         it "is valid on release_ect" do
           expect(subject.valid?(:release_ect)).to be true
@@ -135,9 +135,9 @@ RSpec.describe PendingInductionSubmission do
       end
 
       context "when number_of_terms is an integer" do
-        subject { FactoryBot.build(:pending_induction_submission, appropriate_body:, number_of_terms: 3, finished_on: Date.current) }
+        subject { build(:pending_induction_submission, appropriate_body:, number_of_terms: 3, finished_on: Date.current) }
 
-        let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+        let(:appropriate_body) { create(:appropriate_body) }
 
         it "is valid on release_ect" do
           expect(subject.valid?(:release_ect)).to be true
@@ -155,7 +155,7 @@ RSpec.describe PendingInductionSubmission do
     end
 
     describe "started_on_not_in_future" do
-      let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+      let(:pending_induction_submission) { create(:pending_induction_submission) }
 
       context "when started_on is today" do
         before { pending_induction_submission.started_on = Date.current }
@@ -188,7 +188,7 @@ RSpec.describe PendingInductionSubmission do
     end
 
     describe "finished_on_not_in_future" do
-      let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+      let(:pending_induction_submission) { create(:pending_induction_submission) }
 
       context "when finished_on is today" do
         before do
@@ -227,7 +227,7 @@ RSpec.describe PendingInductionSubmission do
     end
 
     describe "start_date_after_qts_date" do
-      let(:pending_induction_submission) { FactoryBot.build(:pending_induction_submission, started_on:, trs_qts_awarded_on: Date.new(2023, 5, 1)) }
+      let(:pending_induction_submission) { build(:pending_induction_submission, started_on:, trs_qts_awarded_on: Date.new(2023, 5, 1)) }
 
       context "when trs_qts_awarded_on is before started_on" do
         let(:started_on) { Date.new(2023, 5, 2) }
@@ -252,26 +252,26 @@ RSpec.describe PendingInductionSubmission do
   end
 
   describe '#fail?' do
-    subject { FactoryBot.build(:pending_induction_submission, outcome: 'fail') }
+    subject { build(:pending_induction_submission, outcome: 'fail') }
 
     it { is_expected.to be_fail }
   end
 
   describe '#pass?' do
-    subject { FactoryBot.build(:pending_induction_submission, outcome: 'pass') }
+    subject { build(:pending_induction_submission, outcome: 'pass') }
 
     it { is_expected.to be_pass }
   end
 
   describe '#exempt?' do
-    subject { FactoryBot.build(:pending_induction_submission, trs_induction_status: 'Exempt') }
+    subject { build(:pending_induction_submission, trs_induction_status: 'Exempt') }
 
     it { is_expected.to be_exempt }
   end
 
   describe '#teacher' do
-    let(:teacher) { FactoryBot.create(:teacher, trn: '1234567') }
-    let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
+    let(:teacher) { create(:teacher, trn: '1234567') }
+    let(:pending_induction_submission) { create(:pending_induction_submission, trn: teacher.trn) }
 
     it 'returns the teacher associated with the trn' do
       expect(pending_induction_submission.teacher).to eq(teacher)
@@ -279,8 +279,8 @@ RSpec.describe PendingInductionSubmission do
   end
 
   describe '#playback_errors' do
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let(:pending_induction_submission) { FactoryBot.build(:pending_induction_submission, appropriate_body:, finished_on: 1.day.ago) }
+    let(:appropriate_body) { create(:appropriate_body) }
+    let(:pending_induction_submission) { build(:pending_induction_submission, appropriate_body:, finished_on: 1.day.ago) }
 
     before do
       pending_induction_submission.playback_errors unless pending_induction_submission.save(context: :record_outcome)

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -6,7 +6,7 @@ describe SchoolPartnership do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:school_partnership) }
+    subject { create(:school_partnership) }
 
     it { is_expected.to validate_presence_of(:lead_provider_delivery_partnership_id) }
     it { is_expected.to validate_presence_of(:school_id) }
@@ -15,9 +15,9 @@ describe SchoolPartnership do
 
   describe 'scopes' do
     describe '.earliest_first' do
-      let!(:school_partnership_first) { FactoryBot.create(:school_partnership, created_at: 3.weeks.ago) }
-      let!(:school_partnership_second) { FactoryBot.create(:school_partnership, created_at: 2.weeks.ago) }
-      let!(:school_partnership_third) { FactoryBot.create(:school_partnership, created_at: 1.week.ago) }
+      let!(:school_partnership_first) { create(:school_partnership, created_at: 3.weeks.ago) }
+      let!(:school_partnership_second) { create(:school_partnership, created_at: 2.weeks.ago) }
+      let!(:school_partnership_third) { create(:school_partnership, created_at: 1.week.ago) }
 
       it 'orders with earliest created records first' do
         expect(SchoolPartnership.earliest_first).to eq([

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -21,23 +21,23 @@ describe School do
   end
 
   describe 'validations' do
-    subject { FactoryBot.build(:school) }
+    subject { build(:school) }
 
     it { is_expected.to validate_presence_of(:urn) }
     it { is_expected.to validate_uniqueness_of(:urn) }
 
     context "last_chosen_lead_provider_id" do
-      subject { FactoryBot.build(:school) }
+      subject { build(:school) }
 
       context "when last_chosen_training_programme is 'school_led'" do
-        subject { FactoryBot.build(:school, :school_led_last_chosen) }
+        subject { build(:school, :school_led_last_chosen) }
 
         it { is_expected.to validate_absence_of(:last_chosen_lead_provider_id).with_message('Must be nil') }
       end
     end
 
     context "last_chosen_training_programme" do
-      subject { FactoryBot.build(:school) }
+      subject { build(:school) }
 
       it do
         is_expected.to validate_inclusion_of(:last_chosen_training_programme)
@@ -47,7 +47,7 @@ describe School do
       end
 
       context "when last_chosen_lead_provider has been set" do
-        subject { FactoryBot.build(:school, last_chosen_lead_provider_id: 123) }
+        subject { build(:school, last_chosen_lead_provider_id: 123) }
 
         it { is_expected.to validate_presence_of(:last_chosen_training_programme).with_message("Must be provider-led") }
       end
@@ -55,26 +55,26 @@ describe School do
 
     context "last_chosen_appropriate_body_id" do
       context "when the school is independent" do
-        subject { FactoryBot.build(:school, :independent) }
+        subject { build(:school, :independent) }
 
         context "when it is nil" do
           it { is_expected.to be_valid }
         end
 
         context "when national ab chosen" do
-          subject { FactoryBot.build(:school, :independent, :national_ab_last_chosen) }
+          subject { build(:school, :independent, :national_ab_last_chosen) }
 
           it { is_expected.to be_valid }
         end
 
         context "when teaching school hub ab chosen" do
-          subject { FactoryBot.build(:school, :independent, :teaching_school_hub_ab_last_chosen) }
+          subject { build(:school, :independent, :teaching_school_hub_ab_last_chosen) }
 
           it { is_expected.to be_valid }
         end
 
         context "when local authority ab chosen" do
-          subject { FactoryBot.build(:school, :independent, :local_authority_ab_last_chosen) }
+          subject { build(:school, :independent, :local_authority_ab_last_chosen) }
 
           before { subject.valid? }
 
@@ -86,14 +86,14 @@ describe School do
       end
 
       context "when the school is state-funded" do
-        subject { FactoryBot.build(:school, :state_funded) }
+        subject { build(:school, :state_funded) }
 
         context "when it is nil" do
           it { is_expected.to be_valid }
         end
 
         context "when national ab chosen" do
-          subject { FactoryBot.build(:school, :state_funded, :national_ab_last_chosen) }
+          subject { build(:school, :state_funded, :national_ab_last_chosen) }
 
           before { subject.valid? }
 
@@ -104,13 +104,13 @@ describe School do
         end
 
         context "when teaching school hub ab chosen" do
-          subject { FactoryBot.build(:school, :state_funded, :teaching_school_hub_ab_last_chosen) }
+          subject { build(:school, :state_funded, :teaching_school_hub_ab_last_chosen) }
 
           it { is_expected.to be_valid }
         end
 
         context "when local authority ab chosen" do
-          subject { FactoryBot.build(:school, :state_funded, :local_authority_ab_last_chosen) }
+          subject { build(:school, :state_funded, :local_authority_ab_last_chosen) }
 
           before { subject.valid? }
 

--- a/spec/models/statement/adjustment_spec.rb
+++ b/spec/models/statement/adjustment_spec.rb
@@ -4,7 +4,7 @@ describe Statement::Adjustment do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:statement_adjustment) }
+    subject { create(:statement_adjustment) }
 
     it { is_expected.to validate_presence_of(:payment_type).with_message("Payment type is required") }
     it { is_expected.to validate_presence_of(:amount).with_message("Amount is required") }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -9,7 +9,7 @@ describe Teacher do
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:teacher) }
+    subject { build(:teacher) }
 
     it { is_expected.to validate_length_of(:trs_induction_status).with_message('TRS induction status must be shorter than 18 characters') }
 
@@ -31,19 +31,19 @@ describe Teacher do
 
     describe 'mentor ineligibility' do
       context 'when both the ineligibility date and reason are present' do
-        subject { FactoryBot.build(:teacher) }
+        subject { build(:teacher) }
 
         it { is_expected.to be_valid }
       end
 
       context 'when both the ineligibility date and reason are blank' do
-        subject { FactoryBot.build(:teacher, :ineligible_for_mentor_funding) }
+        subject { build(:teacher, :ineligible_for_mentor_funding) }
 
         it { is_expected.to be_valid }
       end
 
       context 'when the ineligibility date is present but the reason is missing' do
-        subject { FactoryBot.build(:teacher, mentor_became_ineligible_for_funding_reason: 'started_not_completed') }
+        subject { build(:teacher, mentor_became_ineligible_for_funding_reason: 'started_not_completed') }
 
         it { is_expected.to be_invalid }
 
@@ -56,7 +56,7 @@ describe Teacher do
       end
 
       context 'when the ineligibility reason is present but the date is missing' do
-        subject { FactoryBot.build(:teacher, mentor_became_ineligible_for_funding_on: 3.days.ago) }
+        subject { build(:teacher, mentor_became_ineligible_for_funding_on: 3.days.ago) }
 
         it { is_expected.to be_invalid }
 
@@ -77,8 +77,8 @@ describe Teacher do
       end
 
       describe 'basic matching' do
-        let!(:target) { FactoryBot.create(:teacher, trs_first_name: "Malcolm", trs_last_name: "Wilkerson", corrected_name: nil) }
-        let!(:other) { FactoryBot.create(:teacher, trs_first_name: "Reese", trs_last_name: "Wilkerson", corrected_name: nil) }
+        let!(:target) { create(:teacher, trs_first_name: "Malcolm", trs_last_name: "Wilkerson", corrected_name: nil) }
+        let!(:other) { create(:teacher, trs_first_name: "Reese", trs_last_name: "Wilkerson", corrected_name: nil) }
 
         it "returns only the expected result" do
           results = Teacher.search('Malcolm')
@@ -89,7 +89,7 @@ describe Teacher do
       end
 
       describe 'matching with accents' do
-        let!(:target) { FactoryBot.create(:teacher, trs_first_name: "Stëvìê", trs_last_name: "Kènårbän", corrected_name: nil) }
+        let!(:target) { create(:teacher, trs_first_name: "Stëvìê", trs_last_name: "Kènårbän", corrected_name: nil) }
 
         it 'matches when names have accents but search terms do not' do
           results = Teacher.search('Stevie Kenarban')
@@ -105,8 +105,8 @@ describe Teacher do
       end
 
       describe 'matching a prefix' do
-        let!(:target) { FactoryBot.create(:teacher, trs_first_name: "Dewey", trs_last_name: "Wilkerson", corrected_name: nil) }
-        let!(:other) { FactoryBot.create(:teacher, trs_first_name: "Reese", trs_last_name: "Wilkerson", corrected_name: nil) }
+        let!(:target) { create(:teacher, trs_first_name: "Dewey", trs_last_name: "Wilkerson", corrected_name: nil) }
+        let!(:other) { create(:teacher, trs_first_name: "Reese", trs_last_name: "Wilkerson", corrected_name: nil) }
 
         it 'matches on the start of a word' do
           results = Teacher.search('Dew')

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -18,7 +18,7 @@ describe TrainingPeriod do
     context "exactly one id of trainee present" do
       context "when ect_at_school_period_id and mentor_at_school_period_id are all nil" do
         subject do
-          FactoryBot.build(:training_period, ect_at_school_period_id: nil, mentor_at_school_period_id: nil)
+          build(:training_period, ect_at_school_period_id: nil, mentor_at_school_period_id: nil)
         end
 
         it "add an error" do
@@ -29,7 +29,7 @@ describe TrainingPeriod do
 
       context "when ect_at_school_period_id and mentor_at_school_period_id are all set" do
         subject do
-          FactoryBot.build(:training_period, ect_at_school_period_id: 200, mentor_at_school_period_id: 300)
+          build(:training_period, ect_at_school_period_id: 200, mentor_at_school_period_id: 300)
         end
 
         it "add an error" do
@@ -41,10 +41,10 @@ describe TrainingPeriod do
 
     describe 'presence of expression of interest or school partnership' do
       let(:dates) { { started_on: 3.years.ago.to_date, finished_on: nil } }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, **dates) }
+      let(:ect_at_school_period) { create(:ect_at_school_period, **dates) }
 
       context 'when neither the expression of interest or school partnership is present' do
-        subject { FactoryBot.build(:training_period, ect_at_school_period:, expression_of_interest: nil, school_partnership: nil, **dates) }
+        subject { build(:training_period, ect_at_school_period:, expression_of_interest: nil, school_partnership: nil, **dates) }
 
         it 'has a base error stating either expression of interest or school partnership required' do
           subject.valid?
@@ -53,19 +53,19 @@ describe TrainingPeriod do
       end
 
       context 'when just the expression of interest is present' do
-        subject { FactoryBot.create(:training_period, :with_expression_of_interest, ect_at_school_period:, **dates) }
+        subject { create(:training_period, :with_expression_of_interest, ect_at_school_period:, **dates) }
 
         it { is_expected.to(be_valid) }
       end
 
       context 'when just the school partnership is present' do
-        subject { FactoryBot.create(:training_period, :with_school_partnership, ect_at_school_period:, **dates) }
+        subject { create(:training_period, :with_school_partnership, ect_at_school_period:, **dates) }
 
         it { is_expected.to(be_valid) }
       end
 
       context 'when both the expression of interest and school partnership are present' do
-        subject { FactoryBot.create(:training_period, :with_school_partnership, :with_expression_of_interest, ect_at_school_period:, **dates) }
+        subject { create(:training_period, :with_school_partnership, :with_expression_of_interest, ect_at_school_period:, **dates) }
 
         it { is_expected.to(be_valid) }
       end
@@ -79,21 +79,21 @@ describe TrainingPeriod do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             let(:ect_at_school_period) do
-              FactoryBot.create(:ect_at_school_period,
-                                started_on: 5.years.ago,
-                                finished_on: nil)
+              create(:ect_at_school_period,
+                     started_on: 5.years.ago,
+                     finished_on: nil)
             end
             let(:period) do
-              FactoryBot.build(:training_period, ect_at_school_period:,
-                                                 started_on: test.new_period_range.first,
-                                                 finished_on: test.new_period_range.last)
+              build(:training_period, ect_at_school_period:,
+                                      started_on: test.new_period_range.first,
+                                      finished_on: test.new_period_range.last)
             end
             let(:messages) { period.errors.messages }
 
             before do
-              FactoryBot.create(:training_period, ect_at_school_period:,
-                                                  started_on: test.existing_period_range.first,
-                                                  finished_on: test.existing_period_range.last)
+              create(:training_period, ect_at_school_period:,
+                                       started_on: test.existing_period_range.first,
+                                       finished_on: test.existing_period_range.last)
               period.valid?
             end
 
@@ -123,21 +123,21 @@ describe TrainingPeriod do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             let(:mentor_at_school_period) do
-              FactoryBot.create(:mentor_at_school_period,
-                                started_on: 5.years.ago,
-                                finished_on: nil)
+              create(:mentor_at_school_period,
+                     started_on: 5.years.ago,
+                     finished_on: nil)
             end
             let(:period) do
-              FactoryBot.build(:training_period, :for_mentor, mentor_at_school_period:,
-                                                              started_on: test.new_period_range.first,
-                                                              finished_on: test.new_period_range.last)
+              build(:training_period, :for_mentor, mentor_at_school_period:,
+                                                   started_on: test.new_period_range.first,
+                                                   finished_on: test.new_period_range.last)
             end
             let(:messages) { period.errors.messages }
 
             before do
-              FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:,
-                                                               started_on: test.existing_period_range.first,
-                                                               finished_on: test.existing_period_range.last)
+              create(:training_period, :for_mentor, mentor_at_school_period:,
+                                                    started_on: test.existing_period_range.first,
+                                                    finished_on: test.existing_period_range.last)
               period.valid?
             end
 
@@ -182,16 +182,16 @@ describe TrainingPeriod do
   describe "#siblings" do
     subject { training_period_1.siblings }
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
-    let!(:training_period_1) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: '2022-01-01', finished_on: '2022-06-01') }
-    let!(:training_period_2) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: '2022-06-01', finished_on: '2023-01-01') }
+    let!(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:training_period_1) { create(:training_period, ect_at_school_period:, started_on: '2022-01-01', finished_on: '2022-06-01') }
+    let!(:training_period_2) { create(:training_period, ect_at_school_period:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
     let!(:unrelated_ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01')
+      create(:ect_at_school_period, :active, started_on: '2021-01-01')
     end
 
     let!(:unrelated_training_period) do
-      FactoryBot.create(:training_period, ect_at_school_period: unrelated_ect_at_school_period, started_on: '2022-06-01', finished_on: '2023-01-01')
+      create(:training_period, ect_at_school_period: unrelated_ect_at_school_period, started_on: '2022-06-01', finished_on: '2023-01-01')
     end
 
     it "only returns records that belong to the same trainee" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 describe User do
-  subject(:user) { FactoryBot.build(:user) }
+  subject(:user) { build(:user) }
 
   describe 'validation' do
     it { is_expected.to validate_presence_of(:email) }

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -2,14 +2,14 @@ describe Admin::StatementPresenter do
   subject { Admin::StatementPresenter.new(statement) }
 
   describe '#month_and_year' do
-    let(:statement) { FactoryBot.build(:statement, month: 6, year: 2023) }
+    let(:statement) { build(:statement, month: 6, year: 2023) }
 
     it 'returns the month name and year in a string' do
       expect(subject.month_and_year).to eql('June 2023')
     end
 
     context 'when the month is invalid' do
-      let(:statement) { FactoryBot.build(:statement, month: 13, year: 2023) }
+      let(:statement) { build(:statement, month: 13, year: 2023) }
 
       it 'raises an IndexError' do
         expect { subject.month_and_year }.to raise_error(IndexError)
@@ -19,7 +19,7 @@ describe Admin::StatementPresenter do
 
   describe '#status_tag_kwargs' do
     context 'when open' do
-      let(:statement) { FactoryBot.build(:statement, :open) }
+      let(:statement) { build(:statement, :open) }
 
       it 'is blue and Open' do
         expect(subject.status_tag_kwargs).to eql({ colour: 'blue', text: 'Open' })
@@ -27,7 +27,7 @@ describe Admin::StatementPresenter do
     end
 
     context 'when payable' do
-      let(:statement) { FactoryBot.build(:statement, :payable) }
+      let(:statement) { build(:statement, :payable) }
 
       it 'is yellow and Payable' do
         expect(subject.status_tag_kwargs).to eql({ colour: 'yellow', text: 'Payable' })
@@ -36,7 +36,7 @@ describe Admin::StatementPresenter do
 
     context 'when paid' do
       context 'when service fee statement' do
-        let(:statement) { FactoryBot.build(:statement, :paid, :service_fee) }
+        let(:statement) { build(:statement, :paid, :service_fee) }
 
         it 'is green and Paid' do
           expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Paid' })
@@ -44,7 +44,7 @@ describe Admin::StatementPresenter do
       end
 
       context 'when output fee statement' do
-        let(:statement) { FactoryBot.build(:statement, :paid, :output_fee) }
+        let(:statement) { build(:statement, :paid, :output_fee) }
 
         it 'is green and Paid' do
           expect(subject.status_tag_kwargs).to eql({ colour: 'green', text: 'Authorised for payment' })
@@ -53,7 +53,7 @@ describe Admin::StatementPresenter do
     end
 
     context 'when unrecognised' do
-      let(:statement) { FactoryBot.build(:statement, status: 'bad_state') }
+      let(:statement) { build(:statement, status: 'bad_state') }
 
       it 'raises an IndexError' do
         expect { subject.status_tag_kwargs }.to raise_error(IndexError)
@@ -62,9 +62,9 @@ describe Admin::StatementPresenter do
   end
 
   describe '#page_title' do
-    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
-    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
-    let(:statement) { FactoryBot.build(:statement, active_lead_provider:, month: 5, year: 2023) }
+    let(:lead_provider) { build(:lead_provider, name: "Some LP") }
+    let(:active_lead_provider) { build(:active_lead_provider, lead_provider:) }
+    let(:statement) { build(:statement, active_lead_provider:, month: 5, year: 2023) }
 
     it 'returns the lead provider, month and year in a string' do
       expect(subject.page_title).to eql('Some LP - May 2023')
@@ -72,9 +72,9 @@ describe Admin::StatementPresenter do
   end
 
   describe '#lead_provider_name' do
-    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
-    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
-    let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+    let(:lead_provider) { build(:lead_provider, name: "Some LP") }
+    let(:active_lead_provider) { build(:active_lead_provider, lead_provider:) }
+    let(:statement) { build(:statement, active_lead_provider:) }
 
     it 'returns the lead provider name' do
       expect(subject.lead_provider_name).to eql('Some LP')
@@ -82,9 +82,9 @@ describe Admin::StatementPresenter do
   end
 
   describe '#contract_period_year' do
-    let(:contract_period) { FactoryBot.build(:contract_period, year: 2022) }
-    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, contract_period:) }
-    let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+    let(:contract_period) { build(:contract_period, year: 2022) }
+    let(:active_lead_provider) { build(:active_lead_provider, contract_period:) }
+    let(:statement) { build(:statement, active_lead_provider:) }
 
     it 'returns the lead provider name' do
       expect(subject.contract_period_year).to eql('2022')
@@ -92,7 +92,7 @@ describe Admin::StatementPresenter do
   end
 
   describe '#formatted_deadline_date' do
-    let(:statement) { FactoryBot.build(:statement, deadline_date: Date.new(2024, 1, 1)) }
+    let(:statement) { build(:statement, deadline_date: Date.new(2024, 1, 1)) }
 
     it 'formats the deadline date in the GOV.UK style' do
       expect(subject.formatted_deadline_date).to eq('1 January 2024')
@@ -100,7 +100,7 @@ describe Admin::StatementPresenter do
   end
 
   describe '#formatted_payment_date' do
-    let(:statement) { FactoryBot.build(:statement, deadline_date: Date.new(2025, 2, 2)) }
+    let(:statement) { build(:statement, deadline_date: Date.new(2025, 2, 2)) }
 
     it 'formats the payment date in the GOV.UK style' do
       expect(subject.formatted_deadline_date).to eq('2 February 2025')

--- a/spec/presenters/pending_induction_submission_batch_presenter_spec.rb
+++ b/spec/presenters/pending_induction_submission_batch_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PendingInductionSubmissionBatchPresenter do
   subject(:presenter) { described_class.new(batch) }
 
-  let(:batch) { FactoryBot.build(:pending_induction_submission_batch, :action) }
+  let(:batch) { build(:pending_induction_submission_batch, :action) }
 
   describe 'decorated model methods' do
     it '#batch_type' do
@@ -15,7 +15,7 @@ RSpec.describe PendingInductionSubmissionBatchPresenter do
 
   describe '#to_csv' do
     context 'when there is no persisted CSV data' do
-      let(:batch) { FactoryBot.build(:pending_induction_submission_batch, :action, data:) }
+      let(:batch) { build(:pending_induction_submission_batch, :action, data:) }
       let(:data) { nil }
 
       it 'raises an error' do
@@ -24,11 +24,11 @@ RSpec.describe PendingInductionSubmissionBatchPresenter do
     end
 
     context 'when there is persisted CSV data' do
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:appropriate_body) { create(:appropriate_body) }
       let(:batch) do
-        FactoryBot.create(:pending_induction_submission_batch, :action,
-                          appropriate_body:,
-                          data:)
+        create(:pending_induction_submission_batch, :action,
+               appropriate_body:,
+               data:)
       end
 
       let(:data) do
@@ -66,21 +66,21 @@ RSpec.describe PendingInductionSubmissionBatchPresenter do
 
       context 'and there are failed_submissions' do
         before do
-          FactoryBot.create(:pending_induction_submission,
-                            appropriate_body:,
-                            pending_induction_submission_batch: batch,
-                            trn: '1234567',
-                            error_messages: [
-                              'error one',
-                              'error two',
-                              'error three',
-                              'error four'
-                            ])
+          create(:pending_induction_submission,
+                 appropriate_body:,
+                 pending_induction_submission_batch: batch,
+                 trn: '1234567',
+                 error_messages: [
+                   'error one',
+                   'error two',
+                   'error three',
+                   'error four'
+                 ])
 
-          FactoryBot.create(:pending_induction_submission,
-                            appropriate_body:,
-                            pending_induction_submission_batch: batch,
-                            trn: '7654321')
+          create(:pending_induction_submission,
+                 appropriate_body:,
+                 pending_induction_submission_batch: batch,
+                 trn: '7654321')
         end
 
         it 'returns only failed submissions with their errors as a sentence' do

--- a/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Listing and searching ECTs belonging to an appropriate body' do
   describe 'GET /admin/organisations/appropriate-bodies/current-ects' do
-    let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let!(:appropriate_body) { create(:appropriate_body) }
 
     context 'when not logged in' do
       it "redirects to sign in path" do
@@ -22,11 +22,11 @@ RSpec.describe 'Listing and searching ECTs belonging to an appropriate body' do
     context "with an authenticated DfE user" do
       include_context 'sign in as DfE user'
 
-      let!(:teacher_1) { FactoryBot.create(:teacher, trs_first_name: "Pam", trs_last_name: "Ferris") }
-      let!(:teacher_2) { FactoryBot.create(:teacher, trs_first_name: "Felicity", trs_last_name: "Kendall") }
+      let!(:teacher_1) { create(:teacher, trs_first_name: "Pam", trs_last_name: "Ferris") }
+      let!(:teacher_2) { create(:teacher, trs_first_name: "Felicity", trs_last_name: "Kendall") }
 
-      let!(:induction_period_1) { FactoryBot.create(:induction_period, :active, teacher: teacher_1, appropriate_body:) }
-      let!(:induction_period_2) { FactoryBot.create(:induction_period, :active, teacher: teacher_2, appropriate_body:) }
+      let!(:induction_period_1) { create(:induction_period, :active, teacher: teacher_1, appropriate_body:) }
+      let!(:induction_period_2) { create(:induction_period, :active, teacher: teacher_2, appropriate_body:) }
 
       it 'shows lists current ECTs' do
         get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"

--- a/spec/requests/admin/appropriate_bodies/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/index_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Viewing the appropriate bodies index", type: :request do
     context "with an authenticated DfE user" do
       include_context 'sign in as DfE user'
 
-      let!(:appropriate_body1) { FactoryBot.create(:appropriate_body, name: "Captain Scrummy") }
-      let!(:appropriate_body2) { FactoryBot.create(:appropriate_body, name: "Captain Hook") }
+      let!(:appropriate_body1) { create(:appropriate_body, name: "Captain Scrummy") }
+      let!(:appropriate_body2) { create(:appropriate_body, name: "Captain Hook") }
 
       it "display appropriate bodies" do
         get "/admin/organisations/appropriate-bodies"

--- a/spec/requests/admin/appropriate_bodies/show_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/show_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Viewing the appropriate bodies index", type: :request do
-  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let!(:appropriate_body) { create(:appropriate_body) }
 
   describe "GET /admin/appropriate-bodies/:id" do
     it "redirects to sign in path" do

--- a/spec/requests/admin/bulk/batches_spec.rb
+++ b/spec/requests/admin/bulk/batches_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "Admin Bulk Batches", type: :request do
   include AuthHelper
 
   let(:admin_user) { sign_in_as(:dfe_staff_user) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:batch) { FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let!(:batch) { create(:pending_induction_submission_batch, :action, appropriate_body:) }
 
   describe "GET /admin/bulk/batches" do
     context "when signed in as admin" do

--- a/spec/requests/admin/finance/statements/statements_spec.rb
+++ b/spec/requests/admin/finance/statements/statements_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Admin finance statements index", type: :request do
     end
 
     context 'when signed in as a DfE user' do
-      let!(:statement) { FactoryBot.create(:statement) }
+      let!(:statement) { create(:statement) }
 
       include_context 'sign in as DfE user'
 

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
   include ActionView::Helpers::SanitizeHelper
   include_context 'sign in as DfE user'
 
-  let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:teacher) { create(:teacher, trs_qts_awarded_on: 1.year.ago) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe "POST /admin/teachers/:teacher_id/induction-periods" do
     let(:valid_params) do
@@ -90,10 +90,10 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
     context "with overlapping dates" do
       let!(:existing_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: 6.months.ago,
-                          finished_on: 3.months.ago)
+        create(:induction_period,
+               teacher:,
+               started_on: 6.months.ago,
+               finished_on: 3.months.ago)
       end
 
       let(:overlapping_params) do
@@ -207,11 +207,11 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
     context "with multiple induction periods" do
       before do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: 9.months.ago,
-                          finished_on: 6.months.ago,
-                          induction_programme: "fip")
+        create(:induction_period,
+               teacher:,
+               started_on: 9.months.ago,
+               finished_on: 6.months.ago,
+               induction_programme: "fip")
       end
 
       it "creates a new induction period" do
@@ -248,7 +248,7 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
   end
 
   describe "GET /admin/teachers/:teacher_id/induction-periods/:id/edit" do
-    let(:induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: 9.months.ago, finished_on: 6.months.ago) }
+    let(:induction_period) { create(:induction_period, teacher:, started_on: 9.months.ago, finished_on: 6.months.ago) }
 
     it "returns success" do
       get edit_admin_teacher_induction_period_path(induction_period.teacher, induction_period)
@@ -258,7 +258,7 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
   describe "PATCH /admin/teachers/:teacher_id/induction-periods/:id" do
     context "when induction period has no outcome" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: 9.months.ago, finished_on: 6.months.ago) }
+      let!(:induction_period) { create(:induction_period, teacher:, started_on: 9.months.ago, finished_on: 6.months.ago) }
 
       context "with valid params" do
         let(:valid_params) do
@@ -310,18 +310,18 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
         context "when dates would cause overlap" do
           let!(:first_period) do
-            FactoryBot.create(:induction_period,
-                              teacher:,
-                              started_on: 1.year.ago,
-                              finished_on: 8.months.ago,
-                              induction_programme: "cip")
+            create(:induction_period,
+                   teacher:,
+                   started_on: 1.year.ago,
+                   finished_on: 8.months.ago,
+                   induction_programme: "cip")
           end
 
           let(:induction_period) do
-            FactoryBot.create(:induction_period,
-                              teacher:,
-                              started_on: 6.months.ago,
-                              finished_on: 3.months.ago)
+            create(:induction_period,
+                   teacher:,
+                   started_on: 6.months.ago,
+                   finished_on: 3.months.ago)
           end
 
           let(:params) do
@@ -348,11 +348,11 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
           end
 
           let!(:earliest_period) do
-            FactoryBot.create(:induction_period,
-                              teacher:,
-                              started_on: 12.months.ago,
-                              finished_on: nil,
-                              number_of_terms: nil)
+            create(:induction_period,
+                   teacher:,
+                   started_on: 12.months.ago,
+                   finished_on: nil,
+                   number_of_terms: nil)
           end
 
           let(:params) do
@@ -393,8 +393,8 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
         end
 
         context "when start date is before QTS date" do
-          let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
-          let(:induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: 9.months.ago, finished_on: 6.months.ago) }
+          let(:teacher) { create(:teacher, trs_qts_awarded_on: 1.year.ago) }
+          let(:induction_period) { create(:induction_period, teacher:, started_on: 9.months.ago, finished_on: 6.months.ago) }
 
           it "returns error" do
             patch admin_teacher_induction_period_path(induction_period.teacher, induction_period), params: {
@@ -409,12 +409,12 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
     context "when induction period has an outcome" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: 9.months.ago,
-                          finished_on: 6.months.ago,
-                          outcome: "pass",
-                          number_of_terms: 3)
+        create(:induction_period,
+               teacher:,
+               started_on: 9.months.ago,
+               finished_on: 6.months.ago,
+               outcome: "pass",
+               number_of_terms: 3)
       end
 
       context "when updating dates" do
@@ -501,12 +501,12 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
     context "when induction period has a fail outcome" do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          started_on: 9.months.ago,
-                          finished_on: 6.months.ago,
-                          outcome: "fail",
-                          number_of_terms: 3)
+        create(:induction_period,
+               teacher:,
+               started_on: 9.months.ago,
+               finished_on: 6.months.ago,
+               outcome: "fail",
+               number_of_terms: 3)
       end
 
       context "when updating end date" do
@@ -548,7 +548,7 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
   describe "DELETE /admin/induction_periods/:id" do
     context "when it is the only induction period" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
+      let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
       let(:trs_api_client) { instance_double(TRS::APIClient) }
 
       before do
@@ -580,8 +580,8 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
     end
 
     context "when there are multiple induction periods" do
-      let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 9.months.ago, number_of_terms: 2) }
-      let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 3.months.ago, number_of_terms: 2) }
+      let!(:induction_period1) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 9.months.ago, number_of_terms: 2) }
+      let!(:induction_period2) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 3.months.ago, number_of_terms: 2) }
       let(:trs_api_client) { instance_double(TRS::APIClient) }
 
       before do
@@ -605,7 +605,7 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
     end
 
     context "when deletion fails" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
+      let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
 
       before do
         service = instance_double(InductionPeriods::DeleteInductionPeriod)

--- a/spec/requests/admin/teachers/extensions_spec.rb
+++ b/spec/requests/admin/teachers/extensions_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Admin::Teachers::Extensions", type: :request do
   include AuthHelper
 
-  let(:admin_user) { FactoryBot.create(:user, :admin) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:admin_user) { create(:user, :admin) }
+  let(:teacher) { create(:teacher) }
 
   before do
     sign_in_as :dfe_user, user: admin_user
@@ -38,7 +38,7 @@ RSpec.describe "Admin::Teachers::Extensions", type: :request do
   end
 
   describe "GET /admin/teachers/:teacher_id/extensions/:id/edit" do
-    let(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+    let(:extension) { create(:induction_extension, teacher:) }
 
     it "renders the edit template successfully" do
       get edit_admin_teacher_extension_path(teacher, extension)
@@ -47,7 +47,7 @@ RSpec.describe "Admin::Teachers::Extensions", type: :request do
   end
 
   describe "PATCH /admin/teachers/:teacher_id/extensions/:id" do
-    let!(:extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 1.0) }
+    let!(:extension) { create(:induction_extension, teacher:, number_of_terms: 1.0) }
 
     context "with valid parameters" do
       let(:valid_params) { { induction_extension: { number_of_terms: 2.5 } } }
@@ -63,7 +63,7 @@ RSpec.describe "Admin::Teachers::Extensions", type: :request do
   end
 
   describe "GET /admin/teachers/:teacher_id/extensions/:id/confirm_delete" do
-    let(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+    let(:extension) { create(:induction_extension, teacher:) }
 
     it "renders the confirm_delete template successfully" do
       get confirm_delete_admin_teacher_extension_path(teacher, extension)
@@ -72,7 +72,7 @@ RSpec.describe "Admin::Teachers::Extensions", type: :request do
   end
 
   describe "DELETE /admin/teachers/:teacher_id/extensions/:id" do
-    let!(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+    let!(:extension) { create(:induction_extension, teacher:) }
 
     it "uses the manage service to delete the extension and redirects to the teacher's page" do
       manage_service = instance_double(InductionExtensions::Manage, delete!: true)

--- a/spec/requests/admin/teachers/index_spec.rb
+++ b/spec/requests/admin/teachers/index_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe "Admin teachers index", type: :request do
 
       context "with search query" do
         it "filters teachers by name" do
-          teacher = FactoryBot.create(:teacher, trs_first_name: "John", trs_last_name: "Smith")
-          other_teacher = FactoryBot.create(:teacher, trs_first_name: "Jane", trs_last_name: "Doe")
+          teacher = create(:teacher, trs_first_name: "John", trs_last_name: "Smith")
+          other_teacher = create(:teacher, trs_first_name: "Jane", trs_last_name: "Doe")
 
-          FactoryBot.create(
+          create(
             :induction_period,
             :active,
             teacher:,
             started_on: 1.month.ago.to_date,
             induction_programme: 'fip'
           )
-          FactoryBot.create(
+          create(
             :induction_period,
             :active,
             teacher: other_teacher,
@@ -45,17 +45,17 @@ RSpec.describe "Admin teachers index", type: :request do
         end
 
         it "filters teachers by TRN" do
-          teacher = FactoryBot.create(:teacher, trn: "1234567")
-          other_teacher = FactoryBot.create(:teacher, trn: "7654321")
+          teacher = create(:teacher, trn: "1234567")
+          other_teacher = create(:teacher, trn: "7654321")
 
-          FactoryBot.create(
+          create(
             :induction_period,
             :active,
             teacher:,
             started_on: 1.month.ago.to_date,
             induction_programme: 'fip'
           )
-          FactoryBot.create(
+          create(
             :induction_period,
             :active,
             teacher: other_teacher,

--- a/spec/requests/admin/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_outcome_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Admin recording a failed outcome for a teacher' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(
+    create(
       :induction_period,
       :active,
       teacher:,
@@ -153,7 +153,7 @@ RSpec.describe 'Admin recording a failed outcome for a teacher' do
 
   describe 'GET /admin/teachers/:teacher_id/record-failed-outcome' do
     let!(:induction_period) do
-      FactoryBot.create(
+      create(
         :induction_period,
         :fail,
         teacher:,

--- a/spec/requests/admin/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_outcome_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Admin recording a passed outcome for a teacher' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(
+    create(
       :induction_period,
       :active,
       teacher:,
@@ -153,7 +153,7 @@ RSpec.describe 'Admin recording a passed outcome for a teacher' do
 
   describe 'GET /admin/teachers/:teacher_id/record-passed-outcome' do
     let!(:induction_period) do
-      FactoryBot.create(
+      create(
         :induction_period,
         :pass,
         teacher:,

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Admin::Teachers#show", type: :request do
   include ActionView::Helpers::SanitizeHelper
 
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+  let(:teacher) { create(:teacher) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:) }
 
   describe "GET /admin/teachers/:id" do
     it "redirects to sign in path" do

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -3,7 +3,7 @@ require "swagger_helper"
 RSpec.describe "Statements endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
-  let(:statement) { FactoryBot.create(:statement, active_lead_provider:) }
+  let(:statement) { create(:statement, active_lead_provider:) }
 
   path "/api/v3/statements" do
     get "Retrieve financial statements" do

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe "Statements API", type: :request do
   let(:serializer) { StatementSerializer }
   let(:query) { Statements::Query }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:active_lead_provider) { create(:active_lead_provider) }
   let(:lead_provider) { active_lead_provider.lead_provider }
 
   def create_resource(active_lead_provider:)
-    FactoryBot.create(:statement, active_lead_provider:)
+    create(:statement, active_lead_provider:)
   end
 
   describe "#index" do

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT' do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:page_heading) { "Check details for" }
-  let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body:) }
+  let!(:pending_induction_submission) { create(:pending_induction_submission, appropriate_body:) }
   let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
 
   describe 'GET /appropriate-body/claim-an-ect/check-ect/:id/edit' do
@@ -28,7 +28,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
       end
 
       context 'when alerts are present' do
-        let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_alerts: %w[some alerts]) }
+        let!(:pending_induction_submission) { create(:pending_induction_submission, appropriate_body:, trs_alerts: %w[some alerts]) }
 
         it 'includes info about the check a teachers record service' do
           get("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}/edit")
@@ -38,7 +38,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
       end
 
       context 'when alerts are absent' do
-        let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_alerts: %w[]) }
+        let!(:pending_induction_submission) { create(:pending_induction_submission, appropriate_body:, trs_alerts: %w[]) }
 
         it 'does not include info about the check a teachers record service' do
           get("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}/edit")
@@ -84,8 +84,8 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
       end
 
       context "when the ECT has an ongoing induction period with another appropriate body" do
-        let!(:preexisting_teacher) { FactoryBot.create(:teacher, trn: pending_induction_submission.trn) }
-        let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher: preexisting_teacher) }
+        let!(:preexisting_teacher) { create(:teacher, trn: pending_induction_submission.trn) }
+        let!(:induction_period) { create(:induction_period, :active, teacher: preexisting_teacher) }
 
         it 'redirects to the ECT already claimed by another AB early exit page' do
           patch(

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
   include_context 'fake trs api client'
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let(:page_heading) { "Find an early career teacher" }
 
@@ -99,12 +99,12 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid but ECT has an active induction period with another AB" do
-        let(:teacher) { FactoryBot.create(:teacher, trn:) }
+        let(:teacher) { create(:teacher, trn:) }
         let!(:induction_period) do
-          FactoryBot.create(
+          create(
             :induction_period,
             :active,
-            appropriate_body: FactoryBot.create(:appropriate_body),
+            appropriate_body: create(:appropriate_body),
             teacher:,
             started_on: Date.parse("2 October 2022")
           )
@@ -123,10 +123,10 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid but ECT has an active induction period with the current AB" do
-        let(:teacher) { FactoryBot.create(:teacher, trn:) }
-        let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
+        let(:teacher) { create(:teacher, trn:) }
+        let!(:pending_induction_submission) { create(:pending_induction_submission, trn: teacher.trn) }
         let!(:induction_period) do
-          FactoryBot.create(
+          create(
             :induction_period,
             :active,
             appropriate_body:,

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
   let(:trs_qts_awarded_on) { 3.years.ago.to_date }
-  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_qts_awarded_on:) }
+  let!(:appropriate_body) { create(:appropriate_body) }
+  let!(:pending_induction_submission) { create(:pending_induction_submission, appropriate_body:, trs_qts_awarded_on:) }
   let(:page_heading) { "Tell us about" }
   let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
 

--- a/spec/requests/appropriate_bodies/process_batch/actions/create_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/create_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Appropriate Body bulk actions upload", type: :request do
   include AuthHelper
   include ActionDispatch::TestProcess
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
 

--- a/spec/requests/appropriate_bodies/process_batch/actions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Appropriate Body bulk actions index page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe 'GET /appropriate-body/bulk/actions' do
     context 'when bulk upload is disabled (ENABLE_BULK_UPLOAD=false)' do

--- a/spec/requests/appropriate_bodies/process_batch/actions/show_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/show_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe "Appropriate Body bulk actions show page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :action,
-                      appropriate_body:,
-                      data:,
-                      filename:)
+    create(:pending_induction_submission_batch, :action,
+           appropriate_body:,
+           data:,
+           filename:)
   end
 
   include_context '3 valid actions'

--- a/spec/requests/appropriate_bodies/process_batch/actions/update_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/update_spec.rb
@@ -2,13 +2,13 @@ RSpec.describe "Appropriate Body bulk actions confirmation", type: :request do
   include AuthHelper
   include ActiveJob::TestHelper
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
   let(:batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :action,
-                      appropriate_body:,
-                      data:,
-                      filename: 'test-file.csv')
+    create(:pending_induction_submission_batch, :action,
+           appropriate_body:,
+           data:,
+           filename: 'test-file.csv')
   end
 
   include_context 'fake trs api client'

--- a/spec/requests/appropriate_bodies/process_batch/claims/index_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/claims/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Appropriate Body bulk claims index page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe 'GET /appropriate-body/bulk/claims' do
     context 'when bulk upload is disabled (ENABLE_BULK_UPLOAD=false)' do

--- a/spec/requests/appropriate_bodies/process_batch/claims/show_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/claims/show_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe "Appropriate Body bulk claims show page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :claim,
-                      appropriate_body:,
-                      data:)
+    create(:pending_induction_submission_batch, :claim,
+           appropriate_body:,
+           data:)
   end
 
   include_context '2 valid claims'

--- a/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe "Appropriate Body teacher extensions edit", type: :request do
   include AuthHelper
   include ActionView::Helpers::SanitizeHelper
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
-  let(:extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2) }
+  let(:extension) { create(:induction_extension, teacher:, number_of_terms: 2) }
 
   describe 'GET /appropriate-body/teachers/:teacher_id/extensions/:id/edit' do
     it 'displays the edit extension form' do

--- a/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Appropriate Body teacher extensions index", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
 
   describe 'when not signed in' do
     it 'redirects to the root page' do
@@ -18,7 +18,7 @@ RSpec.describe "Appropriate Body teacher extensions index", type: :request do
 
     describe 'GET /appropriate-body/teachers/:id/extensions' do
       it 'displays the extensions list' do
-        FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2)
+        create(:induction_extension, teacher:, number_of_terms: 2)
 
         get("/appropriate-body/teachers/#{teacher.id}/extensions")
 

--- a/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Appropriate Body teacher extensions new", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
   describe 'GET /appropriate-body/teachers/:id/extensions/new' do

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Appropriate Body teacher index page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe 'GET /appropriate-body/teachers' do
     context 'when not signed in' do
@@ -17,9 +17,9 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
 
       context "when there are more than 50 teachers" do
         let!(:additional_teachers) do
-          FactoryBot.create_list(:teacher, 51, trs_first_name: "John", trs_last_name: "Smith").tap do |teachers|
+          create_list(:teacher, 51, trs_first_name: "John", trs_last_name: "Smith").tap do |teachers|
             teachers.each do |teacher|
-              FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:)
+              create(:induction_period, :active, teacher:, appropriate_body:)
             end
           end
         end
@@ -35,38 +35,38 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
 
       context "with open and closed induction filtering" do
         let!(:alice_johnson) do
-          FactoryBot.create(:teacher, trs_first_name: 'Alice', trs_last_name: 'Johnson', trn: '1000001', trs_induction_status: 'InProgress').tap do |teacher|
-            FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 3.months.ago)
+          create(:teacher, trs_first_name: 'Alice', trs_last_name: 'Johnson', trn: '1000001', trs_induction_status: 'InProgress').tap do |teacher|
+            create(:induction_period, :active, teacher:, appropriate_body:, started_on: 3.months.ago)
           end
         end
 
         let!(:bob_williams) do
-          FactoryBot.create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Williams', trn: '1000002', trs_induction_status: 'RequiredToComplete').tap do |teacher|
-            FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 2.months.ago)
+          create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Williams', trn: '1000002', trs_induction_status: 'RequiredToComplete').tap do |teacher|
+            create(:induction_period, :active, teacher:, appropriate_body:, started_on: 2.months.ago)
           end
         end
 
         let!(:charlie_brown) do
-          FactoryBot.create(:teacher, trs_first_name: 'Charlie', trs_last_name: 'Brown', trn: '1000003', trs_induction_status: 'InProgress').tap do |teacher|
-            FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 1.month.ago)
+          create(:teacher, trs_first_name: 'Charlie', trs_last_name: 'Brown', trn: '1000003', trs_induction_status: 'InProgress').tap do |teacher|
+            create(:induction_period, :active, teacher:, appropriate_body:, started_on: 1.month.ago)
           end
         end
 
         let!(:david_davis) do
-          FactoryBot.create(:teacher, trs_first_name: 'David', trs_last_name: 'Davis', trn: '2000001', trs_induction_status: 'Passed').tap do |teacher|
-            FactoryBot.create(:induction_period, :pass, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 2.months.ago, number_of_terms: 6)
+          create(:teacher, trs_first_name: 'David', trs_last_name: 'Davis', trn: '2000001', trs_induction_status: 'Passed').tap do |teacher|
+            create(:induction_period, :pass, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 2.months.ago, number_of_terms: 6)
           end
         end
 
         let!(:emma_wilson) do
-          FactoryBot.create(:teacher, trs_first_name: 'Emma', trs_last_name: 'Wilson', trn: '2000002', trs_induction_status: 'Failed').tap do |teacher|
-            FactoryBot.create(:induction_period, :fail, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 1.month.ago, number_of_terms: 6)
+          create(:teacher, trs_first_name: 'Emma', trs_last_name: 'Wilson', trn: '2000002', trs_induction_status: 'Failed').tap do |teacher|
+            create(:induction_period, :fail, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 1.month.ago, number_of_terms: 6)
           end
         end
 
         let!(:frank_miller) do
-          FactoryBot.create(:teacher, trs_first_name: 'Frank', trs_last_name: 'Miller', trn: '2000003', trs_induction_status: 'Exempt').tap do |teacher|
-            FactoryBot.create(:induction_period, :pass, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 3.months.ago, number_of_terms: 6)
+          create(:teacher, trs_first_name: 'Frank', trs_last_name: 'Miller', trn: '2000003', trs_induction_status: 'Exempt').tap do |teacher|
+            create(:induction_period, :pass, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 3.months.ago, number_of_terms: 6)
           end
         end
 
@@ -228,14 +228,14 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
         context 'edge cases' do
           context 'teacher with finished induction period but no outcome' do
             let!(:edge_case_teacher) do
-              teacher = FactoryBot.create(:teacher,
-                                          trs_first_name: 'Grace',
-                                          trs_last_name: 'NoOutcome',
-                                          trn: '3000001',
-                                          trs_induction_status: 'InProgress')
+              teacher = create(:teacher,
+                               trs_first_name: 'Grace',
+                               trs_last_name: 'NoOutcome',
+                               trn: '3000001',
+                               trs_induction_status: 'InProgress')
               # Create finished period with no outcome - should not appear in either list
-              FactoryBot.create(:induction_period, teacher:, appropriate_body:,
-                                                   started_on: 1.year.ago, finished_on: 1.month.ago, outcome: nil, number_of_terms: 6)
+              create(:induction_period, teacher:, appropriate_body:,
+                                        started_on: 1.year.ago, finished_on: 1.month.ago, outcome: nil, number_of_terms: 6)
               teacher
             end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(
+    create(
       :induction_period,
       :active,
       teacher:,
@@ -154,7 +154,7 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
 
   describe 'GET /appropriate-body/teachers/:id/record-failed-outcome' do
     let!(:induction_period) do
-      FactoryBot.create(
+      create(
         :induction_period,
         :fail,
         teacher:,

--- a/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(
+    create(
       :induction_period,
       :active,
       teacher:,
@@ -154,7 +154,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
 
   describe 'GET /appropriate-body/teachers/:teacher_id/record-passed-outcome' do
     let!(:induction_period) do
-      FactoryBot.create(
+      create(
         :induction_period,
         :pass,
         teacher:,

--- a/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Appropriate body releasing an ECT' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   describe 'GET /appropriate-body/teachers/:id/release/new' do
     context 'when not signed in' do
@@ -17,7 +17,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
 
       context 'and a teacher actively training' do
         before do
-          FactoryBot.create(:induction_period, :active, appropriate_body:, teacher:)
+          create(:induction_period, :active, appropriate_body:, teacher:)
         end
 
         it 'instantiates a new PendingInductionSubmission and renders the page' do
@@ -55,7 +55,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
         end
 
         let!(:induction_period) do
-          FactoryBot.create(:induction_period, :active, appropriate_body:, teacher:, started_on: "2022-09-01")
+          create(:induction_period, :active, appropriate_body:, teacher:, started_on: "2022-09-01")
         end
 
         let(:release_params) do

--- a/spec/requests/appropriate_bodies/teachers/show_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/show_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Appropriate Body teacher show page", type: :request do
   include AuthHelper
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
 
   describe 'GET /appropriate-body/teachers/:id' do
     context 'when not signed in' do
@@ -33,18 +33,18 @@ RSpec.describe "Appropriate Body teacher show page", type: :request do
       end
 
       context 'when the teacher is not associated with the appropriate body' do
-        let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
-        let(:other_teacher) { FactoryBot.create(:teacher) }
+        let(:other_appropriate_body) { create(:appropriate_body) }
+        let(:other_teacher) { create(:teacher) }
 
         # Create an induction period that is finished and has no outcome
         # This won't be included in current_or_completed_while_at_appropriate_body
         let!(:other_induction_period) do
-          FactoryBot.create(:induction_period,
-                            teacher: other_teacher,
-                            appropriate_body:,
-                            started_on: 6.months.ago,
-                            finished_on: 1.month.ago,
-                            outcome: nil)
+          create(:induction_period,
+                 teacher: other_teacher,
+                 appropriate_body:,
+                 started_on: 6.months.ago,
+                 finished_on: 1.month.ago,
+                 outcome: nil)
         end
 
         it 'returns a 404 error' do

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "DfE Analytics", type: :request do
   end
 
   context "when disabled" do
-    before { FactoryBot.create(:teacher) }
+    before { create(:teacher) }
 
     context "implicitly" do
       let(:env_var_value) { nil }
@@ -33,7 +33,7 @@ RSpec.describe "DfE Analytics", type: :request do
     end
 
     it "sends DFE Analytics entity events" do
-      FactoryBot.create(:teacher)
+      create(:teacher)
       expect(:create_entity).to have_been_enqueued_as_analytics_events
     end
 

--- a/spec/requests/migration/parity_check_spec.rb
+++ b/spec/requests/migration/parity_check_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Parity check", type: :request do
   end
 
   describe "POST /migration/parity_checks" do
-    let!(:lead_provider) { FactoryBot.create(:lead_provider) }
-    let!(:endpoints) { FactoryBot.create_list(:parity_check_endpoint, 2) }
+    let!(:lead_provider) { create(:lead_provider) }
+    let!(:endpoints) { create_list(:parity_check_endpoint, 2) }
     let(:endpoint_ids) { endpoints.map(&:id) }
     let(:mode) { "sequential" }
 
@@ -113,7 +113,7 @@ RSpec.describe "Parity check", type: :request do
   end
 
   describe "GET /migration/parity_checks/:id" do
-    let(:run) { FactoryBot.create(:parity_check_run, :completed) }
+    let(:run) { create(:parity_check_run, :completed) }
 
     context "when signed in as a DfE user" do
       include_context 'sign in as DfE user'
@@ -125,7 +125,7 @@ RSpec.describe "Parity check", type: :request do
       end
 
       context "when the parity check is not completed" do
-        let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+        let(:run) { create(:parity_check_run, :in_progress) }
 
         it "renders 404 not found" do
           get migration_parity_check_path(run)
@@ -162,8 +162,8 @@ RSpec.describe "Parity check", type: :request do
   end
 
   describe "GET /migration/parity_checks/:run_id/requests/:id" do
-    let(:run) { FactoryBot.create(:parity_check_run, :completed) }
-    let(:request) { FactoryBot.create(:parity_check_request, :completed, run:) }
+    let(:run) { create(:parity_check_run, :completed) }
+    let(:request) { create(:parity_check_request, :completed, run:) }
 
     context "when signed in as a DfE user" do
       include_context 'sign in as DfE user'
@@ -175,7 +175,7 @@ RSpec.describe "Parity check", type: :request do
       end
 
       context "when the parity check is not completed" do
-        let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+        let(:run) { create(:parity_check_run, :in_progress) }
 
         it "renders 404 not found" do
           get migration_parity_check_request_path(run, request)
@@ -219,9 +219,9 @@ RSpec.describe "Parity check", type: :request do
   end
 
   describe "GET /migration/parity_checks/:run_id/responses/:id" do
-    let(:run) { FactoryBot.create(:parity_check_run, :completed) }
-    let(:request) { FactoryBot.create(:parity_check_request, :completed, run:) }
-    let(:parity_check_response) { FactoryBot.create(:parity_check_response, :different, request:) }
+    let(:run) { create(:parity_check_run, :completed) }
+    let(:request) { create(:parity_check_request, :completed, run:) }
+    let(:parity_check_response) { create(:parity_check_response, :different, request:) }
 
     context "when signed in as a DfE user" do
       include_context 'sign in as DfE user'
@@ -233,7 +233,7 @@ RSpec.describe "Parity check", type: :request do
       end
 
       context "when the parity check is not completed" do
-        let(:run) { FactoryBot.create(:parity_check_run, :in_progress) }
+        let(:run) { create(:parity_check_run, :in_progress) }
 
         it "renders 404 not found" do
           get migration_parity_check_response_path(run, request)
@@ -249,7 +249,7 @@ RSpec.describe "Parity check", type: :request do
       end
 
       context "when the response is matching" do
-        let(:parity_check_response) { FactoryBot.create(:parity_check_response, :matching, request:) }
+        let(:parity_check_response) { create(:parity_check_response, :matching, request:) }
 
         it "renders 404 not found" do
           get migration_parity_check_response_path(run, 99)

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Rack::Attack" do
-  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:lead_provider) { create(:lead_provider) }
   let(:ip) { "1.2.3.4" }
   let(:other_ip) { "9.8.7.6" }
 

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'ECT summary' do
-  let(:ect) { FactoryBot.create(:ect_at_school_period) }
-  let(:school) { FactoryBot.create(:school) }
+  let(:ect) { create(:ect_at_school_period) }
+  let(:school) { create(:school) }
 
   context 'when signed in as school user' do
     before do

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Create mentorship of an ECT to a mentor' do
   include ActionView::Helpers::SanitizeHelper
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, school:) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school:) }
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:ect) { create(:ect_at_school_period, :active, school:) }
+  let(:mentor) { create(:mentor_at_school_period, :active, school:) }
+  let(:school) { create(:school, :independent) }
 
   describe 'GET /school/ects/:id/mentorship/new' do
     context 'when not signed in' do
@@ -99,7 +99,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
     end
 
     context 'when signed in as school user' do
-      let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
+      let(:author) { create(:school_user, school_urn: school.urn) }
 
       before do
         sign_in_as(:school_user, school:)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Sessions', type: :request do
 
     context 'when signed in' do
       before do
-        school = FactoryBot.create(:school, urn: '123456')
+        school = create(:school, urn: '123456')
         sign_in_as(:school_user, school:)
       end
 
@@ -37,7 +37,7 @@ RSpec.describe 'Sessions', type: :request do
 
     context 'sign in an appropriate body user' do
       let(:params) { { email:, name:, dfe_sign_in_organisation_id:, dfe_sign_in_user_id: } }
-      let!(:appropriate_body) { FactoryBot.create(:appropriate_body, dfe_sign_in_organisation_id:) }
+      let!(:appropriate_body) { create(:appropriate_body, dfe_sign_in_organisation_id:) }
 
       before do
         allow(DfESignIn::APIClient).to receive(:new).and_return(DfESignIn::FakeAPIClient.new)
@@ -64,7 +64,7 @@ RSpec.describe 'Sessions', type: :request do
 
     context 'sign in a school user' do
       let(:params) { { email:, name:, school_urn:, dfe_sign_in_organisation_id:, dfe_sign_in_user_id: } }
-      let!(:school) { FactoryBot.create(:school, urn: school_urn) }
+      let!(:school) { create(:school, urn: school_urn) }
 
       before do
         allow(DfESignIn::APIClient).to receive(:new).and_return(DfESignIn::FakeAPIClient.new)
@@ -91,7 +91,7 @@ RSpec.describe 'Sessions', type: :request do
     end
 
     context 'sign in an appropriate body persona' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body).id.to_s }
+      let(:appropriate_body_id) { create(:appropriate_body).id.to_s }
       let(:params) { { email:, name:, appropriate_body_id: } }
 
       it 'signs the user and take them to their home page' do
@@ -105,7 +105,7 @@ RSpec.describe 'Sessions', type: :request do
     end
 
     context 'sign in a school persona' do
-      let(:school_urn) { FactoryBot.create(:school).urn.to_s }
+      let(:school_urn) { create(:school).urn.to_s }
       let(:params) { { email:, name:, school_urn: } }
 
       it 'signs the user and take them to their home page' do
@@ -120,7 +120,7 @@ RSpec.describe 'Sessions', type: :request do
 
     context 'sign in a dfe_persona' do
       before do
-        FactoryBot.create(:user, email:, name:).dfe_roles.create!
+        create(:user, email:, name:).dfe_roles.create!
       end
 
       it 'signs the user and take them to their home page' do

--- a/spec/serializers/statement_serializer_spec.rb
+++ b/spec/serializers/statement_serializer_spec.rb
@@ -1,6 +1,6 @@
 describe StatementSerializer, type: :serializer do
-  let(:active_lead_provider) { FactoryBot.build(:active_lead_provider) }
-  let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+  let(:active_lead_provider) { build(:active_lead_provider) }
+  let(:statement) { build(:statement, active_lead_provider:) }
 
   describe "core attributes" do
     subject(:response) { JSON.parse(described_class.render(statement)) }

--- a/spec/services/admin/access_spec.rb
+++ b/spec/services/admin/access_spec.rb
@@ -2,7 +2,7 @@ describe Admin::Access do
   subject { Admin::Access.new(user) }
 
   context 'when the user has a DfE role' do
-    let!(:user) { FactoryBot.create(:user, :admin) }
+    let!(:user) { create(:user, :admin) }
 
     it 'allows access' do
       expect(subject.can_access?).to be(true)
@@ -10,7 +10,7 @@ describe Admin::Access do
   end
 
   context 'when the user has no DfE role' do
-    let!(:user) { FactoryBot.create(:user) }
+    let!(:user) { create(:user) }
 
     it "doesn't allow access" do
       expect(subject.can_access?).to be(false)

--- a/spec/services/admin/current_teachers_spec.rb
+++ b/spec/services/admin/current_teachers_spec.rb
@@ -1,14 +1,14 @@
 describe Admin::CurrentTeachers do
   describe '#current' do
-    let(:teacher_1) { FactoryBot.create(:teacher) }
-    let(:teacher_2) { FactoryBot.create(:teacher) }
-    let(:teacher_3) { FactoryBot.create(:teacher) }
-    let(:appropriate_body_1) { FactoryBot.create(:appropriate_body) }
-    let(:appropriate_body_2) { FactoryBot.create(:appropriate_body) }
+    let(:teacher_1) { create(:teacher) }
+    let(:teacher_2) { create(:teacher) }
+    let(:teacher_3) { create(:teacher) }
+    let(:appropriate_body_1) { create(:appropriate_body) }
+    let(:appropriate_body_2) { create(:appropriate_body) }
 
     context 'with an appropriate body' do
       before do
-        FactoryBot.create(
+        create(
           :induction_period,
           :active,
           teacher: teacher_1,
@@ -16,7 +16,7 @@ describe Admin::CurrentTeachers do
           started_on: 1.month.ago.to_date,
           induction_programme: 'fip'
         )
-        FactoryBot.create(
+        create(
           :induction_period,
           :active,
           teacher: teacher_2,
@@ -24,7 +24,7 @@ describe Admin::CurrentTeachers do
           started_on: 1.month.ago.to_date,
           induction_programme: 'fip'
         )
-        FactoryBot.create(
+        create(
           :induction_period,
           teacher: teacher_3,
           appropriate_body: appropriate_body_1,
@@ -45,14 +45,14 @@ describe Admin::CurrentTeachers do
 
     context 'without an appropriate body' do
       before do
-        FactoryBot.create(
+        create(
           :induction_period,
           :active,
           teacher: teacher_1,
           started_on: 1.month.ago.to_date,
           induction_programme: 'fip'
         )
-        FactoryBot.create(
+        create(
           :induction_period,
           teacher: teacher_2,
           started_on: 2.months.ago.to_date,
@@ -71,7 +71,7 @@ describe Admin::CurrentTeachers do
 
     context 'with multiple periods' do
       before do
-        FactoryBot.create(
+        create(
           :induction_period,
           :active,
           teacher: teacher_1,
@@ -80,7 +80,7 @@ describe Admin::CurrentTeachers do
           induction_programme: 'fip'
         )
 
-        FactoryBot.create(
+        create(
           :induction_period,
           teacher: teacher_1,
           appropriate_body: appropriate_body_1,

--- a/spec/services/admin/destroy_induction_period_spec.rb
+++ b/spec/services/admin/destroy_induction_period_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Admin::DestroyInductionPeriod do
     allow(Events::Record).to receive(:record_induction_period_deleted_event!).and_return(true)
   end
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:author) { FactoryBot.create(:user) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:author) { create(:user) }
+  let!(:induction_period) { create(:induction_period, teacher:, appropriate_body:) }
 
   describe "#destroy_induction_period!" do
     it "destroys the induction period" do

--- a/spec/services/admin/reopen_induction_period_spec.rb
+++ b/spec/services/admin/reopen_induction_period_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe Admin::ReopenInductionPeriod do
   subject(:service) { described_class.new(author:, induction_period:) }
 
-  let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
+  let(:admin) { create(:user, email: 'admin-user@education.gov.uk') }
   let(:author) { Sessions::Users::DfEPersona.new(email: admin.email) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
   let(:outcome) { nil }
   let(:number_of_terms) { 4.5 }
   let(:finished_on) { "2023-12-31" }
 
   let(:induction_period) do
-    FactoryBot.create(
+    create(
       :induction_period,
       teacher:,
       outcome:,
@@ -66,7 +66,7 @@ RSpec.describe Admin::ReopenInductionPeriod do
 
     context "when the induction period is not the last" do
       let!(:newer_period) do
-        FactoryBot.create(
+        create(
           :induction_period,
           teacher:,
           outcome:,

--- a/spec/services/admin/revert_claim_spec.rb
+++ b/spec/services/admin/revert_claim_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Admin::RevertClaim do
     )
   end
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:author) { FactoryBot.create(:user) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, appropriate_body:) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:author) { create(:user) }
+  let!(:induction_period) { create(:induction_period, teacher:, appropriate_body:) }
 
   describe "#revert_claim" do
     it "destroys the induction period" do
@@ -46,7 +46,7 @@ RSpec.describe Admin::RevertClaim do
     end
 
     context "when the teacher has other induction periods" do
-      let!(:other_induction_period) { FactoryBot.create(:induction_period, teacher:, started_on: 2.years.ago) }
+      let!(:other_induction_period) { create(:induction_period, teacher:, started_on: 2.years.ago) }
 
       it "does not enqueue a ResetInductionJob" do
         expect {

--- a/spec/services/admin/update_induction_period_spec.rb
+++ b/spec/services/admin/update_induction_period_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Admin::UpdateInductionPeriod do
   subject(:service) { described_class.new(author:, induction_period:, params:) }
 
-  let(:admin) { FactoryBot.create(:user, email: 'admin-user@education.gov.uk') }
+  let(:admin) { create(:user, email: 'admin-user@education.gov.uk') }
   let(:author) { Sessions::Users::DfEPersona.new(email: admin.email) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:induction_period) do
-    FactoryBot.create(
+    create(
       :induction_period,
       teacher:,
       appropriate_body:,
@@ -37,13 +37,13 @@ RSpec.describe Admin::UpdateInductionPeriod do
 
     context "when induction period has an outcome" do
       let(:induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: "2023-01-01",
-                          finished_on: "2023-12-31",
-                          outcome: "pass",
-                          number_of_terms: 3)
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: "2023-01-01",
+               finished_on: "2023-12-31",
+               outcome: "pass",
+               number_of_terms: 3)
       end
 
       context "when updating dates" do
@@ -117,13 +117,13 @@ RSpec.describe Admin::UpdateInductionPeriod do
 
     context "when induction period has a fail outcome" do
       let(:induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: "2023-01-01",
-                          finished_on: "2023-12-31",
-                          outcome: "fail",
-                          number_of_terms: 3)
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: "2023-01-01",
+               finished_on: "2023-12-31",
+               outcome: "fail",
+               number_of_terms: 3)
       end
 
       context "when updating end date" do
@@ -164,7 +164,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
       end
 
       context "when start date is before QTS award date" do
-        let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: Date.parse("2023-01-01")) }
+        let(:teacher) { create(:teacher, trs_qts_awarded_on: Date.parse("2023-01-01")) }
         let(:params) { { started_on: "2022-12-31" } }
 
         it "raises an error" do
@@ -178,11 +178,11 @@ RSpec.describe Admin::UpdateInductionPeriod do
       context "with overlapping periods" do
         context "when overlapping with previous period" do
           let!(:previous_period) do
-            FactoryBot.create(:induction_period,
-                              teacher:,
-                              started_on: "2023-01-01",
-                              finished_on: "2023-07-01",
-                              induction_programme: "cip")
+            create(:induction_period,
+                   teacher:,
+                   started_on: "2023-01-01",
+                   finished_on: "2023-07-01",
+                   induction_programme: "cip")
           end
 
           let(:params) { { started_on: "2023-05-01" } }
@@ -197,11 +197,11 @@ RSpec.describe Admin::UpdateInductionPeriod do
 
         context "when overlapping with next period" do
           let!(:next_period) do
-            FactoryBot.create(:induction_period,
-                              teacher:,
-                              started_on: "2023-11-01",
-                              finished_on: "2024-05-01",
-                              induction_programme: "cip")
+            create(:induction_period,
+                   teacher:,
+                   started_on: "2023-11-01",
+                   finished_on: "2024-05-01",
+                   induction_programme: "cip")
           end
 
           let(:params) { { finished_on: "2023-12-01" } }
@@ -226,7 +226,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
 
       context "when induction period has no outcome and no end date" do
         let(:induction_period) do
-          FactoryBot.create(
+          create(
             :induction_period,
             teacher:,
             appropriate_body:,
@@ -256,7 +256,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
 
       context "when induction period has an outcome" do
         let(:induction_period) do
-          FactoryBot.create(
+          create(
             :induction_period,
             teacher:,
             appropriate_body:,
@@ -308,7 +308,7 @@ RSpec.describe Admin::UpdateInductionPeriod do
 
     context "when updating end date for induction with outcome" do
       let(:induction_period) do
-        FactoryBot.create(
+        create(
           :induction_period,
           teacher:,
           appropriate_body:,

--- a/spec/services/api/add_api_token_to_lead_provider_spec.rb
+++ b/spec/services/api/add_api_token_to_lead_provider_spec.rb
@@ -14,7 +14,7 @@ describe API::AddAPITokenToLeadProvider do
       let(:lead_provider_name_or_id) { nil }
 
       before do
-        FactoryBot.create_list(:lead_provider, 4)
+        create_list(:lead_provider, 4)
       end
 
       it "creates new API Tokens for all Lead providers" do
@@ -23,7 +23,7 @@ describe API::AddAPITokenToLeadProvider do
     end
 
     describe "using lead provider id in the params" do
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:lead_provider) { create(:lead_provider) }
       let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
 
       context "with known lead provider id" do
@@ -55,7 +55,7 @@ describe API::AddAPITokenToLeadProvider do
     end
 
     describe "using lead provider name in the params" do
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:lead_provider) { create(:lead_provider) }
       let(:api_tokens) { API::Token.where(lead_provider_id: lead_provider.id) }
 
       context "with known lead provider name" do

--- a/spec/services/api/token_manager_spec.rb
+++ b/spec/services/api/token_manager_spec.rb
@@ -3,7 +3,7 @@ describe API::TokenManager do
     subject(:create_token) { described_class.create_lead_provider_api_token!(lead_provider:, token:, description:) }
 
     let(:description) { "A token used for test purposes" }
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:lead_provider) { create(:lead_provider) }
     let(:token) { "a-token" }
 
     it { expect { create_token }.to change(API::Token, :count).by(1) }
@@ -37,7 +37,7 @@ describe API::TokenManager do
   describe ".revoke_lead_provider_api_token!" do
     subject(:revoke_token) { described_class.revoke_lead_provider_api_token!(api_token:) }
 
-    let!(:api_token) { FactoryBot.create(:api_token) }
+    let!(:api_token) { create(:api_token) }
 
     it "destroys the API token" do
       expect { revoke_token }.to change(API::Token, :count).by(-1)
@@ -59,13 +59,13 @@ describe API::TokenManager do
   describe ".find_lead_provider_api_token" do
     subject(:find_token) { described_class.find_lead_provider_api_token(token: api_token.token) }
 
-    let(:api_token) { FactoryBot.create(:api_token) }
+    let(:api_token) { create(:api_token) }
 
     it { expect { find_token }.to change { api_token.reload.last_used_at }.to be_within(5.seconds).of(Time.current) }
     it { is_expected.to eq(api_token) }
 
     context "when the API token does not exist" do
-      let(:api_token) { FactoryBot.build(:api_token, token: "does-not-exist-yet") }
+      let(:api_token) { build(:api_token, token: "does-not-exist-yet") }
 
       it { is_expected.to be_nil }
     end

--- a/spec/services/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe AppropriateBodies::ClaimAnECT::CheckECT do
   subject { AppropriateBodies::ClaimAnECT::CheckECT.new(appropriate_body:, pending_induction_submission:) }
 
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:appropriate_body) { build(:appropriate_body) }
+  let(:pending_induction_submission) { create(:pending_induction_submission) }
 
   describe "#initialize" do
     it "assigns the provided appropriate body and pending induction submission params" do

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:appropriate_body) { build(:appropriate_body) }
 
   describe "#initialize" do
-    let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+    let(:pending_induction_submission) { create(:pending_induction_submission) }
 
     it "assigns the provided appropriate body and pending induction submission params" do
       find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
@@ -14,7 +14,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
 
   describe "#import_from_trs!" do
     context "when the pending_induction_submission is invalid" do
-      let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, date_of_birth: nil) }
+      let(:pending_induction_submission) { create(:pending_induction_submission, date_of_birth: nil) }
 
       it "returns nil" do
         find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
@@ -29,19 +29,19 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
     end
 
     context "when there is a match and the teacher has an active induction period" do
-      let(:teacher) { FactoryBot.create(:teacher) }
-      let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
+      let(:teacher) { create(:teacher) }
+      let!(:pending_induction_submission) { create(:pending_induction_submission, trn: teacher.trn) }
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :active, appropriate_body:, teacher:, started_on: Date.parse("2 October 2022"))
+        create(:induction_period, :active, appropriate_body:, teacher:, started_on: Date.parse("2 October 2022"))
       end
 
       context "when the induction period is with another AB" do
         include_context "fake trs api client"
-        let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+        let(:appropriate_body) { create(:appropriate_body) }
 
         it "returns true" do
           find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(
-            appropriate_body: FactoryBot.create(:appropriate_body), pending_induction_submission:
+            appropriate_body: create(:appropriate_body), pending_induction_submission:
           )
 
           expect(find_ect.import_from_trs!).to be(true)
@@ -64,7 +64,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
       include_context "fake trs api client that finds nothing"
 
       it "raises teacher not found error" do
-        pending_induction_submission = FactoryBot.create(:pending_induction_submission)
+        pending_induction_submission = create(:pending_induction_submission)
         find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
 
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::TeacherNotFound)

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
     allow(author).to receive(:is_a?).with(any_args).and_call_original
   end
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:pending_induction_submission) { create(:pending_induction_submission) }
   let(:author) do
     Sessions::Users::AppropriateBodyUser.new(
       name: 'A user',
@@ -130,7 +130,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
 
     context 'when registering an existing teacher' do
       context "when the teacher has no induction period" do
-        let!(:existing_teacher) { FactoryBot.create(:teacher, trn: "1234567") }
+        let!(:existing_teacher) { create(:teacher, trn: "1234567") }
 
         it "updates the existing teacher and creates a new induction period" do
           expect {
@@ -169,8 +169,8 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
       end
 
       context 'when the teacher has an existing induction period' do
-        let!(:existing_teacher) { FactoryBot.create(:teacher, trn:) }
-        let!(:induction_period) { FactoryBot.create(:induction_period, teacher: existing_teacher, finished_on: Date.new(2025, 4, 21)) }
+        let!(:existing_teacher) { create(:teacher, trn:) }
+        let!(:induction_period) { create(:induction_period, teacher: existing_teacher, finished_on: Date.new(2025, 4, 21)) }
         let(:pending_induction_submission_params) do
           {
             induction_programme: "fip",
@@ -199,7 +199,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
       end
 
       context "when the teacher's name changes" do
-        let!(:existing_teacher) { FactoryBot.create(:teacher, trn: "1234567", trs_first_name: "Jonathan", trs_last_name: "Dole") }
+        let!(:existing_teacher) { create(:teacher, trn: "1234567", trs_first_name: "Jonathan", trs_last_name: "Dole") }
 
         before do
           subject.register(pending_induction_submission_params)
@@ -235,9 +235,9 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
     end
 
     context "when trying to register a teacher with a start_date before future IPs" do
-      let!(:existing_teacher) { FactoryBot.create(:teacher, trn: "1234567") }
+      let!(:existing_teacher) { create(:teacher, trn: "1234567") }
       let(:started_on) { 2.days.ago }
-      let!(:existing_induction_period) { FactoryBot.create(:induction_period, teacher: existing_teacher, started_on:, finished_on: 1.day.ago) }
+      let!(:existing_induction_period) { create(:induction_period, teacher: existing_teacher, started_on:, finished_on: 1.day.ago) }
 
       let(:pending_induction_submission_params) do
         {

--- a/spec/services/appropriate_bodies/ects_spec.rb
+++ b/spec/services/appropriate_bodies/ects_spec.rb
@@ -1,31 +1,31 @@
 RSpec.describe AppropriateBodies::ECTs do
   subject { AppropriateBodies::ECTs.new(appropriate_body) }
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:other_appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   describe "#current_or_completed_while_at_appropriate_body" do
     context 'when the latest induction period is with this appropriate body' do
       let!(:earlier_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body: other_appropriate_body,
-                          started_on: 1.year.ago,
-                          finished_on: 6.months.ago,
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body: other_appropriate_body,
+               started_on: 1.year.ago,
+               finished_on: 6.months.ago,
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       let!(:latest_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 6.months.ago,
-                          finished_on: 1.month.ago,
-                          outcome: 'pass',
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: 6.months.ago,
+               finished_on: 1.month.ago,
+               outcome: 'pass',
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       it 'includes the teacher' do
@@ -35,24 +35,24 @@ RSpec.describe AppropriateBodies::ECTs do
 
     context 'when the latest induction period is with another appropriate body' do
       let!(:earlier_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 1.year.ago,
-                          finished_on: 6.months.ago,
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: 1.year.ago,
+               finished_on: 6.months.ago,
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       let!(:latest_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body: other_appropriate_body,
-                          started_on: 6.months.ago,
-                          finished_on: 1.month.ago,
-                          outcome: 'pass', # pass or fail should be on last IP
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body: other_appropriate_body,
+               started_on: 6.months.ago,
+               finished_on: 1.month.ago,
+               outcome: 'pass', # pass or fail should be on last IP
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       it 'excludes the teacher' do
@@ -62,23 +62,23 @@ RSpec.describe AppropriateBodies::ECTs do
 
     context 'when the teacher has an ongoing induction period with this appropriate body' do
       let!(:earlier_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body: other_appropriate_body,
-                          started_on: 1.year.ago,
-                          finished_on: 6.months.ago,
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body: other_appropriate_body,
+               started_on: 1.year.ago,
+               finished_on: 6.months.ago,
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       let!(:ongoing_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 6.months.ago,
-                          finished_on: nil,
-                          number_of_terms: nil,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: 6.months.ago,
+               finished_on: nil,
+               number_of_terms: nil,
+               induction_programme: 'fip')
       end
 
       it 'includes the teacher' do
@@ -88,25 +88,25 @@ RSpec.describe AppropriateBodies::ECTs do
 
     context 'when the teacher has a failed outcome with this appropriate body' do
       let!(:earlier_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 1.year.ago,
-                          finished_on: 6.months.ago,
-                          outcome: 'pass',
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: 1.year.ago,
+               finished_on: 6.months.ago,
+               outcome: 'pass',
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       let!(:failed_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 6.months.ago,
-                          finished_on: 1.month.ago,
-                          outcome: 'fail',
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: 6.months.ago,
+               finished_on: 1.month.ago,
+               outcome: 'fail',
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       it 'includes the teacher' do
@@ -116,14 +116,14 @@ RSpec.describe AppropriateBodies::ECTs do
 
     context 'when the teacher has a finished induction period with no outcome' do
       let!(:induction_period_without_outcome) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          started_on: 6.months.ago,
-                          finished_on: 1.month.ago,
-                          outcome: nil,
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               started_on: 6.months.ago,
+               finished_on: 1.month.ago,
+               outcome: nil,
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       it 'excludes the teacher' do
@@ -135,12 +135,12 @@ RSpec.describe AppropriateBodies::ECTs do
   describe "#former" do
     context 'when the teacher has a finished induction period' do
       let!(:finished_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          finished_on: 1.month.ago,
-                          number_of_terms: 3,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               finished_on: 1.month.ago,
+               number_of_terms: 3,
+               induction_programme: 'fip')
       end
 
       it 'includes the teacher' do
@@ -150,12 +150,12 @@ RSpec.describe AppropriateBodies::ECTs do
 
     context 'when the teacher has an ongoing induction period' do
       let!(:ongoing_induction_period) do
-        FactoryBot.create(:induction_period,
-                          teacher:,
-                          appropriate_body:,
-                          finished_on: nil,
-                          number_of_terms: nil,
-                          induction_programme: 'fip')
+        create(:induction_period,
+               teacher:,
+               appropriate_body:,
+               finished_on: nil,
+               number_of_terms: nil,
+               induction_programme: 'fip')
       end
 
       it 'excludes the teacher' do

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -22,21 +22,21 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
   let(:outcome) { 'pass' }
   let(:error) { '' }
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let(:teacher) do
-    FactoryBot.create(:teacher, :with_corrected_name,
-                      trn:,
-                      trs_first_name: first_name,
-                      trs_last_name: last_name)
+    create(:teacher, :with_corrected_name,
+           trn:,
+           trs_first_name: first_name,
+           trs_last_name: last_name)
   end
 
   let(:pending_induction_submission_batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :action,
-                      appropriate_body:,
-                      data: [
-                        { trn:, date_of_birth:, finished_on:, number_of_terms:, outcome:, error: }
-                      ])
+    create(:pending_induction_submission_batch, :action,
+           appropriate_body:,
+           data: [
+             { trn:, date_of_birth:, finished_on:, number_of_terms:, outcome:, error: }
+           ])
   end
 
   let(:submission) do
@@ -274,13 +274,13 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
     end
 
     context 'with an ongoing induction at another Appropriate Body' do
-      let(:other_body) { FactoryBot.create(:appropriate_body) }
+      let(:other_body) { create(:appropriate_body) }
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :active,
-                          appropriate_body: other_body,
-                          teacher:,
-                          started_on: '2024-1-1')
+        create(:induction_period, :active,
+               appropriate_body: other_body,
+               teacher:,
+               started_on: '2024-1-1')
       end
 
       before { service.process! }
@@ -292,10 +292,10 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
 
     context 'with an ongoing induction' do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :active,
-                          appropriate_body:,
-                          teacher:,
-                          started_on: '2024-1-1')
+        create(:induction_period, :active,
+               appropriate_body:,
+               teacher:,
+               started_on: '2024-1-1')
       end
 
       before { service.process! }
@@ -354,9 +354,9 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
 
       context 'with a completed induction' do
         let!(:induction_period) do
-          FactoryBot.create(:induction_period, :pass,
-                            appropriate_body:,
-                            teacher:)
+          create(:induction_period, :pass,
+                 appropriate_body:,
+                 teacher:)
         end
 
         before { service.process! }

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
   let(:induction_programme) { 'FIP' }
   let(:error) { '' }
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let(:pending_induction_submission_batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :claim,
-                      appropriate_body:,
-                      data: [
-                        { trn:, date_of_birth:, started_on:, induction_programme:, error: }
-                      ])
+    create(:pending_induction_submission_batch, :claim,
+           appropriate_body:,
+           data: [
+             { trn:, date_of_birth:, started_on:, induction_programme:, error: }
+           ])
   end
 
   let(:submissions) do
@@ -334,13 +334,13 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
 
       let(:started_on) { 1.day.ago.to_date.to_s }
 
-      let(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:teacher) { create(:teacher, trn:) }
 
       before do
-        FactoryBot.create(:induction_period, teacher:,
-                                             appropriate_body:,
-                                             started_on: 30.days.ago.to_date,
-                                             finished_on: 15.days.ago.to_date)
+        create(:induction_period, teacher:,
+                                  appropriate_body:,
+                                  started_on: 30.days.ago.to_date,
+                                  finished_on: 15.days.ago.to_date)
         service.process!
       end
 
@@ -362,13 +362,13 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
 
       let(:started_on) { 15.days.ago.to_date.to_s }
 
-      let(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:teacher) { create(:teacher, trn:) }
 
       before do
-        FactoryBot.create(:induction_period, teacher:,
-                                             appropriate_body:,
-                                             started_on: 30.days.ago.to_date,
-                                             finished_on: 1.day.ago.to_date)
+        create(:induction_period, teacher:,
+                                  appropriate_body:,
+                                  started_on: 30.days.ago.to_date,
+                                  finished_on: 1.day.ago.to_date)
         service.process!
       end
 
@@ -399,10 +399,10 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     context 'when the ECT has already passed' do
       include_context 'fake trs api client that finds teacher that has passed their induction'
 
-      let(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:teacher) { create(:teacher, trn:) }
 
       before do
-        FactoryBot.create(:induction_period, :pass, teacher:, appropriate_body:)
+        create(:induction_period, :pass, teacher:, appropriate_body:)
         service.process!
       end
 
@@ -422,10 +422,10 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     context 'when the ECT has already failed' do
       include_context 'fake trs api client that finds teacher that has failed their induction'
 
-      let(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:teacher) { create(:teacher, trn:) }
 
       before do
-        FactoryBot.create(:induction_period, :fail, teacher:, appropriate_body:)
+        create(:induction_period, :fail, teacher:, appropriate_body:)
         service.process!
       end
 
@@ -445,11 +445,11 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     context 'when the ECT is already claimed by another body' do
       include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
 
-      let(:other_body) { FactoryBot.create(:appropriate_body) }
-      let(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:other_body) { create(:appropriate_body) }
+      let(:teacher) { create(:teacher, trn:) }
 
       before do
-        FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_body)
+        create(:induction_period, :active, teacher:, appropriate_body: other_body)
         service.process!
       end
 

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -20,21 +20,21 @@ RSpec.describe AppropriateBodies::RecordOutcome do
     )
   end
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   let(:induction_period) do
-    FactoryBot.create(:induction_period, :active,
-                      appropriate_body:,
-                      teacher:,
-                      started_on: '2024-1-1')
+    create(:induction_period, :active,
+           appropriate_body:,
+           teacher:,
+           started_on: '2024-1-1')
   end
 
   let(:pending_induction_submission) do
-    FactoryBot.create(:pending_induction_submission,
-                      trn: teacher.trn,
-                      finished_on: 1.day.ago.to_date,
-                      number_of_terms: 6)
+    create(:pending_induction_submission,
+           trn: teacher.trn,
+           finished_on: 1.day.ago.to_date,
+           number_of_terms: 6)
   end
 
   describe "#pass!" do
@@ -80,7 +80,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
       end
 
       context "when the author is a DfE user" do
-        let(:dfe_user) { FactoryBot.create(:user, email: 'dfe_user@education.gov.uk') }
+        let(:dfe_user) { create(:user, email: 'dfe_user@education.gov.uk') }
         let(:author) do
           Sessions::Users::DfEUser.new(
             email: dfe_user.email
@@ -112,10 +112,10 @@ RSpec.describe AppropriateBodies::RecordOutcome do
 
     context "when validation fails on induction period update" do
       let(:pending_induction_submission) do
-        FactoryBot.create(:pending_induction_submission,
-                          trn: teacher.trn,
-                          finished_on: 1.day.ago.to_date,
-                          number_of_terms: 6)
+        create(:pending_induction_submission,
+               trn: teacher.trn,
+               finished_on: 1.day.ago.to_date,
+               number_of_terms: 6)
       end
 
       before do
@@ -206,7 +206,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
       end
 
       context "when the author is a DfE user" do
-        let(:dfe_user) { FactoryBot.create(:user, email: 'dfe_user@education.gov.uk') }
+        let(:dfe_user) { create(:user, email: 'dfe_user@education.gov.uk') }
         let(:author) do
           Sessions::Users::DfEUser.new(
             email: dfe_user.email

--- a/spec/services/appropriate_bodies/release_ect_spec.rb
+++ b/spec/services/appropriate_bodies/release_ect_spec.rb
@@ -9,10 +9,10 @@ describe AppropriateBodies::ReleaseECT do
     )
   end
 
-  let(:induction_period) { FactoryBot.create(:induction_period, :active) }
+  let(:induction_period) { create(:induction_period, :active) }
   let(:appropriate_body) { induction_period.appropriate_body }
   let(:pending_induction_submission) do
-    FactoryBot.create(
+    create(
       :pending_induction_submission,
       :finishing,
       appropriate_body:,

--- a/spec/services/appropriate_bodies/search_spec.rb
+++ b/spec/services/appropriate_bodies/search_spec.rb
@@ -8,7 +8,7 @@ describe AppropriateBodies::Search do
       subject { described_class.istip }
 
       context 'when ISTIP has been registered' do
-        let!(:istip) { FactoryBot.create(:appropriate_body, :istip) }
+        let!(:istip) { create(:appropriate_body, :istip) }
 
         it 'returns it' do
           expect(subject).to eq(istip)

--- a/spec/services/ect_at_school_periods/mentorship_spec.rb
+++ b/spec/services/ect_at_school_periods/mentorship_spec.rb
@@ -2,8 +2,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#current_mentorship_period" do
     subject { described_class.new(mentee).current_mentorship_period }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -11,15 +11,15 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has had past mentorships" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
+        create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
       end
 
       it { is_expected.to be_nil }
     end
 
     context "when the ect has an ongoing mentorship at a school" do
-      let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:) }
-      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee:, mentor:) }
+      let!(:old_mentorship) { create(:mentorship_period, mentee:, mentor:) }
+      let!(:ongoing_mentorship) { create(:mentorship_period, :active, mentee:, mentor:) }
 
       it { is_expected.to eq(ongoing_mentorship) }
     end
@@ -28,8 +28,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#current_mentor" do
     subject { described_class.new(mentee).current_mentor }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -37,7 +37,7 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has had past mentorships" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor:)
+        create(:mentorship_period, mentee:, mentor:)
       end
 
       it { is_expected.to be_nil }
@@ -45,8 +45,8 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at a school" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
+        create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(mentor) }
@@ -56,8 +56,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#current_mentor_name" do
     subject { described_class.new(mentee).current_mentor_name }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -65,7 +65,7 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has had past mentorships" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor:)
+        create(:mentorship_period, mentee:, mentor:)
       end
 
       it { is_expected.to be_nil }
@@ -73,8 +73,8 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at a school" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
+        create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(Teachers::Name.new(mentor.teacher).full_name) }
@@ -84,22 +84,22 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#latest_mentorship_period" do
     subject { described_class.new(mentee).latest_mentorship_period }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has had past mentorships" do
-      let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago) }
+      let!(:old_mentorship) { create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago) }
 
       it { is_expected.to eq(old_mentorship) }
     end
 
     context "when the ect has an ongoing mentorship at the school" do
-      let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:) }
-      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee:, mentor:) }
+      let!(:old_mentorship) { create(:mentorship_period, mentee:, mentor:) }
+      let!(:ongoing_mentorship) { create(:mentorship_period, :active, mentee:, mentor:) }
 
       it { is_expected.to eq(ongoing_mentorship) }
     end
@@ -108,9 +108,9 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#latest_mentor" do
     subject { described_class.new(mentee).latest_mentor }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-    let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:old_mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -118,8 +118,8 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has had past mentorships" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 1.year.ago)
+        create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
+        create(:mentorship_period, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eq(mentor) }
@@ -127,8 +127,8 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at a school" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
+        create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(mentor) }
@@ -138,9 +138,9 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#latest_mentor_name" do
     subject { described_class.new(mentee).latest_mentor_name }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-    let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:old_mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -148,8 +148,8 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has had past mentorships" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 1.year.ago)
+        create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
+        create(:mentorship_period, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eq(Teachers::Name.new(mentor.teacher).full_name) }
@@ -157,8 +157,8 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at a school" do
       before do
-        FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
+        create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(Teachers::Name.new(mentor.teacher).full_name) }

--- a/spec/services/ect_at_school_periods/training_spec.rb
+++ b/spec/services/ect_at_school_periods/training_spec.rb
@@ -2,7 +2,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_training_period" do
     subject { described_class.new(ect_at_school_period).current_training_period }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -10,15 +10,15 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has had past training periods" do
       before do
-        FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+        create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
       end
 
       it { is_expected.to be_nil }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training) }
     end
@@ -27,7 +27,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_delivery_partner" do
     subject { described_class.new(ect_at_school_period).current_delivery_partner }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -35,15 +35,15 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has had past training periods" do
       before do
-        FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+        create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
       end
 
       it { is_expected.to be_nil }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
@@ -52,7 +52,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_delivery_partner_name" do
     subject { described_class.new(ect_at_school_period).current_delivery_partner_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -60,15 +60,15 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has had past training periods" do
       before do
-        FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+        create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
       end
 
       it { is_expected.to be_nil }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
@@ -77,7 +77,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_lead_provider" do
     subject { described_class.new(ect_at_school_period).current_lead_provider }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -85,15 +85,15 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has had past training periods" do
       before do
-        FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+        create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
       end
 
       it { is_expected.to be_nil }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
@@ -102,7 +102,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_lead_provider_name" do
     subject { described_class.new(ect_at_school_period).current_lead_provider_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -110,15 +110,15 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has had past training periods" do
       before do
-        FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+        create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
       end
 
       it { is_expected.to be_nil }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
@@ -127,21 +127,21 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_training_period" do
     subject { described_class.new(ect_at_school_period).latest_training_period }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has had past training periods" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
       it { is_expected.to eq(old_training) }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training) }
     end
@@ -150,21 +150,21 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_delivery_partner" do
     subject { described_class.new(ect_at_school_period).latest_delivery_partner }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has had past training periods" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
       it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
@@ -173,21 +173,21 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_delivery_partner_name" do
     subject { described_class.new(ect_at_school_period).latest_delivery_partner_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has had past training periods" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
       it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
@@ -196,21 +196,21 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_lead_provider" do
     subject { described_class.new(ect_at_school_period).latest_lead_provider }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has had past training periods" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
       it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
@@ -219,21 +219,21 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_lead_provider_name" do
     subject { described_class.new(ect_at_school_period).latest_lead_provider_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
     end
 
     context "when the ect has had past training periods" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:, started_on: 2.years.ago) }
 
       it { is_expected.to eq(old_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
 
     context "when the ect has an ongoing training period at the school" do
-      let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:old_training) { create(:training_period, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { create(:training_period, :active, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end

--- a/spec/services/events/describe_modifications_spec.rb
+++ b/spec/services/events/describe_modifications_spec.rb
@@ -1,7 +1,7 @@
 describe Events::DescribeModifications do
   context 'when the website field is added' do
     it %(is: Website set to 'www.website.com') do
-      school = FactoryBot.create(:gias_school, website: nil)
+      school = create(:gias_school, website: nil)
       school.assign_attributes(website: 'www.school.com')
       description_of_changes = Events::DescribeModifications.new(school.changes).describe
 
@@ -11,7 +11,7 @@ describe Events::DescribeModifications do
 
   context 'when the website field is removed' do
     it %(is: Website 'www.school.com' removed) do
-      school = FactoryBot.create(:gias_school, website: 'www.school.com')
+      school = create(:gias_school, website: 'www.school.com')
       school.assign_attributes(website: '')
       description_of_changes = Events::DescribeModifications.new(school.changes).describe
 
@@ -21,7 +21,7 @@ describe Events::DescribeModifications do
 
   context 'when both TRS first and last names are updated' do
     let(:description_of_changes) do
-      teacher = FactoryBot.create(:teacher, trs_first_name: 'Maurice', trs_last_name: 'Micklewhite')
+      teacher = create(:teacher, trs_first_name: 'Maurice', trs_last_name: 'Micklewhite')
       teacher.assign_attributes(trs_first_name: 'Michael', trs_last_name: 'Caine')
       Events::DescribeModifications.new(teacher.changes).describe
     end
@@ -37,7 +37,7 @@ describe Events::DescribeModifications do
 
   context 'when a date is changed' do
     it %(it is formatted in the GOV.UK short date style: Closed on set to '24 Jan 2025') do
-      school = FactoryBot.create(:gias_school, closed_on: nil)
+      school = create(:gias_school, closed_on: nil)
       school.assign_attributes(closed_on: Date.new(2025, 1, 24))
       description_of_changes = Events::DescribeModifications.new(school.changes).describe
 

--- a/spec/services/events/list_spec.rb
+++ b/spec/services/events/list_spec.rb
@@ -7,7 +7,7 @@ describe 'Events::List' do
 
   describe '.for_teacher' do
     it 'only selects events with a teacher_id matching the provided teacher' do
-      teacher = FactoryBot.create(:teacher)
+      teacher = create(:teacher)
 
       expect(Events::List.new.for_teacher(teacher).to_sql).to include(%(WHERE "events"."teacher_id" = #{teacher.id}))
     end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Events::Record do
   include ActiveJob::TestHelper
 
-  let(:user) { FactoryBot.create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Rhys', trs_last_name: 'Ifans') }
-  let(:induction_period) { FactoryBot.create(:induction_period) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: "Burns Slant Drilling Co.") }
+  let(:user) { create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
+  let(:teacher) { create(:teacher, trs_first_name: 'Rhys', trs_last_name: 'Ifans') }
+  let(:induction_period) { create(:induction_period) }
+  let(:appropriate_body) { create(:appropriate_body, name: "Burns Slant Drilling Co.") }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
   let(:author_params) { { author_id: author.id, author_name: author.name, author_email: author.email, author_type: :dfe_staff_user } }
 
@@ -21,7 +21,7 @@ RSpec.describe Events::Record do
 
   describe '#initialize' do
     context "when the user isn't a Sessions::User" do
-      let(:non_session_user) { FactoryBot.build(:user) }
+      let(:non_session_user) { build(:user) }
 
       it 'fails with a AuthorNotASessionsUser error with a non Sessions::User author' do
         expect {
@@ -31,8 +31,8 @@ RSpec.describe Events::Record do
     end
 
     it 'assigns and saves attributes correctly' do
-      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :active, started_on: 3.weeks.ago)
-      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.weeks.ago)
+      ect_at_school_period = create(:ect_at_school_period, :active, started_on: 3.weeks.ago)
+      mentor_at_school_period = create(:mentor_at_school_period, :active, started_on: 3.weeks.ago)
 
       attributes = {
         author:,
@@ -42,17 +42,17 @@ RSpec.describe Events::Record do
         happened_at:,
         induction_period:,
         teacher:,
-        school: FactoryBot.create(:school),
-        appropriate_body: FactoryBot.create(:appropriate_body),
-        induction_extension: FactoryBot.create(:induction_extension),
+        school: create(:school),
+        appropriate_body: create(:appropriate_body),
+        induction_extension: create(:induction_extension),
         ect_at_school_period:,
         mentor_at_school_period:,
-        school_partnership: FactoryBot.create(:school_partnership),
-        lead_provider: FactoryBot.create(:lead_provider),
-        delivery_partner: FactoryBot.create(:delivery_partner),
-        user: FactoryBot.create(:user),
-        training_period: FactoryBot.create(:training_period, :active, ect_at_school_period:, started_on: 1.week.ago),
-        mentorship_period: FactoryBot.create(
+        school_partnership: create(:school_partnership),
+        lead_provider: create(:lead_provider),
+        delivery_partner: create(:delivery_partner),
+        user: create(:user),
+        training_period: create(:training_period, :active, ect_at_school_period:, started_on: 1.week.ago),
+        mentorship_period: create(
           :mentorship_period,
           mentor: mentor_at_school_period,
           mentee: ect_at_school_period,
@@ -81,19 +81,19 @@ RSpec.describe Events::Record do
 
   describe '#record_event!' do
     {
-      induction_period: FactoryBot.build(:induction_period),
-      teacher: FactoryBot.build(:teacher),
-      school: FactoryBot.build(:school),
-      appropriate_body: FactoryBot.build(:appropriate_body),
-      induction_extension: FactoryBot.build(:induction_extension),
-      ect_at_school_period: FactoryBot.build(:ect_at_school_period),
-      mentor_at_school_period: FactoryBot.build(:mentor_at_school_period),
-      school_partnership: FactoryBot.build(:school_partnership),
-      lead_provider: FactoryBot.build(:lead_provider),
-      delivery_partner: FactoryBot.build(:delivery_partner),
-      user: FactoryBot.build(:user),
-      training_period: FactoryBot.build(:training_period),
-      mentorship_period: FactoryBot.build(:mentorship_period),
+      induction_period: build(:induction_period),
+      teacher: build(:teacher),
+      school: build(:school),
+      appropriate_body: build(:appropriate_body),
+      induction_extension: build(:induction_extension),
+      ect_at_school_period: build(:ect_at_school_period),
+      mentor_at_school_period: build(:mentor_at_school_period),
+      school_partnership: build(:school_partnership),
+      lead_provider: build(:lead_provider),
+      delivery_partner: build(:delivery_partner),
+      user: build(:user),
+      training_period: build(:training_period),
+      mentorship_period: build(:mentorship_period),
     }.each do |attribute, object|
       describe "when #{attribute} is missing" do
         subject { Events::Record.new(author:, event_type:, heading:, happened_at:, **attributes_with_unsaved_school) }
@@ -310,7 +310,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_induction_extension_created_event!' do
-    let(:induction_extension) { FactoryBot.build(:induction_extension) }
+    let(:induction_extension) { build(:induction_extension) }
 
     it 'queues a RecordEventJob with the correct values' do
       raw_modifications = induction_extension.changes
@@ -335,7 +335,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_induction_extension_updated_event!' do
-    let(:induction_extension) { FactoryBot.create(:induction_extension) }
+    let(:induction_extension) { create(:induction_extension) }
 
     it 'queues a RecordEventJob with the correct values' do
       induction_extension.assign_attributes(number_of_terms: 3.2)
@@ -362,7 +362,7 @@ RSpec.describe Events::Record do
   describe '.record_induction_period_updated_event!' do
     let(:three_weeks_ago) { 3.weeks.ago.to_date }
     let(:two_weeks_ago) { 2.weeks.ago.to_date }
-    let(:induction_period) { FactoryBot.create(:induction_period, :active, started_on: three_weeks_ago) }
+    let(:induction_period) { create(:induction_period, :active, started_on: three_weeks_ago) }
 
     it 'queues a RecordEventJob with the correct values' do
       induction_period.assign_attributes(started_on: two_weeks_ago)
@@ -580,7 +580,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_induction_period_reopened_event!' do
-    let(:induction_period) { FactoryBot.create(:induction_period, :pass, teacher:, appropriate_body:) }
+    let(:induction_period) { create(:induction_period, :pass, teacher:, appropriate_body:) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -607,10 +607,10 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_teacher_registered_as_mentor_event!' do
-    let(:school) { FactoryBot.create(:school) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
+    let(:school) { create(:school) }
+    let(:mentor_at_school_period) { create(:mentor_at_school_period, teacher:, school:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
     let(:training_period) do
-      FactoryBot.create(
+      create(
         :training_period,
         :for_mentor,
         :with_school_partnership,
@@ -639,9 +639,9 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_teacher_registered_as_ect_event!' do
-    let(:school) { FactoryBot.create(:school) }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
-    let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
+    let(:school) { create(:school) }
+    let(:ect_at_school_period) { create(:ect_at_school_period, teacher:, school:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
+    let(:training_period) { create(:training_period, ect_at_school_period:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -663,11 +663,11 @@ RSpec.describe Events::Record do
 
   describe '.record_teacher_starts_mentoring_event!' do
     let(:started_on_param) { { started_on: 2.years.ago.to_date } }
-    let(:school) { FactoryBot.create(:school) }
-    let(:mentee) { FactoryBot.create(:teacher, trs_first_name: 'Steffan', trs_last_name: 'Rhodri') }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, teacher: mentee, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:, school:, **started_on_param) }
-    let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
+    let(:school) { create(:school) }
+    let(:mentee) { create(:teacher, trs_first_name: 'Steffan', trs_last_name: 'Rhodri') }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, teacher: mentee, school:, **started_on_param) }
+    let(:mentor_at_school_period) { create(:mentor_at_school_period, :active, teacher:, school:, **started_on_param) }
+    let(:mentorship_period) { create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -690,11 +690,11 @@ RSpec.describe Events::Record do
 
   describe '.record_teacher_starts_being_mentored_event!' do
     let(:started_on_param) { { started_on: 2.years.ago.to_date } }
-    let(:school) { FactoryBot.create(:school) }
-    let(:mentor) { FactoryBot.create(:teacher, trs_first_name: 'Steffan', trs_last_name: 'Rhodri') }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, teacher:, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor, school:, **started_on_param) }
-    let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
+    let(:school) { create(:school) }
+    let(:mentor) { create(:teacher, trs_first_name: 'Steffan', trs_last_name: 'Rhodri') }
+    let(:ect_at_school_period) { create(:ect_at_school_period, :active, teacher:, school:, **started_on_param) }
+    let(:mentor_at_school_period) { create(:mentor_at_school_period, :active, teacher: mentor, school:, **started_on_param) }
+    let(:mentorship_period) { create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -716,7 +716,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_bulk_upload_started_event!' do
-    let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :action, appropriate_body:) }
+    let(:batch) { create(:pending_induction_submission_batch, :action, appropriate_body:) }
 
     let(:csv_data) do
       AppropriateBodies::ProcessBatchForm.from_uploaded_file(
@@ -746,7 +746,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_bulk_upload_completed_event!' do
-    let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body:) }
+    let(:batch) { create(:pending_induction_submission_batch, :claim, appropriate_body:) }
 
     include_context 'fake trs api client'
 
@@ -771,7 +771,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_lead_provider_api_token_created_event!' do
-    let(:api_token) { FactoryBot.create(:api_token) }
+    let(:api_token) { create(:api_token) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -790,7 +790,7 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_lead_provider_api_token_revoked_event!' do
-    let(:api_token) { FactoryBot.create(:api_token) }
+    let(:api_token) { create(:api_token) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -809,8 +809,8 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_statement_adjustment_added_event!' do
-    let(:statement) { FactoryBot.create(:statement) }
-    let(:statement_adjustment) { FactoryBot.create(:statement_adjustment, statement:) }
+    let(:statement) { create(:statement) }
+    let(:statement_adjustment) { create(:statement_adjustment, statement:) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -836,8 +836,8 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_statement_adjustment_updated_event!' do
-    let(:statement) { FactoryBot.create(:statement) }
-    let(:statement_adjustment) { FactoryBot.create(:statement_adjustment, statement:) }
+    let(:statement) { create(:statement) }
+    let(:statement_adjustment) { create(:statement_adjustment, statement:) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
@@ -863,8 +863,8 @@ RSpec.describe Events::Record do
   end
 
   describe '.record_statement_adjustment_deleted_event!' do
-    let(:statement) { FactoryBot.create(:statement) }
-    let(:statement_adjustment) { FactoryBot.create(:statement_adjustment, statement:) }
+    let(:statement) { create(:statement) }
+    let(:statement_adjustment) { create(:statement_adjustment, statement:) }
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do

--- a/spec/services/induction_extensions/manage_spec.rb
+++ b/spec/services/induction_extensions/manage_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe InductionExtensions::Manage do
     )
   end
 
-  let(:user) { FactoryBot.create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Andy', trs_last_name: 'Zaltzman') }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:user) { create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
+  let(:teacher) { create(:teacher, trs_first_name: 'Andy', trs_last_name: 'Zaltzman') }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe '#create_or_update!' do
     before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
@@ -44,7 +44,7 @@ RSpec.describe InductionExtensions::Manage do
     end
 
     context 'when editing an extension' do
-      let!(:induction_extension) { FactoryBot.create(:induction_extension, teacher:) }
+      let!(:induction_extension) { create(:induction_extension, teacher:) }
 
       it 'records an update event' do
         freeze_time do
@@ -74,7 +74,7 @@ RSpec.describe InductionExtensions::Manage do
     before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
 
     context 'when deleting an extension' do
-      let!(:induction_extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2.5) }
+      let!(:induction_extension) { create(:induction_extension, teacher:, number_of_terms: 2.5) }
 
       it 'deletes the extension and records a delete event' do
         freeze_time do

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -4,8 +4,8 @@ describe 'InductionPeriods::CreateInductionPeriod' do
   describe '#initialize' do
     subject { InductionPeriods::CreateInductionPeriod.new(author:, teacher:, params:) }
 
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+    let(:teacher) { create(:teacher) }
+    let(:appropriate_body) { create(:appropriate_body) }
     let(:started_on) { 3.weeks.ago.to_date }
     let(:induction_programme) { 'cip' }
     let(:params) do
@@ -85,7 +85,7 @@ describe 'InductionPeriods::CreateInductionPeriod' do
 
       context 'with existing periods' do
         before do
-          FactoryBot.create(
+          create(
             :induction_period,
             teacher:,
             appropriate_body:,
@@ -141,7 +141,7 @@ describe 'InductionPeriods::CreateInductionPeriod' do
 
       context 'when the teacher has passed induction' do
         before do
-          FactoryBot.create(
+          create(
             :induction_period,
             teacher:,
             appropriate_body:,

--- a/spec/services/induction_periods/delete_induction_period_spec.rb
+++ b/spec/services/induction_periods/delete_induction_period_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
   include_context 'fake trs api client'
   include ActiveJob::TestHelper
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:user) { FactoryBot.create(:user) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:user) { create(:user) }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
   let(:trs_client) { instance_double(TRS::APIClient) }
 
@@ -20,7 +20,7 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
   end
 
   context "when it is the only induction period" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+    let!(:induction_period) { create(:induction_period, :active, teacher:, appropriate_body:) }
 
     before do
       allow(trs_client).to receive(:reset_teacher_induction)
@@ -79,8 +79,8 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
   end
 
   context "when there are other induction periods" do
-    let!(:earliest_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 3) }
-    let!(:later_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 3) }
+    let!(:earliest_period) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 3) }
+    let!(:later_period) { create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 3) }
 
     before do
       allow(trs_client).to receive(:reset_teacher_induction)

--- a/spec/services/lead_providers/active_spec.rb
+++ b/spec/services/lead_providers/active_spec.rb
@@ -1,5 +1,5 @@
 describe LeadProviders::Active do
-  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:lead_provider) { create(:lead_provider) }
 
   describe 'initialization' do
     it 'is initialized with a lead provider' do
@@ -12,11 +12,11 @@ describe LeadProviders::Active do
   describe '#active_in_contract_period?' do
     subject { LeadProviders::Active.new(lead_provider).active_in_contract_period?(contract_period) }
 
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
-    let(:contract_period) { FactoryBot.create(:contract_period) }
+    let(:lead_provider) { create(:lead_provider) }
+    let(:contract_period) { create(:contract_period) }
 
     context 'when an active_lead_provider record exists for the registration period' do
-      let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+      let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
 
       it { is_expected.to be(true) }
     end

--- a/spec/services/pending_induction_submissions/build_spec.rb
+++ b/spec/services/pending_induction_submissions/build_spec.rb
@@ -3,7 +3,7 @@ describe PendingInductionSubmissions::Name do
 
   let(:started_on) { 2.months.ago.to_date }
   let(:finished_on) { 2.weeks.ago.to_date }
-  let(:induction_period) { FactoryBot.create(:induction_period, started_on:) }
+  let(:induction_period) { create(:induction_period, started_on:) }
 
   it { is_expected.to respond_to(:pending_induction_submission) }
 

--- a/spec/services/pending_induction_submissions/name_spec.rb
+++ b/spec/services/pending_induction_submissions/name_spec.rb
@@ -11,7 +11,7 @@ describe PendingInductionSubmissions::Name do
     end
 
     context 'when a corrected_name is set' do
-      let(:pending_induction_submission) { FactoryBot.build(:pending_induction_submission) }
+      let(:pending_induction_submission) { build(:pending_induction_submission) }
 
       it 'returns the corrected name' do
         expect(subject.full_name).to eql("#{pending_induction_submission.trs_first_name} #{pending_induction_submission.trs_last_name}")

--- a/spec/services/sandbox_seed_data/lead_providers_spec.rb
+++ b/spec/services/sandbox_seed_data/lead_providers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SandboxSeedData::LeadProviders do
 
   describe "#plant" do
     before do
-      all_registration_years.uniq.each { |year| FactoryBot.create(:contract_period, year:) }
+      all_registration_years.uniq.each { |year| create(:contract_period, year:) }
     end
 
     it "creates lead providers and active lead providers with correct attributes" do

--- a/spec/services/sandbox_seed_data/statements_spec.rb
+++ b/spec/services/sandbox_seed_data/statements_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SandboxSeedData::Statements do
   end
 
   describe "#plant" do
-    let(:contract_period) { FactoryBot.create(:contract_period, year: Time.zone.now.year - 1) }
-    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+    let(:contract_period) { create(:contract_period, year: Time.zone.now.year - 1) }
+    let!(:active_lead_provider) { create(:active_lead_provider, contract_period:) }
 
     it "creates statements for active lead providers with the correct attributes" do
       instance.plant

--- a/spec/services/school_partnerships/query_spec.rb
+++ b/spec/services/school_partnerships/query_spec.rb
@@ -1,12 +1,12 @@
 describe SchoolPartnerships::Query do
-  let!(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let!(:contract_period) { FactoryBot.create(:contract_period, year: 2027) }
-  let!(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-  let!(:school) { FactoryBot.create(:school) }
+  let!(:lead_provider) { create(:lead_provider) }
+  let!(:contract_period) { create(:contract_period, year: 2027) }
+  let!(:delivery_partner) { create(:delivery_partner) }
+  let!(:school) { create(:school) }
 
-  let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
-  let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-  let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:) }
+  let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
+  let!(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+  let!(:school_partnership) { create(:school_partnership, lead_provider_delivery_partnership:, school:) }
 
   let(:query_params) { { lead_provider:, school:, delivery_partner:, contract_period: } }
 
@@ -36,7 +36,7 @@ describe SchoolPartnerships::Query do
       context 'when contract_period differs' do
         subject { SchoolPartnerships::Query.new(**query_params.merge(contract_period: other_contract_period)) }
 
-        let(:other_contract_period) { FactoryBot.create(:contract_period, year: 2028) }
+        let(:other_contract_period) { create(:contract_period, year: 2028) }
 
         it { is_expected.not_to(exist) }
       end
@@ -52,7 +52,7 @@ describe SchoolPartnerships::Query do
       context 'when lead_provider differs' do
         subject { SchoolPartnerships::Query.new(**query_params.merge(lead_provider: other_lead_provider)) }
 
-        let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
+        let(:other_lead_provider) { create(:lead_provider) }
 
         it { is_expected.not_to(exist) }
       end
@@ -68,7 +68,7 @@ describe SchoolPartnerships::Query do
       context 'when school differs' do
         subject { SchoolPartnerships::Query.new(**query_params.merge(school: other_school)) }
 
-        let(:other_school) { FactoryBot.create(:school) }
+        let(:other_school) { create(:school) }
 
         it { is_expected.not_to(exist) }
       end
@@ -84,7 +84,7 @@ describe SchoolPartnerships::Query do
       context 'when delivery partner differs' do
         subject { SchoolPartnerships::Query.new(**query_params.merge(delivery_partner: other_delivery_partner)) }
 
-        let(:other_delivery_partner) { FactoryBot.create(:delivery_partner) }
+        let(:other_delivery_partner) { create(:delivery_partner) }
 
         it { is_expected.not_to(exist) }
       end

--- a/spec/services/schools/assign_mentor_form_spec.rb
+++ b/spec/services/schools/assign_mentor_form_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       context "when the mentor is not registered at the ect's school" do
         subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active) }
+        let(:ect) { create(:ect_at_school_period, :active) }
+        let(:mentor) { create(:mentor_at_school_period, :active) }
 
         before do
           subject.valid?
@@ -36,8 +36,8 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       context "when the mentor is not eligible for the ect" do
         subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school: ect.school, teacher: ect.teacher) }
+        let(:ect) { create(:ect_at_school_period, :active) }
+        let(:mentor) { create(:mentor_at_school_period, :active, school: ect.school, teacher: ect.teacher) }
 
         before do
           subject.valid?
@@ -54,9 +54,9 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
     context "when the mentor is eligible to mentor the ect at the same school" do
       subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
-      let(:author) { FactoryBot.create(:school_user, school_urn: ect.school.urn) }
-      let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school: ect.school) }
+      let(:ect) { create(:ect_at_school_period, :active) }
+      let(:author) { create(:school_user, school_urn: ect.school.urn) }
+      let(:mentor) { create(:mentor_at_school_period, :active, school: ect.school) }
 
       it 'adds a new mentorship for the ect and the mentor starting today' do
         expect(ECTAtSchoolPeriods::Mentorship.new(ect).current_mentor).to be_nil

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe Schools::AssignMentor do
     described_class.new(author:, ect: mentee, mentor: new_mentor, started_on:)
   end
 
-  let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-  let!(:current_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee:, mentor: current_mentor) }
-  let(:new_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+  let(:mentee) { create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+  let(:current_mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+  let!(:current_mentorship) { create(:mentorship_period, :active, mentee:, mentor: current_mentor) }
+  let(:new_mentor) { create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
   let(:started_on) { Date.yesterday }
-  let(:author) { FactoryBot.create(:school_user, school_urn: mentee.school.urn) }
+  let(:author) { create(:school_user, school_urn: mentee.school.urn) }
 
   describe '#assign!' do
     it 'ends current mentorship of the ect' do

--- a/spec/services/schools/eligible_mentors_spec.rb
+++ b/spec/services/schools/eligible_mentors_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Schools::EligibleMentors do
     described_class.new(school).for_ect(ect)
   end
 
-  let(:school) { FactoryBot.create(:school) }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, started_on: 2.years.ago) }
+  let(:school) { create(:school) }
+  let(:ect) { create(:ect_at_school_period, :active, started_on: 2.years.ago) }
 
   describe '#for_ect' do
     context "when the school has no active mentors" do
@@ -12,7 +12,7 @@ RSpec.describe Schools::EligibleMentors do
     end
 
     context "when the school has active mentors registered" do
-      let!(:active_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :active, school:, started_on: 2.years.ago) }
+      let!(:active_mentors) { create_list(:mentor_at_school_period, 2, :active, school:, started_on: 2.years.ago) }
 
       it "returns those mentors" do
         expect(subject.to_a).to match_array(active_mentors)
@@ -20,10 +20,10 @@ RSpec.describe Schools::EligibleMentors do
     end
 
     context "when the ect is also a mentor at the school" do
-      let!(:mentors_excluding_ect) { FactoryBot.create_list(:mentor_at_school_period, 2, :active, school:, started_on: 2.years.ago) }
+      let!(:mentors_excluding_ect) { create_list(:mentor_at_school_period, 2, :active, school:, started_on: 2.years.ago) }
 
       before do
-        FactoryBot.create(:mentor_at_school_period, :active, school:, teacher: ect.teacher, started_on: 2.years.ago)
+        create(:mentor_at_school_period, :active, school:, teacher: ect.teacher, started_on: 2.years.ago)
       end
 
       it "returns those mentors excluding themself" do

--- a/spec/services/schools/home_spec.rb
+++ b/spec/services/schools/home_spec.rb
@@ -1,39 +1,39 @@
 RSpec.describe Schools::Home do
   subject(:service) { described_class.new(school:) }
 
-  let(:school) { FactoryBot.create(:school) }
-  let(:ect) { FactoryBot.create(:teacher) }
-  let(:mentor) { FactoryBot.create(:teacher, corrected_name: nil) }
+  let(:school) { create(:school) }
+  let(:ect) { create(:teacher) }
+  let(:mentor) { create(:teacher, corrected_name: nil) }
 
   let(:mentor_period) do
-    FactoryBot.create(:mentor_at_school_period, :active,
-                      school:,
-                      teacher: mentor,
-                      started_on: 2.years.ago)
+    create(:mentor_at_school_period, :active,
+           school:,
+           teacher: mentor,
+           started_on: 2.years.ago)
   end
 
   let(:ect_period) do
-    FactoryBot.create(:ect_at_school_period, :active,
-                      school:,
-                      teacher: ect,
-                      started_on: 2.years.ago)
+    create(:ect_at_school_period, :active,
+           school:,
+           teacher: ect,
+           started_on: 2.years.ago)
   end
 
   before do
-    FactoryBot.create(:training_period, :active,
-                      mentor_at_school_period: mentor_period,
-                      ect_at_school_period: nil,
-                      started_on: 1.year.ago)
+    create(:training_period, :active,
+           mentor_at_school_period: mentor_period,
+           ect_at_school_period: nil,
+           started_on: 1.year.ago)
 
-    FactoryBot.create(:mentorship_period,
-                      mentor: mentor_period,
-                      mentee: ect_period,
-                      started_on: 2.years.ago,
-                      finished_on: 1.year.ago)
-    FactoryBot.create(:mentorship_period, :active,
-                      mentor: mentor_period,
-                      mentee: ect_period,
-                      started_on: 1.year.ago)
+    create(:mentorship_period,
+           mentor: mentor_period,
+           mentee: ect_period,
+           started_on: 2.years.ago,
+           finished_on: 1.year.ago)
+    create(:mentorship_period, :active,
+           mentor: mentor_period,
+           mentee: ect_period,
+           started_on: 1.year.ago)
   end
 
   describe '#ects_with_mentors' do

--- a/spec/services/schools/latest_registration_choices_spec.rb
+++ b/spec/services/schools/latest_registration_choices_spec.rb
@@ -1,27 +1,27 @@
 describe Schools::LatestRegistrationChoices do
   let(:service) { Schools::LatestRegistrationChoices.new(school:, contract_period:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
-  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:contract_period) { create(:contract_period, year: 2025) }
+  let(:delivery_partner) { create(:delivery_partner) }
 
   describe '#lead_provider_and_delivery_partner' do
     subject { service.lead_provider_and_delivery_partner }
 
     context 'when there is no last_chosen_lead_provider present on the school' do
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
-      let(:school) { FactoryBot.create(:school, last_chosen_lead_provider: nil) }
+      let(:lead_provider) { create(:lead_provider) }
+      let(:school) { create(:school, last_chosen_lead_provider: nil) }
 
       it { is_expected.to be_nil }
     end
 
     context 'when there is a last_chosen_lead_provider present on the school' do
-      let(:school) { FactoryBot.create(:school, :provider_led_last_chosen) }
+      let(:school) { create(:school, :provider_led_last_chosen) }
       let(:lead_provider) { school.last_chosen_lead_provider }
 
       context 'when the last_chosen_lead_provider is in a partnership with the school' do
-        let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:) }
-        let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-        let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+        let!(:school_partnership) { create(:school_partnership, lead_provider_delivery_partnership:, school:) }
+        let!(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+        let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
 
         it 'returns a Schools::LatestRegistrationChoices::Choice' do
           expect(subject).to be_a(Schools::LatestRegistrationChoices::Choice)
@@ -37,10 +37,10 @@ describe Schools::LatestRegistrationChoices do
       end
 
       context 'when the last_chosen_lead_provider is not currently in a partnership with the school' do
-        let(:previous_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+        let(:previous_contract_period) { create(:contract_period, year: 2024) }
 
         context 'when the last_chosen_lead_provider is active' do
-          let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+          let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
 
           it 'is the last chosen lead provider' do
             expect(subject.lead_provider).to eql(lead_provider)
@@ -52,22 +52,22 @@ describe Schools::LatestRegistrationChoices do
         end
 
         context 'when the last_chosen_lead_provider is inactive' do
-          let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period) }
+          let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period) }
 
           it { is_expected.to be_nil }
         end
       end
 
       context 'when the school is partnered with the same lead provider and multiple delivery partners' do
-        let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+        let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
 
-        let(:earliest_delivery_partner) { FactoryBot.create(:delivery_partner) }
-        let!(:earliest_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner: earliest_delivery_partner) }
-        let!(:earliest_school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: earliest_lead_provider_delivery_partnership, school:, created_at: 2.weeks.ago) }
+        let(:earliest_delivery_partner) { create(:delivery_partner) }
+        let!(:earliest_lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner: earliest_delivery_partner) }
+        let!(:earliest_school_partnership) { create(:school_partnership, lead_provider_delivery_partnership: earliest_lead_provider_delivery_partnership, school:, created_at: 2.weeks.ago) }
 
-        let(:latest_delivery_partner) { FactoryBot.create(:delivery_partner) }
-        let!(:latest_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner: latest_delivery_partner) }
-        let!(:latest_school_partnership) { FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: latest_lead_provider_delivery_partnership, created_at: 1.week.ago) }
+        let(:latest_delivery_partner) { create(:delivery_partner) }
+        let!(:latest_lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner: latest_delivery_partner) }
+        let!(:latest_school_partnership) { create(:school_partnership, school:, lead_provider_delivery_partnership: latest_lead_provider_delivery_partnership, created_at: 1.week.ago) }
 
         it 'uses the earliest partnership' do
           expect(subject.lead_provider).to eql(lead_provider)
@@ -81,8 +81,8 @@ describe Schools::LatestRegistrationChoices do
     context 'when there is a last_chosen_appropriate_body present on the school' do
       subject { service.appropriate_body }
 
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-      let(:school) { FactoryBot.create(:school, last_chosen_appropriate_body: appropriate_body) }
+      let(:appropriate_body) { create(:appropriate_body) }
+      let(:school) { create(:school, last_chosen_appropriate_body: appropriate_body) }
 
       it('returns the last chosen appropriate body') { is_expected.to eql(appropriate_body) }
     end
@@ -90,7 +90,7 @@ describe Schools::LatestRegistrationChoices do
     context 'when there is no last_chosen_appropriate_body present on the school' do
       subject { service.appropriate_body }
 
-      let(:school) { FactoryBot.create(:school, last_chosen_appropriate_body: nil) }
+      let(:school) { create(:school, last_chosen_appropriate_body: nil) }
 
       it { is_expected.to be_nil }
     end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Schools::RegisterECT do
                         author:)
   end
 
-  let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
-  let(:school_reported_appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:author) { create(:school_user, school_urn: school.urn) }
+  let(:school_reported_appropriate_body) { create(:appropriate_body) }
   let(:corrected_name) { "Randy Marsh" }
   let(:email) { "randy@tegridyfarms.com" }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
   let(:started_on) { Date.new(2024, 9, 17) }
   let(:trn) { "3002586" }
   let(:trs_first_name) { "Dusty" }
@@ -26,11 +26,11 @@ RSpec.describe Schools::RegisterECT do
   let(:working_pattern) { "full_time" }
   let(:teacher) { subject.teacher }
   let(:ect_at_school_period) { teacher.ect_at_school_periods.first }
-  let!(:contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+  let!(:contract_period) { create(:contract_period, year: 2024) }
 
   describe '#register!' do
     let(:training_programme) { 'provider_led' }
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:lead_provider) { create(:lead_provider) }
 
     context 'when no ActiveLeadProvider exists for the contract_period' do
       it 'raises an error' do
@@ -39,7 +39,7 @@ RSpec.describe Schools::RegisterECT do
     end
 
     context 'when provider-led' do
-      let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+      let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
 
       context "when a Teacher record with the same TRN don't exist" do
         let(:teacher) { Teacher.first }
@@ -54,7 +54,7 @@ RSpec.describe Schools::RegisterECT do
       end
 
       context "when a Teacher record with the same TRN exists but has no ect records" do
-        let!(:another_teacher) { FactoryBot.create(:teacher, trn:) }
+        let!(:another_teacher) { create(:teacher, trn:) }
 
         it "doesn't create a new Teacher record" do
           expect { service.register! }.not_to change(Teacher, :count)
@@ -62,9 +62,9 @@ RSpec.describe Schools::RegisterECT do
       end
 
       context "when a Teacher record with the same TRN exists and has ect records" do
-        let(:teacher) { FactoryBot.create(:teacher, trn:) }
+        let(:teacher) { create(:teacher, trn:) }
 
-        before { FactoryBot.create(:ect_at_school_period, teacher:) }
+        before { create(:ect_at_school_period, teacher:) }
 
         it "raise an exception" do
           expect { service.register! }.to raise_error(ActiveRecord::RecordInvalid)
@@ -118,9 +118,9 @@ RSpec.describe Schools::RegisterECT do
       end
 
       context 'when a SchoolPartnership exists' do
-        let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-        let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-        let!(:school_partnership) { FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:) }
+        let(:delivery_partner) { create(:delivery_partner) }
+        let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+        let!(:school_partnership) { create(:school_partnership, school:, lead_provider_delivery_partnership:) }
 
         it 'creates a TrainingPeriod with a school_partnership and no expression_of_interest' do
           expect { service.register! }.to change(TrainingPeriod, :count).by(1)

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe Schools::RegisterMentor do
                         author:)
   end
 
-  let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
+  let(:author) { create(:school_user, school_urn: school.urn) }
   let(:trs_first_name) { "Dusty" }
   let(:trs_last_name) { "Rhodes" }
   let(:corrected_name) { "Randy Marsh" }
   let(:trn) { "3002586" }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
   let(:email) { "randy@tegridyfarms.com" }
   let(:started_on) { Date.new(2024, 9, 17) }
   let(:teacher) { subject.teacher }
-  let(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let!(:contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+  let(:lead_provider) { create(:lead_provider) }
+  let!(:contract_period) { create(:contract_period, year: 2024) }
   let(:mentor_at_school_period) { teacher.mentor_at_school_periods.first }
 
   describe '#register!' do
@@ -32,7 +32,7 @@ RSpec.describe Schools::RegisterMentor do
     end
 
     context 'when provider-led' do
-      let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+      let!(:active_lead_provider) { create(:active_lead_provider, lead_provider:, contract_period:) }
 
       context "when a Teacher record with the same trn doesn't exist" do
         it 'creates a new Teacher record' do
@@ -52,14 +52,14 @@ RSpec.describe Schools::RegisterMentor do
       end
 
       context "when a Teacher record with the same trn exists" do
-        let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+        let!(:teacher) { create(:teacher, trn:) }
 
         context "without MentorATSchoolPeriod records" do
           it { expect { service.register! }.not_to change(Teacher, :count) }
         end
 
         context "with MentorATSchoolPeriod records" do
-          before { FactoryBot.create(:mentor_at_school_period, teacher:) }
+          before { create(:mentor_at_school_period, teacher:) }
 
           it { expect { service.register! }.to raise_error(ActiveRecord::RecordInvalid) }
         end
@@ -80,9 +80,9 @@ RSpec.describe Schools::RegisterMentor do
       end
 
       context 'when a SchoolPartnership exists' do
-        let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-        let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-        let!(:school_partnership) { FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:) }
+        let(:delivery_partner) { create(:delivery_partner) }
+        let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+        let!(:school_partnership) { create(:school_partnership, school:, lead_provider_delivery_partnership:) }
 
         it 'creates a TrainingPeriod with a school_partnership and no expression_of_interest' do
           expect { service.register! }.to change(TrainingPeriod, :count).by(1)

--- a/spec/services/schools/teacher_email_spec.rb
+++ b/spec/services/schools/teacher_email_spec.rb
@@ -1,11 +1,11 @@
 describe Schools::TeacherEmail do
   subject { described_class.new(email:, trn:) }
 
-  let(:finished_ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
-  let(:ongoing_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:finished_ect_at_school_period) { create(:ect_at_school_period) }
+  let(:ongoing_ect_at_school_period) { create(:ect_at_school_period, :active) }
 
-  let(:finished_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
-  let(:ongoing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+  let(:finished_mentor_at_school_period) { create(:mentor_at_school_period) }
+  let(:ongoing_mentor_at_school_period) { create(:mentor_at_school_period, :active) }
 
   let(:trn) { '123456' }
 
@@ -38,7 +38,7 @@ describe Schools::TeacherEmail do
     context "when the email has been used by the same teacher in the past" do
       let(:teacher) { ongoing_ect_at_school_period.teacher }
       let(:trn) { teacher.trn }
-      let(:email) { FactoryBot.create(:ect_at_school_period, teacher:).email }
+      let(:email) { create(:ect_at_school_period, teacher:).email }
 
       it "returns false" do
         expect(subject.is_currently_used?).to be false

--- a/spec/services/sessions/one_time_password_spec.rb
+++ b/spec/services/sessions/one_time_password_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Sessions::OneTimePassword do
   subject(:service) { Sessions::OneTimePassword.new(user:) }
 
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   describe "#generate" do
     it "returns a OTP code" do

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Sessions::Manager do
   let(:cookies) { HashWithIndifferentAccess.new }
   let(:email) { 'school_persona@email.com' }
   let(:name) { 'Christopher Lee' }
-  let(:school_urn) { FactoryBot.create(:school).urn }
+  let(:school_urn) { create(:school).urn }
   let(:last_active_at) { 4.minutes.ago }
   let(:user) do
     Sessions::Users::SchoolUser.new(email:,

--- a/spec/services/sessions/user_spec.rb
+++ b/spec/services/sessions/user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Sessions::User do
     context 'when user session stores an appropriate body user' do
       let(:dfe_sign_in_organisation_id) { Faker::Internet.uuid }
       let(:dfe_sign_in_user_id) { Faker::Internet.uuid }
-      let!(:appropriate_body) { FactoryBot.create(:appropriate_body, dfe_sign_in_organisation_id:) }
+      let!(:appropriate_body) { create(:appropriate_body, dfe_sign_in_organisation_id:) }
       let(:fake_user_session) do
         {
           'type' => 'Sessions::Users::AppropriateBodyUser',
@@ -39,7 +39,7 @@ RSpec.describe Sessions::User do
     end
 
     context 'when user session stores an appropriate body persona' do
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:appropriate_body) { create(:appropriate_body) }
       let(:fake_user_session) do
         {
           'type' => 'Sessions::Users::AppropriateBodyPersona',
@@ -60,7 +60,7 @@ RSpec.describe Sessions::User do
     end
 
     context 'when user session stores an existing db dfe user' do
-      let!(:dfe_user) { FactoryBot.create(:user, :admin, name: 'Christopher Lee', email: 'dfe_user@example.com') }
+      let!(:dfe_user) { create(:user, :admin, name: 'Christopher Lee', email: 'dfe_user@example.com') }
       let(:fake_user_session) do
         {
           'type' => 'Sessions::Users::DfEUser',
@@ -78,7 +78,7 @@ RSpec.describe Sessions::User do
     end
 
     context 'when user session stores a dfe persona' do
-      let!(:dfe_user) { FactoryBot.create(:user, :admin, name: 'Christopher Lee', email: 'dfe_persona@example.com') }
+      let!(:dfe_user) { create(:user, :admin, name: 'Christopher Lee', email: 'dfe_persona@example.com') }
       let(:fake_user_session) do
         {
           'type' => 'Sessions::Users::DfEPersona',
@@ -98,7 +98,7 @@ RSpec.describe Sessions::User do
     context 'when user session stores a school user' do
       let(:dfe_sign_in_organisation_id) { Faker::Internet.uuid }
       let(:dfe_sign_in_user_id) { Faker::Internet.uuid }
-      let(:school_urn) { FactoryBot.create(:school).urn }
+      let(:school_urn) { create(:school).urn }
       let(:fake_user_session) do
         {
           'type' => 'Sessions::Users::SchoolUser',

--- a/spec/services/sessions/users/appropriate_body_persona_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_persona_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Sessions::Users::AppropriateBodyPersona do
 
   let(:email) { 'appropriate_body_persona@email.com' }
   let(:name) { 'Christopher Lee' }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:appropriate_body_id) { appropriate_body.id }
   let(:last_active_at) { 4.minutes.ago }
 

--- a/spec/services/sessions/users/appropriate_body_user_spec.rb
+++ b/spec/services/sessions/users/appropriate_body_user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sessions::Users::AppropriateBodyUser do
   let(:dfe_sign_in_organisation_id) { Faker::Internet.uuid }
   let(:dfe_sign_in_user_id) { Faker::Internet.uuid }
   let(:last_active_at) { 4.minutes.ago }
-  let!(:appropriate_body) { FactoryBot.create(:appropriate_body, dfe_sign_in_organisation_id:) }
+  let!(:appropriate_body) { create(:appropriate_body, dfe_sign_in_organisation_id:) }
 
   it_behaves_like 'a session user' do
     let(:user_props) { { email:, name:, dfe_sign_in_organisation_id:, dfe_sign_in_user_id: } }

--- a/spec/services/sessions/users/builder_spec.rb
+++ b/spec/services/sessions/users/builder_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Sessions::Users::Builder do
     subject { described_class.new(omniauth_payload:).session_user }
 
     let(:email) { Faker::Internet.email }
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let(:school) { FactoryBot.create(:school) }
+    let(:appropriate_body) { create(:appropriate_body) }
+    let(:school) { create(:school) }
 
     let(:omniauth_payload) do
       OmniAuth::AuthHash.new(
@@ -85,7 +85,7 @@ RSpec.describe Sessions::Users::Builder do
         let(:dfe_staff) { 'true' }
         let(:organisation_id) { nil }
         let(:organisation_urn) { nil }
-        let!(:user) { FactoryBot.create(:user, email:) }
+        let!(:user) { create(:user, email:) }
 
         before do
           allow(Rails.application.config).to receive(:enable_personas).and_return(false)
@@ -108,7 +108,7 @@ RSpec.describe Sessions::Users::Builder do
           let(:dfe_staff) { 'true' }
           let(:organisation_id) { nil }
           let(:organisation_urn) { nil }
-          let!(:user) { FactoryBot.create(:user, email:) }
+          let!(:user) { create(:user, email:) }
 
           it 'returns a dfe persona' do
             expect(subject).to be_a(Sessions::Users::DfEPersona)
@@ -164,7 +164,7 @@ RSpec.describe Sessions::Users::Builder do
       let(:dfe_staff) { 'true' }
       let(:organisation_id) { nil }
       let(:organisation_urn) { nil }
-      let!(:user) { FactoryBot.create(:user, email:) }
+      let!(:user) { create(:user, email:) }
 
       it 'raises an UnknownProvider error' do
         expect { subject }.to raise_error(described_class::UnknownProvider, provider)

--- a/spec/services/sessions/users/dfe_persona_spec.rb
+++ b/spec/services/sessions/users/dfe_persona_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sessions::Users::DfEPersona do
   let(:email) { 'dfe_user@email.com' }
   let(:name) { 'Christopher Lee' }
   let(:last_active_at) { 4.minutes.ago }
-  let!(:user) { FactoryBot.create(:user, :admin, email:, name:) }
+  let!(:user) { create(:user, :admin, email:, name:) }
 
   it_behaves_like 'a session user' do
     let(:user_props) { { email: } }

--- a/spec/services/sessions/users/dfe_user_spec.rb
+++ b/spec/services/sessions/users/dfe_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sessions::Users::DfEUser do
   let(:email) { 'dfe_user@email.com' }
   let(:name) { 'Christopher Lee' }
   let(:last_active_at) { 4.minutes.ago }
-  let!(:user) { FactoryBot.create(:user, :admin, email:, name:) }
+  let!(:user) { create(:user, :admin, email:, name:) }
 
   it_behaves_like 'a session user' do
     let(:user_props) { { email: } }

--- a/spec/services/sessions/users/school_persona_spec.rb
+++ b/spec/services/sessions/users/school_persona_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sessions::Users::SchoolPersona do
   let(:email) { 'school_persona@email.com' }
   let(:last_active_at) { 4.minutes.ago }
   let(:name) { 'Christopher Lee' }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
 
   it_behaves_like 'a session user' do
     let(:user_props) { { email:, name:, school_urn: school.urn } }

--- a/spec/services/sessions/users/school_user_spec.rb
+++ b/spec/services/sessions/users/school_user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sessions::Users::SchoolUser do
   let(:name) { 'Christopher Lee' }
   let(:dfe_sign_in_organisation_id) { Faker::Internet.uuid }
   let(:dfe_sign_in_user_id) { Faker::Internet.uuid }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
 
   it_behaves_like 'a session user' do
     let(:user_props) { { email:, name:, school_urn: school.urn, dfe_sign_in_organisation_id:, dfe_sign_in_user_id: } }

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Statements::AuthorisePayment do
   subject { described_class.new(statement) }
 
-  let(:statement) { FactoryBot.create(:statement, :payable, marked_as_paid_at: nil) }
+  let(:statement) { create(:statement, :payable, marked_as_paid_at: nil) }
 
   describe "#authorise" do
     context "can authorise payment" do

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -1,18 +1,18 @@
 RSpec.describe Statements::Query do
   describe "#statements" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:lead_provider) { create(:lead_provider) }
 
     it "returns all statements" do
-      statement = FactoryBot.create(:statement)
+      statement = create(:statement)
       query = described_class.new
 
       expect(query.statements).to eq([statement])
     end
 
     it "orders statements by payment date in ascending order" do
-      statement1 = FactoryBot.create(:statement, payment_date: 2.days.ago)
-      statement2 = FactoryBot.create(:statement, payment_date: 1.day.ago)
-      statement3 = FactoryBot.create(:statement, payment_date: Time.zone.now)
+      statement1 = create(:statement, payment_date: 2.days.ago)
+      statement2 = create(:statement, payment_date: 1.day.ago)
+      statement3 = create(:statement, payment_date: Time.zone.now)
 
       query = described_class.new
 
@@ -21,9 +21,9 @@ RSpec.describe Statements::Query do
 
     describe "filtering" do
       describe "by `lead_provider`" do
-        let!(:statement1) { FactoryBot.create(:statement, lead_provider:) }
-        let!(:statement2) { FactoryBot.create(:statement) }
-        let!(:statement3) { FactoryBot.create(:statement) }
+        let!(:statement1) { create(:statement, lead_provider:) }
+        let!(:statement2) { create(:statement) }
+        let!(:statement3) { create(:statement) }
 
         context "when `lead_provider` param is omitted" do
           it "returns all statements" do
@@ -38,7 +38,7 @@ RSpec.describe Statements::Query do
         end
 
         it "returns no statements if no statements are found for the given `lead_provider`" do
-          query = described_class.new(lead_provider: FactoryBot.create(:lead_provider))
+          query = described_class.new(lead_provider: create(:lead_provider))
 
           expect(query.statements).to be_empty
         end
@@ -51,32 +51,32 @@ RSpec.describe Statements::Query do
       end
 
       describe "by `contract_period_years`" do
-        let!(:contract_period1) { FactoryBot.create(:contract_period) }
-        let!(:contract_period2) { FactoryBot.create(:contract_period) }
-        let!(:contract_period3) { FactoryBot.create(:contract_period) }
+        let!(:contract_period1) { create(:contract_period) }
+        let!(:contract_period2) { create(:contract_period) }
+        let!(:contract_period3) { create(:contract_period) }
 
         context "when `contract_period_years` param is omitted" do
           it "returns all statements" do
-            statement1 = FactoryBot.create(:statement, contract_period: contract_period1)
-            statement2 = FactoryBot.create(:statement, contract_period: contract_period2)
-            statement3 = FactoryBot.create(:statement, contract_period: contract_period3)
+            statement1 = create(:statement, contract_period: contract_period1)
+            statement2 = create(:statement, contract_period: contract_period2)
+            statement3 = create(:statement, contract_period: contract_period3)
 
             expect(described_class.new.statements).to contain_exactly(statement1, statement2, statement3)
           end
         end
 
         it "filters by `contract_period_years`" do
-          _statement = FactoryBot.create(:statement, contract_period: contract_period1)
-          statement = FactoryBot.create(:statement, contract_period: contract_period2)
+          _statement = create(:statement, contract_period: contract_period1)
+          statement = create(:statement, contract_period: contract_period2)
           query = described_class.new(contract_period_years: contract_period2.year)
 
           expect(query.statements).to eq([statement])
         end
 
         it "filters by multiple `contract_period_years`" do
-          statement1 = FactoryBot.create(:statement, contract_period: contract_period1)
-          statement2 = FactoryBot.create(:statement, contract_period: contract_period2)
-          statement3 = FactoryBot.create(:statement, contract_period: contract_period3)
+          statement1 = create(:statement, contract_period: contract_period1)
+          statement2 = create(:statement, contract_period: contract_period2)
+          statement3 = create(:statement, contract_period: contract_period3)
 
           query1 = described_class.new(contract_period_years: "#{contract_period1.year},#{contract_period2.year}")
           expect(query1.statements).to contain_exactly(statement1, statement2)
@@ -92,8 +92,8 @@ RSpec.describe Statements::Query do
         end
 
         it "does not filter by `contract_period_years` if blank" do
-          statement1 = FactoryBot.create(:statement, contract_period: contract_period1)
-          statement2 = FactoryBot.create(:statement, contract_period: contract_period2)
+          statement1 = create(:statement, contract_period: contract_period1)
+          statement2 = create(:statement, contract_period: contract_period2)
 
           query = described_class.new(contract_period_years: " ")
 
@@ -105,8 +105,8 @@ RSpec.describe Statements::Query do
         let(:updated_since) { 1.day.ago }
 
         it "filters by `updated_since`" do
-          FactoryBot.create(:statement, lead_provider:, updated_at: 2.days.ago)
-          statement2 = FactoryBot.create(:statement, lead_provider:, updated_at: Time.zone.now)
+          create(:statement, lead_provider:, updated_at: 2.days.ago)
+          statement2 = create(:statement, lead_provider:, updated_at: Time.zone.now)
 
           query = described_class.new(lead_provider:, updated_since:)
 
@@ -115,16 +115,16 @@ RSpec.describe Statements::Query do
 
         context "when `updated_since` param is omitted" do
           it "returns all statements" do
-            statement1 = FactoryBot.create(:statement, updated_at: 1.week.ago)
-            statement2 = FactoryBot.create(:statement, updated_at: 2.weeks.ago)
+            statement1 = create(:statement, updated_at: 1.week.ago)
+            statement2 = create(:statement, updated_at: 2.weeks.ago)
 
             expect(described_class.new.statements).to contain_exactly(statement1, statement2)
           end
         end
 
         it "does not filter by `updated_since` if blank" do
-          statement1 = FactoryBot.create(:statement, updated_at: 1.week.ago)
-          statement2 = FactoryBot.create(:statement, updated_at: 2.weeks.ago)
+          statement1 = create(:statement, updated_at: 1.week.ago)
+          statement2 = create(:statement, updated_at: 2.weeks.ago)
 
           query = described_class.new(updated_since: " ")
 
@@ -133,9 +133,9 @@ RSpec.describe Statements::Query do
       end
 
       describe "by `state`" do
-        let!(:open_statement) { FactoryBot.create(:statement, :open) }
-        let!(:payable_statement) { FactoryBot.create(:statement, :payable) }
-        let!(:paid_statement) { FactoryBot.create(:statement, :paid) }
+        let!(:open_statement) { create(:statement, :open) }
+        let!(:payable_statement) { create(:statement, :payable) }
+        let!(:paid_statement) { create(:statement, :paid) }
 
         it "filters by `state`" do
           expect(described_class.new(status: "open").statements).to eq([open_statement])
@@ -165,8 +165,8 @@ RSpec.describe Statements::Query do
       end
 
       describe "by `fee_type`" do
-        let!(:statement1) { FactoryBot.create(:statement, :output_fee) }
-        let!(:statement2) { FactoryBot.create(:statement, :service_fee) }
+        let!(:statement1) { create(:statement, :output_fee) }
+        let!(:statement2) { create(:statement, :service_fee) }
 
         it "return only statements with `fee_type` 'output' by default" do
           expect(described_class.new.statements).to eq([statement1])
@@ -208,8 +208,8 @@ RSpec.describe Statements::Query do
       end
 
       describe "by `statement_date`" do
-        let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 4) }
-        let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 8) }
+        let!(:statement1) { create(:statement, year: 2025, month: 4) }
+        let!(:statement2) { create(:statement, year: 2024, month: 8) }
 
         it "returns statement1 for 2025-04" do
           query = described_class.new(statement_date: "2025-04")
@@ -246,8 +246,8 @@ RSpec.describe Statements::Query do
     end
 
     describe "ordering" do
-      let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 4, payment_date: "2024-01-01") }
-      let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 8, payment_date: "2025-01-01") }
+      let!(:statement1) { create(:statement, year: 2025, month: 4, payment_date: "2024-01-01") }
+      let!(:statement2) { create(:statement, year: 2024, month: 8, payment_date: "2025-01-01") }
 
       describe "default order" do
         it "returns statements in correct order" do
@@ -273,10 +273,10 @@ RSpec.describe Statements::Query do
   end
 
   describe "#statement_by_api_id" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:lead_provider) { create(:lead_provider) }
 
     it "returns the statement for a Lead Provider" do
-      statement = FactoryBot.create(:statement, lead_provider:)
+      statement = create(:statement, lead_provider:)
       query = described_class.new
 
       expect(query.statement_by_api_id(statement.api_id)).to eq(statement)
@@ -289,8 +289,8 @@ RSpec.describe Statements::Query do
     end
 
     it "raises an error if the statement is not in the filtered query" do
-      other_lead_provider = FactoryBot.create(:lead_provider)
-      other_statement = FactoryBot.create(:statement, lead_provider: other_lead_provider)
+      other_lead_provider = create(:lead_provider)
+      other_statement = create(:statement, lead_provider: other_lead_provider)
 
       query = described_class.new(lead_provider:)
 
@@ -303,10 +303,10 @@ RSpec.describe Statements::Query do
   end
 
   describe "#statement" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:lead_provider) { create(:lead_provider) }
 
     it "returns the statement for a Lead Provider" do
-      statement = FactoryBot.create(:statement, lead_provider:)
+      statement = create(:statement, lead_provider:)
       query = described_class.new
 
       expect(query.statement(statement.id)).to eq(statement)
@@ -319,8 +319,8 @@ RSpec.describe Statements::Query do
     end
 
     it "raises an error if the statement is not in the filtered query" do
-      other_lead_provider = FactoryBot.create(:lead_provider)
-      other_statement = FactoryBot.create(:statement, lead_provider: other_lead_provider)
+      other_lead_provider = create(:lead_provider)
+      other_statement = create(:statement, lead_provider: other_lead_provider)
 
       query = described_class.new(lead_provider:)
 

--- a/spec/services/teachers/induction_extensions_spec.rb
+++ b/spec/services/teachers/induction_extensions_spec.rb
@@ -1,5 +1,5 @@
 describe Teachers::InductionExtensions do
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
 
   describe '#yes_or_no' do
     subject(:yes_or_no) { described_class.new(teacher).yes_or_no }
@@ -9,7 +9,7 @@ describe Teachers::InductionExtensions do
     end
 
     context 'with extensions' do
-      let!(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+      let!(:extension) { create(:induction_extension, teacher:) }
 
       it { expect(yes_or_no).to eq("Yes") }
     end

--- a/spec/services/teachers/induction_period_spec.rb
+++ b/spec/services/teachers/induction_period_spec.rb
@@ -1,7 +1,7 @@
 describe Teachers::InductionPeriod do
   subject(:service) { described_class.new(teacher) }
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
 
   context '#induction_start_date' do
     context 'when teacher does not have induction periods' do
@@ -10,13 +10,13 @@ describe Teachers::InductionPeriod do
 
     context "when the teacher has induction periods" do
       let(:expected_date) { Date.new(2022, 10, 2) }
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+      let(:appropriate_body) { create(:appropriate_body) }
       let!(:first_induction_period) do
-        FactoryBot.create(:induction_period, appropriate_body:, teacher:, started_on: expected_date, finished_on: Date.new(2023, 10, 2))
+        create(:induction_period, appropriate_body:, teacher:, started_on: expected_date, finished_on: Date.new(2023, 10, 2))
       end
 
       let!(:last_induction_period) do
-        FactoryBot.create(:induction_period, appropriate_body:, teacher:, started_on: Date.new(2023, 10, 3))
+        create(:induction_period, appropriate_body:, teacher:, started_on: Date.new(2023, 10, 3))
       end
 
       it 'returns the start date of the first induction period' do
@@ -28,7 +28,7 @@ describe Teachers::InductionPeriod do
   context '#ongoing_induction_period' do
     context 'without ongoing induction period' do
       before do
-        FactoryBot.create(:induction_period, teacher:, started_on: '2023-10-3', finished_on: '2023-12-3')
+        create(:induction_period, teacher:, started_on: '2023-10-3', finished_on: '2023-12-3')
       end
 
       it { expect(service.ongoing_induction_period).to be_nil }
@@ -36,7 +36,7 @@ describe Teachers::InductionPeriod do
 
     context "with ongoing induction period" do
       let!(:ongoing_induction_period) do
-        FactoryBot.create(:induction_period, :active, teacher:, started_on: '2023-10-3')
+        create(:induction_period, :active, teacher:, started_on: '2023-10-3')
       end
 
       it 'returns the active open induction period' do

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -1,18 +1,18 @@
 RSpec.describe Teachers::Induction do
   subject(:service) { described_class.new(teacher) }
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
 
   let(:induction_period_unfinished) do
-    FactoryBot.create(:induction_period, :active, teacher:, started_on: 6.months.ago)
+    create(:induction_period, :active, teacher:, started_on: 6.months.ago)
   end
 
   let(:induction_period_finished_one_year_ago) do
-    FactoryBot.create(:induction_period, teacher:, started_on: 2.years.ago, finished_on: 1.year.ago)
+    create(:induction_period, teacher:, started_on: 2.years.ago, finished_on: 1.year.ago)
   end
 
   let(:induction_period_finished_two_years_ago) do
-    FactoryBot.create(:induction_period, teacher:, started_on: 3.years.ago, finished_on: 2.years.ago)
+    create(:induction_period, teacher:, started_on: 3.years.ago, finished_on: 2.years.ago)
   end
 
   describe "#current_induction_period" do
@@ -80,7 +80,7 @@ RSpec.describe Teachers::Induction do
 
   describe "#has_extensions?" do
     context "with induction extensions" do
-      before { FactoryBot.create(:induction_extension, teacher:) }
+      before { create(:induction_extension, teacher:) }
 
       it { is_expected.to have_extensions }
     end
@@ -91,8 +91,8 @@ RSpec.describe Teachers::Induction do
   end
 
   describe "#with_appropriate_body?" do
-    let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+    let(:other_appropriate_body) { create(:appropriate_body) }
+    let(:induction_period) { create(:induction_period, :active, teacher:) }
 
     it "returns true when the current induction is with the body" do
       expect(service.with_appropriate_body?(induction_period.appropriate_body)).to be true

--- a/spec/services/teachers/induction_status_spec.rb
+++ b/spec/services/teachers/induction_status_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Teachers::InductionStatus do
     let(:trs_induction_status) { nil }
 
     context 'when the ECT has no induction periods' do
-      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:teacher) { create(:teacher) }
       let(:induction_periods) { [] }
       let(:trs_induction_status) { 'Exempt' }
 
@@ -19,13 +19,13 @@ RSpec.describe Teachers::InductionStatus do
     end
 
     context 'when the ECT has induction periods' do
-      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:teacher) { create(:teacher) }
       let(:trs_induction_status) { 'InProgress' }
 
       context 'with an ongoing induction period' do
         let(:induction_periods) do
           [
-            FactoryBot.create(:induction_period, :active, teacher:)
+            create(:induction_period, :active, teacher:)
           ]
         end
 
@@ -41,9 +41,9 @@ RSpec.describe Teachers::InductionStatus do
       context 'with a completed induction period' do
         let(:induction_periods) do
           [
-            FactoryBot.create(:induction_period, :pass, teacher:,
-                                                        started_on: 2.years.ago,
-                                                        finished_on: 1.year.ago)
+            create(:induction_period, :pass, teacher:,
+                                             started_on: 2.years.ago,
+                                             finished_on: 1.year.ago)
           ]
         end
 
@@ -90,9 +90,9 @@ RSpec.describe Teachers::InductionStatus do
         context "when there is no open induction period" do
           let(:induction_periods) do
             [
-              FactoryBot.create(:induction_period,
-                                started_on: 2.years.ago,
-                                finished_on: 1.year.ago)
+              create(:induction_period,
+                     started_on: 2.years.ago,
+                     finished_on: 1.year.ago)
             ]
           end
 
@@ -108,7 +108,7 @@ RSpec.describe Teachers::InductionStatus do
         context "when there is an open induction period" do
           let(:induction_periods) do
             [
-              FactoryBot.create(:induction_period, :active)
+              create(:induction_period, :active)
             ]
           end
 
@@ -166,7 +166,7 @@ RSpec.describe Teachers::InductionStatus do
   end
 
   context 'when induction_periods is nil' do
-    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:teacher) { create(:teacher) }
     let(:induction_periods) { nil }
     let(:trs_induction_status) { 'InProgress' }
 

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Teachers::Manage do
   subject(:service) { described_class.new(author:, teacher:, appropriate_body:) }
 
-  let(:user) { FactoryBot.create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
+  let(:user) { create(:user, name: 'Christopher Biggins', email: 'christopher.biggins@education.gov.uk') }
   let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'Allen', trs_induction_status: 'InProgress') }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:teacher) { create(:teacher, trs_first_name: 'Barry', trs_last_name: 'Allen', trs_induction_status: 'InProgress') }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   describe '#update_name!' do
     before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
@@ -206,7 +206,7 @@ RSpec.describe Teachers::Manage do
     let(:trs_data_last_refreshed_at) { 2.minutes.ago }
 
     context 'when the teacher is already deactivated' do
-      let(:teacher) { FactoryBot.create(:teacher, :deactivated_in_trs) }
+      let(:teacher) { create(:teacher, :deactivated_in_trs) }
 
       it 'fails with a Teachers::Manage::AlreadyDeactivated error' do
         expect { service.mark_teacher_as_deactivated!(trs_data_last_refreshed_at:) }.to raise_error(Teachers::Manage::AlreadyDeactivated)

--- a/spec/services/teachers/mentor_funding_eligibility_spec.rb
+++ b/spec/services/teachers/mentor_funding_eligibility_spec.rb
@@ -5,7 +5,7 @@ describe Teachers::MentorFundingEligibility do
 
   describe 'initialisation with a TRN' do
     context 'when the teacher is present' do
-      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let!(:teacher) { create(:teacher, trn:) }
 
       it 'finds the teacher' do
         expect(subject.teacher).to eql(teacher)
@@ -25,13 +25,13 @@ describe Teachers::MentorFundingEligibility do
     end
 
     context 'when the teacher has an ineligibility reason and date set' do
-      let!(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding, trn:) }
+      let!(:teacher) { create(:teacher, :ineligible_for_mentor_funding, trn:) }
 
       it { is_expected.not_to be_eligible }
     end
 
     context 'when the teacher has no ineligibility reason or date set' do
-      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let!(:teacher) { create(:teacher, trn:) }
 
       it { is_expected.to be_eligible }
     end

--- a/spec/services/teachers/name_spec.rb
+++ b/spec/services/teachers/name_spec.rb
@@ -11,7 +11,7 @@ describe Teachers::Name do
     end
 
     context 'when a corrected_name is set' do
-      let(:teacher) { FactoryBot.build(:teacher, :with_corrected_name) }
+      let(:teacher) { build(:teacher, :with_corrected_name) }
 
       it 'returns the corrected name' do
         expect(teacher.corrected_name).to be_present
@@ -20,7 +20,7 @@ describe Teachers::Name do
     end
 
     context 'when no corrected_name is set' do
-      let(:teacher) { FactoryBot.build(:teacher, corrected_name: nil) }
+      let(:teacher) { build(:teacher, corrected_name: nil) }
 
       it 'returns the first name followed by the last name' do
         expect(service.full_name).to eql(%(#{teacher.trs_first_name} #{teacher.trs_last_name}))
@@ -28,7 +28,7 @@ describe Teachers::Name do
     end
 
     context 'when the corrected_name is an empty string' do
-      let(:teacher) { FactoryBot.build(:teacher, corrected_name: "") }
+      let(:teacher) { build(:teacher, corrected_name: "") }
 
       it 'returns the first name followed by the last name' do
         expect(service.full_name).to eql(%(#{teacher.trs_first_name} #{teacher.trs_last_name}))
@@ -38,7 +38,7 @@ describe Teachers::Name do
     describe 'when both names are missing names in TRS' do
       subject { service.full_name }
 
-      let(:teacher) { FactoryBot.build(:teacher, **names) }
+      let(:teacher) { build(:teacher, **names) }
 
       context 'when both names are nil' do
         let(:names) { { trs_first_name: nil, trs_last_name: nil } }
@@ -61,14 +61,14 @@ describe Teachers::Name do
   end
 
   describe '#full_name_in_trs' do
-    let(:teacher) { FactoryBot.build(:teacher, trs_first_name: 'Diana', trs_last_name: 'Rigg') }
+    let(:teacher) { build(:teacher, trs_first_name: 'Diana', trs_last_name: 'Rigg') }
 
     it 'returns the first name followed by the last name' do
       expect(service.full_name_in_trs).to eql(%(#{teacher.trs_first_name} #{teacher.trs_last_name}))
     end
 
     context 'when the corrected_name is present' do
-      let(:teacher) { FactoryBot.build(:teacher, trs_first_name: 'Diana', trs_last_name: 'Rigg', corrected_name: 'Diana Elizabeth Rigg') }
+      let(:teacher) { build(:teacher, trs_first_name: 'Diana', trs_last_name: 'Rigg', corrected_name: 'Diana Elizabeth Rigg') }
 
       it 'is ignored' do
         expect(service.full_name_in_trs).to eql(%(#{teacher.trs_first_name} #{teacher.trs_last_name}))
@@ -78,7 +78,7 @@ describe Teachers::Name do
     describe 'partial names in TRS' do
       subject { service.full_name_in_trs }
 
-      let(:teacher) { FactoryBot.build(:teacher, **names) }
+      let(:teacher) { build(:teacher, **names) }
 
       context 'when the first name is nil' do
         let(:names) { { trs_first_name: nil, trs_last_name: 'Rigg' } }

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -4,7 +4,7 @@ describe Teachers::RefreshTRSAttributes do
   describe '#refresh!' do
     include_context 'fake trs api client that finds teacher that has passed their induction'
 
-    let(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Kermit", trs_last_name: "Van Bouten") }
+    let(:teacher) { create(:teacher, trs_first_name: "Kermit", trs_last_name: "Van Bouten") }
     let(:enable_trs_teacher_refresh) { true }
 
     before { allow(Rails.application.config).to receive(:enable_trs_teacher_refresh).and_return(enable_trs_teacher_refresh) }

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -16,16 +16,16 @@ describe Teachers::Search do
   end
 
   describe '#search' do
-    let(:ab1) { FactoryBot.create(:appropriate_body) }
-    let(:ab2) { FactoryBot.create(:appropriate_body) }
-    let(:ab3) { FactoryBot.create(:appropriate_body) }
+    let(:ab1) { create(:appropriate_body) }
+    let(:ab2) { create(:appropriate_body) }
+    let(:ab3) { create(:appropriate_body) }
 
-    let(:teacher1) { FactoryBot.create(:teacher) }
-    let(:teacher2) { FactoryBot.create(:teacher) }
-    let(:teacher3) { FactoryBot.create(:teacher) }
+    let(:teacher1) { create(:teacher) }
+    let(:teacher2) { create(:teacher) }
+    let(:teacher3) { create(:teacher) }
 
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher: teacher1, appropriate_body: ab1) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher: teacher2, appropriate_body: ab2) }
+    let!(:induction_period1) { create(:induction_period, :active, teacher: teacher1, appropriate_body: ab1) }
+    let!(:induction_period2) { create(:induction_period, :active, teacher: teacher2, appropriate_body: ab2) }
 
     describe 'belonging to appropriate bodies' do
       context 'when one appropriate body is provided' do
@@ -43,7 +43,7 @@ describe Teachers::Search do
       context 'when multiple appropriate bodies are provided' do
         subject { Teachers::Search.new(appropriate_bodies: [ab1, ab3]) }
 
-        let!(:induction_period3) { FactoryBot.create(:induction_period, :active, teacher: teacher3, appropriate_body: ab3) }
+        let!(:induction_period3) { create(:induction_period, :active, teacher: teacher3, appropriate_body: ab3) }
 
         it 'includes teachers with ongoing induction periods with the specified appropriate bodies' do
           expect(subject.search).to include(teacher1, teacher3)
@@ -72,12 +72,12 @@ describe Teachers::Search do
     end
 
     describe 'status-based filtering with appropriate bodies' do
-      let(:teacher_with_open_induction) { FactoryBot.create(:teacher) }
-      let(:teacher_with_completed_induction) { FactoryBot.create(:teacher) }
-      let(:teacher_with_no_induction) { FactoryBot.create(:teacher) }
+      let(:teacher_with_open_induction) { create(:teacher) }
+      let(:teacher_with_completed_induction) { create(:teacher) }
+      let(:teacher_with_no_induction) { create(:teacher) }
 
-      let!(:open_induction_period) { FactoryBot.create(:induction_period, :active, teacher: teacher_with_open_induction, appropriate_body: ab1) }
-      let!(:completed_induction_period) { FactoryBot.create(:induction_period, :pass, teacher: teacher_with_completed_induction, appropriate_body: ab1) }
+      let!(:open_induction_period) { create(:induction_period, :active, teacher: teacher_with_open_induction, appropriate_body: ab1) }
+      let!(:completed_induction_period) { create(:induction_period, :pass, teacher: teacher_with_completed_induction, appropriate_body: ab1) }
 
       context 'when status is "open"' do
         subject { Teachers::Search.new(appropriate_bodies: ab1, status: 'open') }
@@ -175,8 +175,8 @@ describe Teachers::Search do
 
     describe 'when a query string is provided' do
       context 'when there are 7 digit numbers in the search string' do
-        let(:teacher1) { FactoryBot.create(:teacher, trn: '1234567') }
-        let(:teacher2) { FactoryBot.create(:teacher, trn: '2345678') }
+        let(:teacher1) { create(:teacher, trn: '1234567') }
+        let(:teacher2) { create(:teacher, trn: '2345678') }
 
         it 'searches for all present 7 digit numbers (TRNs)' do
           result = described_class.new(query_string: 'the quick brown 1234567 jumped over the lazy 2345678').search
@@ -186,7 +186,7 @@ describe Teachers::Search do
       end
 
       context 'when the search string contains some text' do
-        let(:teacher1) { FactoryBot.create(:teacher, trs_first_name: 'Captain', trs_last_name: 'Scrummy') }
+        let(:teacher1) { create(:teacher, trs_first_name: 'Captain', trs_last_name: 'Scrummy') }
 
         it 'initiates a full text search with the given search string' do
           result = described_class.new(query_string: 'Captain Scrummy').search
@@ -197,8 +197,8 @@ describe Teachers::Search do
     end
 
     describe 'when both an appropriate body and query string are provided' do
-      let(:teacher1) { FactoryBot.create(:teacher, trs_first_name: 'Joey') }
-      let(:teacher2) { FactoryBot.create(:teacher, trs_first_name: 'Joey') }
+      let(:teacher1) { create(:teacher, trs_first_name: 'Joey') }
+      let(:teacher2) { create(:teacher, trs_first_name: 'Joey') }
 
       it 'scopes the query to the selected appropriate body' do
         result = described_class.new(query_string: 'Joey', appropriate_bodies: ab1).search
@@ -250,21 +250,21 @@ describe Teachers::Search do
       describe 'ordering the results' do
         let(:started_on) { 2.years.ago }
 
-        let(:school1) { FactoryBot.create(:school) }
-        let(:mentored_teacher1) { FactoryBot.create(:teacher) }
-        let(:mentored_teacher2) { FactoryBot.create(:teacher) }
+        let(:school1) { create(:school) }
+        let(:mentored_teacher1) { create(:teacher) }
+        let(:mentored_teacher2) { create(:teacher) }
 
         # unmentored
-        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :active, teacher: teacher1, school: school1, started_on:, created_at: 2.days.ago) }
-        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :active, teacher: teacher2, school: school1, started_on:, created_at: 1.day.ago) }
+        let!(:ect_at_school_period1) { create(:ect_at_school_period, :active, teacher: teacher1, school: school1, started_on:, created_at: 2.days.ago) }
+        let!(:ect_at_school_period2) { create(:ect_at_school_period, :active, teacher: teacher2, school: school1, started_on:, created_at: 1.day.ago) }
 
         # mentored
-        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :active, teacher: teacher3, school: school1, started_on:) }
-        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :active, teacher: mentored_teacher1, school: school1, started_on:, created_at: 2.days.ago) }
-        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :active, teacher: mentored_teacher2, school: school1, started_on:, created_at: 1.day.ago) }
+        let!(:mentor_at_school_period1) { create(:mentor_at_school_period, :active, teacher: teacher3, school: school1, started_on:) }
+        let!(:ect_at_school_period3) { create(:ect_at_school_period, :active, teacher: mentored_teacher1, school: school1, started_on:, created_at: 2.days.ago) }
+        let!(:ect_at_school_period4) { create(:ect_at_school_period, :active, teacher: mentored_teacher2, school: school1, started_on:, created_at: 1.day.ago) }
 
-        let!(:mentorship_period1) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on:) }
-        let!(:mentorship_period2) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on:) }
+        let!(:mentorship_period1) { create(:mentorship_period, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on:) }
+        let!(:mentorship_period2) { create(:mentorship_period, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on:) }
 
         it 'orders with unmentored teachers first, then by registration date' do
           results = Teachers::Search.new(ect_at_school: school1).search

--- a/spec/services/teachers/terms_completed_spec.rb
+++ b/spec/services/teachers/terms_completed_spec.rb
@@ -1,7 +1,7 @@
 describe Teachers::TermsCompleted do
   subject(:service) { described_class.new(teacher) }
 
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:teacher) { create(:teacher) }
 
   describe '#formatted_terms_completed' do
     context 'when the teacher does not have induction periods' do
@@ -15,8 +15,8 @@ describe Teachers::TermsCompleted do
 
       context "with extensions" do
         before do
-          FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2)
-          FactoryBot.create(:induction_extension, teacher:, number_of_terms: 1.1)
+          create(:induction_extension, teacher:, number_of_terms: 2)
+          create(:induction_extension, teacher:, number_of_terms: 1.1)
         end
 
         it 'returns the default number of terms plus the extensions' do
@@ -26,7 +26,7 @@ describe Teachers::TermsCompleted do
     end
 
     context 'when the teacher has induction periods' do
-      let!(:induction_period) { FactoryBot.create(:induction_period, teacher:, number_of_terms: 2) }
+      let!(:induction_period) { create(:induction_period, teacher:, number_of_terms: 2) }
 
       context 'without extensions' do
         it 'returns the default number of terms' do
@@ -35,8 +35,8 @@ describe Teachers::TermsCompleted do
 
         context "with extensions" do
           before do
-            FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2)
-            FactoryBot.create(:induction_extension, teacher:, number_of_terms: 1.1)
+            create(:induction_extension, teacher:, number_of_terms: 2)
+            create(:induction_extension, teacher:, number_of_terms: 1.1)
           end
 
           it 'returns the default number of terms plus the extensions' do

--- a/spec/services/training_periods/create_spec.rb
+++ b/spec/services/training_periods/create_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe TrainingPeriods::Create do
   end
 
   let(:started_on) { Time.zone.today - 1.month }
-  let(:school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:school_partnership) { create(:school_partnership) }
   let(:expression_of_interest) { nil }
 
   context 'with an ECTAtSchoolPeriod' do
-    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:teacher) { create(:teacher) }
     let(:period) do
-      FactoryBot.create(
+      create(
         :ect_at_school_period,
         teacher:,
         started_on: started_on - 2.weeks,
@@ -36,9 +36,9 @@ RSpec.describe TrainingPeriods::Create do
   end
 
   context 'with a MentorAtSchoolPeriod' do
-    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:teacher) { create(:teacher) }
     let(:period) do
-      FactoryBot.create(
+      create(
         :mentor_at_school_period,
         teacher:,
         started_on: started_on - 1.month,

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -31,7 +31,7 @@ module UserHelper
     stop_mocking_dfe_sign_in_provider!
   end
 
-  def sign_in_as_dfe_user(role:, user: FactoryBot.create(:user, role, email: Faker::Internet.email, name: Faker::Name.name))
+  def sign_in_as_dfe_user(role:, user: create(:user, role, email: Faker::Internet.email, name: Faker::Name.name))
     page.goto(otp_sign_in_path)
     page.get_by_label('Email address').type(user.email)
     page.get_by_role("button", name: 'Request code to sign in').click

--- a/spec/support/requests/api_helper.rb
+++ b/spec/support/requests/api_helper.rb
@@ -22,7 +22,7 @@ module APIHelper
   end
 
   def lead_provider_to_authenticate_with
-    return FactoryBot.create(:lead_provider) unless defined?(active_lead_provider)
+    return create(:lead_provider) unless defined?(active_lead_provider)
 
     active_lead_provider.lead_provider
   end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -1,10 +1,10 @@
 RSpec.shared_examples "a filter by cohort (contract_period year) endpoint" do
   it "returns only resources for the specified cohorts" do
-    previous_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year - 1)
-    next_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)
+    previous_contract_period = create(:contract_period, year: active_lead_provider.contract_period.year - 1)
+    next_contract_period = create(:contract_period, year: active_lead_provider.contract_period.year + 1)
 
-    previous_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period)
-    next_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
+    previous_active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period)
+    next_active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
 
     previous_contract_period_resource = create_resource(active_lead_provider: previous_active_lead_provider)
     next_contract_period_resource = create_resource(active_lead_provider: next_active_lead_provider)
@@ -23,8 +23,8 @@ RSpec.shared_examples "a filter by cohort (contract_period year) endpoint" do
     resource = create_resource(active_lead_provider:)
 
     # Resource for the next contract_period should not be included.
-    next_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)
-    next_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
+    next_contract_period = create(:contract_period, year: active_lead_provider.contract_period.year + 1)
+    next_active_lead_provider = create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
     create_resource(active_lead_provider: next_active_lead_provider)
 
     authenticated_api_get(path, params: { filter: { cohort: "#{active_lead_provider.contract_period.year},invalid,cohort" } })

--- a/spec/support/shared_contexts/api/index_endpoint.rb
+++ b/spec/support/shared_contexts/api/index_endpoint.rb
@@ -9,9 +9,9 @@ shared_examples "an index endpoint" do
 
     before do
       # Resource for a different lead provider.
-      lead_provider = FactoryBot.create(:lead_provider, name: "Other Lead Provider")
+      lead_provider = create(:lead_provider, name: "Other Lead Provider")
       contract_period = active_lead_provider.contract_period
-      create_resource(active_lead_provider: FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:))
+      create_resource(active_lead_provider: create(:active_lead_provider, lead_provider:, contract_period:))
     end
 
     it "returns the correct resources in a serialized format" do

--- a/spec/support/shared_contexts/api/show_endpoint.rb
+++ b/spec/support/shared_contexts/api/show_endpoint.rb
@@ -21,9 +21,9 @@ shared_examples "a show endpoint" do
 
   context "when the resource exists but does not belong to the lead provider" do
     let(:resource) do
-      lead_provider = FactoryBot.create(:lead_provider, name: "Other Lead Provider")
+      lead_provider = create(:lead_provider, name: "Other Lead Provider")
       contract_period = active_lead_provider.contract_period
-      create_resource(active_lead_provider: FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:))
+      create_resource(active_lead_provider: create(:active_lead_provider, lead_provider:, contract_period:))
     end
 
     it "returns 404 not found" do

--- a/spec/support/shared_contexts/api_doc_request_auth.rb
+++ b/spec/support/shared_contexts/api_doc_request_auth.rb
@@ -1,5 +1,5 @@
 RSpec.shared_context("with authorization for api doc request") do
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:active_lead_provider) { create(:active_lead_provider) }
   let(:lead_provider) { active_lead_provider.lead_provider }
   let(:token) { generate_api_token.token }
   let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName

--- a/spec/support/shared_contexts/requests/sign_in.rb
+++ b/spec/support/shared_contexts/requests/sign_in.rb
@@ -1,11 +1,11 @@
 RSpec.shared_context 'sign in as non-DfE user' do
   before do
-    sign_in_as(:appropriate_body_user, appropriate_body: FactoryBot.create(:appropriate_body))
+    sign_in_as(:appropriate_body_user, appropriate_body: create(:appropriate_body))
   end
 end
 
 RSpec.shared_context 'sign in as DfE user' do
   before do
-    sign_in_as(:dfe_user, user: FactoryBot.create(:user, :admin))
+    sign_in_as(:dfe_user, user: create(:user, :admin))
   end
 end

--- a/spec/support/shared_examples/induction_period.rb
+++ b/spec/support/shared_examples/induction_period.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'an induction period' do
 
     describe '#started_on_from_september_2021_onwards' do
       context 'when start date is before September 2021' do
-        subject { FactoryBot.build(factory, started_on: '2021-8-31') }
+        subject { build(factory, started_on: '2021-8-31') }
 
         before { subject.valid?(:register_ect) }
 
@@ -17,7 +17,7 @@ RSpec.shared_examples 'an induction period' do
 
     describe '#started_on_from_september_1999_onwards' do
       context 'when start date is before September 1999' do
-        subject { FactoryBot.build(factory, started_on: '1999-8-31') }
+        subject { build(factory, started_on: '1999-8-31') }
 
         before { subject.valid? }
 

--- a/spec/support/shared_examples/migrator_support.rb
+++ b/spec/support/shared_examples/migrator_support.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples "a migrator" do |model, dependencies|
   let(:worker) { 0 }
   let(:instance) { described_class.new(worker:) }
-  let(:data_migration) { FactoryBot.create(:data_migration, model:, worker: 0) }
+  let(:data_migration) { create(:data_migration, model:, worker: 0) }
   let(:failure_manager) { instance_double(FailureManager, record_failure: nil) }
   let(:migration_resource1) { create_migration_resource }
   let(:migration_resource2) { create_migration_resource }
@@ -84,13 +84,13 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
       end
     else
       context "when the dependencies are not complete" do
-        before { FactoryBot.create(:data_migration, model: dependencies.sample) }
+        before { create(:data_migration, model: dependencies.sample) }
 
         it { is_expected.not_to be_runnable }
       end
 
       context "when the dependencies are all complete" do
-        before { FactoryBot.create(:data_migration, :completed, model: dependencies.sample) }
+        before { create(:data_migration, :completed, model: dependencies.sample) }
 
         it { is_expected.to be_runnable }
 
@@ -123,7 +123,7 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
     context "when there are models across multiple workers" do
       let(:records_per_worker) { 1 }
 
-      before { FactoryBot.create(:data_migration, model:, worker: 1) }
+      before { create(:data_migration, model:, worker: 1) }
 
       it "queues a job for each worker" do
         expect { queue }.to have_enqueued_job(MigratorJob).with(migrator: described_class, worker: 0)
@@ -185,7 +185,7 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
     context "when there are models across multiple workers" do
       let(:records_per_worker) { 1 }
 
-      before { FactoryBot.create(:data_migration, model:, worker: 1) }
+      before { create(:data_migration, model:, worker: 1) }
 
       it "only processes a portion of the models" do
         expect { migrate! }.to change { data_migration.reload.processed_count }.by(1)

--- a/spec/validators/appropriate_body_validator_spec.rb
+++ b/spec/validators/appropriate_body_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AppropriateBodyValidator, type: :model do
   end
 
   context 'when the appropriate_body is a local authority' do
-    let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :local_authority) }
+    let(:appropriate_body_id) { create(:appropriate_body, :local_authority) }
 
     it 'adds an error' do
       expect(subject).not_to be_valid
@@ -47,7 +47,7 @@ RSpec.describe AppropriateBodyValidator, type: :model do
     let(:school) { double(state_funded?: true) }
 
     context 'when the appropriate_body is a national' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :national) }
+      let(:appropriate_body_id) { create(:appropriate_body, :national) }
 
       it 'add an error' do
         expect(subject).not_to be_valid
@@ -56,7 +56,7 @@ RSpec.describe AppropriateBodyValidator, type: :model do
     end
 
     context 'when the appropriate_body is a teaching school hub' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :teaching_school_hub) }
+      let(:appropriate_body_id) { create(:appropriate_body, :teaching_school_hub) }
 
       it 'adds no error' do
         expect(subject).to be_valid
@@ -68,7 +68,7 @@ RSpec.describe AppropriateBodyValidator, type: :model do
     let(:school) { double(state_funded?: false) }
 
     context 'when the appropriate_body is a national' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :national) }
+      let(:appropriate_body_id) { create(:appropriate_body, :national) }
 
       it 'adds no error' do
         expect(subject).to be_valid
@@ -76,7 +76,7 @@ RSpec.describe AppropriateBodyValidator, type: :model do
     end
 
     context 'when the appropriate_body is a teaching school hub' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :teaching_school_hub) }
+      let(:appropriate_body_id) { create(:appropriate_body, :teaching_school_hub) }
 
       it 'adds no error' do
         expect(subject).to be_valid

--- a/spec/views/admin/appropriate_bodies/current_ects/index.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/current_ects/index.html.erb_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'admin/appropriate_bodies/current_ects/index.html.erb' do
   include Pagy::Backend
 
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
   let(:number_of_teachers) { 2 }
-  let!(:teachers) { FactoryBot.create_list(:teacher, number_of_teachers) }
+  let!(:teachers) { create_list(:teacher, number_of_teachers) }
 
   before do
     pagy, teachers = pagy(Teacher.all)

--- a/spec/views/admin/appropriate_bodies/index.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/index.html.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'admin/appropriate_bodies/index.html.erb' do
   include Pagy::Backend
 
   let(:number_of_appropriate_bodies) { 2 }
-  let(:appropriate_bodies) { FactoryBot.create_list(:appropriate_body, number_of_appropriate_bodies) }
+  let(:appropriate_bodies) { create_list(:appropriate_body, number_of_appropriate_bodies) }
   let(:pagy) { pagy_array(appropriate_bodies, items: 5, page: 1) }
 
   before do

--- a/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'admin/appropriate_bodies/show.html.erb' do
   let(:current_ect_count) { 5 }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   before do
     assign(:appropriate_body, appropriate_body)

--- a/spec/views/admin/finance/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'admin/finance/statements/index.html.erb' do
-  let(:raw_statements) { FactoryBot.create_list(:statement, 3) }
+  let(:raw_statements) { create_list(:statement, 3) }
   let(:pagy) { Pagy.new(count: raw_statements.count, limit: 10, page: 1) }
   let(:statements) { Admin::StatementPresenter.wrap(raw_statements) }
   let(:locals) { { filter_params: {} } }

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'admin/finance/statements/show.html.erb' do
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-  let(:statement_rec) { FactoryBot.create(:statement, active_lead_provider:, month: 5, year: 2023) }
+  let(:lead_provider) { create(:lead_provider, name: "Some LP") }
+  let(:active_lead_provider) { create(:active_lead_provider, lead_provider:) }
+  let(:statement_rec) { create(:statement, active_lead_provider:, month: 5, year: 2023) }
   let(:statement) { Admin::StatementPresenter.new(statement_rec) }
 
   before do

--- a/spec/views/admin/induction_period/edit.html.erb_spec.rb
+++ b/spec/views/admin/induction_period/edit.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'admin/induction_periods/edit.html.erb' do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { create(:ect_at_school_period, :active) }
   let(:back_path) { admin_teacher_path(ect.teacher) }
-  let(:induction_period) { FactoryBot.create(:induction_period, teacher: ect.teacher) }
+  let(:induction_period) { create(:induction_period, teacher: ect.teacher) }
 
   before do
     assign(:induction_period, induction_period)

--- a/spec/views/admin/teachers/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/show.html.erb_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'admin/teachers/show.html.erb' do
-  let(:teacher) { FactoryBot.create(:teacher, trn: '1234567', trs_first_name: 'Floella', trs_last_name: 'Benjamin') }
+  let(:teacher) { create(:teacher, trn: '1234567', trs_first_name: 'Floella', trs_last_name: 'Benjamin') }
 
   before do
-    FactoryBot.create(:induction_period, :active, teacher:)
+    create(:induction_period, :active, teacher:)
     assign(:teacher, Admin::TeacherPresenter.new(teacher))
     render
   end

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { create(:appropriate_body) }
 
   let(:pending_induction_submission) do
-    FactoryBot.create(:pending_induction_submission, appropriate_body:, trs_first_name: 'Anna', trs_last_name: 'Chancellor')
+    create(:pending_induction_submission, appropriate_body:, trs_first_name: 'Anna', trs_last_name: 'Chancellor')
   end
 
   let(:teacher) do
-    FactoryBot.create(:teacher,
-                      trs_first_name: pending_induction_submission.trs_first_name,
-                      trs_last_name: pending_induction_submission.trs_last_name,
-                      trn: pending_induction_submission.trn)
+    create(:teacher,
+           trs_first_name: pending_induction_submission.trs_first_name,
+           trs_last_name: pending_induction_submission.trs_last_name,
+           trn: pending_induction_submission.trn)
   end
 
   before do
@@ -37,7 +37,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
     end
 
     context 'when the ECT has an ongoing induction period with another appropriate body' do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+      let!(:induction_period) { create(:induction_period, :active, teacher:) }
 
       before { assign(:current_appropriate_body, appropriate_body) }
 
@@ -52,7 +52,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
 
   describe 'induction status' do
     let(:teacher) { nil }
-    let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_induction_status: 'FailedInWales') }
+    let(:pending_induction_submission) { create(:pending_induction_submission, trs_induction_status: 'FailedInWales') }
 
     it 'displays the status tag that corresponds to the TRS induction status on the pending induction submission' do
       render
@@ -62,7 +62,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
 
   describe 'induction periods' do
     context 'when the ECT has past induction periods' do
-      let!(:current_induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+      let!(:current_induction_period) { create(:induction_period, :active, teacher:) }
 
       it 'shows the current induction period' do
         render
@@ -76,7 +76,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
     end
 
     context 'when the ECT has past induction periods' do
-      let!(:past_induction_period) { FactoryBot.create(:induction_period, teacher:) }
+      let!(:past_induction_period) { create(:induction_period, teacher:) }
 
       it 'shows a list of past induction periods' do
         render
@@ -105,7 +105,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
     end
 
     context 'with extensions and teacher' do
-      let!(:extension) { FactoryBot.create(:induction_extension, teacher:) }
+      let!(:extension) { create(:induction_extension, teacher:) }
 
       it 'displays the row' do
         render

--- a/spec/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/claim_an_ect/find_ect/new.html.erb" do
-  let(:pending_induction_submission) { FactoryBot.build(:pending_induction_submission) }
+  let(:pending_induction_submission) { build(:pending_induction_submission) }
 
   expected_title = "Find an early career teacher's (ECT) record"
   it "sets the page title to '#{expected_title}'" do

--- a/spec/views/appropriate_bodies/claim_an_ect/register_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/register_ect/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/claim_an_ect/register_ect/edit.html.erb" do
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_first_name: 'Benjamin', trs_last_name: 'Whiterow') }
+  let(:pending_induction_submission) { create(:pending_induction_submission, trs_first_name: 'Benjamin', trs_last_name: 'Whiterow') }
 
   it "sets the page title to 'Tell us about <name>'" do
     assign(:pending_induction_submission, pending_induction_submission)

--- a/spec/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/register_ect/show.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/claim_an_ect/register_ect/show.html.erb" do
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trs_first_name: 'Crispin', trs_last_name: 'Bonham-Carter') }
+  let(:pending_induction_submission) { create(:pending_induction_submission, trs_first_name: 'Crispin', trs_last_name: 'Bonham-Carter') }
 
   it "sets the page title to '<name> is registered'" do
     assign(:appropriate_body, pending_induction_submission.appropriate_body)

--- a/spec/views/appropriate_bodies/process_batch/actions/completed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/completed.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/actions/_completed.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :action, :completed) }
+  let(:pending_induction_submission_batch) { create(:pending_induction_submission_batch, :action, :completed) }
 
   before do
     render locals: { batch: pending_induction_submission_batch }

--- a/spec/views/appropriate_bodies/process_batch/actions/failed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/failed.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/actions/_failed.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :action, :failed) }
+  let(:pending_induction_submission_batch) { create(:pending_induction_submission_batch, :action, :failed) }
 
   before do
     assign(:pending_induction_submission_batch, pending_induction_submission_batch)

--- a/spec/views/appropriate_bodies/process_batch/actions/index.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/index.html.erb_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "appropriate_bodies/process_batch/actions/index.html.erb" do
   let(:pending_induction_submission_batches) do
     [
-      FactoryBot.create(:pending_induction_submission_batch, :action, :completed),
-      FactoryBot.create(:pending_induction_submission_batch, :action, :processed),
-      FactoryBot.create(:pending_induction_submission_batch, :action, :processing)
+      create(:pending_induction_submission_batch, :action, :completed),
+      create(:pending_induction_submission_batch, :action, :processed),
+      create(:pending_induction_submission_batch, :action, :processing)
     ]
   end
 

--- a/spec/views/appropriate_bodies/process_batch/actions/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/actions/new.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.build(:pending_induction_submission_batch) }
+  let(:pending_induction_submission_batch) { build(:pending_induction_submission_batch) }
 
   before do
     assign(:pending_induction_submission_batch, pending_induction_submission_batch)

--- a/spec/views/appropriate_bodies/process_batch/actions/processed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/processed.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/actions/_processed.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :action, :processed) }
+  let(:pending_induction_submission_batch) { create(:pending_induction_submission_batch, :action, :processed) }
 
   before do
     render locals: { batch: pending_induction_submission_batch }

--- a/spec/views/appropriate_bodies/process_batch/actions/processing.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/actions/processing.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "appropriate_bodies/process_batch/actions/_processing.html.erb" do
   let(:pending_induction_submission_batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :action, :processing)
+    create(:pending_induction_submission_batch, :action, :processing)
   end
 
   before do

--- a/spec/views/appropriate_bodies/process_batch/claims/completed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/claims/completed.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/claims/_completed.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, :completed) }
+  let(:pending_induction_submission_batch) { create(:pending_induction_submission_batch, :claim, :completed) }
 
   before do
     render locals: { batch: pending_induction_submission_batch }

--- a/spec/views/appropriate_bodies/process_batch/claims/failed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/claims/failed.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/claims/_failed.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, :failed) }
+  let(:pending_induction_submission_batch) { create(:pending_induction_submission_batch, :claim, :failed) }
 
   before do
     assign(:pending_induction_submission_batch, pending_induction_submission_batch)

--- a/spec/views/appropriate_bodies/process_batch/claims/index.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/claims/index.html.erb_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "appropriate_bodies/process_batch/claims/index.html.erb" do
   let(:pending_induction_submission_batches) do
     [
-      FactoryBot.create(:pending_induction_submission_batch, :claim, :completed),
-      FactoryBot.create(:pending_induction_submission_batch, :claim, :processed),
-      FactoryBot.create(:pending_induction_submission_batch, :claim, :processing)
+      create(:pending_induction_submission_batch, :claim, :completed),
+      create(:pending_induction_submission_batch, :claim, :processed),
+      create(:pending_induction_submission_batch, :claim, :processing)
     ]
   end
 

--- a/spec/views/appropriate_bodies/process_batch/claims/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/claims/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/claims/new.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.build(:pending_induction_submission_batch) }
+  let(:pending_induction_submission_batch) { build(:pending_induction_submission_batch) }
 
   before do
     assign(:pending_induction_submission_batch, pending_induction_submission_batch)

--- a/spec/views/appropriate_bodies/process_batch/claims/processed.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/claims/processed.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "appropriate_bodies/process_batch/claims/_processed.html.erb" do
-  let(:pending_induction_submission_batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, :processed) }
+  let(:pending_induction_submission_batch) { create(:pending_induction_submission_batch, :claim, :processed) }
 
   before do
     render locals: { batch: pending_induction_submission_batch }

--- a/spec/views/appropriate_bodies/process_batch/claims/processing.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/process_batch/claims/processing.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "appropriate_bodies/process_batch/claims/_processing.html.erb" do
   let(:pending_induction_submission_batch) do
-    FactoryBot.create(:pending_induction_submission_batch, :claim, :processing)
+    create(:pending_induction_submission_batch, :claim, :processing)
   end
 
   before do

--- a/spec/views/appropriate_bodies/teachers/extensions/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/extensions/edit.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "appropriate_bodies/teachers/extensions/edit.html.erb" do
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:extension) { FactoryBot.create(:induction_extension) }
+  let(:appropriate_body) { build(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:extension) { create(:induction_extension) }
 
   before do
     assign(:appropriate_body, appropriate_body)
@@ -16,7 +16,7 @@ RSpec.describe "appropriate_bodies/teachers/extensions/edit.html.erb" do
   end
 
   context 'when the extension has an error' do
-    let(:extension) { FactoryBot.create(:induction_extension, number_of_terms: 10) }
+    let(:extension) { create(:induction_extension, number_of_terms: 10) }
 
     before do
       extension.number_of_terms = 17

--- a/spec/views/appropriate_bodies/teachers/extensions/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/extensions/new.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "appropriate_bodies/teachers/extensions/new.html.erb" do
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:extension) { FactoryBot.build(:induction_extension) }
+  let(:appropriate_body) { build(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:extension) { build(:induction_extension) }
 
   before do
     assign(:appropriate_body, appropriate_body)
@@ -16,7 +16,7 @@ RSpec.describe "appropriate_bodies/teachers/extensions/new.html.erb" do
   end
 
   context 'when the extension has an error' do
-    let(:extension) { FactoryBot.build(:induction_extension, number_of_terms: 17) }
+    let(:extension) { build(:induction_extension, number_of_terms: 17) }
 
     before do
       extension.valid?

--- a/spec/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_failed_outcome/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "appropriate_bodies/teachers/record_failed_outcome/new.html.erb" do
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:appropriate_body) { build(:appropriate_body) }
   let(:pending_induction_submission) { PendingInductionSubmission.new }
 
   before do

--- a/spec/views/appropriate_bodies/teachers/record_passed_outcome/new.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/record_passed_outcome/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "appropriate_bodies/teachers/record_passed_outcome/new.html.erb" do
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
+  let(:appropriate_body) { build(:appropriate_body) }
   let(:pending_induction_submission) { PendingInductionSubmission.new }
 
   before do

--- a/spec/views/appropriate_bodies/teachers/show.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/teachers/show.html.erb_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe 'appropriate_bodies/teachers/show.html.erb' do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:teacher) { create(:teacher) }
 
   before do
-    FactoryBot.create(:induction_period, teacher:, appropriate_body:, started_on: 24.months.ago, finished_on: 12.months.ago)
-    FactoryBot.create(:induction_period, teacher:, appropriate_body:, started_on: 11.months.ago, finished_on: 3.months.ago)
+    create(:induction_period, teacher:, appropriate_body:, started_on: 24.months.ago, finished_on: 12.months.ago)
+    create(:induction_period, teacher:, appropriate_body:, started_on: 11.months.ago, finished_on: 3.months.ago)
 
     assign(:teacher, teacher)
     assign(:appropriate_body, appropriate_body)

--- a/spec/views/schools/ects/index.html.erb_spec.rb
+++ b/spec/views/schools/ects/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'schools/ects/index.html.erb' do
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
 
   before do
     assign(:filtered_teachers, [])
@@ -32,8 +32,8 @@ RSpec.describe 'schools/ects/index.html.erb' do
   end
 
   context 'when there are teachers' do
-    let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Johnnie', trs_last_name: 'Walker') }
-    let(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:) }
+    let(:teacher) { create(:teacher, trs_first_name: 'Johnnie', trs_last_name: 'Walker') }
+    let(:ect_period) { create(:ect_at_school_period, teacher:, school:) }
 
     before do
       assign(:filtered_teachers, [teacher])

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -1,38 +1,38 @@
 RSpec.describe 'schools/ects/show.html.erb' do
-  let(:contract_period) { FactoryBot.create(:contract_period) }
+  let(:contract_period) { create(:contract_period) }
   let!(:current_ect_period) do
-    FactoryBot.create(:ect_at_school_period,
-                      :teaching_school_hub_ab,
-                      teacher:,
-                      started_on: '2025-01-11',
-                      finished_on: nil,
-                      lead_provider: requested_lead_provider,
-                      school_reported_appropriate_body: requested_appropriate_body,
-                      school: current_school,
-                      working_pattern: 'full_time',
-                      training_programme:,
-                      email: 'love@whale.com')
+    create(:ect_at_school_period,
+           :teaching_school_hub_ab,
+           teacher:,
+           started_on: '2025-01-11',
+           finished_on: nil,
+           lead_provider: requested_lead_provider,
+           school_reported_appropriate_body: requested_appropriate_body,
+           school: current_school,
+           working_pattern: 'full_time',
+           training_programme:,
+           email: 'love@whale.com')
   end
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Ambition institute') }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Alpha Teaching School Hub') }
-  let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White', corrected_name: 'Baz White') }
-  let(:previous_school) { FactoryBot.create(:school, urn: '123456') }
-  let(:current_school) { FactoryBot.create(:school, :state_funded, urn: '987654') }
-  let(:requested_lead_provider) { FactoryBot.create(:lead_provider, name: 'Requested LP') }
-  let(:requested_appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Requested AB') }
+  let(:lead_provider) { create(:lead_provider, name: 'Ambition institute') }
+  let(:active_lead_provider) { create(:active_lead_provider, lead_provider:) }
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+  let(:school_partnership) { create(:school_partnership, lead_provider_delivery_partnership:) }
+  let(:appropriate_body) { create(:appropriate_body, name: 'Alpha Teaching School Hub') }
+  let(:teacher) { create(:teacher, trs_first_name: 'Barry', trs_last_name: 'White', corrected_name: 'Baz White') }
+  let(:previous_school) { create(:school, urn: '123456') }
+  let(:current_school) { create(:school, :state_funded, urn: '987654') }
+  let(:requested_lead_provider) { create(:lead_provider, name: 'Requested LP') }
+  let(:requested_appropriate_body) { create(:appropriate_body, name: 'Requested AB') }
   let(:training_programme) { 'provider_led' }
 
   before do
-    FactoryBot.create(:ect_at_school_period, :state_funded_school,
-                      teacher:,
-                      started_on: '2024-01-11',
-                      finished_on: '2025-01-11',
-                      school: previous_school,
-                      email: 'previous-address@whale.com')
+    create(:ect_at_school_period, :state_funded_school,
+           teacher:,
+           started_on: '2024-01-11',
+           finished_on: '2025-01-11',
+           school: previous_school,
+           email: 'previous-address@whale.com')
     assign(:ect, current_ect_period)
     render
   end
@@ -63,13 +63,13 @@ RSpec.describe 'schools/ects/show.html.erb' do
     describe 'mentor' do
       context 'when assigned' do
         before do
-          mentor = FactoryBot.create(:teacher, trs_first_name: 'Moby', trs_last_name: 'Dick')
-          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: current_school, teacher: mentor)
+          mentor = create(:teacher, trs_first_name: 'Moby', trs_last_name: 'Dick')
+          mentor_at_school_period = create(:mentor_at_school_period, :active, school: current_school, teacher: mentor)
 
-          FactoryBot.create(:mentorship_period, :active,
-                            started_on: current_ect_period.started_on,
-                            mentee: current_ect_period,
-                            mentor: mentor_at_school_period)
+          create(:mentorship_period, :active,
+                 started_on: current_ect_period.started_on,
+                 mentee: current_ect_period,
+                 mentor: mentor_at_school_period)
 
           render
         end
@@ -101,11 +101,11 @@ RSpec.describe 'schools/ects/show.html.erb' do
 
   describe 'ECTE training details' do
     before do
-      FactoryBot.create(:training_period, :active, :for_ect, school_partnership:,
-                                                             ect_at_school_period: current_ect_period,
-                                                             started_on: current_ect_period.started_on)
+      create(:training_period, :active, :for_ect, school_partnership:,
+                                                  ect_at_school_period: current_ect_period,
+                                                  started_on: current_ect_period.started_on)
 
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:)
+      create(:induction_period, :active, teacher:, appropriate_body:)
 
       render
     end

--- a/spec/views/schools/mentors/index.html.erb_spec.rb
+++ b/spec/views/schools/mentors/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'schools/mentors/index.html.erb' do
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
 
   before do
     assign(:school, school)
@@ -27,8 +27,8 @@ RSpec.describe 'schools/mentors/index.html.erb' do
   end
 
   context 'when there are mentors' do
-    let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Johnnie', trs_last_name: 'Walker') }
-    let(:mentor_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:) }
+    let(:teacher) { create(:teacher, trs_first_name: 'Johnnie', trs_last_name: 'Walker') }
+    let(:mentor_period) { create(:mentor_at_school_period, teacher:, school:) }
 
     before do
       assign(:school, school)

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -1,26 +1,26 @@
 RSpec.describe 'schools/mentors/show.html.erb' do
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { create(:school) }
   let(:start_date) { Date.new(2023, 9, 1) }
 
   let(:mentor_teacher) do
-    FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki', mentor_became_ineligible_for_funding_on:, mentor_became_ineligible_for_funding_reason:)
+    create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki', mentor_became_ineligible_for_funding_on:, mentor_became_ineligible_for_funding_reason:)
   end
 
   let(:mentor_became_ineligible_for_funding_on) { nil }
   let(:mentor_became_ineligible_for_funding_reason) { nil }
 
   let(:mentor_period) do
-    FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: nil)
+    create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date, finished_on: nil)
   end
 
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Hidden leaf village') }
+  let(:lead_provider) { create(:lead_provider, name: 'Hidden leaf village') }
 
   let(:ect_teacher) do
-    FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi')
+    create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi')
   end
 
   let(:ect_period) do
-    FactoryBot.create(
+    create(
       :ect_at_school_period,
       teacher: ect_teacher,
       school:,
@@ -32,7 +32,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
   end
 
   let!(:mentorship_period) do
-    FactoryBot.create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: nil)
+    create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: nil)
   end
 
   before do
@@ -99,7 +99,7 @@ RSpec.describe 'schools/mentors/show.html.erb' do
 
   context 'when all ECTs are school-led' do
     let(:ect_period) do
-      FactoryBot.create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
+      create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
     end
 
     before do

--- a/spec/views/schools/mentorships/new.html.erb_spec.rb
+++ b/spec/views/schools/mentorships/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/mentorships/new.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { create(:ect_at_school_period, :active) }
   let(:ect_name) { Teachers::Name.new(ect.teacher).full_name }
   let(:mentor) { double("mentor_at_school_period", full_name: 'Peter Times', id: 7) }
   let(:mentor_id) { mentor.id }

--- a/spec/views/schools/register_ect_wizard/cannot_register_ect_yet.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/cannot_register_ect_yet.html.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "schools/register_ect_wizard/cannot_register_ect_yet" do
   let(:ect) { double('ECT', full_name: 'John Doe', start_date: '15 May 2025') }
 
   before do
-    FactoryBot.create(:contract_period, year: 2024, enabled: true)
+    create(:contract_period, year: 2024, enabled: true)
     assign(:ect, ect)
     render
   end

--- a/spec/views/schools/register_ect_wizard/cant_use_email.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/cant_use_email.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'schools/register_ect_wizard/cant_use_email.html.erb' do
   let(:back_path) { schools_register_ect_wizard_email_address_path }
-  let(:store) { FactoryBot.build(:session_repository, trs_first_name: "John", trs_last_name: "Waters", email: 'a@email.com') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :cant_use_email, store:) }
+  let(:store) { build(:session_repository, trs_first_name: "John", trs_last_name: "Waters", email: 'a@email.com') }
+  let(:wizard) { build(:register_ect_wizard, current_step: :cant_use_email, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_ect_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/check_answers.html.erb_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
   let(:use_previous_ect_choices) { nil }
-  let(:store) { FactoryBot.build(:session_repository, working_pattern: 'Full time', use_previous_ect_choices:, training_programme: 'provider_led') }
+  let(:store) { build(:session_repository, working_pattern: 'Full time', use_previous_ect_choices:, training_programme: 'provider_led') }
 
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :check_answers, store:)
+    build(:register_ect_wizard, current_step: :check_answers, store:)
   end
 
   before do

--- a/spec/views/schools/register_ect_wizard/confirmation.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/confirmation.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/register_ect_wizard/confirmation.html.erb" do
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, id: 1) }
+  let(:ect_at_school_period) { create(:ect_at_school_period, id: 1) }
 
   let(:ect) do
     double('ECT',

--- a/spec/views/schools/register_ect_wizard/find_ect.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/find_ect.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "schools/register_ect_wizard/find_ect.html.erb" do
-  let(:store) { FactoryBot.build(:session_repository, trn: "1234567") }
+  let(:store) { build(:session_repository, trn: "1234567") }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :find_ect, store:)
+    build(:register_ect_wizard, current_step: :find_ect, store:)
   end
 
   before do

--- a/spec/views/schools/register_ect_wizard/lead_provider.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/lead_provider.html.erb_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "schools/register_ect_wizard/lead_provider.html.erb" do
   let(:store) do
-    FactoryBot.build(:session_repository, lead_provider_id: "1", trs_first_name: 'John', trs_last_name: 'Smith')
+    build(:session_repository, lead_provider_id: "1", trs_first_name: 'John', trs_last_name: 'Smith')
   end
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :lead_provider, store:)
+    build(:register_ect_wizard, current_step: :lead_provider, store:)
   end
 
   before do

--- a/spec/views/schools/register_ect_wizard/national_insurance_number.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/national_insurance_number.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "schools/register_ect_wizard/national_insurance_number.html.erb" do
-  let(:store) { FactoryBot.build(:session_repository, national_insurance_number: "1234567") }
+  let(:store) { build(:session_repository, national_insurance_number: "1234567") }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number, store:)
+    build(:register_ect_wizard, current_step: :national_insurance_number, store:)
   end
 
   before do

--- a/spec/views/schools/register_ect_wizard/registered_before.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/registered_before.html.erb_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
-  let(:school) { FactoryBot.create(:school) }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Confirmed LP") }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner:, active_lead_provider:) }
-  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+  let(:school) { create(:school) }
+  let(:teacher) { create(:teacher) }
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:appropriate_body) { create(:appropriate_body) }
+  let(:lead_provider) { create(:lead_provider, name: "Confirmed LP") }
+  let(:active_lead_provider) { create(:active_lead_provider, lead_provider:) }
+  let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, delivery_partner:, active_lead_provider:) }
+  let(:school_partnership) { create(:school_partnership, lead_provider_delivery_partnership:) }
 
   let(:ect_at_school_period) do
-    FactoryBot.create(
+    create(
       :ect_at_school_period,
       finished_on: nil,
       school:,
@@ -20,7 +20,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
   end
 
   let(:store) do
-    FactoryBot.build(
+    build(
       :session_repository,
       trs_first_name: 'Konohamaru',
       trs_last_name: 'Sarutobi',
@@ -30,7 +30,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
   end
 
   let(:wizard) do
-    FactoryBot.build(
+    build(
       :register_ect_wizard,
       current_step: :registered_before,
       school:,
@@ -41,7 +41,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
   let(:wizard_ect) { Schools::RegisterECTWizard::ECT.new(store) }
 
   before do
-    FactoryBot.create(
+    create(
       :training_period,
       ect_at_school_period:,
       started_on: Date.new(2023, 9, 1),
@@ -49,7 +49,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
       school_partnership:
     )
 
-    FactoryBot.create(
+    create(
       :induction_period,
       teacher:,
       appropriate_body:,
@@ -57,7 +57,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
       finished_on: Date.new(2024, 7, 31)
     )
 
-    FactoryBot.create(:gias_school, school:, name: "Really cool school")
+    create(:gias_school, school:, name: "Really cool school")
 
     assign(:school, school)
     assign(:ect, wizard_ect)
@@ -103,7 +103,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
 
   context 'School-led' do
     let(:ect_at_school_period) do
-      FactoryBot.create(
+      create(
         :ect_at_school_period,
         started_on: Date.new(2023, 9, 1),
         finished_on: nil,

--- a/spec/views/schools/register_ect_wizard/shared_examples/independent_school_appropriate_body_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/independent_school_appropriate_body_view.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples "an independent school appropriate body view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:ect) { wizard.ect }
-  let(:store) { FactoryBot.build(:session_repository, trs_first_name: 'John', trs_last_name: 'Smith') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step:, store:) }
+  let(:store) { build(:session_repository, trs_first_name: 'John', trs_last_name: 'Smith') }
+  let(:wizard) { build(:register_ect_wizard, current_step:, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_ect_wizard/shared_examples/start_date_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/start_date_view.rb
@@ -1,8 +1,8 @@
 RSpec.shared_examples "a start date view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:ect) { wizard.ect }
   let(:start_date) { nil }
-  let(:store) { FactoryBot.build(:session_repository, start_date:, trs_first_name: 'John', trs_last_name: 'Smith') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step:, store:) }
+  let(:store) { build(:session_repository, start_date:, trs_first_name: 'John', trs_last_name: 'Smith') }
+  let(:wizard) { build(:register_ect_wizard, current_step:, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_ect_wizard/shared_examples/state_school_appropriate_body_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/state_school_appropriate_body_view.rb
@@ -2,8 +2,8 @@ RSpec.shared_examples "a state school appropriate body view" do |current_step:, 
   let(:ect) { wizard.ect }
   let(:title) { "Which appropriate body will be supporting #{ect.full_name}'s induction?" }
   let(:appropriate_body_name) { nil }
-  let(:store) { FactoryBot.build(:session_repository, appropriate_body_name:, trs_first_name: 'John', trs_last_name: 'Smith') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step:, store:) }
+  let(:store) { build(:session_repository, appropriate_body_name:, trs_first_name: 'John', trs_last_name: 'Smith') }
+  let(:wizard) { build(:register_ect_wizard, current_step:, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_ect_wizard/shared_examples/training_programme_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/training_programme_view.rb
@@ -1,14 +1,14 @@
 RSpec.shared_examples "a training programme view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:ect) { wizard.ect }
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:training_programme) { nil }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     training_programme:,
-                     trs_first_name: 'John',
-                     trs_last_name: 'Smith')
+    build(:session_repository,
+          training_programme:,
+          trs_first_name: 'John',
+          trs_last_name: 'Smith')
   end
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step:, school:, store:) }
+  let(:wizard) { build(:register_ect_wizard, current_step:, school:, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
@@ -1,20 +1,20 @@
 RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     full_name: 'John Doe',
-                     trn: '123456',
-                     email: 'foo@bar.com',
-                     govuk_date_of_birth: '12 January 1931',
-                     start_date: 'September 2022',
-                     training_programme: 'school_led',
-                     appropriate_body_type: 'teaching_school_hub',
-                     appropriate_body: double(name: 'Teaching Regulation Agency'),
-                     lead_provider: double(name: 'Acme Lead Provider'),
-                     formatted_working_pattern: 'Full time',
-                     use_previous_ect_choices: false)
+    build(:session_repository,
+          full_name: 'John Doe',
+          trn: '123456',
+          email: 'foo@bar.com',
+          govuk_date_of_birth: '12 January 1931',
+          start_date: 'September 2022',
+          training_programme: 'school_led',
+          appropriate_body_type: 'teaching_school_hub',
+          appropriate_body: double(name: 'Teaching Regulation Agency'),
+          lead_provider: double(name: 'Acme Lead Provider'),
+          formatted_working_pattern: 'Full time',
+          use_previous_ect_choices: false)
   end
-  let(:school) { FactoryBot.create(:school, :independent) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step:, store:, school:) }
+  let(:school) { create(:school, :independent) }
+  let(:wizard) { build(:register_ect_wizard, current_step:, store:, school:) }
 
   before do
     assign(:ect, wizard.ect)
@@ -58,7 +58,7 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
   end
 
   context "when school-led" do
-    let(:school) { FactoryBot.create(:school, :school_led_last_chosen) }
+    let(:school) { create(:school, :school_led_last_chosen) }
 
     before do
       assign(:school, school)
@@ -72,7 +72,7 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
   end
 
   context "when provider-led" do
-    let(:school) { FactoryBot.create(:school, :provider_led_last_chosen) }
+    let(:school) { create(:school, :provider_led_last_chosen) }
 
     before do
       assign(:school, school)

--- a/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/already_active_at_school.md.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "schools/register_mentor_wizard/already_active_at_school.md.erb" 
   let(:assign_mentor_path) { wizard.current_step_path }
   let(:ect_name) { Faker::Name.name }
   let(:store) { double(trs_first_name: "John", trs_last_name: "Waters", change_name: "yes", corrected_name: "Jim Waters") }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :already_active_at_school, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :already_active_at_school, store:) }
   let(:mentor) { wizard.mentor }
 
   before do

--- a/spec/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/cannot_mentor_themself.md.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "schools/register_mentor_wizard/cannot_mentor_themself.md.erb" do
   let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:store) { double(trs_first_name: "John", trs_last_name: "Waters") }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :cannot_mentor_themself, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :cannot_mentor_themself, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -1,26 +1,26 @@
 RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'FraggleRock') }
+  let(:lead_provider) { create(:lead_provider, name: 'FraggleRock') }
 
   let(:teacher) do
-    FactoryBot.create(:teacher, trn: '1234568')
+    create(:teacher, trn: '1234568')
   end
 
   let(:ect) do
-    FactoryBot.create(:ect_at_school_period, :active, teacher:, lead_provider:)
+    create(:ect_at_school_period, :active, teacher:, lead_provider:)
   end
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Wayne",
-                     change_name: 'yes',
-                     corrected_name: "Jim Wayne",
-                     email: "john.wayne@example.com")
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Wayne",
+          change_name: 'yes',
+          corrected_name: "Jim Wayne",
+          email: "john.wayne@example.com")
   end
 
   let(:wizard) do
-    FactoryBot.build(:register_mentor_wizard, current_step: :check_answers, ect_id: ect.id, store:)
+    build(:register_mentor_wizard, current_step: :check_answers, ect_id: ect.id, store:)
   end
 
   let(:mentor) { wizard.mentor }
@@ -50,7 +50,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
     context 'with legacy exemption' do
       before do
-        FactoryBot.create(:teacher, :early_roll_out_mentor, trn: mentor.trn)
+        create(:teacher, :early_roll_out_mentor, trn: mentor.trn)
         render
       end
 
@@ -59,10 +59,10 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
     context 'with existing training exemption' do
       before do
-        FactoryBot.create(:teacher,
-                          trn: mentor.trn,
-                          mentor_became_ineligible_for_funding_on: Time.zone.today,
-                          mentor_became_ineligible_for_funding_reason: 'completed_declaration_received')
+        create(:teacher,
+               trn: mentor.trn,
+               mentor_became_ineligible_for_funding_on: Time.zone.today,
+               mentor_became_ineligible_for_funding_reason: 'completed_declaration_received')
 
         render
       end
@@ -74,7 +74,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   describe 'summary' do
     context 'with school led ect' do
       let(:ect) do
-        FactoryBot.create(:ect_at_school_period, :active, :school_led, teacher:)
+        create(:ect_at_school_period, :active, :school_led, teacher:)
       end
 
       it 'hides lead provider' do
@@ -99,7 +99,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
     context 'with legacy exemption' do
       before do
-        FactoryBot.create(:teacher, :early_roll_out_mentor, trn: mentor.trn)
+        create(:teacher, :early_roll_out_mentor, trn: mentor.trn)
         render
       end
 
@@ -111,10 +111,10 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
     context 'with existing training exemption' do
       before do
-        FactoryBot.create(:teacher,
-                          trn: mentor.trn,
-                          mentor_became_ineligible_for_funding_on: Time.zone.today,
-                          mentor_became_ineligible_for_funding_reason: 'completed_declaration_received')
+        create(:teacher,
+               trn: mentor.trn,
+               mentor_became_ineligible_for_funding_on: Time.zone.today,
+               mentor_became_ineligible_for_funding_reason: 'completed_declaration_received')
 
         render
       end

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
   let(:already_active_at_school) { false }
 
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'FraggleRock') }
+  let(:lead_provider) { create(:lead_provider, name: 'FraggleRock') }
 
-  let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+  let(:teacher) { create(:teacher, trn: '1234568') }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher:, lead_provider:) }
+  let(:ect) { create(:ect_at_school_period, :active, teacher:, lead_provider:) }
 
   let(:store) do
     double(
@@ -20,7 +20,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
   end
 
   let(:wizard) do
-    FactoryBot.build(:register_mentor_wizard, current_step: :confirmation, ect_id: ect.id, store:)
+    build(:register_mentor_wizard, current_step: :confirmation, ect_id: ect.id, store:)
   end
 
   let(:mentor) { wizard.mentor }
@@ -54,7 +54,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       end
 
       context 'when the ect is not provider_led' do
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, teacher:) }
+        let(:ect) { create(:ect_at_school_period, :active, :school_led, teacher:) }
 
         it { expect(rendered).not_to have_content("We’ll pass on their details to FraggleRock") }
       end
@@ -62,7 +62,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
     context 'when ineligible' do
       before do
-        FactoryBot.create(:teacher, :ineligible_for_mentor_funding, trn: '0000007')
+        create(:teacher, :ineligible_for_mentor_funding, trn: '0000007')
         render
       end
 
@@ -71,7 +71,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       end
 
       context 'when the ect is not provider_led' do
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, teacher:) }
+        let(:ect) { create(:ect_at_school_period, :active, :school_led, teacher:) }
 
         it { expect(rendered).not_to have_content('They cannot do mentor training according to our records.') }
       end

--- a/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "schools/register_mentor_wizard/find_mentor.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { create(:ect_at_school_period, :active) }
   let(:back_path) { schools_register_mentor_wizard_start_path(ect_id: ect.id) }
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, ect_id: ect.id) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :find_mentor, ect_id: ect.id) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_mentor_wizard/national_insurance_number.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/national_insurance_number.html.erb_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe "schools/register_mentor_wizard/national_insurance_number.html.er
   let(:back_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:continue_path) { schools_register_mentor_wizard_national_insurance_number_path }
   let(:wizard) do
-    FactoryBot.build(:register_mentor_wizard,
-                     current_step: :national_insurance_number,
-                     store: FactoryBot.build(:session_repository))
+    build(:register_mentor_wizard,
+          current_step: :national_insurance_number,
+          store: build(:session_repository))
   end
 
   before do

--- a/spec/views/schools/register_mentor_wizard/not_found.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/not_found.md.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "schools/register_mentor_wizard/not_found.md.erb" do
   let(:review_teacher_record_path) { "https://www.gov.uk/guidance/check-a-teachers-record" }
   let(:try_again_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:store) { double(trs_first_name: "John", trs_last_name: "Waters") }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :not_found, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :not_found, store:) }
 
   before do
     assign(:wizard, wizard)

--- a/spec/views/schools/register_mentor_wizard/shared_examples/cant_use_email_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/cant_use_email_view.rb
@@ -1,15 +1,15 @@
 RSpec.shared_examples "a can't use email step view" do |current_step:, back_path:|
   let(:mentor) { wizard.mentor }
   let(:email) { nil }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Waters",
-                     trs_date_of_birth: "1950-01-01",
-                     change_name: "no",
-                     email: 'a@email.com')
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Waters",
+          trs_date_of_birth: "1950-01-01",
+          change_name: "no",
+          email: 'a@email.com')
   end
 
   before do

--- a/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
@@ -1,16 +1,16 @@
 RSpec.shared_examples "an email address step view" do |current_step:, back_path:, back_step_name:, continue_path:, continue_step_name:|
   let(:mentor) { wizard.mentor }
   let(:email) { nil }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Waters",
-                     trs_date_of_birth: "1950-01-01",
-                     change_name: "yes",
-                     corrected_name: "Jim Waters",
-                     email:)
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Waters",
+          trs_date_of_birth: "1950-01-01",
+          change_name: "yes",
+          corrected_name: "Jim Waters",
+          email:)
   end
 
   before do

--- a/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
@@ -9,18 +9,18 @@ RSpec.shared_examples "a review mentor details step view" do |current_step:,
   let(:national_insurance_number) { "AD12345ED" }
   let(:email) { nil }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Wayne",
-                     trs_date_of_birth: "1950-01-01",
-                     change_name: "no",
-                     corrected_name: nil,
-                     date_of_birth:,
-                     national_insurance_number:,
-                     email:)
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Wayne",
+          trs_date_of_birth: "1950-01-01",
+          change_name: "no",
+          corrected_name: nil,
+          date_of_birth:,
+          national_insurance_number:,
+          email:)
   end
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:) }
   let(:mentor) { wizard.mentor }
 
   before do

--- a/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led) }
+  let(:ect) { create(:ect_at_school_period, :active, :school_led) }
   let(:ect_name) { Teachers::Name.new(ect.teacher).full_name }
 
   before do
@@ -29,7 +29,7 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
       let(:back_path) { new_schools_ect_mentorship_path(ect) }
 
       before do
-        FactoryBot.create(:mentor_at_school_period, :active, school: ect.school)
+        create(:mentor_at_school_period, :active, school: ect.school)
         render
       end
 
@@ -46,7 +46,7 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   end
 
   context 'when the ect has chosen a provider led training programme' do
-    let(:ect) { FactoryBot.build(:ect_at_school_period, :provider_led) }
+    let(:ect) { build(:ect_at_school_period, :provider_led) }
 
     it 'informs the user about the mentor training programme requirements' do
       render
@@ -56,7 +56,7 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   end
 
   context 'when the ect has chosen a school led training programme' do
-    let(:ect) { FactoryBot.build(:ect_at_school_period, :school_led) }
+    let(:ect) { build(:ect_at_school_period, :school_led) }
 
     it 'does not inform the user about the mentor training programme requirements' do
       render

--- a/spec/wizards/schools/register_ect_wizard/appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/appropriate_body_step_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Schools::RegisterECTWizard::AppropriateBodyStep, type: :model do
-  let(:school) { FactoryBot.create(:school, :state_funded) }
-  let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:) }
+  let(:school) { create(:school, :state_funded) }
+  let(:store) { build(:session_repository, appropriate_body_id: '123') }
+  let(:wizard) { build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -47,7 +47,7 @@ RSpec.describe Schools::RegisterECTWizard::AppropriateBodyStep, type: :model do
     end
 
     context 'when the appropriate_body is a local authority' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :local_authority) }
+      let(:appropriate_body_id) { create(:appropriate_body, :local_authority) }
 
       it 'adds an error' do
         expect(subject).not_to be_valid
@@ -60,7 +60,7 @@ RSpec.describe Schools::RegisterECTWizard::AppropriateBodyStep, type: :model do
     subject { wizard.current_step }
 
     let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:)
+      build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:)
     end
 
     describe '#next_step' do
@@ -77,7 +77,7 @@ RSpec.describe Schools::RegisterECTWizard::AppropriateBodyStep, type: :model do
       end
 
       context 'when the school has last programme choices' do
-        let(:school) { FactoryBot.create(:school, :independent, :national_ab_last_chosen, :school_led_last_chosen) }
+        let(:school) { create(:school, :independent, :national_ab_last_chosen, :school_led_last_chosen) }
 
         it 'returns the previous step' do
           expect(subject.previous_step).to eq(:use_previous_ect_choices)
@@ -98,7 +98,7 @@ RSpec.describe Schools::RegisterECTWizard::AppropriateBodyStep, type: :model do
     end
 
     let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, step_params:)
+      build(:register_ect_wizard, current_step: :state_school_appropriate_body, step_params:)
     end
 
     context 'when the step is not valid' do

--- a/spec/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_independent_school_appropriate_body_step_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::RegisterECTWizard::ChangeIndependentSchoolAppropriateBodyStep, type: :model do
   subject { described_class.new(wizard:, appropriate_body_id: '123', appropriate_body_type: 'Some Teaching School Hub') }
 
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_independent_school_appropriate_body, school:)
+    build(:register_ect_wizard, current_step: :change_independent_school_appropriate_body, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/change_lead_provider_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_lead_provider_step_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Schools::RegisterECTWizard::ChangeLeadProviderStep, type: :model 
   subject { described_class.new(wizard:, lead_provider_id:) }
 
   let(:lead_provider_id) { '1' }
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_lead_provider, school:)
+    build(:register_ect_wizard, current_step: :change_lead_provider, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_state_school_appropriate_body_step_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::RegisterECTWizard::ChangeStateSchoolAppropriateBodyStep, type: :model do
   subject { described_class.new(wizard:, appropriate_body_id: '123') }
 
-  let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
+  let(:school) { create(:school, :state_funded, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_state_school_appropriate_body, school:)
+    build(:register_ect_wizard, current_step: :change_state_school_appropriate_body, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/change_training_programme_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_training_programme_step_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Schools::RegisterECTWizard::ChangeTrainingProgrammeStep, type: :model do
   subject { described_class.new(wizard:, training_programme: new_training_programme) }
 
-  let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
+  let(:lead_provider_id) { create(:lead_provider).id }
   let(:training_programme) { 'school_led' }
   let(:new_training_programme) { 'provider_led' }
-  let(:school) { FactoryBot.create(:school, :independent) }
-  let(:store) { FactoryBot.build(:session_repository, training_programme:, lead_provider_id:) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :change_training_programme, store:, school:) }
+  let(:school) { create(:school, :independent) }
+  let(:store) { build(:session_repository, training_programme:, lead_provider_id:) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :change_training_programme, store:, school:) }
 
   describe "inheritance" do
     it "inherits from TrainingProgrammeStep" do
@@ -27,7 +27,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeTrainingProgrammeStep, type: :m
       let(:new_training_programme) { 'provider_led' }
 
       context 'when the school has last programme choices' do
-        let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
+        let(:school) { create(:school, :independent, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
 
         it { expect(subject.next_step).to eq(:training_programme_change_lead_provider) }
       end
@@ -46,7 +46,7 @@ RSpec.describe Schools::RegisterECTWizard::ChangeTrainingProgrammeStep, type: :m
 
       context 'when a lead provider has already been selected' do
         let(:training_programme) { 'provider_led' }
-        let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
+        let(:lead_provider_id) { create(:lead_provider).id }
 
         it { expect(subject.next_step).to eq(:check_answers) }
       end

--- a/spec/wizards/schools/register_ect_wizard/change_use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/change_use_previous_ect_choices_step_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Schools::RegisterECTWizard::ChangeUsePreviousECTChoicesStep, type: :model do
   subject { described_class.new(wizard:, use_previous_ect_choices: new_use_previous_ect_choices) }
 
-  let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
+  let(:lead_provider_id) { create(:lead_provider).id }
   let(:use_previous_ect_choices) { false }
   let(:new_use_previous_ect_choices) { false }
   let(:training_programme) { 'school_led' }
-  let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
-  let(:store) { FactoryBot.build(:session_repository, use_previous_ect_choices:, training_programme:, lead_provider_id:) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :change_use_previous_ect_choices, store:, school:) }
+  let(:school) { create(:school, :independent, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
+  let(:store) { build(:session_repository, use_previous_ect_choices:, training_programme:, lead_provider_id:) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :change_use_previous_ect_choices, store:, school:) }
 
   describe "inheritance" do
     it "inherits from UsePreviousECTChoicesStep" do
@@ -28,13 +28,13 @@ RSpec.describe Schools::RegisterECTWizard::ChangeUsePreviousECTChoicesStep, type
       let(:new_use_previous_ect_choices) { false }
 
       context 'when the school is independent' do
-        let(:school) { FactoryBot.create(:school, :independent, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
+        let(:school) { create(:school, :independent, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
 
         it { expect(subject.next_step).to eq(:no_previous_ect_choices_change_independent_school_appropriate_body) }
       end
 
       context 'when the school is state funded' do
-        let(:school) { FactoryBot.create(:school, :state_funded, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
+        let(:school) { create(:school, :state_funded, :teaching_school_hub_ab_last_chosen, :school_led_last_chosen) }
 
         it { expect(subject.next_step).to eq(:no_previous_ect_choices_change_state_school_appropriate_body) }
       end

--- a/spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb
@@ -3,9 +3,9 @@ describe Schools::RegisterECTWizard::CheckAnswersStep, type: :model do
 
   let(:training_programme) { 'provider_led' }
   let(:use_previous_ect_choices) { true }
-  let(:school) { FactoryBot.build(:school, :independent) }
-  let(:store) { FactoryBot.build(:session_repository, use_previous_ect_choices:, training_programme:) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :check_answers, store:, school:) }
+  let(:school) { build(:school, :independent) }
+  let(:store) { build(:session_repository, use_previous_ect_choices:, training_programme:) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :check_answers, store:, school:) }
 
   describe 'steps' do
     describe '#next_step' do

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -1,31 +1,31 @@
 RSpec.describe Schools::RegisterECTWizard::ECT do
   subject(:ect) { described_class.new(store) }
 
-  let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body, :national) }
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:author) { create(:school_user, school_urn: school.urn) }
+  let(:appropriate_body) { create(:appropriate_body, :national) }
+  let(:school) { create(:school, :independent) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     change_name: 'no',
-                     corrected_name: nil,
-                     date_of_birth: "11-10-1945",
-                     email: "dusty@rhodes.com",
-                     appropriate_body_id: appropriate_body.id,
-                     training_programme: "school_led",
-                     start_date: 'January 2025',
-                     trn: "3002586",
-                     trs_first_name: "Dusty",
-                     trs_last_name: "Rhodes",
-                     trs_date_of_birth: "1945-10-11",
-                     trs_national_insurance_number: "OWAD23455",
-                     working_pattern: "full_time")
+    build(:session_repository,
+          change_name: 'no',
+          corrected_name: nil,
+          date_of_birth: "11-10-1945",
+          email: "dusty@rhodes.com",
+          appropriate_body_id: appropriate_body.id,
+          training_programme: "school_led",
+          start_date: 'January 2025',
+          trn: "3002586",
+          trs_first_name: "Dusty",
+          trs_last_name: "Rhodes",
+          trs_date_of_birth: "1945-10-11",
+          trs_national_insurance_number: "OWAD23455",
+          working_pattern: "full_time")
   end
 
   describe '#active_record_at_school' do
-    let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
+    let(:teacher) { create(:teacher, trn: '3002586') }
 
     context 'when the ECT has an ongoing ECT record at the school' do
-      let!(:existing_ect_record) { FactoryBot.create(:ect_at_school_period, :active, school:, teacher:) }
+      let!(:existing_ect_record) { create(:ect_at_school_period, :active, school:, teacher:) }
 
       it 'returns the ECT record' do
         expect(ect.active_record_at_school(school.urn)).to eq(existing_ect_record)
@@ -33,7 +33,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     end
 
     context 'when the ECT has no ongoing ECT record at the school' do
-      let!(:existing_ect_record) { FactoryBot.create(:ect_at_school_period, school:, teacher:) }
+      let!(:existing_ect_record) { create(:ect_at_school_period, school:, teacher:) }
 
       it 'returns nil' do
         expect(ect.active_record_at_school(school.urn)).to be_nil
@@ -42,16 +42,16 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
   end
 
   describe '#active_at_school?' do
-    let(:teacher) { FactoryBot.create(:teacher, trn: ect.trn) }
+    let(:teacher) { create(:teacher, trn: ect.trn) }
 
     it 'returns true if the ECT is active at the given school' do
-      FactoryBot.create(:ect_at_school_period, :active, teacher:, school:)
+      create(:ect_at_school_period, :active, teacher:, school:)
 
       expect(ect.active_at_school?(school.urn)).to be_truthy
     end
 
     it 'returns false if the ECT is not at the given school' do
-      FactoryBot.create(:ect_at_school_period, teacher:)
+      create(:ect_at_school_period, teacher:)
 
       expect(ect.active_at_school?(school.urn)).to be_falsey
     end
@@ -324,9 +324,9 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
   end
 
   describe 'previous registration' do
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:school) { FactoryBot.create(:school) }
-    let(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: Date.new(2023, 12, 25), finished_on: Date.new(2024, 12, 25)) }
+    let(:teacher) { create(:teacher) }
+    let(:school) { create(:school) }
+    let(:ect_period) { create(:ect_at_school_period, teacher:, school:, started_on: Date.new(2023, 12, 25), finished_on: Date.new(2024, 12, 25)) }
 
     before do
       store.trn = teacher.trn
@@ -335,9 +335,9 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     describe '#induction_start_date' do
       context 'when the teacher has induction periods' do
         before do
-          FactoryBot.create(:induction_period, teacher:, started_on: Date.new(2023, 6, 10), finished_on: Date.new(2023, 9, 30))
-          FactoryBot.create(:induction_period, teacher:, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2024, 4, 30))
-          FactoryBot.create(:induction_period, teacher:, started_on: Date.new(2024, 5, 1), finished_on: Date.new(2024, 6, 30))
+          create(:induction_period, teacher:, started_on: Date.new(2023, 6, 10), finished_on: Date.new(2023, 9, 30))
+          create(:induction_period, teacher:, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2024, 4, 30))
+          create(:induction_period, teacher:, started_on: Date.new(2024, 5, 1), finished_on: Date.new(2024, 6, 30))
         end
 
         it 'returns the earliest started_on date' do
@@ -354,12 +354,12 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
     describe '#previous_appropriate_body_name' do
       context 'when the teacher has induction periods' do
-        let!(:older_body) { FactoryBot.create(:appropriate_body, name: 'Older Body') }
-        let!(:more_recent_body) { FactoryBot.create(:appropriate_body, name: 'More Recent Body') }
+        let!(:older_body) { create(:appropriate_body, name: 'Older Body') }
+        let!(:more_recent_body) { create(:appropriate_body, name: 'More Recent Body') }
 
         before do
-          FactoryBot.create(:induction_period, teacher:, started_on: Date.new(2023, 6, 10), finished_on: Date.new(2023, 9, 30), appropriate_body: older_body)
-          FactoryBot.create(:induction_period, teacher:, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2024, 4, 30), appropriate_body: more_recent_body)
+          create(:induction_period, teacher:, started_on: Date.new(2023, 6, 10), finished_on: Date.new(2023, 9, 30), appropriate_body: older_body)
+          create(:induction_period, teacher:, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2024, 4, 30), appropriate_body: more_recent_body)
         end
 
         it 'returns the name of the latest appropriate body by started_on' do
@@ -377,8 +377,8 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     describe '#previous_training_programme' do
       context 'when the teacher has ECTAtSchoolPeriods' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :school_led, lead_provider_id: nil, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          create(:ect_at_school_period, teacher:, training_programme: :school_led, lead_provider_id: nil, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
+          create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
         end
 
         it 'returns the training programme from the latest ECTAtSchoolPeriod by started_on' do
@@ -396,7 +396,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     describe '#previous_provider_led?' do
       context 'when the latest ECTAtSchoolPeriod is provider-led' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
         end
 
         it 'returns true' do
@@ -406,7 +406,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
       context 'when the latest ECTAtSchoolPeriod is school-led' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :school_led, lead_provider_id: nil, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          create(:ect_at_school_period, teacher:, training_programme: :school_led, lead_provider_id: nil, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
         end
 
         it 'returns false' do
@@ -422,16 +422,16 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     end
 
     describe '#previous_lead_provider_name' do
-      let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Confirmed LP') }
-      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+      let(:lead_provider) { create(:lead_provider, name: 'Confirmed LP') }
+      let(:active_lead_provider) { create(:active_lead_provider, lead_provider:) }
+      let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, active_lead_provider:) }
 
       before do
-        FactoryBot.create(:training_period,
-                          ect_at_school_period: ect_period,
-                          school_partnership: FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:),
-                          started_on: Date.new(2024, 1, 1),
-                          finished_on: Date.new(2024, 6, 1))
+        create(:training_period,
+               ect_at_school_period: ect_period,
+               school_partnership: create(:school_partnership, lead_provider_delivery_partnership:),
+               started_on: Date.new(2024, 1, 1),
+               finished_on: Date.new(2024, 6, 1))
       end
 
       it 'returns the name of the lead provider from the latest training period' do
@@ -440,15 +440,15 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     end
 
     describe '#previous_delivery_partner_name' do
-      let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'DP') }
-      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner:) }
+      let(:delivery_partner) { create(:delivery_partner, name: 'DP') }
+      let(:lead_provider_delivery_partnership) { create(:lead_provider_delivery_partnership, delivery_partner:) }
 
       before do
-        FactoryBot.create(:training_period,
-                          ect_at_school_period: ect_period,
-                          school_partnership: FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:),
-                          started_on: Date.new(2024, 1, 1),
-                          finished_on: Date.new(2024, 6, 1))
+        create(:training_period,
+               ect_at_school_period: ect_period,
+               school_partnership: create(:school_partnership, lead_provider_delivery_partnership:),
+               started_on: Date.new(2024, 1, 1),
+               finished_on: Date.new(2024, 6, 1))
       end
 
       it 'returns the name of the delivery partner from the latest training period' do
@@ -458,15 +458,15 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
     describe '#previous_school_name' do
       context 'when ECTAtSchoolPeriods exist' do
-        let(:school_1) { FactoryBot.create(:school) }
-        let(:school_2) { FactoryBot.create(:school) }
+        let(:school_1) { create(:school) }
+        let(:school_2) { create(:school) }
 
         before do
-          FactoryBot.create(:gias_school, school: school_1, name: 'Old School')
-          FactoryBot.create(:gias_school, school: school_2, name: 'Recent School')
+          create(:gias_school, school: school_1, name: 'Old School')
+          create(:gias_school, school: school_2, name: 'Recent School')
 
-          FactoryBot.create(:ect_at_school_period, teacher:, school: school_1, started_on: Date.new(2023, 1, 1), finished_on: Date.new(2023, 6, 30))
-          FactoryBot.create(:ect_at_school_period, teacher:, school: school_2, started_on: Date.new(2023, 9, 1), finished_on: nil)
+          create(:ect_at_school_period, teacher:, school: school_1, started_on: Date.new(2023, 1, 1), finished_on: Date.new(2023, 6, 30))
+          create(:ect_at_school_period, teacher:, school: school_2, started_on: Date.new(2023, 9, 1), finished_on: nil)
         end
 
         it 'returns the name of the most recent school by started_on' do

--- a/spec/wizards/schools/register_ect_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/email_address_step_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::RegisterECTWizard::EmailAddressStep, type: :model do
   subject { described_class.new(wizard:) }
 
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:store) { FactoryBot.build(:session_repository, email: 'prepopulated@example.com', trn: teacher.trn) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :email_address, store:) }
+  let(:teacher) { create(:teacher) }
+  let(:store) { build(:session_repository, email: 'prepopulated@example.com', trn: teacher.trn) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :email_address, store:) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -64,7 +64,7 @@ RSpec.describe Schools::RegisterECTWizard::EmailAddressStep, type: :model do
 
   describe '#previous_step' do
     context 'when the teacher has been registered before' do
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+      let!(:ect_at_school_period) { create(:ect_at_school_period, teacher:) }
 
       it 'returns the previous ect details page' do
         expect(subject.previous_step).to eq(:registered_before)
@@ -88,7 +88,7 @@ RSpec.describe Schools::RegisterECTWizard::EmailAddressStep, type: :model do
         }
       )
     end
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :email_address, step_params:) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :email_address, step_params:) }
 
     context 'when the step is not valid' do
       before do

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -2,15 +2,15 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
   subject { described_class.new(wizard:) }
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Wayne",
-                     change_name: "yes",
-                     corrected_name: "Jim Wayne",
-                     date_of_birth: "01/01/1990")
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Wayne",
+          change_name: "yes",
+          corrected_name: "Jim Wayne",
+          date_of_birth: "01/01/1990")
   end
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :find_ect, store:) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :find_ect, store:) }
 
   describe 'validations' do
     ['12345', 'RP99/12345', 'RP / 1234567', '  R P 99 / 1234', 'ZZ-123445 '].each do |trn|
@@ -39,8 +39,8 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
   describe '#next_step' do
     subject { wizard.current_step }
 
-    let(:school) { FactoryBot.create(:school, :state_funded) }
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :find_ect, step_params:, school:) }
+    let(:school) { create(:school, :state_funded) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :find_ect, step_params:, school:) }
     let(:step_params) do
       ActionController::Parameters.new(
         "find_ect" => {
@@ -86,8 +86,8 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
 
     context 'when the ect is already active at the school' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :active, teacher:, school:) }
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:active_ect_period) { create(:ect_at_school_period, :teaching_school_hub_ab, :active, teacher:, school:) }
 
       before do
         wizard.store.update!(school_urn: active_ect_period.school.urn)
@@ -101,7 +101,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
 
     context 'when the teacher completed induction' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new
@@ -127,7 +127,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
 
     context 'when the teacher is exempt from induction' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new
@@ -153,7 +153,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
 
     context 'when the teacher failed induction' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new
@@ -179,7 +179,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
 
     context 'when the teacher is prohibited from teaching' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new
@@ -211,7 +211,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
 
     context 'otherwise' do
-      let(:school) { FactoryBot.create(:school) }
+      let(:school) { create(:school) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
@@ -229,7 +229,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :find_ect) }
+      let(:wizard) { build(:register_ect_wizard, current_step: :find_ect) }
 
       it 'does not update any data in the wizard ect' do
         expect { subject.save! }.not_to change(subject.ect, :trn)
@@ -243,7 +243,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     context 'when the step is valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :find_ect, step_params:) }
+      let(:wizard) { build(:register_ect_wizard, current_step: :find_ect, step_params:) }
       let(:step_params) do
         ActionController::Parameters.new(
           "find_ect" => {

--- a/spec/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/independent_school_appropriate_body_step_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep, type: :model do
   subject { described_class.new(wizard:, appropriate_body_id: '123') }
 
-  let(:school) { FactoryBot.create(:school, :independent) }
-  let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :independent_school_appropriate_body, store:, school:) }
+  let(:school) { create(:school, :independent) }
+  let(:store) { build(:session_repository, appropriate_body_id: '123') }
+  let(:wizard) { build(:register_ect_wizard, current_step: :independent_school_appropriate_body, store:, school:) }
 
   describe "inheritance" do
     it "inherits from AppropriateBodyStep" do
@@ -22,7 +22,7 @@ RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep,
 
       context "when the type is 'national'" do
         let(:appropriate_body_type) { 'national' }
-        let!(:istip) { FactoryBot.create(:appropriate_body, :istip) }
+        let!(:istip) { create(:appropriate_body, :istip) }
 
         it 'populate the instance from ISTIP' do
           expect(subject.appropriate_body_id).to eq(istip.id.to_s)
@@ -51,7 +51,7 @@ RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep,
     subject { described_class.new(wizard:, appropriate_body_id:, appropriate_body_type:) }
 
     context 'when the appropriate_body is a national' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :istip).id }
+      let(:appropriate_body_id) { create(:appropriate_body, :istip).id }
       let(:appropriate_body_type) { 'national' }
 
       it 'adds no error' do
@@ -60,7 +60,7 @@ RSpec.describe Schools::RegisterECTWizard::IndependentSchoolAppropriateBodyStep,
     end
 
     context 'when the appropriate_body is a teaching school hub' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :teaching_school_hub).id }
+      let(:appropriate_body_id) { create(:appropriate_body, :teaching_school_hub).id }
       let(:appropriate_body_type) { 'teaching_school_hub' }
 
       it 'adds no error' do

--- a/spec/wizards/schools/register_ect_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/lead_provider_step_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Schools::RegisterECTWizard::LeadProviderStep, type: :model do
 
     context 'when the lead_provider_id is present and the lead provider exists' do
       let(:lead_provider_id) { lead_provider.id }
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:lead_provider) { create(:lead_provider) }
 
       it { expect(subject).to be_valid }
     end
@@ -32,7 +32,7 @@ RSpec.describe Schools::RegisterECTWizard::LeadProviderStep, type: :model do
     subject { wizard.current_step }
 
     let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :lead_provider)
+      build(:register_ect_wizard, current_step: :lead_provider)
     end
 
     describe '#next_step' do
@@ -60,7 +60,7 @@ RSpec.describe Schools::RegisterECTWizard::LeadProviderStep, type: :model do
     end
 
     let(:wizard) do
-      FactoryBot.build(:register_ect_wizard, current_step: :lead_provider, step_params:)
+      build(:register_ect_wizard, current_step: :lead_provider, step_params:)
     end
 
     context 'when the step is not valid' do

--- a/spec/wizards/schools/register_ect_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/national_insurance_number_step_spec.rb
@@ -10,16 +10,16 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
   end
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Wayne",
-                     change_name: "yes",
-                     corrected_name: "Jim Wayne",
-                     date_of_birth: "01/01/1990",
-                     national_insurance_number: "JL056123D")
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Wayne",
+          change_name: "yes",
+          corrected_name: "Jim Wayne",
+          date_of_birth: "01/01/1990",
+          national_insurance_number: "JL056123D")
   end
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number, store:) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :national_insurance_number, store:) }
 
   describe 'validations' do
     [
@@ -56,8 +56,8 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
       )
     end
     let(:induction_status) {}
-    let(:school) { FactoryBot.create(:school, :state_funded) }
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number, step_params:, school:) }
+    let(:school) { create(:school, :state_funded) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :national_insurance_number, step_params:, school:) }
 
     context 'when the ect is not found in TRS' do
       before do
@@ -71,7 +71,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
     end
 
     context 'blocking registration' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         allow(fake_trs_client).to receive(:find_teacher).and_return(fake_trs_teacher)
@@ -105,7 +105,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
     end
 
     context 'otherwise' do
-      let(:school) { FactoryBot.create(:school) }
+      let(:school) { create(:school) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
@@ -122,8 +122,8 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
   describe '#previous_step' do
     subject { wizard.current_step }
 
-    let(:school) { FactoryBot.create(:school, :state_funded) }
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number, step_params:, school:) }
+    let(:school) { create(:school, :state_funded) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :national_insurance_number, step_params:, school:) }
 
     it 'returns :find_ect' do
       expect(subject.previous_step).to eq(:find_ect)
@@ -134,7 +134,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
     context 'when the step is not valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number) }
+      let(:wizard) { build(:register_ect_wizard, current_step: :national_insurance_number) }
 
       it 'does not update any data in the wizard ect' do
         expect { subject.save! }.not_to change(subject.ect, :national_insurance_number)
@@ -149,7 +149,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
     context 'when the step is valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number, step_params:) }
+      let(:wizard) { build(:register_ect_wizard, current_step: :national_insurance_number, step_params:) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)

--- a/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_independent_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_independent_school_appropriate_body_step_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::RegisterECTWizard::NoPreviousECTChoicesChangeIndependentSchoolAppropriateBodyStep, type: :model do
   subject { described_class.new(wizard:, appropriate_body_id: '123', appropriate_body_type: 'Some Teaching School Hub') }
 
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_independent_school_appropriate_body, school:)
+    build(:register_ect_wizard, current_step: :change_independent_school_appropriate_body, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_lead_provider_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_lead_provider_step_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Schools::RegisterECTWizard::NoPreviousECTChoicesChangeLeadProvide
   subject { described_class.new(wizard:, lead_provider_id:) }
 
   let(:lead_provider_id) { '1' }
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_lead_provider, school:)
+    build(:register_ect_wizard, current_step: :change_lead_provider, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_state_school_appropriate_body_step_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Schools::RegisterECTWizard::NoPreviousECTChoicesChangeStateSchoolAppropriateBodyStep, type: :model do
   subject { described_class.new(wizard:, appropriate_body_id: '123') }
 
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_independent_school_appropriate_body, school:)
+    build(:register_ect_wizard, current_step: :change_independent_school_appropriate_body, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_training_programme_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/no_previous_ect_choices_change_training_programme_step_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Schools::RegisterECTWizard::NoPreviousECTChoicesChangeTrainingProgrammeStep, type: :model do
   subject { described_class.new(wizard:, training_programme: new_training_programme) }
 
-  let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
+  let(:lead_provider_id) { create(:lead_provider).id }
   let(:training_programme) { 'school_led' }
   let(:new_training_programme) { 'provider_led' }
-  let(:independent_school) { FactoryBot.create(:school, :independent) }
-  let(:state_funded_school) { FactoryBot.create(:school, :state_funded) }
+  let(:independent_school) { create(:school, :independent) }
+  let(:state_funded_school) { create(:school, :state_funded) }
   let(:school) { independent_school }
-  let(:store) { FactoryBot.build(:session_repository, training_programme:, lead_provider_id:) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :change_training_programme, store:, school:) }
+  let(:store) { build(:session_repository, training_programme:, lead_provider_id:) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :change_training_programme, store:, school:) }
 
   describe "inheritance" do
     it "inherits from TrainingProgrammeStep" do

--- a/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
@@ -3,9 +3,9 @@ describe Schools::RegisterECTWizard::ReviewECTDetailsStep, type: :model do
 
   let(:change_name) { "yes" }
   let(:corrected_name) { "Jane Smith" }
-  let(:teacher) { FactoryBot.create(:teacher) }
-  let(:store) { FactoryBot.build(:session_repository, change_name:, corrected_name:, trn: teacher.trn) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :review_ect_details, store:) }
+  let(:teacher) { create(:teacher) }
+  let(:store) { build(:session_repository, change_name:, corrected_name:, trn: teacher.trn) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :review_ect_details, store:) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -62,7 +62,7 @@ describe Schools::RegisterECTWizard::ReviewECTDetailsStep, type: :model do
 
   describe '#next_step' do
     context 'when the teacher has been registered before' do
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+      let!(:ect_at_school_period) { create(:ect_at_school_period, teacher:) }
 
       it 'returns the previous ect details page' do
         expect(subject.next_step).to eq(:registered_before)
@@ -93,7 +93,7 @@ describe Schools::RegisterECTWizard::ReviewECTDetailsStep, type: :model do
         }
       )
     end
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :review_ect_details, step_params:) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :review_ect_details, step_params:) }
 
     context 'when the step is not valid' do
       before do

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
   let(:prepopulated_start_date) { { 1 => "2025", 2 => "01", 3 => '01' } }
   let(:provided_start_date) { { 1 => "2024", 2 => "12", 3 => '01' } }
-  let(:school) { FactoryBot.build(:school) }
+  let(:school) { build(:school) }
   let(:step_params) { {} }
-  let(:store) { FactoryBot.build(:session_repository, start_date: prepopulated_start_date) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :start_date, school:, store:, step_params:) }
+  let(:store) { build(:session_repository, start_date: prepopulated_start_date) }
+  let(:wizard) { build(:register_ect_wizard, current_step: :start_date, school:, store:, step_params:) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -57,13 +57,13 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
     end
 
     let(:today) { Date.new(2024, 4, 15) }
-    let(:period_2023) { FactoryBot.create(:contract_period, year: 2023, enabled: enabled_2023) }
+    let(:period_2023) { create(:contract_period, year: 2023, enabled: enabled_2023) }
     let(:enabled_2023) { true }
 
-    let(:period_2024) { FactoryBot.create(:contract_period, year: 2024, enabled: enabled_2024) }
+    let(:period_2024) { create(:contract_period, year: 2024, enabled: enabled_2024) }
     let(:enabled_2024) { true }
 
-    let(:period_2025) { FactoryBot.create(:contract_period, year: 2025, enabled: enabled_2025) }
+    let(:period_2025) { create(:contract_period, year: 2025, enabled: enabled_2025) }
     let(:enabled_2025) { true }
 
     before do

--- a/spec/wizards/schools/register_ect_wizard/state_school_appropriate_body_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/state_school_appropriate_body_step_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep, type: :model do
-  let(:school) { FactoryBot.create(:school, :state_funded) }
-  let(:store) { FactoryBot.build(:session_repository, appropriate_body_id: '123') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:) }
+  let(:school) { create(:school, :state_funded) }
+  let(:store) { build(:session_repository, appropriate_body_id: '123') }
+  let(:wizard) { build(:register_ect_wizard, current_step: :state_school_appropriate_body, store:, school:) }
 
   describe 'validations' do
     subject { described_class.new(wizard:, appropriate_body_id:) }
 
     context 'when the appropriate_body is a national' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :national).id }
+      let(:appropriate_body_id) { create(:appropriate_body, :national).id }
 
       it 'is not valid' do
         expect(subject).not_to be_valid
@@ -16,7 +16,7 @@ RSpec.describe Schools::RegisterECTWizard::StateSchoolAppropriateBodyStep, type:
     end
 
     context 'when the appropriate_body is a teaching school hub' do
-      let(:appropriate_body_id) { FactoryBot.create(:appropriate_body, :teaching_school_hub).id }
+      let(:appropriate_body_id) { create(:appropriate_body, :teaching_school_hub).id }
       let(:appropriate_body_type) { 'teaching_school_hub' }
 
       it 'adds no error' do

--- a/spec/wizards/schools/register_ect_wizard/training_programme_change_lead_provider_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/training_programme_change_lead_provider_step_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe Schools::RegisterECTWizard::TrainingProgrammeChangeLeadProviderSt
   subject { described_class.new(wizard:, lead_provider_id:) }
 
   let(:lead_provider_id) { '1' }
-  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:school) { create(:school, :independent) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :change_lead_provider, school:)
+    build(:register_ect_wizard, current_step: :change_lead_provider, school:)
   end
 
   describe "inheritance" do

--- a/spec/wizards/schools/register_ect_wizard/training_programme_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/training_programme_step_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Schools::RegisterECTWizard::TrainingProgrammeStep, type: :model do
-  let(:school) { FactoryBot.build(:school) }
-  let(:store) { FactoryBot.build(:session_repository, training_programme: 'prepopulated_training_programme') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :training_programme, school:, store:) }
+  let(:school) { build(:school) }
+  let(:store) { build(:session_repository, training_programme: 'prepopulated_training_programme') }
+  let(:wizard) { build(:register_ect_wizard, current_step: :training_programme, school:, store:) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -76,7 +76,7 @@ RSpec.describe Schools::RegisterECTWizard::TrainingProgrammeStep, type: :model d
 
     describe '#previous_step' do
       context 'when the school is independent' do
-        let(:school) { FactoryBot.create(:school, :independent) }
+        let(:school) { create(:school, :independent) }
 
         it 'returns :independent_school_appropriate_body' do
           expect(subject.previous_step).to eq(:independent_school_appropriate_body)
@@ -84,7 +84,7 @@ RSpec.describe Schools::RegisterECTWizard::TrainingProgrammeStep, type: :model d
       end
 
       context 'when the school is state-funded' do
-        let(:school) { FactoryBot.create(:school, :state_funded) }
+        let(:school) { create(:school, :state_funded) }
 
         it 'returns :state_school_appropriate_body' do
           expect(subject.previous_step).to eq(:state_school_appropriate_body)
@@ -96,7 +96,7 @@ RSpec.describe Schools::RegisterECTWizard::TrainingProgrammeStep, type: :model d
   context '#save!' do
     subject { wizard.current_step }
 
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :training_programme, step_params:) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :training_programme, step_params:) }
 
     context 'when the step is not valid' do
       let(:step_params) { ActionController::Parameters.new("training_programme" => {}) }

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
 
   let(:use_previous_ect_choices) { true }
   let(:step_params) { {} }
-  let(:school) { FactoryBot.create(:school) }
-  let(:store) { FactoryBot.build(:session_repository, use_previous_ect_choices:) }
+  let(:school) { create(:school) }
+  let(:store) { build(:session_repository, use_previous_ect_choices:) }
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :use_previous_ect_choices, school:, store:, step_params:)
+    build(:register_ect_wizard, current_step: :use_previous_ect_choices, school:, store:, step_params:)
   end
 
   describe '#initialize' do
@@ -40,13 +40,13 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       let(:use_previous_ect_choices) { false }
 
       context 'for independent schools' do
-        let(:school) { FactoryBot.create(:school, :independent) }
+        let(:school) { create(:school, :independent) }
 
         it { expect(subject.next_step).to eq(:independent_school_appropriate_body) }
       end
 
       context 'for state-funded schools' do
-        let(:school) { FactoryBot.create(:school, :state_funded) }
+        let(:school) { create(:school, :state_funded) }
 
         it { expect(subject.next_step).to eq(:state_school_appropriate_body) }
       end

--- a/spec/wizards/schools/register_ect_wizard/working_pattern_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/working_pattern_step_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Schools::RegisterECTWizard::WorkingPatternStep, type: :model do
-  let(:school) { FactoryBot.build(:school) }
-  let(:store) { FactoryBot.build(:session_repository, working_pattern: 'prepopulated_value') }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :working_pattern, school:, store:) }
+  let(:school) { build(:school) }
+  let(:store) { build(:session_repository, working_pattern: 'prepopulated_value') }
+  let(:wizard) { build(:register_ect_wizard, current_step: :working_pattern, school:, store:) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -97,7 +97,7 @@ RSpec.describe Schools::RegisterECTWizard::WorkingPatternStep, type: :model do
         }
       )
     end
-    let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :working_pattern, step_params:) }
+    let(:wizard) { build(:register_ect_wizard, current_step: :working_pattern, step_params:) }
 
     context 'when the step is not valid' do
       before do

--- a/spec/wizards/schools/register_mentor_wizard/change_mentor_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/change_mentor_details_step_spec.rb
@@ -9,16 +9,16 @@ describe Schools::RegisterMentorWizard::ChangeMentorDetailsStep, type: :model do
     subject { wizard.current_step }
 
     let(:store) do
-      FactoryBot.build(:session_repository,
-                       trn: '1234567',
-                       trs_first_name: 'John',
-                       trs_last_name: 'Wayne',
-                       change_name: 'yes',
-                       corrected_name: 'Jim Wayne',
-                       date_of_birth: '01/01/1990',
-                       email: 'initial@email.com')
+      build(:session_repository,
+            trn: '1234567',
+            trs_first_name: 'John',
+            trs_last_name: 'Wayne',
+            change_name: 'yes',
+            corrected_name: 'Jim Wayne',
+            date_of_birth: '01/01/1990',
+            email: 'initial@email.com')
     end
-    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :change_mentor_details, store:) }
+    let(:wizard) { build(:register_mentor_wizard, current_step: :change_mentor_details, store:) }
 
     it { expect(subject.previous_step).to eq(:check_answers) }
   end

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -1,12 +1,12 @@
 describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
   subject { wizard.current_step }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :provider_led) }
+  let(:ect) { create(:ect_at_school_period, :active, :provider_led) }
   let(:training_programme) { 'provider_led' }
   let(:use_previous_ect_choices) { true }
-  let(:store) { FactoryBot.build(:session_repository) }
-  let(:author) { FactoryBot.create(:school_user, school_urn: ect.school.urn) }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :check_answers, store:, author:, ect_id: ect.id) }
+  let(:store) { build(:session_repository) }
+  let(:author) { create(:school_user, school_urn: ect.school.urn) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :check_answers, store:, author:, ect_id: ect.id) }
 
   describe 'steps' do
     describe '#next_step' do
@@ -24,7 +24,7 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
         end
 
         context 'when the ect is not provider led' do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led) }
+          let(:ect) { create(:ect_at_school_period, :active, :school_led) }
 
           it { expect(subject.previous_step).to eq(:email_address) }
         end
@@ -41,7 +41,7 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
   end
 
   context '#save!' do
-    let(:ect) { FactoryBot.create(:ect_at_school_period) }
+    let(:ect) { create(:ect_at_school_period) }
     let(:ect_id) { ect.id }
 
     context 'when the step is not valid' do

--- a/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
@@ -19,7 +19,7 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
 
   context 'with funding exemption' do
     before do
-      FactoryBot.create(:teacher, :early_roll_out_mentor, trn: "1234567")
+      create(:teacher, :early_roll_out_mentor, trn: "1234567")
     end
 
     it_behaves_like 'an email step', current_step: :email_address,
@@ -31,7 +31,7 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
     it_behaves_like 'an email step', current_step: :email_address,
                                      previous_step: :review_mentor_details,
                                      next_step: :check_answers do
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led) }
+      let(:ect) { create(:ect_at_school_period, :active, :school_led) }
     end
   end
 end

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -2,14 +2,14 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
   subject { described_class.new(wizard:) }
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Wayne",
-                     corrected_name: "Jim Wayne",
-                     date_of_birth: "01/01/1990")
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Wayne",
+          corrected_name: "Jim Wayne",
+          date_of_birth: "01/01/1990")
   end
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :find_mentor, store:) }
 
   describe '#initialize' do
     subject(:instance) { described_class.new(wizard:, **params) }
@@ -61,8 +61,8 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
   describe '#next_step' do
     subject { wizard.current_step }
 
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
-    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, step_params:, ect_id: ect.id) }
+    let(:ect) { create(:ect_at_school_period, :active) }
+    let(:wizard) { build(:register_mentor_wizard, current_step: :find_mentor, step_params:, ect_id: ect.id) }
     let(:step_params) do
       ActionController::Parameters.new(
         "find_mentor" => {
@@ -86,8 +86,8 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     end
 
     context 'when the mentor trn matches that of the ECT' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher:) }
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:ect) { create(:ect_at_school_period, :active, teacher:) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
@@ -122,8 +122,8 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     end
 
     context 'when the mentor is already active at the school' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher:) }
 
       before do
         wizard.store.update!(school_urn: active_mentor_period.school.urn)
@@ -137,7 +137,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     end
 
     context 'when the mentor is prohibited from teaching' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new
@@ -169,7 +169,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     end
 
     context 'otherwise' do
-      let(:school) { FactoryBot.create(:school) }
+      let(:school) { create(:school) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
@@ -187,7 +187,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor) }
+      let(:wizard) { build(:register_mentor_wizard, current_step: :find_mentor) }
 
       it 'does not update any data in the wizard mentor' do
         expect { subject.save! }.not_to change(subject.mentor, :trn)
@@ -201,7 +201,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     context 'when the step is valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, step_params:) }
+      let(:wizard) { build(:register_mentor_wizard, current_step: :find_mentor, step_params:) }
       let(:step_params) do
         ActionController::Parameters.new(
           "find_mentor" => {

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -1,25 +1,25 @@
 describe Schools::RegisterMentorWizard::Mentor do
   subject(:mentor) { described_class.new(store) }
 
-  let(:school) { FactoryBot.create(:school) }
-  let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
+  let(:school) { create(:school) }
+  let(:author) { create(:school_user, school_urn: school.urn) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: '3002586',
-                     date_of_birth: '11-10-1945',
-                     trs_first_name: 'Dusty',
-                     trs_last_name: 'Rhodes',
-                     trs_date_of_birth: '1945-10-11',
-                     corrected_name: nil,
-                     email: 'dusty@rhodes.com',
-                     school_urn: school.urn)
+    build(:session_repository,
+          trn: '3002586',
+          date_of_birth: '11-10-1945',
+          trs_first_name: 'Dusty',
+          trs_last_name: 'Rhodes',
+          trs_date_of_birth: '1945-10-11',
+          corrected_name: nil,
+          email: 'dusty@rhodes.com',
+          school_urn: school.urn)
   end
 
   describe '#active_at_school?' do
-    let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
+    let(:teacher) { create(:teacher, trn: '3002586') }
 
     context 'when the mentor has an ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :active, school:, teacher:) }
+      let!(:existing_mentor_record) { create(:mentor_at_school_period, :active, school:, teacher:) }
 
       it 'returns true' do
         expect(mentor.active_at_school?).to be(true)
@@ -27,7 +27,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
 
     context 'when the mentor has no ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, school:, teacher:) }
+      let!(:existing_mentor_record) { create(:mentor_at_school_period, school:, teacher:) }
 
       it 'returns false' do
         expect(mentor.active_at_school?).to be(false)
@@ -36,10 +36,10 @@ describe Schools::RegisterMentorWizard::Mentor do
   end
 
   describe '#active_record_at_school' do
-    let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
+    let(:teacher) { create(:teacher, trn: '3002586') }
 
     context 'when the mentor has an ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :active, school:, teacher:) }
+      let!(:existing_mentor_record) { create(:mentor_at_school_period, :active, school:, teacher:) }
 
       it 'returns the mentor record' do
         expect(mentor.active_record_at_school).to eq(existing_mentor_record)
@@ -47,7 +47,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
 
     context 'when the mentor has no ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, school:, teacher:) }
+      let!(:existing_mentor_record) { create(:mentor_at_school_period, school:, teacher:) }
 
       it 'returns nil' do
         expect(mentor.active_record_at_school).to be_nil

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -2,17 +2,17 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
   subject { described_class.new(wizard:) }
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: '1234567',
-                     trs_first_name: 'John',
-                     trs_last_name: 'Wayne',
-                     change_name: 'yes',
-                     corrected_name: 'Jim Wayne',
-                     date_of_birth: '01/01/1990',
-                     email: 'initial@email.com',
-                     national_insurance_number: 'Ab123456A')
+    build(:session_repository,
+          trn: '1234567',
+          trs_first_name: 'John',
+          trs_last_name: 'Wayne',
+          change_name: 'yes',
+          corrected_name: 'Jim Wayne',
+          date_of_birth: '01/01/1990',
+          email: 'initial@email.com',
+          national_insurance_number: 'Ab123456A')
   end
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :national_insurance_number, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step: :national_insurance_number, store:) }
 
   describe '#initialisation' do
     subject { described_class.new(wizard:, **params) }
@@ -60,7 +60,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
   describe '#next_step' do
     subject { wizard.current_step }
 
-    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :national_insurance_number, step_params:) }
+    let(:wizard) { build(:register_mentor_wizard, current_step: :national_insurance_number, step_params:) }
     let(:step_params) do
       ActionController::Parameters.new(
         "national_insurance_number" => {
@@ -81,8 +81,8 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
 
     context 'when the mentor is already active at the school' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher:) }
 
       before do
         wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
@@ -96,8 +96,8 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
 
     context 'when the mentor is already active at the school' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+      let(:teacher) { create(:teacher, trn: '1234568') }
+      let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher:) }
 
       before do
         wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
@@ -111,7 +111,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
 
     context 'when the mentor is prohibited from teaching' do
-      let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
+      let(:teacher) { create(:teacher, trn: '1234568') }
 
       before do
         fake_client = TRS::FakeAPIClient.new
@@ -143,7 +143,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
 
     context 'otherwise' do
-      let(:school) { FactoryBot.create(:school) }
+      let(:school) { create(:school) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
@@ -169,7 +169,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     context 'when the step is not valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :national_insurance_number) }
+      let(:wizard) { build(:register_mentor_wizard, current_step: :national_insurance_number) }
 
       it 'does not update any data in the wizard mentor' do
         expect { subject.save! }.not_to change(subject.mentor, :national_insurance_number)
@@ -181,7 +181,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     context 'when the step is valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :national_insurance_number, step_params:) }
+      let(:wizard) { build(:register_mentor_wizard, current_step: :national_insurance_number, step_params:) }
       let(:step_params) do
         ActionController::Parameters.new(
           "national_insurance_number" => {

--- a/spec/wizards/schools/register_mentor_wizard/review_mentor_details_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/review_mentor_details_step_spec.rb
@@ -9,16 +9,16 @@ describe Schools::RegisterMentorWizard::ReviewMentorDetailsStep, type: :model do
     subject { wizard.current_step }
 
     let(:store) do
-      FactoryBot.build(:session_repository,
-                       trn: '1234567',
-                       trs_first_name: 'John',
-                       trs_last_name: 'Wayne',
-                       change_name: 'yes',
-                       corrected_name: 'Jim Wayne',
-                       date_of_birth: '01/01/1990',
-                       email: 'initial@email.com')
+      build(:session_repository,
+            trn: '1234567',
+            trs_first_name: 'John',
+            trs_last_name: 'Wayne',
+            change_name: 'yes',
+            corrected_name: 'Jim Wayne',
+            date_of_birth: '01/01/1990',
+            email: 'initial@email.com')
     end
-    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :review_mentor_details, store:) }
+    let(:wizard) { build(:register_mentor_wizard, current_step: :review_mentor_details, store:) }
 
     context "when the date of birth matches TRS" do
       before { allow(wizard.mentor).to receive(:matches_trs_dob?).and_return(true) }

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/cant_use_email_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/cant_use_email_step.rb
@@ -2,15 +2,15 @@ RSpec.shared_examples "a can't use email step" do |current_step:, previous_step:
   subject { described_class.new(wizard:) }
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: '1234567',
-                     trs_first_name: 'John',
-                     trs_last_name: 'Wayne',
-                     change_name: 'no',
-                     date_of_birth: '01/01/1990',
-                     email: 'initial@email.com')
+    build(:session_repository,
+          trn: '1234567',
+          trs_first_name: 'John',
+          trs_last_name: 'Wayne',
+          change_name: 'no',
+          date_of_birth: '01/01/1990',
+          email: 'initial@email.com')
   end
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:) }
 
   describe '#next_step' do
     it { expect(wizard.next_step).to eq(next_step) }

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
@@ -1,17 +1,17 @@
 RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_step:|
   subject { described_class.new(wizard:) }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :provider_led) }
+  let(:ect) { create(:ect_at_school_period, :active, :provider_led) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: "1234567",
-                     trs_first_name: "John",
-                     trs_last_name: "Wayne",
-                     corrected_name: "Jim Wayne",
-                     date_of_birth: "01/01/1990",
-                     email: 'initial@email.com')
+    build(:session_repository,
+          trn: "1234567",
+          trs_first_name: "John",
+          trs_last_name: "Wayne",
+          corrected_name: "Jim Wayne",
+          date_of_birth: "01/01/1990",
+          email: 'initial@email.com')
   end
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:, ect_id: ect.id) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:, ect_id: ect.id) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }
@@ -46,14 +46,14 @@ RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_st
     end
 
     let(:wizard) do
-      FactoryBot.build(:register_mentor_wizard, current_step:, store:, step_params:, ect_id: ect.id)
+      build(:register_mentor_wizard, current_step:, store:, step_params:, ect_id: ect.id)
     end
 
     it { expect(wizard.next_step).to eq(next_step) }
   end
 
   describe '#previous_step' do
-    subject { FactoryBot.build(:register_mentor_wizard, current_step:, step_params:, ect_id: ect.id).current_step }
+    subject { build(:register_mentor_wizard, current_step:, step_params:, ect_id: ect.id).current_step }
 
     let(:step_params) do
       ActionController::Parameters.new("email_address" => { "email" => 'valid@email.com' })

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
@@ -2,16 +2,16 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
   subject { described_class.new(wizard:) }
 
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     trn: '1234567',
-                     trs_first_name: 'John',
-                     trs_last_name: 'Wayne',
-                     change_name: 'yes',
-                     corrected_name: 'Jim Wayne',
-                     date_of_birth: '01/01/1990',
-                     email: 'initial@email.com')
+    build(:session_repository,
+          trn: '1234567',
+          trs_first_name: 'John',
+          trs_last_name: 'Wayne',
+          change_name: 'yes',
+          corrected_name: 'Jim Wayne',
+          date_of_birth: '01/01/1990',
+          email: 'initial@email.com')
   end
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:) }
 
   describe '#initialisation' do
     subject { described_class.new(wizard:, **params) }
@@ -70,7 +70,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
     end
 
     let(:wizard) do
-      FactoryBot.build(:register_mentor_wizard, current_step:, step_params:)
+      build(:register_mentor_wizard, current_step:, step_params:)
     end
 
     it { expect(subject.next_step).to eq(next_step) }
@@ -80,7 +80,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
     context 'when the step is not valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:) }
+      let(:wizard) { build(:register_mentor_wizard, current_step:) }
 
       it 'does not update any data in the wizard mentor' do
         expect { subject.save! }.not_to change(subject.mentor, :corrected_name)
@@ -90,7 +90,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
     context 'when the step is valid' do
       subject { wizard.current_step }
 
-      let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, step_params:) }
+      let(:wizard) { build(:register_mentor_wizard, current_step:, step_params:) }
       let(:step_params) do
         ActionController::Parameters.new(
           current_step.to_s => {

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -1,7 +1,7 @@
 describe Schools::RegisterMentorWizard::Wizard do
   let(:current_step) { :find_mentor }
-  let(:ect_teacher) { FactoryBot.create(:teacher, trn: "7654321") }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher: ect_teacher) }
+  let(:ect_teacher) { create(:teacher, trn: "7654321") }
+  let(:ect) { create(:ect_at_school_period, :active, teacher: ect_teacher) }
   let(:ect_id) { ect.id }
   let(:mentor_trn) { "1234567" }
   let(:mentor_date_of_birth) { "1977-02-03" }
@@ -10,19 +10,19 @@ describe Schools::RegisterMentorWizard::Wizard do
   let(:trs_date_of_birth) { "1977-02-03" }
   let(:trs_first_name) { "Mentor" }
   let(:trs_last_name) { "LastName" }
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:, ect_id:) }
+  let(:wizard) { build(:register_mentor_wizard, current_step:, store:, ect_id:) }
 
   describe '#allowed_steps' do
     subject { wizard.allowed_steps }
 
     context 'when no data has been set yet' do
-      let(:store) { FactoryBot.build(:session_repository, school_urn:) }
+      let(:store) { build(:session_repository, school_urn:) }
 
       it { is_expected.to eq(%i[no_trn find_mentor]) }
     end
 
     context 'when only TRN has been set' do
-      let(:store) { FactoryBot.build(:session_repository, trn: mentor_trn, school_urn:) }
+      let(:store) { build(:session_repository, trn: mentor_trn, school_urn:) }
 
       described_class.steps.first.each_key do |step|
         context "when the requested step is #{step}" do
@@ -35,14 +35,14 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context 'when only TRN and DoB have been set' do
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:)
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:)
       end
 
       context 'when the mentor has not been found in TRS' do
@@ -67,8 +67,8 @@ describe Schools::RegisterMentorWizard::Wizard do
       end
 
       context 'when the mentor is already active at the school' do
-        let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+        let(:mentor_teacher) { create(:teacher, trn: mentor_trn) }
+        let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
         let(:school_urn) { active_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor already_active_at_school]) }
@@ -88,15 +88,15 @@ describe Schools::RegisterMentorWizard::Wizard do
     context 'when only TRN, DoB and Nino have been set' do
       let(:mentor_date_of_birth) { "2000-01-01" }
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         national_insurance_number: 'ZZ123456A')
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              national_insurance_number: 'ZZ123456A')
       end
 
       context 'when the mentor has not been found in TRS' do
@@ -109,8 +109,8 @@ describe Schools::RegisterMentorWizard::Wizard do
       end
 
       context 'when the mentor is already active at the school' do
-        let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+        let(:mentor_teacher) { create(:teacher, trn: mentor_trn) }
+        let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
         let(:school_urn) { active_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor national_insurance_number already_active_at_school]) }
@@ -128,20 +128,20 @@ describe Schools::RegisterMentorWizard::Wizard do
     end
 
     context 'when only TRN, DoB and already active at school have been set' do
-      let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+      let(:mentor_teacher) { create(:teacher, trn: mentor_trn) }
+      let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
       let(:school_urn) { active_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         already_active_at_school:)
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              already_active_at_school:)
       end
 
       it { is_expected.to eq(%i[confirmation]) }
@@ -149,21 +149,21 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context 'when only TRN, DoB, Nino and already active at school have been set' do
       let(:mentor_date_of_birth) { "2000-01-01" }
-      let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+      let(:mentor_teacher) { create(:teacher, trn: mentor_trn) }
+      let(:active_mentor_period) { create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
       let(:school_urn) { active_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         national_insurance_number: 'ZZ123456A',
-                         already_active_at_school:)
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              national_insurance_number: 'ZZ123456A',
+              already_active_at_school:)
       end
 
       it { is_expected.to eq(%i[confirmation]) }
@@ -171,15 +171,15 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context 'when only TRN, DoB and change name (and maybe corrected name) have been set' do
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         change_name: 'no')
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              change_name: 'no')
       end
 
       it { is_expected.to eq(%i[find_mentor review_mentor_details email_address]) }
@@ -188,17 +188,17 @@ describe Schools::RegisterMentorWizard::Wizard do
     context 'when only TRN, DoB, Nino and change name (and maybe corrected name) have been set' do
       let(:mentor_date_of_birth) { "2000-01-01" }
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         national_insurance_number: 'ZZ123456A',
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         change_name: 'yes',
-                         corrected_name: 'Mentor CorrectedName')
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              national_insurance_number: 'ZZ123456A',
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              change_name: 'yes',
+              corrected_name: 'Mentor CorrectedName')
       end
 
       it { is_expected.to eq(%i[find_mentor national_insurance_number review_mentor_details email_address]) }
@@ -206,16 +206,16 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context 'when only TRN, DoB, change name (and maybe corrected name) and email have been set' do
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         change_name: 'no',
-                         email: 'any@email.address')
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              change_name: 'no',
+              email: 'any@email.address')
       end
 
       context 'when the email is in use by another participant' do
@@ -249,18 +249,18 @@ describe Schools::RegisterMentorWizard::Wizard do
     context 'when only TRN, DoB, Nino, change name (and maybe corrected name) and email address have been set' do
       let(:mentor_date_of_birth) { "2000-01-01" }
       let(:store) do
-        FactoryBot.build(:session_repository,
-                         school_urn:,
-                         trn: mentor_trn,
-                         date_of_birth: mentor_date_of_birth,
-                         national_insurance_number: 'ZZ123456A',
-                         prohibited_from_teaching:,
-                         trs_date_of_birth:,
-                         trs_first_name:,
-                         trs_last_name:,
-                         change_name: 'yes',
-                         corrected_name: 'Mentor CorrectedName',
-                         email: 'any@email.address')
+        build(:session_repository,
+              school_urn:,
+              trn: mentor_trn,
+              date_of_birth: mentor_date_of_birth,
+              national_insurance_number: 'ZZ123456A',
+              prohibited_from_teaching:,
+              trs_date_of_birth:,
+              trs_first_name:,
+              trs_last_name:,
+              change_name: 'yes',
+              corrected_name: 'Mentor CorrectedName',
+              email: 'any@email.address')
       end
 
       context 'when the email is in use by another participant' do
@@ -297,7 +297,7 @@ describe Schools::RegisterMentorWizard::Wizard do
   describe '#allowed_step_path' do
     subject { wizard.allowed_step_path }
 
-    let(:store) { FactoryBot.build(:session_repository, school_urn:) }
+    let(:store) { build(:session_repository, school_urn:) }
 
     before { allow(wizard).to receive(:allowed_steps).and_return(%i[find_mentor check_answers]) }
 


### PR DESCRIPTION
### Context

So we can do things like `create(:factory)` instead of `FactoryBot.create(:factory)`.

### Changes proposed in this pull request

Including `FactoryBot::Syntax::Methods` by default in tests

### Guidance to review

Tests 💚
