### PR TITLE
[1906] - Explicitly exclude some schools from the schools migrator

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -25,7 +25,10 @@ module Migrators
 
     def self.reset! = nil
 
-    def self.schools = ::Migration::School.includes(:local_authority).eligible_or_cip_only_except_welsh
+    def self.schools = ::Migration::School
+                         .includes(:local_authority)
+                         .eligible_or_cip_only_except_welsh
+                         .not_explictly_excluded
 
     def migrate!
       migrate(self.class.schools) do |ecf_school|

--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -1,11 +1,16 @@
 module Migration
   class School < Migration::Base
     ALL_TYPE_CODES = [1, 2, 3, 5, 6, 7, 8, 10, 11, 12, 14, 15, 18, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 49, 56, 57].freeze
+
     CIP_ONLY_TYPE_CODES = [10, 11, 30, 37].freeze
     CIP_ONLY_EXCEPT_WELSH_TYPE_CODES = [10, 11, 37].freeze
+
     ELIGIBLE_TYPE_CODES = [1, 2, 3, 5, 6, 7, 8, 12, 14, 15, 18, 28, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 57].freeze
     NON_ELIGIBLE_TYPE_CODES = [10, 11, 24, 25, 26, 27, 29, 30, 37, 49, 56].freeze
+
     OPEN_STATUS_CODES = [1, 3].freeze
+
+    URNS_EXPLICITLY_EXCLUDED = %w[141310 145151 148048 148196 148197 149463 149464 149465].freeze
 
     has_many :school_cohorts
     has_many :partnerships
@@ -24,6 +29,7 @@ module Migration
     scope :cip_only_except_welsh, -> { currently_open.where(school_type_code: CIP_ONLY_EXCEPT_WELSH_TYPE_CODES) }
     scope :eligible_or_cip_only_except_welsh, -> { eligible.or(cip_only_except_welsh) }
     scope :not_cip_only, -> { where.not(id: cip_only) }
+    scope :not_explictly_excluded, -> { where.not(urn: URNS_EXPLICITLY_EXCLUDED) }
 
     def cip_only_type? = GIAS::Types::CIP_ONLY_EXCEPT_WELSH.include?(school_type_name)
 


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/1906)

Some schools of type `Special post 16 institutions` currently registered on ECF1 are missing on GIAS and therefore RECT.

We have identified these facts about these schools:

- URNs: `["141310", "145151", "148048", "148196", "148197", "149463", "149464", "149465"]`
- None of them can be found in GIAS (as opposed to be discarded by us in the GIAS-RECT importing process)
- Most of these schools on ECF1 don't even have a cohort setup
- Those with cohorts set up on ECF1 chose "no ECTs expected this year" and have no induction programme defined (or partnerships or participants).
- Many other `"Special post 16 institutions"` are coming from GIAS and are currently registered in RECT.


We have decided to exclude these schools explicitly from the ECF1 set on the schools migrator to prevent them to be checked on RECT.

### Changes proposed in this pull request

Do not include schools with urn `["141310", "145151", "148048", "148196", "148197", "149463", "149464", "149465"]`  in the comparision of schools ECF1 - RECT in `Migrators::School` 