### PR TITLE
Clarify omission of `FactoryBot::Syntax::Methods`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ RSpec.configure do |config|
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include Playwright::Test::Matchers, type: :feature
+  # FactoryBot::Syntax::Methods deliberately omitted to avoid confusion with AR's `create`/`build`.
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
### Context

The `FactoryBot::Syntax::Methods` module has been re-included multiple times with good intentions. 

To try and prevent this from happening in future, this comment explains why it's deliberately omitted. Hopefully, this prevents further changes without discussion.