### PR TITLE
Fix link in release note example

### DIFF
--- a/app/views/api/guidance/show.html.erb
+++ b/app/views/api/guidance/show.html.erb
@@ -16,7 +16,7 @@
 
     <h3 class="govuk-caption-xl">23 June 2025</h3>
     <h3 class="govuk-heading-s">View financial statements in test environment</h3>
-    <p><%= govuk_link_to("Lead providers can now check their financial statements in the API sandbox", "https://sandbox.register-early-career-teachers.education.gov.uk/api/docs/v3") %></p>
+    <p><%= govuk_link_to("Lead providers can now check their financial statements in the API sandbox", api_guidance_release_notes_path) %></p>
   </div>
 </div>
 


### PR DESCRIPTION
This link should go to the main release notes page not sandbox.

This is just an example release note, we'll be making it dynamic soon and this will all go away

