### PR TITLE
Describe event transitions consistently

### DIFF
--- a/app/services/events/describe_modifications.rb
+++ b/app/services/events/describe_modifications.rb
@@ -21,13 +21,11 @@ module Events
       return if modifications.nil?
 
       modifications.map do |attribute_name, modification|
-        if modification[0].blank?
-          "#{attribute_name.humanize} set to #{format(modification[1])}"
-        elsif modification[1].blank?
-          "#{attribute_name.humanize} #{format(modification[0])} removed"
-        else
-          "#{attribute_name.humanize} changed from #{format(modification[0])} to #{format(modification[1])}"
-        end
+        TransitionDescription.for(
+          attribute_name,
+          from: modification[0],
+          to: modification[1]
+        )
       end
     end
 

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -179,14 +179,14 @@ module Events
 
     def self.teacher_name_changed_in_trs_event!(old_name:, new_name:, author:, teacher:, appropriate_body: nil, happened_at: Time.zone.now)
       event_type = :teacher_name_updated_by_trs
-      heading = "Name changed from '#{old_name}' to '#{new_name}'"
+      heading = TransitionDescription.for("name", from: old_name, to: new_name)
 
       new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
     end
 
     def self.teacher_induction_status_changed_in_trs_event!(old_induction_status:, new_induction_status:, author:, teacher:, appropriate_body: nil, happened_at: Time.zone.now)
       event_type = :teacher_trs_induction_status_updated
-      heading = "Induction status changed from '#{old_induction_status}' to '#{new_induction_status}'"
+      heading = TransitionDescription.for("induction_status", from: old_induction_status, to: new_induction_status)
 
       new(event_type:, author:, appropriate_body:, teacher:, heading:, happened_at:).record_event!
     end

--- a/app/services/events/transition_description.rb
+++ b/app/services/events/transition_description.rb
@@ -1,0 +1,39 @@
+module Events
+  class TransitionDescription
+    def self.for(...) = new(...).describe
+
+    def initialize(attribute_name, from:, to:)
+      @attribute_name = attribute_name
+      @from = from
+      @to = to
+    end
+
+    def describe
+      case
+      when @from.blank? && @to.blank?
+        "#{@attribute_name.humanize} is not set"
+      when @from.blank?
+        "#{@attribute_name.humanize} set to #{format(@to)}"
+      when @to.blank?
+        "#{@attribute_name.humanize} #{format(@from)} removed"
+      when @from == @to
+        "#{@attribute_name.humanize} #{format(@from)} unchanged"
+      else
+        "#{@attribute_name.humanize} changed from #{format(@from)} to #{format(@to)}"
+      end
+    end
+
+  private
+
+    def format(value)
+      formatted_value = case value
+                        when Date
+                          value.to_formatted_s(:govuk_short)
+                        else
+                          value
+                        end
+
+      %('#{formatted_value}')
+    end
+  end
+end

--- a/db/scripts/fix_event_headings_with_empty_strings.rb
+++ b/db/scripts/fix_event_headings_with_empty_strings.rb
@@ -1,0 +1,15 @@
+# We introduced `Events::TransitionDescription` as a consistent entrypoint
+# for describing transitions between events.
+# This brings how we describe Event headings in line with how we describe lists of
+# event modifications.
+# We need to migrate existing data, though.
+
+# Retrieve all the events with headings that "changed from ''"
+#
+# Before: "Induction status changed from '' to 'InProgress'"
+# After: "Induction status set to 'InProgress'"
+
+Event.where("heading LIKE ?", "%changed from ''%").find_each do |event|
+  heading = event.heading.gsub("changed from ''", "set")
+  event.update_column(:heading, heading)
+end

--- a/spec/features/appropriate_bodies/process_batch_combo_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_combo_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe 'Process bulk claims then actions events' do
       "The Appropriate Body started a bulk claim",
       "The Appropriate Body completed a bulk claim",
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/
     )
 
@@ -65,10 +65,10 @@ RSpec.describe 'Process bulk claims then actions events' do
       "The Appropriate Body started a bulk claim",
       "The Appropriate Body completed a bulk claim",
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "The Appropriate Body started a bulk action"
     )
@@ -88,10 +88,10 @@ RSpec.describe 'Process bulk claims then actions events' do
       "The Appropriate Body started a bulk claim",
       "The Appropriate Body completed a bulk claim",
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "The Appropriate Body started a bulk action",
       "The Appropriate Body completed a bulk action"
@@ -102,10 +102,10 @@ RSpec.describe 'Process bulk claims then actions events' do
       "The Appropriate Body started a bulk claim",
       "The Appropriate Body completed a bulk claim",
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "Imported from TRS",
-      "Induction status changed from '' to 'InProgress'",
+      "Induction status set to 'InProgress'",
       /was claimed by The Appropriate Body/,
       "The Appropriate Body started a bulk action",
       "The Appropriate Body completed a bulk action",

--- a/spec/services/events/transition_description_spec.rb
+++ b/spec/services/events/transition_description_spec.rb
@@ -1,0 +1,86 @@
+describe Events::TransitionDescription do
+  it "describes a transition from something to something else" do
+    attribute_name = "induction_status"
+    initial_value = "NotStarted"
+    transitioned_to_value = "InProgress"
+
+    description = Events::TransitionDescription.for(
+      attribute_name,
+      from: initial_value,
+      to: transitioned_to_value
+    )
+
+    expect(description)
+      .to eq("Induction status changed from 'NotStarted' to 'InProgress'")
+  end
+
+  it "describes a transition from something to nothing" do
+    attribute_name = "induction_status"
+    initial_value = "InProgress"
+    transitioned_to_value = nil
+
+    description = Events::TransitionDescription.for(
+      attribute_name,
+      from: initial_value,
+      to: transitioned_to_value
+    )
+
+    expect(description).to eq("Induction status 'InProgress' removed")
+  end
+
+  it "describes a transition from nothing to something" do
+    attribute_name = "induction_status"
+    initial_value = nil
+    transitioned_to_value = "InProgress"
+
+    description = Events::TransitionDescription.for(
+      attribute_name,
+      from: initial_value,
+      to: transitioned_to_value
+    )
+
+    expect(description).to eq("Induction status set to 'InProgress'")
+  end
+
+  it "describes a transition from nothing to nothing" do
+    attribute_name = "induction_status"
+    initial_value = nil
+    transitioned_to_value = nil
+
+    description = Events::TransitionDescription.for(
+      attribute_name,
+      from: initial_value,
+      to: transitioned_to_value
+    )
+
+    expect(description).to eq("Induction status is not set")
+  end
+
+  it "describes a transition that hasn't changed" do
+    attribute_name = "induction_status"
+    initial_value = "InProgress"
+    transitioned_to_value = "InProgress"
+
+    description = Events::TransitionDescription.for(
+      attribute_name,
+      from: initial_value,
+      to: transitioned_to_value
+    )
+
+    expect(description).to eq("Induction status 'InProgress' unchanged")
+  end
+
+  it "describes a transition with formatted dates" do
+    attribute_name = "closed_on"
+    initial_value = nil
+    transitioned_to_value = Date.new(2025, 4, 1)
+
+    description = Events::TransitionDescription.for(
+      attribute_name,
+      from: initial_value,
+      to: transitioned_to_value
+    )
+
+    expect(description).to eq("Closed on set to '1 Apr 2025'")
+  end
+end


### PR DESCRIPTION
### Context

#761 

### Changes proposed in this pull request

Before, we described event modifications one way, but described some event headings another way.

At first we thought this was due to a bug #761, but in fact it was a consequence of this inconsistency.

This introduces an `Events::TransitionDescription` service that returns a human-readable description of an event transition. It gracefully handles blank values like the existing code, as well as handling some extra edge cases.

Now, we can use this to describe event modifications and for event headings when reporting events. Event timelines should now be clearer in all circumstances!

### Guidance to review

- Record some teacher name change and induction status change events
- Look at the timeline!
