### PR TITLE
Revert SolidQueue queue config to a single worker

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -7,10 +7,6 @@ default: &default
       threads: 3
       processes: 3
       polling_interval: 0.1
-    - queues: [parity_check_requests]
-      threads: 3
-      processes: 3
-      polling_interval: 0.1
 
 development:
   <<: *default


### PR DESCRIPTION
### Context

Worker pod was in a crash loop with `OOMKilled`. MissionControl job failures suggest this is the culprit.

### Changes proposed in this pull request

Remove second worker temporarily to mitigate crashes and restore OTP mailing

### Guidance to review
