### PR TITLE
Add env-specific entries to queue.yml

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -8,6 +8,29 @@ default: &default
       processes: 3
       polling_interval: 0.1
 
+migration:
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: [mailers, events, migration, parity_check_requests, trs_sync, dfe_analytics, "*"]
+      threads: 3
+      processes: 3
+      polling_interval: 0.1
+    - queues: [parity_check_requests]
+      threads: 3
+      processes: 3
+      polling_interval: 0.1
+
+review:
+  <<: *default
+
+staging:
+  <<: *default
+
+sandbox:
+  <<: *default
+
 development:
   <<: *default
 


### PR DESCRIPTION
In production we're seeing OOMKilled errors on workers when under load.

We suspect that the second worker in the default settings is causing each worker to have half the memory. The migration env currently has 2GB but production only has 1GB (it does far less, for now)

This change gives the migration env a parity-check spec second worker but leaves production with just one multipurpose one.

Note, this follows on from #892 and should restore any functionality removed there.