### PR TITLE
Bump production workers to 2Gi

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -11,5 +11,6 @@
     "postgres_snapshot_flexible_server_sku": "B_Standard_B2s",
     "deploy_snapshot_database": true,
     "postgres_enable_high_availability": true,
-    "azure_enable_backup_storage": true
+    "azure_enable_backup_storage": true,
+    "worker_memory_max": "2Gi"
 }


### PR DESCRIPTION
Previously it was 1Gi and it looks like we're struggling in production with it normally running in the 80-90% region.

This changes the default to 2Gi and removes the setting in migration, so:

* at 2Gi
  - production
  - migration
* at 1Gi
  - sandbox
  - staging
  - review
