### PR TITLE
Update production webapp memory max to 2Gi

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -12,5 +12,6 @@
     "deploy_snapshot_database": true,
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true,
-    "worker_memory_max": "2Gi"
+    "worker_memory_max": "2Gi",
+    "webapp_memory_max": "2Gi"
 }


### PR DESCRIPTION
Following on from #896 bump the web apps from 1Gi to 2Gi too as they're running a bit high.
