### PR TITLE
[1502] Add extra validation checks for start date when registering an ECT

### DIFF
--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -25,6 +25,18 @@ class ContractPeriod < ApplicationRecord
     find_by(*date_in_range(date))
   end
 
+  def self.earliest_permitted_start_date
+    current = containing_date(Time.zone.today)
+    return unless current
+
+    current
+      .predecessors
+      .latest_first
+      .offset(1)
+      .first
+      &.started_on
+  end
+
 private
 
   def siblings

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -134,6 +134,13 @@ module Schools
         Teachers::Name.new(self).full_name_in_trs
       end
 
+      def previous_ect_at_school_period
+        @previous_ect_at_school_period ||= ECTAtSchoolPeriods::Search
+          .new(order: :started_on)
+          .ect_periods(trn:)
+          .last
+      end
+
     private
 
       def first_induction_period
@@ -152,13 +159,6 @@ module Schools
 
       def previous_delivery_partner
         previous_training_period&.delivery_partner
-      end
-
-      def previous_ect_at_school_period
-        @previous_ect_at_school_period ||= ECTAtSchoolPeriods::Search
-          .new(order: :started_on)
-          .ect_periods(trn:)
-          .last
       end
 
       def previous_induction_period

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -40,7 +40,7 @@ module Schools
       def add_start_date_too_early_error(period)
         errors.add(
           :start_date,
-          "This ECT was previously registered at #{period.school&.name} (#{period.started_on.to_formatted_s(:govuk)}). Enter a later date."
+          "Our records show that #{wizard.ect.full_name} started teaching at #{period.school&.name} on #{period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
         )
       end
 

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -23,17 +23,17 @@ module Schools
     private
 
       def start_date_not_before_previous_school
-        return if start_date.blank? || errors[:start_date].any?
+        return if skip_start_date_validation?
 
         previous_period = ect.previous_ect_at_school_period
-        return unless valid_previous_period?(previous_period)
+        return unless previous_start_date_invalid?(previous_period)
 
         if start_date_as_date < previous_period.started_on
           add_start_date_too_early_error(previous_period)
         end
       end
 
-      def valid_previous_period?(period)
+      def previous_start_date_invalid?(period)
         period&.started_on.present?
       end
 
@@ -42,6 +42,10 @@ module Schools
           :start_date,
           "Our records show that #{wizard.ect.full_name} started teaching at #{period.school&.name} on #{period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
         )
+      end
+
+      def skip_start_date_validation?
+        start_date.blank? || errors[:start_date].any?
       end
 
       def persist

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -26,14 +26,22 @@ module Schools
         return if start_date.blank? || errors[:start_date].any?
 
         previous_period = ect.previous_ect_at_school_period
-        return if previous_period.blank? || previous_period.started_on.blank?
+        return unless valid_previous_period?(previous_period)
 
         if start_date_as_date < previous_period.started_on
-          errors.add(
-            :start_date,
-            "This ECT was previously registered at #{previous_period.school&.name} (#{previous_period.started_on.to_formatted_s(:govuk)}). Enter a later date."
-          )
+          add_start_date_too_early_error(previous_period)
         end
+      end
+
+      def valid_previous_period?(period)
+        period&.started_on.present?
+      end
+
+      def add_start_date_too_early_error(period)
+        errors.add(
+          :start_date,
+          "This ECT was previously registered at #{period.school&.name} (#{period.started_on.to_formatted_s(:govuk)}). Enter a later date."
+        )
       end
 
       def persist

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -26,7 +26,7 @@ module Schools
         return unless earliest_permitted_date
         return unless value_as_date < earliest_permitted_date
 
-        "Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}"
+        "Start date cannot be earlier than the last 2 registration periods. Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}"
       end
 
       def earliest_permitted_date

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -26,7 +26,7 @@ module Schools
         return unless earliest_permitted_date
         return unless value_as_date < earliest_permitted_date
 
-        "Enter a date later than #{earliest_permitted_date.strftime('%-d %B %Y')}"
+        "Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}"
       end
 
       def earliest_permitted_date

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -26,7 +26,7 @@ module Schools
         return unless earliest_permitted_date
         return unless value_as_date < earliest_permitted_date
 
-        "Start date cannot be earlier than the last 2 registration periods. Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}"
+        "Start date cannot be earlier than the last 2 registration periods. Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}."
       end
 
       def earliest_permitted_date

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -21,6 +21,17 @@ module Schools
       def date_missing?
         super || date_as_hash.values_at(1, 2, 3).all?(&:nil?)
       end
+
+      def extra_validation_error_message
+        return unless earliest_permitted_date
+        return unless value_as_date < earliest_permitted_date
+
+        "Enter a date later than #{earliest_permitted_date.strftime('%-d %B %Y')}"
+      end
+
+      def earliest_permitted_date
+        ContractPeriod.earliest_permitted_start_date
+      end
     end
   end
 end

--- a/lib/schools/validation/hash_date.rb
+++ b/lib/schools/validation/hash_date.rb
@@ -17,7 +17,7 @@ module Schools
       end
 
       def value_as_date
-        @value_as_date ||= Time.zone.local(*date_as_hash.values_at(1, 2, 3).map(&:to_i))
+        @value_as_date ||= Time.zone.local(*date_as_hash.values_at(1, 2, 3).map(&:to_i)).to_date
       end
 
     private

--- a/spec/lib/schools/validation/ect_start_date_spec.rb
+++ b/spec/lib/schools/validation/ect_start_date_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::Validation::ECTStartDate do
 
       it 'is not valid and returns the correct error message' do
         expect(subject).not_to be_valid
-        expect(subject.error_message).to eq('Start date cannot be earlier than the last 2 registration periods. Enter a date later than 1 June 2024')
+        expect(subject.error_message).to eq('Start date cannot be earlier than the last 2 registration periods. Enter a date later than 1 June 2024.')
       end
     end
 

--- a/spec/lib/schools/validation/ect_start_date_spec.rb
+++ b/spec/lib/schools/validation/ect_start_date_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::Validation::ECTStartDate do
 
       it 'is not valid and returns the correct error message' do
         expect(subject).not_to be_valid
-        expect(subject.error_message).to eq('Enter a date later than 1 June 2024')
+        expect(subject.error_message).to eq('Start date cannot be earlier than the last 2 registration periods. Enter a date later than 1 June 2024')
       end
     end
 

--- a/spec/lib/schools/validation/ect_start_date_spec.rb
+++ b/spec/lib/schools/validation/ect_start_date_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Schools::Validation::ECTStartDate do
+  describe '#valid?' do
+    subject { described_class.new(date_as_hash:) }
+
+    let(:cut_off_date) { Date.new(2024, 6, 1) }
+    let(:date_as_hash) { {} }
+
+    before do
+      allow(ContractPeriod).to receive(:earliest_permitted_start_date).and_return(cut_off_date)
+    end
+
+    context 'when the date is before the cut off' do
+      let(:date_as_hash) { { 1 => 2024, 2 => 5, 3 => 31 } }
+
+      it 'is not valid and returns the correct error message' do
+        expect(subject).not_to be_valid
+        expect(subject.error_message).to eq('Enter a date later than 1 June 2024')
+      end
+    end
+
+    context 'when the date is exactly on the cut off' do
+      let(:date_as_hash) { { 1 => 2024, 2 => 6, 3 => 1 } }
+
+      it 'is valid and has no error message' do
+        expect(subject).to be_valid
+        expect(subject.error_message).to be_blank
+      end
+    end
+
+    context 'when the date is after the cut off' do
+      let(:date_as_hash) { { 1 => 2024, 2 => 6, 3 => 2 } }
+
+      it 'is valid and has no error message' do
+        expect(subject).to be_valid
+        expect(subject.error_message).to be_blank
+      end
+    end
+
+    context 'when the cut off is nil (no current contract period)' do
+      let(:cut_off_date) { nil }
+      let(:date_as_hash) { { 1 => 2024, 2 => 6, 3 => 1 } }
+
+      it 'is valid and has no error message' do
+        expect(subject).to be_valid
+        expect(subject.error_message).to be_blank
+      end
+    end
+  end
+end

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -44,4 +44,38 @@ describe ContractPeriod do
       expect(ContractPeriod.containing_date(Date.new(2023, 1, 1))).to be_nil
     end
   end
+
+  describe '.earliest_permitted_start_date' do
+    context 'when there are contract periods' do
+      let!(:oldest) do
+        FactoryBot.create(:contract_period, year: 2022)
+      end
+
+      let!(:third_oldest) do
+        FactoryBot.create(:contract_period, year: 2023)
+      end
+
+      let!(:second_oldest) do
+        FactoryBot.create(:contract_period, year: 2024)
+      end
+
+      let!(:current) do
+        FactoryBot.create(:contract_period, year: 2025)
+      end
+
+      it 'returns the start date of the contract period two periods before the current one' do
+        freeze_time do
+          expect(ContractPeriod.earliest_permitted_start_date).to eq(third_oldest.started_on)
+        end
+      end
+    end
+
+    context 'when there are no current contract periods' do
+      it 'returns nil' do
+        freeze_time do
+          expect(ContractPeriod.earliest_permitted_start_date).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -74,6 +74,7 @@ describe ContractPeriod do
       it 'returns nil' do
         freeze_time do
           expect(ContractPeriod.earliest_permitted_start_date).to be_nil
+          expect(ContractPeriod.count).to eq(0)
         end
       end
     end

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -67,7 +67,11 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
       let(:wizard) do
         FactoryBot.build(:register_ect_wizard, current_step: :start_date, store:, school:).tap do |instance|
-          allow(instance).to receive(:ect).and_return(Schools::RegisterECTWizard::ECT.new(teacher))
+          allow(instance).to receive(:ect).and_return(
+            Schools::RegisterECTWizard::ECT.new(store).tap do |ect|
+              allow(ect).to receive_messages(trs_first_name: 'Johnnie', trs_last_name: 'Walker')
+            end
+          )
         end
       end
 
@@ -79,7 +83,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
         it 'is not valid' do
           expect(subject).not_to be_valid
           expect(subject.errors[:start_date]).to include(
-            "This ECT was previously registered at Springfield Primary (1 September 2024). Enter a later date."
+            "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a later start date."
           )
         end
       end


### PR DESCRIPTION
### Context

We are adding two new validation checks for the start date when registering an ECT. 

### Changes proposed in this pull request

#### Prevent users entering a start date that is more than 2 registration periods ago.

<img width="757" height="669" alt="image" src="https://github.com/user-attachments/assets/49941a2b-6504-48ae-9ac0-f0839ab09917" />

#### If the ECT has been registered at another school before we will prevent them from adding a start date that is before the  previous registration start date. 

<img width="932" height="818" alt="image" src="https://github.com/user-attachments/assets/f66e8592-270a-40e7-b38a-a624a574a6f9" />


### Guidance to review

I considered extracting the previous registration logic into a `ECTRegistrationHistory` service object. However the existing methods in the ECT wrapper already provided the neccssary functionality.  Also a lack of a `Teacher` at times during the wizard flow would have added complexity so I decided against it in the end but happy to revisit if others feel strongly.