### PR TITLE
Fix N+1 queries on the admin teachers page

### DIFF
--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -7,7 +7,12 @@ module Admin
       @pagy, @teachers = pagy(
         ::Teachers::Search.new(
           query_string: params[:q]
-        ).search
+        )
+        .search
+        .includes(
+          :induction_periods,
+          :current_appropriate_body
+        )
       )
     end
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -17,7 +17,10 @@ class Teacher < ApplicationRecord
   has_many :induction_periods
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"
   has_one :last_induction_period, -> { order(started_on: :desc) }, class_name: "InductionPeriod"
+  has_one :ongoing_induction_period, -> { ongoing }, class_name: "InductionPeriod"
+
   has_many :appropriate_bodies, through: :induction_periods
+  has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body
 
   has_many :events
 

--- a/app/views/admin/teachers/index.html.erb
+++ b/app/views/admin/teachers/index.html.erb
@@ -29,11 +29,11 @@
               { key: { text: "TRN" }, value: { text: teacher.trn } },
               {
                 key: { text: "Appropriate body" },
-                value: { text: Teachers::InductionPeriod.new(teacher).ongoing_induction_period&.appropriate_body&.name },
+                value: { text: teacher.current_appropriate_body&.name },
               },
               {
                 key: { text: "Induction periods recorded" },
-                value: { text: teacher.induction_periods.count },
+                value: { text: teacher.induction_periods.size },
               },
               {
                 key: { text: "Status" },


### PR DESCRIPTION
### Context

This addresses some N+1 queries on the admin teachers page.

### Changes proposed in this pull request

1. Calling `count` on an ActiveRecord association **always** makes a database request. If we include `induction_periods` when retrieving the Teacher records, we can use `size` instead.

2. Similarly to #858, if we define a `current_appropriate_body` association, we can leverage ActiveRecord and `include` it without make an extra trip to the database.

### Guidance to review

**Before**
<img width="1470" height="791" alt="image" src="https://github.com/user-attachments/assets/4b59a9a8-a17e-487b-ab8a-8385baf5d101" />
<img width="887" height="25" alt="image" src="https://github.com/user-attachments/assets/acbf547a-7340-4ac9-8086-eaa05d74b36f" />


**After**
<img width="1469" height="581" alt="image" src="https://github.com/user-attachments/assets/1519434c-a264-4538-b6d4-9b23e9b9ffa4" />
