### PR TITLE
Improving the fake TRS API client

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,6 +31,7 @@ jobs:
       ENCRYPTION_DETERMINISTIC_KEY: test_deterministic_key
       ENCRYPTION_DERIVATION_SALT: test_derivation_salt
       CI: true
+      REDIS_CACHE_URL: 'redis://127.0.0.1:6379'
 
     services:
       postgres:
@@ -42,6 +43,12 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
 
     steps:
       - name: Checkout code

--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -70,6 +70,8 @@ class TestGuidanceComponent < ViewComponent::Base
             '7000002 (teacher not found)',
             '7000003 (prohibited from teaching)',
             '7000004 (teacher has been deactivated in TRS)',
+            '7000005 (teacher has alerts but is not prohibited)',
+            '7000006 (teacher is exempt from mentor funding)',
           ],
           type: 'bullet'
         )

--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -32,7 +32,8 @@ teachers = [
   { trs_first_name: 'Helen', trs_last_name: 'Mirren', corrected_name: 'Dame Helen Mirren', trn: '0000007', trs_induction_status: 'Passed' },
   { trs_first_name: 'Dominic', trs_last_name: 'West', trn: '9292929', trs_induction_status: 'InProgress' },
   { trs_first_name: 'Robson', trs_last_name: 'Scottie', trn: '3002582', **early_roll_out_mentor_attrs },
-  { trs_first_name: 'Muhammed', trs_last_name: 'Ali', trn: '3002580', **early_roll_out_mentor_attrs }
+  { trs_first_name: 'Muhammed', trs_last_name: 'Ali', trn: '3002580', **early_roll_out_mentor_attrs },
+  { trs_first_name: 'Roy', trs_last_name: 'Dotrice', trn: '7000007', **early_roll_out_mentor_attrs }
 ]
 
 teachers.each do |attrs|

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -17,7 +17,7 @@ module TRS
       if Rails.application.config.enable_fake_trs_api
         Rails.logger.warn("Using TRS::FakeAPIClient")
 
-        return TRS::FakeAPIClient.new(random_names: true)
+        return TRS::FakeAPIClient.new
       end
 
       new

--- a/lib/trs/fake_api_client.rb
+++ b/lib/trs/fake_api_client.rb
@@ -1,26 +1,12 @@
 module TRS
   class FakeAPIClient
     class FakeAPIClientUsedInProduction < StandardError; end
-    attr_reader :random_names
 
-    def initialize(
-      raise_not_found: false,
-      raise_deactivated: false,
-      include_qts: true,
-      include_itt: true,
-      prohibited_from_teaching: false,
-      induction_status: nil,
-      random_names: false
-    )
+    def initialize(raise_not_found: false, raise_deactivated: false)
       fail(FakeAPIClientUsedInProduction) if Rails.env.production?
 
       @raise_not_found = raise_not_found
       @raise_deactivated = raise_deactivated
-      @include_qts = include_qts
-      @include_itt = include_itt
-      @prohibited_from_teaching = prohibited_from_teaching
-      @induction_status = induction_status
-      @random_names = random_names
     end
 
     def find_teacher(trn:, date_of_birth: "1977-02-03", national_insurance_number: nil)
@@ -29,112 +15,213 @@ module TRS
 
       Rails.logger.info("TRSFakeAPIClient pretending to find teacher with TRN=#{trn} and Date of birth=#{date_of_birth} and National Insurance Number=#{national_insurance_number}")
 
-      if random_names
-        build_trs_teacher_based_on_trn_range(trn:, date_of_birth:, national_insurance_number:)
-      else
-        build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
-      end
+      override_data_for_special_trns(trn)
+
+      build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
     end
 
-    def pass_induction!(...)
+    def begin_induction!(trn:, start_date:, modified_at: Time.zone.now)
+      Rails.logger.info("TRSFakeAPIClient pretending to begin teacher with TRN=#{trn}'s induction")
+
+      update_induction_status(
+        trn:,
+        status: 'InProgress',
+        start_date: start_date.iso8601,
+        modified_at: modified_at.utc.iso8601(3)
+      )
     end
 
-    def fail_induction!(...)
+    def pass_induction!(trn:, start_date:, completed_date:, modified_at: Time.zone.now)
+      Rails.logger.info("TRSFakeAPIClient pretending to pass teacher with TRN=#{trn}'s induction")
+
+      update_induction_status(
+        trn:,
+        status: 'Passed',
+        start_date: start_date.iso8601,
+        completed_date: completed_date.iso8601,
+        modified_at: modified_at.utc.iso8601(3)
+      )
     end
 
-    def begin_induction!(...)
+    def fail_induction!(trn:, start_date:, completed_date:, modified_at: Time.zone.now)
+      Rails.logger.info("TRSFakeAPIClient pretending to fail teacher with TRN=#{trn}'s induction")
+
+      update_induction_status(
+        trn:,
+        status: 'Failed',
+        start_date: start_date.iso8601,
+        completed_date: completed_date.iso8601,
+        modified_at: modified_at.utc.iso8601(3)
+      )
     end
 
-    def reset_teacher_induction(...)
+    def reset_teacher_induction(trn:, modified_at: Time.zone.now)
+      Rails.logger.info("TRSFakeAPIClient pretending to reset teacher with TRN=#{trn}'s induction")
+
+      update_induction_status(
+        trn:,
+        status: 'RequiredToComplete',
+        start_date: nil,
+        completed_date: nil,
+        modified_at: modified_at.utc.iso8601(3)
+      )
     end
 
   private
 
+    def redis_client
+      @redis_client ||= Redis.new(url: ENV.fetch('REDIS_CACHE_URL', 'redis://localhost:6379'))
+    end
+
+    def redis_induction_key(trn)
+      "#{trn}:induction"
+    end
+
+    def update_induction_status(trn:, status:, modified_at:, start_date:, completed_date: nil)
+      payload = { 'status' => status,
+                  'startDate' => start_date,
+                  'completedDate' => completed_date,
+                  'modifiedOn' => modified_at }.transform_values { |v| (v.present?) ? v : '' }
+
+      redis_client.mapped_hmset(redis_induction_key(trn), payload)
+    end
+
+    # FIXME: Named for consistency with update_induction_status in the real client, but it's doing more
+    #        than just the status, both should probably end with _induction_details
+    def retrieve_induction_status(trn)
+      redis_client
+        .hgetall(redis_induction_key(trn))
+        .transform_values { |v| (v.present?) ? v : nil }
+    end
+
     def build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
       TRS::Teacher.new(
-        teacher_params(trn:, date_of_birth:, national_insurance_number:)
-          .merge(qts)
-          .merge(itt)
-          .merge(prohibited_from_teaching)
-          .merge(induction_status)
+        teacher_params(trn:, date_of_birth:, national_insurance_number:).tap do |tp|
+          tp.merge!(qts_data)
+          tp.merge!(itt_data)
+
+          if @is_prohibited_from_teaching
+            tp.merge!(prohibited_from_teaching_data)
+          elsif @has_alerts_but_not_prohibited
+            tp.merge!(other_alert_data)
+          end
+
+          tp.merge!(induction_data(trn))
+        end
       )
     end
 
-    def build_trs_teacher_based_on_trn_range(trn:, date_of_birth:, national_insurance_number:)
-      @induction_status = 'RequiredToComplete'
-
+    def override_data_for_special_trns(trn)
       case trn.to_i
-      when 7_000_001 then raise(TRS::Errors::QTSNotAwarded)
+      when 7_000_001 then @has_qts = false
       when 7_000_002 then raise(TRS::Errors::TeacherNotFound)
-      when 7_000_003 then raise(TRS::Errors::ProhibitedFromTeaching)
+      when 7_000_003 then @is_prohibited_from_teaching = true
       when 7_000_004 then raise(TRS::Errors::TeacherDeactivated)
+      when 7_000_005 then @has_alerts_but_not_prohibited = true
+      when 7_000_006 then nil # teacher with TRN 7000006 is seeded as an early roll out mentor
       else
-        build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
+        @has_qts = true
+        @has_itt = true
+        @is_prohibited_from_teaching = false
+        @has_alerts_but_not_prohibited = false
       end
     end
 
     def teacher_params(trn:, date_of_birth:, national_insurance_number:, first_name: 'Kirk', last_name: 'Van Houten')
-      first_name, last_name = *random_name if @random_names
+      if (teacher = ::Teacher.find_by(trn:))
+        {
+          'trn' => teacher.trn,
+          'firstName' => teacher.trs_first_name,
+          'lastName' => teacher.trs_last_name,
+          'dateOfBirth' => date_of_birth,
+          'nationalInsuranceNumber' => national_insurance_number,
+        }
+      else
+        first_name, last_name = *random_name
 
-      {
-        'trn' => trn,
-        'firstName' => first_name,
-        'lastName' => last_name,
-        'dateOfBirth' => date_of_birth,
-        'nationalInsuranceNumber' => national_insurance_number,
-      }
+        {
+          'trn' => trn,
+          'firstName' => first_name,
+          'lastName' => last_name,
+          'dateOfBirth' => date_of_birth,
+          'nationalInsuranceNumber' => national_insurance_number,
+        }
+      end
     end
 
     def random_name
       File.read(Rails.root.join('lib/trs/fake_api_names.yml')).split("\n").sample.split(" ", 2)
     end
 
-    def qts
-      return {} unless @include_qts
-
-      {
-        'qts' => {
-          'awarded' => Time.zone.today - 3.years,
-          'certificateUrl' => 'https://fancy-certificates.example.com/1234',
-          'statusDescription' => 'Passed'
-        }
-      }
-    end
-
-    def prohibited_from_teaching
-      return {} unless @prohibited_from_teaching
-
-      {
-        'alerts' => [{ 'alertType' => { 'alertCategory' => { 'alertCategoryId' => 'b2b19019-b165-47a3-8745-3297ff152581' } } }],
-      }
-    end
-
-    def induction_status
-      return {} unless @induction_status
-
-      {
-        'induction' => { 'status' => @induction_status },
-      }
-    end
-
-    def itt
-      return {} unless @include_itt
-
-      {
-        "initialTeacherTraining" => [
-          {
-            "qualification" => { "name" => "Postgraduate Certificate in Education" },
-            "startDate" => "2020-12-31",
-            "result" => "Pass",
-            "subjects" => [],
-            "endDate" => "2021-04-05",
-            "programmeType" => nil,
-            "programmeTypeDescription" => nil,
-            "ageRange" => nil,
-            "provider" => { "name" => "Example Provider Ltd." },
+    def qts_data
+      if @has_qts
+        {
+          'qts' => {
+            'awarded' => Time.zone.today - 3.years,
+            'certificateUrl' => 'https://fancy-certificates.example.com/1234',
+            'statusDescription' => 'Passed'
           }
-        ]
+        }
+      else
+        { 'qts' => nil }
+      end
+    end
+
+    def prohibited_from_teaching_data
+      {
+        'alerts' => [{ 'alertType' => { 'alertCategory' => { 'alertCategoryId' => TRS::Teacher::PROHIBITED_FROM_TEACHING_CATEGORY_ID } } }]
       }
+    end
+
+    def other_alert_data
+      {
+        # Conditional Registration Order - unacceptable professional conduct
+        'alerts' => [{ 'alertType' => { 'alertCategory' => { 'alertCategoryId' => '5562a5b7-3e32-eb11-a814-000d3a23980a' } } }]
+      }
+    end
+
+    def induction_data(trn)
+      return { 'induction' => { 'status' => @induction_status } } if @induction_status
+
+      if (induction_status = retrieve_induction_status(trn)) && induction_status.present?
+        {
+          'induction' => {
+            'status' => induction_status['status'],
+            'startDate' => induction_status['startDate'],
+            'completedDate' => induction_status['completedDate']
+          }
+        }
+      else
+        {
+          'induction' => {
+            'status' => 'InProgress',
+            'startDate' => 2.years.ago.to_date.to_s,
+            'completedDate' => 1.year.ago.to_date.to_s
+          }
+        }
+      end
+    end
+
+    def itt_data
+      if @has_itt
+        {
+          "initialTeacherTraining" => [
+            {
+              "qualification" => { "name" => "Postgraduate Certificate in Education" },
+              "startDate" => "2020-12-31",
+              "result" => "Pass",
+              "subjects" => [],
+              "endDate" => "2021-04-05",
+              "programmeType" => nil,
+              "programmeTypeDescription" => nil,
+              "ageRange" => nil,
+              "provider" => { "name" => "Example Provider Ltd." },
+            }
+          ]
+        }
+      else
+        { "initialTeacherTraining" => [] }
+      end
     end
   end
 end

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -61,7 +61,15 @@ module TRS
     end
 
     def prohibited_from_teaching?
-      @alerts&.any? { |alert| alert.dig('alertType', 'alertCategory', 'alertCategoryId') == PROHIBITED_FROM_TEACHING_CATEGORY_ID }
+      PROHIBITED_FROM_TEACHING_CATEGORY_ID.in?(alert_codes)
+    end
+
+    def has_alerts?
+      alert_codes.any?
+    end
+
+    def qts_awarded?
+      @qts_awarded_on.present?
     end
 
   private
@@ -70,8 +78,10 @@ module TRS
       @api_client ||= TRS::APIClient.build
     end
 
-    def qts_awarded?
-      @qts_awarded_on.present?
+    def alert_codes
+      return [] if @alerts.blank?
+
+      @alerts.map { |a| a.dig(*%w[alertType alertCategory alertCategoryId]) }
     end
   end
 end

--- a/spec/features/admin/import_ect_spec.rb
+++ b/spec/features/admin/import_ect_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Admin importing an ECT' do
   before { sign_in_as_dfe_user(role: :admin, user: admin_user) }
 
   describe "Happy path - importing a valid teacher" do
-    include_context 'fake trs api client'
+    include_context 'test trs api client'
 
     scenario 'Successfully import an ECT from TRS' do
       given_i_am_on_the_admin_teachers_index_page
@@ -27,7 +27,7 @@ RSpec.describe 'Admin importing an ECT' do
 
   describe "Error cases" do
     context "when teacher not found in TRS" do
-      include_context 'fake trs api client that finds nothing'
+      include_context 'test trs api client that finds nothing'
 
       scenario 'Shows teacher not found error' do
         given_i_am_on_the_find_ect_page
@@ -39,7 +39,7 @@ RSpec.describe 'Admin importing an ECT' do
     end
 
     context "when teacher already exists in RIAB" do
-      include_context 'fake trs api client'
+      include_context 'test trs api client'
 
       let!(:existing_teacher) { FactoryBot.create(:teacher, trn: '1234567') }
 
@@ -54,7 +54,7 @@ RSpec.describe 'Admin importing an ECT' do
     end
 
     context "when teacher does not have QTS" do
-      include_context 'fake trs api client that finds teacher without QTS'
+      include_context 'test trs api client that finds teacher without QTS'
 
       scenario 'Shows QTS not awarded error page' do
         given_i_am_on_the_find_ect_page
@@ -67,7 +67,7 @@ RSpec.describe 'Admin importing an ECT' do
     end
 
     context "when teacher is prohibited from teaching" do
-      include_context 'fake trs api client that finds teacher prohibited from teaching'
+      include_context 'test trs api client that finds teacher prohibited from teaching'
 
       scenario 'Shows prohibited from teaching error page' do
         given_i_am_on_the_find_ect_page

--- a/spec/features/admin/teachers/delete_induction_period_spec.rb
+++ b/spec/features/admin/teachers/delete_induction_period_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Admin deletes an induction period" do
   include ActiveJob::TestHelper
-  include_context "fake trs api client"
+  include_context "test trs api client"
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Claiming an ECT' do
       FactoryBot.create(:induction_period, teacher:, started_on: 14.months.ago, finished_on: 13.months.ago, appropriate_body: other_body)
     end
 
-    include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+    include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
     scenario 'Happy path when induction is not completed' do
       given_i_am_on_the_claim_an_ect_find_page
@@ -31,7 +31,7 @@ RSpec.describe 'Claiming an ECT' do
   end
 
   describe "when the ECT is already claimed by another appropriate body" do
-    include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+    include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
     before do
       FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_body)
@@ -51,7 +51,7 @@ RSpec.describe 'Claiming an ECT' do
   end
 
   describe "when the ECT has passed the induction" do
-    include_context 'fake trs api client that finds teacher with specific induction status', 'Passed'
+    include_context 'test trs api client that finds teacher with specific induction status', 'Passed'
 
     scenario 'Button is hidden when induction is completed' do
       given_i_am_on_the_claim_an_ect_find_page
@@ -64,7 +64,7 @@ RSpec.describe 'Claiming an ECT' do
   end
 
   describe "when the ECT is exempt from induction" do
-    include_context 'fake trs api client that finds teacher with specific induction status', 'Exempt'
+    include_context 'test trs api client that finds teacher with specific induction status', 'Exempt'
 
     scenario 'Button is hidden and exempt message is shown' do
       given_i_am_on_the_claim_an_ect_find_page

--- a/spec/features/appropriate_bodies/process_batch_action_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_action_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Process bulk actions' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 

--- a/spec/features/appropriate_bodies/process_batch_claim_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_claim_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe 'Process bulk claims' do
         perform_enqueued_jobs
         page.reload
         expect(page.get_by_text('CSV file summary')).to be_visible
-        expect(page.get_by_text("Your CSV named 'valid_complete_claim.csv' has 2 ECTs")).to be_visible
-        expect(page.get_by_role('link', name: 'Download CSV with error messages included')).to be_visible
+        expect(page.get_by_text("Your CSV named 'valid_complete_claim.csv' has 2 ECT records")).to be_visible
       end
     end
 
@@ -78,8 +77,7 @@ RSpec.describe 'Process bulk claims' do
           perform_enqueued_jobs
           page.reload
           expect(page.get_by_text('CSV file summary')).to be_visible
-          expect(page.get_by_text("Your CSV named 'valid_complete_claim.csv' has 2 ECTs")).to be_visible
-          expect(page.get_by_role('link', name: 'Download CSV with error messages included')).to be_visible
+          expect(page.get_by_text("Your CSV named 'valid_complete_claim.csv' has 2 ECT records")).to be_visible
         end
       end
     end

--- a/spec/features/appropriate_bodies/process_batch_claim_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_claim_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Process bulk claims' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 

--- a/spec/features/appropriate_bodies/process_batch_combo_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_combo_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Process bulk claims then actions events' do
   include ActiveJob::TestHelper
 
-  include_context 'fake trs api returns 2 random teachers'
+  include_context 'test trs api client'
 
   let(:appropriate_body) do
     FactoryBot.create(:appropriate_body, name: 'The Appropriate Body')

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT', :js do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'Finding a teacher using national insurance number' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client that finds teacher that has passed their induction'
+  include_context 'test trs api client that finds teacher that has passed their induction'
 
   scenario 'User enters date of birth (find ECT step) but teacher has completed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api returns a teacher and then a teacher that has completed their induction'
+  include_context 'test trs api returns a teacher and then a teacher that has completed their induction'
 
   scenario 'User enters national insurance number but teacher has completed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client that finds teacher that is exempt from induction'
+  include_context 'test trs api client that finds teacher that is exempt from induction'
 
   scenario 'User enters date of birth (find ECT step) but teacher has completed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api returns a teacher and then a teacher that is exempt from induction'
+  include_context 'test trs api returns a teacher and then a teacher that is exempt from induction'
 
   scenario 'User enters national insurance number but teacher is exempt from induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client that finds teacher that has failed their induction'
+  include_context 'test trs api client that finds teacher that has failed their induction'
 
   scenario 'User enters date of birth (find ECT step) but teacher has failed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api returns a teacher and then a teacher that has failed their induction'
+  include_context 'test trs api returns a teacher and then a teacher that has failed their induction'
 
   scenario 'User enters national insurance number but teacher has failed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'Teacher with trn has already registered as an ECT at a school' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client that finds teacher prohibited from teaching'
+  include_context 'test trs api client that finds teacher prohibited from teaching'
 
   scenario 'The ECT is prohibited from teaching' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client returns 200 then 400'
+  include_context 'test trs api client returns 200 then 400'
 
   scenario 'Teacher with national insurance number is not found' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client that finds nothing'
+  include_context 'test trs api client that finds nothing'
 
   scenario 'Teacher with TRN is not found' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   before do
     create_contract_period_for_start_date

--- a/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
+++ b/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering an ECT' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'previously registered' do
     given_i_am_logged_in_as_a_state_funded_school_user_who_has_previously_registered_an_ect

--- a/spec/features/schools/ects/search_spec.rb
+++ b/spec/features/schools/ects/search_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Searching for an ECT', type: :feature do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   before do
     given_there_is_a_school_with_teachers

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor', :js do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'mentor already active at the school from trn and nino' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor', :js do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'mentor already active at the school from trn and dob' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'An ECT becoming mentor cannot mentor themself' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor', :js do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   scenario 'Finding a teacher using national insurance number' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor' do
-  include_context 'fake trs api client that finds teacher prohibited from teaching'
+  include_context 'test trs api client that finds teacher prohibited from teaching'
 
   scenario 'School attempts to register a prohibited teacher as a mentor' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor' do
-  include_context 'fake trs api client returns 200 then 400'
+  include_context 'test trs api client returns 200 then 400'
 
   scenario 'Teacher with TRN is not found' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor' do
-  include_context 'fake trs api client that finds nothing'
+  include_context 'test trs api client that finds nothing'
 
   scenario 'Teacher with TRN is not found' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor' do
-  include_context 'fake trs api client that finds nothing'
+  include_context 'test trs api client that finds nothing'
 
   scenario 'Teacher with TRN is not found' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registering a mentor', :js do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/search_spec.rb
+++ b/spec/features/schools/mentors/search_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Searching for a mentor', type: :feature do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   before do
     given_there_is_a_school_with_teachers

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Redirect to register a new mentor for an ECT' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:trn) { '9876543' }
 

--- a/spec/jobs/process_batch_action_job_spec.rb
+++ b/spec/jobs/process_batch_action_job_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ProcessBatchActionJob, type: :job do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:author) { FactoryBot.create(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
 

--- a/spec/jobs/process_batch_claim_job_spec.rb
+++ b/spec/jobs/process_batch_claim_job_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ProcessBatchClaimJob, type: :job do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:author) { FactoryBot.create(:user, name: 'Barry Cryer', email: 'barry@not-a-clue.co.uk') }
 

--- a/spec/lib/bulk_generate_spec.rb
+++ b/spec/lib/bulk_generate_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe BulkGenerate do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:bulk_generate) { described_class.new }
 

--- a/spec/lib/dfe_sign_in/api_client_spec.rb
+++ b/spec/lib/dfe_sign_in/api_client_spec.rb
@@ -1,6 +1,6 @@
 describe DfESignIn::APIClient do
   let(:fake_base_url) { 'https://api.very-nice-website.org/' }
-  let(:fake_client_id) { 'SomeService' }
+  let(:test_client_id) { 'SomeService' }
   let(:fake_api_audience) { 'signin.very-nice-website.org' }
   let(:fake_api_secret) { 'ABC123' }
 
@@ -10,7 +10,7 @@ describe DfESignIn::APIClient do
   before do
     stub_const('ENV', {
       'DFE_SIGN_IN_API_BASE_URL' => fake_base_url,
-      'DFE_SIGN_IN_CLIENT_ID' => fake_client_id,
+      'DFE_SIGN_IN_CLIENT_ID' => test_client_id,
       'DFE_SIGN_IN_API_AUDIENCE' => fake_api_audience,
       'DFE_SIGN_IN_API_SECRET' => fake_api_secret,
     })
@@ -56,7 +56,7 @@ describe DfESignIn::APIClient do
       DfESignIn::APIClient.new
 
       expect(JWT).to have_received(:encode).with(
-        { iss: fake_client_id, aud: fake_api_audience },
+        { iss: test_client_id, aud: fake_api_audience },
         fake_api_secret,
         'HS256'
       )

--- a/spec/lib/trs/fake_api_client_spec.rb
+++ b/spec/lib/trs/fake_api_client_spec.rb
@@ -1,7 +1,178 @@
 describe TRS::FakeAPIClient do
-  it 'fails when used in production' do
-    allow(Rails.env).to receive(:production?).and_return(true)
+  describe 'initializing' do
+    it 'fails when used in production' do
+      allow(Rails.env).to receive(:production?).and_return(true)
 
-    expect { TRS::FakeAPIClient.new }.to raise_error(TRS::FakeAPIClient::FakeAPIClientUsedInProduction)
+      expect { TRS::FakeAPIClient.new }.to raise_error(TRS::FakeAPIClient::FakeAPIClientUsedInProduction)
+    end
+  end
+
+  describe '#find_teacher' do
+    subject { TRS::FakeAPIClient.new }
+
+    context 'without a special TRN' do
+      let(:trn) { 1_234_567 }
+
+      it 'returns a teacher with a qts_awarded_on date' do
+        expect(subject.find_teacher(trn:).qts_awarded_on).not_to be_nil
+      end
+
+      it 'returns a teacher who is not prohibited from teaching' do
+        expect(subject.find_teacher(trn:)).not_to be_prohibited_from_teaching
+      end
+    end
+
+    context 'with TRN is 7_000_001' do
+      let(:trn) { 7_000_001 }
+
+      it 'returns a teacher who is not QTS awarded' do
+        expect(subject.find_teacher(trn:)).not_to be_qts_awarded
+      end
+
+      it 'returns a teacher without a qts_awarded_on date' do
+        expect(subject.find_teacher(trn:).qts_awarded_on).to be_nil
+      end
+    end
+
+    context 'when TRN is 7_000_002' do
+      let(:trn) { 7_000_002 }
+
+      it 'raises a TRS::Errors::TeacherNotFound error' do
+        expect { subject.find_teacher(trn:) }.to raise_error(TRS::Errors::TeacherNotFound)
+      end
+    end
+
+    context 'when TRN is 7_000_003' do
+      let(:trn) { 7_000_003 }
+
+      it 'returns a teacher with a prhohibited from teaching alert' do
+        expect(subject.find_teacher(trn:)).to be_prohibited_from_teaching
+      end
+    end
+
+    context 'when TRN is 7_000_004' do
+      let(:trn) { 7_000_004 }
+
+      it 'raises a TRS::Errors::TeacherNotFound error' do
+        expect { subject.find_teacher(trn:) }.to raise_error(TRS::Errors::TeacherDeactivated)
+      end
+    end
+
+    context 'when TRN is 7_000_005' do
+      let(:trn) { 7_000_005 }
+
+      it 'returns a teacher who has alerts' do
+        expect(subject.find_teacher(trn:)).to have_alerts
+      end
+
+      it 'returns a teacher is not prohibited from teaching' do
+        expect(subject.find_teacher(trn:)).not_to be_prohibited_from_teaching
+      end
+    end
+
+    context "when TRN is 7_000_006" do
+      let(:trn) { 7_000_006 }
+
+      it 'returns a teacher (this teacher should be seeded with early_roll_out_mentor_attrs, see db/seeds/teachers.rb)' do
+        expect(subject.find_teacher(trn:)).to be_present
+      end
+    end
+  end
+
+  describe 'Redis data storing functionality' do
+    subject { TRS::FakeAPIClient.new }
+
+    let(:teacher) { FactoryBot.build(:teacher) }
+    let(:trn) { teacher.trn }
+    let(:key) { trn + ':induction' }
+    let(:start_date) { 3.months.ago.to_date }
+    let(:redis_client) { Redis.new }
+
+    before { redis_client.del(key) }
+
+    describe '#begin_induction!' do
+      before { subject.begin_induction!(trn: teacher.trn, start_date:) }
+
+      it 'writes the in progress status to Redis' do
+        expect(redis_client.hgetall(key)).to match(
+          include(
+            'status' => 'InProgress',
+            'startDate' => start_date.to_s
+          )
+        )
+      end
+
+      it 'retrieves the teacher record with the updated info' do
+        trs_teacher = subject.find_teacher(trn:)
+
+        expect(trs_teacher.induction_status).to eql('InProgress')
+      end
+    end
+
+    describe '#pass_induction!' do
+      let(:completed_date) { 1.day.ago.to_date }
+
+      before { subject.pass_induction!(trn: teacher.trn, start_date:, completed_date:) }
+
+      it 'writes the passed status to Redis' do
+        expect(redis_client.hgetall(key)).to match(
+          include(
+            'status' => 'Passed',
+            'startDate' => start_date.to_s,
+            'completedDate' => completed_date.to_s
+          )
+        )
+      end
+
+      it 'retrieves the teacher record with the updated info' do
+        trs_teacher = subject.find_teacher(trn:)
+
+        expect(trs_teacher.induction_status).to eql('Passed')
+      end
+    end
+
+    describe '#fail_induction!' do
+      let(:completed_date) { 1.day.ago.to_date }
+
+      before { subject.fail_induction!(trn: teacher.trn, start_date:, completed_date:) }
+
+      it 'writes the failed status to Redis' do
+        expect(redis_client.hgetall(key)).to match(
+          include(
+            'status' => 'Failed',
+            'startDate' => start_date.to_s,
+            'completedDate' => completed_date.to_s
+          )
+        )
+      end
+
+      it 'retrieves the teacher record with the updated info' do
+        trs_teacher = subject.find_teacher(trn:)
+
+        expect(trs_teacher.induction_status).to eql('Failed')
+      end
+    end
+
+    describe '#reset_teacher_induction' do
+      let(:completed_date) { 1.day.ago.to_date }
+
+      before { subject.reset_teacher_induction(trn: teacher.trn) }
+
+      it 'clears the start date and completed date in Redis, and sets status back to required to complete' do
+        expect(redis_client.hgetall(key)).to match(
+          include(
+            'status' => 'RequiredToComplete',
+            'startDate' => '',
+            'completedDate' => ''
+          )
+        )
+      end
+
+      it 'retrieves the teacher record with the updated info' do
+        trs_teacher = subject.find_teacher(trn:)
+
+        expect(trs_teacher.induction_status).to eql('RequiredToComplete')
+      end
+    end
   end
 end

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   let(:page_heading) { "Find an early career teacher" }
@@ -73,7 +73,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid but ECT does not have QTS awarded" do
-        include_context 'fake trs api client that finds teacher without QTS'
+        include_context 'test trs api client that finds teacher without QTS'
 
         it 're-renders the find page and displays the relevant error' do
           post(
@@ -86,7 +86,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid but ECT was prohibited from teaching" do
-        include_context 'fake trs api client that finds teacher prohibited from teaching'
+        include_context 'test trs api client that finds teacher prohibited from teaching'
 
         it 're-renders the find page and displays the relevant error' do
           post(
@@ -148,7 +148,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid but no ECT is found" do
-        include_context 'fake trs api client that finds nothing'
+        include_context 'test trs api client that finds nothing'
         let(:birth_year_param) { "2001" }
 
         it 're-renders the find page and displays the relevant error' do
@@ -164,7 +164,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid but the ECT is deactivated" do
-        include_context 'fake trs api client deactivated teacher'
+        include_context 'test trs api client deactivated teacher'
         let(:birth_year_param) { "2001" }
 
         it 're-renders the find page and displays the relevant error' do

--- a/spec/requests/appropriate_bodies/process_batch/actions/create_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Appropriate Body bulk actions upload", type: :request do
     PendingInductionSubmissionBatch.for_appropriate_body(appropriate_body).last
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   describe 'POST /appropriate-body/bulk/actions' do
     it "enqueues a job" do

--- a/spec/requests/appropriate_bodies/process_batch/actions/update_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/update_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Appropriate Body bulk actions confirmation", type: :request do
                       file_name: 'test-file.csv')
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
   include_context '3 valid actions'
 
   describe 'PATCH /appropriate-body/bulk/actions/:batch_id' do

--- a/spec/requests/appropriate_bodies/process_batch/claims/create_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/claims/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Appropriate Body bulk claims upload", type: :request do
     PendingInductionSubmissionBatch.for_appropriate_body(appropriate_body).last
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   describe 'POST /appropriate-body/bulk/claims' do
     it "enqueues a job" do

--- a/spec/requests/appropriate_bodies/process_batch/claims/update_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/claims/update_spec.rb
@@ -11,43 +11,64 @@ RSpec.describe "Appropriate Body bulk claims confirmation", type: :request do
                       file_name: 'test-file.csv')
   end
 
-  include_context 'fake trs api client'
-  include_context '2 valid claims'
+  include_context 'test trs api client'
 
   describe 'PATCH /appropriate-body/bulk/claims/:batch_id' do
-    it "enqueues a job" do
-      expect {
+    context 'when both claims are valid' do
+      include_context '2 valid claims'
+
+      it "enqueues a job" do
+        expect {
+          put ab_batch_claim_path(batch)
+        }.to have_enqueued_job(ProcessBatchClaimJob).with(batch, user.email, user.name)
+      end
+
+      it "records an upload completed event" do
+        allow(Events::Record).to receive(:record_bulk_upload_completed_event!).and_call_original
+
         put ab_batch_claim_path(batch)
-      }.to have_enqueued_job(ProcessBatchClaimJob).with(batch, user.email, user.name)
+
+        expect(Events::Record).to have_received(:record_bulk_upload_completed_event!).with(
+          batch:,
+          author: an_instance_of(Sessions::Users::AppropriateBodyPersona)
+        )
+
+        perform_enqueued_jobs
+
+        expect(Event.last.event_type).to eq("bulk_upload_completed")
+        expect(Event.last.pending_induction_submission_batch.id).to eq(batch.id)
+      end
+
+      it "redirects" do
+        put ab_batch_claim_path(batch)
+
+        expect(response).to redirect_to(ab_batch_claim_path(batch))
+        follow_redirect!
+        expect(response.body).to include("We're processing your CSV file, it could take up to 5 minutes.")
+
+        perform_enqueued_jobs
+        get ab_batch_claim_path(batch)
+
+        expect(response.body).to include("Your CSV named 'test-file.csv' has 2 ECT records that you can claim")
+      end
     end
 
-    it "records an upload completed event" do
-      allow(Events::Record).to receive(:record_bulk_upload_completed_event!).and_call_original
+    context 'when 1 valid and one invalid claim' do
+      include_context '1 valid and 1 invalid claim'
 
-      put ab_batch_claim_path(batch)
+      it "redirects" do
+        put ab_batch_claim_path(batch)
 
-      expect(Events::Record).to have_received(:record_bulk_upload_completed_event!).with(
-        batch:,
-        author: an_instance_of(Sessions::Users::AppropriateBodyPersona)
-      )
+        expect(response).to redirect_to(ab_batch_claim_path(batch))
+        follow_redirect!
+        expect(response.body).to include("We're processing your CSV file, it could take up to 5 minutes.")
 
-      perform_enqueued_jobs
+        perform_enqueued_jobs
+        get ab_batch_claim_path(batch)
 
-      expect(Event.last.event_type).to eq("bulk_upload_completed")
-      expect(Event.last.pending_induction_submission_batch.id).to eq(batch.id)
-    end
-
-    it "redirects" do
-      put ab_batch_claim_path(batch)
-
-      expect(response).to redirect_to(ab_batch_claim_path(batch))
-      follow_redirect!
-      expect(response.body).to include("We're processing your CSV file, it could take up to 5 minutes.")
-
-      perform_enqueued_jobs
-      get ab_batch_claim_path(batch)
-      # NB: these will have failed because we have not factoried the ECTs and their inductions
-      expect(response.body).to include("Your CSV named 'test-file.csv' has 2 ECTs with errors")
+        expect(response.body).to include("Your CSV named 'test-file.csv' has 1 ECT records that you can claim")
+        expect(response.body).to include("You have 1 ECTs with errors")
+      end
     end
   end
 end

--- a/spec/services/admin/destroy_induction_period_spec.rb
+++ b/spec/services/admin/destroy_induction_period_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::DestroyInductionPeriod do
     )
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
   include ActiveJob::TestHelper
 
   before do

--- a/spec/services/admin/import_ect/find_ect_spec.rb
+++ b/spec/services/admin/import_ect/find_ect_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when there is a match" do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'RequiredToComplete'
+      include_context 'test trs api client that finds teacher with specific induction status', 'RequiredToComplete'
 
       let(:find_ect) { Admin::ImportECT::FindECT.new(pending_induction_submission:) }
 
@@ -51,7 +51,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher already exists in system" do
-      include_context 'fake trs api client'
+      include_context 'test trs api client'
 
       let!(:existing_teacher) { FactoryBot.create(:teacher, trn: pending_induction_submission.trn) }
       let(:find_ect) { Admin::ImportECT::FindECT.new(pending_induction_submission:) }
@@ -65,7 +65,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when there is no match" do
-      include_context 'fake trs api client that finds nothing'
+      include_context 'test trs api client that finds nothing'
 
       it "raises teacher not found error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
@@ -75,7 +75,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher is prohibited from teaching" do
-      include_context 'fake trs api client that finds teacher prohibited from teaching'
+      include_context 'test trs api client that finds teacher prohibited from teaching'
 
       it "raises prohibited from teaching error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
@@ -85,7 +85,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher does not have QTS" do
-      include_context 'fake trs api client that finds teacher without QTS'
+      include_context 'test trs api client that finds teacher without QTS'
 
       it "raises QTS not awarded error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
@@ -95,7 +95,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher has completed induction" do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'Passed'
+      include_context 'test trs api client that finds teacher with specific induction status', 'Passed'
 
       it "raises induction already completed error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
@@ -105,7 +105,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher has failed induction" do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'Failed'
+      include_context 'test trs api client that finds teacher with specific induction status', 'Failed'
 
       it "raises induction already completed error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
@@ -115,7 +115,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher is exempt from induction" do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'Exempt'
+      include_context 'test trs api client that finds teacher with specific induction status', 'Exempt'
 
       it "raises induction already completed error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
@@ -125,7 +125,7 @@ RSpec.describe Admin::ImportECT::FindECT do
     end
 
     context "when teacher is deactivated" do
-      include_context 'fake trs api client deactivated teacher'
+      include_context 'test trs api client deactivated teacher'
 
       it "raises teacher deactivated error" do
         find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)

--- a/spec/services/admin/import_ect/register_ect_spec.rb
+++ b/spec/services/admin/import_ect/register_ect_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Admin::ImportECT::RegisterECT do
 
   subject { described_class.new(pending_induction_submission:, author:) }
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   before do
     allow(Events::Record).to receive(:new).and_call_original

--- a/spec/services/admin/revert_claim_spec.rb
+++ b/spec/services/admin/revert_claim_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::RevertClaim do
     )
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
   include ActiveJob::TestHelper
 
   before do

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
       end
 
       context "when the induction period is with another AB" do
-        include_context "fake trs api client"
+        include_context "test trs api client"
         let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
         it "returns true" do
@@ -49,7 +49,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
       end
 
       context "when there's an open induction_period with the same AB" do
-        include_context "fake trs api client"
+        include_context "test trs api client"
         let(:appropriate_body) { pending_induction_submission.appropriate_body }
 
         it "raises TeacherHasActiveInductionPeriodWithCurrentAB" do
@@ -61,7 +61,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
     end
 
     context "when there is no match" do
-      include_context "fake trs api client that finds nothing"
+      include_context "test trs api client that finds nothing"
 
       it "raises teacher not found error" do
         pending_induction_submission = FactoryBot.create(:pending_induction_submission)

--- a/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::RegisterECT do
   include ActiveJob::TestHelper
   subject { described_class.new(appropriate_body:, pending_induction_submission:, author:) }
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   before do
     allow(Events::Record).to receive(:new).and_call_original

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
     described_class.new(pending_induction_submission_batch:, author:)
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:author) do
     Sessions::Users::AppropriateBodyUser.new(

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
 
   describe '#process!' do
     context 'when happy' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       before { service.process! }
 
@@ -278,7 +278,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the TRN is not found' do
-      include_context 'fake trs api client that finds nothing'
+      include_context 'test trs api client that finds nothing'
 
       before { service.process! }
 
@@ -300,7 +300,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the ECT is prohibited' do
-      include_context 'fake trs api client that finds teacher prohibited from teaching'
+      include_context 'test trs api client that finds teacher prohibited from teaching'
 
       before { service.process! }
 
@@ -322,7 +322,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the ECT does not have QTS awarded' do
-      include_context 'fake trs api client that finds teacher without QTS'
+      include_context 'test trs api client that finds teacher without QTS'
 
       before { service.process! }
 
@@ -344,7 +344,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the ECT is already claimed by the AB' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       let(:started_on) { 1.day.ago.to_date.to_s }
 
@@ -372,7 +372,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the submission overlaps an earlier induction period' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       let(:started_on) { 15.days.ago.to_date.to_s }
 
@@ -394,7 +394,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'start date before QTS' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       let(:qts_date) { 3.years.ago.to_date }
       let(:started_on) { (qts_date - 1.day).to_s }
@@ -411,7 +411,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the ECT has already passed' do
-      include_context 'fake trs api client that finds teacher that has passed their induction'
+      include_context 'test trs api client that finds teacher that has passed their induction'
 
       let(:teacher) { FactoryBot.create(:teacher, trn:) }
 
@@ -434,7 +434,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the ECT has already failed' do
-      include_context 'fake trs api client that finds teacher that has failed their induction'
+      include_context 'test trs api client that finds teacher that has failed their induction'
 
       let(:teacher) { FactoryBot.create(:teacher, trn:) }
 
@@ -457,7 +457,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when the ECT is already claimed by another body' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       let(:other_body) { FactoryBot.create(:appropriate_body) }
       let(:teacher) { FactoryBot.create(:teacher, trn:) }
@@ -481,7 +481,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when induction programme is unknown' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       let(:induction_programme) { 'foo' }
 
@@ -502,7 +502,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     end
 
     context 'when start date is in the future' do
-      include_context 'fake trs api client that finds teacher with specific induction status', 'InProgress'
+      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
       let(:started_on) { 1.year.from_now.to_date.to_s }
 

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
     )
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
 
   let(:author) do
     Sessions::Users::AppropriateBodyUser.new(

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -737,7 +737,7 @@ RSpec.describe Events::Record do
   describe '.record_bulk_upload_completed_event!' do
     let(:batch) { FactoryBot.create(:pending_induction_submission_batch, :claim, appropriate_body:) }
 
-    include_context 'fake trs api client'
+    include_context 'test trs api client'
 
     before do
       ProcessBatchClaimJob.perform_now(batch, author.email, author.name)

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -32,7 +32,7 @@ describe 'InductionPeriods::CreateInductionPeriod' do
 
     describe '#create_induction_period!' do
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         allow(BeginECTInductionJob).to receive(:perform_later)
       end
 

--- a/spec/services/induction_periods/delete_induction_period_spec.rb
+++ b/spec/services/induction_periods/delete_induction_period_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
     )
   end
 
-  include_context 'fake trs api client'
+  include_context 'test trs api client'
   include ActiveJob::TestHelper
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -2,7 +2,7 @@ describe Teachers::RefreshTRSAttributes do
   include ActiveJob::TestHelper
 
   describe '#refresh!' do
-    include_context 'fake trs api client that finds teacher that has passed their induction'
+    include_context 'test trs api client that finds teacher that has passed their induction'
 
     let(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Kermit", trs_last_name: "Van Bouten") }
     let(:enable_trs_teacher_refresh) { true }
@@ -62,7 +62,7 @@ describe Teachers::RefreshTRSAttributes do
     end
 
     context 'when the teacher has been deactivated in TRS' do
-      include_context 'fake trs api client deactivated teacher'
+      include_context 'test trs api client deactivated teacher'
 
       let(:fake_manage) do
         double(Teachers::Manage, mark_teacher_as_deactivated!: true)

--- a/spec/support/api/trs/test_api_client.rb
+++ b/spec/support/api/trs/test_api_client.rb
@@ -1,0 +1,123 @@
+module TRS
+  class TestAPIClient
+    class TestAPIClientUsedInProduction < StandardError; end
+
+    def initialize(
+      raise_not_found: false,
+      raise_deactivated: false,
+      induction_status: nil,
+      has_qts: true,
+      has_itt: true,
+      is_prohibited_from_teaching: false,
+      has_alerts_but_not_prohibited: false
+    )
+      fail(TestAPIClientUsedInProduction) if Rails.env.production?
+
+      @raise_not_found = raise_not_found
+      @raise_deactivated = raise_deactivated
+      @induction_status = induction_status
+      @has_qts = has_qts
+      @has_itt = has_itt
+      @is_prohibited_from_teaching = is_prohibited_from_teaching
+      @has_alerts_but_not_prohibited = has_alerts_but_not_prohibited
+    end
+
+    def find_teacher(trn:, date_of_birth: "1977-02-03", national_insurance_number: nil)
+      raise(TRS::Errors::TeacherNotFound, "Teacher with TRN #{trn} not found") if @raise_not_found
+      raise(TRS::Errors::TeacherDeactivated, "Teacher with TRN #{trn} deactivated") if @raise_deactivated
+
+      build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
+    end
+
+    def begin_induction!(...) = nil
+    def pass_induction!(...) = nil
+    def fail_induction!(...) = nil
+    def reset_teacher_induction(...) = nil
+
+  private
+
+    def build_trs_teacher(trn:, date_of_birth:, national_insurance_number:)
+      TRS::Teacher.new(
+        teacher_params(trn:, date_of_birth:, national_insurance_number:).tap do |tp|
+          tp.merge!(qts_data)
+          tp.merge!(itt_data)
+
+          if @is_prohibited_from_teaching
+            tp.merge!(prohibited_from_teaching_data)
+          elsif @has_alerts_but_not_prohibited
+            tp.merge!(other_alert_data)
+          end
+
+          tp.merge!(induction_data)
+        end
+      )
+    end
+
+    def teacher_params(trn:, date_of_birth:, national_insurance_number:, first_name: 'Kirk', last_name: 'Van Houten')
+      {
+        'trn' => trn,
+        'firstName' => first_name,
+        'lastName' => last_name,
+        'dateOfBirth' => date_of_birth,
+        'nationalInsuranceNumber' => national_insurance_number,
+      }
+    end
+
+    def qts_data
+      if @has_qts
+        {
+          'qts' => {
+            'awarded' => Time.zone.today - 3.years,
+            'certificateUrl' => 'https://fancy-certificates.example.com/1234',
+            'statusDescription' => 'Passed'
+          }
+        }
+      else
+        { 'qts' => nil }
+      end
+    end
+
+    def prohibited_from_teaching_data
+      {
+        'alerts' => [{ 'alertType' => { 'alertCategory' => { 'alertCategoryId' => TRS::Teacher::PROHIBITED_FROM_TEACHING_CATEGORY_ID } } }]
+      }
+    end
+
+    def other_alert_data
+      {
+        # Conditional Registration Order - unacceptable professional conduct
+        'alerts' => [{ 'alertType' => { 'alertCategory' => { 'alertCategoryId' => '5562a5b7-3e32-eb11-a814-000d3a23980a' } } }]
+      }
+    end
+
+    def induction_data
+      if @induction_status
+        { 'induction' => { 'status' => @induction_status } }
+      else
+        { 'induction' => { 'status' => 'RequiredToComplete' } }
+      end
+    end
+
+    def itt_data
+      if @has_itt
+        {
+          "initialTeacherTraining" => [
+            {
+              "qualification" => { "name" => "Postgraduate Certificate in Education" },
+              "startDate" => "2020-12-31",
+              "result" => "Pass",
+              "subjects" => [],
+              "endDate" => "2021-04-05",
+              "programmeType" => nil,
+              "programmeTypeDescription" => nil,
+              "ageRange" => nil,
+              "provider" => { "name" => "Example Provider Ltd." },
+            }
+          ]
+        }
+      else
+        { "initialTeacherTraining" => [] }
+      end
+    end
+  end
+end

--- a/spec/support/api/trs/test_api_client_spec.rb
+++ b/spec/support/api/trs/test_api_client_spec.rb
@@ -1,0 +1,109 @@
+describe TRS::TestAPIClient do
+  describe 'initializing' do
+    it 'fails when used in production' do
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      expect { TRS::TestAPIClient.new }.to raise_error(TRS::TestAPIClient::TestAPIClientUsedInProduction)
+    end
+  end
+
+  describe '#find_teacher' do
+    subject { TRS::TestAPIClient.new(**kwargs) }
+
+    let(:trn) { '1234567' }
+
+    context 'when initialized with raise_not_found' do
+      let(:kwargs) { { raise_not_found: true } }
+
+      it 'raises a TRS::Errors::TeacherNotFound error' do
+        expect { subject.find_teacher(trn:) }.to raise_error(TRS::Errors::TeacherNotFound)
+      end
+    end
+
+    context 'when initialized with raise_deactivated' do
+      let(:kwargs) { { raise_deactivated: true } }
+
+      it 'raises a TRS::Errors::TeacherDeactivated error' do
+        expect { subject.find_teacher(trn:) }.to raise_error(TRS::Errors::TeacherDeactivated)
+      end
+    end
+
+    context 'when initialized with has_alerts_but_not_prohibited' do
+      let(:kwargs) { { has_alerts_but_not_prohibited: true } }
+
+      it 'the teacher has alerts' do
+        expect(subject.find_teacher(trn:)).to have_alerts
+      end
+
+      it 'the teacher is not prohibited_from_teaching' do
+        expect(subject.find_teacher(trn:)).not_to be_prohibited_from_teaching
+      end
+    end
+
+    context 'when initialized with prohibited_from_teaching' do
+      let(:kwargs) { { is_prohibited_from_teaching: true } }
+
+      it 'the teacher is prohibited from teaching' do
+        expect(subject.find_teacher(trn:)).to be_prohibited_from_teaching
+      end
+    end
+
+    describe 'induction_statuses' do
+      subject { TRS::TestAPIClient.new(**kwargs).find_teacher(trn:).induction_status }
+
+      context 'when initialized induction_status: InProgress' do
+        let(:kwargs) { { induction_status: 'InProgress' } }
+
+        it { is_expected.to eql('InProgress') }
+      end
+
+      context 'when initialized induction_status: Passed' do
+        let(:kwargs) { { induction_status: 'Passed' } }
+
+        it { is_expected.to eql('Passed') }
+      end
+
+      context 'when initialized induction_status: Failed' do
+        let(:kwargs) { { induction_status: 'Failed' } }
+
+        it { is_expected.to eql('Failed') }
+      end
+    end
+
+    describe 'QTS data' do
+      context 'when initialized with has_qts: false' do
+        let(:kwargs) { { has_qts: false } }
+
+        it 'the teacher has no QTS awarded on date' do
+          expect(subject.find_teacher(trn:).qts_awarded_on).to be_nil
+        end
+      end
+
+      context 'when initialized with has_qts: true' do
+        let(:kwargs) { { has_qts: true } }
+
+        it 'the teacher has a QTS awarded on date of 3 years ago' do
+          expect(subject.find_teacher(trn:).qts_awarded_on).to eql(3.years.ago.to_date)
+        end
+      end
+    end
+
+    describe 'ITT data' do
+      context 'when initialized with has_itt: false' do
+        let(:kwargs) { { has_itt: false } }
+
+        it 'the teacher has no ITT training provider' do
+          expect(subject.find_teacher(trn:).initial_teacher_training_provider_name).to be_nil
+        end
+      end
+
+      context 'when initialized with has_itt: true' do
+        let(:kwargs) { { has_itt: true } }
+
+        it 'the teacher has no ITT training provider' do
+          expect(subject.find_teacher(trn:).initial_teacher_training_provider_name).to eql('Example Provider Ltd.')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/csv_file.rb
+++ b/spec/support/shared_contexts/csv_file.rb
@@ -11,6 +11,24 @@ RSpec.shared_context '2 valid claims' do
   end
 end
 
+RSpec.shared_context '1 valid and 1 invalid claim' do
+  let(:file_name) do
+    '1 valid 1 invalid claim.csv'
+  end
+
+  let(:data) do
+    [
+      { trn: '1234567', date_of_birth: '1981-06-30', induction_programme: 'fip', started_on: '2025-01-30', error: '' },
+      { trn: '7654321', date_of_birth: '1981-06-30', induction_programme: 'CIP', started_on: '2025-01-30', error: '' }
+    ]
+  end
+
+  before do
+    already_claimed_teacher = FactoryBot.create(:teacher, trn: '1234567')
+    FactoryBot.create(:induction_period, :active, teacher: already_claimed_teacher)
+  end
+end
+
 RSpec.shared_context '3 valid actions' do
   let(:file_name) do
     '3 valid actions.csv'

--- a/spec/support/shared_contexts/fake_trs_api_client.rb
+++ b/spec/support/shared_contexts/fake_trs_api_client.rb
@@ -1,98 +1,89 @@
-RSpec.shared_context 'fake trs api client' do
+RSpec.shared_context 'test trs api client' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds nothing' do
+RSpec.shared_context 'test trs api client that finds nothing' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(raise_not_found: true))
   end
 end
 
-RSpec.shared_context 'fake trs api client deactivated teacher' do
+RSpec.shared_context 'test trs api client deactivated teacher' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_deactivated: true))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(raise_deactivated: true))
   end
 end
 
-RSpec.shared_context 'fake trs api client returns 200 then 400' do
+RSpec.shared_context 'test trs api client returns 200 then 400' do
   before do
     allow(TRS::APIClient).to receive(:new).and_return(
-      TRS::FakeAPIClient.new,
-      TRS::FakeAPIClient.new(raise_not_found: true)
+      TRS::TestAPIClient.new,
+      TRS::TestAPIClient.new(raise_not_found: true)
     )
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds teacher without QTS' do
+RSpec.shared_context 'test trs api client that finds teacher without QTS' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(include_qts: false))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(has_qts: false))
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds teacher prohibited from teaching' do
+RSpec.shared_context 'test trs api client that finds teacher prohibited from teaching' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(prohibited_from_teaching: true))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(is_prohibited_from_teaching: true))
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds teacher with specific induction status' do |status|
+RSpec.shared_context 'test trs api client that finds teacher with specific induction status' do |status|
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: status))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(induction_status: status))
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds teacher that has passed their induction' do
+RSpec.shared_context 'test trs api client that finds teacher that has passed their induction' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: 'Passed'))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(induction_status: 'Passed'))
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds teacher that has failed their induction' do
+RSpec.shared_context 'test trs api client that finds teacher that has failed their induction' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: 'Failed'))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(induction_status: 'Failed'))
   end
 end
 
-RSpec.shared_context 'fake trs api client that finds teacher that is exempt from induction' do
+RSpec.shared_context 'test trs api client that finds teacher that is exempt from induction' do
   before do
-    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(induction_status: 'Exempt'))
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(induction_status: 'Exempt'))
   end
 end
 
-RSpec.shared_context 'fake trs api returns a teacher and then a teacher that has completed their induction' do
+RSpec.shared_context 'test trs api returns a teacher and then a teacher that has completed their induction' do
   before do
     allow(TRS::APIClient).to receive(:new).and_return(
-      TRS::FakeAPIClient.new,
-      TRS::FakeAPIClient.new(induction_status: 'Passed')
+      TRS::TestAPIClient.new,
+      TRS::TestAPIClient.new(induction_status: 'Passed')
     )
   end
 end
 
-RSpec.shared_context 'fake trs api returns a teacher and then a teacher that has failed their induction' do
+RSpec.shared_context 'test trs api returns a teacher and then a teacher that has failed their induction' do
   before do
     allow(TRS::APIClient).to receive(:new).and_return(
-      TRS::FakeAPIClient.new,
-      TRS::FakeAPIClient.new(induction_status: 'Failed')
+      TRS::TestAPIClient.new,
+      TRS::TestAPIClient.new(induction_status: 'Failed')
     )
   end
 end
 
-RSpec.shared_context 'fake trs api returns a teacher and then a teacher that is exempt from induction' do
+RSpec.shared_context 'test trs api returns a teacher and then a teacher that is exempt from induction' do
   before do
     allow(TRS::APIClient).to receive(:new).and_return(
-      TRS::FakeAPIClient.new,
-      TRS::FakeAPIClient.new(induction_status: 'Exempt')
-    )
-  end
-end
-
-RSpec.shared_context 'fake trs api returns 2 random teachers' do
-  before do
-    allow(TRS::APIClient).to receive(:new).and_return(
-      TRS::FakeAPIClient.new(random_names: true),
-      TRS::FakeAPIClient.new(random_names: true)
+      TRS::TestAPIClient.new,
+      TRS::TestAPIClient.new(induction_status: 'Exempt')
     )
   end
 end

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -54,7 +54,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     context 'when the ect is not found in TRS' do
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(raise_not_found: true))
         subject.save!
       end
 
@@ -76,7 +76,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       end
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -91,7 +91,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
       before do
         wizard.store.update!(school_urn: active_ect_period.school.urn)
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -104,9 +104,9 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        fake_client = TRS::FakeAPIClient.new
+        test_client = TRS::TestAPIClient.new
 
-        allow(fake_client).to receive(:find_teacher).and_return(
+        allow(test_client).to receive(:find_teacher).and_return(
           TRS::Teacher.new(
             'trn' => '1234568',
             'firstName' => 'Kirk',
@@ -117,7 +117,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
             }
           )
         )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
         subject.save!
       end
 
@@ -130,9 +130,9 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        fake_client = TRS::FakeAPIClient.new
+        test_client = TRS::TestAPIClient.new
 
-        allow(fake_client).to receive(:find_teacher).and_return(
+        allow(test_client).to receive(:find_teacher).and_return(
           TRS::Teacher.new(
             'trn' => '1234568',
             'firstName' => 'Kirk',
@@ -143,7 +143,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
             }
           )
         )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
         subject.save!
       end
 
@@ -156,9 +156,9 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        fake_client = TRS::FakeAPIClient.new
+        test_client = TRS::TestAPIClient.new
 
-        allow(fake_client).to receive(:find_teacher).and_return(
+        allow(test_client).to receive(:find_teacher).and_return(
           TRS::Teacher.new(
             'trn' => '1234568',
             'firstName' => 'Kirk',
@@ -169,7 +169,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
             }
           )
         )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
         subject.save!
       end
 
@@ -182,9 +182,9 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        fake_client = TRS::FakeAPIClient.new
+        test_client = TRS::TestAPIClient.new
 
-        allow(fake_client).to receive(:find_teacher).and_return(
+        allow(test_client).to receive(:find_teacher).and_return(
           TRS::Teacher.new(
             'trn' => '1234568',
             'firstName' => 'Kirk',
@@ -201,7 +201,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
             ]
           )
         )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
         subject.save!
       end
 
@@ -214,7 +214,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       let(:school) { FactoryBot.create(:school) }
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         wizard.store.update!(school_urn: school.urn)
         subject.save!
       end
@@ -256,7 +256,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
       end
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
       end
 
       it 'updates the wizard ect trn and TRS data' do

--- a/spec/wizards/schools/register_ect_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/national_insurance_number_step_spec.rb
@@ -43,7 +43,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
   describe '#next_step' do
     subject { wizard.current_step }
 
-    let(:fake_trs_client) { TRS::FakeAPIClient.new }
+    let(:test_trs_client) { TRS::TestAPIClient.new }
     let(:fake_trs_teacher) do
       TRS::Teacher.new(
         'trn' => '1234568',
@@ -61,7 +61,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
 
     context 'when the ect is not found in TRS' do
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(raise_not_found: true))
         subject.save!
       end
 
@@ -74,8 +74,8 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        allow(fake_trs_client).to receive(:find_teacher).and_return(fake_trs_teacher)
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_trs_client)
+        allow(test_trs_client).to receive(:find_teacher).and_return(fake_trs_teacher)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_trs_client)
         subject.save!
       end
 
@@ -108,7 +108,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
       let(:school) { FactoryBot.create(:school) }
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         wizard.store.update!(school_urn: school.urn)
         subject.save!
       end
@@ -152,7 +152,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
       let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :national_insurance_number, step_params:) }
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
       end
 
       it 'updates the wizard ect and TRS data' do

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -76,7 +76,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context 'when the mentor is not found in TRS' do
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(raise_not_found: true))
         subject.save!
       end
 
@@ -90,7 +90,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
       let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher:) }
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -112,7 +112,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
       end
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -127,7 +127,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
       before do
         wizard.store.update!(school_urn: active_mentor_period.school.urn)
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -140,9 +140,9 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        fake_client = TRS::FakeAPIClient.new
+        test_client = TRS::TestAPIClient.new
 
-        allow(fake_client).to receive(:find_teacher).and_return(
+        allow(test_client).to receive(:find_teacher).and_return(
           TRS::Teacher.new(
             'trn' => '1234568',
             'firstName' => 'Jane',
@@ -159,7 +159,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
             ]
           )
         )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
         subject.save!
       end
 
@@ -172,7 +172,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
       let(:school) { FactoryBot.create(:school) }
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         wizard.store.update!(school_urn: school.urn)
         subject.save!
       end
@@ -214,7 +214,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
       end
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
       end
 
       it 'updates the wizard mentor trn and TRS data' do

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -71,7 +71,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context 'when the mentor is not found in TRS' do
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new(raise_not_found: true))
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new(raise_not_found: true))
         subject.save!
       end
 
@@ -86,7 +86,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
       before do
         wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -101,7 +101,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
       before do
         wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
 
@@ -114,9 +114,9 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
       before do
-        fake_client = TRS::FakeAPIClient.new
+        test_client = TRS::TestAPIClient.new
 
-        allow(fake_client).to receive(:find_teacher).and_return(
+        allow(test_client).to receive(:find_teacher).and_return(
           TRS::Teacher.new(
             'trn' => '1234568',
             'firstName' => 'Jane',
@@ -133,7 +133,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
             ]
           )
         )
-        allow(::TRS::APIClient).to receive(:new).and_return(fake_client)
+        allow(::TRS::APIClient).to receive(:new).and_return(test_client)
         subject.save!
       end
 
@@ -146,7 +146,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
       let(:school) { FactoryBot.create(:school) }
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         wizard.store.update!(school_urn: school.urn)
         subject.save!
       end
@@ -191,7 +191,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
       end
 
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
       end
 
       it 'updates the wizard mentor national insurance number and TRS data' do


### PR DESCRIPTION
### Context

We've had several problems caused by several using and overwriting the same data in TRS's preprod API.

For example, when someone's induction is marked as complete in RIAB, they're no longer claimable in RECT. This meant team members had to reset/reseed `staging` to be able to re-claim teachers.

### Changes

This PR splits the `TRS::FakeAPIClient` in two:
  1. the `TRS::TestAPIClient` which is used by tests and has values set on initialization
  2. the `TRS::FakeAPICLient` which can be used by the app when `config.enable_fake_trs_api = true` (and will fail in production regardless of the setting)

The main reason for the split was the original approach of having an `app_mode` setting made the behaviour of the class more complex and changes could potentially either break the tests or the fake behaviour, adding risk.

Now they are separate the risk is reduced and the classes are much simpler.

### Using the test API client

The intended way of using `TRS::TestAPIClient` is by stubbing the call before running the test, so to return a teacher who has alerts which prohibit them from teaching we can do this:

```ruby
  before do
    test_api_client = TRS::TestAPIClient.new(is_prohibited_from_teaching: true)
    allow(TRS::APIClient).to receive(:new).and_return(test_api_client)
  end
```

### Using the fake API client

First set `ENABLE_FAKE_TRS_API=true` in your `.envrc`/`.env` file.

Now restart the application. The blue help box will look like this:

<img width="709" height="454" alt="image" src="https://github.com/user-attachments/assets/9312a9a0-b03a-4de6-a5e3-e05e7dcdf8e3" />

These special TRNs will illicit a predetermined response. All other TRNs will return a new `TRS::Teacher` with a [fake name](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/lib/trs/fake_api_names.yml).

### Making the fake API remember changes

Until now the fake API didn't actually do anything when inductions are started, passed, failed or reset. This means when a teacher is 'Passed' their TRS induction status remains `InProgress`, which would be confusing and unrealistic.

Additionally, if teachers exist in an environment and the `Teachers::RefreshTRSAttributes` job runs, their status would be overwritten.

We already have Redis deployed in all environments (thus far only used for recording Rack Attack hits) and this functionality uses it. It's probably going to surprise devs when they pull these changes so I'll post about it in the channel first. It should just be a case of installing Valkey/Redis and setting `REDIS_CACHE_URL='redis://localhost:6379'`.

https://github.com/user-attachments/assets/f507c9db-9544-4cc2-b017-a52e95315222

### Review notes

Go commit by commit. It looks like lots has changed but nearly all of it is changing references to the fake API with the test API.