### PR TITLE
Configure `:net_http` as default Faraday adapter (again)

### DIFF
--- a/app/migration/parity_check/client.rb
+++ b/app/migration/parity_check/client.rb
@@ -1,5 +1,3 @@
-require "async/http/faraday/default"
-
 module ParityCheck
   class Client
     include ActiveModel::Model

--- a/config/faraday.rb
+++ b/config/faraday.rb
@@ -1,0 +1,1 @@
+Faraday.default_adapter = :net_http

--- a/lib/dfe_sign_in/api_client.rb
+++ b/lib/dfe_sign_in/api_client.rb
@@ -13,7 +13,6 @@ module DfESignIn
         faraday.request(:authorization, 'Bearer', jwt)
         faraday.request(:json)
         faraday.response(:json)
-        faraday.adapter(Faraday.default_adapter)
       end
     end
 

--- a/lib/trs/api_client.rb
+++ b/lib/trs/api_client.rb
@@ -8,7 +8,6 @@ module TRS
         faraday.headers['Accept'] = 'application/json'
         faraday.headers['X-Api-Version'] = Rails.application.config.trs_api_version
         faraday.headers['Content-Type'] = 'application/json'
-        faraday.adapter Faraday.default_adapter
         faraday.response :logger if Rails.env.development?
       end
     end


### PR DESCRIPTION
### Context

I couldn't connect to the TRS API locally via IPv6, and it wasn't as simple as enabling it 😢.

### Changes proposed in this pull request

In #782, we adopted the `:async_http` Faraday adapter so we could make parity check requests in parallel.

As part of this change, we changed the default Faraday adapter for all clients.

Unfortunately not all ISPs support IPv6, so this broke the application for some people (me).

To resolve this, I've configured the default Faraday adapter *back* to `:net_http`.

The `ParityCheck::Client` explicitly sets the Faraday adapter to `:async_http`, so the behaviour there should be unchanged.

### Guidance to review

- [ ] Connect with `TRS::APIClient`
- [ ] Connect with `DfESignIn::APIClient`
- [ ] Connect with `Migration::ParityCheck::Client`