### PR TITLE
Remove the debugging screenshot from parity check spec

### DIFF
--- a/spec/features/migration/run_parity_check_spec.rb
+++ b/spec/features/migration/run_parity_check_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe "Run parity check" do
     page.get_by_label(post_endpoint.description).click
 
     page.get_by_role("button", name: "Run").click
-    page.screenshot(path: "tmp.png")
 
     expect(page.get_by_role("heading", name: "There is a problem")).to be_visible
     expect(page.locator(".govuk-error-summary a").and(page.get_by_text("There are no lead providers available; create at least one lead provider to run a parity check."))).to be_visible


### PR DESCRIPTION
This file kept creeping into my commits when it's saved to the root of the app, moving it to the tmp dir means it'll be ignored by git.
