### PR TITLE
Bump workers and web apps to at least 2 pods

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -13,5 +13,7 @@
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true,
     "worker_memory_max": "2Gi",
-    "webapp_memory_max": "2Gi"
+    "webapp_memory_max": "2Gi",
+    "webapp_replicas": 2,
+    "worker_replicas": 2
 }


### PR DESCRIPTION
### Context

RECT gets scanned and although we added rate limiting 1 pod is not coping with the load and the app is getting downtime

### Changes proposed in this pull request

Bump pods to 2 for both workers and web app incase for contingency, we might need more later, after monitoring

### Guidance to review
Will keep monitoring