### PR TITLE
Make teacher failure query a distinct list of teachers in Migration env

### DIFF
--- a/app/controllers/migration/teacher_failures_controller.rb
+++ b/app/controllers/migration/teacher_failures_controller.rb
@@ -16,6 +16,6 @@ private
       tmf = TeacherMigrationFailure.arel_table
       scope = scope.where(tmf[:message].matches("%#{failure_message}%"))
     end
-    scope
+    scope.distinct
   end
 end


### PR DESCRIPTION
### Context
In migration, the list of teachers with failures contains duplicates because of the joins to failure records, so adding a `distinct` clause to the query so that the list of teachers and the count of teachers with the failure is correct.

### Changes proposed in this pull request
Add distinct clause to query

### Guidance to review
