### PR TITLE
Move `ECTAtSchoolPeriod` fields to the blocklist (for now)

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -9,9 +9,6 @@ shared:
     - establishment_number
     - dfe_sign_in_organisation_id
     - dqt_id
-  :ect_at_school_periods:
-    - school_reported_appropriate_body_id
-    - training_programme
   :induction_extensions:
     - id
     - teacher_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -267,7 +267,7 @@
   - released_count
   - passed_count
   - failed_count
-  - claimed_count  
+  - claimed_count
   - error_message
   - created_at
   - updated_at
@@ -329,7 +329,7 @@
   - delivery_partner_id
   - active_lead_provider_id
   - lead_provider_delivery_partnership_id
-  - pending_induction_submission_batch_id  
+  - pending_induction_submission_batch_id
   - statement_id
   - statement_adjustment_id
   - user_id
@@ -354,6 +354,8 @@
   - ecf_end_induction_record_id
   - working_pattern
   - email
+  - school_reported_appropriate_body_id
+  - training_programme
   :dfe_roles:
   - id
   - role_type


### PR DESCRIPTION
This data won't be present until the main Register ECTs service goes live next year, so blocking for now.

Also tidied up a few trailing bits of whitespace while I was there.
