### PR TITLE
Change `parity_checks;' path to dashified `parity-checks/`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,7 +151,7 @@ Rails.application.routes.draw do
     resources :teachers, only: %i[index show]
 
     constraints -> { Rails.application.config.parity_check[:enabled] } do
-      resources :parity_checks, only: %i[new create show], param: :run_id do
+      resources :parity_checks, path: "parity-checks", only: %i[new create show], param: :run_id do
         collection do
           get :completed
         end

--- a/spec/requests/migration/parity_check_spec.rb
+++ b/spec/requests/migration/parity_check_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Parity check", type: :request do
 
   before { allow(Rails.configuration).to receive(:parity_check).and_return({ enabled: }) }
 
-  describe "GET /migration/parity_checks/new" do
+  describe "GET /migration/parity-checks/new" do
     context "when signed in as a DfE user" do
       include_context 'sign in as DfE user'
 
@@ -81,7 +81,7 @@ RSpec.describe "Parity check", type: :request do
     end
   end
 
-  describe "GET /migration/parity_checks/completed" do
+  describe "GET /migration/parity-checks/completed" do
     context "when signed in as a DfE user" do
       include_context 'sign in as DfE user'
 
@@ -112,7 +112,7 @@ RSpec.describe "Parity check", type: :request do
     end
   end
 
-  describe "GET /migration/parity_checks/:id" do
+  describe "GET /migration/parity-checks/:id" do
     let(:run) { FactoryBot.create(:parity_check_run, :completed) }
 
     context "when signed in as a DfE user" do
@@ -161,7 +161,7 @@ RSpec.describe "Parity check", type: :request do
     end
   end
 
-  describe "GET /migration/parity_checks/:run_id/requests/:id" do
+  describe "GET /migration/parity-checks/:run_id/requests/:id" do
     let(:run) { FactoryBot.create(:parity_check_run, :completed) }
     let(:request) { FactoryBot.create(:parity_check_request, :completed, run:) }
 
@@ -218,7 +218,7 @@ RSpec.describe "Parity check", type: :request do
     end
   end
 
-  describe "GET /migration/parity_checks/:run_id/responses/:id" do
+  describe "GET /migration/parity-checks/:run_id/responses/:id" do
     let(:run) { FactoryBot.create(:parity_check_run, :completed) }
     let(:request) { FactoryBot.create(:parity_check_request, :completed, run:) }
     let(:parity_check_response) { FactoryBot.create(:parity_check_response, :different, request:) }


### PR DESCRIPTION
### Context

Current path in parity check is `migration/parity_checks/new`, we should change to dashified version

### Changes proposed in this pull request
amend routes to use dashified `migration/parity-checks/new`

### Guidance to review
