### PR TITLE
Fix bad terms links in the service manual

### DIFF
--- a/documentation/policy/induction-for-early-career-teachers.adoc
+++ b/documentation/policy/induction-for-early-career-teachers.adoc
@@ -663,15 +663,15 @@ Teachers’ Standards over a period of less than one term. After the
 minimum period has been served, any continuous employment of any length
 of time will count towards the 2 year induction period on the ECT’s
 records. Therefore if a full time ECT ends a contract of employment
-after serving <<para-2-5,2.5>> terms, their recordsfootnote:[Please note that TRA
+after serving 2.5 terms, their recordsfootnote:[Please note that TRA
 records only record full terms. Local records held by the ECT’s
 school/institution and the appropriate body should record the exact
 length of induction served.] (and interim assessment) should show that
-they have completed <<para-2-5,2.5>> terms and they will be expected to complete a
-further <<para-3-5,3.5>> terms when they resume induction. And if a part time ECT
-working <<para-0-5,0.5>>FTE ends a contract of employment after <<para-2-5,2.5>> terms, their
+they have completed 2.5 terms and they will be expected to complete a
+further 3.5 terms when they resume induction. And if a part time ECT
+working 0.5 FTE ends a contract of employment after 2.5 terms, their
 records (and interim assessment) would show that they have completed
-<<para-1-25,1.25>> terms and would be expected to resume induction from that point
+1.25 terms and would be expected to resume induction from that point
 (although this should be read in conjunction with guidance around
 reductions to induction periods available for part time ECTs – please
 see <<_section_3_special_circumstances,Section 3>>).


### PR DESCRIPTION
Here my matching for paragraph numbers added links to decimal term values, so 2.5 terms linked to section 2 paragraph 5 🙈

Easiest to see in word diff mode `git log -n1 --patch --word-diff`
