### PR TITLE
Fix flaky spec for `LeadProviderDeliveryPartnership`

### DIFF
--- a/spec/factories/migration/delivery_partner_factory.rb
+++ b/spec/factories/migration/delivery_partner_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :migration_delivery_partner, class: "Migration::DeliveryPartner" do
-    name  { Faker::Company.name }
+    sequence(:name) { |n| "Migration Delivery Partner #{n}" }
   end
 end

--- a/spec/migration/migrators/delivery_partner_spec.rb
+++ b/spec/migration/migrators/delivery_partner_spec.rb
@@ -1,65 +1,33 @@
 RSpec.describe Migrators::DeliveryPartner do
-  # TODO: would be nice to use the 'it_behaves_like "a migrator"' shared_example but this one is difficult to make fail
-  # so the failure handling specs fail
-
-  describe '.record_count' do
-    it 'returns the count of delivery partners' do
-      FactoryBot.create_list(:migration_delivery_partner, 2)
-      expect(described_class.record_count).to eq(2)
-    end
-  end
-
-  describe '.model' do
-    it 'returns :delivery_partner' do
-      expect(described_class.model).to eq(:delivery_partner)
-    end
-  end
-
-  describe '.delivery_partners' do
-    it 'returns all delivery_partners' do
-      delivery_partner = FactoryBot.create(:migration_delivery_partner)
-      expect(described_class.delivery_partners).to include(delivery_partner)
-    end
-  end
-
-  describe '.reset!' do
-    before do
-      FactoryBot.create(:delivery_partner)
-      allow(Rails.application.config).to receive(:enable_migration_testing).and_return(enable_migration_testing)
+  it_behaves_like "a migrator", :delivery_partner, [] do
+    def create_migration_resource
+      FactoryBot.create(:migration_delivery_partner)
     end
 
-    context 'when migration testing is enabled' do
-      let(:enable_migration_testing) { true }
+    def create_resource(migration_resource)
+    end
 
-      it 'removes all records from the contract_periods table' do
-        expect { described_class.reset! }.to change(DeliveryPartner, :count).from(1).to(0)
+    def setup_failure_state
+      dp = FactoryBot.create(:migration_delivery_partner)
+      FactoryBot.create(:delivery_partner, name: dp.name, api_id: SecureRandom.uuid)
+    end
+
+    describe "#migrate!" do
+      it 'creates a record in the ecf2 database' do
+        expect {
+          instance.migrate!
+        }.to change(::DeliveryPartner, :count).by(Migration::DeliveryPartner.count)
       end
-    end
 
-    context 'when migration testing is disabled' do
-      let(:enable_migration_testing) { false }
+      it "populates the ecf2 model correctly" do
+        instance.migrate!
 
-      it 'does not remove records from the contract_periods table' do
-        expect { described_class.reset! }.not_to(change(DeliveryPartner, :count))
-      end
-    end
-  end
-
-  describe '#migrate!' do
-    subject { described_class.new(worker: 0) }
-
-    let!(:delivery_partner1) { FactoryBot.create(:migration_delivery_partner) }
-    let!(:delivery_partner2) { FactoryBot.create(:migration_delivery_partner) }
-    let!(:data_migration) { FactoryBot.create(:data_migration, model: :delivery_partner) }
-
-    before { subject.migrate! }
-
-    it 'creates a delivery partner for each ecf delivery partner' do
-      described_class.delivery_partners.find_each do |delivery_partner|
-        dp = DeliveryPartner.find_by(api_id: delivery_partner.id)
-        expect(dp.name).to eq delivery_partner.name
-        expect(dp.created_at).to eq delivery_partner.created_at
-        expect(dp.updated_at).to eq delivery_partner.updated_at
+        ::DeliveryPartner.find_each do |delivery_partner|
+          source_record = Migration::DeliveryPartner.find(delivery_partner.api_id)
+          expect(delivery_partner.name).to eq source_record.name
+          expect(delivery_partner.created_at).to eq source_record.created_at
+          expect(delivery_partner.updated_at).to eq source_record.updated_at
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

A flaky spec was spotted related to duplicate names (assume a small pool in `Faker`) so moved to a name with a sequence number:

```
 1) Migrators::LeadProviderDeliveryPartnership behaves like a migrator .prepare! when there are enough models for two workers creates two pending data migrations
     Failure/Error: FactoryBot.create(:delivery_partner, name: dp.name, api_id: dp.id)

     ActiveRecord::RecordInvalid:
       Validation failed: Name has already been taken
     Shared Example Group: "a migrator" called from ./spec/migration/migrators/lead_provider_delivery_partnership_spec.rb:2
     # ./spec/migration/migrators/lead_provider_delivery_partnership_spec.rb:14:in 'RSpec::ExampleGroups::MigratorsLeadProviderDeliveryPartnership::BehavesLikeAMigrator#create_resource'
     # ./spec/support/shared_examples/migrator_support.rb:14:in 'block (2 levels) in <main>'
     # ./spec/support/rack_attack.rb:17:in 'block (2 levels) in <main>'

Finished in 2 minutes 38.9 seconds (files took 9.28 seconds to load)
4262 examples, 1 failure, 11 pending

Failed examples:

rspec ./spec/migration/migrators/lead_provider_delivery_partnership_spec.rb[1:1:1:2:1] # Migrators::LeadProviderDeliveryPartnership behaves like a migrator .prepare! when there are enough models for two workers creates two pending data migrations
```

### Changes proposed in this pull request

- Change Migration Delivery Partner to use a name with a sequence number
- Refactor DeliveryPartner migrator spec to use the shared examples

### Guidance to review

Tried 7 times locally without failure
