### PR TITLE
[1696] Show EOI lead provider if no confirmed partnership

### DIFF
--- a/app/components/schools/ects/listing_card_component.html.erb
+++ b/app/components/schools/ects/listing_card_component.html.erb
@@ -13,6 +13,6 @@
         <%= govuk_summary_list(borders: false, rows: right_rows) %>
       </div>
     </div>
-    <%= govuk_summary_list(html_attributes: { class: "govuk-!-margin-bottom-0" }, borders: false, rows: [mentor_row]) %>
+    <%= govuk_summary_list(borders: false, rows: [mentor_row]) %>
   </div>
 </div>

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -19,13 +19,27 @@ module Schools
       def delivery_partner_row
         return if ect.school_led_training_programme?
 
-        { key: { text: 'Delivery partner' }, value: { text: latest_delivery_partner_name(ect) } }
+        {
+          key: { text: 'Delivery partner' },
+          value: {
+            text: latest_training_period_only_expression_of_interest? ? 'Their lead provider will confirm this' : latest_delivery_partner_name(ect)
+          }
+        }
       end
 
       def lead_provider_row
         return if ect.school_led_training_programme?
 
-        { key: { text: 'Lead provider' }, value: { text: latest_lead_provider_name(ect) } }
+        {
+          key: { text: 'Lead provider' },
+          value: {
+            text: latest_training_period_only_expression_of_interest? ? latest_eoi_lead_provider_name(ect) : latest_lead_provider_name(ect)
+          }
+        }
+      end
+
+      def latest_training_period_only_expression_of_interest?
+        ECTAtSchoolPeriods::Training.new(ect).latest_training_period&.only_expression_of_interest?
       end
 
       def left_rows

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -21,9 +21,7 @@ module Schools
 
         {
           key: { text: 'Delivery partner' },
-          value: {
-            text: latest_training_period_only_expression_of_interest? ? 'Their lead provider will confirm this' : latest_delivery_partner_name(ect)
-          }
+          value: { text: delivery_partner_display_text }
         }
       end
 
@@ -32,10 +30,24 @@ module Schools
 
         {
           key: { text: 'Lead provider' },
-          value: {
-            text: latest_training_period_only_expression_of_interest? ? latest_eoi_lead_provider_name(ect) : latest_lead_provider_name(ect)
-          }
+          value: { text: lead_provider_display_text }
         }
+      end
+
+      def delivery_partner_display_text
+        if latest_training_period_only_expression_of_interest?
+          'Their lead provider will confirm this'
+        else
+          latest_delivery_partner_name(ect)
+        end
+      end
+
+      def lead_provider_display_text
+        if latest_training_period_only_expression_of_interest?
+          latest_eoi_lead_provider_name(ect)
+        else
+          latest_lead_provider_name(ect)
+        end
       end
 
       def latest_training_period_only_expression_of_interest?

--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -20,6 +20,11 @@ module ECTHelper
   end
 
   # @param ect [ECTAtSchoolPeriod]
+  def latest_eoi_lead_provider_name(ect)
+    ECTAtSchoolPeriods::Training.new(ect).latest_eoi_lead_provider_name
+  end
+
+  # @param ect [ECTAtSchoolPeriod]
   def link_to_assign_mentor(ect)
     govuk_warning_text(text: "You must #{assign_or_create_mentor_link(ect)} for this ECT.".html_safe)
   end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -51,6 +51,10 @@ class TrainingPeriod < ApplicationRecord
     trainee.training_periods.excluding(self)
   end
 
+  def only_expression_of_interest?
+    school_partnership_id.blank? && expression_of_interest.present?
+  end
+
 private
 
   def one_id_of_trainee_present

--- a/app/services/ect_at_school_periods/training.rb
+++ b/app/services/ect_at_school_periods/training.rb
@@ -60,5 +60,16 @@ module ECTAtSchoolPeriods
 
     # latest_lead_provider_name
     delegate :name, to: :latest_lead_provider, allow_nil: true, prefix: true
+
+    # latest_eoi_lead_provider_name
+    delegate :name, to: :latest_eoi_lead_provider, allow_nil: true, prefix: true
+
+  private
+
+    def latest_eoi_lead_provider
+      return if latest_training_period.nil? || latest_training_period.school_partnership_id.present?
+
+      latest_training_period.expression_of_interest&.lead_provider
+    end
   end
 end

--- a/app/services/ect_at_school_periods/training.rb
+++ b/app/services/ect_at_school_periods/training.rb
@@ -67,7 +67,7 @@ module ECTAtSchoolPeriods
   private
 
     def latest_eoi_lead_provider
-      return if latest_training_period.nil? || latest_training_period.school_partnership_id.present?
+      return unless latest_training_period&.only_expression_of_interest?
 
       latest_training_period.expression_of_interest&.lead_provider
     end

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -71,4 +71,31 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
       expect(rendered_content).not_to have_selector('.govuk-summary-list__row', text: 'Lead provider')
     end
   end
+
+  context 'when latest training period is an expression of interest only' do
+    let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Jimmy Provider') }
+    let(:ect) do
+      FactoryBot.create(
+        :ect_at_school_period,
+        :active,
+        :with_eoi_only_training_period,
+        lead_provider:,
+        school:,
+        started_on:
+      )
+    end
+
+    it 'renders lead provider name on the EOI' do
+      render_inline(described_class.new(ect:))
+
+      expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Lead provider')
+      expect(rendered_content).to have_text('Jimmy Provider')
+    end
+
+    it 'renders the delivery partner fallback text' do
+      render_inline(described_class.new(ect:))
+      expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
+      expect(rendered_content).to have_text('Their lead provider will confirm this')
+    end
+  end
 end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -74,5 +74,25 @@ FactoryBot.define do
                           started_on: ect.started_on)
       end
     end
+
+    trait :with_eoi_only_training_period do
+      transient do
+        lead_provider { FactoryBot.create(:lead_provider) }
+      end
+
+      after(:create) do |ect, evaluator|
+        active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider: evaluator.lead_provider)
+
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period: ect,
+          school_partnership: nil,
+          expression_of_interest: active_lead_provider,
+          started_on: ect.started_on + 1.week,
+          finished_on: ect.started_on + 1.month
+        )
+      end
+    end
   end
 end

--- a/spec/services/ect_at_school_periods/training_spec.rb
+++ b/spec/services/ect_at_school_periods/training_spec.rb
@@ -238,4 +238,80 @@ describe ECTAtSchoolPeriods::Training do
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
   end
+
+  describe '#latest_eoi_lead_provider_name' do
+    subject { described_class.new(ect_at_school_period).latest_eoi_lead_provider_name }
+
+    context 'when the latest training period is an expression of interest' do
+      let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Jimmy Provider') }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, :with_eoi_only_training_period, lead_provider:) }
+
+      it 'returns the lead provider name from the EOI' do
+        expect(subject).to eq('Jimmy Provider')
+      end
+    end
+
+    context 'when there is no training period' do
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'when the latest training period has a school partnership' do
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :with_training_period) }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'when multiple training periods exist and the latest is EOI only' do
+      let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'EOI Provider') }
+
+      let(:ect_at_school_period) do
+        FactoryBot.create(:ect_at_school_period, :active).tap do |ect|
+          FactoryBot.create(:training_period, :for_ect, ect_at_school_period: ect, started_on: ect.started_on + 1.week, finished_on: ect.started_on + 10.days)
+
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            school_partnership: nil,
+            expression_of_interest: FactoryBot.create(:active_lead_provider, lead_provider:),
+            ect_at_school_period: ect,
+            started_on: ect.started_on + 2.weeks,
+            finished_on: ect.started_on + 1.month
+          )
+        end
+      end
+
+      it 'returns the lead provider name from the latest EOI only training period' do
+        expect(subject).to eq('EOI Provider')
+      end
+    end
+
+    context 'when multiple training periods exist and the latest is confirmed (not EOI only)' do
+      let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Old EOI Provider') }
+
+      let(:ect_at_school_period) do
+        FactoryBot.create(:ect_at_school_period, :active, :with_eoi_only_training_period, lead_provider:)
+      end
+
+      let!(:confirmed_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period:,
+          started_on: ect_at_school_period.started_on + 2.months,
+          finished_on: ect_at_school_period.started_on + 3.months,
+          school_partnership: FactoryBot.create(:school_partnership)
+        )
+      end
+
+      it 'returns nil because latest training period is confirmed, and not an EOI' do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

If there is no confirmed partnership (`school_partnership`), but there is an expression of interest (EOI), we want to surface that. On the ECT index page:

- The **lead provider** section should display the name from the EOI.
- The **delivery partner** section should show fallback text: *"Their lead provider will confirm this."*

### Changes proposed in this pull request

- Show EOI lead provider name if the most recent training period has an EOI but no `school_partnership`
- Show fallback text in the delivery partner section in this scenario
- Add `only_expression_of_interest?` method to `TrainingPeriod` to capture this logic
- Add `with_eoi_only_training_period` trait to the ECT factory (creates a `training_period` with no `school_partnership`, but with an EOI)
- When a confirmed `school_partnership` exists, show lead provider and delivery partner names as usual

### Screenshot

<img width="564" height="208" alt="image" src="https://github.com/user-attachments/assets/c59ab9a4-a606-4024-bbac-57daeebbb15c" />


