### PR TITLE
Bump sandbox to 2 web/workers apps

### DIFF
--- a/config/terraform/application/config/sandbox.tfvars.json
+++ b/config/terraform/application/config/sandbox.tfvars.json
@@ -5,5 +5,7 @@
     "azure_enable_backup_storage": true,
     "enable_logit": true,
     "enable_monitoring": true,
-    "external_url": "https://sandbox.register-early-career-teachers.education.gov.uk/healthcheck"
+    "external_url": "https://sandbox.register-early-career-teachers.education.gov.uk/healthcheck",
+    "webapp_replicas": 2,
+    "worker_replicas": 2
 }


### PR DESCRIPTION
### Context

We are getting scraped and with 1 web app pod there is downtime

### Changes proposed in this pull request
Bump sandbox to 2 web apps and 2 workers to avoid any issues especially since providers will be testing, we'll probably need more then

### Guidance to review
