### PR TITLE
Add induction records analysis

### DIFF
--- a/app/models/migration/induction_record.rb
+++ b/app/models/migration/induction_record.rb
@@ -6,5 +6,11 @@ module Migration
     belongs_to :mentor_profile, class_name: "Migration::ParticipantProfile"
     belongs_to :schedule
     belongs_to :preferred_identity, class_name: "Migration::ParticipantIdentity"
+
+    has_one :school_cohort, through: :induction_programme
+    has_one :school, through: :school_cohort
+    has_one :partnership, through: :induction_programme
+    has_one :delivery_partner, through: :partnership
+    has_one :lead_provider, through: :partnership
   end
 end

--- a/app/services/migration/analyse_induction_sequences.rb
+++ b/app/services/migration/analyse_induction_sequences.rb
@@ -1,0 +1,72 @@
+module Migration
+  # Main service for analysing induction sequences and providing reports
+  #
+  # This service orchestrates the analysis of participant induction records,
+  # identifying timeline gaps, overlaps, and data quality issues during migration.
+  #
+  # @example With specific participants and options
+  #   participants = ParticipantProfile.where(id: [1, 2, 3])
+  #   results = Migration::AnalyseInductionSequences.call(
+  #     participants,
+  #     verbose: true,
+  #     export: true
+  #   )
+  class AnalyseInductionSequences
+    # Public API for running the analysis
+    # @param participant_profiles [ActiveRecord::Relation, Array] Profiles to analyse
+    def self.call(participant_profiles, verbose: false, export: false, filename: nil, batch_size: 1000)
+      new(participant_profiles, batch_size:).call(
+        verbose:,
+        export:,
+        filename:
+      )
+    end
+
+    def initialize(participant_profiles, batch_size: 1000)
+      @participant_profiles = participant_profiles
+      @batch_size = batch_size
+    end
+
+    # Run the analysis with optional display and export
+    def call(verbose: false, export: false, filename: nil)
+      Rails.logger.info("AnalyseInductionSequences: Starting analysis")
+
+      # Perform the core analysis
+      results = analyser.analyse
+
+      Rails.logger.info("AnalyseInductionSequences: Analysis completed. Found #{results.size} results")
+
+      # Display results to console if requested
+      display_results(results) if verbose
+
+      # Export to CSV if requested
+      export_results(results, filename) if export
+
+      results
+    end
+
+    def export_to_csv(results: nil, filename: nil)
+      results ||= analyser.analyse
+      export_results(results, filename)
+    end
+
+  private
+
+    def analyser
+      @analyser ||= InductionSequenceAnalyser.new(@participant_profiles, batch_size: @batch_size)
+    end
+
+    def display_results(results)
+      formatter = InductionSequenceFormatter.new(results)
+      formatter.display_results
+    end
+
+    def export_results(results, filename)
+      exporter = InductionSequenceExporter.new(results)
+      file_path = exporter.export_to_csv(filename:)
+
+      Rails.logger.info("AnalyseInductionSequences: Results exported to #{file_path}")
+      file_path
+    end
+  end
+end

--- a/app/services/migration/induction_sequence_analyser.rb
+++ b/app/services/migration/induction_sequence_analyser.rb
@@ -1,0 +1,176 @@
+module Migration
+  # Analyses induction sequences for participant profiles to identify
+  # timeline gaps, overlaps, and data quality issues during migration
+  class InductionSequenceAnalyser
+    DEFAULT_BATCH_SIZE = 1000
+
+    def initialize(participant_profiles = nil, batch_size: DEFAULT_BATCH_SIZE)
+      @participant_profiles = validate_participant_profiles(participant_profiles)
+      @batch_size = batch_size
+    end
+
+    # Perform the analysis on the participant profiles
+    def analyse
+      results = []
+
+      if @participant_profiles.respond_to?(:find_each)
+        @participant_profiles.find_each(batch_size: @batch_size) do |participant_profile|
+          participant_results = analyse_participant_records(participant_profile)
+          results.concat(participant_results)
+        end
+      else
+        @participant_profiles.each do |participant_profile|
+          participant_results = analyse_participant_records(participant_profile)
+          results.concat(participant_results)
+        end
+      end
+
+      results
+    end
+
+  private
+
+    def validate_participant_profiles(participant_profiles)
+      unless participant_profiles.respond_to?(:each)
+        raise ArgumentError, "Expected enumerable participant profiles, got #{participant_profiles.class}"
+      end
+
+      participant_profiles
+    end
+
+    def analyse_participant_records(participant_profile)
+      # Get ALL induction records to understand the complete timeline
+      all_records = fetch_induction_records(participant_profile)
+
+      # Group ALL records by lead provider
+      records_by_provider = group_records_by_provider(all_records)
+
+      build_participant_results(participant_profile, records_by_provider)
+    end
+
+    def fetch_induction_records(participant_profile)
+      participant_profile
+        .induction_records
+        .includes(
+          :lead_provider,
+          :delivery_partner,
+          :school,
+          induction_programme: :partnership
+        )
+        .order(:start_date, :created_at)
+    end
+
+    def group_records_by_provider(records)
+      records.group_by do |record|
+        record.lead_provider&.name || "No Lead Provider"
+      end
+    end
+
+    def build_participant_results(participant_profile, records_by_provider)
+      participant_results = []
+
+      records_by_provider.each do |provider_name, records|
+        provider_periods = build_timeline_periods(records)
+        null_end_date_count = count_null_end_dates(records)
+
+        result = {
+          participant_id: participant_profile.id,
+          participant_type: participant_profile.type,
+          lead_provider_name: provider_name,
+          total_record_count: records.count,
+          null_end_date_count:,
+          record_ids: records.map(&:id).sort,
+          provider_periods:,
+          total_days: calculate_total_days(provider_periods),
+          schools: extract_unique_schools(records),
+          programme_types: extract_unique_programme_types(records),
+        }
+
+        participant_results << result
+      end
+
+      participant_results
+    end
+
+    def build_timeline_periods(provider_records)
+      provider_records.map.with_index { |record, index|
+        begin
+          build_period(record, provider_records, index)
+        rescue StandardError => e
+          Rails.logger.error "InductionSequenceAnalyser: Failed to process record #{record.id}: #{e.message}"
+          nil
+        end
+      }.compact
+    end
+
+    def build_period(record, provider_records, index)
+      next_record = provider_records[index + 1] if index < provider_records.length - 1
+      next_record_id = next_record&.id
+
+      start_date = record.start_date
+      end_date = determine_end_date(record, next_record)
+      duration_days = calculate_duration(start_date, end_date)
+
+      {
+        record_id: record.id,
+        created_at: record.created_at,
+        start_date:,
+        end_date:,
+        explicit_end_date: record.end_date.present?,
+        next_record_id:,
+        duration_days:,
+        status: determine_period_status(record),
+        school: record.school&.name,
+        school_urn: record.school&.urn,
+        mentor_profile_id: record.mentor_profile_id,
+        programme: record.induction_programme&.training_programme,
+        core_induction_programme: record.induction_programme.core_induction_programme&.name,
+        programme_id: record.induction_programme_id,
+        partnership_id: record.induction_programme&.partnership_id,
+        delivery_partner: record.delivery_partner&.name,
+        induction_status: record.induction_status,
+        training_status: record.training_status,
+      }
+    end
+
+    def determine_end_date(record, next_record)
+      # Use explicit end_date if present
+      return record.end_date if record.end_date.present?
+
+      # Otherwise, use next record's start_date as this record's end_date
+      next_record&.start_date
+    end
+
+    def determine_period_status(record)
+      record.end_date.present? ? "Completed" : "Ongoing"
+    end
+
+    def count_null_end_dates(records)
+      records.count { |r| r.end_date.nil? }
+    end
+
+    def calculate_total_days(provider_periods)
+      provider_periods.sum { |p| p[:duration_days] || 0 }
+    end
+
+    def extract_unique_schools(records)
+      records.map { |r| r.school&.name }.compact.uniq
+    end
+
+    def extract_unique_programme_types(records)
+      records.map { |r| r.induction_programme&.training_programme }.compact.uniq
+    end
+
+    def calculate_duration(start_date, end_date)
+      return unless start_date
+
+      # Ensure both values are Date objects before subtraction.
+      # If end_date is nil (e.g. an ongoing record), use the
+      # current date to calculate duration up to today.
+      start_date = start_date.to_date
+      end_date = end_date&.to_date || Date.current
+
+      (end_date - start_date).to_i
+    end
+  end
+end

--- a/app/services/migration/induction_sequence_exporter.rb
+++ b/app/services/migration/induction_sequence_exporter.rb
@@ -16,45 +16,16 @@ module Migration
 
       Rails.logger.info("InductionSequenceExporter: Exporting analysis to CSV: #{file_path}")
 
-      CSV.open(file_path, "w", write_headers: true, headers: csv_headers) do |csv|
-        @results.each do |result|
-          write_result_to_csv(csv, result)
-        end
+      data = @results.flat_map do |result|
+        result[:provider_periods].map { |period| build_csv_row(result, period) }
+      end
+
+      CSV.open(file_path, "w", headers: data.first.keys, write_headers: true) do |csv|
+        data.each { |row| csv << row }
       end
 
       Rails.logger.info("InductionSequenceExporter: Export completed: #{file_path}")
       file_path.to_s
-    end
-
-    def csv_headers
-      [
-        "Participant ID",
-        "Participant Type",
-        "Lead Provider",
-        "Total Records",
-        "NULL End Date Records",
-        "Total Days with Provider",
-        "Schools",
-        "Programme Types",
-        "Induction Record ID",
-        "Created At",
-        "Start Date",
-        "End Date",
-        "Explicit End Date",
-        "Next Induction Record ID",
-        "Duration Days",
-        "Period Status",
-        "School",
-        "School URN",
-        "Mentor Profile ID",
-        "Induction Programme Type",
-        "Core Induction Programme",
-        "Induction Programme ID",
-        "Partnership ID",
-        "Delivery Partner",
-        "Induction Status",
-        "Training Status",
-      ]
     end
 
   private
@@ -71,42 +42,35 @@ module Migration
       "/tmp/#{DEFAULT_FILE_NAME}_#{timestamp}.csv"
     end
 
-    def write_result_to_csv(csv, result)
-      result[:provider_periods].each do |period|
-        row_data = build_csv_row(result, period)
-        csv << row_data
-      end
-    end
-
     def build_csv_row(result, period)
-      [
-        result[:participant_id],
-        result[:participant_type],
-        result[:lead_provider_name],
-        result[:total_record_count],
-        result[:null_end_date_count],
-        result[:total_days],
-        result[:schools].join(";"),
-        result[:programme_types].join(";"),
-        period[:record_id],
-        period[:created_at],
-        period[:start_date],
-        period[:end_date],
-        period[:explicit_end_date] ? "Yes" : "No",
-        period[:next_record_id],
-        period[:duration_days],
-        period[:status],
-        period[:school],
-        period[:school_urn],
-        period[:mentor_profile_id],
-        period[:programme],
-        period[:core_induction_programme],
-        period[:programme_id],
-        period[:partnership_id],
-        period[:delivery_partner],
-        period[:induction_status],
-        period[:training_status],
-      ]
+      {
+        "Participant ID" => result[:participant_id],
+        "Participant Type" => result[:participant_type],
+        "Lead Provider" => result[:lead_provider_name],
+        "Total Records" => result[:total_record_count],
+        "NULL End Date Records" => result[:null_end_date_count],
+        "Total Days with Provider" => result[:total_days],
+        "Schools" => result[:schools].join(";"),
+        "Programme Types" => result[:programme_types].join(";"),
+        "Induction Record ID" => period[:record_id],
+        "Created At" => period[:created_at],
+        "Start Date" => period[:start_date],
+        "End Date" => period[:end_date],
+        "Explicit End Date" => period[:explicit_end_date] ? "Yes" : "No",
+        "Next Induction Record ID" => period[:next_record_id],
+        "Duration Days" => period[:duration_days],
+        "Period Status" => period[:status],
+        "School" => period[:school],
+        "School URN" => period[:school_urn],
+        "Mentor Profile ID" => period[:mentor_profile_id],
+        "Induction Programme Type" => period[:programme],
+        "Core Induction Programme" => period[:core_induction_programme],
+        "Induction Programme ID" => period[:programme_id],
+        "Partnership ID" => period[:partnership_id],
+        "Delivery Partner" => period[:delivery_partner],
+        "Induction Status" => period[:induction_status],
+        "Training Status" => period[:training_status]
+      }
     end
   end
 end

--- a/app/services/migration/induction_sequence_exporter.rb
+++ b/app/services/migration/induction_sequence_exporter.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Migration
+  # Exports induction sequence analysis results to CSV format
+  class InductionSequenceExporter
+    DEFAULT_FILE_NAME = 'induction_sequences_analysis'
+
+    def initialize(results)
+      @results = results
+    end
+
+    def export_to_csv(filename: nil)
+      file_path = prepare_file_path(filename)
+
+      Rails.logger.info("InductionSequenceExporter: Exporting analysis to CSV: #{file_path}")
+
+      CSV.open(file_path, "w", write_headers: true, headers: csv_headers) do |csv|
+        @results.each do |result|
+          write_result_to_csv(csv, result)
+        end
+      end
+
+      Rails.logger.info("InductionSequenceExporter: Export completed: #{file_path}")
+      file_path.to_s
+    end
+
+    def csv_headers
+      [
+        "Participant ID",
+        "Participant Type",
+        "Lead Provider",
+        "Total Records",
+        "NULL End Date Records",
+        "Total Days with Provider",
+        "Schools",
+        "Programme Types",
+        "Induction Record ID",
+        "Created At",
+        "Start Date",
+        "End Date",
+        "Explicit End Date",
+        "Next Induction Record ID",
+        "Duration Days",
+        "Period Status",
+        "School",
+        "School URN",
+        "Mentor Profile ID",
+        "Induction Programme Type",
+        "Core Induction Programme",
+        "Induction Programme ID",
+        "Partnership ID",
+        "Delivery Partner",
+        "Induction Status",
+        "Training Status",
+      ]
+    end
+
+  private
+
+    def prepare_file_path(filename)
+      return default_file_path if filename.blank?
+
+      filename
+    end
+
+    def default_file_path
+      timestamp = Time.current.strftime('%Y%m%d%H%M%S')
+
+      "/tmp/#{DEFAULT_FILE_NAME}_#{timestamp}.csv"
+    end
+
+    def write_result_to_csv(csv, result)
+      result[:provider_periods].each do |period|
+        row_data = build_csv_row(result, period)
+        csv << row_data
+      end
+    end
+
+    def build_csv_row(result, period)
+      [
+        result[:participant_id],
+        result[:participant_type],
+        result[:lead_provider_name],
+        result[:total_record_count],
+        result[:null_end_date_count],
+        result[:total_days],
+        result[:schools].join(";"),
+        result[:programme_types].join(";"),
+        period[:record_id],
+        period[:created_at],
+        period[:start_date],
+        period[:end_date],
+        period[:explicit_end_date] ? "Yes" : "No",
+        period[:next_record_id],
+        period[:duration_days],
+        period[:status],
+        period[:school],
+        period[:school_urn],
+        period[:mentor_profile_id],
+        period[:programme],
+        period[:core_induction_programme],
+        period[:programme_id],
+        period[:partnership_id],
+        period[:delivery_partner],
+        period[:induction_status],
+        period[:training_status],
+      ]
+    end
+  end
+end

--- a/app/services/migration/induction_sequence_formatter.rb
+++ b/app/services/migration/induction_sequence_formatter.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Migration
+  # Formats and displays induction sequence analysis results to the console
+  class InductionSequenceFormatter
+    HEADER_SEPARATOR_LENGTH = 80
+    SUB_SEPARATOR_LENGTH = 60
+
+    def initialize(results)
+      @results = results
+    end
+
+    def display_results
+      display_header
+      display_participants
+      display_summary
+    end
+
+  private
+
+    def display_header
+      Rails.logger.debug "\n" + "=" * HEADER_SEPARATOR_LENGTH
+      Rails.logger.debug "COMPLETE INDUCTION TIMELINE BY LEAD PROVIDER"
+      Rails.logger.debug "=" * HEADER_SEPARATOR_LENGTH
+    end
+
+    def display_participants
+      grouped_results = @results.group_by { |r| r[:participant_id] }
+
+      grouped_results.each do |participant_id, participant_results|
+        display_participant_summary(participant_id, participant_results)
+      end
+    end
+
+    def display_participant_summary(participant_id, participant_results)
+      first_result = participant_results.first
+
+      Rails.logger.debug "\n👤 Participant ID: #{participant_id}"
+      Rails.logger.debug "   Type: #{first_result[:participant_type]}"
+
+      display_participant_totals(participant_results)
+
+      participant_results.each do |result|
+        display_provider_details(result)
+      end
+
+      Rails.logger.debug "\n   " + "-" * SUB_SEPARATOR_LENGTH
+    end
+
+    def display_participant_totals(participant_results)
+      total_records = participant_results.sum { |r| r[:total_record_count] }
+      total_null_end_dates = participant_results.sum { |r| r[:null_end_date_count] }
+
+      Rails.logger.debug "   Total induction records: #{total_records}"
+      Rails.logger.debug "   Records with NULL end_date: #{total_null_end_dates}"
+    end
+
+    def display_provider_details(result)
+      Rails.logger.debug "\n   🏢 Lead Provider: #{result[:lead_provider_name]}"
+      Rails.logger.debug "      Total records: #{result[:total_record_count]} (#{result[:null_end_date_count]} with NULL end_date)"
+      Rails.logger.debug "      Schools: #{result[:schools].join(', ')}" if result[:schools].any?
+      Rails.logger.debug "      Programme Types: #{result[:programme_types].join(', ')}" if result[:programme_types].any?
+      Rails.logger.debug "      Total Days with Provider: #{result[:total_days]} days"
+
+      display_timeline(result[:provider_periods])
+    end
+
+    def display_timeline(provider_periods)
+      Rails.logger.debug "\n      🗓️ COMPLETE TIMELINE:"
+
+      provider_periods.each do |period|
+        display_period_details(period)
+      end
+    end
+
+    def display_period_details(period)
+      duration_text = format_duration(period[:duration_days])
+      end_date_text = format_end_date(period)
+
+      Rails.logger.debug "         • Record #{period[:record_id]}: #{period[:start_date]} → #{end_date_text}"
+
+      display_period_inference(period)
+      display_period_metadata(period, duration_text)
+    end
+
+    def display_period_inference(period)
+      if period[:next_record_id] && !period[:explicit_end_date]
+        Rails.logger.debug "           End date inferred from record: #{period[:next_record_id]}"
+      end
+    end
+
+    def display_period_metadata(period, duration_text)
+      Rails.logger.debug "           Created date: #{period[:created_at]}"
+      Rails.logger.debug "           Duration: #{duration_text}"
+      Rails.logger.debug "           Period status: #{period[:status]}"
+      Rails.logger.debug "           School: #{period[:school]}" if period[:school]
+      Rails.logger.debug "           School URN: #{period[:school_urn]}" if period[:school_urn]
+      Rails.logger.debug "           Mentor profile id : #{period[:mentor_profile_id]}" if period[:mentor_profile_id]
+      Rails.logger.debug "           Induction status: #{period[:induction_status]}" if period[:induction_status]
+      Rails.logger.debug "           Training status: #{period[:training_status]}" if period[:training_status]
+      Rails.logger.debug "           Programme type: #{period[:programme]}" if period[:programme]
+      Rails.logger.debug "           Core Induction Programme: #{period[:core_induction_programme]}" if period[:core_induction_programme]
+      Rails.logger.debug "           Programme id: #{period[:programme_id]}" if period[:programme_id]
+      Rails.logger.debug "           Partnership id: #{period[:partnership_id]}" if period[:partnership_id]
+    end
+
+    def format_duration(duration_days)
+      duration_days ? "#{duration_days} days" : "Unknown duration"
+    end
+
+    def format_end_date(period)
+      if period[:explicit_end_date]
+        period[:end_date].to_s
+      elsif period[:end_date]
+        "#{period[:end_date]} (inferred)"
+      else
+        "Ongoing"
+      end
+    end
+
+    def display_summary
+      Rails.logger.debug "\n📝 SUMMARY:"
+      Rails.logger.debug "   Total problematic participants: #{count_unique_participants}"
+      Rails.logger.debug "   Total induction records: #{sum_total_records}"
+      Rails.logger.debug "   Total NULL end_date records: #{sum_null_end_date_records}"
+      Rails.logger.debug "   Lead providers involved: #{list_lead_providers.join(', ')}"
+    end
+
+    def count_unique_participants
+      @results.group_by { |r| r[:participant_id] }.count
+    end
+
+    def sum_total_records
+      @results.sum { |r| r[:total_record_count] }
+    end
+
+    def sum_null_end_date_records
+      @results.sum { |r| r[:null_end_date_count] }
+    end
+
+    def list_lead_providers
+      @results.map { |r| r[:lead_provider_name] }.uniq.sort
+    end
+  end
+end

--- a/app/services/migration/induction_sequence_formatter.rb
+++ b/app/services/migration/induction_sequence_formatter.rb
@@ -121,7 +121,7 @@ module Migration
 
     def display_summary
       puts "\n📝 SUMMARY:"
-      puts "   Total problematic participants: #{count_unique_participants}"
+      puts "   Total participants: #{count_unique_participants}"
       puts "   Total induction records: #{sum_total_records}"
       puts "   Total NULL end_date records: #{sum_null_end_date_records}"
       puts "   Lead providers involved: #{list_lead_providers.join(', ')}"

--- a/app/services/migration/induction_sequence_formatter.rb
+++ b/app/services/migration/induction_sequence_formatter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/Output
 module Migration
   # Formats and displays induction sequence analysis results to the console
   class InductionSequenceFormatter
@@ -19,9 +20,9 @@ module Migration
   private
 
     def display_header
-      Rails.logger.debug "\n" + "=" * HEADER_SEPARATOR_LENGTH
-      Rails.logger.debug "COMPLETE INDUCTION TIMELINE BY LEAD PROVIDER"
-      Rails.logger.debug "=" * HEADER_SEPARATOR_LENGTH
+      puts "\n" + "=" * HEADER_SEPARATOR_LENGTH
+      puts "COMPLETE INDUCTION TIMELINE BY LEAD PROVIDER"
+      puts "=" * HEADER_SEPARATOR_LENGTH
     end
 
     def display_participants
@@ -35,8 +36,8 @@ module Migration
     def display_participant_summary(participant_id, participant_results)
       first_result = participant_results.first
 
-      Rails.logger.debug "\n👤 Participant ID: #{participant_id}"
-      Rails.logger.debug "   Type: #{first_result[:participant_type]}"
+      puts "\n👤 Participant ID: #{participant_id}"
+      puts "   Type: #{first_result[:participant_type]}"
 
       display_participant_totals(participant_results)
 
@@ -44,29 +45,29 @@ module Migration
         display_provider_details(result)
       end
 
-      Rails.logger.debug "\n   " + "-" * SUB_SEPARATOR_LENGTH
+      puts "\n   " + "-" * SUB_SEPARATOR_LENGTH
     end
 
     def display_participant_totals(participant_results)
       total_records = participant_results.sum { |r| r[:total_record_count] }
       total_null_end_dates = participant_results.sum { |r| r[:null_end_date_count] }
 
-      Rails.logger.debug "   Total induction records: #{total_records}"
-      Rails.logger.debug "   Records with NULL end_date: #{total_null_end_dates}"
+      puts "   Total induction records: #{total_records}"
+      puts "   Records with NULL end_date: #{total_null_end_dates}"
     end
 
     def display_provider_details(result)
-      Rails.logger.debug "\n   🏢 Lead Provider: #{result[:lead_provider_name]}"
-      Rails.logger.debug "      Total records: #{result[:total_record_count]} (#{result[:null_end_date_count]} with NULL end_date)"
-      Rails.logger.debug "      Schools: #{result[:schools].join(', ')}" if result[:schools].any?
-      Rails.logger.debug "      Programme Types: #{result[:programme_types].join(', ')}" if result[:programme_types].any?
-      Rails.logger.debug "      Total Days with Provider: #{result[:total_days]} days"
+      puts "\n   🏢 Lead Provider: #{result[:lead_provider_name]}"
+      puts "      Total records: #{result[:total_record_count]} (#{result[:null_end_date_count]} with NULL end_date)"
+      puts "      Schools: #{result[:schools].join(', ')}" if result[:schools].any?
+      puts "      Programme Types: #{result[:programme_types].join(', ')}" if result[:programme_types].any?
+      puts "      Total Days with Provider: #{result[:total_days]} days"
 
       display_timeline(result[:provider_periods])
     end
 
     def display_timeline(provider_periods)
-      Rails.logger.debug "\n      🗓️ COMPLETE TIMELINE:"
+      puts "\n      🗓️ COMPLETE TIMELINE:"
 
       provider_periods.each do |period|
         display_period_details(period)
@@ -77,7 +78,7 @@ module Migration
       duration_text = format_duration(period[:duration_days])
       end_date_text = format_end_date(period)
 
-      Rails.logger.debug "         • Record #{period[:record_id]}: #{period[:start_date]} → #{end_date_text}"
+      puts "         • Record #{period[:record_id]}: #{period[:start_date]} → #{end_date_text}"
 
       display_period_inference(period)
       display_period_metadata(period, duration_text)
@@ -85,23 +86,23 @@ module Migration
 
     def display_period_inference(period)
       if period[:next_record_id] && !period[:explicit_end_date]
-        Rails.logger.debug "           End date inferred from record: #{period[:next_record_id]}"
+        puts "           End date inferred from record: #{period[:next_record_id]}"
       end
     end
 
     def display_period_metadata(period, duration_text)
-      Rails.logger.debug "           Created date: #{period[:created_at]}"
-      Rails.logger.debug "           Duration: #{duration_text}"
-      Rails.logger.debug "           Period status: #{period[:status]}"
-      Rails.logger.debug "           School: #{period[:school]}" if period[:school]
-      Rails.logger.debug "           School URN: #{period[:school_urn]}" if period[:school_urn]
-      Rails.logger.debug "           Mentor profile id : #{period[:mentor_profile_id]}" if period[:mentor_profile_id]
-      Rails.logger.debug "           Induction status: #{period[:induction_status]}" if period[:induction_status]
-      Rails.logger.debug "           Training status: #{period[:training_status]}" if period[:training_status]
-      Rails.logger.debug "           Programme type: #{period[:programme]}" if period[:programme]
-      Rails.logger.debug "           Core Induction Programme: #{period[:core_induction_programme]}" if period[:core_induction_programme]
-      Rails.logger.debug "           Programme id: #{period[:programme_id]}" if period[:programme_id]
-      Rails.logger.debug "           Partnership id: #{period[:partnership_id]}" if period[:partnership_id]
+      puts "           Created date: #{period[:created_at]}"
+      puts "           Duration: #{duration_text}"
+      puts "           Period status: #{period[:status]}"
+      puts "           School: #{period[:school]}" if period[:school]
+      puts "           School URN: #{period[:school_urn]}" if period[:school_urn]
+      puts "           Mentor profile id : #{period[:mentor_profile_id]}" if period[:mentor_profile_id]
+      puts "           Induction status: #{period[:induction_status]}" if period[:induction_status]
+      puts "           Training status: #{period[:training_status]}" if period[:training_status]
+      puts "           Programme type: #{period[:programme]}" if period[:programme]
+      puts "           Core Induction Programme: #{period[:core_induction_programme]}" if period[:core_induction_programme]
+      puts "           Programme id: #{period[:programme_id]}" if period[:programme_id]
+      puts "           Partnership id: #{period[:partnership_id]}" if period[:partnership_id]
     end
 
     def format_duration(duration_days)
@@ -119,11 +120,11 @@ module Migration
     end
 
     def display_summary
-      Rails.logger.debug "\n📝 SUMMARY:"
-      Rails.logger.debug "   Total problematic participants: #{count_unique_participants}"
-      Rails.logger.debug "   Total induction records: #{sum_total_records}"
-      Rails.logger.debug "   Total NULL end_date records: #{sum_null_end_date_records}"
-      Rails.logger.debug "   Lead providers involved: #{list_lead_providers.join(', ')}"
+      puts "\n📝 SUMMARY:"
+      puts "   Total problematic participants: #{count_unique_participants}"
+      puts "   Total induction records: #{sum_total_records}"
+      puts "   Total NULL end_date records: #{sum_null_end_date_records}"
+      puts "   Lead providers involved: #{list_lead_providers.join(', ')}"
     end
 
     def count_unique_participants
@@ -143,3 +144,4 @@ module Migration
     end
   end
 end
+# rubocop:enable Rails/Output

--- a/spec/models/migration/induction_record_spec.rb
+++ b/spec/models/migration/induction_record_spec.rb
@@ -1,0 +1,9 @@
+describe Migration::InductionRecord, type: :model do
+  describe "associations" do
+    it { is_expected.to have_one(:school_cohort).through(:induction_programme) }
+    it { is_expected.to have_one(:school).through(:school_cohort) }
+    it { is_expected.to have_one(:partnership).through(:induction_programme) }
+    it { is_expected.to have_one(:delivery_partner).through(:partnership) }
+    it { is_expected.to have_one(:lead_provider).through(:partnership) }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1269

This PR adds functionality to analyze participants' induction records grouped by lead providers, to identify timeline gaps, overlaps, and data quality issues in ECF participant induction records that we will need to migrate over.

### Changes proposed in this pull request

- Add service class to orchestrate the analysis
- Add class to export the results in csv
- Add class to print the results
- Add model associations to `Migration::InductionRecord` required for the analysis

### Guidance to review

1. Get a list of participants you want to analyse i.e. participants with multiple induction records with blank end dates
```
participant_profiles = ::Migration::ParticipantProfile.joins(:induction_records).where(induction_records: { end_date: nil }).group("participant_profiles.id").having("COUNT(induction_records.id) > 1")
```
2. Run the analysis, print, export and keep the results in a var
```
results = Migration::AnalyseInductionSequences.call(participant_profiles, verbose: true, export: true)
```
The printed results look like this:
<img width="745" height="779" alt="Screenshot 2025-07-16 at 10 13 36" src="https://github.com/user-attachments/assets/589250c7-aceb-4006-8b40-23fb394a5ab1" />


