### PR TITLE
Admins can add induction periods for Teachers without data

### DIFF
--- a/app/views/admin/induction_periods/new.html.erb
+++ b/app/views/admin/induction_periods/new.html.erb
@@ -33,7 +33,7 @@
           width: 4,
           inputmode: "numeric" %>
 
-      <%= f.govuk_collection_radio_buttons :induction_programme, training_programme_choices, :identifier, :name, legend: { text: 'Induction programme' }  %>
+      <%= f.govuk_collection_radio_buttons :induction_programme, induction_programme_choices, :identifier, :name, legend: { text: 'Induction programme' }  %>
 
       <%= f.submit "Save", class: "govuk-button" %>
     <% end %>

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -23,4 +23,10 @@ end %>
   <%= govuk_link_to('View change history', admin_teacher_timeline_path(@teacher)) %>
 </p>
 
+<% if @teacher.induction_periods.none? %>
+  <p class="govuk-body">
+    <%= govuk_link_to("Add an induction period", new_admin_teacher_induction_period_path(@teacher)) %>
+  </p>
+<% end %>
+
 <%= govuk_warning_text(text: "Some of this teacher's records could not be migrated") if @teacher.has_migration_failures? %>

--- a/spec/features/admin/teachers/add_induction_period_spec.rb
+++ b/spec/features/admin/teachers/add_induction_period_spec.rb
@@ -1,0 +1,160 @@
+describe "Admin adds an induction period" do
+  before { sign_in_as_dfe_user(role: :admin) }
+
+  context "when the teacher has no induction periods" do
+    it "adds a closed induction period" do
+      given_an_appropriate_body_exists(name: "Test Appropriate Body")
+      given_a_teacher_exists(first_name: "Test", last_name: "Person")
+      when_i_go_to_the_teacher_page
+      then_there_is_no_induction_summary
+      and_there_are_no_past_induction_periods
+
+      when_i_click_the_add_an_induction_period_link
+      then_there_is_a_form_to_add_an_induction_period(
+        for_teacher: "Test Person"
+      )
+
+      when_i_fill_in_the_form_with(
+        appropriate_body: "Test Appropriate Body",
+        start_date: "1-1-2024",
+        end_date: "1-1-2025",
+        number_of_terms: "2",
+        induction_programme: "Full induction programme"
+      )
+      and_i_submit_the_form
+      then_i_see_a_success_message
+      and_there_is_an_induction_summary
+      and_there_is_a_past_induction_period(
+        appropriate_body: "Test Appropriate Body"
+      )
+    end
+
+    it "adds an open induction period" do
+      given_an_appropriate_body_exists(name: "Test Appropriate Body")
+      given_a_teacher_exists(first_name: "Test", last_name: "Person")
+      when_i_go_to_the_teacher_page
+      then_there_is_no_induction_summary
+      and_there_are_no_past_induction_periods
+
+      when_i_click_the_add_an_induction_period_link
+      then_there_is_a_form_to_add_an_induction_period(
+        for_teacher: "Test Person"
+      )
+
+      when_i_fill_in_the_form_with(
+        appropriate_body: "Test Appropriate Body",
+        start_date: "1-1-2024",
+        induction_programme: "Full induction programme"
+      )
+      and_i_submit_the_form
+      then_i_see_a_success_message
+      and_there_is_an_induction_summary
+      and_there_is_a_current_induction_period(
+        appropriate_body: "Test Appropriate Body"
+      )
+    end
+  end
+
+private
+
+  def given_an_appropriate_body_exists(name:)
+    FactoryBot.create(:appropriate_body, name:)
+  end
+
+  def given_a_teacher_exists(first_name:, last_name:)
+    @teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: first_name,
+      trs_last_name: last_name
+    )
+  end
+
+  def when_i_go_to_the_teacher_page
+    page.goto(admin_teacher_path(@teacher))
+  end
+
+  def then_there_is_no_induction_summary
+    expect(page.locator("h2", hasText: "Induction summary")).not_to be_visible
+  end
+
+  def and_there_are_no_past_induction_periods
+    expect(page.locator("h2", hasText: "Past induction periods"))
+      .not_to be_visible
+  end
+
+  def when_i_click_the_add_an_induction_period_link
+    page.locator("a", hasText: "Add an induction period").click
+  end
+
+  def then_there_is_a_form_to_add_an_induction_period(for_teacher:)
+    form_heading = page.locator(
+      "h1",
+      hasText: "Add induction period for #{for_teacher}"
+    )
+    expect(form_heading).to be_visible
+  end
+
+  def when_i_fill_in_the_form_with(
+    appropriate_body:,
+    start_date:,
+    induction_programme:,
+    end_date: nil,
+    number_of_terms: nil
+  )
+    appropriate_body_label = <<~TXT
+      Which appropriate body was this induction period completed with
+    TXT
+    page.get_by_label(appropriate_body_label)
+      .select_option(label: appropriate_body)
+
+    start_date_fieldset = page.locator("fieldset", hasText: "Start date")
+    day, month, year = start_date.split("-")
+    start_date_fieldset.get_by_label("Day").fill(day)
+    start_date_fieldset.get_by_label("Month").fill(month)
+    start_date_fieldset.get_by_label("Year").fill(year)
+
+    if end_date.present?
+      end_date_fieldset = page.locator("fieldset", hasText: "End date")
+      day, month, year = end_date.split("-")
+      end_date_fieldset.get_by_label("Day").fill(day)
+      end_date_fieldset.get_by_label("Month").fill(month)
+      end_date_fieldset.get_by_label("Year").fill(year)
+    end
+
+    if number_of_terms.present?
+      page.get_by_label("Number of terms").fill(number_of_terms)
+    end
+
+    programme_fieldset = page.locator(
+      "fieldset",
+      hasText: "Induction programme"
+    )
+    programme_fieldset.get_by_label(induction_programme).check
+  end
+
+  def and_i_submit_the_form
+    page.locator("input[type=submit]", hasText: "Save").click
+  end
+
+  def then_i_see_a_success_message
+    expect(page.locator(".govuk-notification-banner"))
+      .to have_text("Induction period created successfully")
+  end
+
+  def and_there_is_an_induction_summary
+    expect(page.locator("h2", hasText: "Induction summary")).to be_visible
+  end
+
+  def and_there_is_a_past_induction_period(appropriate_body:)
+    expect(page.locator("h2", hasText: "Past induction periods")).to be_visible
+    expect(page.locator(".govuk-summary-card", hasText: appropriate_body))
+      .to be_visible
+  end
+
+  def and_there_is_a_current_induction_period(appropriate_body:)
+    expect(page.locator("h2", hasText: "Current induction period"))
+      .to be_visible
+    expect(page.locator(".govuk-summary-card", hasText: appropriate_body))
+      .to be_visible
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/1891

### Changes proposed in this pull request

Before, Admins could only add an induction period for a Teacher if they already had some induction period data.

This meant support were unable to add induction periods for "empty" Teachers. "Empty" Teachers can happen when the only induction period is deleted or they are imported from TRS.

This adds a link to the teacher page when there are no induction periods.

As part of this change, a bug was fixed where the induction period form was using traning programme choices instead of induction period choices. It looks like this was introduced in #765 (specifically
2d53a517accd4933f502a5dfcb1011069812ff03).

### Guidance to review

When logged in as an admin user:

- [ ] Add an induction period is available on records where there is no other induction period data
- [ ] I am able to add a closed induction period to an "empty" teacher record (i.e. start date and end date)
- [ ] I am able to add an open induction period to an "empty" teacher record (i.e. start date, no end date)
- [ ] The service updates the induction start date in TRS to the start date of the added induction period
- [ ] The service updates the induction status in TRS to "in progress"
