### PR TITLE
[1519] Show only lead providers active in the contract period

### DIFF
--- a/app/services/lead_providers/active.rb
+++ b/app/services/lead_providers/active.rb
@@ -9,5 +9,11 @@ module LeadProviders
     def active_in_contract_period?(contract_period)
       lead_provider.active_lead_providers.exists?(contract_period:)
     end
+
+    def self.in_contract_period(contract_period)
+      LeadProvider
+        .joins(:active_lead_providers)
+        .where(active_lead_providers: { contract_period_id: contract_period.id })
+    end
   end
 end

--- a/app/views/schools/register_ect_wizard/_lead_provider.html.erb
+++ b/app/views/schools/register_ect_wizard/_lead_provider.html.erb
@@ -17,7 +17,7 @@ We will let the lead provider know your school wants to work with them so they c
 
   <%=
     f.govuk_collection_radio_buttons(:lead_provider_id,
-                                     @ect.possible_lead_providers,
+                                     @ect.lead_providers_within_contract_period,
                                      :id,
                                      :name,
                                      legend: {

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -70,9 +70,14 @@ module Schools
         trs_date_of_birth.to_date == date_of_birth.to_date
       end
 
-      # Extract into their own SO when this logic becomes dependant of the ECT being assigned
-      def possible_lead_providers
-        @possible_lead_providers ||= LeadProvider.select(:id, :name).all
+      def lead_providers_within_contract_period
+        return [] unless contract_start_date
+
+        @lead_providers_within_contract_period ||= LeadProviders::Active.in_contract_period(contract_start_date).select(:id, :name)
+      end
+
+      def contract_start_date
+        ContractPeriod.containing_date(start_date&.to_date)
       end
 
       def previously_registered?

--- a/spec/services/lead_providers/active_spec.rb
+++ b/spec/services/lead_providers/active_spec.rb
@@ -25,4 +25,21 @@ describe LeadProviders::Active do
       it { is_expected.to be(false) }
     end
   end
+
+  describe '.in_contract_period' do
+    subject { described_class.in_contract_period(contract_period) }
+
+    let(:contract_period) { FactoryBot.create(:contract_period) }
+    let!(:included_lp) { FactoryBot.create(:lead_provider) }
+    let!(:excluded_lp) { FactoryBot.create(:lead_provider) }
+
+    before do
+      FactoryBot.create(:active_lead_provider, lead_provider: included_lp, contract_period:)
+    end
+
+    it 'returns only lead providers active in the given contract period' do
+      expect(subject).to include(included_lp)
+      expect(subject).not_to include(excluded_lp)
+    end
+  end
 end

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -480,5 +480,29 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         end
       end
     end
+
+    describe '#lead_providers_within_contract_period' do
+      let!(:contract_period) { FactoryBot.create(:contract_period, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 12, 31)) }
+      let!(:lp_in) { FactoryBot.create(:lead_provider) }
+      let!(:lp_out) { FactoryBot.create(:lead_provider) }
+
+      before do
+        FactoryBot.create(:active_lead_provider, contract_period:, lead_provider: lp_in)
+        store.start_date = "1 March 2025"
+      end
+
+      it 'returns lead providers active in the contract period' do
+        expect(ect.lead_providers_within_contract_period).to include(lp_in)
+        expect(ect.lead_providers_within_contract_period).not_to include(lp_out)
+      end
+
+      context 'when no contract period matches the start_date' do
+        before { store.start_date = nil }
+
+        it 'returns an empty array' do
+          expect(ect.lead_providers_within_contract_period).to eq([])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

In the ECT registration journey, the **lead provider selection** page now only displays lead providers that are active in the relevant contract period, instead of listing all available lead providers.

### Changes proposed

- Add a method to `LeadProviders::Active` to fetch lead providers within a contract period
- Use the method above to only surface the relevant providers on the lead provider selection page.