### PR TITLE
[1940] Implement SO for identifying the contract period for a given ECT

### DIFF
--- a/app/services/contract_periods/for_ect.rb
+++ b/app/services/contract_periods/for_ect.rb
@@ -1,0 +1,13 @@
+module ContractPeriods
+  class ForECT
+    def initialize(started_on:, created_at:)
+      @started_on = started_on
+      @created_at = created_at
+    end
+
+    def call
+      ContractPeriod.ongoing_on(@started_on).first ||
+        ContractPeriod.ongoing_on(@created_at).first
+    end
+  end
+end

--- a/app/services/contract_periods/for_ect.rb
+++ b/app/services/contract_periods/for_ect.rb
@@ -1,13 +1,14 @@
 module ContractPeriods
   class ForECT
-    def initialize(started_on:, created_at:)
+    class NoContractPeriodFoundForStartedOnDate < StandardError; end
+
+    def initialize(started_on:)
       @started_on = started_on
-      @created_at = created_at
     end
 
     def call
       ContractPeriod.ongoing_on(@started_on).first ||
-        ContractPeriod.ongoing_on(@created_at).first
+        raise(NoContractPeriodFoundForStartedOnDate, "No contract period found for started_on=#{@started_on}")
     end
   end
 end

--- a/spec/services/contract_periods/for_ect_spec.rb
+++ b/spec/services/contract_periods/for_ect_spec.rb
@@ -1,5 +1,5 @@
 describe ContractPeriods::ForECT do
-  subject { described_class.new(started_on:, created_at:) }
+  subject { described_class.new(started_on:) }
 
   let!(:contract_2024) do
     FactoryBot.create(
@@ -20,64 +20,41 @@ describe ContractPeriods::ForECT do
   describe '#call' do
     context 'when started_on falls within a contract period' do
       let(:started_on) { Date.new(2024, 9, 5) }
-      let(:created_at) { Date.new(2025, 1, 10) }
 
       it 'returns the contract period covering the start date' do
         expect(subject.call).to eq(contract_2024)
       end
     end
 
-    context 'when started_on does not match but created_at does' do
-      let(:started_on) { Date.new(2023, 8, 1) }
-      let(:created_at) { Date.new(2025, 9, 5) }
-
-      it 'returns the contract period covering the created_at date' do
-        expect(subject.call).to eq(contract_2025)
-      end
-    end
-
-    context 'when both started_on and created_at fall within the same period' do
-      let(:started_on) { Date.new(2025, 9, 2) }
-      let(:created_at) { Date.new(2025, 9, 3) }
-
-      it 'returns the matching contract period' do
-        expect(subject.call).to eq(contract_2025)
-      end
-    end
-
-    context 'when neither date falls within any contract period' do
-      let(:started_on) { Date.new(2023, 1, 1) }
-      let(:created_at) { Date.new(2023, 2, 1) }
-
-      it 'returns nil' do
-        expect(subject.call).to be_nil
-      end
-    end
-
     context 'when started_on is exactly the start date of a contract period' do
       let(:started_on) { Date.new(2025, 9, 1) }
-      let(:created_at) { Date.new(2024, 9, 1) }
 
       it 'returns the matching contract period' do
         expect(subject.call).to eq(contract_2025)
       end
     end
 
-    context 'when started_on is exactly the end date of a contract period' do
-      let(:started_on) { Date.new(2025, 8, 31) }
-      let(:created_at) { Date.new(2024, 9, 1) }
+    context 'when started_on is the last included date of a contract period' do
+      let(:started_on) { Date.new(2025, 8, 30) }
 
       it 'returns the matching contract period' do
         expect(subject.call).to eq(contract_2024)
       end
     end
 
-    context 'when started_on and created_at are in a future contract period' do
-      let(:started_on) { Date.new(2026, 9, 1) }
-      let(:created_at) { Date.new(2026, 9, 2) }
+    context 'when started_on does not fall within any contract period' do
+      let(:started_on) { Date.new(2023, 1, 1) }
 
-      it 'returns nil because the period does not exist yet' do
-        expect(subject.call).to be_nil
+      it 'raises an error' do
+        expect { subject.call }.to raise_error(ContractPeriods::ForECT::NoContractPeriodFoundForStartedOnDate)
+      end
+    end
+
+    context 'when started_on is in a future period that does not yet exist' do
+      let(:started_on) { Date.new(2026, 9, 1) }
+
+      it 'raises an error' do
+        expect { subject.call }.to raise_error(ContractPeriods::ForECT::NoContractPeriodFoundForStartedOnDate)
       end
     end
   end

--- a/spec/services/contract_periods/for_ect_spec.rb
+++ b/spec/services/contract_periods/for_ect_spec.rb
@@ -1,0 +1,84 @@
+describe ContractPeriods::ForECT do
+  subject { described_class.new(started_on:, created_at:) }
+
+  let!(:contract_2024) do
+    FactoryBot.create(
+      :contract_period,
+      started_on: Date.new(2024, 9, 1),
+      finished_on: Date.new(2025, 8, 31)
+    )
+  end
+
+  let!(:contract_2025) do
+    FactoryBot.create(
+      :contract_period,
+      started_on: Date.new(2025, 9, 1),
+      finished_on: Date.new(2026, 8, 31)
+    )
+  end
+
+  describe '#call' do
+    context 'when started_on falls within a contract period' do
+      let(:started_on) { Date.new(2024, 9, 5) }
+      let(:created_at) { Date.new(2025, 1, 10) }
+
+      it 'returns the contract period covering the start date' do
+        expect(subject.call).to eq(contract_2024)
+      end
+    end
+
+    context 'when started_on does not match but created_at does' do
+      let(:started_on) { Date.new(2023, 8, 1) }
+      let(:created_at) { Date.new(2025, 9, 5) }
+
+      it 'returns the contract period covering the created_at date' do
+        expect(subject.call).to eq(contract_2025)
+      end
+    end
+
+    context 'when both started_on and created_at fall within the same period' do
+      let(:started_on) { Date.new(2025, 9, 2) }
+      let(:created_at) { Date.new(2025, 9, 3) }
+
+      it 'returns the matching contract period' do
+        expect(subject.call).to eq(contract_2025)
+      end
+    end
+
+    context 'when neither date falls within any contract period' do
+      let(:started_on) { Date.new(2023, 1, 1) }
+      let(:created_at) { Date.new(2023, 2, 1) }
+
+      it 'returns nil' do
+        expect(subject.call).to be_nil
+      end
+    end
+
+    context 'when started_on is exactly the start date of a contract period' do
+      let(:started_on) { Date.new(2025, 9, 1) }
+      let(:created_at) { Date.new(2024, 9, 1) }
+
+      it 'returns the matching contract period' do
+        expect(subject.call).to eq(contract_2025)
+      end
+    end
+
+    context 'when started_on is exactly the end date of a contract period' do
+      let(:started_on) { Date.new(2025, 8, 31) }
+      let(:created_at) { Date.new(2024, 9, 1) }
+
+      it 'returns the matching contract period' do
+        expect(subject.call).to eq(contract_2024)
+      end
+    end
+
+    context 'when started_on and created_at are in a future contract period' do
+      let(:started_on) { Date.new(2026, 9, 1) }
+      let(:created_at) { Date.new(2026, 9, 2) }
+
+      it 'returns nil because the period does not exist yet' do
+        expect(subject.call).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Implementing a service object for identifying the contract period for a given ECT

This uses the `started_on` date from the `ECTAtSchoolPeriod` to identify the correct `ContractPeriod` for the ECT. If no match is found, it falls back to the `created_at` timestamp, which acts as the registration date.

We use the `ContractPeriod.ongoing_on(date)` scope, which checks whether a given date falls within a contract periods date range. This range is calculated by a virtual column (range) using`started_on..finished_on`.