### PR TITLE
Raise rate limit for staging

### DIFF
--- a/config/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/config/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -13,5 +13,5 @@
       "origin_hostname": "cpd-ec2-staging-web.test.teacherservices.cloud"
     }
   },
-  "rate_limit_max": 2000
+  "rate_limit_max": 200
 }


### PR DESCRIPTION
### Context

We are being scraped and added rate limits to different environments. However we went to 2000 in sandbox/production as our rate limit for the API is 1000/5 minutes. However for staging we don't need that limit

### Changes proposed in this pull request

We aren't serving the API to providers from staging, and being scraped quite heavily. Instead of scaling up staging we can safely raise the rate limit.

### Guidance to review
We should stop seeing downtime/restarts in staging hopefully.