### PR TITLE
Removed fields we don't need in BQ

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,10 +1,7 @@
 ---
 shared:
   :teachers:
-  - corrected_name
   - trn
-  - trs_first_name
-  - trs_last_name
   :events:
   - heading
   - body


### PR DESCRIPTION
We need to remove these fields from hidden_pii as they are also in the blocklist