### PR TITLE
AB teacher search URLs

### DIFF
--- a/app/components/teachers_index/header_section_component.rb
+++ b/app/components/teachers_index/header_section_component.rb
@@ -48,9 +48,9 @@ module TeachersIndex
 
     def navigation_link_path
       if showing_closed?
-        ab_teachers_path(q: query)
+        open_ab_teachers_path(q: query)
       else
-        ab_teachers_path(status: 'closed', q: query)
+        closed_ab_teachers_path(q: query)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,9 @@ Rails.application.routes.draw do
   resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab_landing', controller: 'appropriate_bodies/landing'
   namespace :appropriate_bodies, path: 'appropriate-body', as: 'ab' do
     resources :teachers, only: %i[show index], controller: 'teachers' do
+      match 'closed', to: 'teachers#index', via: :get, on: :collection, as: 'closed', defaults: { status: 'closed' }
+      match 'open', to: 'teachers#index', via: :get, on: :collection, as: 'open', defaults: { status: 'open' }
+
       resource :release_ect, only: %i[new create show], path: 'release', controller: 'teachers/release_ect'
       resource :record_passed_outcome, only: %i[new create show], path: 'record-passed-outcome', controller: 'teachers/record_passed_outcome'
       resource :record_failed_outcome, only: %i[new create show], path: 'record-failed-outcome', controller: 'teachers/record_failed_outcome'

--- a/spec/components/teachers_index/header_section_component_spec.rb
+++ b/spec/components/teachers_index/header_section_component_spec.rb
@@ -1,37 +1,25 @@
 RSpec.describe TeachersIndex::HeaderSectionComponent, type: :component do
-  subject(:rendered) { render_inline(component) }
+  include Rails.application.routes.url_helpers
 
-  let(:component) do
-    TeachersIndex::HeaderSectionComponent.new(
-      status:,
-      current_count:,
-      open_count:,
-      closed_count:
-    )
+  subject(:component) do
+    TeachersIndex::HeaderSectionComponent.new(status:, current_count:, open_count:, closed_count:)
   end
 
   let(:open_count) { 5 }
   let(:closed_count) { 3 }
+  let(:status) { 'open' }
+  let(:current_count) { open_count }
+  let(:rendered) { render_inline(component) }
+  let(:subheading) { rendered.css('h2.govuk-heading-m') }
 
   context 'when viewing open inductions' do
-    let(:status) { 'open' }
-    let(:current_count) { open_count }
-
-    it 'renders correct heading text' do
-      expect(rendered.css('h2').text).to include('5 open inductions')
-    end
-
-    it 'uses correct heading CSS classes' do
-      expect(rendered.css('h2.govuk-heading-m').length).to eq(1)
+    it 'has correct subheading' do
+      expect(subheading).to have_text('5 open inductions')
     end
 
     context 'when closed inductions exist' do
-      it 'renders navigation link to closed inductions' do
-        expect(rendered.to_html).to include('View closed inductions (3)')
-        expect(rendered.css('a[href*="status=closed"]').length).to eq(1)
-      end
-
-      it 'renders navigation link with correct styling' do
+      it 'links to closed inductions' do
+        expect(rendered).to have_link('View closed inductions (3)', href: closed_ab_teachers_path)
         expect(rendered.css('[class*="govuk-"][class*="padding-bottom"]').length).to eq(1)
       end
     end
@@ -39,10 +27,9 @@ RSpec.describe TeachersIndex::HeaderSectionComponent, type: :component do
     context 'when no closed inductions exist' do
       let(:closed_count) { 0 }
 
-      it 'renders navigation text but not as clickable link' do
-        expect(rendered.to_html).to include('No closed inductions')
-        # Should not be a clickable link since count is 0
-        expect(rendered.css('a').text).not_to include('closed inductions')
+      it 'does not link to closed inductions' do
+        expect(rendered).to have_text('No closed inductions')
+        expect(rendered).not_to have_link('No closed inductions')
         # Should still render the padding container
         expect(rendered.css('[class*="govuk-"][class*="padding-bottom"]').length).to eq(1)
       end
@@ -53,127 +40,37 @@ RSpec.describe TeachersIndex::HeaderSectionComponent, type: :component do
     let(:status) { 'closed' }
     let(:current_count) { closed_count }
 
-    it 'renders correct heading text' do
-      expect(rendered.css('h2').text).to include('3 closed inductions')
+    it 'has correct subheading' do
+      expect(subheading).to have_text('3 closed inductions')
     end
 
-    it 'always renders navigation link to open inductions' do
-      expect(rendered.to_html).to include('View open inductions (5)')
-      expect(rendered.css('a').length).to eq(1)
-    end
-
-    it 'navigation link points to default teachers path' do
-      expect(rendered.css('a[href*="/teachers"]').length).to eq(1)
-      expect(rendered.css('a[href*="status=closed"]').length).to eq(0)
+    it 'links to open inductions' do
+      expect(rendered).to have_link('View open inductions (5)', href: open_ab_teachers_path)
     end
   end
 
-  context 'with singular counts' do
-    let(:status) { 'open' }
-    let(:current_count) { 1 }
-    let(:open_count) { 1 }
-    let(:closed_count) { 1 }
+  describe 'pluralization' do
+    context 'with one induction' do
+      let(:open_count) { 1 }
+      let(:closed_count) { 1 }
 
-    it 'pluralizes correctly for single induction' do
-      expect(rendered.css('h2').text).to include('1 open induction')
-      expect(rendered.css('h2').text).not_to include('inductions')
-    end
-
-    it 'renders correct navigation text for singular counts' do
-      expect(rendered.to_html).to include('View closed inductions (1)')
-    end
-  end
-
-  context 'with zero counts' do
-    let(:status) { 'open' }
-    let(:current_count) { 0 }
-    let(:open_count) { 0 }
-    let(:closed_count) { 0 }
-
-    it 'pluralizes correctly for zero inductions' do
-      expect(rendered.css('h2').text).to include('0 open inductions')
-    end
-  end
-
-  describe 'component behavior' do
-    let(:status) { 'open' }
-    let(:current_count) { open_count }
-
-    it 'includes necessary helpers' do
-      expect(component.class.included_modules).to include(GovukLinkHelper)
-      expect(component.class.included_modules).to include(Rails.application.routes.url_helpers)
-      expect(component.class.included_modules).to include(ActionView::Helpers::TextHelper)
-    end
-
-    describe '#heading_text' do
-      it 'returns correct pluralized text' do
-        expect(component.send(:heading_text)).to eq('5 open inductions')
+      it 'is not plural' do
+        expect(subheading).to have_text('1 open induction')
+        expect(subheading).not_to have_text('inductions')
       end
     end
 
-    describe '#showing_closed?' do
-      context 'when status is closed' do
-        let(:status) { 'closed' }
+    context 'with no inductions' do
+      let(:open_count) { 0 }
+      let(:closed_count) { 0 }
 
-        it 'returns true' do
-          expect(component.send(:showing_closed?)).to be(true)
-        end
-      end
-
-      context 'when status is open' do
-        it 'returns false' do
-          expect(component.send(:showing_closed?)).to be(false)
-        end
-      end
-    end
-
-    describe '#should_show_navigation_link?' do
-      context 'when viewing closed inductions' do
-        let(:status) { 'closed' }
-
-        it 'always returns true' do
-          expect(component.send(:should_show_navigation_link?)).to be(true)
-        end
-      end
-
-      context 'when viewing open inductions' do
-        context 'with closed inductions available' do
-          it 'returns true' do
-            expect(component.send(:should_show_navigation_link?)).to be(true)
-          end
-        end
-
-        context 'with no closed inductions' do
-          let(:closed_count) { 0 }
-
-          it 'returns false' do
-            expect(component.send(:should_show_navigation_link?)).to be(false)
-          end
-        end
-      end
-    end
-
-    describe '#navigation_link_text' do
-      context 'when viewing closed inductions' do
-        let(:status) { 'closed' }
-
-        it 'returns correct text for open link' do
-          expect(component.send(:navigation_link_text)).to eq('View open inductions (5)')
-        end
-      end
-
-      context 'when viewing open inductions' do
-        it 'returns correct text for closed link' do
-          expect(component.send(:navigation_link_text)).to eq('View closed inductions (3)')
-        end
+      it 'is plural' do
+        expect(subheading).to have_text('0 open inductions')
       end
     end
   end
 
   describe 'layout structure' do
-    let(:status) { 'open' }
-    let(:current_count) { open_count }
-
     it 'renders within grid layout' do
       expect(rendered.css('.govuk-grid-row .govuk-grid-column-full').length).to eq(1)
     end


### PR DESCRIPTION
### Context

Make the URLs friendlier by matching params

### Changes proposed in this pull request

- Update routes for filtering open/closed teacher inductions as an AB
- Simplify component testing

### Guidance to review

- `/appropriate-body/teachers?status=closed` becomes `/appropriate-body/teachers/closed`
- add corresponding `/appropriate-body/teachers/open` which is the default view of `/appropriate-body/teachers`
