### PR TITLE
Enable Lead provider API in migration

### DIFF
--- a/config/terraform/application/config/migration.yml
+++ b/config/terraform/application/config/migration.yml
@@ -12,6 +12,7 @@ ENABLE_PERSONAS: false
 ENABLE_BULK_UPLOAD: true
 ENABLE_BULK_CLAIM: false
 ENABLE_PARITY_CHECK: true
+ENABLE_API: true
 SERVICE_URL: "https://cpd-ec2-migration-web.teacherservices.cloud"
 DFE_ANALYTICS_ENABLED: false
 TRS_API_BASE_URL: "https://preprod.teacher-qualifications-api.education.gov.uk"


### PR DESCRIPTION
### Context

When running the parity check on the migration environment we get 302s instead of getting responses. This is because the API isn't enabled

### Changes proposed in this pull request
Enable API in migration env

### Guidance to review
