### PR TITLE
Clear User OTP tokens when copying data from prod to migration

### DIFF
--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -58,4 +58,9 @@ jobs:
         shell: bash
         run: |
           kubectl -n cpd-production exec -ti --tty deployment/cpd-ec2-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner ParityCheck::SeedEndpoints.new.plant!"
+
+      - name: Clear User OTP tokens
+        shell: bash
+        run: |
+          kubectl -n cpd-production exec -ti --tty deployment/cpd-ec2-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner User.update_all(otp_secret: nil)"
           


### PR DESCRIPTION
### Context
On every data copy from prod to migration, we also copy over Users and their encrypted OTP tokens. This causes errors when trying to access the users even in the console.

### Changes proposed in this pull request

When refreshing migration, add a step to clear OTP tokens on all users to avoid doing manually.


### Guidance to review
@tonyheadford suggested using:
```
ActiveRecord::Encryption.without_encryption do
  my_user.update!(otp_secret: nil)
end
```

It seems using `update_all` is ok and doesn't need the without encryption block.

I'll test this on migration before merging
