### PR TITLE
Ensure required attributes are set when creating a Migration::SchoolPeriod

### DIFF
--- a/app/migration/school_mentors_to_school_periods.rb
+++ b/app/migration/school_mentors_to_school_periods.rb
@@ -26,8 +26,7 @@ private
                                   end_date: nil,
                                   start_source_id: school_mentor.id,
                                   end_source_id: nil,
-                                  training_programme: nil,
-                                  lead_provider_id: nil)
+                                  training_programme: nil)
     end
   end
 end

--- a/app/migration/school_mentors_to_school_periods.rb
+++ b/app/migration/school_mentors_to_school_periods.rb
@@ -25,7 +25,9 @@ private
                                   start_date: school_mentor.created_at.to_date,
                                   end_date: nil,
                                   start_source_id: school_mentor.id,
-                                  end_source_id: nil)
+                                  end_source_id: nil,
+                                  training_programme: nil,
+                                  lead_provider_id: nil)
     end
   end
 end

--- a/app/migration/school_period_extractor.rb
+++ b/app/migration/school_period_extractor.rb
@@ -33,7 +33,6 @@ private
     induction_records.each_with_object([]) do |induction_record, periods|
       record_school = induction_record.induction_programme.school_cohort.school
       training_programme = discover_training_programme(induction_record)
-      lead_provider_id = discover_lead_provider_id(induction_record, training_programme)
 
       if current_school != record_school
         current_school = record_school
@@ -73,14 +72,5 @@ private
   def discover_training_programme(induction_record)
     extracted_training_programme = induction_record.induction_programme.training_programme
     Mappers::TrainingProgrammeMapper.new(extracted_training_programme).mapped_value
-  end
-
-  def discover_lead_provider_id(induction_record, training_programme)
-    return nil if training_programme == 'school_led'
-
-    return nil if induction_record.induction_programme.partnership.nil?
-
-    extracted_lead_provider_name = induction_record.induction_programme.partnership.lead_provider.name
-    LeadProvider.find_by(name: extracted_lead_provider_name).id
   end
 end

--- a/app/migration/school_period_extractor.rb
+++ b/app/migration/school_period_extractor.rb
@@ -43,8 +43,7 @@ private
                                                      end_date: induction_record.end_date,
                                                      start_source_id: induction_record.id,
                                                      end_source_id: induction_record.id,
-                                                     training_programme:,
-                                                     lead_provider_id:)
+                                                     training_programme:)
         periods << current_period
       else
         current_period.end_date = induction_record.end_date

--- a/app/models/migration/school_period.rb
+++ b/app/models/migration/school_period.rb
@@ -10,14 +10,13 @@ module Migration
     attr_accessor :urn, :start_date, :end_date, :start_source_id, :end_source_id,
                   :training_programme, :lead_provider_id
 
-    def initialize(urn:, start_date:, end_date:, start_source_id:, end_source_id:, training_programme:, lead_provider_id:)
+    def initialize(urn:, start_date:, end_date:, start_source_id:, end_source_id:, training_programme:)
       @urn = urn
       @start_date = start_date
       @end_date = end_date
       @start_source_id = start_source_id
       @end_source_id = end_source_id
       @training_programme = training_programme
-      @lead_provider_id = lead_provider_id
     end
   end
 end

--- a/spec/factories/migration/school_period_factory.rb
+++ b/spec/factories/migration/school_period_factory.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     start_source_id { SecureRandom.uuid }
     end_source_id { SecureRandom.uuid }
     training_programme { "school_led" }
-    lead_provider_id { nil }
 
     initialize_with { new(**attributes) }
   end


### PR DESCRIPTION
### Context
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1994

The MentorAtSchoolPeriod migrator instantiates Migration::SchoolPeriod without passing `training_programme` and `lead_provider_id`, triggering a missing keywords error that breaks MentorAtSchoolPeriod creation and affects dependent records.

The `lead_provider_id` however is no longer stored on school periods, so the attribute is now redundant and can be removed.

### Changes proposed in this pull request
- Pass the missing argument `training_programme` when creating the Migration::SchoolPeriod objects
- Remove the redundant `lead_provider_id` attribute from the Migration::SchoolPeriod class and factory
- Remove the redundant `discover_lead_provider_id` method from the SchoolPeriodExtractor

### Guidance to review
