### PR TITLE
Only use example ids with output fees for statement parity checks

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -18,6 +18,7 @@ module ParityCheck
 
     def example_id
       Statement
+        .output_fee
         .joins(:active_lead_provider)
         .where(active_lead_provider: lead_provider.active_lead_providers)
         .order("RANDOM()")

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -13,10 +13,14 @@ RSpec.describe ParityCheck::DynamicRequestContent do
 
     context "when fetching example_id" do
       let(:identifier) { :example_id }
-      let!(:statement) { FactoryBot.create(:statement, lead_provider:) }
+      let!(:statement) { FactoryBot.create(:statement, :output_fee, lead_provider:) }
 
-      # Statement for different lead provider should not be used.
-      before { FactoryBot.create(:statement) }
+      before do
+        # Statement for different lead provider should not be used.
+        FactoryBot.create(:statement)
+        # Statement for service fee should not be used
+        FactoryBot.create(:statement, :service_fee, lead_provider:)
+      end
 
       it { is_expected.to eq(statement.api_id) }
     end


### PR DESCRIPTION
### Context
When running the parity check we get failures on single ids due to finding statements that are service fees. We only surface output fee in RECT. ECF scopes are incorrect for the GET endpoint 

### Changes proposed in this pull request
Change the scope for statement example ids to output fee

### Guidance to review
running on migration to check results