### PR TITLE
Simplify `Teachers::Details::PastInductionPeriodsComponent`

### DIFF
--- a/app/components/teachers/details/past_induction_periods_component.html.erb
+++ b/app/components/teachers/details/past_induction_periods_component.html.erb
@@ -8,7 +8,7 @@
           card: {
             heading_level: 3,
             title: period.appropriate_body.name,
-            actions: enable_edit ? [edit_link(period), delete_link(period)] : []
+            actions: actions_for(period)
           }
         ) do |sl|
           sl.with_row do |row|

--- a/app/components/teachers/details/past_induction_periods_component.rb
+++ b/app/components/teachers/details/past_induction_periods_component.rb
@@ -26,16 +26,23 @@ module Teachers::Details
       end
     end
 
-    def edit_link(period)
-      return unless enable_edit
+    delegate :govuk_link_to, to: :helpers
 
-      helpers.govuk_link_to('Edit', helpers.edit_admin_teacher_induction_period_path(teacher_id: teacher.id, id: period.id), no_visited_state: true)
-    end
+    def actions_for(period)
+      return [] unless enable_edit
 
-    def delete_link(period)
-      return unless enable_edit
-
-      helpers.govuk_link_to('Delete', helpers.confirm_delete_admin_teacher_induction_period_path(teacher_id: teacher.id, id: period.id), method: :get, class: 'govuk-link--destructive', no_visited_state: true)
+      [
+        govuk_link_to(
+          'Edit',
+          helpers.edit_admin_teacher_induction_period_path(teacher, period),
+          no_visited_state: true
+        ),
+        govuk_link_to(
+          'Delete',
+          helpers.confirm_delete_admin_teacher_induction_period_path(teacher, period),
+          no_visited_state: true
+        )
+      ]
     end
   end
 end

--- a/spec/components/teachers/details/past_induction_periods_component_spec.rb
+++ b/spec/components/teachers/details/past_induction_periods_component_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe Teachers::Details::PastInductionPeriodsComponent, type: :componen
   include AppropriateBodyHelper
 
   let(:teacher) { FactoryBot.create(:teacher) }
-  let(:component) { described_class.new(teacher:) }
+  let(:enable_edit) { false }
+  let(:component) { described_class.new(teacher:, enable_edit:) }
 
   context "when teacher has no past induction periods" do
     it "does not render" do
@@ -12,7 +13,7 @@ RSpec.describe Teachers::Details::PastInductionPeriodsComponent, type: :componen
 
   context "when teacher has past induction periods" do
     let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: "Past AB") }
-    let!(:past_period) do
+    let!(:past_induction_period) do
       FactoryBot.create(:induction_period,
                         teacher:,
                         appropriate_body:,
@@ -49,6 +50,32 @@ RSpec.describe Teachers::Details::PastInductionPeriodsComponent, type: :componen
     it "displays the number of terms" do
       render_inline(component)
       expect(page).to have_content("3")
+    end
+
+    context "when edit is enabled" do
+      let(:enable_edit) { true }
+
+      it "renders actions when edit is enabled" do
+        render_inline(component)
+        expect(page).to have_link(
+          "Edit",
+          href: "/admin/teachers/#{teacher.id}/induction-periods/#{past_induction_period.id}/edit"
+        )
+        expect(page).to have_link(
+          "Delete",
+          href: "/admin/teachers/#{teacher.id}/induction-periods/#{past_induction_period.id}/confirm_delete"
+        )
+      end
+    end
+
+    context "when edit is disabled" do
+      let(:enable_edit) { false }
+
+      it "does not render actions when edit is disabled" do
+        render_inline(component)
+        expect(page).not_to have_link("Edit")
+        expect(page).not_to have_link("Delete")
+      end
     end
   end
 end


### PR DESCRIPTION
As highlighted by Avin in #936, we can simplify the logic for rendering action links in the summary list.

This refactors the component and adds some tests for when editing is enabled and when it isn't.