### PR TITLE
[BUG] Notify TRS when an Admin adds an "earliest" induction period

### DIFF
--- a/app/services/induction_periods/create_induction_period.rb
+++ b/app/services/induction_periods/create_induction_period.rb
@@ -17,30 +17,30 @@ module InductionPeriods
     # @return [InductionPeriod]
     # @raise [ActiveRecord::RecordInvalid, ActiveRecord::Rollback]
     def create_induction_period!
-      raise ActiveRecord::RecordInvalid, @induction_period unless @induction_period.valid?
+      raise ActiveRecord::RecordInvalid, induction_period unless induction_period.valid?
 
       ActiveRecord::Base.transaction do
-        @induction_period.save!
+        induction_period.save!
         record_event or raise ActiveRecord::Rollback
       end
 
       notify_trs_of_new_induction_start if notify_trs?
 
-      @induction_period
+      induction_period
     end
 
   private
 
     # @return [Boolean]
     def record_event
-      return false unless @induction_period.persisted?
+      return false unless induction_period.persisted?
 
       Events::Record.record_induction_period_opened_event!(
-        author: @author,
+        author:,
         teacher:,
-        appropriate_body: @induction_period.appropriate_body,
-        induction_period: @induction_period,
-        modifications: @induction_period.changes
+        appropriate_body: induction_period.appropriate_body,
+        induction_period:,
+        modifications: induction_period.changes
       )
 
       true
@@ -55,7 +55,7 @@ module InductionPeriods
 
     # @return [Boolean]
     def teacher_has_earlier_induction_periods?
-      InductionPeriod.where(teacher:).started_before(@induction_period.started_on).exists?
+      InductionPeriod.where(teacher:).started_before(induction_period.started_on).exists?
     end
 
     # @return [Boolean]
@@ -66,7 +66,7 @@ module InductionPeriods
     def notify_trs_of_new_induction_start
       BeginECTInductionJob.perform_later(
         trn: teacher.trn,
-        start_date: @induction_period.started_on
+        start_date: induction_period.started_on
       )
     end
   end

--- a/app/services/induction_periods/create_induction_period.rb
+++ b/app/services/induction_periods/create_induction_period.rb
@@ -2,7 +2,6 @@ module InductionPeriods
   class CreateInductionPeriod
     attr_reader :induction_period,
                 :event,
-                :params,
                 :teacher,
                 :author
 
@@ -12,7 +11,6 @@ module InductionPeriods
     def initialize(author:, teacher:, params:)
       @author = author
       @teacher = teacher
-      @params = params
       @induction_period = InductionPeriod.new(params.merge(teacher:))
     end
 
@@ -39,7 +37,7 @@ module InductionPeriods
 
       Events::Record.record_induction_period_opened_event!(
         author: @author,
-        teacher: @teacher,
+        teacher:,
         appropriate_body: @induction_period.appropriate_body,
         induction_period: @induction_period,
         modifications: @induction_period.changes

--- a/app/services/induction_periods/create_induction_period.rb
+++ b/app/services/induction_periods/create_induction_period.rb
@@ -57,7 +57,7 @@ module InductionPeriods
 
     # @return [Boolean]
     def teacher_has_earlier_induction_periods?
-      InductionPeriod.where(teacher:).started_before(params[:started_on]).exists?
+      InductionPeriod.where(teacher:).started_before(@induction_period.started_on).exists?
     end
 
     # @return [Boolean]
@@ -68,7 +68,7 @@ module InductionPeriods
     def notify_trs_of_new_induction_start
       BeginECTInductionJob.perform_later(
         trn: teacher.trn,
-        start_date: params[:started_on]
+        start_date: @induction_period.started_on
       )
     end
   end

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -6,63 +6,81 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   describe "POST /admin/teachers/:teacher_id/induction-periods" do
-    let(:valid_params) do
-      {
-        induction_period: {
-          started_on: 6.months.ago,
-          finished_on: 3.months.ago,
-          induction_programme: 'fip',
-          appropriate_body_id: appropriate_body.id,
-          number_of_terms: 2
-        }
-      }
-    end
-
     context "with valid parameters" do
+      let(:started_on) { 6.months.ago }
+      let(:finished_on) { 3.months.ago }
+      let(:valid_params) do
+        {
+          induction_period: {
+            "started_on(3i)" => started_on.day,
+            "started_on(2i)" => started_on.month,
+            "started_on(1i)" => started_on.year,
+            "finished_on(3i)" => finished_on.day,
+            "finished_on(2i)" => finished_on.month,
+            "finished_on(1i)" => finished_on.year,
+            induction_programme: 'fip',
+            appropriate_body_id: appropriate_body.id,
+            number_of_terms: 2
+          }
+        }
+      end
+
       it "creates a new induction period" do
-        expect {
-          post admin_teacher_induction_periods_path(teacher), params: valid_params
-        }.to change(InductionPeriod, :count).by(1)
+        expect { post admin_teacher_induction_periods_path(teacher), params: valid_params }
+          .to change(InductionPeriod, :count).by(1)
       end
 
       it "redirects to the teacher page with success message" do
         post admin_teacher_induction_periods_path(teacher), params: valid_params
+
         expect(response).to redirect_to(admin_teacher_path(teacher))
         expect(flash[:alert]).to eq('Induction period created successfully')
       end
 
       it "records an 'admin creates induction period' event" do
-        allow(Events::Record).to receive(:record_induction_period_opened_event!).once.and_call_original
+        allow(Events::Record)
+          .to receive(:record_induction_period_opened_event!)
+          .once.and_call_original
 
         post admin_teacher_induction_periods_path(teacher), params: valid_params
 
-        expect(Events::Record).to have_received(:record_induction_period_opened_event!).once.with(
-          hash_including(
-            {
-              appropriate_body:,
-              author: kind_of(Sessions::User),
-              induction_period: kind_of(InductionPeriod),
-              teacher:,
-            }
+        expect(Events::Record)
+          .to have_received(:record_induction_period_opened_event!)
+          .once
+          .with(
+            hash_including(
+              {
+                appropriate_body:,
+                author: kind_of(Sessions::User),
+                induction_period: kind_of(InductionPeriod),
+                teacher:,
+              }
+            )
           )
-        )
       end
 
       it "creates the period with correct attributes" do
         post admin_teacher_induction_periods_path(teacher), params: valid_params
+
         period = InductionPeriod.last
-        expect(period.started_on).to eq(valid_params[:induction_period][:started_on].to_date)
-        expect(period.finished_on).to eq(valid_params[:induction_period][:finished_on].to_date)
-        expect(period.induction_programme).to eq(valid_params[:induction_period][:induction_programme])
+        expect(period.started_on).to eq(started_on.to_date)
+        expect(period.finished_on).to eq(finished_on.to_date)
+        expect(period.induction_programme).to eq('fip')
       end
     end
 
     context "with invalid parameters" do
+      let(:started_on) { nil }
+      let(:finished_on) { 3.months.ago }
       let(:invalid_params) do
         {
           induction_period: {
-            started_on: nil,
-            finished_on: 1.year.ago + 6.months,
+            "started_on(3i)" => "",
+            "started_on(2i)" => "",
+            "started_on(1i)" => "",
+            "finished_on(3i)" => finished_on.day,
+            "finished_on(2i)" => finished_on.month,
+            "finished_on(1i)" => finished_on.year,
             induction_programme: 'fip',
             appropriate_body_id: appropriate_body.id,
             number_of_terms: 2
@@ -72,7 +90,8 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
 
       it "does not create a new induction period" do
         expect {
-          post admin_teacher_induction_periods_path(teacher), params: invalid_params
+          post admin_teacher_induction_periods_path(teacher),
+               params: invalid_params
         }.not_to change(InductionPeriod, :count)
       end
 
@@ -127,9 +146,21 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
     end
 
     context "with invalid appropriate body" do
+      let(:started_on) { 6.months.ago }
+      let(:finished_on) { 3.months.ago }
       let(:params) do
         {
-          induction_period: valid_params[:induction_period].merge(appropriate_body_id: nil)
+          induction_period: {
+            "started_on(3i)" => started_on.day,
+            "started_on(2i)" => started_on.month,
+            "started_on(1i)" => started_on.year,
+            "finished_on(3i)" => finished_on.day,
+            "finished_on(2i)" => finished_on.month,
+            "finished_on(1i)" => finished_on.year,
+            induction_programme: 'fip',
+            appropriate_body_id: nil,
+            number_of_terms: 2
+          }
         }
       end
 
@@ -152,11 +183,21 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
     end
 
     context "with start date before QTS award date" do
+      let(:started_on) { teacher.trs_qts_awarded_on - 1.day }
+      let(:finished_on) { 3.months.ago }
       let(:params) do
         {
-          induction_period: valid_params[:induction_period].merge(
-            started_on: teacher.trs_qts_awarded_on - 1.day
-          )
+          induction_period: {
+            "started_on(3i)" => started_on.day,
+            "started_on(2i)" => started_on.month,
+            "started_on(1i)" => started_on.year,
+            "finished_on(3i)" => finished_on.day,
+            "finished_on(2i)" => finished_on.month,
+            "finished_on(1i)" => finished_on.year,
+            induction_programme: 'fip',
+            appropriate_body_id: appropriate_body.id,
+            number_of_terms: 2
+          }
         }
       end
 
@@ -179,11 +220,21 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
     end
 
     context "with end date before start date" do
+      let(:started_on) { 6.months.ago }
+      let(:finished_on) { started_on - 1.day }
       let(:params) do
         {
-          induction_period: valid_params[:induction_period].merge(
-            finished_on: valid_params[:induction_period][:started_on] - 1.day
-          )
+          induction_period: {
+            "started_on(3i)" => started_on.day,
+            "started_on(2i)" => started_on.month,
+            "started_on(1i)" => started_on.year,
+            "finished_on(3i)" => finished_on.day,
+            "finished_on(2i)" => finished_on.month,
+            "finished_on(1i)" => finished_on.year,
+            induction_programme: 'fip',
+            appropriate_body_id: appropriate_body.id,
+            number_of_terms: 2
+          }
         }
       end
 
@@ -214,6 +265,24 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
                           induction_programme: "fip")
       end
 
+      let(:started_on) { 6.months.ago }
+      let(:finished_on) { 3.months.ago }
+      let(:valid_params) do
+        {
+          induction_period: {
+            "started_on(3i)" => started_on.day,
+            "started_on(2i)" => started_on.month,
+            "started_on(1i)" => started_on.year,
+            "finished_on(3i)" => finished_on.day,
+            "finished_on(2i)" => finished_on.month,
+            "finished_on(1i)" => finished_on.year,
+            induction_programme: 'fip',
+            appropriate_body_id: appropriate_body.id,
+            number_of_terms: 2
+          }
+        }
+      end
+
       it "creates a new induction period" do
         expect {
           post admin_teacher_induction_periods_path(teacher), params: valid_params
@@ -223,9 +292,9 @@ RSpec.describe "Admin::InductionPeriods", type: :request do
       it "creates the period with correct attributes" do
         post admin_teacher_induction_periods_path(teacher), params: valid_params
         period = InductionPeriod.last
-        expect(period.started_on).to eq(valid_params[:induction_period][:started_on].to_date)
-        expect(period.finished_on).to eq(valid_params[:induction_period][:finished_on].to_date)
-        expect(period.induction_programme).to eq(valid_params[:induction_period][:induction_programme])
+        expect(period.started_on).to eq(started_on.to_date)
+        expect(period.finished_on).to eq(finished_on.to_date)
+        expect(period.induction_programme).to eq('fip')
         expect(period.training_programme).to eq('provider_led')
       end
     end

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -1,182 +1,177 @@
-describe 'InductionPeriods::CreateInductionPeriod' do
+describe InductionPeriods::CreateInductionPeriod do
   include ActiveJob::TestHelper
 
+  subject { described_class.new(author:, teacher:, params:) }
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:started_on) { 3.weeks.ago.to_date }
+  let(:induction_programme) { 'cip' }
+  let(:params) do
+    {
+      started_on:,
+      appropriate_body_id: appropriate_body.id,
+      induction_programme:
+    }
+  end
+  let(:author) do
+    Sessions::Users::AppropriateBodyUser.new(
+      name: 'A user',
+      email: 'ab_user@something.org',
+      dfe_sign_in_user_id: SecureRandom.uuid,
+      dfe_sign_in_organisation_id: appropriate_body.dfe_sign_in_organisation_id
+    )
+  end
+
   describe '#initialize' do
-    subject { InductionPeriods::CreateInductionPeriod.new(author:, teacher:, params:) }
-
-    let(:teacher) { FactoryBot.create(:teacher) }
-    let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let(:started_on) { 3.weeks.ago.to_date }
-    let(:induction_programme) { 'cip' }
-    let(:params) do
-      {
-        started_on:,
-        appropriate_body_id: appropriate_body.id,
-        induction_programme:
-      }
-    end
-    let(:author) do
-      Sessions::Users::AppropriateBodyUser.new(
-        name: 'A user',
-        email: 'ab_user@something.org',
-        dfe_sign_in_user_id: SecureRandom.uuid,
-        dfe_sign_in_organisation_id: appropriate_body.dfe_sign_in_organisation_id
-      )
-    end
-
     it 'accepts and assigns the author, teacher and params' do
       expect(subject.author).to eql(author)
       expect(subject.teacher).to eql(teacher)
       expect(subject.params).to eql(params)
     end
+  end
 
-    describe '#create_induction_period!' do
+  describe '#create_induction_period!' do
+    before do
+      allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
+    end
+
+    context 'when the induction period is valid' do
+      it 'saves the record' do
+        induction_period = subject.create_induction_period!
+
+        expect(induction_period).to be_a(InductionPeriod)
+        expect(induction_period).to be_persisted
+      end
+
+      it 'records an induction_period_opened event' do
+        subject.create_induction_period!
+
+        perform_enqueued_jobs
+
+        expect(Event.last.event_type).to eql('induction_period_opened')
+      end
+
+      it 'creates the event with the expected values' do
+        freeze_time
+
+        subject.create_induction_period!
+
+        perform_enqueued_jobs
+
+        last_event = Event.last
+        expect(last_event.appropriate_body).to eql(appropriate_body)
+        expect(last_event.teacher).to eql(teacher)
+        expect(last_event.happened_at.to_date).to eql(started_on)
+      end
+
+      it 'returns the induction period and exposes it as a attr' do
+        returned_value = subject.create_induction_period!
+
+        expect(returned_value).to be_an(InductionPeriod)
+        expect(subject.induction_period).to be(returned_value)
+      end
+
+      it 'notifies TRS of the new induction start date' do
+        expect { subject.create_induction_period! }
+          .to have_enqueued_job(BeginECTInductionJob)
+          .with(trn: teacher.trn, start_date: started_on)
+      end
+    end
+
+    context 'with existing periods' do
       before do
-        allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
-        allow(BeginECTInductionJob).to receive(:perform_later)
+        FactoryBot.create(
+          :induction_period,
+          teacher:,
+          appropriate_body:,
+          started_on: Date.parse('2024-1-1'),
+          finished_on: Date.parse('2024-6-1'),
+          number_of_terms: 2
+        )
       end
 
-      context 'when the induction period is valid' do
-        it 'saves the record' do
-          induction_period = subject.create_induction_period!
-
-          expect(induction_period).to be_a(InductionPeriod)
-          expect(induction_period).to be_persisted
-        end
-
-        it 'records an induction_period_opened event' do
-          subject.create_induction_period!
-
-          perform_enqueued_jobs
-
-          expect(Event.last.event_type).to eql('induction_period_opened')
-        end
-
-        it 'creates the event with the expected values' do
-          freeze_time do
-            subject.create_induction_period!
-
-            perform_enqueued_jobs
-
-            last_event = Event.last
-
-            expect(last_event.appropriate_body).to eql(appropriate_body)
-            expect(last_event.teacher).to eql(teacher)
-            expect(last_event.happened_at.to_date).to eql(started_on)
-          end
-        end
-
-        it 'returns the induction period and exposes it as a attr' do
-          returned_value = subject.create_induction_period!
-
-          expect(returned_value).to be_an(InductionPeriod)
-          expect(subject.induction_period).to be(returned_value)
-        end
-
-        it 'notifies TRS of the new induction start date' do
-          subject.create_induction_period!
-
-          expect(BeginECTInductionJob).to have_received(:perform_later).with(
-            trn: teacher.trn,
-            start_date: started_on
-          )
-        end
-      end
-
-      context 'with existing periods' do
-        before do
-          FactoryBot.create(
-            :induction_period,
-            teacher:,
-            appropriate_body:,
-            started_on: Date.parse('2024-1-1'),
-            finished_on: Date.parse('2024-6-1'),
+      context 'when creating an earlier period' do
+        let(:started_on) { Date.parse('2023-1-1') }
+        let(:finished_on) { Date.parse('2023-6-1') }
+        let(:params) do
+          {
+            started_on:,
+            finished_on:,
+            appropriate_body_id: appropriate_body.id,
+            induction_programme:,
             number_of_terms: 2
-          )
+          }
         end
 
-        context 'when creating an earlier period' do
-          let(:started_on) { Date.parse('2023-1-1') }
-          let(:finished_on) { Date.parse('2023-6-1') }
-          let(:params) do
-            {
-              started_on:,
-              finished_on:,
-              appropriate_body_id: appropriate_body.id,
-              induction_programme:,
-              number_of_terms: 2
-            }
-          end
-
-          it 'notifies TRS of the earlier induction start date' do
-            subject.create_induction_period!
-
-            expect(BeginECTInductionJob).to have_received(:perform_later).with(
-              trn: teacher.trn,
-              start_date: started_on
-            )
-          end
-        end
-
-        context 'when creating a later period' do
-          let(:started_on) { Date.parse('2024-7-1') }
-          let(:finished_on) { Date.parse('2024-12-1') }
-          let(:params) do
-            {
-              started_on:,
-              finished_on:,
-              appropriate_body_id: appropriate_body.id,
-              induction_programme:,
-              number_of_terms: 2
-            }
-          end
-
-          it 'does not notify TRS' do
-            subject.create_induction_period!
-
-            expect(BeginECTInductionJob).not_to have_received(:perform_later)
-          end
+        it 'notifies TRS of the earlier induction start date' do
+          expect { subject.create_induction_period! }
+            .to have_enqueued_job(BeginECTInductionJob)
+            .with(trn: teacher.trn, start_date: started_on)
         end
       end
 
-      context 'when the teacher has passed induction' do
-        before do
-          FactoryBot.create(
-            :induction_period,
-            teacher:,
-            appropriate_body:,
-            started_on: Date.parse('2023-1-1'),
-            finished_on: Date.parse('2023-6-1'),
-            outcome: 'pass',
+      context 'when creating a later period' do
+        let(:started_on) { Date.parse('2024-7-1') }
+        let(:finished_on) { Date.parse('2024-12-1') }
+        let(:params) do
+          {
+            started_on:,
+            finished_on:,
+            appropriate_body_id: appropriate_body.id,
+            induction_programme:,
             number_of_terms: 2
-          )
+          }
         end
 
         it 'does not notify TRS' do
-          subject.create_induction_period!
-
-          expect(BeginECTInductionJob).not_to have_received(:perform_later)
+          expect { subject.create_induction_period! }
+            .not_to have_enqueued_job(BeginECTInductionJob)
         end
       end
+    end
 
-      context 'when the induction period is invalid' do
-        before { allow(Events::Record).to receive(:record_induction_period_opened_event!).and_call_original }
+    context 'when the teacher has passed induction' do
+      before do
+        FactoryBot.create(
+          :induction_period,
+          teacher:,
+          appropriate_body:,
+          started_on: Date.parse('2023-1-1'),
+          finished_on: Date.parse('2023-6-1'),
+          outcome: 'pass',
+          number_of_terms: 2
+        )
+      end
 
-        let(:started_on) { 3.weeks.from_now.to_date }
+      it 'does not notify TRS' do
+        expect { subject.create_induction_period! }
+          .not_to have_enqueued_job(BeginECTInductionJob)
+      end
+    end
 
-        it 'raises error and does not record event' do
-          expect { subject.create_induction_period! }.to raise_error(ActiveRecord::RecordInvalid)
+    context 'when the induction period is invalid' do
+      before do
+        allow(Events::Record)
+          .to receive(:record_induction_period_opened_event!)
+          .and_call_original
+      end
 
-          perform_enqueued_jobs
+      let(:started_on) { 3.weeks.from_now.to_date }
 
-          expect(Event.count).to be_zero
-        end
+      it 'raises error and does not record event' do
+        expect { subject.create_induction_period! }
+          .to raise_error(ActiveRecord::RecordInvalid)
 
-        it 'does not notify TRS' do
-          expect { subject.create_induction_period! }.to raise_error(ActiveRecord::RecordInvalid)
+        perform_enqueued_jobs
 
-          expect(BeginECTInductionJob).not_to have_received(:perform_later)
-        end
+        expect(Event.count).to be_zero
+      end
+
+      it 'does not notify TRS' do
+        expect { subject.create_induction_period! }
+          .to raise_error(ActiveRecord::RecordInvalid)
+          .and not_have_enqueued_job(BeginECTInductionJob)
       end
     end
   end

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -27,7 +27,7 @@ describe InductionPeriods::CreateInductionPeriod do
     it 'accepts and assigns the author, teacher and params' do
       expect(subject.author).to eql(author)
       expect(subject.teacher).to eql(teacher)
-      expect(subject.params).to eql(params)
+      expect(subject.induction_period).to be_a(InductionPeriod)
     end
   end
 

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -79,7 +79,7 @@ describe InductionPeriods::CreateInductionPeriod do
       end
     end
 
-    context 'with existing periods' do
+    context "when the induction period is earlier than existing periods" do
       before do
         FactoryBot.create(
           :induction_period,
@@ -91,43 +91,52 @@ describe InductionPeriods::CreateInductionPeriod do
         )
       end
 
-      context 'when creating an earlier period' do
-        let(:started_on) { Date.parse('2023-1-1') }
-        let(:finished_on) { Date.parse('2023-6-1') }
-        let(:params) do
-          {
-            started_on:,
-            finished_on:,
-            appropriate_body_id: appropriate_body.id,
-            induction_programme:,
-            number_of_terms: 2
-          }
-        end
-
-        it 'notifies TRS of the earlier induction start date' do
-          expect { subject.create_induction_period! }
-            .to have_enqueued_job(BeginECTInductionJob)
-            .with(trn: teacher.trn, start_date: started_on)
-        end
+      let(:started_on) { Date.parse('2023-1-1') }
+      let(:finished_on) { Date.parse('2023-6-1') }
+      let(:params) do
+        {
+          started_on:,
+          finished_on:,
+          appropriate_body_id: appropriate_body.id,
+          induction_programme:,
+          number_of_terms: 2
+        }
       end
 
-      context 'when creating a later period' do
-        let(:started_on) { Date.parse('2024-7-1') }
-        let(:finished_on) { Date.parse('2024-12-1') }
-        let(:params) do
-          {
-            started_on:,
-            finished_on:,
-            appropriate_body_id: appropriate_body.id,
-            induction_programme:,
-            number_of_terms: 2
-          }
-        end
+      it 'notifies TRS of the earlier induction start date' do
+        expect { subject.create_induction_period! }
+          .to have_enqueued_job(BeginECTInductionJob)
+          .with(trn: teacher.trn, start_date: started_on)
+      end
+    end
 
-        it 'does not notify TRS' do
-          expect { subject.create_induction_period! }
-            .not_to have_enqueued_job(BeginECTInductionJob)
-        end
+    context "when the induction period is later than existing periods" do
+      before do
+        FactoryBot.create(
+          :induction_period,
+          teacher:,
+          appropriate_body:,
+          started_on: Date.parse('2024-1-1'),
+          finished_on: Date.parse('2024-6-1'),
+          number_of_terms: 2
+        )
+      end
+
+      let(:started_on) { Date.parse('2024-7-1') }
+      let(:finished_on) { Date.parse('2024-12-1') }
+      let(:params) do
+        {
+          started_on:,
+          finished_on:,
+          appropriate_body_id: appropriate_body.id,
+          induction_programme:,
+          number_of_terms: 2
+        }
+      end
+
+      it 'does not notify TRS' do
+        expect { subject.create_induction_period! }
+          .not_to have_enqueued_job(BeginECTInductionJob)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,4 +25,5 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
+RSpec::Matchers.define_negated_matcher :not_have_enqueued_job, :have_enqueued_job
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2002

### Changes proposed in this pull request

**A bunch!**

There is a lot of noise, so I'd recommend traversing the commits.

9ba06149312d4cc7d7f80022ebf3148b12586000 is where the magic happens.

The other changes are refactoring, or adding tests.

### Guidance to review

- [ ] As an Admin, add an "earliest" induction period, see TRS notified (i.e job enqueued)
