### PR TITLE
Raise rate limit to stop downtime on sandbox

### DIFF
--- a/config/terraform/domains/environment_domains/config/sandbox.tfvars.json
+++ b/config/terraform/domains/environment_domains/config/sandbox.tfvars.json
@@ -13,5 +13,5 @@
       "origin_hostname": "cpd-ec2-sandbox-web.teacherservices.cloud"
     }
   },
-  "rate_limit_max": 2000
+  "rate_limit_max": 1500
 }


### PR DESCRIPTION
We are being scraped, and this brought sandbox down. We set it to 2000 initally, now set to 1500 and monitor
