### PR TITLE
1936 add content to sandbox info page

### DIFF
--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -51,8 +51,8 @@ module Navigation
         ],
         api_guidance: [
           { text: "Home", href: '/api/guidance' },
-          { text: "Technical documentation", href: '/api/guidance/technical-documentation' },
-          { text: "Release notes", href: '/api/guidance/release-notes' },
+          { text: "Swagger API documentation", href: '/api/guidance/swagger_api_documentation' },
+          { text: "Release notes", href: '/api/guidance/release_notes' },
           { text: "Sandbox", href: '/api/guidance/sandbox' },
           { text: "Guidance", href: '/api/guidance/early-career-training-programme-guidance' },
         ]

--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -54,7 +54,7 @@ module Navigation
           { text: "Swagger API documentation", href: '/api/guidance/swagger_api_documentation' },
           { text: "Release notes", href: '/api/guidance/release_notes' },
           { text: "Sandbox", href: '/api/guidance/sandbox' },
-          { text: "Guidance", href: '/api/guidance/early-career-training-programme-guidance' },
+          { text: "Guidance", href: '/api/guidance/guidance_for_lead_providers' },
         ]
       }.fetch(navigation_area, [])
     end

--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -51,10 +51,10 @@ module Navigation
         ],
         api_guidance: [
           { text: "Home", href: '/api/guidance' },
-          { text: "Swagger API documentation", href: '/api/guidance/swagger_api_documentation' },
-          { text: "Release notes", href: '/api/guidance/release_notes' },
+          { text: "Swagger API documentation", href: '/api/guidance/swagger-api-documentation' },
+          { text: "Release notes", href: '/api/guidance/release-notes' },
           { text: "Sandbox", href: '/api/guidance/sandbox' },
-          { text: "Guidance", href: '/api/guidance/guidance_for_lead_providers' },
+          { text: "Guidance", href: '/api/guidance/guidance-for-lead-providers' },
         ]
       }.fetch(navigation_area, [])
     end

--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -21,6 +21,9 @@ module API
         "swagger-api-documentation" => "swagger_api_documentation",
         "guidance-for-lead-providers" => "guidance_for_lead_providers",
         "sandbox" => "sandbox",
+        "guidance-for-lead-providers/api-data-states" => "guidance_for_lead_providers/api_data_states",
+        "guidance-for-lead-providers/data-syncing" => "guidance_for_lead_providers/data_syncing",
+        "guidance-for-lead-providers/ids-explained" => "guidance_for_lead_providers/ids_explained",
       }.fetch(path)
 
       render "api/guidance/" + template

--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -18,9 +18,8 @@ module API
       path = params[:page]
 
       template = {
-        "how-to-use-api" => "how_to_use_api",
-        "technical-documentation" => "technical_documentation",
-        "early-career-training-programme-guidance" => "ect_programme_guidance",
+        "swagger-api-documentation" => "swagger_api_documentation",
+        "guidance-for-lead-providers" => "guidance_for_lead_providers",
         "sandbox" => "sandbox",
       }.fetch(path)
 

--- a/app/views/api/guidance/ect_programme_guidance.md
+++ b/app/views/api/guidance/ect_programme_guidance.md
@@ -1,5 +1,0 @@
----
-title: ECT guidance
----
-
-Hi

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -22,13 +22,14 @@ Lead providers are responsible for delivering high-quality early career teacher 
 
 ## Where to manage ECT training data 
 
-Lead providers must use the [‘Register early career teachers’ API](add link) to submit and update data about: 
+Lead providers must use the [‘Register early career teachers’ API](relative URL + /api) to submit and update data about: 
 
 * early career teachers
 * mentors
 * training schedules
 * programme declarations
-* participant deferrals, withdrawals and reinstatements 
+* participant deferrals, withdrawals and reinstatements
+* creating and updating partnerships
 
 This data enables: 
 
@@ -38,15 +39,15 @@ This data enables:
 
 ## Testing and going live 
 
-Lead providers should use the [sandbox environment](add link) to test sending data before moving to production when it goes live. This will help ensure: 
+Lead providers should use the [sandbox environment](https://sandbox.register-early-career-teachers.education.gov.uk/api) to test sending data before moving to production when it goes live. This will help ensure: 
 
 * their integration works correctly
 * errors can be fixed early
 * payments are not delayed due to data issues 
 
-[Read the sandbox guidance](add link) 
+[Read the sandbox guidance](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/sandbox)) 
 
-[Read the live environment guidance](add link) 
+[Read the live environment guidance](add link when page has been created) 
 
 ## Other interactions with DfE 
 
@@ -62,4 +63,4 @@ They’ll typically hear from DfE through:
 * emails
 * Slack messages 
 
-DfE also publishes [release notes](add link) whenever it updates the API.  
+DfE also publishes [release notes](relative link + api/guidance/release-notes) whenever it updates the API.  

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -18,7 +18,7 @@ Lead providers are responsible for delivering high-quality early career teacher 
 * managing changes to participant details and training status
 * making sure declarations are correct so funding can be released 
 
-## Where to manage ECT training data 
+## Where to manage participant training data 
 
 Lead providers must use the [‘Register early career teachers’ API](/api) to submit and update data about:
 

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -22,7 +22,7 @@ Lead providers are responsible for delivering high-quality early career teacher 
 
 ## Where to manage ECT training data 
 
-Lead providers must use the [‘Register early career teachers’ API](relative URL + /api) to submit and update data about: 
+Lead providers must use the [‘Register early career teachers’ API](/api) to submit and update data about:
 
 * early career teachers
 * mentors
@@ -45,7 +45,7 @@ Lead providers should use the [sandbox environment](https://sandbox.register-ear
 * errors can be fixed early
 * payments are not delayed due to data issues 
 
-[Read the sandbox guidance](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/sandbox) 
+[Read the sandbox guidance](/api/guidance/sandbox)
 
 [Read the live environment guidance](add link when page has been created) 
 
@@ -63,4 +63,4 @@ They’ll typically hear from DfE through:
 * emails
 * Slack messages 
 
-DfE also publishes [release notes](relative link + api/guidance/release-notes) whenever it updates the API.  
+DfE also publishes [release notes](/api/guidance/release-notes) whenever it updates the API.

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -45,7 +45,7 @@ Lead providers should use the [sandbox environment](https://sandbox.register-ear
 * errors can be fixed early
 * payments are not delayed due to data issues 
 
-[Read the sandbox guidance](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/sandbox)) 
+[Read the sandbox guidance](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/sandbox) 
 
 [Read the live environment guidance](add link when page has been created) 
 

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -2,12 +2,10 @@
 title: Guidance for lead providers 
 ---
 
-## Working with DfE on early career teacher training programmes 
-
 Use this guidance to: 
 
 * understand lead providers responsibilities
-* know how lead providers should interact with the DfE and the ‘Register early career teachers’ service
+* know how lead providers should interact with the Department for Education (DfE) and the ‘Register early career teachers’ service
 * find where to manage data, funding and reporting 
 
 ## What lead providers are responsible for 

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -47,8 +47,6 @@ Lead providers should use the [sandbox environment](https://sandbox.register-ear
 
 [Read the sandbox guidance](/api/guidance/sandbox)
 
-[Read the live environment guidance](add link when page has been created) 
-
 ## Other interactions with DfE 
 
 In addition to managing training data, lead providers may also need to: 

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -1,0 +1,65 @@
+---
+title: Guidance for lead providers 
+---
+
+## Working with DfE on early career teacher training programmes 
+
+Use this guidance to: 
+
+* understand lead providers responsibilities
+* know how lead providers should interact with the DfE and the ‘Register early career teachers’ service
+* find where to manage data, funding and reporting 
+
+## What lead providers are responsible for 
+
+Lead providers are responsible for delivering high-quality early career teacher (ECT) training based on the initial teacher training and early career framework. This includes: 
+
+* coordinating with delivery partners and schools
+* ensuring ECTs and mentors receive the full programme entitlement
+* submitting timely, accurate data to DfE
+* managing changes to participant details and training status
+* making sure declarations are correct so funding can be released 
+
+## Where to manage ECT training data 
+
+Lead providers must use the [‘Register early career teachers’ API](add link) to submit and update data about: 
+
+* early career teachers
+* mentors
+* training schedules
+* programme declarations
+* participant deferrals, withdrawals and reinstatements 
+
+This data enables: 
+
+* delivery of training
+* accurate payments
+* oversight of participant progress 
+
+## Testing and going live 
+
+Lead providers should use the [sandbox environment](add link) to test sending data before moving to production when it goes live. This will help ensure: 
+
+* their integration works correctly
+* errors can be fixed early
+* payments are not delayed due to data issues 
+
+[Read the sandbox guidance](add link) 
+
+[Read the live environment guidance](add link) 
+
+## Other interactions with DfE 
+
+In addition to managing training data, lead providers may also need to: 
+
+* submit reports and quality assurance data
+* respond to DfE communications or data checks
+* access funding statements and programme documentation
+* collaborate with appropriate bodies on ECT progress and assessment 
+
+They’ll typically hear from DfE through: 
+
+* emails
+* Slack messages 
+
+DfE also publishes [release notes](add link) whenever it updates the API.  

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -1,6 +1,4 @@
----
-title: Guidance for lead providers 
----
+# Guidance for lead providers 
 
 Use this guidance to: 
 
@@ -44,6 +42,10 @@ Lead providers should use the [sandbox environment](https://sandbox.register-ear
 * payments are not delayed due to data issues 
 
 [Read the sandbox guidance](/api/guidance/sandbox)
+
+The sandbox works just like the live environment, but no real training records, payments, or notifications are sent. 
+
+To help get started, we recommend technical teams bookmark the [Swagger API documentation](/api/docs/v3) so they can quickly find the latest information about endpoints, request formats, and validation rules.
 
 ## Other interactions with DfE 
 

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -1,4 +1,6 @@
-# Guidance for lead providers 
+---
+title: Guidance for lead providers
+---
 
 Use this guidance to: 
 

--- a/app/views/api/guidance/guidance_for_lead_providers/api-data-states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api-data-states.md
@@ -1,0 +1,78 @@
+# API data states 
+
+## What this page covers  
+
+In the 'Register early career teachers’ API, participants and declarations move through defined states. These reflect their training journey and whether funding is due. Understanding each state is essential for submitting the right data at the right time. 
+
+Use this page to: 
+
+* understand the different states a participant or declaration can be in
+* learn how these states affect data submission and funding
+* handle transitions correctly in lead provider systems 
+
+## Participant states 
+
+Participant states are defined by the `training_status` attribute. 
+
+A participant's `training_status` highlights data entered **by lead providers** via the API. It then determines what onward actions providers can take via the API. Providers should also consider supplementary data available via the API, including the `participant_status`. 
+
+A participant’s `training_status` value will determine whether a lead provider can: 
+
+* [update their details](add link to ‘view and update participant data’ guidance). For example, notifying DfE that a participant has withdrawn from training 
+
+* [submit a declaration](add link to ‘submit view and void declarations' guidance). For example, notifying DfE that a participant has started their training 
+
+| Training status | Definition | Action | 
+| -------- | -------- | -------- | 
+| `active`     | Participants currently in training     | Lead providers can update participant data and submit declarations for `active` participants     | 
+| `deferred`     | Participants who have deferred training     | Lead providers **cannot** update participant data or submit declarations for `deferred` participants. Lead providers must [notify DfE when the participant resumes training](add link to ‘notify DfE a participant has resumed training' guidance)    | 
+| `withdrawn`     | Participants who have withdrawn from training     | Lead providers **cannot** update participant data for `withdrawn` participants. Lead providers can **only** submit declarations for `withdrawn` participants if the `declaration_date` is backdated to before the `withdrawal_date`     | 
+
+[View more detailed specifications for the participants schema](add link to participants schema). 
+
+### Participant status
+
+The `participant_status` attribute highlights information given **by school induction tutors** via the 'Register early career teachers’ service. 
+
+Values include `active`, `joining`, `leaving`, `left` and `withdrawn`, and will update according to the associated transfer or withdrawal dates induction tutors have given. For example, the `participant_status` will change from `leaving` to `left` after the date an induction tutor has given for when a participant is leaving their school. 
+
+We have occasionally seen cases where this information has been inaccurate because an induction tutor made an error when entering participant data. 
+
+## Declaration states 
+
+Declaration states are defined by the `state` attribute. 
+
+Lead providers must [submit declarations](add link to ‘submit view and void declarations' guidance) to confirm a participant has engaged in training within a given milestone period. A declaration’s `state` value will reflect if and when DfE will pay lead providers for the training delivered. 
+
+| State | Definition | Action | 
+| -------- | -------- | -------- | 
+| `submitted`     | A declaration associated with to a participant who has not yet been confirmed to be eligible for funding    | Providers can view and void `submitted` declarations    | 
+| `eligible`     | A declaration associated with a participant who has been confirmed to be eligible for funding     | Providers can view and void `eligible` declarations    | 
+| `ineligible`     | A declaration associated with 1) a participant who is not eligible for funding 2) a duplicate submission for a given participant    | Providers can view and void `ineligible` declarations     | 
+| `payable`     | A declaration that has been approved and is ready for payment by DfE    | Providers can view and void `payable` declarations     | 
+| `voided`     | A declaration that has been retracted by a provider    | Providers can **only** view `voided` declarations   | 
+| `paid`     | A declaration that has been paid for by DfE    | Providers can view and void `paid` declarations     | 
+| `awaiting_clawback`     | A `paid` declaration that has since been voided by a provider    | Providers can **only** view `awaiting_clawback` declarations     | 
+| `clawed_back`     | An `awaiting_clawback` declaration that has since had its value deducted from payment by DfE to a provider     | Providers can **only** view `clawed_back` declarations     | 
+
+[View more detailed specifications for the participant declarations schema](add participant declarations schema link). 
+
+## Example of how states change over time 
+
+An ECT might move through the following participant states: 
+
+* `pending` when added to the system   
+* `active` when they’ve started training
+* `deferred` if they’ve paused training
+* `active` when they’ve been reinstated
+* `completed` when they’ve finished the programme 
+
+At each stage, declarations (like `started`, `retained-1`, `completed`) are submitted and will move through their own states (for example, `submitted` to `eligible` to `paid`). 
+
+## Best practice 
+
+Lead providers should:  
+
+* match their data to the current state of each participant
+* monitor declaration responses for issues
+* use sandbox testing to see how state transitions behave before working in live 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -26,7 +26,7 @@ A participant’s `training_status` value will determine whether a lead provider
 | -------- | -------- | -------- | 
 | `active`     | Participants currently in training     | Lead providers can update participant data and submit declarations for `active` participants     | 
 | `deferred`     | Participants who have deferred training     | Lead providers **cannot** update participant data or submit declarations for `deferred` participants. Lead providers must [notify DfE when the participant resumes training](add link to ‘notify DfE a participant has resumed training' guidance)    | 
-| `withdrawn`     | Participants who have withdrawn from training     | Lead providers **cannot** update participant data for `withdrawn` participants. Lead providers can **only** submit declarations for `withdrawn` participants if the `declaration_date` is backdated to before the `withdrawal_date`     | 
+| `withdrawn`     | Participants who have withdrawn from training     | Lead providers **cannot** update participant data for `withdrawn` participants. Lead providers can **only** submit declarations for `withdrawn` participants if the `declaration_date` is backdated to before the `withdrawal_date`    | 
 
 [View more detailed specifications for the participants schema](add link to participants schema). 
 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -12,7 +12,9 @@ Use this page to:
 * learn how these states affect data submission and funding
 * handle transitions correctly in lead provider systems 
 
-## Participant states 
+## Participant states
+
+### Training status
 
 Participant states are defined by the `training_status` attribute. 
 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -1,4 +1,6 @@
-# API data states 
+---
+title: API data states
+---
 
 ## What this page covers  
 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -20,9 +20,8 @@ A participant's `training_status` highlights data entered **by lead providers** 
 
 A participant’s `training_status` value will determine whether a lead provider can: 
 
-* [update their details](add link to ‘view and update participant data’ guidance). For example, notifying DfE that a participant has withdrawn from training 
-
-* [submit a declaration](add link to ‘submit view and void declarations' guidance). For example, notifying DfE that a participant has started their training 
+* update their details. For example, notifying DfE that a participant has withdrawn from training 
+* submit a declaration. For example, notifying DfE that a participant has started their training 
 
 | Training status | Definition | Action | 
 | -------- | -------- | -------- | 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -20,8 +20,8 @@ A participant's `training_status` highlights data entered **by lead providers** 
 
 A participant’s `training_status` value will determine whether a lead provider can: 
 
-* update their details. For example, notifying DfE that a participant has withdrawn from training 
-* submit a declaration. For example, notifying DfE that a participant has started their training 
+* update their details
+* submit a declaration 
 
 | Training status | Definition | Action | 
 | -------- | -------- | -------- | 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -29,8 +29,6 @@ A participant’s `training_status` value will determine whether a lead provider
 | `deferred`     | Participants who have deferred training     | Lead providers **cannot** update participant data or submit declarations for `deferred` participants. Lead providers must [notify DfE when the participant resumes training](add link to ‘notify DfE a participant has resumed training' guidance)    | 
 | `withdrawn`     | Participants who have withdrawn from training     | Lead providers **cannot** update participant data for `withdrawn` participants. Lead providers can **only** submit declarations for `withdrawn` participants if the `declaration_date` is backdated to before the `withdrawal_date`    | 
 
-[View more detailed specifications for the participants schema](add link to participants schema). 
-
 ### Participant status
 
 The `participant_status` attribute highlights information given **by school induction tutors** via the 'Register early career teachers’ service. 
@@ -43,7 +41,7 @@ We have occasionally seen cases where this information has been inaccurate becau
 
 Declaration states are defined by the `state` attribute. 
 
-Lead providers must [submit declarations](add link to ‘submit view and void declarations' guidance) to confirm a participant has engaged in training within a given milestone period. A declaration’s `state` value will reflect if and when DfE will pay lead providers for the training delivered. 
+Lead providers must submit declarations to confirm a participant has engaged in training within a given milestone period. A declaration’s `state` value will reflect if and when DfE will pay lead providers for the training delivered. 
 
 | State | Definition | Action | 
 | -------- | -------- | -------- | 
@@ -55,8 +53,6 @@ Lead providers must [submit declarations](add link to ‘submit view and void de
 | `paid`     | A declaration that has been paid for by DfE    | Providers can view and void `paid` declarations     | 
 | `awaiting_clawback`     | A `paid` declaration that has since been voided by a provider    | Providers can **only** view `awaiting_clawback` declarations     | 
 | `clawed_back`     | An `awaiting_clawback` declaration that has since had its value deducted from payment by DfE to a provider     | Providers can **only** view `clawed_back` declarations     | 
-
-[View more detailed specifications for the participant declarations schema](add participant declarations schema link). 
 
 ## Example of how states change over time 
 

--- a/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/api_data_states.md
@@ -54,18 +54,6 @@ Lead providers must submit declarations to confirm a participant has engaged in 
 | `awaiting_clawback`     | A `paid` declaration that has since been voided by a provider    | Providers can **only** view `awaiting_clawback` declarations     | 
 | `clawed_back`     | An `awaiting_clawback` declaration that has since had its value deducted from payment by DfE to a provider     | Providers can **only** view `clawed_back` declarations     | 
 
-## Example of how states change over time 
-
-An ECT might move through the following participant states: 
-
-* `pending` when added to the system   
-* `active` when they’ve started training
-* `deferred` if they’ve paused training
-* `active` when they’ve been reinstated
-* `completed` when they’ve finished the programme 
-
-At each stage, declarations (like `started`, `retained-1`, `completed`) are submitted and will move through their own states (for example, `submitted` to `eligible` to `paid`). 
-
 ## Best practice 
 
 Lead providers should:  

--- a/app/views/api/guidance/guidance_for_lead_providers/data_syncing.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/data_syncing.md
@@ -60,7 +60,7 @@ If a record fails, providers need to:
 * avoid re-submitting the same bad data
 * apply corrections where needed 
 
-For example, if a provider gets a `422 Unprocessable entity` message due to a missing training programme ID, they need to fix the local record before reattempting the sync. 
+For example, if a provider gets a `422 Unprocessable entity` message due to a missing participant ID, they need to fix the local record before reattempting the sync. 
 
 ## Avoid common syncing issues
 

--- a/app/views/api/guidance/guidance_for_lead_providers/data_syncing.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/data_syncing.md
@@ -1,4 +1,6 @@
-# Syncing data best practice
+---
+title: Syncing data best practice
+---
 
 To ensure smooth and reliable integration with the API, it’s important to follow best practice when syncing participant and training data. 
 

--- a/app/views/api/guidance/guidance_for_lead_providers/data_syncing.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/data_syncing.md
@@ -1,0 +1,85 @@
+# Syncing data best practice 
+
+To ensure smooth and reliable integration with the API, it’s important to follow best practice when syncing participant and training data. 
+
+Poor syncing can lead to: 
+
+* duplicated records 
+* payment delays 
+* conflicting updates 
+* unnecessary API load 
+
+## Only send what's changed 
+
+Send data only when it has been added, updated, or corrected. 
+
+Repeatedly submitting unchanged records increases the risk of version conflicts or overwriting correct data. For example, if an ECT’s mentor has not changed, lead providers should not re-submit their mentor record with the same details. 
+
+## Use timestamps or status flags to detect changes 
+
+Store and compare: 
+
+* last updated timestamps 
+* change flags 
+* status values such as `new`, `updated` and `withdrawn` 
+
+This helps systems detect and sync only what's needed. For example, compare the local `last_updated` timestamp for a participant against the value in their sync logs before deciding to re-send the record. 
+
+## Sync regularly  
+
+Use timed or event-triggered syncs. Avoid real-time syncs unless absolutely necessary. This balances freshness with performance and API limits. 
+Schedule a sync once every [X?] hours or after significant updates such as a declaration submission. 
+
+## Handle API responses and errors properly 
+
+Always log responses and use them to update records. 
+
+If a record fails, providers need to: 
+
+* avoid re-submitting the same bad data 
+* apply corrections where needed 
+
+For example, if a provider gets a `422 Unprocessable entity` message due to a missing training programme ID, they need to fix the local record before reattempting the sync. 
+
+## Avoid common syncing issues
+
+| Issue   | How to avoid it |
+| -------------------- | ---------------------- |
+| Submitting unchanged records repeatedly | Implement change detection and skip unchanged records | 
+| Re-sending withdrawn participants as active | Use clear status tracking and validation before syncing | 
+| Syncing large volumes at peak hours | Schedule batch syncs during off-peak hours | 
+| Missing required fields | Validate all required data fields locally before submitting |
+
+## Example: syncing a participant and declaration 
+
+After a participant starts training, lead providers would send: 
+
+```
+POST /participants 
+{ 
+  "full_name": "Joe Bloggs", 
+  "start_date": "2025-09-01", 
+  "mentor_id": "MENTOR123" 
+}
+```
+
+Once that’s successfully created, they might later send a declaration: 
+
+```
+POST /declarations
+{
+  "participant_id": "PART123",
+  "declaration_type": "started",
+  "declaration_date": "2025-09-05"
+}
+```
+
+If nothing changes after that, no further data is needed until a meaningful update occurs (for example, deferral, reinstatement, mentor change). 
+ 
+## Test syncing strategy in the sandbox
+
+Before going live, providers should: 
+
+* simulate missed updates 
+* test edge cases (for example, mentor swaps, schedule changes) 
+* validate their change detection logic 

--- a/app/views/api/guidance/guidance_for_lead_providers/ids_explained.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/ids_explained.md
@@ -1,4 +1,6 @@
-# IDs explained
+---
+title: IDs explained
+---
 
 We use various unique identifiers (IDs) in the endpoint requests and responses to help make the API reliable, efficient, and unambiguous.
 

--- a/app/views/api/guidance/guidance_for_lead_providers/ids_explained.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/ids_explained.md
@@ -1,0 +1,16 @@
+# IDs explained
+
+We use various unique identifiers (IDs) in the endpoint requests and responses to help make the API reliable, efficient, and unambiguous.
+
+| ID                   | What the ID is for |
+|---------------------------|------------------------|
+| `clawback_statement_id`   | Identifies a clawback statement we’ve attached when funding paid to a lead provider needs to be returned due to overpayments or participant data changes (for example, someone withdraws from training or is found to be ineligible). Enables lead providers using the declarations endpoints to identify which clawback statement a participant’s funding adjustment relates to and reconcile clawbacks against their monthly or cumulative funding reports. |
+| `declaration_id`          | Created when providers submit a declaration. This ID can also be used to void a declaration. It’s shown as simply `id` at the top of successful responses in the declarations endpoints. |
+| `delivery_partner_id`     | Identifies delivery partners. Used when providers form partnerships as part of the POST partnerships endpoint. It’s also listed in `GET participants/ecf` and `GET participants/ecf/{id}` responses in API v3. |
+| `mentor_id`               | Identifies individual ECT mentors within the API. This ID is used to link mentors to ECTs they’re supporting, and tracks their training status, funding eligibility, and contact information. The same `mentor_id` is used whether the mentor is funded or unfunded, including those trained by a different lead provider than the one supporting their ECT. |
+| `participant_id`          | Identifies participants registered for training. This is used for declarations, changing schedules, notifying us of a change in circumstances related to their training as well as other endpoints to monitor training and progress. |
+| `participant_id_changes`  | A record of changes where a participant’s ID has been updated, usually to fix a data issue like a duplicate or incorrect registration. In such cases, the `from_participant_id` field is the original ID that has been retired or replaced. The `to_participant_id` is the new ID that should now be used when referring to this participant. |
+| `partnership_id`          | Identifies the partnership between schools, delivery partners and providers for a specific cohort who work together to deliver training to participants. It’s shown as simply `id` at the top of successful responses in the partnership endpoints. |
+| `statement_id`            | Identifies a financial statement we’ve attached to a lead provider. It acts as a reference for each individual payment cycle or statement and allows lead providers to retrieve financial data using the `GET statements` endpoints. |
+| `school_id`               | Identifies schools. Used when providers form partnerships as part of the `POST partnerships` endpoint. |
+| `training_record_id`      | Identifies participants with multiple enrolments, such as an ECT who later becomes a mentor. Providers using the participants endpoints will see separate records for the same participant, each with a different `training_record_id` based on their role. |

--- a/app/views/api/guidance/sandbox.md
+++ b/app/views/api/guidance/sandbox.md
@@ -47,7 +47,7 @@ They'll receive:
 
 ### 2. Use the sandbox URL 
 
-The sandbox runs on a separate domain from the live service: [https://sandbox.register-early-career-teachers.education.gov.uk/api](https://sandbox.register-early-career-teachers.education.gov.uk/api)
+The [sandbox runs on a separate domain](https://sandbox.register-early-career-teachers.education.gov.uk/api) from the live service. 
 
 ### 3. Check your setup 
 

--- a/app/views/api/guidance/sandbox.md
+++ b/app/views/api/guidance/sandbox.md
@@ -18,7 +18,7 @@ Lead providers can use the sandbox to:
 * simulate common tasks (such as submitting declarations or changing participant schedules)
 * check how their system handles responses from the service
 * prepare for live data submissions with confidence
-* test new functionality before it goes live 
+* test new functionality and give us feedback before it goes live
 
 The sandbox works just like the live environment, but no real training records, payments, or notifications are sent. 
 

--- a/app/views/api/guidance/sandbox.md
+++ b/app/views/api/guidance/sandbox.md
@@ -1,4 +1,6 @@
-# Using the API sandbox 
+---
+title: Using the API sandbox
+---
 
 Use this guidance to understand: 
 
@@ -20,7 +22,7 @@ Lead providers can use the sandbox to:
 
 The sandbox works just like the live environment, but no real training records, payments, or notifications are sent. 
 
-To help get started, we recommend that technical teams bookmark the [Swagger API documentation](relative path “/api/docs/v3”) so they can quickly find the latest information about endpoints, request formats, and validation rules. 
+To help get started, we recommend that technical teams bookmark the [Swagger API documentation](/api/docs/v3) so they can quickly find the latest information about endpoints, request formats, and validation rules.
 
 ## Benefits of using the sandbox 
 
@@ -45,7 +47,7 @@ They'll receive:
 
 ### 2. Use the sandbox URL 
 
-The sandbox runs on a separate domain from the live service: https://sandbox.register-early-career-teachers.education.gov.uk/api 
+The sandbox runs on a separate domain from the live service: [https://sandbox.register-early-career-teachers.education.gov.uk/api](https://sandbox.register-early-career-teachers.education.gov.uk/api)
 
 ### 3. Check your setup 
 
@@ -63,6 +65,6 @@ Things to keep in mind:
   
 ## Access YAML format API specs 
 
-Lead provider development teams can also access the OpenAPI spec in a YAML format: [View the OpenAPI v3.0.0. spec](/lead-providers/api-docs/v3/api_spec.yml)  
+Lead provider development teams can also access the OpenAPI spec in a YAML format: [View the OpenAPI v3.0.0. spec](/api/docs/v3/swagger.yaml)
 
 They can use API testing tools such as [Postman](https://www.postman.com/) to make test API calls. Lead providers can import the API as a collection by using Postman's import feature and copying in the YAML URL of the API specification. 

--- a/app/views/api/guidance/sandbox.md
+++ b/app/views/api/guidance/sandbox.md
@@ -1,6 +1,4 @@
----
-title: Using the API sandbox
----
+# Using the API sandbox 
 
 Use this guidance to understand: 
 
@@ -14,24 +12,24 @@ The sandbox is a safe, test version of the live service. It lets lead providers 
 
 Lead providers can use the sandbox to: 
 
-* explore the API and test their integration 
-* simulate common tasks (such as submitting participant data or changing mentor details)
+* explore the API and test their integration
+* simulate common tasks (such as submitting declarations or changing participant schedules)
 * check how their system handles responses from the service
 * prepare for live data submissions with confidence
 * test new functionality before it goes live 
 
 The sandbox works just like the live environment, but no real training records, payments, or notifications are sent. 
 
-To help get started, we recommend that technical teams bookmark the [Swagger API documentation](add link) so they can quickly find the latest information about endpoints, request formats, and validation rules. 
+To help get started, we recommend that technical teams bookmark the [Swagger API documentation](relative path “/api/docs/v3”) so they can quickly find the latest information about endpoints, request formats, and validation rules. 
 
 ## Benefits of using the sandbox 
 
 Using the sandbox helps lead providers: 
 
-* test safely by experimenting with data and functionality without risk to live records or triggering real-world consequences
+* test new and existing features safely by experimenting with data and functionality without risk to live records or triggering real-world consequences
 * build confidence by verifying their integration works as expected before going live
 * reduce errors by spotting and fixing issues early to avoid delays or data problems in the live system
-* understand user journeys by simulating common actions (like deferring a participant or assigning a mentor) to understand how they work in practice
+* understand user journeys by simulating common actions (like deferring a participant) to understand how they work in practice
 * train their team by giving staff a risk-free environment to learn how to use the service and test workflows 
 
 ## Access the sandbox 

--- a/app/views/api/guidance/sandbox.md
+++ b/app/views/api/guidance/sandbox.md
@@ -1,5 +1,70 @@
 ---
-title: Sandbox
+title: Using the API sandbox
 ---
 
-Sandbox
+Use this guidance to understand: 
+
+* what the sandbox is for
+* why it's helpful to use the sandbox before going live
+* how to access and start using it 
+
+## What is the sandbox? 
+
+The sandbox is a safe, test version of the live service. It lets lead providers try out the 'Register early career teachers' API functionality without affecting real data or triggering any actions in the live system. 
+
+Lead providers can use the sandbox to: 
+
+* explore the API and test their integration 
+* simulate common tasks (such as submitting participant data or changing mentor details)
+* check how their system handles responses from the service
+* prepare for live data submissions with confidence
+* test new functionality before it goes live 
+
+The sandbox works just like the live environment, but no real training records, payments, or notifications are sent. 
+
+To help get started, we recommend that technical teams bookmark the [Swagger API documentation](add link) so they can quickly find the latest information about endpoints, request formats, and validation rules. 
+
+## Benefits of using the sandbox 
+
+Using the sandbox helps lead providers: 
+
+* test safely by experimenting with data and functionality without risk to live records or triggering real-world consequences
+* build confidence by verifying their integration works as expected before going live
+* reduce errors by spotting and fixing issues early to avoid delays or data problems in the live system
+* understand user journeys by simulating common actions (like deferring a participant or assigning a mentor) to understand how they work in practice
+* train their team by giving staff a risk-free environment to learn how to use the service and test workflows 
+
+## Access the sandbox 
+
+### 1. Use the API authentication token credentials 
+
+Lead providers should contact the DfE support team or their account manager to request sandbox access if they do not already have it.  
+
+They'll receive: 
+
+* a unique sandbox authentication token
+* example credentials and test data 
+
+### 2. Use the sandbox URL 
+
+The sandbox runs on a separate domain from the live service: https://sandbox.register-early-career-teachers.education.gov.uk/api 
+
+### 3. Check your setup 
+
+Once lead providers have connected their system to the sandbox, they can: 
+
+* send test data to endpoints
+* simulate common user journeys
+* receive mock responses 
+
+Things to keep in mind: 
+
+* the sandbox is for testing only, so only data entered will be saved or used in the live system
+* providers will need separate credentials from their live environment
+* test data may be refreshed or reset at any time
+  
+## Access YAML format API specs 
+
+Lead provider development teams can also access the OpenAPI spec in a YAML format: [View the OpenAPI v3.0.0. spec](/lead-providers/api-docs/v3/api_spec.yml)  
+
+They can use API testing tools such as [Postman](https://www.postman.com/) to make test API calls. Lead providers can import the API as a collection by using Postman's import feature and copying in the YAML URL of the API specification. 

--- a/app/views/api/guidance/swagger_api_documentation.md
+++ b/app/views/api/guidance/swagger_api_documentation.md
@@ -1,8 +1,10 @@
-# Swagger API documentation
+---
+title: Swagger API documentation
+---
 
 ## What is Swagger API documentation? 
 
-The [Swagger documentation](relative path “/api/docs/v3”) explains how lead providers connect their organisation’s system to the 'Register early career teachers’ service’s API. 
+The [Swagger documentation](/api/docs/v3) explains how lead providers connect their organisation’s system to the 'Register early career teachers’ service’s API.
 
 It includes: 
 

--- a/app/views/api/guidance/swagger_api_documentation.md
+++ b/app/views/api/guidance/swagger_api_documentation.md
@@ -1,0 +1,25 @@
+---
+title: Swagger API documentation
+---
+
+## What is Swagger API documentation? 
+
+The [Swagger documentation](ADD LINK) explains how lead providers connect their organisation’s system to the 'Register early career teachers’ service’s API. 
+
+It includes: 
+
+* a list of all available API endpoints
+* required data fields and formats
+* response types and error messages
+* authentication methods
+* sandbox and live production environment details 
+
+The documentation supports lead providers sending and updating participant data, managing training records, and triggering payment milestones. 
+
+## Who the Swagger documentation is for 
+
+The documentation is designed for technical teams and developers working with lead providers to: 
+
+* manage integration of data for early career teachers and mentors
+* submit training declarations that affect funding
+* need to test, update, or debug your system's API calls 

--- a/app/views/api/guidance/swagger_api_documentation.md
+++ b/app/views/api/guidance/swagger_api_documentation.md
@@ -1,18 +1,14 @@
----
-title: Swagger API documentation
----
+# Swagger API documentation
 
 ## What is Swagger API documentation? 
 
-The [Swagger documentation](ADD LINK) explains how lead providers connect their organisation’s system to the 'Register early career teachers’ service’s API. 
+The [Swagger documentation](relative path “/api/docs/v3”) explains how lead providers connect their organisation’s system to the 'Register early career teachers’ service’s API. 
 
 It includes: 
 
 * a list of all available API endpoints
 * required data fields and formats
 * response types and error messages
-* authentication methods
-* sandbox and live production environment details 
 
 The documentation supports lead providers sending and updating participant data, managing training records, and triggering payment milestones. 
 
@@ -22,4 +18,4 @@ The documentation is designed for technical teams and developers working with le
 
 * manage integration of data for early career teachers and mentors
 * submit training declarations that affect funding
-* need to test, update, or debug your system's API calls 
+* test, update, or debug their system's API calls

--- a/app/views/api/guidance/technical_documentation.md
+++ b/app/views/api/guidance/technical_documentation.md
@@ -1,5 +1,0 @@
----
-title: Technical documentation
----
-
-Hi

--- a/spec/components/navigation/primary_navigation_component_spec.rb
+++ b/spec/components/navigation/primary_navigation_component_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Navigation::PrimaryNavigationComponent, type: :component do
       it "lists the other pages" do
         render_inline(subject)
 
-        ["Technical documentation", "Release notes", "Sandbox", "Guidance"].each do |other_page|
+        ["Swagger API documentation", "Release notes", "Sandbox", "Guidance"].each do |other_page|
           expect(rendered_content).to have_css(".govuk-service-navigation__link", text: other_page)
         end
       end

--- a/spec/requests/api/guidance_spec.rb
+++ b/spec/requests/api/guidance_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API Guidance pages" do
     end
   end
 
-  describe "GET /api/release_notes" do
+  describe "GET /api/release-notes" do
     before { get(api_guidance_release_notes_path) }
 
     it "returns http success" do
@@ -15,24 +15,24 @@ RSpec.describe "API Guidance pages" do
     end
   end
 
-  describe "GET /api/early-career-training-programme-guidance" do
-    before { get(api_guidance_page_path('early-career-training-programme-guidance')) }
+  describe "GET /api/swagger-api-documentation" do
+    before { get(api_guidance_page_path('swagger-api-documentation')) }
 
     it "returns http success" do
       expect(response).to be_successful
     end
   end
 
-  describe "GET /api/how-to-use-api" do
-    before { get(api_guidance_page_path('how-to-use-api')) }
+  describe "GET /api/sandbox" do
+    before { get(api_guidance_page_path('sandbox')) }
 
     it "returns http success" do
       expect(response).to be_successful
     end
   end
 
-  describe "GET /api/technical-documentation" do
-    before { get(api_guidance_page_path('technical-documentation')) }
+  describe "GET /api/guidance-for-lead-providers" do
+    before { get(api_guidance_page_path('guidance-for-lead-providers')) }
 
     it "returns http success" do
       expect(response).to be_successful


### PR DESCRIPTION
### Context

Starting to populate the technical information for lead providers by adding or updating the following pages: 

* Using the API sandbox
* Swagger API documentation
* Guidance for lead providers
* Syncing data best practice
* API data states
* IDs explained 
