### PR TITLE
Report errors to Sentry even when jobs are retried

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,5 +7,6 @@ if Rails.application.config.enable_sentry
     config.release = ENV["COMMIT_SHA"]
     config.traces_sample_rate = 0.1
     config.profiles_sample_rate = 0.1
+    config.active_job_report_on_retry_error = true
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/1964

### Changes proposed in this pull request

This has been around the houses a little recently in [sentry-ruby]:

- [#2500]
- [#2573]
- [#2617]

but the TLDR seems to be we should enable a configuration option `active_job_report_on_retry_error` if we want to report errors when jobs are retried in `ActiveJob`.

This enables the configuration.

We want to do this, because it gives us better observablity of when things are going wrong (e.g we're not sending OTP emails due to errors).

[sentry-ruby]: https://github.com/getsentry/sentry-ruby
[#2500]: https://github.com/getsentry/sentry-ruby/pull/2500
[#2573]: https://github.com/getsentry/sentry-ruby/pull/2573
[#2617]: https://github.com/getsentry/sentry-ruby/pull/2617

### Guidance to review
