### PR TITLE
Always assign an induction programme to Induction Periods

### DIFF
--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -57,6 +57,14 @@ class InductionPeriod < ApplicationRecord
     super || ::PROGRAMME_MAPPER[induction_programme]
   end
 
+  def training_programme=(value)
+    if Rails.application.config.enable_bulk_claim
+      self.induction_programme = ::PROGRAMME_MAPPER[value]
+    end
+
+    super
+  end
+
 private
 
   # Ensure admin users inserting new induction periods include end dates.

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -185,6 +185,48 @@ RSpec.describe InductionPeriod do
     end
   end
 
+  describe "training_programme=" do
+    subject { FactoryBot.build(:induction_period, appropriate_body_id: 1) }
+
+    context "when `enable_bulk_claim` is true" do
+      before do
+        allow(Rails.application.config).to receive(:enable_bulk_claim).and_return(true)
+      end
+
+      it "assigns the induction_programme for provider_led and is valid" do
+        subject.induction_programme = nil
+        subject.training_programme = "provider_led"
+
+        expect(subject.induction_programme).to eq("fip")
+        expect(subject).to be_valid
+      end
+
+      it "assigns the induction_programme for school_led and is valid" do
+        subject.induction_programme = nil
+        subject.training_programme = "school_led"
+
+        expect(subject.induction_programme).to eq("unknown")
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when `enable_bulk_claim` is false" do
+      before do
+        allow(Rails.application.config).to receive(:enable_bulk_claim).and_return(false)
+      end
+
+      it "does not assign the induction_programme and is invalid" do
+        subject.induction_programme = nil
+        subject.training_programme = "provider_led"
+
+        expect(subject.induction_programme).to be_nil
+        expect(subject).to be_invalid
+        expect(subject.errors[:induction_programme])
+          .to eq(["Choose an induction programme"])
+      end
+    end
+  end
+
   describe "scopes" do
     describe ".for_teacher" do
       it "returns induction periods only for the specified ect at school period" do


### PR DESCRIPTION
We validate an `InductionPeriod` has an `induction_programme` and we enforce this at the database level with a non-null constraint.

Before #765 this wasn't an issue, because we always assigned an induction programme.

Since then, we have only been assigning an induction programme if `ENABLE_BULK_CLAIM` is false. Otherwise, we have been assigning only a `training_programme`.

This results in validation errors wherever we try to create a new `InductionPeriod` (e.g Admins, ABs).

Not good!

This overrides the `training_programme` setter to ensure that even when `ENABLE_BULK_CLAIM` is true we still assign an `induction_programme`. We are using the `PROGRAMME_MAPPER` to do this.

Now, users can create induction periods with the flag enabled and disabled without error.

This is one approach, but I'm not sure whether it makes the most sense or not.

Alternatively we could only validate `induction_programme` when the flag is disabled. To do this we would also need to remove the database constraint.
