### PR TITLE
Fix code block style bug on swagger docs

### DIFF
--- a/app/assets/stylesheets/api_guidance.scss
+++ b/app/assets/stylesheets/api_guidance.scss
@@ -7,14 +7,14 @@ $x-govuk-masthead-text-colour: govuk-colour("white");
   // phase banner
   .x-govuk-phase-banner--inverse {
     border-bottom-color: $x-govuk-masthead-border-colour;
+  }
 
-    .govuk-phase-banner__content {
-      color: $x-govuk-masthead-text-colour;
+  .x-govuk-phase-banner--inverse .govuk-phase-banner__content {
+    color: $x-govuk-masthead-text-colour;
+  }
 
-      a {
-        color: $x-govuk-masthead-text-colour;
-      }
-    }
+  .x-govuk-phase-banner--inverse .govuk-phase-banner__content a {
+    color: $x-govuk-masthead-text-colour;
   }
 
   // tag
@@ -42,32 +42,32 @@ $x-govuk-masthead-text-colour: govuk-colour("white");
     @include govuk-font($size: 24);
     @include govuk-responsive-margin(6, "bottom");
     color: $x-govuk-masthead-text-colour;
+  }
 
-    a {
-      @include govuk-link-style-inverse;
-    }
+  .x-govuk-masthead__description a {
+    @include govuk-link-style-inverse;
   }
 
   .x-govuk-masthead__image {
     @include govuk-responsive-padding(6, "top");
+  }
 
-    img {
-      max-width: 100%;
-    }
+  .x-govuk-masthead__image img {
+    max-width: 100%;
+  }
 
-    @include govuk-media-query($until: desktop) {
+  @include govuk-media-query($until: desktop) {
+    .api-guidance .x-govuk-masthead__image {
       display: none;
     }
   }
 
-  .release-notes-tags {
-    .tag-group {
-      line-height: 2em;
-    }
+  .release-notes-tags .tag-group {
+    line-height: 2em;
+  }
 
-    .govuk-tag {
-      margin: 0 10px 8px 0;
-    }
+  .release-notes-tags .govuk-tag {
+    margin: 0 10px 8px 0;
   }
 
   code {
@@ -76,13 +76,14 @@ $x-govuk-masthead-text-colour: govuk-colour("white");
     background-color: $govuk-template-background-colour;
     white-space: pre-wrap;
     font-size: 0.8em;
-
-    a {
-      text-decoration: none;
-    }
-
-    a:hover {
-      text-decoration: underline;
-    }
   }
+
+  code a {
+    text-decoration: none;
+  }
+
+  code a:hover {
+    text-decoration: underline;
+  }
+
 }

--- a/app/assets/stylesheets/api_guidance.scss
+++ b/app/assets/stylesheets/api_guidance.scss
@@ -68,7 +68,7 @@ $x-govuk-masthead-text-colour: govuk-colour("white");
   }
 }
 
-code {
+.release-notes code {
   padding: 2px 5px;
   font-family: monospace;
   background-color: $govuk-template-background-colour;

--- a/app/assets/stylesheets/api_guidance.scss
+++ b/app/assets/stylesheets/api_guidance.scss
@@ -2,84 +2,87 @@ $x-govuk-masthead-background-colour: $govuk-brand-colour;
 $x-govuk-masthead-border-colour: govuk-tint($govuk-brand-colour, 25%);
 $x-govuk-masthead-text-colour: govuk-colour("white");
 
-// phase banner
-.x-govuk-phase-banner--inverse {
-  border-bottom-color: $x-govuk-masthead-border-colour;
+.api-guidance {
 
-  .govuk-phase-banner__content {
+  // phase banner
+  .x-govuk-phase-banner--inverse {
+    border-bottom-color: $x-govuk-masthead-border-colour;
+
+    .govuk-phase-banner__content {
+      color: $x-govuk-masthead-text-colour;
+
+      a {
+        color: $x-govuk-masthead-text-colour;
+      }
+    }
+  }
+
+  // tag
+  .x-govuk-tag--inverse {
+    background-color: $x-govuk-masthead-text-colour;
+    color: $x-govuk-masthead-background-colour;
+  }
+
+  // masthead
+  .x-govuk-masthead {
+    @include govuk-responsive-padding(4, "bottom");
+    background-color: $x-govuk-masthead-background-colour;
+    color: $x-govuk-masthead-text-colour;
+    padding-top: 0.1px; // Prevent margin collapse
+  }
+
+  .x-govuk-masthead__title {
+    @include govuk-font($size: 48, $weight: "bold");
+    @include govuk-responsive-margin(6, "bottom");
+    @include govuk-responsive-margin(6, "top");
+    color: $x-govuk-masthead-text-colour;
+  }
+
+  .x-govuk-masthead__description {
+    @include govuk-font($size: 24);
+    @include govuk-responsive-margin(6, "bottom");
     color: $x-govuk-masthead-text-colour;
 
     a {
-      color: $x-govuk-masthead-text-colour;
+      @include govuk-link-style-inverse;
     }
   }
-}
 
-// tag
-.x-govuk-tag--inverse {
-  background-color: $x-govuk-masthead-text-colour;
-  color: $x-govuk-masthead-background-colour;
-}
+  .x-govuk-masthead__image {
+    @include govuk-responsive-padding(6, "top");
 
-// masthead
-.x-govuk-masthead {
-  @include govuk-responsive-padding(4, "bottom");
-  background-color: $x-govuk-masthead-background-colour;
-  color: $x-govuk-masthead-text-colour;
-  padding-top: 0.1px; // Prevent margin collapse
-}
+    img {
+      max-width: 100%;
+    }
 
-.x-govuk-masthead__title {
-  @include govuk-font($size: 48, $weight: "bold");
-  @include govuk-responsive-margin(6, "bottom");
-  @include govuk-responsive-margin(6, "top");
-  color: $x-govuk-masthead-text-colour;
-}
-
-.x-govuk-masthead__description {
-  @include govuk-font($size: 24);
-  @include govuk-responsive-margin(6, "bottom");
-  color: $x-govuk-masthead-text-colour;
-
-  a {
-    @include govuk-link-style-inverse;
-  }
-}
-
-.x-govuk-masthead__image {
-  @include govuk-responsive-padding(6, "top");
-
-  img {
-    max-width: 100%;
+    @include govuk-media-query($until: desktop) {
+      display: none;
+    }
   }
 
-  @include govuk-media-query($until: desktop) {
-    display: none;
-  }
-}
+  .release-notes-tags {
+    .tag-group {
+      line-height: 2em;
+    }
 
-.release-notes-tags {
-  .tag-group {
-    line-height: 2em;
-  }
-
-  .govuk-tag {
-    margin: 0 10px 8px 0;
-  }
-}
-
-.release-notes code {
-  padding: 2px 5px;
-  font-family: monospace;
-  background-color: $govuk-template-background-colour;
-  white-space: pre-wrap;
-  font-size: 0.8em;
-
-  a {
-    text-decoration: none;
+    .govuk-tag {
+      margin: 0 10px 8px 0;
+    }
   }
 
-  a:hover {
-    text-decoration: underline;
+  code {
+    padding: 2px 5px;
+    font-family: monospace;
+    background-color: $govuk-template-background-colour;
+    white-space: pre-wrap;
+    font-size: 0.8em;
+
+    a {
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -2,7 +2,7 @@ module API
   class GuidanceController < ApplicationController
     skip_before_action :authenticate
 
-    layout 'api_guidance', only: 'show'
+    layout 'api_guidance'
 
     def show
     end

--- a/app/views/api/guidance/release_notes.html.erb
+++ b/app/views/api/guidance/release_notes.html.erb
@@ -1,12 +1,10 @@
 <% page_data(title: "Release notes") %>
 
-<div class="release-notes">
-  <% @release_notes.each do |release_note| %>
-    <h2 class="govuk-heading-m">
-      <span class="govuk-caption-m"><%= release_note.date %></span>
-      <%= release_note.title %>
-    </h2>
-    <%= render API::Guidance::ReleaseNotes::TagsComponent.new(tags: release_note.tags) %>
-    <%== release_note.body %>
-  <% end %>
-</div>
+<% @release_notes.each do |release_note| %>
+  <h2 class="govuk-heading-m">
+    <span class="govuk-caption-m"><%= release_note.date %></span>
+    <%= release_note.title %>
+  </h2>
+  <%= render API::Guidance::ReleaseNotes::TagsComponent.new(tags: release_note.tags) %>
+  <%== release_note.body %>
+<% end %>

--- a/app/views/api/guidance/release_notes.html.erb
+++ b/app/views/api/guidance/release_notes.html.erb
@@ -1,10 +1,12 @@
 <% page_data(title: "Release notes") %>
 
-<% @release_notes.each do |release_note| %>
-  <h2 class="govuk-heading-m">
-    <span class="govuk-caption-m"><%= release_note.date %></span>
-    <%= release_note.title %>
-  </h2>
-  <%= render API::Guidance::ReleaseNotes::TagsComponent.new(tags: release_note.tags) %>
-  <%== release_note.body %>
-<% end %>
+<div class="release-notes">
+  <% @release_notes.each do |release_note| %>
+    <h2 class="govuk-heading-m">
+      <span class="govuk-caption-m"><%= release_note.date %></span>
+      <%= release_note.title %>
+    </h2>
+    <%= render API::Guidance::ReleaseNotes::TagsComponent.new(tags: release_note.tags) %>
+    <%== release_note.body %>
+  <% end %>
+</div>

--- a/app/views/api/guidance/show.html.erb
+++ b/app/views/api/guidance/show.html.erb
@@ -6,6 +6,30 @@
   )
 %>
 
+<% content_for :api_guidance_home_header do %>
+  <div class="x-govuk-masthead">
+    <div class="govuk-width-container">
+      <%=
+        environment_specific_phase_banner(
+          html_attributes: { class: %w[x-govuk-phase-banner--inverse] },
+          tag_html_attributes: { class: %w[x-govuk-tag--inverse] }
+        )
+      %>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= yield(:page_header) %>
+
+          <p class="x-govuk-masthead__description">
+          Find out what data lead providers need to submit to DfE, how to keep it up to date, and when to report changes about early career teachers and their mentors.
+          </p>
+
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Release notes</h2>

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -2,7 +2,7 @@
 <%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
-  <body class="govuk-template__body">
+  <body class="govuk-template__body api-guidance">
     <%= render partial: "layouts/shared/js_enabled" %>
 
     <%= govuk_skip_link %>
@@ -14,36 +14,40 @@
     <%= render Navigation::PrimaryNavigationComponent.new(
       current_path: request.fullpath,
       current_user_type: current_user&.user_type,
-      inverse: true
+      inverse: content_for?(:api_guidance_home_header)
     ) %>
 
-    <div class="x-govuk-masthead">
-      <div class="govuk-width-container">
-        <%=
-          environment_specific_phase_banner(
-            html_attributes: { class: %w[x-govuk-phase-banner--inverse] },
-            tag_html_attributes: { class: %w[x-govuk-tag--inverse] }
-          )
-        %>
-
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <%= yield(:page_header) %>
-
-            <p class="x-govuk-masthead__description">
-            Find out what data lead providers need to submit to DfE, how to keep it up to date, and when to report changes about early career teachers and their mentors.
-            </p>
-
-          </div>
-        </div>
-      </div>
-    </div>
-
+    <% if content_for?(:api_guidance_home_header) %>
+      <%= yield(:api_guidance_home_header) %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-width-container">
           <%= yield %>
         </div>
       </main>
+    <% else %>
+      <div class="govuk-width-container">
+        <%= environment_specific_phase_banner %>
+        <%= yield(:backlink_or_breadcrumb) %>
+
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+          <%= render partial: "layouts/shared/main_preamble" %>
+
+          <div class="govuk-grid-row">
+            <% if content_for?(:sidebar) %>
+              <div class="govuk-grid-column-one-third">
+                <%= yield(:sidebar) %>
+              </div>
+            <% end %>
+            <div class="govuk-grid-column-two-thirds">
+              <%= yield(:page_caption) %>
+              <%= yield(:page_header) %>
+
+              <%= yield %>
+            </div>
+          </div>
+        </main>
+      </div>
+    <% end %>
 
     <%= render partial: "layouts/shared/footer" %>
   </body>


### PR DESCRIPTION
### Context

Release notes `<code>` style/css is overriding css on swagger docs.

### Changes proposed in this pull request

- Restrict `<code>` style/css to release notes page only.

### Guidance to review

[Review app docs](https://cpd-ec2-review-996-web.test.teacherservices.cloud/api/docs/v3#/Statements/get_api_v3_statements)

[Review app release notes](https://cpd-ec2-review-996-web.test.teacherservices.cloud/api/guidance/release-notes)

Before:
<img width="524" height="451" alt="Screenshot 2025-07-23 at 10 06 08" src="https://github.com/user-attachments/assets/a3b4c728-ed15-432b-a57f-76df096b9998" />

After:
<img width="524" height="495" alt="Screenshot 2025-07-23 at 10 07 59" src="https://github.com/user-attachments/assets/4ff2f0c3-d7a8-492f-be10-5c4dcf2ff7d2" />
