### PR TITLE
[1785] Add schools endpoints to swagger docs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,5 +113,5 @@ RSpec/EmptyExampleGroup:
 
 RSpec/VariableName:
   Exclude:
-    - 'spec/requests/api/docs/**/*'
+    - 'spec/support/shared_contexts/api/docs/**/*'
     - 'spec/support/shared_contexts/api_doc_request_auth.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,5 +113,5 @@ RSpec/EmptyExampleGroup:
 
 RSpec/VariableName:
   Exclude:
-    - 'spec/support/shared_contexts/api/docs/**/*'
+    - 'spec/requests/api/docs/**/*'
     - 'spec/support/shared_contexts/api_doc_request_auth.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,3 +110,8 @@ RSpec/SpecFilePathFormat:
 RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/requests/api/docs/**/*'
+
+RSpec/VariableName:
+  Exclude:
+    - 'spec/requests/api/docs/**/*'
+    - 'spec/support/shared_contexts/api_doc_request_auth.rb'

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -9,7 +9,7 @@ externalDocs:
 paths:
   "/api/v3/schools":
     get:
-      summary: Retrieve multiple ECF schools scoped to cohort
+      summary: Retrieve multiple schools scoped to cohort
       tags:
       - Schools
       security:
@@ -34,7 +34,7 @@ paths:
           "$ref": "#/components/schemas/SortingOptions"
       responses:
         '200':
-          description: A list of ECF schools scoped to cohort
+          description: A list of schools scoped to cohort
           content:
             application/json:
               schema:
@@ -47,7 +47,7 @@ paths:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
   "/api/v3/schools/{id}":
     get:
-      summary: Retrieve a single ECF school scoped to cohort
+      summary: Retrieve a single school scoped to cohort
       tags:
       - Schools
       security:
@@ -66,7 +66,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          description: A single ECF school scoped to cohort
+          description: A single school scoped to cohort
           content:
             application/json:
               schema:
@@ -202,7 +202,7 @@ components:
       - "-updated_at"
       example: created_at
     School:
-      description: The data attributes associated with an ECF school
+      description: The data attributes associated with a school
       type: object
       required:
       - id

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -15,11 +15,6 @@ paths:
       security:
       - api_key: []
       parameters:
-      - name: filter[cohort]
-        example: '2024'
-        in: query
-        style: deepObject
-        required: true
       - name: filter
         in: query
         required: false
@@ -63,11 +58,12 @@ paths:
         required: true
         schema:
           "$ref": "#/components/schemas/IDAttribute"
-      - name: filter[cohort]
-        example: '2024'
+      - name: filter
         in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/SchoolFilter"
         style: deepObject
-        required: true
       responses:
         '200':
           description: A single ECF school scoped to cohort
@@ -242,7 +238,7 @@ components:
               example: '2021'
             in_partnership:
               description: Whether or not the school already has an active partnership,
-                if it is doing a funded induction programme
+                if it is doing a provider-led training programme
               type: boolean
               nullable: false
               example: false
@@ -256,8 +252,8 @@ components:
               - provider_led
               - not_yet_known
             expression_of_interest:
-              description: Whether or not an ECF participant linked to the school
-                has expressed interest in doing a funded induction programme
+              description: Whether or not the school has expressed interest in doing
+                a provider-led training programme for participants
               type: boolean
               nullable: false
               example: false
@@ -292,6 +288,16 @@ components:
             and time (ISO 8601 date format)
           type: string
           example: '2021-05-13T11:21:55Z'
+    SchoolFilter:
+      description: Filter schools to return more specific results
+      type: object
+      required:
+      - cohort
+      properties:
+        cohort:
+          description: Return schools within the specified cohort.
+          type: string
+          example: '2021'
     SchoolResponse:
       description: A single school.
       type: object

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -16,7 +16,7 @@ paths:
       - api_key: []
       parameters:
       - name: filter[cohort]
-        example: '2021'
+        example: '2024'
         in: query
         style: deepObject
         required: true
@@ -64,7 +64,7 @@ paths:
         schema:
           "$ref": "#/components/schemas/IDAttribute"
       - name: filter[cohort]
-        example: '2021'
+        example: '2024'
         in: query
         style: deepObject
         required: true

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -15,6 +15,11 @@ paths:
       security:
       - api_key: []
       parameters:
+      - name: filter[cohort]
+        example: '2021'
+        in: query
+        style: deepObject
+        required: true
       - name: filter
         in: query
         required: false
@@ -58,6 +63,11 @@ paths:
         required: true
         schema:
           "$ref": "#/components/schemas/IDAttribute"
+      - name: filter[cohort]
+        example: '2021'
+        in: query
+        style: deepObject
+        required: true
       responses:
         '200':
           description: A single ECF school scoped to cohort

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -7,9 +7,80 @@ externalDocs:
   description: Find out more about Swagger
   url: https://swagger.io/
 paths:
+  "/api/v3/schools":
+    get:
+      summary: Retrieve multiple ECF schools scoped to cohort
+      tags:
+      - Schools
+      security:
+      - api_key: []
+      parameters:
+      - name: filter
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/SchoolsFilter"
+        style: deepObject
+      - name: page
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
+      - name: sort
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/SortingOptions"
+      responses:
+        '200':
+          description: A list of ECF schools scoped to cohort
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SchoolsResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+  "/api/v3/schools/{id}":
+    get:
+      summary: Retrieve a single ECF school scoped to cohort
+      tags:
+      - Schools
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: A single ECF school scoped to cohort
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SchoolResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
   "/api/v3/statements":
     get:
-      summary: Retrieve financial statements
+      summary: Retrieve multiple statements as part of which the DfE will make output
+        payments for participants
       tags:
       - Statements
       security:
@@ -43,7 +114,7 @@ paths:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
   "/api/v3/statements/{id}":
     get:
-      summary: Retrieve a specific financial statement
+      summary: Retrieve a single financial statement
       tags:
       - Statements
       security:
@@ -56,23 +127,23 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: A specific financial statement
+          description: A single financial statement
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StatementResponse"
-        '404':
-          description: Not found
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/NotFoundResponse"
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
 components:
   securitySchemes:
     api_key:
@@ -116,6 +187,119 @@ components:
             is 3000, if the value is greater that the maximum allowed it will fallback
             to 3000.
           example: 10
+    SortingOptions:
+      description: Sort records being returned.
+      enum:
+      - created_at
+      - "-created_at"
+      - updated_at
+      - "-updated_at"
+      example: created_at
+    School:
+      description: The data attributes associated with an ECF school
+      type: object
+      required:
+      - id
+      - type
+      - attributes
+      properties:
+        id:
+          "$ref": "#/components/schemas/IDAttribute"
+        type:
+          description: The data type.
+          type: string
+          example: school
+          enum:
+          - school
+        attributes:
+          properties:
+            name:
+              description: The name of the school
+              type: string
+              nullable: false
+              example: School Example
+            urn:
+              description: The Unique Reference Number (URN) of the school
+              type: string
+              nullable: false
+              example: '123456'
+            cohort:
+              description: Indicates which call-off contract funds this participant's
+                training. 2021 indicates a participant that has started, or will start,
+                their training in the 2021/22 academic year.
+              type: string
+              nullable: false
+              example: '2021'
+            in_partnership:
+              description: Whether or not the school already has an active partnership,
+                if it is doing a funded induction programme
+              type: boolean
+              nullable: false
+              example: false
+            induction_programme_choice:
+              description: The induction programme the school offers
+              type: string
+              nullable: false
+              example: not_yet_known
+              enum:
+              - school_led
+              - provider_led
+              - not_yet_known
+            expression_of_interest:
+              description: Whether or not an ECF participant linked to the school
+                has expressed interest in doing a funded induction programme
+              type: boolean
+              nullable: false
+              example: false
+            created_at:
+              description: The date and time the school was created
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+            updated_at:
+              description: The last time a change was made to this school record by
+                the DfE
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+    SchoolsFilter:
+      description: Filter schools to return more specific results
+      type: object
+      required:
+      - cohort
+      properties:
+        cohort:
+          description: Return schools within the specified cohort.
+          type: string
+          example: '2021'
+        urn:
+          description: Return a school with the specified Unique Reference Number
+            (URN).
+          type: string
+          example: '106286'
+        updated_since:
+          description: Return only records that have been updated since this date
+            and time (ISO 8601 date format)
+          type: string
+          example: '2021-05-13T11:21:55Z'
+    SchoolResponse:
+      description: A single school.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          "$ref": "#/components/schemas/School"
+    SchoolsResponse:
+      description: A list of schools for the given cohort.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/School"
     Statement:
       description: A financial statement.
       type: object

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
                   {
                     url: "/api/v3/schools",
                     tag: "Schools",
-                    resource_description: "ECF schools scoped to cohort",
+                    resource_description: "schools scoped to cohort",
                     response_schema_ref: "#/components/schemas/SchoolsResponse",
                     filter_schema_ref: "#/components/schemas/SchoolsFilter",
                     default_sortable: true
@@ -30,7 +30,7 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
                   {
                     url: "/api/v3/schools/{id}",
                     tag: "Schools",
-                    resource_description: "ECF school scoped to cohort",
+                    resource_description: "school scoped to cohort",
                     response_schema_ref: "#/components/schemas/SchoolResponse",
                     filter_schema_ref: "#/components/schemas/SchoolFilter",
                   } do

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
 
   let(:school) { FactoryBot.create(:school, :eligible) }
   let(:school_partnership) { FactoryBot.create(:school_partnership, school:) }
-  let(:"filter[cohort]") { school_partnership.contract_period.year }
 
   it_behaves_like "an API index endpoint documentation",
                   "/api/v3/schools",
@@ -13,6 +12,7 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
                   "ECF schools scoped to cohort",
                   "#/components/schemas/SchoolsResponse",
                   "#/components/schemas/SchoolsFilter",
+                  true,
                   true
 
   it_behaves_like "an API show endpoint documentation",
@@ -20,7 +20,7 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
                   "Schools",
                   "ECF school scoped to cohort",
                   "#/components/schemas/SchoolResponse",
-                  "#/components/schemas/SchoolsFilter" do
+                  true do
     let(:resource) { school }
   end
 end

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -1,0 +1,34 @@
+require "swagger_helper"
+
+RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+  include_context "with authorization for api doc request"
+
+  let(:school) { FactoryBot.create(:school, :eligible) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, school:) }
+  let(:"filter[cohort]") { school_partnership.contract_period.year }
+
+  before do |example|
+    example.metadata[:example_group][:operation][:parameters] += [{
+      name: "filter[cohort]",
+      in: :query,
+      type: :string,
+      required: true
+    }]
+  end
+
+  it_behaves_like "an API index endpoint documentation",
+                  "/api/v3/schools",
+                  "Schools",
+                  "ECF schools scoped to cohort",
+                  "#/components/schemas/SchoolsFilter",
+                  "#/components/schemas/SchoolsResponse",
+                  true
+
+  it_behaves_like "an API show endpoint documentation",
+                  "/api/v3/schools/{id}",
+                  "Schools",
+                  "ECF school scoped to cohort",
+                  "#/components/schemas/SchoolResponse" do
+    let(:resource) { school }
+  end
+end

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -5,22 +5,35 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
 
   let(:school) { FactoryBot.create(:school, :eligible) }
   let(:school_partnership) { FactoryBot.create(:school_partnership, school:) }
+  let(:"filter[cohort]") { school_partnership.contract_period.year }
+
+  before do |example|
+    example.metadata[:example_group][:operation][:parameters] += [{
+      name: "filter[cohort]",
+      in: :query,
+      style: :string,
+      required: true
+    }]
+  end
 
   it_behaves_like "an API index endpoint documentation",
-                  "/api/v3/schools",
-                  "Schools",
-                  "ECF schools scoped to cohort",
-                  "#/components/schemas/SchoolsResponse",
-                  "#/components/schemas/SchoolsFilter",
-                  true,
-                  true
+                  {
+                    url: "/api/v3/schools",
+                    tag: "Schools",
+                    resource_description: "ECF schools scoped to cohort",
+                    response_schema_ref: "#/components/schemas/SchoolsResponse",
+                    filter_schema_ref: "#/components/schemas/SchoolsFilter",
+                    default_sortable: true
+                  }
 
   it_behaves_like "an API show endpoint documentation",
-                  "/api/v3/schools/{id}",
-                  "Schools",
-                  "ECF school scoped to cohort",
-                  "#/components/schemas/SchoolResponse",
-                  true do
+                  {
+                    url: "/api/v3/schools/{id}",
+                    tag: "Schools",
+                    resource_description: "ECF school scoped to cohort",
+                    response_schema_ref: "#/components/schemas/SchoolResponse",
+                    filter_schema_ref: "#/components/schemas/SchoolFilter",
+                  } do
     let(:resource) { school }
   end
 end

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -7,28 +7,20 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
   let(:school_partnership) { FactoryBot.create(:school_partnership, school:) }
   let(:"filter[cohort]") { school_partnership.contract_period.year }
 
-  before do |example|
-    example.metadata[:example_group][:operation][:parameters] += [{
-      name: "filter[cohort]",
-      in: :query,
-      type: :string,
-      required: true
-    }]
-  end
-
   it_behaves_like "an API index endpoint documentation",
                   "/api/v3/schools",
                   "Schools",
                   "ECF schools scoped to cohort",
-                  "#/components/schemas/SchoolsFilter",
                   "#/components/schemas/SchoolsResponse",
+                  "#/components/schemas/SchoolsFilter",
                   true
 
   it_behaves_like "an API show endpoint documentation",
                   "/api/v3/schools/{id}",
                   "Schools",
                   "ECF school scoped to cohort",
-                  "#/components/schemas/SchoolResponse" do
+                  "#/components/schemas/SchoolResponse",
+                  "#/components/schemas/SchoolsFilter" do
     let(:resource) { school }
   end
 end

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -5,81 +5,18 @@ RSpec.describe "Statements endpoint", openapi_spec: "v3/swagger.yaml", type: :re
 
   let(:statement) { FactoryBot.create(:statement, active_lead_provider:) }
 
-  path "/api/v3/statements" do
-    get "Retrieve financial statements" do
-      tags "Statements"
-      produces "application/json"
-      security [api_key: []]
+  it_behaves_like "an API index endpoint documentation",
+                  "/api/v3/statements",
+                  "Statements",
+                  "statements as part of which the DfE will make output payments for participants",
+                  "#/components/schemas/StatementsFilter",
+                  "#/components/schemas/StatementsResponse"
 
-      parameter name: :filter,
-                in: :query,
-                required: false,
-                schema: {
-                  "$ref": "#/components/schemas/StatementsFilter",
-                },
-                style: "deepObject"
-
-      parameter name: :page,
-                in: :query,
-                required: false,
-                schema: {
-                  "$ref": "#/components/schemas/PaginationFilter",
-                },
-                style: "deepObject"
-
-      response "200", "A list of statements as part of which the DfE will make output payments for participants" do
-        schema({ "$ref": "#/components/schemas/StatementsResponse" })
-
-        run_test!
-      end
-
-      response "401", "Unauthorized" do
-        let(:token) { "invalid" }
-
-        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
-
-        run_test!
-      end
-    end
-  end
-
-  path "/api/v3/statements/{id}" do
-    get "Retrieve a specific financial statement" do
-      tags "Statements"
-      produces "application/json"
-      security [api_key: []]
-
-      parameter name: :id,
-                in: :path,
-                required: true,
-                schema: {
-                  "$ref": "#/components/schemas/IDAttribute",
-                }
-
-      response "200", "A specific financial statement" do
-        let(:id) { statement.api_id }
-
-        schema({ "$ref": "#/components/schemas/StatementResponse" })
-
-        run_test!
-      end
-
-      response "404", "Not found" do
-        let(:id) { SecureRandom.uuid }
-
-        schema({ "$ref": "#/components/schemas/NotFoundResponse" })
-
-        run_test!
-      end
-
-      response "401", "Unauthorized" do
-        let(:id) { statement.api_id }
-        let(:token) { "invalid" }
-
-        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
-
-        run_test!
-      end
-    end
+  it_behaves_like "an API show endpoint documentation",
+                  "/api/v3/statements/{id}",
+                  "Statements",
+                  "financial statement",
+                  "#/components/schemas/StatementResponse" do
+    let(:resource) { statement }
   end
 end

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Statements endpoint", openapi_spec: "v3/swagger.yaml", type: :re
                   "/api/v3/statements",
                   "Statements",
                   "statements as part of which the DfE will make output payments for participants",
-                  "#/components/schemas/StatementsFilter",
-                  "#/components/schemas/StatementsResponse"
+                  "#/components/schemas/StatementsResponse",
+                  "#/components/schemas/StatementsFilter"
 
   it_behaves_like "an API show endpoint documentation",
                   "/api/v3/statements/{id}",

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -6,17 +6,21 @@ RSpec.describe "Statements endpoint", openapi_spec: "v3/swagger.yaml", type: :re
   let(:statement) { FactoryBot.create(:statement, active_lead_provider:) }
 
   it_behaves_like "an API index endpoint documentation",
-                  "/api/v3/statements",
-                  "Statements",
-                  "statements as part of which the DfE will make output payments for participants",
-                  "#/components/schemas/StatementsResponse",
-                  "#/components/schemas/StatementsFilter"
+                  {
+                    url: "/api/v3/statements",
+                    tag: "Statements",
+                    resource_description: "statements as part of which the DfE will make output payments for participants",
+                    response_schema_ref: "#/components/schemas/StatementsResponse",
+                    filter_schema_ref: "#/components/schemas/StatementsFilter",
+                  }
 
   it_behaves_like "an API show endpoint documentation",
-                  "/api/v3/statements/{id}",
-                  "Statements",
-                  "financial statement",
-                  "#/components/schemas/StatementResponse" do
+                  {
+                    url: "/api/v3/statements/{id}",
+                    tag: "Statements",
+                    resource_description: "financial statement",
+                    response_schema_ref: "#/components/schemas/StatementResponse",
+                  } do
     let(:resource) { statement }
   end
 end

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, filter_schema_ref, default_sortable, sorting_schema_ref = nil|
+RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, filter_schema_ref, default_sortable, mandatory_cohort_filter = nil, sorting_schema_ref = nil|
   path url do
     get "Retrieve multiple #{resource_description}" do
       tags tag
@@ -6,12 +6,13 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
       produces "application/json"
       security [api_key: []]
 
-      if url.match?(/schools/)
+      if mandatory_cohort_filter
         parameter name: "filter[cohort]",
                   example: "2024",
                   in: :query,
                   style: "deepObject",
                   required: true
+        let(:"filter[cohort]") { school_partnership.contract_period.year }
       end
 
       if filter_schema_ref

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -1,0 +1,63 @@
+RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, filter_schema_ref, response_schema_ref, default_sortable, sorting_schema_ref = nil|
+  path url do
+    get "Retrieve multiple #{resource_description}" do
+      tags tag
+      consumes "application/json"
+      produces "application/json"
+      security [api_key: []]
+
+      if filter_schema_ref
+        parameter name: :filter,
+                  in: :query,
+                  required: false,
+                  schema: {
+                    "$ref": filter_schema_ref,
+                  },
+                  style: "deepObject"
+      end
+
+      parameter name: :page,
+                in: :query,
+                required: false,
+                schema: {
+                  "$ref": "#/components/schemas/PaginationFilter",
+                },
+                style: "deepObject"
+
+      if default_sortable
+        parameter name: :sort,
+                  in: :query,
+                  required: false,
+                  schema: {
+                    "$ref": "#/components/schemas/SortingOptions",
+                  }
+      end
+
+      if sorting_schema_ref
+        parameter name: :sort,
+                  in: :query,
+                  required: false,
+                  schema: {
+                    "$ref": sorting_schema_ref,
+                  }
+      end
+
+      response "200", "A list of #{resource_description}" do
+        let(:id) { resource&.api_id }
+
+        schema({ "$ref": response_schema_ref })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { resource&.api_id }
+        let(:token) { "invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -1,10 +1,18 @@
-RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, filter_schema_ref, response_schema_ref, default_sortable, sorting_schema_ref = nil|
+RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, filter_schema_ref, default_sortable, sorting_schema_ref = nil|
   path url do
     get "Retrieve multiple #{resource_description}" do
       tags tag
       consumes "application/json"
       produces "application/json"
       security [api_key: []]
+
+      if url.match?(/schools/)
+        parameter name: "filter[cohort]",
+                  example: "2024",
+                  in: :query,
+                  style: "deepObject",
+                  required: true
+      end
 
       if filter_schema_ref
         parameter name: :filter,
@@ -43,15 +51,12 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
       end
 
       response "200", "A list of #{resource_description}" do
-        let(:id) { resource&.api_id }
-
         schema({ "$ref": response_schema_ref })
 
         run_test!
       end
 
       response "401", "Unauthorized" do
-        let(:id) { resource&.api_id }
         let(:token) { "invalid" }
 
         schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -1,26 +1,17 @@
-RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, filter_schema_ref, default_sortable, mandatory_cohort_filter = nil, sorting_schema_ref = nil|
-  path url do
-    get "Retrieve multiple #{resource_description}" do
-      tags tag
+RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |params = {}|
+  path params[:url] do
+    get "Retrieve multiple #{params[:resource_description]}" do
+      tags params[:tag]
       consumes "application/json"
       produces "application/json"
       security [api_key: []]
 
-      if mandatory_cohort_filter
-        parameter name: "filter[cohort]",
-                  example: "2024",
-                  in: :query,
-                  style: "deepObject",
-                  required: true
-        let(:"filter[cohort]") { school_partnership.contract_period.year }
-      end
-
-      if filter_schema_ref
+      if params[:filter_schema_ref]
         parameter name: :filter,
                   in: :query,
                   required: false,
                   schema: {
-                    "$ref": filter_schema_ref,
+                    "$ref": params[:filter_schema_ref],
                   },
                   style: "deepObject"
       end
@@ -33,7 +24,7 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
                 },
                 style: "deepObject"
 
-      if default_sortable
+      if params[:default_sortable]
         parameter name: :sort,
                   in: :query,
                   required: false,
@@ -42,17 +33,17 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
                   }
       end
 
-      if sorting_schema_ref
+      if params[:sorting_schema_ref]
         parameter name: :sort,
                   in: :query,
                   required: false,
                   schema: {
-                    "$ref": sorting_schema_ref,
+                    "$ref": params[:sorting_schema_ref],
                   }
       end
 
-      response "200", "A list of #{resource_description}" do
-        schema({ "$ref": response_schema_ref })
+      response "200", "A list of #{params[:resource_description]}" do
+        schema({ "$ref": params[:response_schema_ref] })
 
         run_test!
       end

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -1,0 +1,42 @@
+RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref|
+  path url do
+    get "Retrieve a single #{resource_description}" do
+      tags tag
+      consumes "application/json"
+      produces "application/json"
+      security [api_key: []]
+
+      parameter name: :id,
+                in: :path,
+                required: true,
+                schema: {
+                  "$ref": "#/components/schemas/IDAttribute",
+                }
+
+      response "200", "A single #{resource_description}" do
+        let(:id) { resource.api_id }
+
+        schema({ "$ref": response_schema_ref })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { resource.api_id }
+        let(:token) { "invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+
+      response "404", "Not found" do
+        let(:id) { SecureRandom.uuid }
+
+        schema({ "$ref": "#/components/schemas/NotFoundResponse" })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -1,7 +1,7 @@
-RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, mandatory_cohort_filter = nil|
-  path url do
-    get "Retrieve a single #{resource_description}" do
-      tags tag
+RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |params = {}|
+  path params[:url] do
+    get "Retrieve a single #{params[:resource_description]}" do
+      tags params[:tag]
       consumes "application/json"
       produces "application/json"
       security [api_key: []]
@@ -13,19 +13,20 @@ RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |u
                   "$ref": "#/components/schemas/IDAttribute",
                 }
 
-      if mandatory_cohort_filter
-        parameter name: "filter[cohort]",
-                  example: "2024",
+      if params[:filter_schema_ref]
+        parameter name: :filter,
                   in: :query,
-                  style: "deepObject",
-                  required: true
-        let(:"filter[cohort]") { school_partnership.contract_period.year }
+                  required: false,
+                  schema: {
+                    "$ref": params[:filter_schema_ref],
+                  },
+                  style: "deepObject"
       end
 
-      response "200", "A single #{resource_description}" do
+      response "200", "A single #{params[:resource_description]}" do
         let(:id) { resource.api_id }
 
-        schema({ "$ref": response_schema_ref })
+        schema({ "$ref": params[:response_schema_ref] })
 
         run_test!
       end

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, filter_schema_ref = nil|
+RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, mandatory_cohort_filter = nil|
   path url do
     get "Retrieve a single #{resource_description}" do
       tags tag
@@ -13,12 +13,13 @@ RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |u
                   "$ref": "#/components/schemas/IDAttribute",
                 }
 
-      if url.match?(/schools/)
+      if mandatory_cohort_filter
         parameter name: "filter[cohort]",
                   example: "2024",
                   in: :query,
                   style: "deepObject",
                   required: true
+        let(:"filter[cohort]") { school_partnership.contract_period.year }
       end
 
       response "200", "A single #{resource_description}" do

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref|
+RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref, filter_schema_ref = nil|
   path url do
     get "Retrieve a single #{resource_description}" do
       tags tag
@@ -12,6 +12,14 @@ RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |u
                 schema: {
                   "$ref": "#/components/schemas/IDAttribute",
                 }
+
+      if url.match?(/schools/)
+        parameter name: "filter[cohort]",
+                  example: "2024",
+                  in: :query,
+                  style: "deepObject",
+                  required: true
+      end
 
       response "200", "A single #{resource_description}" do
         let(:id) { resource.api_id }

--- a/spec/support/shared_contexts/api_doc_request_auth.rb
+++ b/spec/support/shared_contexts/api_doc_request_auth.rb
@@ -2,5 +2,5 @@ RSpec.shared_context("with authorization for api doc request") do
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let(:lead_provider) { active_lead_provider.lead_provider }
   let(:token) { generate_api_token.token }
-  let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName
+  let(:Authorization) { "Bearer #{token}" }
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
           # Schools
           School: SCHOOL,
           SchoolsFilter: SCHOOLS_FILTER,
+          SchoolFilter: SCHOOL_FILTER,
           SchoolResponse: SCHOOL_RESPONSE,
           SchoolsResponse: SCHOOLS_RESPONSE,
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -42,6 +42,13 @@ RSpec.configure do |config|
           UnauthorisedResponse: UNAUTHORISED_RESPONSE,
           NotFoundResponse: NOT_FOUND_RESPONSE,
           PaginationFilter: PAGINATION_FILTER,
+          SortingOptions: SORTING_OPTIONS,
+
+          # Schools
+          School: SCHOOL,
+          SchoolsFilter: SCHOOLS_FILTER,
+          SchoolResponse: SCHOOL_RESPONSE,
+          SchoolsResponse: SCHOOLS_RESPONSE,
 
           # Statements
           Statement: STATEMENT,

--- a/spec/swagger_schemas/concerns/sorting.rb
+++ b/spec/swagger_schemas/concerns/sorting.rb
@@ -1,0 +1,10 @@
+SORTING_OPTIONS = {
+  description: "Sort records being returned.",
+  enum: [
+    "created_at",
+    "-created_at",
+    "updated_at",
+    "-updated_at",
+  ],
+  example: "created_at",
+}.freeze

--- a/spec/swagger_schemas/filters/school.rb
+++ b/spec/swagger_schemas/filters/school.rb
@@ -1,0 +1,14 @@
+SCHOOL_FILTER = {
+  description: "Filter schools to return more specific results",
+  type: "object",
+  required: %i[
+    cohort
+  ],
+  properties: {
+    cohort: {
+      description: "Return schools within the specified cohort.",
+      type: "string",
+      example: "2021",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/filters/schools.rb
+++ b/spec/swagger_schemas/filters/schools.rb
@@ -1,0 +1,24 @@
+SCHOOLS_FILTER = {
+  description: "Filter schools to return more specific results",
+  type: "object",
+  required: %i[
+    cohort
+  ],
+  properties: {
+    cohort: {
+      description: "Return schools within the specified cohort.",
+      type: "string",
+      example: "2021",
+    },
+    urn: {
+      description: "Return a school with the specified Unique Reference Number (URN).",
+      type: "string",
+      example: "106286",
+    },
+    updated_since: {
+      description: "Return only records that have been updated since this date and time (ISO 8601 date format)",
+      type: "string",
+      example: "2021-05-13T11:21:55Z",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/models/school.rb
+++ b/spec/swagger_schemas/models/school.rb
@@ -1,0 +1,75 @@
+SCHOOL = {
+  description: "The data attributes associated with an ECF school",
+  type: :object,
+  required: %i[id type attributes],
+  properties: {
+    id: {
+      "$ref": "#/components/schemas/IDAttribute",
+    },
+    type: {
+      description: "The data type.",
+      type: :string,
+      example: "school",
+      enum: %w[
+        school
+      ],
+    },
+    attributes: {
+      properties: {
+        name: {
+          description: "The name of the school",
+          type: :string,
+          nullable: false,
+          example: "School Example",
+        },
+        urn: {
+          description: "The Unique Reference Number (URN) of the school",
+          type: :string,
+          nullable: false,
+          example: "123456",
+        },
+        cohort: {
+          description: "Indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.",
+          type: :string,
+          nullable: false,
+          example: "2021",
+        },
+        in_partnership: {
+          description: "Whether or not the school already has an active partnership, if it is doing a funded induction programme",
+          type: :boolean,
+          nullable: false,
+          example: false,
+        },
+        induction_programme_choice: {
+          description: "The induction programme the school offers",
+          type: :string,
+          nullable: false,
+          example: "not_yet_known",
+          enum: %w[
+            school_led
+            provider_led
+            not_yet_known
+          ],
+        },
+        expression_of_interest: {
+          description: "Whether or not an ECF participant linked to the school has expressed interest in doing a funded induction programme",
+          type: :boolean,
+          nullable: false,
+          example: false,
+        },
+        created_at: {
+          description: "The date and time the school was created",
+          type: :string,
+          format: :"date-time",
+          example: "2021-05-31T02:22:32.000Z",
+        },
+        updated_at: {
+          description: "The last time a change was made to this school record by the DfE",
+          type: :string,
+          format: :"date-time",
+          example: "2021-05-31T02:22:32.000Z",
+        },
+      },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/models/school.rb
+++ b/spec/swagger_schemas/models/school.rb
@@ -35,7 +35,7 @@ SCHOOL = {
           example: "2021",
         },
         in_partnership: {
-          description: "Whether or not the school already has an active partnership, if it is doing a funded induction programme",
+          description: "Whether or not the school already has an active partnership, if it is doing a provider-led training programme",
           type: :boolean,
           nullable: false,
           example: false,
@@ -52,7 +52,7 @@ SCHOOL = {
           ],
         },
         expression_of_interest: {
-          description: "Whether or not an ECF participant linked to the school has expressed interest in doing a funded induction programme",
+          description: "Whether or not the school has expressed interest in doing a provider-led training programme for participants",
           type: :boolean,
           nullable: false,
           example: false,

--- a/spec/swagger_schemas/models/school.rb
+++ b/spec/swagger_schemas/models/school.rb
@@ -1,5 +1,5 @@
 SCHOOL = {
-  description: "The data attributes associated with an ECF school",
+  description: "The data attributes associated with a school",
   type: :object,
   required: %i[id type attributes],
   properties: {

--- a/spec/swagger_schemas/responses/school.rb
+++ b/spec/swagger_schemas/responses/school.rb
@@ -1,0 +1,10 @@
+SCHOOL_RESPONSE = {
+  description: "A single school.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      "$ref": "#/components/schemas/School",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/schools.rb
+++ b/spec/swagger_schemas/responses/schools.rb
@@ -1,0 +1,11 @@
+SCHOOLS_RESPONSE = {
+  description: "A list of schools for the given cohort.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      type: :array,
+      items: { "$ref": "#/components/schemas/School" },
+    },
+  },
+}.freeze


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1785

This is to set up Swagger documentation for schools, initial swagger set up was done as part of statements

### Changes proposed in this pull request

- Add schools endpoints to swagger docs

### Guidance to review

[Review app swagger docs](https://cpd-ec2-review-997-web.test.teacherservices.cloud/api/docs/v3)
