### PR TITLE
Add `api_updated_at` into school API serialiser logic

### DIFF
--- a/app/serializers/school_serializer.rb
+++ b/app/serializers/school_serializer.rb
@@ -17,7 +17,7 @@ class SchoolSerializer < Blueprinter::Base
       expressions_of_interest?(school)
     end
     field :created_at
-    field :updated_at
+    field(:api_updated_at, name: :updated_at)
 
     class << self
       def in_partnership?(school)

--- a/spec/serializers/school_serializer_spec.rb
+++ b/spec/serializers/school_serializer_spec.rb
@@ -86,8 +86,14 @@ describe SchoolSerializer, type: :serializer do
         expect(attributes["created_at"]).to eq("2023-07-01T12:00:00Z")
       end
 
-      it "serializes `updated_at`" do
-        expect(attributes["updated_at"]).to eq("2023-07-01T12:00:00Z")
+      context "when serializing `updated_at`" do
+        let(:api_updated_at) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "serializes the `api_updated_at`" do
+          school.update!(api_updated_at:)
+
+          expect(attributes["updated_at"]).to eq(api_updated_at.rfc3339)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

New field called `api_updated_at` was added in https://github.com/DFE-Digital/register-early-career-teachers-public/pull/971

### Changes proposed in this pull request

- Add `api_updated_at` into school serialiser logic

### Guidance to review
