### PR TITLE
Fix Sentry config

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,6 +7,6 @@ if Rails.application.config.enable_sentry
     config.release = ENV["COMMIT_SHA"]
     config.traces_sample_rate = 0.1
     config.profiles_sample_rate = 0.1
-    config.active_job_report_on_retry_error = true
+    config.rails.active_job_report_on_retry_error = true
   end
 end


### PR DESCRIPTION
In #981, I missed the `.rails`.

We didn't catch it because Sentry is disabled in review apps, but it blew up on Staging.

This fixes things.

Verified locally with `ENABLE_SENTRY=true bin/dev` before/after the change.