### PR TITLE
Enable `maxlength` for date field

### DIFF
--- a/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
+++ b/app/views/appropriate_bodies/claim_an_ect/find_ect/new.html.erb
@@ -22,6 +22,7 @@
       :date_of_birth,
       legend: { text: "Date of birth" },
       hint: { text: teacher_date_of_birth_hint_text },
+      maxlength_enabled: true
     )
   %>
 


### PR DESCRIPTION
We've seen a few handfuls of [errors] in production when ABs enter the date of birth to claim an ECT.

These errors seem to happen because the user enters (or pastes?) the whole date of birth in the day input, or these just enter too many digits.

Since these errors are not handled, the UX is degraded.

Enabling this option should prevent users entering too many digits in a given input on this page.

We might want to do some work to handle
`ActiveRecord::MultiparameterAssignmentErrors` generally when the argument is out of range, but we can cover that in another PR.

[errors]: https://dfe-teacher-services.sentry.io/issues/6385934864/?environment=production&project=4508369974788096&query=&referrer=issue-stream