### PR TITLE
[1441] Allow schools to re use lead provider and delivery partner choices for a new ECT where possible

### DIFF
--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -4,29 +4,43 @@
 
 <p class="govuk-body">You used these programme choices the last time you registered an ECT.</p>
 
-<%= govuk_summary_list do |summary_list|
-  summary_list.with_row do |row|
-    row.with_key(text: 'Appropriate body')
-    row.with_value(text: @school.last_chosen_appropriate_body_name)
-  end
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: 'Appropriate body') %>
+    <% row.with_value(text: @school.last_chosen_appropriate_body_name) %>
+  <% end %>
 
-  summary_list.with_row do |row|
-    row.with_key(text: 'Training programme')
-    row.with_value(text: training_programme_name(@school.last_chosen_training_programme))
-  end
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: 'Training programme') %>
+    <% row.with_value(text: training_programme_name(@school.last_chosen_training_programme)) %>
+  <% end %>
 
-  if @school.provider_led_training_programme_chosen? && @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school)
-      summary_list.with_row do |row|
-        row.with_key(text: 'Lead provider')
-        row.with_value(text: @ect.previous_lead_provider_name)
-      end
+  <% if @school.provider_led_training_programme_chosen? %>
+    <% if @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: 'Lead provider') %>
+        <% row.with_value(text: @ect.previous_lead_provider_name) %>
+      <% end %>
 
-    summary_list.with_row do |row|
-      row.with_key(text: 'Delivery partner')
-      row.with_value(text: @ect.previous_delivery_partner_name)
-    end
-  end
-end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: 'Delivery partner') %>
+        <% row.with_value(text: @ect.previous_delivery_partner_name) %>
+    <% end %>
+    <% else %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: 'Lead provider') %>
+        <% row.with_value(text: @ect.previous_eoi_lead_provider_name) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% if @school.provider_led_training_programme_chosen? && !@ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
+  <p class="govuk-body">
+    <%= @ect.previous_eoi_lead_provider_name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
+  </p>
+<% end %>
+
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -15,17 +15,18 @@
     row.with_value(text: training_programme_name(@school.last_chosen_training_programme))
   end
 
-  if @school.provider_led_training_programme_chosen?
+  if @school.provider_led_training_programme_chosen? && @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school)
+      summary_list.with_row do |row|
+        row.with_key(text: 'Lead provider')
+        row.with_value(text: @ect.previous_lead_provider_name)
+      end
+
     summary_list.with_row do |row|
-      row.with_key(text: 'Lead provider')
-      row.with_value(text: @school.last_chosen_lead_provider_name)
+      row.with_key(text: 'Delivery partner')
+      row.with_value(text: @ect.previous_delivery_partner_name)
     end
   end
 end %>
-
-<% if @school.provider_led_training_programme_chosen? %>
-  <p class="govuk-body"><%= @school.last_chosen_lead_provider_name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.</p>
-<% end %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -4,36 +4,36 @@
 
 <p class="govuk-body">You used these programme choices the last time you registered an ECT.</p>
 
-<%= govuk_summary_list do |summary_list| %>
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: 'Appropriate body') %>
-    <% row.with_value(text: @school.last_chosen_appropriate_body_name) %>
-  <% end %>
+<%= govuk_summary_list do |summary_list|
+  summary_list.with_row do |row|
+    row.with_key(text: 'Appropriate body')
+    row.with_value(text: @school.last_chosen_appropriate_body_name)
+  end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: 'Training programme') %>
-    <% row.with_value(text: training_programme_name(@school.last_chosen_training_programme)) %>
-  <% end %>
+  summary_list.with_row do |row|
+    row.with_key(text: 'Training programme')
+    row.with_value(text: training_programme_name(@school.last_chosen_training_programme))
+  end
 
-  <% if @school.provider_led_training_programme_chosen? %>
-    <% if @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: 'Lead provider') %>
-        <% row.with_value(text: @ect.previous_lead_provider_name) %>
-      <% end %>
+  if @school.provider_led_training_programme_chosen?
+    if @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school)
+      summary_list.with_row do |row|
+        row.with_key(text: 'Lead provider')
+        row.with_value(text: @ect.previous_lead_provider_name)
+      end
 
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: 'Delivery partner') %>
-        <% row.with_value(text: @ect.previous_delivery_partner_name) %>
-    <% end %>
-    <% else %>
-      <% summary_list.with_row do |row| %>
-        <% row.with_key(text: 'Lead provider') %>
-        <% row.with_value(text: @ect.previous_eoi_lead_provider_name) %>
-      <% end %>
-    <% end %>
-  <% end %>
-<% end %>
+      summary_list.with_row do |row|
+        row.with_key(text: 'Delivery partner')
+        row.with_value(text: @ect.previous_delivery_partner_name)
+      end 
+    else
+      summary_list.with_row do |row|
+        row.with_key(text: 'Lead provider')
+        row.with_value(text: @ect.previous_eoi_lead_provider_name)
+      end 
+    end 
+  end 
+end %>
 
 <% if @school.provider_led_training_programme_chosen? && !@ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
   <p class="govuk-body">

--- a/app/views/schools/register_ect_wizard/check_answers.html.erb
+++ b/app/views/schools/register_ect_wizard/check_answers.html.erb
@@ -84,6 +84,12 @@ end %>
                         visually_hidden_text: 'lead provider')
       end
     end
+    if @ect.use_previous_ect_choices && @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school)
+      summary_list.with_row do |row|
+        row.with_key(text: 'Delivery partner')
+        row.with_value(text: @ect.delivery_partner_name)
+      end
+    end
   end
 end %>
 

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -158,6 +158,12 @@ module Schools
           .exists?
       end
 
+      def previous_eoi_lead_provider_name
+        return unless previous_training_period&.expression_of_interest
+
+        previous_training_period&.expression_of_interest&.lead_provider&.name
+      end
+
     private
 
       def first_induction_period

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -146,6 +146,18 @@ module Schools
           .last
       end
 
+      def lead_provider_has_confirmed_partnership_for_contract_period?(school)
+        return false unless previous_lead_provider && contract_start_date && school
+
+        SchoolPartnerships::Query
+          .new(
+            school:,
+            lead_provider: previous_lead_provider,
+            contract_period: contract_start_date
+          )
+          .exists?
+      end
+
     private
 
       def first_induction_period
@@ -175,6 +187,8 @@ module Schools
       end
 
       def previous_training_period
+        return unless previous_ect_at_school_period
+
         @previous_training_period ||= TrainingPeriods::Search
           .new(order: :started_on)
           .training_periods(ect_id: previous_ect_at_school_period.id)

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -51,6 +51,7 @@ FactoryBot.define do
       transient do
         lead_provider { nil }
         delivery_partner { nil }
+        contract_period { nil }
       end
 
       after(:create) do |ect, evaluator|
@@ -58,8 +59,10 @@ FactoryBot.define do
 
         selected_lead_provider = evaluator.lead_provider || FactoryBot.create(:lead_provider)
         selected_delivery_partner = evaluator.delivery_partner || FactoryBot.create(:delivery_partner)
+        selected_contract_period = evaluator.contract_period || FactoryBot.create(:contract_period)
 
-        active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider: selected_lead_provider)
+        active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider: selected_lead_provider, contract_period: selected_contract_period)
+
         lpdp = FactoryBot.create(:lead_provider_delivery_partnership,
                                  active_lead_provider:,
                                  delivery_partner: selected_delivery_partner)

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -233,7 +233,6 @@ RSpec.describe 'Registering an ECT' do
     row = page.locator('.govuk-summary-list__row', has: page.locator('text=Training programme'))
     expect(row.text_content).to include('Training programme')
     expect(row.text_content).to include('Provider-led')
-    expect(page.get_by_text(@school.last_chosen_lead_provider_name).first).to be_visible
   end
 
   def when_i_select_that_i_dont_want_to_use_the_school_previous_choices

--- a/spec/views/schools/register_ect_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/check_answers.html.erb_spec.rb
@@ -62,11 +62,20 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
         context 'when ECT has provider-led programme' do
           before do
             allow(wizard.ect).to receive(:provider_led?).and_return(true)
+            allow(wizard.ect).to receive(:lead_provider_has_confirmed_partnership_for_contract_period?).with(wizard.school).and_return(true)
+            allow(wizard.ect).to receive_messages(lead_provider_name: "Confirmed LP", delivery_partner_name: "Confirmed DP")
           end
 
           it 'hides change link for lead provider' do
             render
             expect(rendered).not_to have_link('Change', href: schools_register_ect_wizard_change_training_programme_path)
+          end
+
+          it 'renders the delivery partner name from confirmed previous choices' do
+            render
+
+            expect(rendered).to have_css('.govuk-summary-list__key', text: 'Delivery partner')
+            expect(rendered).to have_css('.govuk-summary-list__value', text: 'Confirmed DP')
           end
         end
       end
@@ -116,12 +125,20 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
 
       context 'when ECT has provider-led programme' do
         before do
-          allow(wizard.ect).to receive(:provider_led?).and_return(true)
+          allow(wizard.ect).to receive(:lead_provider_has_confirmed_partnership_for_contract_period?)
+            .with(wizard.school).and_return(true)
+          allow(wizard.ect).to receive_messages(provider_led?: true, delivery_partner_name: "Should Not Show")
         end
 
         it 'hides change link for lead provider' do
           render
           expect(rendered).to have_link('Change', href: schools_register_ect_wizard_change_training_programme_path)
+        end
+
+        it 'does not render the delivery partner row' do
+          render
+          expect(rendered).not_to have_css('.govuk-summary-list__key', text: 'Delivery partner')
+          expect(rendered).not_to have_css('.govuk-summary-list__value', text: 'Should Not Show')
         end
       end
     end

--- a/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
@@ -115,4 +115,29 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
       expect(rendered).to have_css('.govuk-summary-list__value', text: 'Akatsuki')
     end
   end
+
+  context 'when provider-led with expression of interest only' do
+    let(:school) { FactoryBot.create(:school, :provider_led_last_chosen) }
+
+    before do
+      allow(wizard.ect).to receive(:lead_provider_has_confirmed_partnership_for_contract_period?).with(school).and_return(false)
+      allow(wizard.ect).to receive(:previous_eoi_lead_provider_name).and_return('Uchiha Clan')
+
+      assign(:school, school)
+      render
+    end
+
+    it 'renders the lead provider row with the EOI name' do
+      expect(rendered).to have_css('.govuk-summary-list__key', text: 'Lead provider')
+      expect(rendered).to have_css('.govuk-summary-list__value', text: 'Uchiha Clan')
+    end
+
+    it 'does not render the delivery partner row' do
+      expect(rendered).not_to have_css('.govuk-summary-list__key', text: 'Delivery partner')
+    end
+
+    it 'renders the explanatory paragraph' do
+      expect(rendered).to include('Uchiha Clan will confirm if they’ll be working with your school and which delivery partner will deliver training events.')
+    end
+  end
 end

--- a/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
@@ -58,30 +58,61 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
   end
 
   context "when school-led" do
-    let(:school) { FactoryBot.create(:school, :school_led_last_chosen) }
+    let(:appropriate_body) { FactoryBot.create(:appropriate_body, :teaching_school_hub, name: 'Team 7') }
+    let(:school) do
+      FactoryBot.create(
+        :school,
+        :school_led_last_chosen,
+        last_chosen_appropriate_body: appropriate_body
+      )
+    end
 
     before do
       assign(:school, school)
+      render
     end
 
-    it "does not render the content" do
-      render
+    it 'renders the appropriate body row' do
+      expect(rendered).to have_css('.govuk-summary-list__key', text: 'Appropriate body')
+      expect(rendered).to have_css('.govuk-summary-list__value', text: 'Team 7')
+    end
 
-      expect(rendered).not_to have_content("will confirm if they’ll be working with your school and which delivery partner will deliver training events.")
+    it 'renders the training programme row' do
+      expect(rendered).to have_css('.govuk-summary-list__key', text: 'Training programme')
+      expect(rendered).to have_css('.govuk-summary-list__value', text: 'School-led')
+    end
+
+    it 'does not render the lead provider row' do
+      expect(rendered).not_to have_css('.govuk-summary-list__key', text: 'Lead provider')
+    end
+
+    it 'does not render the delivery partner row' do
+      expect(rendered).not_to have_css('.govuk-summary-list__key', text: 'Delivery partner')
     end
   end
 
-  context "when provider-led" do
+  context 'when provider-led with confirmed partnership' do
     let(:school) { FactoryBot.create(:school, :provider_led_last_chosen) }
 
     before do
+      allow(wizard.ect).to receive(:lead_provider_has_confirmed_partnership_for_contract_period?).with(school).and_return(true)
+      allow(wizard.ect).to receive_messages(
+        previous_lead_provider_name: 'Orochimaru',
+        previous_delivery_partner_name: 'Akatsuki'
+      )
+
       assign(:school, school)
+      render
     end
 
-    it "renders the content" do
-      render
+    it 'renders the lead provider row' do
+      expect(rendered).to have_css('.govuk-summary-list__key', text: 'Lead provider')
+      expect(rendered).to have_css('.govuk-summary-list__value', text: 'Orochimaru')
+    end
 
-      expect(rendered).to have_content("will confirm if they’ll be working with your school and which delivery partner will deliver training events.")
+    it 'renders the delivery partner row' do
+      expect(rendered).to have_css('.govuk-summary-list__key', text: 'Delivery partner')
+      expect(rendered).to have_css('.govuk-summary-list__value', text: 'Akatsuki')
     end
   end
 end

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -602,5 +602,73 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         end
       end
     end
+
+    describe '#previous_eoi_lead_provider_name' do
+      let(:school) { FactoryBot.create(:school) }
+
+      context 'when there is a previous training period with an EOI' do
+        let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Team Kurenai") }
+        let(:expression_of_interest) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+        let(:teacher) { FactoryBot.create(:teacher) }
+
+        let!(:ect_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :provider_led,
+            school:,
+            teacher:,
+            started_on: Date.new(2025, 3, 10)
+          )
+        end
+
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            ect_at_school_period: ect_period,
+            started_on: Date.new(2025, 3, 10),
+            expression_of_interest:
+          )
+        end
+
+        it 'returns the name of the EOI lead provider for the previous training period' do
+          expect(ect.previous_eoi_lead_provider_name).to eq("Team Kurenai")
+        end
+      end
+
+      context 'when there is no previous training period' do
+        it 'returns nil' do
+          expect(ect.previous_eoi_lead_provider_name).to be_nil
+        end
+      end
+
+      context 'when the previous training period has no EOI' do
+        let(:teacher) { FactoryBot.create(:teacher) }
+
+        let!(:ect_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :provider_led,
+            school:,
+            teacher:,
+            started_on: Date.new(2025, 3, 10)
+          )
+        end
+
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            ect_at_school_period: ect_period,
+            started_on: Date.new(2025, 3, 10),
+            expression_of_interest: nil
+          )
+        end
+
+        it 'returns nil' do
+          expect(ect.previous_eoi_lead_provider_name).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### Context

This PR introduces support for the "rollover" concept from ECF1, where schools can reuse previously selected training programme choices (e.g. lead provider and delivery partner) when registering a new ECT - but only when those choices are still valid for the current contract period.

#### Screenshots

<img width="847" height="730" alt="image" src="https://github.com/user-attachments/assets/172bd4d9-96fd-42e2-9fea-734b76c6f107" />


####  Changes in this PR

- **Check Your Answers (CYA) Logic**  
  - The Delivery Partner row now appears on the CYA page **only if**:
    - `use_previous_ect_choices` is `true`, and
    - there is a confirmed school partnership between the previous lead provider and the school for the relevant contract period.
  - This ensures we only show delivery partner info when it reflects an actual partnership.

- **Use Previous Choices View**
  - Now conditionally shows the lead provider and delivery partner from the previous ECT if a confirmed partnership exists.
  - Falls back to the expression of interest lead provider if no confirmed partnership is found.

- **Wizard Logic**
  - Adds `#lead_provider_has_confirmed_partnership_for_contract_period?` to encapsulate the above check.
  - Adds `#previous_eoi_lead_provider_name` to support fallback scenarios.

- **Specs**
  - FactoryBot updates to support `contract_period:` in test setup.

#### ❗️What this **doesn’t** do (by design)

- This PR **does not persist** the delivery partner or school partnership in the database.
  - The school never explicitly chooses a delivery partner - it’s inferred based on the confirmed partnership with the lead provider.
  - Persisting or recreating partnerships is part of separate ongoing work.
