### PR TITLE
Group Ruby and JS Playwright updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
 version: 2
+multi-ecosystem-groups:
+  playwright-group:
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
 updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 5
+    patterns:
+      - playwright-ruby-client
     labels:
       - Dependencies
     groups:
@@ -12,11 +18,13 @@ updates:
         patterns:
           - govuk-components
           - govuk_design_system_formbuilder
+    multi-ecosystem-group: playwright-group
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 5
+    patterns:
+      - playwright
     labels:
       - Dependencies
     groups:
@@ -25,6 +33,7 @@ updates:
           - esbuild
           - "@esbuild/linux-x64"
           - "@esbuild/darwin-arm64"
+    multi-ecosystem-group: playwright-group
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Group Ruby and JS Playwright updates in Dependabot

We can leverage [multi-ecosystem updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates) which became available at the [beginning of this month ](https://github.blog/changelog/2025-07-01-single-pull-request-for-dependabot-multi-ecosystem-support/) to ensure that updates to `playwright-ruby-client` (Ruby) and `playwright` (npm) are grouped into a single PR by Dependabot. 

This prevents version mismatches that cause spec failures, such as `PlaywrightMajorVersionMismatch`.
