### PR TITLE
Update school queries to use the training programme from training periods

### DIFF
--- a/app/services/schools/query.rb
+++ b/app/services/schools/query.rb
@@ -95,7 +95,7 @@ module Schools
 
       "(
         #{
-          School.distinct.select('ect_at_school_periods.training_programme').from('schools s')
+          School.distinct.select('training_periods.training_programme').from('schools s')
           .left_joins(ect_at_school_periods: { training_periods: { expression_of_interest: :contract_period } })
           .left_joins(ect_at_school_periods: { training_periods: { active_lead_provider: :contract_period } })
           .where('contract_periods.year = ? OR contract_periods_active_lead_providers.year = ?', contract_period_id, contract_period_id)

--- a/app/services/schools/training_programme.rb
+++ b/app/services/schools/training_programme.rb
@@ -40,7 +40,10 @@ module Schools
     def ect_training_programme
       return school.transient_ects_at_school_training_programme if school.respond_to?(:transient_ects_at_school_training_programme)
 
-      ECTAtSchoolPeriod.joins(:training_periods).where(id: ects_expressions_of_interest.pluck(:id) + ect_at_school_periods.pluck(:id)).order(training_programme: :asc).pick('training_periods.training_programme')
+      TrainingPeriod
+        .where(ect_at_school_period_id: ects_expressions_of_interest.pluck(:id) + ect_at_school_periods.pluck(:id))
+        .order(training_programme: :asc)
+        .pick(:training_programme)
     end
 
     def not_yet_known

--- a/app/services/schools/training_programme.rb
+++ b/app/services/schools/training_programme.rb
@@ -40,7 +40,7 @@ module Schools
     def ect_training_programme
       return school.transient_ects_at_school_training_programme if school.respond_to?(:transient_ects_at_school_training_programme)
 
-      ECTAtSchoolPeriod.where(id: ects_expressions_of_interest.pluck(:id) + ect_at_school_periods.pluck(:id)).order(training_programme: :asc).pick(:training_programme)
+      ECTAtSchoolPeriod.joins(:training_periods).where(id: ects_expressions_of_interest.pluck(:id) + ect_at_school_periods.pluck(:id)).order(training_programme: :asc).pick('training_periods.training_programme')
     end
 
     def not_yet_known

--- a/spec/services/schools/query_spec.rb
+++ b/spec/services/schools/query_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Schools::Query do
 
         context "when ect has chosen `school_led` as training programme" do
           before do
-            training_period.ect_at_school_period.update!(training_programme: "school_led")
+            training_period.update!(training_programme: "school_led")
           end
 
           it "returns `provider_led`" do

--- a/spec/services/schools/query_spec.rb
+++ b/spec/services/schools/query_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Schools::Query do
             training_period.update!(training_programme: "school_led")
           end
 
-          it "returns `provider_led`" do
+          it "returns `school_led`" do
             expect(returned_school.transient_ects_at_school_training_programme).to eq("school_led")
           end
         end

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -48,7 +48,6 @@ describe Schools::TrainingProgramme do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
                               :active,
-                              :provider_led,
                               school:,
                               started_on: '2021-01-01')
           end
@@ -91,13 +90,13 @@ describe Schools::TrainingProgramme do
             let(:ect_at_school_period) do
               FactoryBot.create(:ect_at_school_period,
                                 :active,
-                                :provider_led,
                                 school:,
                                 started_on: '2021-01-01')
             end
             let!(:training_period) do
               FactoryBot.create(:training_period,
                                 :for_ect,
+                                :provider_led,
                                 ect_at_school_period:,
                                 school_partnership:,
                                 started_on: ect_at_school_period.started_on)
@@ -112,12 +111,12 @@ describe Schools::TrainingProgramme do
             let(:ect_at_school_period) do
               FactoryBot.create(:ect_at_school_period,
                                 :active,
-                                :school_led,
                                 school:,
                                 started_on: '2021-01-01')
             end
             let!(:training_period) do
               FactoryBot.create(:training_period,
+                                :school_led,
                                 ect_at_school_period:,
                                 school_partnership:,
                                 started_on: '2022-01-01',
@@ -133,12 +132,12 @@ describe Schools::TrainingProgramme do
             let(:ect_at_school_period_1) do
               FactoryBot.create(:ect_at_school_period,
                                 :active,
-                                :provider_led,
                                 school:,
                                 started_on: '2021-01-01')
             end
             let!(:training_period_1) do
               FactoryBot.create(:training_period,
+                                :provider_led,
                                 ect_at_school_period: ect_at_school_period_1,
                                 school_partnership:,
                                 started_on: '2022-01-01',
@@ -148,12 +147,12 @@ describe Schools::TrainingProgramme do
             let(:ect_at_school_period_2) do
               FactoryBot.create(:ect_at_school_period,
                                 :active,
-                                :school_led,
                                 school:,
                                 started_on: '2021-01-01')
             end
             let!(:training_period) do
               FactoryBot.create(:training_period,
+                                :school_led,
                                 ect_at_school_period: ect_at_school_period_2,
                                 school_partnership:,
                                 started_on: '2022-01-01',
@@ -170,13 +169,13 @@ describe Schools::TrainingProgramme do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
                               :active,
-                              :school_led,
                               school:,
                               started_on: '2021-01-01')
           end
           let!(:training_period) do
             FactoryBot.create(:training_period,
                               :for_ect,
+                              :school_led,
                               school_partnership_id: nil,
                               expression_of_interest: FactoryBot.create(:active_lead_provider, contract_period:),
                               ect_at_school_period:,
@@ -227,13 +226,13 @@ describe Schools::TrainingProgramme do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
                               :active,
-                              :provider_led,
                               school:,
                               started_on: '2021-01-01')
           end
           let!(:training_period) do
             FactoryBot.create(:training_period,
                               :for_ect,
+                              :provider_led,
                               ect_at_school_period:,
                               school_partnership:,
                               started_on: ect_at_school_period.started_on)


### PR DESCRIPTION
### Context

We're moving the `training_programme` field from `ECTAtSchoolPeriod` to `TrainingPeriod` bit by bit.

#982 added the `training_programme` field to `TrainingPeriod` and this change updates the school queries so they use it instead of the one on `ECTAtSchoolPeriod`.

Thankfully it was quite minimal as the query objects had joined the relevant tables already.

Refs DFE-Digital/register-ects-project-board#2013
