### PR TITLE
Remove redundant columns from appropriate bodies

### DIFF
--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -15,25 +15,4 @@ class AppropriateBody < ApplicationRecord
   validates :name,
             presence: true,
             uniqueness: true
-
-  validates :local_authority_code,
-            presence: { message: 'Enter a local authority code', allow_blank: true },
-            inclusion: {
-              in: 50..999,
-              message: 'Must be a number between 50 and 999',
-              allow_blank: true
-            },
-            uniqueness: {
-              scope: :establishment_number,
-              message: "An appropriate body with this local authority code and establishment number already exists",
-              allow_blank: true
-            }
-
-  validates :establishment_number,
-            presence: { message: 'Enter a establishment number', allow_blank: true },
-            inclusion: {
-              in: 1000..9999,
-              message: 'Must be a number between 1000 and 9999',
-              allow_blank: true
-            }
 end

--- a/app/views/admin/appropriate_bodies/show.html.erb
+++ b/app/views/admin/appropriate_bodies/show.html.erb
@@ -22,16 +22,6 @@
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Establishment number")
-      row.with_value(text: @appropriate_body.establishment_number)
-    end
-
-    sl.with_row do |row|
-      row.with_key(text: "Local authority code")
-      row.with_value(text: @appropriate_body.local_authority_code)
-    end
-
-    sl.with_row do |row|
       row.with_key(text: "DfE Sign-in organisation ID")
       row.with_value(text: tag.code(@appropriate_body.dfe_sign_in_organisation_id))
     end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -5,8 +5,6 @@ shared:
     - name
     - created_at
     - updated_at
-    - local_authority_code
-    - establishment_number
     - dfe_sign_in_organisation_id
     - dqt_id
   :induction_extensions:
@@ -40,4 +38,3 @@ shared:
     - trs_initial_teacher_training_end_date
     - trs_data_last_refreshed_at
     - trs_deactivated
-    

--- a/db/migrate/20250724140228_remove_redundant_appropriate_bodies_columns.rb
+++ b/db/migrate/20250724140228_remove_redundant_appropriate_bodies_columns.rb
@@ -1,0 +1,8 @@
+class RemoveRedundantAppropriateBodiesColumns < ActiveRecord::Migration[8.0]
+  def change
+    change_table :appropriate_bodies, bulk: true do |t|
+      t.remove :establishment_number, type: :integer, null: true
+      t.remove :local_authority_code, type: :integer, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,8 +63,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "local_authority_code"
-    t.integer "establishment_number"
     t.uuid "dfe_sign_in_organisation_id"
     t.uuid "dqt_id"
     t.enum "body_type", default: "teaching_school_hub", enum_type: "appropriate_body_type"

--- a/db/seeds/appropriate_bodies.rb
+++ b/db/seeds/appropriate_bodies.rb
@@ -6,58 +6,41 @@ AppropriateBody.create!([
   {
     body_type: 'national',
     name: AppropriateBodies::Search::ISTIP,
-    local_authority_code: 50,
     dfe_sign_in_organisation_id: "203606a4-4199-46a9-84e4-56fbc5da2a36",
     dqt_id: "6ae042bb-c7ae-e311-b8ed-005056822391"
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Canvas Teaching School Hub',
-    local_authority_code: 109,
-    establishment_number: 2367
   },
   {
     body_type: 'teaching_school_hub',
     name: 'South Yorkshire Studio Hub',
-    local_authority_code: 678,
-    establishment_number: 9728
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Ochre Education Partnership',
-    local_authority_code: 238,
-    establishment_number: 6582
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Umber Teaching School Hub',
-    local_authority_code: 957,
-    establishment_number: 7361,
     dfe_sign_in_organisation_id: 'd245ec79-534e-4547-a7e4-ccd98803b627'
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Golden Leaf Teaching School Hub',
-    local_authority_code: 648,
-    establishment_number: 3986
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Frame University London',
-    local_authority_code: 832,
-    establishment_number: 6864
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Easelcroft Teaching School Hub',
-    local_authority_code: 573,
-    establishment_number: 9273
   },
   {
     body_type: 'teaching_school_hub',
     name: 'Vista College',
-    local_authority_code: 418,
-    establishment_number: 3735
   }
 ]).each do |describe_appropriate|
   describe_appropriate_body(describe_appropriate)

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -253,6 +253,7 @@ erDiagram
     datetime created_at
     datetime updated_at
     uuid api_id
+    datetime api_updated_at
   }
   Declaration {
     integer id
@@ -276,8 +277,6 @@ erDiagram
     string name
     datetime created_at
     datetime updated_at
-    integer local_authority_code
-    integer establishment_number
     uuid dfe_sign_in_organisation_id
     uuid dqt_id
     enum body_type

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,15 +1,12 @@
 FactoryBot.define do
   factory(:appropriate_body) do
     sequence(:name) { |n| "Appropriate Body #{n}" }
-    sequence(:local_authority_code, 55) { |n| 55 + (n % 945) }
-    sequence(:establishment_number) { |n| 1000 + (n / 945) }
     dfe_sign_in_organisation_id { SecureRandom.uuid }
     teaching_school_hub
 
     trait :istip do
       body_type { 'national' }
       name { AppropriateBodies::Search::ISTIP }
-      local_authority_code { 50 }
       dfe_sign_in_organisation_id { "203606a4-4199-46a9-84e4-56fbc5da2a36" }
     end
 

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -21,20 +21,5 @@ describe AppropriateBody do
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
-
-    it { is_expected.to validate_presence_of(:local_authority_code).with_message('Enter a local authority code').allow_blank }
-    it { is_expected.to validate_inclusion_of(:local_authority_code).in_range(50..999).allow_blank.with_message('Must be a number between 50 and 999') }
-
-    it { is_expected.to validate_presence_of(:establishment_number).with_message('Enter a establishment number').allow_blank }
-    it { is_expected.to validate_inclusion_of(:establishment_number).in_range(1000..9999).allow_blank.with_message('Must be a number between 1000 and 9999') }
-
-    it "ensures local_authority_code and establishment_number are unique in combination" do
-      ab_args = { local_authority_code: 123, establishment_number: 4567 }
-      FactoryBot.create(:appropriate_body, name: "AB1", **ab_args)
-      FactoryBot.build(:appropriate_body, name: "AB2", **ab_args).tap do |duplicate_ab|
-        expect(duplicate_ab).to be_invalid
-        expect(duplicate_ab.errors.messages.fetch(:local_authority_code)).to include(/local authority code and establishment number already exists/)
-      end
-    end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-early-career-teachers-public/issues/941

### Changes proposed in this pull request

We're not using this data anywhere (we just imported it from DQT as a starting point).

This removes it in the interests of maintenance!

### Guidance to review

~~- [ ] Data pipelines not borked!~~ We're leaving `dqt_id` since the analytics team are still using it to associate historical induction periods to appropriate bodies