### PR TITLE
Use dashes in Register ECT wizard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,7 +187,7 @@ Rails.application.routes.draw do
       get "cannot-register-ect", action: :new
       get "cannot-register-ect-yet", action: :new
 
-      get "already_active_at_school", action: :new
+      get "already-active_at-school", action: :new
       get "induction-completed", action: :new
       get "induction-exempt", action: :new
       get "induction-failed", action: :new

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_ect_already_registered_error_page
-    expect(page.url).to end_with('/schools/register-ect/already_active_at_school')
+    expect(page.url).to end_with('/schools/register-ect/already-active_at-school')
   end
 
   def when_i_click_try_again


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-early-career-teachers-public/issues/556

### Changes proposed in this pull request

This path was the only route_with_underscores in the wizard.

Now it-has-dashes-like-the-others.

Closes #556 

### Guidance to review
