### PR TITLE
Add school endpoints to the parity check

### DIFF
--- a/app/controllers/migration/parity_checks/requests_controller.rb
+++ b/app/controllers/migration/parity_checks/requests_controller.rb
@@ -4,7 +4,7 @@ module Migration::ParityChecks
 
     def show
       @request = ParityCheck::Run.completed.find(params[:parity_check_run_id]).requests.find(params[:id])
-      @pagy, @responses = pagy(@request.responses)
+      @pagy, @responses = pagy(@request.responses.ordered_by_page)
 
       @multiple_pages = @responses.any?(&:page)
       @breadcrumbs = {

--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -1,7 +1,7 @@
 class Migration::ParityChecksController < ::AdminController
   layout "full"
 
-  before_action :load_endpoints, :load_pending_and_in_progress_runs, only: %i[new create]
+  before_action :load_endpoints, :load_pending_and_in_progress_runs, :load_lead_providers, only: %i[new create]
   before_action :load_completed_runs, only: %i[new create completed]
 
   def new
@@ -42,6 +42,10 @@ private
   def load_pending_and_in_progress_runs
     @in_progress_run = ParityCheck::Run.in_progress.first
     @pending_runs = ParityCheck::Run.pending
+  end
+
+  def load_lead_providers
+    @lead_providers = LeadProvider.where.not(ecf_id: nil)
   end
 
   def load_completed_runs

--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -17,12 +17,21 @@ module ParityCheck
     # Path ID methods
 
     def statement_id
-      Statement
-        .output_fee
-        .joins(:active_lead_provider)
-        .where(active_lead_provider: lead_provider.active_lead_providers)
-        .order("RANDOM()")
+      Statements::Query.new(lead_provider:)
+        .statements
+        .distinct(false)
+        .reorder("RANDOM()")
         .pick(:api_id)
+    end
+
+    def school_id
+      contract_period_id = ContractPeriod.order("RANDOM()").pick(:year)
+      Schools::Query.new(lead_provider_id: lead_provider.id, contract_period_id:)
+        .schools
+        .distinct(false)
+        .includes(:gias_school)
+        .reorder("RANDOM()")
+        .pick(gias_school: :api_id)
     end
 
     # Request body methods

--- a/app/migration/parity_check/runner.rb
+++ b/app/migration/parity_check/runner.rb
@@ -49,7 +49,7 @@ module ParityCheck
     end
 
     def lead_providers
-      @lead_providers ||= LeadProvider.all
+      @lead_providers ||= LeadProvider.where.not(ecf_id: nil)
     end
   end
 end

--- a/app/migration/parity_check/token_provider.rb
+++ b/app/migration/parity_check/token_provider.rb
@@ -14,7 +14,7 @@ module ParityCheck
     def token(lead_provider:)
       ensure_parity_check_enabled!
 
-      known_tokens_by_lead_provider_ecf_id[lead_provider.ecf_id]
+      known_tokens_by_lead_provider_ecf_id.fetch(lead_provider.ecf_id)
     end
 
   private

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -21,6 +21,7 @@ module ParityCheck
     scope :bodies_matching, -> { where(ecf_body: nil, rect_body: nil) } # We nil matching response bodies.
     scope :matching, -> { status_codes_matching.bodies_matching }
     scope :different, -> { status_codes_different.or(bodies_different) }
+    scope :ordered_by_page, -> { order(:page) }
 
     def rect_performance_gain_ratio
       return unless ecf_time_ms && rect_time_ms

--- a/app/views/migration/parity_checks/new.html.erb
+++ b/app/views/migration/parity_checks/new.html.erb
@@ -2,16 +2,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p>
-      Select endpoints you would like to run a parity check against.
-    </p>
-
-    <% if @endpoints.any? %>
-      <%= render partial: "form" %>
-    <% else %>
+    <% if @lead_providers.none? %>
+      <p>
+        Lead providers with an <strong>ecf_id</strong> are required for parity checks.
+      </p>
+    <% elsif @endpoints.none? %>
       <p>
         No endpoints available for parity checks.
       </p>
+    <% else %>
+      <p>
+        Select endpoints you would like to run a parity check against.
+      </p>
+
+      <%= render partial: "form" %>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -18,9 +18,43 @@ get:
           updated_since: "2024-11-13T11:21:55Z"
   - "/api/v3/statements/:id":
       id: statement_id
+    
+  - "/api/v3/schools/ecf":
+      paginate: true
+      query:
+        filter:
+          cohort: 2022
+  - "/api/v3/schools/ecf":
+      paginate: true
+      query:
+        filter:
+          urn: "102396"
+          cohort: 2023
+  - "/api/v3/schools/ecf":
+      paginate: true
+      query:
+        filter:
+          cohort: 2023
+          updated_since: "2025-04-13T11:21:55Z"
+  - "/api/v3/schools/ecf":
+      paginate: true
+      query:
+        cohort: 2021
+        sort: "-updated_at"
+  - "/api/v3/schools/ecf":
+      paginate: true
+      query:
+        filter:
+          cohort: "2021,2022"
+          urn: "102396"
+          updated_since: "2025-04-13T11:21:55Z"
+  - "/api/v3/schools/ecf/:id":
+      id: school_id
+
 post:
   - "/api/v3/partnerships/ecf":
       body: example_body
+
 put:
   - "/api/v3/participant-declarations/:id":
       id: example_id

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -52,9 +52,14 @@ RSpec.describe "View parity check request" do
     responses = FactoryBot.create_list(:parity_check_response, Pagy::DEFAULT[:limit] + 1, :matching)
     request = FactoryBot.create(:parity_check_request, :completed, run:, responses:)
 
+    responses.each.with_index { |response, index| response.update(page: index + 1) }
+
     page.goto(migration_parity_check_request_path(run, request))
 
     expect(page.locator("tbody tr")).to have_count(Pagy::DEFAULT[:limit])
+
+    page_numbers_in_order = page.locator("table tbody tr td:first-child").all.map(&:text_content).map(&:to_i)
+    expect(page_numbers_in_order).to eq(page_numbers_in_order.sort)
 
     pagination = page.locator(".govuk-pagination")
     expect(pagination).to be_visible

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe ParityCheck::DynamicRequestContent do
       it { is_expected.to eq(statement.api_id) }
     end
 
+    context "when fetching school_id" do
+      let(:identifier) { :school_id }
+      let!(:school_partnership) { FactoryBot.create(:school_partnership, school:) }
+      let!(:school) { FactoryBot.create(:school, :eligible, :not_cip_only) }
+
+      before do
+        # Ineligible school
+        FactoryBot.create(:school, :ineligible, :not_cip_only)
+          .tap { it.gias_school.update!(funding_eligibility: :ineligible) }
+        # CIP only school
+        FactoryBot.create(:school, :eligible, :cip_only)
+      end
+
+      it { is_expected.to eq(school.api_id) }
+    end
+
     context "when fetching example_body" do
       let(:identifier) { :example_body }
 

--- a/spec/migration/parity_check/runner_spec.rb
+++ b/spec/migration/parity_check/runner_spec.rb
@@ -53,8 +53,9 @@ RSpec.describe ParityCheck::Runner, type: :model do
       expect(created_run.mode).to eq(mode)
     end
 
-    it "creates a request for each lead provider and endpoint" do
+    it "creates a request for each lead provider and endpoint, ignoring lead providers without an ecf_id" do
       other_lead_provider = FactoryBot.create(:lead_provider)
+      FactoryBot.create(:lead_provider, ecf_id: nil) # Ignored due to ecf_id being nil
       lead_providers = [lead_provider, other_lead_provider]
 
       created_run = nil

--- a/spec/migration/parity_check/token_provider_spec.rb
+++ b/spec/migration/parity_check/token_provider_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ParityCheck::TokenProvider do
     context "when the keys are not present" do
       let(:tokens) { nil }
 
-      it { is_expected.to be_nil }
+      it { expect { token }.to raise_error(KeyError, /key not found: "#{lead_provider.ecf_id}"/) }
     end
 
     context "when the keys are present" do

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -42,9 +42,9 @@ describe ParityCheck::Response do
   describe "scopes" do
     let(:request) { FactoryBot.create(:parity_check_request, :in_progress) }
     let!(:matching_response) { FactoryBot.create(:parity_check_response, :matching, request:) }
-    let!(:matching_status_codes_response) { FactoryBot.create(:parity_check_response, :matching, ecf_body: "different", request:) }
-    let!(:matching_bodies_response) { FactoryBot.create(:parity_check_response, :matching, ecf_status_code: 404, request:) }
-    let!(:different_response) { FactoryBot.create(:parity_check_response, :different, request:) }
+    let!(:matching_status_codes_response) { FactoryBot.create(:parity_check_response, :matching, ecf_body: "different", request:, page: 2) }
+    let!(:matching_bodies_response) { FactoryBot.create(:parity_check_response, :matching, ecf_status_code: 404, request:, page: 3) }
+    let!(:different_response) { FactoryBot.create(:parity_check_response, :different, request:, page: 1) }
 
     describe ".different" do
       subject { described_class.different }
@@ -80,6 +80,12 @@ describe ParityCheck::Response do
       subject { described_class.bodies_matching }
 
       it { is_expected.to contain_exactly(matching_response, matching_bodies_response) }
+    end
+
+    describe ".ordered_by_page" do
+      subject { described_class.ordered_by_page }
+
+      it { is_expected.to eq([different_response, matching_status_codes_response, matching_bodies_response, matching_response]) }
     end
   end
 


### PR DESCRIPTION
### Context

Now that we have the schools endpoint setup in RECT we want to run the parity check against them to determine if we have parity with ECF.

### Changes proposed in this pull request

- Ensure lead providers are present and have an ecf_id

This is just a small housekeeping update to avoid running into a silent failure when trying to run the parity check when there are no lead providers that have an `ecf_id` (it would hang/fail trying to get tokens).

Prevent running the migrator until there are valid lead providers present.

Only queue requests for lead providers with an `ecf_id`.

- Display parity check responses in page order

When we have multiple pages of responses its helpful to view them in page order.

- Add schools endpoints to parity check

Include the schools endpoints in the parity check; this includes all the filters applied both individually and together.

### Guidance to review

We can't currently test this as after running the migrators in RECT there are no `SchoolPartnership` records, so we always get back no results (as we have to filter on `ContractPeriod`).

The RECT url for schools is also different to the ECF URL, so we need to update the parity check tool to support different URLs, which will be in a follow up ticket.