### PR TITLE
[1808] Add schools to sandbox seeds generator task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,12 +82,15 @@ end
 group :development, :test do
   gem "brakeman"
   gem "debug", platforms: %i[mri windows]
-  gem "factory_bot_rails"
-  gem "faker"
   gem 'rswag-specs'
   gem 'rubocop-factory_bot', require: false
   gem 'rubocop-govuk', require: false
   gem 'rubocop-performance', require: false
+end
+
+group :development, :test, :review, :sandbox do
+  gem "factory_bot_rails"
+  gem "faker"
 end
 
 group :nanoc do

--- a/app/services/sandbox_seed_data/base.rb
+++ b/app/services/sandbox_seed_data/base.rb
@@ -17,7 +17,7 @@ module SandboxSeedData
     end
 
     def plantable?
-      Rails.env.sandbox? || Rails.env.development?
+      %w[development review sandbox].include?(Rails.env)
     end
 
   private

--- a/app/services/sandbox_seed_data/delivery_partners.rb
+++ b/app/services/sandbox_seed_data/delivery_partners.rb
@@ -1,0 +1,27 @@
+module SandboxSeedData
+  class DeliveryPartners < Base
+    NUMBER_OF_RECORDS = 50
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("delivery partners")
+
+      NUMBER_OF_RECORDS.times do
+        delivery_partner = create_delivery_partner
+
+        log_seed_info(delivery_partner.name, colour: Colourize::COLOURS.keys.sample)
+      end
+    end
+
+  private
+
+    def create_delivery_partner
+      lead_provider = LeadProvider.all.sample
+      active_lead_provider = lead_provider.active_lead_providers.sample
+      lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+
+      lead_provider_delivery_partnership.delivery_partner
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/delivery_partners.rb
+++ b/app/services/sandbox_seed_data/delivery_partners.rb
@@ -1,27 +1,25 @@
 module SandboxSeedData
   class DeliveryPartners < Base
-    NUMBER_OF_RECORDS = 50
+    NUMBER_OF_RECORDS_PER_LEAD_PROVIDER = 5
 
     def plant
       return unless plantable?
 
       log_plant_info("delivery partners")
 
-      NUMBER_OF_RECORDS.times do
-        delivery_partner = create_delivery_partner
-
-        log_seed_info(delivery_partner.name, colour: Colourize::COLOURS.keys.sample)
-      end
+      create_delivery_partners
     end
 
   private
 
-    def create_delivery_partner
-      lead_provider = LeadProvider.all.sample
-      active_lead_provider = lead_provider.active_lead_providers.sample
-      lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+    def create_delivery_partners
+      ActiveLeadProvider.find_each do |active_lead_provider|
+        NUMBER_OF_RECORDS_PER_LEAD_PROVIDER.times do
+          delivery_partner = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:).delivery_partner
 
-      lead_provider_delivery_partnership.delivery_partner
+          log_seed_info("#{delivery_partner.name} -> #{active_lead_provider.lead_provider.name} / #{active_lead_provider.contract_period_id}", colour: Colourize::COLOURS.keys.sample)
+        end
+      end
     end
   end
 end

--- a/app/services/sandbox_seed_data/helpers/school_urn_generator.rb
+++ b/app/services/sandbox_seed_data/helpers/school_urn_generator.rb
@@ -1,0 +1,37 @@
+ALL_URNS = (1..999_999) unless defined?(ALL_URNS)
+
+module SandboxSeedData
+  module Helpers
+    class SchoolUrnGenerator
+      class << self
+        def next
+          next_urn = next_from_available_stack
+          add_to_taken_stack(next_urn)
+          sprintf("%06d", next_urn)
+        end
+
+      private
+
+        def add_to_taken_stack(next_urn)
+          taken.push(next_urn)
+        end
+
+        def next_from_available_stack
+          available.pop || (raise "URN available list exhausted")
+        end
+
+        def available
+          @available.presence || reseed
+        end
+
+        def reseed
+          @available = (Array.new(1_000) { rand(ALL_URNS) }.uniq - taken)
+        end
+
+        def taken
+          @taken ||= School.where.not(urn: nil).pluck(:urn).map(&:to_i)
+        end
+      end
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/school_partnerships.rb
+++ b/app/services/sandbox_seed_data/school_partnerships.rb
@@ -1,0 +1,25 @@
+module SandboxSeedData
+  class SchoolPartnerships < Base
+    NUMBER_OF_RECORDS = 100
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("school partnerships")
+
+      NUMBER_OF_RECORDS.times do
+        school_partnership = create_school_partnership(school: School.order("RANDOM()").first)
+
+        log_seed_info("#{school_partnership.school.name} -> #{school_partnership.lead_provider.name}", colour: Colourize::COLOURS.keys.sample)
+      end
+    end
+
+  private
+
+    def create_school_partnership(school:)
+      lead_provider_delivery_partnership = LeadProviderDeliveryPartnership.where.not(id: school.school_partnerships.map(&:lead_provider_delivery_partnership).map(&:id)).sample
+
+      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/school_partnerships.rb
+++ b/app/services/sandbox_seed_data/school_partnerships.rb
@@ -1,25 +1,29 @@
 module SandboxSeedData
   class SchoolPartnerships < Base
-    NUMBER_OF_RECORDS = 100
+    NUMBER_OF_RECORDS_PER_PARTNERSHIP = 2
 
     def plant
       return unless plantable?
 
       log_plant_info("school partnerships")
 
-      NUMBER_OF_RECORDS.times do
-        school_partnership = create_school_partnership(school: School.order("RANDOM()").first)
-
-        log_seed_info("#{school_partnership.school.name} -> #{school_partnership.lead_provider.name}", colour: Colourize::COLOURS.keys.sample)
+      NUMBER_OF_RECORDS_PER_PARTNERSHIP.times do
+        create_school_partnerships
       end
     end
 
   private
 
-    def create_school_partnership(school:)
-      lead_provider_delivery_partnership = LeadProviderDeliveryPartnership.where.not(id: school.school_partnerships.map(&:lead_provider_delivery_partnership).map(&:id)).sample
+    def create_school_partnerships
+      LeadProviderDeliveryPartnership.find_each do |lead_provider_delivery_partnership|
+        school = School.order("RANDOM()").first
 
-      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+        next if school.school_partnerships.map(&:lead_provider_delivery_partnership).map(&:id).include?(lead_provider_delivery_partnership.id)
+
+        school_partnership = FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+
+        log_seed_info("#{school_partnership.school.name} -> #{school_partnership.lead_provider.name}", colour: Colourize::COLOURS.keys.sample)
+      end
     end
   end
 end

--- a/app/services/sandbox_seed_data/schools.rb
+++ b/app/services/sandbox_seed_data/schools.rb
@@ -1,6 +1,6 @@
 module SandboxSeedData
   class Schools < Base
-    NUMBER_OF_SCHOOLS = 100
+    NUMBER_OF_RECORDS = 100
     SCHOOL_TYPES = %i[independent state_funded eligible ineligible cip_only not_cip_only].freeze
 
     def plant
@@ -8,10 +8,8 @@ module SandboxSeedData
 
       log_plant_info("schools")
 
-      NUMBER_OF_SCHOOLS.times do
-        school = create_school(urn: Helpers::SchoolUrnGenerator.next)
-
-        log_seed_info(Colourize.text(school.name, Colourize::COLOURS.keys.sample).to_s)
+      NUMBER_OF_RECORDS.times do
+        create_school(urn: Helpers::SchoolUrnGenerator.next)
       end
     end
 
@@ -19,20 +17,9 @@ module SandboxSeedData
 
     def create_school(urn:)
       school_type = SCHOOL_TYPES.sample
-      school = FactoryBot.create(:school, SCHOOL_TYPES.sample, urn:)
+      school = FactoryBot.create(:school, school_type, urn:)
 
-      return school unless %i[eligible state_funded].include?(school_type)
-
-      create_school_partnership(school)
-      school
-    end
-
-    def create_school_partnership(school)
-      lead_provider = LeadProvider.all.sample
-      active_lead_provider = lead_provider.active_lead_providers.sample
-      delivery_partner = FactoryBot.create(:delivery_partner, name: "Delivery Partner - #{active_lead_provider.contract_period_id} - #{SecureRandom.hex(4)}")
-      lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
-      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+      log_seed_info("#{school.name} - type: #{school_type}", colour: Colourize::COLOURS.keys.sample)
     end
   end
 end

--- a/app/services/sandbox_seed_data/schools.rb
+++ b/app/services/sandbox_seed_data/schools.rb
@@ -1,0 +1,38 @@
+module SandboxSeedData
+  class Schools < Base
+    NUMBER_OF_SCHOOLS = 100
+    SCHOOL_TYPES = %i[independent state_funded eligible ineligible cip_only not_cip_only].freeze
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("schools")
+
+      NUMBER_OF_SCHOOLS.times do
+        school = create_school(urn: Helpers::SchoolUrnGenerator.next)
+
+        log_seed_info(Colourize.text(school.name, Colourize::COLOURS.keys.sample).to_s)
+      end
+    end
+
+  private
+
+    def create_school(urn:)
+      school_type = SCHOOL_TYPES.sample
+      school = FactoryBot.create(:school, SCHOOL_TYPES.sample, urn:)
+
+      return school unless %i[eligible state_funded].include?(school_type)
+
+      create_school_partnership(school)
+      school
+    end
+
+    def create_school_partnership(school)
+      lead_provider = LeadProvider.all.sample
+      active_lead_provider = lead_provider.active_lead_providers.sample
+      delivery_partner = FactoryBot.create(:delivery_partner, name: "Delivery Partner - #{active_lead_provider.contract_period_id} - #{SecureRandom.hex(4)}")
+      lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+    end
+  end
+end

--- a/lib/tasks/sandbox_seed_data.rake
+++ b/lib/tasks/sandbox_seed_data.rake
@@ -4,7 +4,8 @@ namespace :sandbox_seed_data do
     seeds = [
       SandboxSeedData::ContractPeriods,
       SandboxSeedData::LeadProviders,
-      SandboxSeedData::Statements
+      SandboxSeedData::Statements,
+      SandboxSeedData::Schools,
     ]
 
     seeds.each do |seed_class|

--- a/lib/tasks/sandbox_seed_data.rake
+++ b/lib/tasks/sandbox_seed_data.rake
@@ -6,6 +6,8 @@ namespace :sandbox_seed_data do
       SandboxSeedData::LeadProviders,
       SandboxSeedData::Statements,
       SandboxSeedData::Schools,
+      SandboxSeedData::DeliveryPartners,
+      SandboxSeedData::SchoolPartnerships,
     ]
 
     seeds.each do |seed_class|

--- a/spec/factories/delivery_partner_factory.rb
+++ b/spec/factories/delivery_partner_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory(:delivery_partner) do
-    sequence(:name) { |n| "Delivery Partner #{n}" }
+    sequence(:name) { |n| "#{Faker::University.name} Delivery Partner #{n}" }
   end
 end

--- a/spec/factories/gias/school_factory.rb
+++ b/spec/factories/gias/school_factory.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     establishment_number { Faker::Number.unique.within(range: 1..9_999) }
     phase_name { "Phase one" }
     urn { Faker::Number.unique.within(range: 10_000..9_999_999) }
-    ukprn { rand(10_000_000..99_999_999).to_s }
+    ukprn { rand(1_000_000..99_999_999).to_s }
 
     # eligibility to be registered in the service
     trait(:eligible_for_registration) do

--- a/spec/factories/gias/school_factory.rb
+++ b/spec/factories/gias/school_factory.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     establishment_number { Faker::Number.unique.within(range: 1..9_999) }
     phase_name { "Phase one" }
     urn { Faker::Number.unique.within(range: 10_000..9_999_999) }
-    ukprn { Faker::Number.unique.number(digits: 5) }
+    ukprn { rand(10_000_000..99_999_999).to_s }
 
     # eligibility to be registered in the service
     trait(:eligible_for_registration) do

--- a/spec/services/sandbox_seed_data/delivery_partners_spec.rb
+++ b/spec/services/sandbox_seed_data/delivery_partners_spec.rb
@@ -15,7 +15,19 @@ RSpec.describe SandboxSeedData::DeliveryPartners do
     it "creates the correct quantity of delivery partners" do
       instance.plant
 
-      expect(DeliveryPartner.all.size).to eq(described_class::NUMBER_OF_RECORDS)
+      expect(DeliveryPartner.all.size).to eq(described_class::NUMBER_OF_RECORDS_PER_LEAD_PROVIDER)
+    end
+
+    it "creates delivery partners and lead providers partnerships" do
+      instance.plant
+
+      expect(LeadProviderDeliveryPartnership.all.size).to eq(described_class::NUMBER_OF_RECORDS_PER_LEAD_PROVIDER)
+    end
+
+    it "creates delivery partners for all lead providers and contract periods" do
+      instance.plant
+
+      expect(LeadProviderDeliveryPartnership.all.map(&:active_lead_provider).uniq).to eq(ActiveLeadProvider.all)
     end
 
     it "logs the creation of delivery partners" do

--- a/spec/services/sandbox_seed_data/delivery_partners_spec.rb
+++ b/spec/services/sandbox_seed_data/delivery_partners_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe SandboxSeedData::Schools do
+RSpec.describe SandboxSeedData::DeliveryPartners do
   let(:instance) { described_class.new }
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
@@ -12,26 +12,26 @@ RSpec.describe SandboxSeedData::Schools do
     let(:contract_period) { FactoryBot.create(:contract_period) }
     let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
 
-    it "creates the correct quantity of schools" do
+    it "creates the correct quantity of delivery partners" do
       instance.plant
 
-      expect(School.all.size).to eq(described_class::NUMBER_OF_RECORDS)
+      expect(DeliveryPartner.all.size).to eq(described_class::NUMBER_OF_RECORDS)
     end
 
-    it "logs the creation of schools" do
+    it "logs the creation of delivery partners" do
       instance.plant
 
       expect(logger).to have_received("level=").with(Logger::INFO)
       expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
 
-      expect(logger).to have_received(:info).with(/Planting schools/).once
-      expect(logger).to have_received(:info).with(/#{School.all.sample.urn}/).at_least(:once)
+      expect(logger).to have_received(:info).with(/Planting delivery partners/).once
+      expect(logger).to have_received(:info).with(/#{DeliveryPartner.all.sample.name}/).at_least(:once)
     end
 
     context "when in the production environment" do
       let(:environment) { "production" }
 
-      it "does not create any schools" do
+      it "does not create any delivery partners" do
         expect { instance.plant }.not_to change(ContractPeriod, :count)
       end
     end

--- a/spec/services/sandbox_seed_data/helpers/school_urn_generator_spec.rb
+++ b/spec/services/sandbox_seed_data/helpers/school_urn_generator_spec.rb
@@ -1,16 +1,9 @@
 RSpec.describe SandboxSeedData::Helpers::SchoolUrnGenerator, type: :helper do
+  before { FactoryBot.create_list(:school, 5) }
+
   describe ".next" do
     it "produces a new unassigned value" do
       expect(::School.pluck(:urn)).not_to include(described_class.next)
-    end
-
-    it "generates 10_000 unallocated TRNs in under a second" do
-      benchmark = Benchmark.measure do
-        10_000.times do
-          described_class.next
-        end
-      end
-      expect(benchmark.total).to be < 1
     end
 
     it "moves the new URN to unavailable" do

--- a/spec/services/sandbox_seed_data/helpers/school_urn_generator_spec.rb
+++ b/spec/services/sandbox_seed_data/helpers/school_urn_generator_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe SandboxSeedData::Helpers::SchoolUrnGenerator, type: :helper do
+  describe ".next" do
+    it "produces a new unassigned value" do
+      expect(::School.pluck(:urn)).not_to include(described_class.next)
+    end
+
+    it "generates 10_000 unallocated TRNs in under a second" do
+      benchmark = Benchmark.measure do
+        10_000.times do
+          described_class.next
+        end
+      end
+      expect(benchmark.total).to be < 1
+    end
+
+    it "moves the new URN to unavailable" do
+      number_of_urns_to_generate = 100
+      before_count = described_class.send(:available).count
+      number_of_urns_to_generate.times do
+        described_class.next
+      end
+      after_count = described_class.send(:available).count
+      expect(before_count - after_count).to eq number_of_urns_to_generate
+    end
+  end
+end

--- a/spec/services/sandbox_seed_data/school_partnerships_spec.rb
+++ b/spec/services/sandbox_seed_data/school_partnerships_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe SandboxSeedData::SchoolPartnerships do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+  end
+
+  describe "#plant" do
+    let(:contract_period) { FactoryBot.create(:contract_period) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+
+    # Ensure there are schools to create partnerships with
+    before do
+      FactoryBot.create_list(:lead_provider_delivery_partnership, 10, active_lead_provider:)
+      FactoryBot.create_list(:school, 100)
+    end
+
+    it "creates the correct quantity of school partnerships" do
+      instance.plant
+
+      expect(SchoolPartnership.all.size).to eq(described_class::NUMBER_OF_RECORDS)
+    end
+
+    it "logs the creation of school partnerships" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting school partnerships/).once
+
+      school_partnership = SchoolPartnership.all.sample
+      expect(logger).to have_received(:info).with(/#{school_partnership.school.urn}/).at_least(:once)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any school partnerships" do
+        expect { instance.plant }.not_to change(ContractPeriod, :count)
+      end
+    end
+  end
+end

--- a/spec/services/sandbox_seed_data/school_partnerships_spec.rb
+++ b/spec/services/sandbox_seed_data/school_partnerships_spec.rb
@@ -14,14 +14,20 @@ RSpec.describe SandboxSeedData::SchoolPartnerships do
 
     # Ensure there are schools to create partnerships with
     before do
-      FactoryBot.create_list(:lead_provider_delivery_partnership, 10, active_lead_provider:)
+      FactoryBot.create_list(:lead_provider_delivery_partnership, 5, active_lead_provider:)
       FactoryBot.create_list(:school, 100)
     end
 
-    it "creates the correct quantity of school partnerships" do
+    it "creates school partnerships for all lead providers" do
       instance.plant
 
-      expect(SchoolPartnership.all.size).to eq(described_class::NUMBER_OF_RECORDS)
+      expect(SchoolPartnership.all.map(&:lead_provider).uniq).to eq(LeadProvider.all)
+    end
+
+    it "creates school partnerships for all contract periods" do
+      instance.plant
+
+      expect(SchoolPartnership.all.map(&:contract_period).uniq).to eq(ContractPeriod.all)
     end
 
     it "logs the creation of school partnerships" do

--- a/spec/services/sandbox_seed_data/schools_spec.rb
+++ b/spec/services/sandbox_seed_data/schools_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe SandboxSeedData::Schools do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+  end
+
+  describe "#plant" do
+    let(:contract_period) { FactoryBot.create(:contract_period) }
+    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+
+    it "creates the correct quantity of schools" do
+      instance.plant
+
+      expect(School.all.size).to eq(described_class::NUMBER_OF_SCHOOLS)
+    end
+
+    it "creates some schools with partnerships" do
+      instance.plant
+
+      expect(School.all.map(&:school_partnerships).flatten).not_to be_empty
+    end
+
+    it "logs the creation of schools" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting schools/).once
+      expect(logger).to have_received(:info).with(/#{School.all.sample.urn}/).at_least(:once)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any schools" do
+        expect { instance.plant }.not_to change(ContractPeriod, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1808

LPs need to be able to view schools on the GET Schools endpoint in sandbox env.

### Changes proposed in this pull request

- Add schools generator to the existing sandbox seeds generator task;
- Some schools will get partnerships created;

### Guidance to review

- Fetch branch locally (`git fetch`)
- Checkout to the branch (`git checkout 1808-add-schools-to-sandbox-seeds`)
- Run rake task:
  - `bundle exec rake sandbox_seed_data:generate`
- Check new schools in admin dashboard