### PR TITLE
Move bulk uploads to appropriate bodies page

### DIFF
--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -42,8 +42,7 @@ module Navigation
         dfe_staff_user: [
           { text: "Teachers", href: admin_teachers_path, active_when: '/admin/teachers' },
           { text: "Organisations", href: admin_organisations_path, active_when: '/admin/organisations' },
-          { text: "Finance", href: admin_finance_path, active_when: '/admin/finance' },
-          { text: "Bulk uploads", href: admin_bulk_batches_path, active_when: '/admin/bulk' },
+          { text: "Finance", href: admin_finance_path, active_when: '/admin/finance' }
         ],
         school_user: [
           { text: "ECTs", href: schools_ects_home_path },

--- a/app/views/admin/appropriate_bodies/index.html.erb
+++ b/app/views/admin/appropriate_bodies/index.html.erb
@@ -2,6 +2,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= govuk_link_to("View all bulk uploads", admin_bulk_batches_path) %>
+    </p>
+
     <%= form_with method: :get do |f| %>
       <%=
         f.govuk_text_field(

--- a/app/views/admin/bulk/batches/index.html.erb
+++ b/app/views/admin/bulk/batches/index.html.erb
@@ -1,7 +1,7 @@
 <%
   page_data(
     title: "Bulk upload batches",
-    backlink_href: admin_teachers_path
+    backlink_href: admin_appropriate_bodies_path
   )
 %>
 

--- a/spec/components/navigation/primary_navigation_component_spec.rb
+++ b/spec/components/navigation/primary_navigation_component_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Navigation::PrimaryNavigationComponent, type: :component do
         expected_items = [
           { text: "Teachers", href: "/admin/teachers" },
           { text: "Organisations", href: "/admin/organisations" },
+          { text: "Finance", href: "/admin/finance" }
         ]
 
         validate_navigation_items(expected_items)

--- a/spec/views/admin/appropriate_bodies/index.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/index.html.erb_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe 'admin/appropriate_bodies/index.html.erb' do
     expect(view.content_for(:backlink_or_breadcrumb)).not_to have_link('Appropriate bodies')
   end
 
+  it "renders a link to view all bulk uploads" do
+    render
+
+    expect(rendered).to have_link("View all bulk uploads", href: admin_bulk_batches_path)
+  end
+
   it 'renders a list of appropriate bodies' do
     render
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2080

### Changes proposed in this pull request

In testing, Admin users could navigate to the bulk uploads page via the service navigation menu.

This was always a temporary decision.

Now we've found a permanent home for it, we can move it!

This moves the link to navigate to bulk uploads to the appropriate bodies page.

### Guidance to review

<img width="1468" height="872" alt="image" src="https://github.com/user-attachments/assets/ef9a8f66-e0c0-46e1-b13f-640e6a2539c1" />

