### PR TITLE
Add `DeliveryPartnerSerializer`

### DIFF
--- a/app/serializers/delivery_partner_serializer.rb
+++ b/app/serializers/delivery_partner_serializer.rb
@@ -1,0 +1,26 @@
+class DeliveryPartnerSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field :name
+    field(:cohort) do |delivery_partner, options|
+      lead_provider = options[:lead_provider]
+
+      delivery_partner
+        .lead_provider_delivery_partnerships
+        .joins(:active_lead_provider)
+        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
+        .pluck("active_lead_providers.contract_period_id")
+    end
+
+    field :created_at
+    field(:api_updated_at, name: :updated_at)
+  end
+
+  identifier :api_id, name: :id
+  field(:type) { "delivery-partner" }
+
+  association :attributes, blueprint: AttributesSerializer do |delivery_partner|
+    delivery_partner
+  end
+end

--- a/spec/serializers/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/delivery_partner_serializer_spec.rb
@@ -1,0 +1,68 @@
+describe DeliveryPartnerSerializer, type: :serializer do
+  subject(:response) do
+    JSON.parse(described_class.render(delivery_partner, lead_provider:))
+  end
+
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+  let(:delivery_partner) { lead_provider_delivery_partnership.delivery_partner }
+
+  describe "core attributes" do
+    it "serializes `id`" do
+      expect(response["id"]).to eq(delivery_partner.api_id)
+    end
+
+    it "serializes `type`" do
+      expect(response["type"]).to eq("delivery-partner")
+    end
+  end
+
+  describe "nested attributes" do
+    subject(:attributes) { response["attributes"] }
+
+    it "serializes `name`" do
+      expect(attributes["name"]).to eq(delivery_partner.name)
+    end
+
+    it "serializes `cohort`" do
+      expect(attributes["cohort"]).to contain_exactly(2024)
+    end
+
+    it "serializes `created_at`" do
+      expect(attributes["created_at"]).to eq(delivery_partner.created_at.utc.rfc3339)
+    end
+
+    it "serializes `updated_at`" do
+      delivery_partner.update!(api_updated_at: 3.days.ago)
+      expect(attributes["updated_at"]).to eq(delivery_partner.api_updated_at.utc.rfc3339)
+    end
+
+    context "when there are delivery partnerships for other lead providers" do
+      before do
+        other_lead_provider = FactoryBot.create(:lead_provider)
+        other_contract_period = FactoryBot.create(:contract_period, year: 2023)
+        active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider: other_lead_provider, contract_period: other_contract_period)
+        FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+      end
+
+      it "does not include other lead provider's cohorts" do
+        expect(attributes["cohort"]).to contain_exactly(2024)
+      end
+    end
+
+    context "when there are multiple delivery partnerships with different contract periods for the same lead provider" do
+      before do
+        # Delivery partnership with a different contract period.
+        other_contract_period = FactoryBot.create(:contract_period, year: 2023)
+        active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: other_contract_period)
+        FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+      end
+
+      it "serializes `cohort` with unique contract periods" do
+        expect(attributes["cohort"]).to contain_exactly(2023, 2024)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to add the `DeliveryPartnerSerializer` so that we can return delivery partners from the appropriate APIs.

### Changes proposed in this pull request

- Add DeliveryPartnerSerializer

Add the delivery partner serializer. We return the `name` of the delivery partner, the `created_at` and `api_updated_at` and the `cohort`, which is retrieved via the `lead_provider_delivery_partnerships`.

### Guidance for review

We do not need to `uniq` the cohorts as there is already a unique index on `active_lead_provider` and `delivery_partner` for `lead_provider_delivery_partnerships` and also on `lead_provider_id` and `contract_period_id` for `active_lead_providers`.
