### PR TITLE
Show future ECTs in the school list

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -18,6 +18,11 @@ module Interval
     scope :overlapping_with, ->(period) { where(*overlapping_with_range(period.started_on, period.finished_on)) }
     scope :containing_period, ->(period) { where(*containing_range(period.started_on, period.finished_on)) }
     scope :ongoing_on, ->(date) { where(*date_in_range(date)) }
+
+    # Date relative scopes
+    scope :ongoing_today, -> { ongoing_on(Time.zone.today) }
+    scope :starting_in_the_future, -> { started_on_or_after(Time.zone.tomorrow) }
+    scope :ongoing_today_or_starting_in_the_future, -> { ongoing_today.or(starting_in_the_future) }
   end
 
   # Validations

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -21,8 +21,8 @@ module Interval
 
     # Date relative scopes
     scope :ongoing_today, -> { ongoing_on(Time.zone.today) }
-    scope :starting_in_the_future, -> { started_on_or_after(Time.zone.tomorrow) }
-    scope :ongoing_today_or_starting_in_the_future, -> { ongoing_today.or(starting_in_the_future) }
+    scope :starting_tomorrow_or_after, -> { started_on_or_after(Time.zone.tomorrow) }
+    scope :ongoing_today_or_starting_tomorrow_or_after, -> { ongoing_today.or(starting_tomorrow_or_after) }
   end
 
   # Validations

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -68,7 +68,7 @@ module Teachers
       @scope.merge!(
         @scope.eager_load(ect_at_school_periods: [:school, { mentorship_periods: { mentor: :teacher } }])
               .where(ect_at_school_periods: { school: })
-              .merge(ECTAtSchoolPeriod.ongoing)
+              .merge(ECTAtSchoolPeriod.ongoing_today_or_starting_in_the_future)
       )
 
       @sort_order = :mentorless_first_then_by_registration_date

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -68,7 +68,7 @@ module Teachers
       @scope.merge!(
         @scope.eager_load(ect_at_school_periods: [:school, { mentorship_periods: { mentor: :teacher } }])
               .where(ect_at_school_periods: { school: })
-              .merge(ECTAtSchoolPeriod.ongoing_today_or_starting_in_the_future)
+              .merge(ECTAtSchoolPeriod.ongoing_today_or_starting_tomorrow_or_after)
       )
 
       @sort_order = :mentorless_first_then_by_registration_date

--- a/db/seeds/lead_provider_delivery_partnerships.rb
+++ b/db/seeds/lead_provider_delivery_partnerships.rb
@@ -16,6 +16,8 @@ ambitious_institute_2023 = active_lead_providers.fetch([ambitious_institute, 202
 ambitious_institute_2024 = active_lead_providers.fetch([ambitious_institute, 2024])
 teach_fast_2022 = active_lead_providers.fetch([teach_fast, 2022])
 teach_fast_2023 = active_lead_providers.fetch([teach_fast, 2023])
+teach_fast_2024 = active_lead_providers.fetch([teach_fast, 2024])
+teach_fast_2025 = active_lead_providers.fetch([teach_fast, 2025])
 better_practice_network_2023 = active_lead_providers.fetch([better_practice_network, 2023])
 better_practice_network_2024 = active_lead_providers.fetch([better_practice_network, 2024])
 
@@ -29,6 +31,8 @@ rising_minds = DeliveryPartner.find_by!(name: "Rising Minds Network")
   { active_lead_provider: ambitious_institute_2024, delivery_partner: artisan },
   { active_lead_provider: teach_fast_2022, delivery_partner: grain },
   { active_lead_provider: teach_fast_2023, delivery_partner: grain },
+  { active_lead_provider: teach_fast_2024, delivery_partner: grain },
+  { active_lead_provider: teach_fast_2025, delivery_partner: grain },
   { active_lead_provider: better_practice_network_2023, delivery_partner: rising_minds },
   { active_lead_provider: better_practice_network_2024, delivery_partner: rising_minds }
 ].each do |data|

--- a/db/seeds/school_partnerships.rb
+++ b/db/seeds/school_partnerships.rb
@@ -26,6 +26,7 @@ brookfield_school = School.find_by!(urn: 2_976_163)
 
 rp2022 = ContractPeriod.find_by(year: 2022)
 rp2023 = ContractPeriod.find_by(year: 2023)
+rp2025 = ContractPeriod.find_by(year: 2025)
 
 ambitious_institute = LeadProvider.find_by!(name: 'Ambitious Institute')
 teach_fast = LeadProvider.find_by!(name: 'Teach Fast')
@@ -37,10 +38,12 @@ ambitious_institute__artisan__2022 = find_lead_provider_delivery_partnership(del
 ambitious_institute__artisan__2023 = find_lead_provider_delivery_partnership(delivery_partner: artisan, lead_provider: ambitious_institute, contract_period: rp2023)
 teach_fast__grain__2022 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_fast, contract_period: rp2022)
 teach_fast__grain__2023 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_fast, contract_period: rp2023)
+teach_fast__grain__2025 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_fast, contract_period: rp2025)
 [
   { school: abbey_grove_school, lead_provider_delivery_partnership: ambitious_institute__artisan__2022 },
   { school: abbey_grove_school, lead_provider_delivery_partnership: ambitious_institute__artisan__2023 },
   { school: abbey_grove_school, lead_provider_delivery_partnership: teach_fast__grain__2023 },
+  { school: abbey_grove_school, lead_provider_delivery_partnership: teach_fast__grain__2025 },
   { school: ackley_bridge, lead_provider_delivery_partnership: ambitious_institute__artisan__2023 },
   { school: mallory_towers, lead_provider_delivery_partnership: teach_fast__grain__2022 },
   { school: brookfield_school, lead_provider_delivery_partnership: teach_fast__grain__2022 },

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -15,7 +15,7 @@ def describe_period_duration(period)
   case
   when period.started_on.future?
     "from #{period.started_on}"
-  when period.finished_on.present?
+  when period.finished_on
     "between #{period.started_on} and #{period.finished_on}"
   else
     "since #{period.started_on}"

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -12,7 +12,14 @@ def teacher_name(teacher)
 end
 
 def describe_period_duration(period)
-  period.finished_on ? "between #{period.started_on} and #{period.finished_on}" : "since #{period.started_on}"
+  case
+  when period.started_on.future?
+    "from #{period.started_on}"
+  when period.finished_on.present?
+    "between #{period.started_on} and #{period.finished_on}"
+  else
+    "since #{period.started_on}"
+  end
 end
 
 def describe_mentorship_period(mp)
@@ -70,7 +77,9 @@ def describe_training_period(tp)
     lead_provider_name = lpdp.active_lead_provider.lead_provider.name
     delivery_partner_name = lpdp.delivery_partner.name
 
-    print_seed_info("* was trained by #{lead_provider_name} (LP) and #{delivery_partner_name} #{describe_period_duration(tp)} #{suffix}", indent: 4)
+    prefix = (tp.started_on.future?) ? 'will be' : 'was'
+
+    print_seed_info("* #{prefix} trained by #{lead_provider_name} (LP) and #{delivery_partner_name} #{describe_period_duration(tp)} #{suffix}", indent: 4)
   else
     lead_provider_name = tp.expression_of_interest.lead_provider.name
 
@@ -115,12 +124,15 @@ def find_school_partnership(delivery_partner:, lead_provider:, contract_period:)
     )
 end
 
-rp_2022 = ContractPeriod.find_by(year: 2022)
-rp_2023 = ContractPeriod.find_by(year: 2023)
+cp_2022 = ContractPeriod.find_by(year: 2022)
+cp_2023 = ContractPeriod.find_by(year: 2023)
+_cp_2024 = ContractPeriod.find_by(year: 2024)
+cp_2025 = ContractPeriod.find_by(year: 2025)
 
-ambitious_artisan_2022 = ActiveLeadProvider.find_by!(contract_period: rp_2022, lead_provider: ambitious_institute)
-ambitious_artisan_2023 = ActiveLeadProvider.find_by!(contract_period: rp_2023, lead_provider: ambitious_institute)
-teach_fast_grain_2022 = ActiveLeadProvider.find_by!(contract_period: rp_2022, lead_provider: teach_fast)
+ambitious_artisan_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: ambitious_institute)
+ambitious_artisan_2023 = ActiveLeadProvider.find_by!(contract_period: cp_2023, lead_provider: ambitious_institute)
+teach_fast_grain_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: teach_fast)
+teach_fast_grain_2025 = ActiveLeadProvider.find_by!(contract_period: cp_2025, lead_provider: teach_fast)
 
 ambitious_artisan_partnership_2022 = find_school_partnership(
   lead_provider: ambitious_institute,
@@ -134,6 +146,11 @@ ambitious_artisan_partnership_2023 = find_school_partnership(
 )
 teach_fast_grain_partnership_2022 = find_school_partnership(
   contract_period: ContractPeriod.find_by!(year: 2022),
+  lead_provider: teach_fast,
+  delivery_partner: grain_teaching_school_hub
+)
+teach_fast_grain_partnership_2025 = find_school_partnership(
+  contract_period: ContractPeriod.find_by!(year: 2025),
   lead_provider: teach_fast,
   delivery_partner: grain_teaching_school_hub
 )
@@ -602,6 +619,26 @@ TrainingPeriod.create!(
   started_on: 18.months.ago,
   expression_of_interest: ambitious_artisan_2023,
   training_programme: 'provider_led'
+).tap { |tp| describe_training_period(tp) }
+
+print_seed_info("Peter Davison (ECT)", indent: 2, colour: ECT_COLOUR)
+
+peter_davison = Teacher.find_by!(trs_first_name: 'Peter', trs_last_name: 'Davison')
+peter_davison_at_abbey_grove_school = ECTAtSchoolPeriod.create!(
+  teacher: peter_davison,
+  school: abbey_grove_school,
+  email: 'pd@tardis.bbc',
+  started_on: 2.weeks.from_now,
+  school_reported_appropriate_body: south_yorkshire_studio_hub,
+  training_programme: 'provider_led'
+).tap { |sp| describe_ect_at_school_period(sp) }
+
+TrainingPeriod.create!(
+  ect_at_school_period: peter_davison_at_abbey_grove_school,
+  started_on: 2.weeks.from_now,
+  school_partnership: teach_fast_grain_partnership_2025,
+  training_programme: 'provider_led',
+  expression_of_interest: teach_fast_grain_2025
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Adding mentorships:")

--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -31,6 +31,7 @@ teachers = [
   { trs_first_name: 'John', trs_last_name: 'Withers', corrected_name: 'Old Man Withers', trn: '8590123', trs_induction_status: 'Failed' },
   { trs_first_name: 'Helen', trs_last_name: 'Mirren', corrected_name: 'Dame Helen Mirren', trn: '0000007', trs_induction_status: 'Passed' },
   { trs_first_name: 'Dominic', trs_last_name: 'West', trn: '9292929', trs_induction_status: 'InProgress' },
+  { trs_first_name: 'Peter', trs_last_name: 'Davison', trn: '0011223', trs_induction_status: 'RequiredToComplete' },
   { trs_first_name: 'Robson', trs_last_name: 'Scottie', trn: '3002582', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Muhammed', trs_last_name: 'Ali', trn: '3002580', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Roy', trs_last_name: 'Dotrice', trn: '7000007', **early_roll_out_mentor_attrs }

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -12,6 +12,16 @@ FactoryBot.define do
     email { Faker::Internet.email }
     working_pattern { WORKING_PATTERNS.keys.sample }
 
+    trait :future do
+      started_on { 2.weeks.from_now }
+      finished_on { nil }
+    end
+
+    trait :past do
+      started_on { 1.year.ago }
+      finished_on { 2.weeks.ago }
+    end
+
     trait :active do
       started_on { generate(:base_ect_date) + 1.year }
       finished_on { nil }

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -12,12 +12,12 @@ FactoryBot.define do
     email { Faker::Internet.email }
     working_pattern { WORKING_PATTERNS.keys.sample }
 
-    trait :future do
+    trait :not_started_yet do
       started_on { 2.weeks.from_now }
       finished_on { nil }
     end
 
-    trait :past do
+    trait :finished do
       started_on { 1.year.ago }
       finished_on { 2.weeks.ago }
     end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -103,22 +103,22 @@ describe Interval do
       end
     end
 
-    describe '.starting_in_the_future' do
+    describe '.starting_tomorrow_or_after' do
       it 'queries for start dates on or after tomorrow' do
         tomorrow = Time.zone.tomorrow.to_s
-        expect(DummyMentor.starting_in_the_future.to_sql).to end_with(%("started_on" >= '#{tomorrow}'))
+        expect(DummyMentor.starting_tomorrow_or_after.to_sql).to end_with(%("started_on" >= '#{tomorrow}'))
       end
     end
 
-    describe '.ongoing_today_or_starting_in_the_future' do
-      it 'chains together .ongoing_today and .starting_in_the_future' do
+    describe '.ongoing_today_or_starting_tomorrow_or_after' do
+      it 'chains together .ongoing_today and .starting_tomorrow_or_after' do
         allow(DummyMentor).to receive(:ongoing_today).and_call_original
-        allow(DummyMentor).to receive(:starting_in_the_future).and_call_original
+        allow(DummyMentor).to receive(:starting_tomorrow_or_after).and_call_original
 
-        DummyMentor.ongoing_today_or_starting_in_the_future
+        DummyMentor.ongoing_today_or_starting_tomorrow_or_after
 
         expect(DummyMentor).to have_received(:ongoing_today).once
-        expect(DummyMentor).to have_received(:starting_in_the_future).once
+        expect(DummyMentor).to have_received(:starting_tomorrow_or_after).once
       end
     end
   end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -95,6 +95,32 @@ describe Interval do
         expect(DummyMentor.finished_on_or_after(Date.yesterday).to_sql).to end_with(%("finished_on" >= '#{Date.yesterday.iso8601}'))
       end
     end
+
+    describe '.ongoing_today' do
+      it 'queries for dates within the range field' do
+        today = Time.zone.today.to_s
+        expect(DummyMentor.ongoing_today.to_sql).to end_with(%{"range" @> date('#{today}'))})
+      end
+    end
+
+    describe '.starting_in_the_future' do
+      it 'queries for start dates on or after tomorrow' do
+        tomorrow = Time.zone.tomorrow.to_s
+        expect(DummyMentor.starting_in_the_future.to_sql).to end_with(%("started_on" >= '#{tomorrow}'))
+      end
+    end
+
+    describe '.ongoing_today_or_starting_in_the_future' do
+      it 'chains together .ongoing_today and .starting_in_the_future' do
+        allow(DummyMentor).to receive(:ongoing_today).and_call_original
+        allow(DummyMentor).to receive(:starting_in_the_future).and_call_original
+
+        DummyMentor.ongoing_today_or_starting_in_the_future
+
+        expect(DummyMentor).to have_received(:ongoing_today).once
+        expect(DummyMentor).to have_received(:starting_in_the_future).once
+      end
+    end
   end
 
   describe "#finish!" do

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -229,7 +229,7 @@ describe Teachers::Search do
           let(:school) { FactoryBot.create(:school) }
 
           context 'when ECT has left the school' do
-            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :past, school:, teacher:) }
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :finished, school:, teacher:) }
 
             it 'returns no teachers' do
               expect(Teachers::Search.new(ect_at_school: school).search).to be_empty
@@ -245,7 +245,7 @@ describe Teachers::Search do
           end
 
           context 'when ECT is scheduled to join the school' do
-            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :future, school:, teacher:) }
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :not_started_yet, school:, teacher:) }
 
             it 'returns the teacher' do
               expect(Teachers::Search.new(ect_at_school: school).search).to include(teacher)

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -224,10 +224,33 @@ describe Teachers::Search do
           expect(query.to_sql).to include(%("ect_at_school_periods"."school_id" = 123))
         end
 
-        it 'only selects ongoing ECT at school periods' do
-          query = Teachers::Search.new(ect_at_school: 123).search
+        describe 'current and future teachers' do
+          let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'John', trs_last_name: 'Connor') }
+          let(:school) { FactoryBot.create(:school) }
 
-          expect(query.to_sql).to include(%("ect_at_school_periods"."finished_on" IS NULL))
+          context 'when ECT has left the school' do
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :past, school:, teacher:) }
+
+            it 'returns no teachers' do
+              expect(Teachers::Search.new(ect_at_school: school).search).to be_empty
+            end
+          end
+
+          context 'when currently an ECT at the school' do
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, school:, teacher:) }
+
+            it 'returns the teacher' do
+              expect(Teachers::Search.new(ect_at_school: school).search).to include(teacher)
+            end
+          end
+
+          context 'when ECT is scheduled to join the school' do
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :future, school:, teacher:) }
+
+            it 'returns the teacher' do
+              expect(Teachers::Search.new(ect_at_school: school).search).to include(teacher)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
### Context

Update the schools ECT index so future joiners are listed too.

To support this there are a few new scopes that are relative to the current date, and a new person in the seed data who has a future joining date so we can see how things look in review apps.

### Changes proposed in this pull request

* Add new scopes so we can search for current **or** future teachers
* Update `Teachers::Search#ect_at_school` so it searches for `ECTAtSchoolPeriod` records that are either currently ongoing or start in the future
* Add seed data so this kind of teacher can be previewed

### Preview

| Searching for teacher who hasn't started yet | Seed data with appropriate description |
| ------ | ------ |
| <img width="1033" height="511" alt="image" src="https://github.com/user-attachments/assets/17647657-17e9-479b-b0e7-20dbeff0f846" /> | <img width="912" height="84" alt="image" src="https://github.com/user-attachments/assets/3d8d82e1-c421-470d-b917-04faa843f187" /> |

### Guidance to review

Log in with Bob Belcher (Abbey Grove School) and you should see Peter Davison at the top of the list. He's from the future.


### Related work

DFE-Digital/register-ects-project-board#2013 (this work supports that)
DFE-Digital/register-ects-project-board#1513 (this work will solve some of it)
