### PR TITLE
[SPIKE][2021] Add db view in order to join schools, lead_providers and contract_periods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "govuk_markdown"
 
 gem "mail-notify"
 
+gem "scenic"
 gem "sentry-rails"
 gem "sentry-ruby"
 gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,6 +702,9 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (>= 3.7, < 6)
+    scenic (1.9.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     securerandom (0.4.1)
     sentry-rails (5.26.0)
       railties (>= 5.0)
@@ -863,6 +866,7 @@ DEPENDENCIES
   rubypants
   rubyzip
   savon
+  scenic
   sentry-rails
   sentry-ruby
   shoulda-matchers

--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -4,14 +4,26 @@ module API
       filter_validation required_filters: %i[cohort]
 
       def index
-        render json: to_json(paginate(schools_query.schools))
+        render json: to_json(schools)
       end
 
       def show
-        render json: to_json(schools_query.school_by_api_id(api_id))
+        render json: to_json(school)
       end
 
     private
+
+      def paginated_results
+        paginate(schools_query.schools_for_pagination)
+      end
+
+      def schools
+        @schools ||= schools_query.schools_from(paginated_results)
+      end
+
+      def school
+        @school ||= schools_query.school_by_api_id(api_id)
+      end
 
       def schools_query
         conditions = {

--- a/app/models/concerns/gias_helpers.rb
+++ b/app/models/concerns/gias_helpers.rb
@@ -2,7 +2,7 @@ module GIASHelpers
   extend ActiveSupport::Concern
 
   included do
-    scope :in_gias_schools, -> { includes(:gias_school).references(:gias_schools) }
+    scope :in_gias_schools, -> { joins(:gias_school) }
     scope :eligible, -> { in_gias_schools.where(gias_school: { funding_eligibility: :eligible_for_fip }) }
     scope :cip_only, -> { in_gias_schools.where(gias_school: { funding_eligibility: :eligible_for_cip }) }
     scope :not_cip_only, -> { where.not(id: cip_only) }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -23,6 +23,7 @@ class School < ApplicationRecord
   has_many :mentor_at_school_periods, inverse_of: :school
   has_many :mentor_teachers, -> { distinct }, through: :mentor_at_school_periods, source: :teacher
   has_many :school_partnerships
+  has_many :lead_provider_contract_periods, class_name: "SchoolLeadProviderContractPeriod"
 
   # Validations
   validates :last_chosen_lead_provider_id,

--- a/app/models/school_lead_provider_contract_period.rb
+++ b/app/models/school_lead_provider_contract_period.rb
@@ -1,0 +1,30 @@
+class SchoolLeadProviderContractPeriod < ApplicationRecord
+  self.primary_key = :school_id, :lead_provider_id, :contract_period_id
+  self.table_name = :schools_lead_providers_contract_periods
+
+  enum :training_programme, {
+    not_yet_known: "not_yet_known",
+    provider_led: "provider_led",
+    school_led: "school_led"
+  }
+
+  belongs_to :school
+  belongs_to :lead_provider
+  belongs_to :contract_period
+
+  validates :school, presence: true
+  validates :lead_provider, presence: true
+  validates :contract_period, presence: true
+  validates :in_partnership, inclusion: { in: [true, false] }
+  validates :expression_of_interest, inclusion: { in: [true, false] }
+  validates :training_programme, inclusion: { in: training_programmes.keys }
+
+  scope :for_lead_provider_contract_period, ->(lead_provider_id, contract_period_id) {
+    where(lead_provider_id:,
+          contract_period_id:)
+  }
+
+  def readonly?
+    true
+  end
+end

--- a/app/serializers/school_serializer.rb
+++ b/app/serializers/school_serializer.rb
@@ -11,7 +11,7 @@ class SchoolSerializer < Blueprinter::Base
       in_partnership?(school, options)
     end
     field(:induction_programme_choice) do |school, options|
-      school.training_programme_for(school_contrat_period_id(school, options))
+      training_programme_for(school, options)
     end
     field(:expression_of_interest) do |school, options|
       expressions_of_interest?(school, options)
@@ -28,20 +28,24 @@ class SchoolSerializer < Blueprinter::Base
         end
       end
 
+      def training_programme_for(school, options)
+        if school.respond_to?(:transient_lead_provider_contract_period)
+          school.transient_lead_provider_contract_period[1]
+        else
+          school.training_programme_for(options[:contract_period_id].to_s)
+        end
+      end
+
       def in_partnership?(school, options)
-        if school.respond_to?(:transient_in_partnership)
-          school.transient_in_partnership
+        if school.respond_to?(:transient_lead_provider_contract_period)
+          school.transient_lead_provider_contract_period[0]
         else
           school.school_partnerships.for_contract_period(options[:contract_period_id]).exists?
         end
       end
 
       def expressions_of_interest?(school, options)
-        if school.respond_to?(:transient_expression_of_interest_ects) &&
-            school.respond_to?(:transient_expression_of_interest_mentors)
-          return school.transient_expression_of_interest_ects ||
-              school.transient_expression_of_interest_mentors
-        end
+        return school.transient_lead_provider_contract_period[2] if school.respond_to?(:transient_lead_provider_contract_period)
 
         school.ect_at_school_periods.with_expressions_of_interest_for_lead_provider_and_contract_period(options[:contract_period_id], options[:lead_provider_id]).exists? ||
           school.mentor_at_school_periods.with_expressions_of_interest_for_lead_provider_and_contract_period(options[:contract_period_id], options[:lead_provider_id]).exists?

--- a/app/services/schools/query.rb
+++ b/app/services/schools/query.rb
@@ -7,13 +7,9 @@ module Schools
     attr_reader :scope, :sort
 
     def initialize(lead_provider_id: :ignore, urn: :ignore, updated_since: :ignore, contract_period_id: :ignore, sort: nil)
-      @scope = default_scope(contract_period_id).select(
+      @scope = default_scope(contract_period_id, lead_provider_id).select(
         "schools.*",
-        transient_in_partnership(contract_period_id),
-        transient_mentors_at_school(contract_period_id),
-        transient_ects_at_school_training_programme(contract_period_id),
-        transient_expression_of_interest_ects(lead_provider_id, contract_period_id),
-        transient_expression_of_interest_mentors(lead_provider_id, contract_period_id),
+        transient_lead_provider_contract_period(contract_period_id, lead_provider_id),
         "'#{contract_period_id}' AS transient_contract_period_id",
         "'#{lead_provider_id}' AS transient_lead_provider_id"
       ).or(schools_with_existing_partnerships(contract_period_id))
@@ -43,10 +39,22 @@ module Schools
 
   private
 
+    def transient_lead_provider_contract_period(contract_period_id, lead_provider_id)
+      <<~SQL
+        (
+          SELECT ARRAY[slpcp.in_partnership::text, slpcp.training_programme::text, slpcp.expression_of_interest::text] AS transient_lead_provider_contract_period
+          FROM schools_lead_providers_contract_periods slpcp
+          WHERE slpcp.school_id = schools.id
+          AND slpcp.contract_period_id = #{contract_period_id}
+          AND slpcp.lead_provider_id = #{lead_provider_id}
+        )
+      SQL
+    end
+
     def schools_with_existing_partnerships(contract_period_id)
       School.where(id: School.select("schools.id")
-        .joins(school_partnerships: { lead_provider_delivery_partnership: { active_lead_provider: :contract_period } })
-        .where(contract_periods: { year: contract_period_id }))
+         .joins(:lead_provider_contract_periods)
+         .where(lead_provider_contract_periods: { contract_period_id:, in_partnership: true }))
     end
 
     def where_urn_is(urn)
@@ -61,91 +69,7 @@ module Schools
       scope.merge!(School.where(updated_at: updated_since..))
     end
 
-    def transient_in_partnership(contract_period_id)
-      "EXISTS(
-        #{
-          School.select('1 AS one').from('schools s')
-          .joins(school_partnerships: { lead_provider_delivery_partnership: { active_lead_provider: :contract_period } })
-          .where(contract_periods: { year: contract_period_id })
-          .where('schools.id = s.id')
-          .limit(1)
-          .to_sql
-        }
-      ) AS transient_in_partnership"
-    end
-
-    def transient_mentors_at_school(contract_period_id)
-      return School.none if ignore?(filter: contract_period_id) || contract_period_id.blank?
-
-      "EXISTS(
-        #{
-          School.select('1 AS one').from('schools s')
-          .left_joins(mentor_at_school_periods: { training_periods: { expression_of_interest: :contract_period } })
-          .left_joins(mentor_at_school_periods: { training_periods: { active_lead_provider: :contract_period } })
-          .where('contract_periods.year = ? OR contract_periods_active_lead_providers.year = ?', contract_period_id, contract_period_id)
-          .where('schools.id = s.id')
-          .limit(1)
-          .to_sql
-        }
-      ) AS transient_mentors_at_school"
-    end
-
-    def transient_ects_at_school_training_programme(contract_period_id)
-      return School.none if ignore?(filter: contract_period_id) || contract_period_id.blank?
-
-      "(
-        #{
-          School.distinct.select('training_periods.training_programme').from('schools s')
-          .left_joins(ect_at_school_periods: { training_periods: { expression_of_interest: :contract_period } })
-          .left_joins(ect_at_school_periods: { training_periods: { active_lead_provider: :contract_period } })
-          .where('contract_periods.year = ? OR contract_periods_active_lead_providers.year = ?', contract_period_id, contract_period_id)
-          .where('schools.id = s.id')
-          .order(training_programme: :asc)
-          .limit(1)
-          .to_sql
-        }
-      ) AS transient_ects_at_school_training_programme"
-    end
-
-    def transient_expression_of_interest_ects(lead_provider_id, contract_period_id)
-      return School.none if ignore?(filter: lead_provider_id) ||
-        lead_provider_id.blank? ||
-        ignore?(filter: contract_period_id) ||
-        contract_period_id.blank?
-
-      "EXISTS(
-        #{
-          School.select('1 AS one').from('schools s')
-          .joins(ect_at_school_periods: { training_periods: { expression_of_interest: :contract_period } })
-          .where(contract_periods: { year: contract_period_id })
-          .where(expression_of_interest: { lead_provider_id: })
-          .where('schools.id = s.id')
-          .limit(1)
-          .to_sql
-        }
-      ) AS transient_expression_of_interest_ects"
-    end
-
-    def transient_expression_of_interest_mentors(lead_provider_id, contract_period_id)
-      return School.none if ignore?(filter: lead_provider_id) ||
-        lead_provider_id.blank? ||
-        ignore?(filter: contract_period_id) ||
-        contract_period_id.blank?
-
-      "EXISTS(
-        #{
-          School.select('1 AS one').from('schools s')
-          .joins(mentor_at_school_periods: { training_periods: { expression_of_interest: :contract_period } })
-          .where(contract_periods: { year: contract_period_id })
-          .where(expression_of_interest: { lead_provider_id: })
-          .where('schools.id = s.id')
-          .limit(1)
-          .to_sql
-        }
-      ) AS transient_expression_of_interest_mentors"
-    end
-
-    def default_scope(contract_period_id)
+    def default_scope(contract_period_id, lead_provider_id)
       return School.none if ignore?(filter: contract_period_id) ||
         contract_period_id.blank? ||
         ContractPeriod.find_by(year: contract_period_id).blank?
@@ -153,7 +77,7 @@ module Schools
       School
         .eligible
         .not_cip_only
-        .eager_load(:gias_school)
+        .eager_load(:gias_school, :lead_provider_contract_periods)
     end
 
     def order_by

--- a/app/services/schools/query.rb
+++ b/app/services/schools/query.rb
@@ -4,57 +4,63 @@ module Schools
     include FilterIgnorable
     include QueryOrderable
 
-    attr_reader :scope, :sort
+    attr_reader :sort, :contract_period_id, :urn, :updated_since, :lead_provider_id, :scope
 
     def initialize(lead_provider_id: :ignore, urn: :ignore, updated_since: :ignore, contract_period_id: :ignore, sort: nil)
-      @scope = default_scope(contract_period_id, lead_provider_id).select(
-        "schools.*",
-        transient_lead_provider_contract_period(contract_period_id, lead_provider_id),
-        "'#{contract_period_id}' AS transient_contract_period_id",
-        "'#{lead_provider_id}' AS transient_lead_provider_id"
-      ).or(schools_with_existing_partnerships(contract_period_id))
-        .distinct
-
+      @lead_provider_id = lead_provider_id
+      @contract_period_id = contract_period_id
       @sort = sort
-
-      where_urn_is(urn)
-      where_updated_since(updated_since)
+      @urn = urn
+      @updated_since = updated_since
+      @scope = default_scope(contract_period_id)
+               .or(schools_with_existing_partnerships(contract_period_id))
+               .distinct
     end
 
-    def schools
-      scope.order(order_by)
+    def schools_for_pagination
+      where_urn_is(urn)
+      where_updated_since(updated_since)
+
+      scope
+      .select("schools.id", "schools.urn", "schools.created_at", "schools.updated_at")
+      .order(order_by)
+    end
+
+    def schools_from(paginated_join)
+      School.select(*select_fields)
+      .where(schools: { id: paginated_join.map(&:id) })
+      .eager_load(:gias_school)
+      .order(order_by)
+      .distinct
     end
 
     def school_by_api_id(api_id)
-      return scope.find_by!(gias_school: { api_id: }) if api_id.present?
+      return scope.select(*select_fields).find_by!(gias_school: { api_id: }) if api_id.present?
 
       fail(ArgumentError, "api_id needed")
     end
 
     def school(id)
-      return scope.find(id) if id.present?
+      return scope.select(*select_fields).find(id) if id.present?
 
       fail(ArgumentError, "id needed")
     end
 
   private
 
-    def transient_lead_provider_contract_period(contract_period_id, lead_provider_id)
-      <<~SQL
-        (
-          SELECT ARRAY[slpcp.in_partnership::text, slpcp.training_programme::text, slpcp.expression_of_interest::text] AS transient_lead_provider_contract_period
-          FROM schools_lead_providers_contract_periods slpcp
-          WHERE slpcp.school_id = schools.id
-          AND slpcp.contract_period_id = #{contract_period_id}
-          AND slpcp.lead_provider_id = #{lead_provider_id}
-        )
-      SQL
+    def select_fields
+      [
+        "schools.*",
+        transient_lead_provider_contract_period(contract_period_id, lead_provider_id),
+        "'#{contract_period_id}' AS transient_contract_period_id",
+        "'#{lead_provider_id}' AS transient_lead_provider_id"
+      ]
     end
 
     def schools_with_existing_partnerships(contract_period_id)
       School.where(id: School.select("schools.id")
-         .joins(:lead_provider_contract_periods)
-         .where(lead_provider_contract_periods: { contract_period_id:, in_partnership: true }))
+        .joins(school_partnerships: { lead_provider_delivery_partnership: { active_lead_provider: :contract_period } })
+        .where(contract_periods: { year: contract_period_id }))
     end
 
     def where_urn_is(urn)
@@ -69,7 +75,19 @@ module Schools
       scope.merge!(School.where(updated_at: updated_since..))
     end
 
-    def default_scope(contract_period_id, lead_provider_id)
+    def transient_lead_provider_contract_period(contract_period_id, lead_provider_id)
+      <<~SQL
+        (
+          SELECT ARRAY[slpcp.in_partnership::text, slpcp.training_programme::text, slpcp.expression_of_interest::text] AS transient_lead_provider_contract_period
+          FROM schools_lead_providers_contract_periods slpcp
+          WHERE slpcp.school_id = schools.id
+          AND slpcp.contract_period_id = #{contract_period_id}
+          AND slpcp.lead_provider_id = #{lead_provider_id}
+        )
+      SQL
+    end
+
+    def default_scope(contract_period_id)
       return School.none if ignore?(filter: contract_period_id) ||
         contract_period_id.blank? ||
         ContractPeriod.find_by(year: contract_period_id).blank?
@@ -77,7 +95,6 @@ module Schools
       School
         .eligible
         .not_cip_only
-        .eager_load(:gias_school, :lead_provider_contract_periods)
     end
 
     def order_by

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -477,3 +477,10 @@
   - options
   - created_at
   - updated_at
+  :schools_lead_providers_contract_periods:
+  - school_id
+  - lead_provider_id
+  - contract_period_id
+  - in_partnership
+  - training_programme
+  - expression_of_interest

--- a/db/migrate/20250728100512_create_schools_lead_providers_contract_periods.rb
+++ b/db/migrate/20250728100512_create_schools_lead_providers_contract_periods.rb
@@ -1,0 +1,5 @@
+class CreateSchoolsLeadProvidersContractPeriods < ActiveRecord::Migration[8.0]
+  def change
+    create_view :schools_lead_providers_contract_periods
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -791,7 +791,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
                JOIN lead_provider_delivery_partnerships lpd ON ((sp.lead_provider_delivery_partnership_id = lpd.id)))
                JOIN active_lead_providers alp ON ((lpd.active_lead_provider_id = alp.id)))
                JOIN contract_periods cp ON ((alp.contract_period_id = cp.year)))
-            WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year) AND (alp.lead_provider_id = lead_providers.id))
+            WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year))
            LIMIT 1)) AS in_partnership,
           CASE
               WHEN (EXISTS ( SELECT 1
@@ -802,7 +802,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
                    JOIN lead_provider_delivery_partnerships lpd ON ((sp.lead_provider_delivery_partnership_id = lpd.id)))
                    JOIN active_lead_providers alp ON ((lpd.active_lead_provider_id = alp.id)))
                    JOIN contract_periods cp ON ((alp.contract_period_id = cp.year)))
-                WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year) AND (alp.lead_provider_id = lead_providers.id))
+                WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year))
                LIMIT 1)) THEN 'provider_led'::text
               WHEN (EXISTS ( SELECT 1
                  FROM ((((((schools s
@@ -812,7 +812,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
                    JOIN lead_provider_delivery_partnerships lpd ON ((sp.lead_provider_delivery_partnership_id = lpd.id)))
                    JOIN active_lead_providers alp ON ((lpd.active_lead_provider_id = alp.id)))
                    JOIN contract_periods cp ON ((alp.contract_period_id = cp.year)))
-                WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year) AND (alp.lead_provider_id = lead_providers.id))
+                WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year))
                LIMIT 1)) THEN
               CASE
                   WHEN (( SELECT DISTINCT tp.training_programme
@@ -823,7 +823,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
                        JOIN lead_provider_delivery_partnerships lpd ON ((sp.lead_provider_delivery_partnership_id = lpd.id)))
                        JOIN active_lead_providers alp ON ((lpd.active_lead_provider_id = alp.id)))
                        JOIN contract_periods cp ON ((alp.contract_period_id = cp.year)))
-                    WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year) AND (alp.lead_provider_id = lead_providers.id))
+                    WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year))
                     ORDER BY tp.training_programme
                    LIMIT 1) = 'provider_led'::training_programme) THEN 'provider_led'::text
                   WHEN (( SELECT DISTINCT tp.training_programme
@@ -834,7 +834,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
                        JOIN lead_provider_delivery_partnerships lpd ON ((sp.lead_provider_delivery_partnership_id = lpd.id)))
                        JOIN active_lead_providers alp ON ((lpd.active_lead_provider_id = alp.id)))
                        JOIN contract_periods cp ON ((alp.contract_period_id = cp.year)))
-                    WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year) AND (alp.lead_provider_id = lead_providers.id))
+                    WHERE ((schools.id = s.id) AND (cp.year = contract_periods.year))
                     ORDER BY tp.training_programme
                    LIMIT 1) = 'school_led'::training_programme) THEN 'school_led'::text
                   ELSE NULL::text

--- a/db/views/schools_lead_providers_contract_periods_v01.sql
+++ b/db/views/schools_lead_providers_contract_periods_v01.sql
@@ -1,0 +1,116 @@
+SELECT
+    schools.id AS school_id,
+    lead_providers.id AS lead_provider_id,
+    contract_periods.year AS contract_period_id,
+    -- in_partnership
+    EXISTS (
+        SELECT 1
+        FROM schools s
+        INNER JOIN school_partnerships sp ON s.id = sp.school_id
+        INNER JOIN lead_provider_delivery_partnerships lpd ON sp.lead_provider_delivery_partnership_id = lpd.id
+        INNER JOIN active_lead_providers alp ON lpd.active_lead_provider_id = alp.id
+        INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+        WHERE schools.id = s.id
+          AND cp.year = contract_periods.year
+          AND alp.lead_provider_id = lead_providers.id
+        LIMIT 1
+    ) AS in_partnership,
+    -- training_programme
+    CASE
+      WHEN EXISTS (
+        SELECT 1
+        FROM schools s
+        INNER JOIN mentor_at_school_periods masp ON s.id = masp.school_id
+        INNER JOIN training_periods tp ON masp.id = tp.mentor_at_school_period_id
+        INNER JOIN school_partnerships sp ON tp.school_partnership_id = sp.id
+        INNER JOIN lead_provider_delivery_partnerships lpd ON sp.lead_provider_delivery_partnership_id = lpd.id
+        INNER JOIN active_lead_providers alp ON lpd.active_lead_provider_id = alp.id
+        INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+        WHERE schools.id = s.id
+          AND cp.year = contract_periods.year
+          AND alp.lead_provider_id = lead_providers.id
+        LIMIT 1
+      ) THEN 'provider_led'
+      WHEN EXISTS (
+        SELECT 1
+        FROM schools s
+        INNER JOIN ect_at_school_periods easp ON s.id = easp.school_id
+        INNER JOIN training_periods tp ON easp.id = tp.ect_at_school_period_id
+        INNER JOIN school_partnerships sp ON tp.school_partnership_id = sp.id
+        INNER JOIN lead_provider_delivery_partnerships lpd ON sp.lead_provider_delivery_partnership_id = lpd.id
+        INNER JOIN active_lead_providers alp ON lpd.active_lead_provider_id = alp.id
+        INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+        WHERE schools.id = s.id
+          AND cp.year = contract_periods.year
+          AND alp.lead_provider_id = lead_providers.id
+        LIMIT 1
+      ) THEN (
+        CASE
+          WHEN (
+            SELECT DISTINCT(tp.training_programme)
+            FROM schools s
+            INNER JOIN ect_at_school_periods easp ON s.id = easp.school_id
+            INNER JOIN training_periods tp ON easp.id = tp.ect_at_school_period_id
+            INNER JOIN school_partnerships sp ON tp.school_partnership_id = sp.id
+            INNER JOIN lead_provider_delivery_partnerships lpd ON sp.lead_provider_delivery_partnership_id = lpd.id
+            INNER JOIN active_lead_providers alp ON lpd.active_lead_provider_id = alp.id
+            INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+            WHERE schools.id = s.id
+              AND cp.year = contract_periods.year
+              AND alp.lead_provider_id = lead_providers.id
+            ORDER BY tp.training_programme ASC
+            LIMIT 1
+          ) = 'provider_led'
+          THEN 'provider_led'
+          WHEN (
+            SELECT DISTINCT(tp.training_programme)
+            FROM schools s
+            INNER JOIN ect_at_school_periods easp ON s.id = easp.school_id
+            INNER JOIN training_periods tp ON easp.id = tp.ect_at_school_period_id
+            INNER JOIN school_partnerships sp ON tp.school_partnership_id = sp.id
+            INNER JOIN lead_provider_delivery_partnerships lpd ON sp.lead_provider_delivery_partnership_id = lpd.id
+            INNER JOIN active_lead_providers alp ON lpd.active_lead_provider_id = alp.id
+            INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+            WHERE schools.id = s.id
+              AND cp.year = contract_periods.year
+              AND alp.lead_provider_id = lead_providers.id
+            ORDER BY tp.training_programme ASC
+            LIMIT 1
+          ) = 'school_led'
+          THEN 'school_led'
+        END
+      )
+      ELSE 'not_yet_known'
+    END AS training_programme,
+    -- expression_of_interest
+    CASE
+      WHEN EXISTS (
+        SELECT 1
+        FROM schools s
+        INNER JOIN mentor_at_school_periods masp ON s.id = masp.school_id
+        INNER JOIN training_periods tp ON masp.id = tp.mentor_at_school_period_id
+        INNER JOIN active_lead_providers alp ON tp.expression_of_interest_id = alp.id
+        INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+        WHERE schools.id = s.id
+          AND cp.year = contract_periods.year
+          AND alp.lead_provider_id = lead_providers.id
+        LIMIT 1
+      ) THEN true
+      WHEN EXISTS (
+        SELECT 1
+        FROM schools s
+        INNER JOIN ect_at_school_periods easp ON s.id = easp.school_id
+        INNER JOIN training_periods tp ON easp.id = tp.ect_at_school_period_id
+        INNER JOIN active_lead_providers alp ON tp.expression_of_interest_id = alp.id
+        INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
+        WHERE schools.id = s.id
+          AND cp.year = contract_periods.year
+          AND alp.lead_provider_id = lead_providers.id
+        LIMIT 1
+      ) THEN true
+      ELSE false
+    END AS expression_of_interest
+FROM
+    schools
+    CROSS JOIN lead_providers
+    CROSS JOIN contract_periods

--- a/db/views/schools_lead_providers_contract_periods_v01.sql
+++ b/db/views/schools_lead_providers_contract_periods_v01.sql
@@ -12,7 +12,6 @@ SELECT
         INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
         WHERE schools.id = s.id
           AND cp.year = contract_periods.year
-          AND alp.lead_provider_id = lead_providers.id
         LIMIT 1
     ) AS in_partnership,
     -- training_programme
@@ -28,7 +27,6 @@ SELECT
         INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
         WHERE schools.id = s.id
           AND cp.year = contract_periods.year
-          AND alp.lead_provider_id = lead_providers.id
         LIMIT 1
       ) THEN 'provider_led'
       WHEN EXISTS (
@@ -42,7 +40,6 @@ SELECT
         INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
         WHERE schools.id = s.id
           AND cp.year = contract_periods.year
-          AND alp.lead_provider_id = lead_providers.id
         LIMIT 1
       ) THEN (
         CASE
@@ -57,7 +54,6 @@ SELECT
             INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
             WHERE schools.id = s.id
               AND cp.year = contract_periods.year
-              AND alp.lead_provider_id = lead_providers.id
             ORDER BY tp.training_programme ASC
             LIMIT 1
           ) = 'provider_led'
@@ -73,7 +69,6 @@ SELECT
             INNER JOIN contract_periods cp ON alp.contract_period_id = cp.year
             WHERE schools.id = s.id
               AND cp.year = contract_periods.year
-              AND alp.lead_provider_id = lead_providers.id
             ORDER BY tp.training_programme ASC
             LIMIT 1
           ) = 'school_led'

--- a/spec/models/school_lead_provider_contract_period_spec.rb
+++ b/spec/models/school_lead_provider_contract_period_spec.rb
@@ -1,0 +1,23 @@
+describe SchoolLeadProviderContractPeriod, type: :model do
+  describe "enums" do
+    let(:expected_choices) { { not_yet_known: "not_yet_known", provider_led: "provider_led", school_led: "school_led" } }
+
+    it { is_expected.to define_enum_for(:training_programme).with_values(expected_choices).backed_by_column_of_type(:text) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:contract_period) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:school) }
+    it { is_expected.to validate_presence_of(:lead_provider) }
+    it { is_expected.to validate_presence_of(:contract_period) }
+    it { is_expected.to allow_values(true, false).for(:in_partnership) }
+    it { is_expected.not_to allow_values(nil, "").for(:in_partnership) }
+    it { is_expected.to allow_values(true, false).for(:expression_of_interest) }
+    it { is_expected.not_to allow_values(nil, "").for(:expression_of_interest) }
+    it { is_expected.to allow_values(*described_class.training_programmes.keys).for(:training_programme) }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2021

After working through the schools endpoint, we realised how complex it is to dynamically calculate values based on a school level, from a model where most things are on a participant level.

### Changes proposed in this pull request

- Add db view in order to join schools, lead_providers and contract_periods

Pros:
- Real time data is ready/available to be used;
- No need for a refresh (it's not materialized view);
- The sql is run dynamically for every school × contract_period × lead_provider (using cross joins);
- It's not over complex to understand;

Cons:
- Potentially big result set, as we have around 25k schools in 6 cohorts and 7 lead providers.. so ~1.05M rows;
- Performance can be slow (we can't fully test it right now as altho we have schools, we don't have partnerships neither ect/mentors/training periods in migration env);
- Some data can be useless in the end as some of the rows might be for combinations that are meaningless or unused (ie: a school not working with a lead provider in a specific contract period);
- Materialized view can be also used, but it'll need to be refreshed often in order to have "real" time data;
- Haven't really tested other options (ie: triggers) as it'd add too much complexity in comparison with views and would sit in the database level as well.