### PR TITLE
[2015] - Migrate closed schools on ECF1 with induction records

### DIFF
--- a/app/migration/builders/gias/school.rb
+++ b/app/migration/builders/gias/school.rb
@@ -1,0 +1,42 @@
+module Builders
+  module GIAS
+    class School
+      attr_reader :ecf_school, :error
+
+      def initialize(ecf_school)
+        @ecf_school = ecf_school
+      end
+
+      def build
+        ActiveRecord::Base.transaction do
+          ::GIAS::School.create!(
+            address_line1: ecf_school.address_line1,
+            address_line2: ecf_school.address_line2,
+            address_line3: ecf_school.address_line3,
+            administrative_district_name: ecf_school.administrative_district_name,
+            api_id: ecf_school.id,
+            establishment_number: ecf_school.urn,
+            funding_eligibility: ecf_school.funding_eligibility,
+            induction_eligibility: ecf_school.induction_eligibility,
+            in_england: ecf_school.in_england?,
+            local_authority_code: ecf_school.local_authority_code,
+            name: ecf_school.name,
+            phase_name: ecf_school.school_phase_name,
+            postcode: ecf_school.postcode,
+            primary_contact_email: ecf_school.primary_contact_email,
+            secondary_contact_email: ecf_school.secondary_contact_email,
+            section_41_approved: ecf_school.section_41_approved?,
+            status: ecf_school.status,
+            type_name: ecf_school.school_type_name,
+            ukprn: ecf_school.ukprn,
+            urn: ecf_school.urn,
+            website: ecf_school.school_website
+          ).tap(&:create_school!)
+        end
+      rescue ActiveRecord::ActiveRecordError => e
+        @error = e.message
+        nil
+      end
+    end
+  end
+end

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -63,32 +63,6 @@ module Migrators
       }.all?
     end
 
-    def create_school_from!(ecf_school)
-      GIAS::School.create!(
-        address_line1: ecf_school.address_line1,
-        address_line2: ecf_school.address_line2,
-        address_line3: ecf_school.address_line3,
-        administrative_district_name: ecf_school.administrative_district_name,
-        api_id: ecf_school.id,
-        establishment_number: ecf_school.urn,
-        funding_eligibility: ecf_school.funding_eligibility,
-        induction_eligibility: ecf_school.induction_eligibility,
-        in_england: ecf_school.in_england?,
-        local_authority_code: ecf_school.local_authority_code,
-        name: ecf_school.name,
-        phase_name: ecf_school.school_phase_name,
-        postcode: ecf_school.postcode,
-        primary_contact_email: ecf_school.primary_contact_email,
-        secondary_contact_email: ecf_school.secondary_contact_email,
-        section_41_approved: ecf_school.section_41_approved?,
-        status: ecf_school.status,
-        type_name: ecf_school.school_type_name,
-        ukprn: ecf_school.ukprn,
-        urn: ecf_school.urn,
-        website: ecf_school.school_website
-      ).tap(&:create_school!)
-    end
-
     def field_mismatch(school, field, gias_value, ecf_value)
       failure_manager.record_failure(school, MISMATCH_FIELD_MESSAGE.call(school, field, gias_value, ecf_value))
 
@@ -101,9 +75,9 @@ module Migrators
 
     def migrate_school!(ecf_school)
       return false if ecf_school.open?
-      return false unless ecf_school.with_induction_records?
+      return false if ecf_school.induction_records.blank?
 
-      create_school_from!(ecf_school)
+      Builders::GIAS::School.new(ecf_school).build
     end
 
     def update_gias_school!(gias_school:, api_id:) = gias_school.update!(api_id:)

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -24,12 +24,18 @@ module Migrators
 
     def self.reset! = nil
 
-    def self.schools = ::Migration::School.includes(:local_authority).eligible_or_cip_only_except_welsh
+    def self.schools
+      ::Migration::School.with(eligible_or_cip_or_with_irs:
+                                 [
+                                   ::Migration::School.includes(:local_authority).eligible_or_cip_only_except_welsh.distinct,
+                                   ::Migration::School.not_open.with_induction_records.distinct
+                                 ])
+                         .from("eligible_or_cip_or_with_irs AS schools")
+    end
 
     def migrate!
       migrate(self.class.schools) do |ecf_school|
-        gias_school = find_gias_school(urn: ecf_school.urn.to_i)
-
+        gias_school = find_gias_school(urn: ecf_school.urn.to_i) || migrate_school!(ecf_school)
         if check_gias_school(gias_school:, ecf_school:)
           [compare_fields(gias_school:, ecf_school:),
            update_gias_school!(gias_school:, api_id: ecf_school.id)].all?
@@ -57,6 +63,32 @@ module Migrators
       }.all?
     end
 
+    def create_school_from!(ecf_school)
+      GIAS::School.create!(
+        address_line1: ecf_school.address_line1,
+        address_line2: ecf_school.address_line2,
+        address_line3: ecf_school.address_line3,
+        administrative_district_name: ecf_school.administrative_district_name,
+        api_id: ecf_school.id,
+        establishment_number: ecf_school.urn,
+        funding_eligibility: ecf_school.funding_eligibility,
+        induction_eligibility: ecf_school.induction_eligibility,
+        in_england: ecf_school.in_england?,
+        local_authority_code: ecf_school.local_authority_code,
+        name: ecf_school.name,
+        phase_name: ecf_school.school_phase_name,
+        postcode: ecf_school.postcode,
+        primary_contact_email: ecf_school.primary_contact_email,
+        secondary_contact_email: ecf_school.secondary_contact_email,
+        section_41_approved: ecf_school.section_41_approved?,
+        status: ecf_school.status,
+        type_name: ecf_school.school_type_name,
+        ukprn: ecf_school.ukprn,
+        urn: ecf_school.urn,
+        website: ecf_school.school_website
+      ).tap(&:create_school!)
+    end
+
     def field_mismatch(school, field, gias_value, ecf_value)
       failure_manager.record_failure(school, MISMATCH_FIELD_MESSAGE.call(school, field, gias_value, ecf_value))
 
@@ -66,6 +98,13 @@ module Migrators
     def find_gias_school(urn:) = gias_schools.find { |school| school.urn == urn }
 
     def gias_schools = @gias_schools ||= ::GIAS::School.where(urn: self.class.schools.pluck(:urn).sort)
+
+    def migrate_school!(ecf_school)
+      return false if ecf_school.open?
+      return false unless ecf_school.with_induction_records?
+
+      create_school_from!(ecf_school)
+    end
 
     def update_gias_school!(gias_school:, api_id:) = gias_school.update!(api_id:)
   end

--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -8,6 +8,8 @@ module Migration
     OPEN_STATUS_CODES = [1, 3].freeze
 
     has_many :school_cohorts
+    has_many :induction_programmes, through: :school_cohorts
+    has_many :induction_records, through: :induction_programmes
     has_many :partnerships
 
     has_many :school_local_authorities
@@ -16,6 +18,7 @@ module Migration
     has_one :local_authority, through: :latest_school_authority
 
     scope :currently_open, -> { where(school_status_code: OPEN_STATUS_CODES) }
+    scope :not_open, -> { where.not(school_status_code: OPEN_STATUS_CODES) }
     scope :eligible_establishment_type, -> { where(school_type_code: ELIGIBLE_TYPE_CODES) }
     scope :in_england, -> { where("administrative_district_code ILIKE 'E%' OR administrative_district_code = '9999'") }
     scope :section_41, -> { where(section_41_approved: true) }
@@ -24,6 +27,12 @@ module Migration
     scope :cip_only_except_welsh, -> { currently_open.where(school_type_code: CIP_ONLY_EXCEPT_WELSH_TYPE_CODES) }
     scope :eligible_or_cip_only_except_welsh, -> { eligible.or(cip_only_except_welsh) }
     scope :not_cip_only, -> { where.not(id: cip_only) }
+
+    def self.with_induction_records
+      joins(school_cohorts: { induction_programmes: :induction_records })
+        .where.not(induction_records: { id: nil })
+        .distinct
+    end
 
     def cip_only_type? = GIAS::Types::CIP_ONLY_EXCEPT_WELSH.include?(school_type_name)
 
@@ -42,7 +51,7 @@ module Migration
 
     def in_england? = GIAS::Types::IN_ENGLAND_TYPES.include?(school_type_name)
 
-    def local_authority_code = local_authority&.code&.to_i
+    def local_authority_code = local_authority&.code.to_i
 
     # local_authority_name
     delegate :name, to: :local_authority, prefix: true, allow_nil: true
@@ -54,5 +63,9 @@ module Migration
     def status = school_status_name.underscore.parameterize(separator: "_").sub("open_but_", "")
 
     def ukprn_to_i = ukprn.presence&.to_i
+
+    def with_induction_records?
+      induction_records.exists?
+    end
   end
 end

--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -27,12 +27,7 @@ module Migration
     scope :cip_only_except_welsh, -> { currently_open.where(school_type_code: CIP_ONLY_EXCEPT_WELSH_TYPE_CODES) }
     scope :eligible_or_cip_only_except_welsh, -> { eligible.or(cip_only_except_welsh) }
     scope :not_cip_only, -> { where.not(id: cip_only) }
-
-    def self.with_induction_records
-      joins(school_cohorts: { induction_programmes: :induction_records })
-        .where.not(induction_records: { id: nil })
-        .distinct
-    end
+    scope :with_induction_records, -> { joins(:induction_records).distinct }
 
     def cip_only_type? = GIAS::Types::CIP_ONLY_EXCEPT_WELSH.include?(school_type_name)
 
@@ -63,9 +58,5 @@ module Migration
     def status = school_status_name.underscore.parameterize(separator: "_").sub("open_but_", "")
 
     def ukprn_to_i = ukprn.presence&.to_i
-
-    def with_induction_records?
-      induction_records.exists?
-    end
   end
 end

--- a/app/services/gias/school_row.rb
+++ b/app/services/gias/school_row.rb
@@ -142,6 +142,10 @@ module GIAS
       @type_name ||= data.fetch("TypeOfEstablishment (name)")
     end
 
+    def type_code
+      @type_code ||= data.fetch("TypeOfEstablishment (code)")
+    end
+
     def ukprn
       @ukprn ||= data.fetch("UKPRN").presence
     end

--- a/app/services/gias/school_row.rb
+++ b/app/services/gias/school_row.rb
@@ -138,12 +138,12 @@ module GIAS
       @status ||= data.fetch("EstablishmentStatus (name)").underscore.parameterize(separator: "_").sub("open_but_", "")
     end
 
-    def type_name
-      @type_name ||= data.fetch("TypeOfEstablishment (name)")
-    end
-
     def type_code
       @type_code ||= data.fetch("TypeOfEstablishment (code)")
+    end
+
+    def type_name
+      @type_name ||= data.fetch("TypeOfEstablishment (name)")
     end
 
     def ukprn

--- a/spec/migration/builders/gias/school_spec.rb
+++ b/spec/migration/builders/gias/school_spec.rb
@@ -1,0 +1,50 @@
+describe Builders::GIAS::School do
+  subject { described_class.new(ecf_school) }
+
+  let(:ecf_school) do
+    FactoryBot.create(:ecf_migration_school,
+                      school_status_code: 2,
+                      school_type_code: 10,
+                      school_status_name: 'closed',
+                      school_type_name: 'Community school')
+  end
+
+  describe '#build' do
+    it "creates a new GIAS::School with an associated School record" do
+      expect { subject.build }
+        .to change(GIAS::School, :count).by(1)
+        .and change(School, :count).by(1)
+    end
+
+    it "returns the created GIAS::School record" do
+      expect(subject.build).to be_a(GIAS::School)
+    end
+
+    it "migrate fields" do
+      gias_school = subject.build
+
+      expect(gias_school.school).to be_present
+      expect(gias_school.api_id).to eq(ecf_school.id)
+      expect(gias_school.address_line1).to eq(ecf_school.address_line1)
+      expect(gias_school.address_line2).to eq(ecf_school.address_line2)
+      expect(gias_school.address_line3).to eq(ecf_school.address_line3)
+      expect(gias_school.administrative_district_name).to eq(ecf_school.administrative_district_name)
+      expect(gias_school.establishment_number.to_s).to eq(ecf_school.urn)
+      expect(gias_school.funding_eligibility).to eq(ecf_school.funding_eligibility)
+      expect(gias_school.induction_eligibility).to eq(ecf_school.induction_eligibility)
+      expect(gias_school.in_england).to eq(ecf_school.in_england?)
+      expect(gias_school.local_authority_code).to eq(ecf_school.local_authority_code)
+      expect(gias_school.name).to eq(ecf_school.name)
+      expect(gias_school.phase_name).to eq(ecf_school.school_phase_name)
+      expect(gias_school.postcode).to eq(ecf_school.postcode)
+      expect(gias_school.primary_contact_email).to eq(ecf_school.primary_contact_email)
+      expect(gias_school.secondary_contact_email).to eq(ecf_school.secondary_contact_email)
+      expect(gias_school.section_41_approved).to eq(ecf_school.section_41_approved?)
+      expect(gias_school.status).to eq(ecf_school.status)
+      expect(gias_school.type_name).to eq(ecf_school.school_type_name)
+      expect(gias_school.ukprn.to_s).to eq(ecf_school.ukprn)
+      expect(gias_school.urn.to_s).to eq(ecf_school.urn)
+      expect(gias_school.website).to eq(ecf_school.school_website)
+    end
+  end
+end

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -77,8 +77,8 @@ describe Migrators::School do
         end
       end
 
-      context "otherwise" do
-        let!(:ecf_school) { FactoryBot.create(:ecf_migration_school, school_status_code: 1, school_type_code: 10) }
+      context "when the school is open or has no induction records" do
+        let!(:ecf_school) { FactoryBot.create(:ecf_migration_school, school_status_code: 1, school_status_name: 'open', school_type_code: 10) }
 
         before do
           described_class.new(worker: 0).migrate!


### PR DESCRIPTION
### Context
[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/2015)

We are importing only open schools from GIAS into RECT.
Similarly, we are comparing only open schools on ECF1 with those in RECT.

However, some closed schools still registered have school partnerships defined.
As those partnerships will need to be migrated into RECT, we need their schools to be migrated as well.

### Changes proposed in this pull request

Extend the schools comparision migrator to migrate these school to RECT.

### Guidance to review
