### PR TITLE
Revert "Group Ruby and JS Playwright updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,10 @@
 version: 2
-multi-ecosystem-groups:
-  playwright-group:
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 5
 updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
       interval: daily
-    patterns:
-      - playwright-ruby-client
+    open-pull-requests-limit: 5
     labels:
       - Dependencies
     groups:
@@ -18,13 +12,11 @@ updates:
         patterns:
           - govuk-components
           - govuk_design_system_formbuilder
-    multi-ecosystem-group: playwright-group
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
-    patterns:
-      - playwright
+    open-pull-requests-limit: 5
     labels:
       - Dependencies
     groups:
@@ -33,7 +25,6 @@ updates:
           - esbuild
           - "@esbuild/linux-x64"
           - "@esbuild/darwin-arm64"
-    multi-ecosystem-group: playwright-group
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Reverting  DFE-Digital/register-early-career-teachers-public#1006. 

The behaviour of `multi-ecosystem-groups` was a bit unexpected and It doesn't guarantee version sync between dependencies, so we're better off relying on CI to catch mismatches for now.

Can revisit with a custom github action if it becomes a pain.