### PR TITLE
Add `DeliveryPartners::Query` service

### DIFF
--- a/app/serializers/delivery_partner_serializer.rb
+++ b/app/serializers/delivery_partner_serializer.rb
@@ -4,13 +4,15 @@ class DeliveryPartnerSerializer < Blueprinter::Base
 
     field :name
     field(:cohort) do |delivery_partner, options|
-      lead_provider = options[:lead_provider]
-
-      delivery_partner
-        .lead_provider_delivery_partnerships
-        .joins(:active_lead_provider)
-        .where(active_lead_providers: { lead_provider_id: lead_provider.id })
-        .pluck("active_lead_providers.contract_period_id")
+      if delivery_partner.respond_to?(:transient_cohort)
+        delivery_partner.transient_cohort
+      else
+        delivery_partner
+          .lead_provider_delivery_partnerships
+          .joins(:active_lead_provider)
+          .where(active_lead_providers: { lead_provider_id: options[:lead_provider].id })
+          .pluck("active_lead_providers.contract_period_id")
+      end
     end
 
     field :created_at

--- a/app/serializers/delivery_partner_serializer.rb
+++ b/app/serializers/delivery_partner_serializer.rb
@@ -4,8 +4,8 @@ class DeliveryPartnerSerializer < Blueprinter::Base
 
     field :name
     field(:cohort) do |delivery_partner, options|
-      if delivery_partner.respond_to?(:transient_cohort)
-        delivery_partner.transient_cohort
+      if delivery_partner.respond_to?(:transient_cohorts)
+        delivery_partner.transient_cohorts
       else
         delivery_partner
           .lead_provider_delivery_partnerships

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -1,0 +1,77 @@
+module DeliveryPartners
+  class Query
+    include Queries::ConditionFormats
+    include QueryOrderable
+    include FilterIgnorable
+
+    attr_reader :scope
+
+    def initialize(lead_provider: :ignore, contract_period_years: :ignore, sort: nil)
+      @scope = DeliveryPartner
+        .select("delivery_partners.*", transient_cohort_subquery(lead_provider:))
+        .distinct
+
+      where_lead_provider_is(lead_provider)
+      where_contract_period_year_in(contract_period_years)
+      set_sort_by(sort)
+    end
+
+    def delivery_partners
+      scope
+    end
+
+    def delivery_partner_by_api_id(api_id)
+      return scope.find_by!(api_id:) if api_id.present?
+
+      fail(ArgumentError, "You must specify an api_id")
+    end
+
+    def delivery_partner_by_id(id)
+      return scope.find(id) if id.present?
+
+      fail(ArgumentError, "You must specify an id")
+    end
+
+  private
+
+    def transient_cohort_subquery(lead_provider:)
+      lead_provider_where_clause = %(AND active_lead_providers.lead_provider_id = #{ActiveRecord::Base.connection.quote(lead_provider.id)}) unless ignore?(filter: lead_provider)
+
+      <<~SQL.squish
+        (
+          SELECT ARRAY(
+            SELECT DISTINCT active_lead_providers.contract_period_id::text
+            FROM lead_provider_delivery_partnerships
+            INNER JOIN active_lead_providers ON active_lead_providers.id = lead_provider_delivery_partnerships.active_lead_provider_id
+            WHERE lead_provider_delivery_partnerships.delivery_partner_id = delivery_partners.id #{lead_provider_where_clause}
+            ORDER BY active_lead_providers.contract_period_id::text
+          )
+        ) AS transient_cohort
+      SQL
+    end
+
+    def where_lead_provider_is(lead_provider)
+      return if ignore?(filter: lead_provider)
+
+      delivery_partners_with_lead_provider = DeliveryPartner
+        .joins(lead_provider_delivery_partnerships: :active_lead_provider)
+        .where(active_lead_provider: { lead_provider_id: lead_provider.id })
+
+      scope.merge!(delivery_partners_with_lead_provider)
+    end
+
+    def where_contract_period_year_in(contract_period_years)
+      return if ignore?(filter: contract_period_years)
+
+      delivery_partners_with_contract_periods = DeliveryPartner
+        .joins(lead_provider_delivery_partnerships: :active_lead_provider)
+        .where("active_lead_providers.contract_period_id IN (?)", extract_conditions(contract_period_years))
+
+      scope.merge!(delivery_partners_with_contract_periods)
+    end
+
+    def set_sort_by(sort)
+      @scope = scope.order(sort_order(sort:, model: DeliveryPartner, default: { created_at: :asc }))
+    end
+  end
+end

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -8,7 +8,7 @@ module DeliveryPartners
 
     def initialize(lead_provider: :ignore, contract_period_years: :ignore, sort: nil)
       @scope = DeliveryPartner
-        .select("delivery_partners.*", transient_cohort_subquery(lead_provider:))
+        .select("delivery_partners.*", transient_cohorts_subquery(lead_provider:))
         .distinct
 
       where_lead_provider_is(lead_provider)
@@ -34,7 +34,7 @@ module DeliveryPartners
 
   private
 
-    def transient_cohort_subquery(lead_provider:)
+    def transient_cohorts_subquery(lead_provider:)
       lead_provider_where_clause = %(AND active_lead_providers.lead_provider_id = #{ActiveRecord::Base.connection.quote(lead_provider.id)}) unless ignore?(filter: lead_provider)
 
       <<~SQL.squish
@@ -46,7 +46,7 @@ module DeliveryPartners
             WHERE lead_provider_delivery_partnerships.delivery_partner_id = delivery_partners.id #{lead_provider_where_clause}
             ORDER BY active_lead_providers.contract_period_id::text
           )
-        ) AS transient_cohort
+        ) AS transient_cohorts
       SQL
     end
 

--- a/spec/serializers/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/delivery_partner_serializer_spec.rb
@@ -39,17 +39,17 @@ describe DeliveryPartnerSerializer, type: :serializer do
       expect(attributes["updated_at"]).to eq(delivery_partner.api_updated_at.utc.rfc3339)
     end
 
-    context "when `transient_cohort` is present" do
+    context "when `transient_cohorts` is present" do
       before do
-        # We simulate the transient cohort here; it is usually set in the query service.
+        # We simulate the transient cohorts here; it is usually set in the query service.
         class << delivery_partner
-          attr_accessor :transient_cohort
+          attr_accessor :transient_cohorts
         end
 
-        delivery_partner.transient_cohort = %w[2024 2025]
+        delivery_partner.transient_cohorts = %w[2024 2025]
       end
 
-      it "includes the transient cohort" do
+      it "includes the transient cohorts" do
         expect(attributes["cohort"]).to contain_exactly("2024", "2025")
       end
     end

--- a/spec/serializers/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/delivery_partner_serializer_spec.rb
@@ -39,6 +39,21 @@ describe DeliveryPartnerSerializer, type: :serializer do
       expect(attributes["updated_at"]).to eq(delivery_partner.api_updated_at.utc.rfc3339)
     end
 
+    context "when `transient_cohort` is present" do
+      before do
+        # We simulate the transient cohort here; it is usually set in the query service.
+        class << delivery_partner
+          attr_accessor :transient_cohort
+        end
+
+        delivery_partner.transient_cohort = %w[2024 2025]
+      end
+
+      it "includes the transient cohort" do
+        expect(attributes["cohort"]).to contain_exactly("2024", "2025")
+      end
+    end
+
     context "when there are delivery partnerships for other lead providers" do
       before do
         other_lead_provider = FactoryBot.create(:lead_provider)

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DeliveryPartners::Query do
       expect(query.delivery_partners).to eq([delivery_partner1, delivery_partner2, delivery_partner3])
     end
 
-    describe "transient_cohort" do
+    describe "transient_cohorts" do
       let(:lead_provider_2024) { FactoryBot.create(:lead_provider) }
       let(:lead_provider_2025) { FactoryBot.create(:lead_provider) }
 
@@ -38,7 +38,7 @@ RSpec.describe DeliveryPartners::Query do
           query = described_class.new(lead_provider:)
 
           expect(query.delivery_partners).to contain_exactly(delivery_partner1)
-          expect(query.delivery_partners.map(&:transient_cohort)).to contain_exactly(%w[2024 2025])
+          expect(query.delivery_partners.map(&:transient_cohorts)).to contain_exactly(%w[2024 2025])
         end
       end
 
@@ -49,7 +49,7 @@ RSpec.describe DeliveryPartners::Query do
           query = described_class.new(lead_provider:)
 
           expect(query.delivery_partners).to contain_exactly(delivery_partner1)
-          expect(query.delivery_partners.map(&:transient_cohort)).to contain_exactly(%w[2024])
+          expect(query.delivery_partners.map(&:transient_cohorts)).to contain_exactly(%w[2024])
         end
       end
     end

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -1,0 +1,236 @@
+RSpec.describe DeliveryPartners::Query do
+  describe "#delivery_partners" do
+    it "returns all delivery partners" do
+      delivery_partners = FactoryBot.create_list(:delivery_partner, 3)
+      query = described_class.new
+
+      expect(query.delivery_partners).to match_array(delivery_partners)
+    end
+
+    it "orders delivery partners by created_at in ascending order" do
+      delivery_partner1 = travel_to(2.days.ago) { FactoryBot.create(:delivery_partner) }
+      delivery_partner2 = travel_to(1.day.ago) { FactoryBot.create(:delivery_partner) }
+      delivery_partner3 = FactoryBot.create(:delivery_partner)
+
+      query = described_class.new
+
+      expect(query.delivery_partners).to eq([delivery_partner1, delivery_partner2, delivery_partner3])
+    end
+
+    describe "transient_cohort" do
+      let(:lead_provider_2024) { FactoryBot.create(:lead_provider) }
+      let(:lead_provider_2025) { FactoryBot.create(:lead_provider) }
+
+      let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
+      let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+
+      let(:active_lead_provider_2024) { FactoryBot.create(:active_lead_provider, lead_provider: lead_provider_2024, contract_period: contract_period_2024) }
+      let(:active_lead_provider_2025) { FactoryBot.create(:active_lead_provider, lead_provider: lead_provider_2025, contract_period: contract_period_2025) }
+
+      let(:lead_provider_delivery_partnership_2024) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider_2024) }
+      let!(:delivery_partner1) { lead_provider_delivery_partnership_2024.delivery_partner }
+      let!(:lead_provider_delivery_partnership_2025) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner: delivery_partner1, active_lead_provider: active_lead_provider_2025) }
+
+      context "when ignoring lead provider" do
+        let(:lead_provider) { :ignore }
+
+        it "loads the cohorts for all lead providers" do
+          query = described_class.new(lead_provider:)
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1)
+          expect(query.delivery_partners.map(&:transient_cohort)).to contain_exactly(%w[2024 2025])
+        end
+      end
+
+      context "when filter by lead provider" do
+        let(:lead_provider) { lead_provider_2024 }
+
+        it "only includes cohorts for the given lead provider" do
+          query = described_class.new(lead_provider:)
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1)
+          expect(query.delivery_partners.map(&:transient_cohort)).to contain_exactly(%w[2024])
+        end
+      end
+    end
+
+    describe "filtering" do
+      describe "by `lead_provider`" do
+        let(:lead_provider_delivery_partnership1) { FactoryBot.create(:lead_provider_delivery_partnership) }
+        let!(:delivery_partner1) { lead_provider_delivery_partnership1.delivery_partner }
+        let!(:delivery_partner2) { FactoryBot.create(:lead_provider_delivery_partnership).delivery_partner }
+        let!(:delivery_partner3) { FactoryBot.create(:lead_provider_delivery_partnership).delivery_partner }
+
+        context "when `lead_provider` param is omitted" do
+          it "returns all delivery partners" do
+            expect(described_class.new.delivery_partners).to contain_exactly(delivery_partner1, delivery_partner2, delivery_partner3)
+          end
+        end
+
+        it "filters by `lead_provider`" do
+          lead_provider = lead_provider_delivery_partnership1.active_lead_provider.lead_provider
+          query = described_class.new(lead_provider:)
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1)
+        end
+
+        it "returns empty if no delivery partners are found for the given `lead_provider`" do
+          query = described_class.new(lead_provider: FactoryBot.create(:lead_provider))
+
+          expect(query.delivery_partners).to be_empty
+        end
+
+        it "does not filter by `lead_provider` if an empty string is supplied" do
+          query = described_class.new(lead_provider: " ")
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1, delivery_partner2, delivery_partner3)
+        end
+      end
+
+      describe "by `contract_period_years`" do
+        let!(:contract_period1) { FactoryBot.create(:contract_period) }
+        let!(:contract_period2) { FactoryBot.create(:contract_period) }
+        let!(:contract_period3) { FactoryBot.create(:contract_period) }
+        let!(:active_lead_provider1) { FactoryBot.create(:active_lead_provider, contract_period: contract_period1) }
+        let!(:active_lead_provider2) { FactoryBot.create(:active_lead_provider, contract_period: contract_period2) }
+        let!(:active_lead_provider3) { FactoryBot.create(:active_lead_provider, contract_period: contract_period3) }
+
+        context "when `contract_period_years` param is omitted" do
+          it "returns all delivery partners" do
+            delivery_partner1 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+            delivery_partner2 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2).delivery_partner
+            delivery_partner3 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider3).delivery_partner
+
+            expect(described_class.new.delivery_partners).to contain_exactly(delivery_partner1, delivery_partner2, delivery_partner3)
+          end
+        end
+
+        it "filters by `contract_period_years`" do
+          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1)
+          delivery_partner2 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2).delivery_partner
+          query = described_class.new(contract_period_years: contract_period2.year)
+
+          expect(query.delivery_partners).to eq([delivery_partner2])
+        end
+
+        it "filters by multiple `contract_period_years`" do
+          delivery_partner1 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+          delivery_partner2 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2).delivery_partner
+          delivery_partner3 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider3).delivery_partner
+
+          query1 = described_class.new(contract_period_years: "#{contract_period1.year},#{contract_period2.year}")
+          expect(query1.delivery_partners).to contain_exactly(delivery_partner1, delivery_partner2)
+
+          query2 = described_class.new(contract_period_years: [contract_period2.year.to_s, contract_period3.year.to_s])
+          expect(query2.delivery_partners).to contain_exactly(delivery_partner2, delivery_partner3)
+        end
+
+        it "returns no delivery partners if no `contract_period_years` are found" do
+          query = described_class.new(contract_period_years: "0000")
+
+          expect(query.delivery_partners).to be_empty
+        end
+
+        it "does not filter by `contract_period_years` if blank" do
+          delivery_partner1 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+          delivery_partner2 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2).delivery_partner
+
+          query = described_class.new(contract_period_years: " ")
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1, delivery_partner2)
+        end
+      end
+    end
+
+    describe "ordering" do
+      let!(:lead_provider_delivery_partnership1) { FactoryBot.create(:lead_provider_delivery_partnership) }
+      let!(:lead_provider_delivery_partnership2) { travel_to(1.day.ago) { FactoryBot.create(:lead_provider_delivery_partnership) } }
+
+      describe "default order" do
+        it "returns delivery partners ordered by created_at, in ascending order" do
+          query = described_class.new
+          expect(query.delivery_partners).to eq([lead_provider_delivery_partnership2.delivery_partner, lead_provider_delivery_partnership1.delivery_partner])
+        end
+      end
+
+      describe "order by created_at, in descending order" do
+        it "returns delivery partners in correct order" do
+          query = described_class.new(sort: "-created_at")
+          expect(query.delivery_partners).to eq([lead_provider_delivery_partnership1.delivery_partner, lead_provider_delivery_partnership2.delivery_partner])
+        end
+      end
+
+      describe "order by updated_at, in ascending order" do
+        it "returns delivery partners in correct order" do
+          query = described_class.new(sort: "+updated_at")
+          expect(query.delivery_partners).to eq([lead_provider_delivery_partnership2.delivery_partner, lead_provider_delivery_partnership1.delivery_partner])
+        end
+      end
+
+      describe "order by updated_at, in descending order" do
+        it "returns delivery partners in correct order" do
+          query = described_class.new(sort: "-updated_at")
+          expect(query.delivery_partners).to eq([lead_provider_delivery_partnership1.delivery_partner, lead_provider_delivery_partnership2.delivery_partner])
+        end
+      end
+    end
+  end
+
+  describe "#delivery_partner_by_api_id" do
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+
+    it "returns the delivery partners for a given id" do
+      delivery_partner = FactoryBot.create(:delivery_partner)
+      query = described_class.new
+
+      expect(query.delivery_partner_by_api_id(delivery_partner.api_id)).to eq(delivery_partner)
+    end
+
+    it "raises an error if the delivery partner does not exist" do
+      query = described_class.new
+
+      expect { query.delivery_partner_by_api_id("XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if the delivery partner is not in the filtered query" do
+      lead_provider_delivery_partnership1 = FactoryBot.create(:lead_provider_delivery_partnership)
+      lead_provider_delivery_partnership2 = FactoryBot.create(:lead_provider_delivery_partnership)
+
+      query = described_class.new(lead_provider: lead_provider_delivery_partnership1.active_lead_provider.lead_provider)
+
+      expect { query.delivery_partner_by_api_id(lead_provider_delivery_partnership2.delivery_partner.api_id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if an api_id is not supplied" do
+      expect { described_class.new.delivery_partner_by_api_id(nil) }.to raise_error(ArgumentError, "You must specify an api_id")
+    end
+  end
+
+  describe "#delivery_partner_by_id" do
+    it "returns the delivery_partner for a given id" do
+      delivery_partner = FactoryBot.create(:delivery_partner)
+      query = described_class.new
+
+      expect(query.delivery_partner_by_id(delivery_partner.id)).to eq(delivery_partner)
+    end
+
+    it "raises an error if the delivery partner does not exist" do
+      query = described_class.new
+
+      expect { query.delivery_partner_by_id("XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if the delivery partner is not in the filtered query" do
+      lead_provider_delivery_partnership1 = FactoryBot.create(:lead_provider_delivery_partnership)
+      lead_provider_delivery_partnership2 = FactoryBot.create(:lead_provider_delivery_partnership)
+
+      query = described_class.new(lead_provider: lead_provider_delivery_partnership1.active_lead_provider.lead_provider)
+
+      expect { query.delivery_partner_by_id(lead_provider_delivery_partnership2.delivery_partner.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if an id is not supplied" do
+      expect { described_class.new.delivery_partner_by_id(nil) }.to raise_error(ArgumentError, "You must specify an id")
+    end
+  end
+end


### PR DESCRIPTION
### Context

As part of the delivery partners epic we want to add the query service that can be called from the controller. This should mimic the behaviour of the delivery partners query service in ECF.

### Changes proposed in this pull request

- Add DeliveryPartners::Query

Add a query service for retrieving delivery partners, which will be called from the controller. The results will be passed into the `DeliveryPartnerSerializer`.

### Guidance to review

We calculate a `transient_cohort` in the query service for efficiency and fallback to looking it up from sratch if its not present. This will be replaced in the future by a pre-calculated field.