### PR TITLE
Fix claim bug party programme type validation

### DIFF
--- a/app/models/concerns/batch_rows.rb
+++ b/app/models/concerns/batch_rows.rb
@@ -26,7 +26,7 @@ module BatchRows
 
       # @return [Boolean] 7 digits only
       def invalid_trn?
-        trn.strip !~ /\A\d{7}\z/
+        trn.to_s.strip !~ /\A\d{7}\z/
       end
 
       # @return [Boolean] only "error" cell can be blank

--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -99,7 +99,7 @@ module AppropriateBodies
 
       # @return [Boolean] school-led, provider-led (case-insensitive)
       def invalid_training_programme?
-        TRAINING_PROGRAMME.keys.map(&:to_s).exclude?(row.training_programme.downcase.underscore.strip)
+        TRAINING_PROGRAMME.keys.map(&:to_s).exclude?(row.training_programme.to_s.downcase.underscore.strip)
       end
 
       # @return [Boolean] started_on before 1 September 2021

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
   let(:finished_on) { 1.week.ago.to_date.to_s }
   let(:number_of_terms) { '3.2' }
   let(:outcome) { 'pass' }
-  let(:error) { '' }
+  let(:error) { nil }
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
@@ -69,7 +69,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       before { service.process! }
 
       context 'when the TRN is missing' do
-        let(:trn) { '' }
+        let(:trn) { nil }
         let(:teacher) {}
 
         it 'captures an error message' do
@@ -81,7 +81,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       end
 
       context 'when the date of birth is missing' do
-        let(:date_of_birth) { '' }
+        let(:date_of_birth) { nil }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
@@ -93,7 +93,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       end
 
       context 'when the date of birth is unrealistic' do
-        let(:date_of_birth) { 100.years.ago }
+        let(:date_of_birth) { 100.years.ago.to_date.to_s }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
@@ -103,7 +103,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       end
 
       context 'when the date of birth is in the future' do
-        let(:date_of_birth) { 1.year.from_now }
+        let(:date_of_birth) { 1.year.from_now.to_date.to_s }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
@@ -113,7 +113,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       end
 
       context 'when the number of terms is missing' do
-        let(:number_of_terms) { '' }
+        let(:number_of_terms) { nil }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
@@ -124,7 +124,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       end
 
       context 'when the end date is missing' do
-        let(:finished_on) { '' }
+        let(:finished_on) { nil }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
@@ -136,7 +136,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       end
 
       context 'when the outcome is missing' do
-        let(:outcome) { '' }
+        let(:outcome) { nil }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [
@@ -268,7 +268,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         let(:date_of_birth) { '30/06/1981' }
         let(:outcome) { 'foo' }
         let(:number_of_terms) { '12.06' }
-        let(:finished_on) { '' }
+        let(:finished_on) { nil }
 
         it 'captures an error message' do
           expect(submission.error_messages).to eq [

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
   let(:date_of_birth) { '1997-03-15' }
   let(:started_on) { 1.week.ago.to_date.to_s }
   let(:training_programme) { 'provider-led' }
-  let(:error) { '' }
+  let(:error) { nil }
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
@@ -65,7 +65,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         before { service.process! }
 
         context 'when the TRN is missing' do
-          let(:trn) { '' }
+          let(:trn) { nil }
           let(:teacher) {}
 
           it 'captures an error message' do
@@ -77,7 +77,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         end
 
         context 'when the date of birth is missing' do
-          let(:date_of_birth) { '' }
+          let(:date_of_birth) { nil }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
@@ -89,7 +89,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         end
 
         context 'when the date of birth is unrealistic' do
-          let(:date_of_birth) { 100.years.ago }
+          let(:date_of_birth) { 100.years.ago.to_date.to_s }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
@@ -99,7 +99,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         end
 
         context 'when the date of birth is in the future' do
-          let(:date_of_birth) { 1.year.from_now }
+          let(:date_of_birth) { 1.year.from_now.to_date.to_s }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
@@ -109,7 +109,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         end
 
         context 'when the start date is missing' do
-          let(:started_on) { '' }
+          let(:started_on) { nil }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
@@ -132,7 +132,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
         end
 
         context 'when the training programme is missing' do
-          let(:training_programme) { '' }
+          let(:training_programme) { nil }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq [
@@ -231,7 +231,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
           let(:trn) { '0004' }
           let(:date_of_birth) { '30/06/1981' }
           let(:training_programme) { 'foo' }
-          let(:started_on) { '' }
+          let(:started_on) { nil }
 
           it 'captures an error message' do
             expect(submission.error_messages).to eq [


### PR DESCRIPTION
### Context

Ensure programme type validation can cope with a blank cell

### Changes proposed in this pull request

Change specs to assert missing values using nil which is what the validation receives

### Guidance to review

- Bulk claim with no programme type
- Bulk claim with a file where each row has a blank cell for a different field (extra hardcore test)