### PR TITLE
[xxxx] Use secondary true on `govuk_submit`

### DIFF
--- a/app/components/shared/top_search_component.rb
+++ b/app/components/shared/top_search_component.rb
@@ -24,7 +24,7 @@ module Shared
               label: { text: label_text, size: "s" }
             )
           end,
-          f.govuk_submit(submit_text, class: "govuk-button--secondary app-search__button")
+          f.govuk_submit(submit_text, secondary: true, class: "app-search__button")
         ])
       end
     end


### PR DESCRIPTION
### Context

Use `secondary: true` on govuk_submit instead of the class.

See: https://github.com/x-govuk/govuk-form-builder/blob/main/lib/govuk_design_system_formbuilder/builder.rb#L912-L914

