### PR TITLE
Add delivery partner APIs

### DIFF
--- a/app/controllers/api/v3/delivery_partners_controller.rb
+++ b/app/controllers/api/v3/delivery_partners_controller.rb
@@ -1,8 +1,37 @@
 module API
   module V3
     class DeliveryPartnersController < BaseController
-      def show = head(:method_not_allowed)
-      def index = head(:method_not_allowed)
+      def index
+        conditions = { contract_period_years:, sort: }
+        render json: to_json(paginate(delivery_partners_query(conditions:).delivery_partners))
+      end
+
+      def show
+        render json: to_json(delivery_partners_query.delivery_partner_by_api_id(api_id))
+      end
+
+    private
+
+      def delivery_partners_query(conditions: {})
+        conditions[:lead_provider] = current_lead_provider
+        DeliveryPartners::Query.new(**conditions.compact)
+      end
+
+      def delivery_partner_params
+        params.permit(:api_id, :sort)
+      end
+
+      def api_id
+        delivery_partner_params[:api_id]
+      end
+
+      def sort
+        delivery_partner_params[:sort]
+      end
+
+      def to_json(obj)
+        DeliveryPartnerSerializer.render(obj, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -5,6 +5,7 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
   belongs_to :delivery_partner
   has_many :school_partnerships
   has_many :events
+  has_one :lead_provider, through: :active_lead_provider
 
   touch -> { delivery_partner }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
 

--- a/app/serializers/delivery_partner_serializer.rb
+++ b/app/serializers/delivery_partner_serializer.rb
@@ -12,6 +12,7 @@ class DeliveryPartnerSerializer < Blueprinter::Base
           .joins(:active_lead_provider)
           .where(active_lead_providers: { lead_provider_id: options[:lead_provider].id })
           .pluck("active_lead_providers.contract_period_id")
+          .map(&:to_s)
       end
     end
 

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -64,8 +64,8 @@ module DeliveryPartners
       return if ignore?(filter: contract_period_years)
 
       delivery_partners_with_contract_periods = DeliveryPartner
-        .joins(lead_provider_delivery_partnerships: :active_lead_provider)
-        .where("active_lead_providers.contract_period_id IN (?)", extract_conditions(contract_period_years))
+        .joins(lead_provider_delivery_partnerships: { active_lead_provider: :contract_period })
+        .where(contract_period: { year: extract_conditions(contract_period_years, integers: true) })
 
       scope.merge!(delivery_partners_with_contract_periods)
     end

--- a/app/services/queries/condition_formats.rb
+++ b/app/services/queries/condition_formats.rb
@@ -1,6 +1,6 @@
 module Queries
   module ConditionFormats
-    def extract_conditions(list, allowlist: nil, uuids: false)
+    def extract_conditions(list, allowlist: nil, uuids: false, integers: false)
       conditions = case list
                    when String
                      list.split(",")
@@ -11,6 +11,7 @@ module Queries
                    end
 
       conditions.select! { |uuid| uuid_valid?(uuid) } if uuids
+      conditions.select! { |value| integer_valid?(value) } if integers
 
       return conditions if allowlist.blank?
 
@@ -26,6 +27,10 @@ module Queries
 
     def uuid_valid?(uuid)
       uuid =~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+    end
+
+    def integer_valid?(value)
+      value.to_s.match?(/\A\d+\z/)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,7 +340,7 @@ Rails.application.routes.draw do
         end
 
         resources :statements, only: %i[index show], param: :api_id
-        resources :delivery_partners, only: %i[index show], path: "delivery-partners"
+        resources :delivery_partners, only: %i[index show], path: "delivery-partners", param: :api_id
         resources :partnerships, only: %i[show index create update]
         resources :schools, only: %i[index show], param: :api_id
         resources :unfunded_mentors, only: %i[index show], path: "unfunded-mentors"

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -4,6 +4,7 @@ describe LeadProviderDeliveryPartnership do
     it { is_expected.to belong_to(:delivery_partner) }
     it { is_expected.to have_many(:school_partnerships) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_one(:lead_provider).through(:active_lead_provider) }
   end
 
   describe 'validation' do

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -1,23 +1,34 @@
 RSpec.describe "Delivery partners API", type: :request do
+  let(:serializer) { DeliveryPartnerSerializer }
+  let(:serializer_options) { { lead_provider: } }
+  let(:query) { DeliveryPartners::Query }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:lead_provider) { active_lead_provider.lead_provider }
+
+  def create_resource(active_lead_provider:)
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:).delivery_partner
+  end
+
   describe "#index" do
     let(:path) { api_v3_delivery_partners_path }
 
-    it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
+    def apply_expected_order(resources)
+      resources.sort_by(&:created_at)
     end
+
+    it_behaves_like "a paginated endpoint"
+    it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
+    it_behaves_like "an index endpoint"
+    it_behaves_like "a sortable endpoint"
   end
 
   describe "#show" do
-    let(:path) { api_v3_delivery_partner_path(123) }
+    let(:resource) { create_resource(active_lead_provider:) }
+    let(:path_id) { resource.api_id }
+    let(:path) { api_v3_delivery_partner_path(path_id) }
 
     it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
+    it_behaves_like "a show endpoint"
   end
 end

--- a/spec/serializers/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/delivery_partner_serializer_spec.rb
@@ -27,7 +27,7 @@ describe DeliveryPartnerSerializer, type: :serializer do
     end
 
     it "serializes `cohort`" do
-      expect(attributes["cohort"]).to contain_exactly(2024)
+      expect(attributes["cohort"]).to contain_exactly("2024")
     end
 
     it "serializes `created_at`" do
@@ -63,7 +63,7 @@ describe DeliveryPartnerSerializer, type: :serializer do
       end
 
       it "does not include other lead provider's cohorts" do
-        expect(attributes["cohort"]).to contain_exactly(2024)
+        expect(attributes["cohort"]).to contain_exactly("2024")
       end
     end
 
@@ -76,7 +76,7 @@ describe DeliveryPartnerSerializer, type: :serializer do
       end
 
       it "serializes `cohort` with unique contract periods" do
-        expect(attributes["cohort"]).to contain_exactly(2023, 2024)
+        expect(attributes["cohort"]).to contain_exactly("2023", "2024")
       end
     end
   end

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe DeliveryPartners::Query do
         it "filters by `contract_period_years`" do
           FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1)
           delivery_partner2 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2).delivery_partner
-          query = described_class.new(contract_period_years: contract_period2.year)
+          query = described_class.new(contract_period_years: contract_period2.year.to_s)
 
           expect(query.delivery_partners).to eq([delivery_partner2])
         end
@@ -129,6 +129,14 @@ RSpec.describe DeliveryPartners::Query do
           query = described_class.new(contract_period_years: "0000")
 
           expect(query.delivery_partners).to be_empty
+        end
+
+        it "ignores invalid `contract_period_years`" do
+          delivery_partner1 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+
+          query = described_class.new(contract_period_years: "#{contract_period1.year},invalid_year")
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1)
         end
 
         it "does not filter by `contract_period_years` if blank" do

--- a/spec/services/queries/condition_formats_spec.rb
+++ b/spec/services/queries/condition_formats_spec.rb
@@ -52,5 +52,12 @@ RSpec.describe Queries::ConditionFormats do
           .to eql(%w[123e4567-e89b-12d3-a456-426614174000])
       end
     end
+
+    context "when integer is true" do
+      it "returns only valid integers" do
+        expect(object.extract_conditions(["2022", 123, 4.56, "not-a-uuid"], integers: true))
+          .to eql(["2022", 123])
+      end
+    end
   end
 end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -1,4 +1,6 @@
 RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
+
   it "returns only resources for the specified cohorts" do
     previous_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year - 1)
     next_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)
@@ -16,7 +18,7 @@ RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpo
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render(apply_expected_order([previous_contract_period_resource, next_contract_period_resource]), root: "data", **serializer_options))
+    expect(response.body).to eq(serializer.render(apply_expected_order([previous_contract_period_resource, next_contract_period_resource]), root: "data", **options))
   end
 
   it "ignores invalid cohorts" do
@@ -31,11 +33,12 @@ RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpo
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
+    expect(response.body).to eq(serializer.render(apply_expected_order([resource]), root: "data", **options))
   end
 end
 
 RSpec.shared_examples "a filter by updated_since endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
   let!(:resource_updated_one_week_ago) { travel_to(1.week.ago) { create_resource(active_lead_provider:) } }
   let!(:resource_updated_one_month_ago) { travel_to(1.month.ago) { create_resource(active_lead_provider:) } }
 
@@ -51,7 +54,7 @@ RSpec.shared_examples "a filter by updated_since endpoint" do
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render(apply_expected_order([resource_updated_one_week_ago, resource_updated_one_month_ago]), root: "data", **serializer_options))
+    expect(response.body).to eq(serializer.render(apply_expected_order([resource_updated_one_week_ago, resource_updated_one_month_ago]), root: "data", **options))
   end
 
   it "correctly decodes URL encoded dates" do
@@ -61,7 +64,7 @@ RSpec.shared_examples "a filter by updated_since endpoint" do
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render(apply_expected_order([resource_updated_one_week_ago, resource_updated_one_month_ago]), root: "data", **serializer_options))
+    expect(response.body).to eq(serializer.render(apply_expected_order([resource_updated_one_week_ago, resource_updated_one_month_ago]), root: "data", **options))
   end
 
   it "returns 400 bad request when the updated_since is not a valid date" do

--- a/spec/support/shared_contexts/api/index_endpoint.rb
+++ b/spec/support/shared_contexts/api/index_endpoint.rb
@@ -1,4 +1,6 @@
 shared_examples "an index endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
+
   context "when 2 resources exist for the lead provider" do
     let!(:resources) do
       [
@@ -19,7 +21,7 @@ shared_examples "an index endpoint" do
 
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to eql("application/json; charset=utf-8")
-      expect(response.body).to eq(serializer.render(apply_expected_order(resources), root: "data", **serializer_options))
+      expect(response.body).to eq(serializer.render(apply_expected_order(resources), root: "data", **options))
     end
   end
 

--- a/spec/support/shared_contexts/api/show_endpoint.rb
+++ b/spec/support/shared_contexts/api/show_endpoint.rb
@@ -1,10 +1,12 @@
 shared_examples "a show endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
+
   it "returns the correct resource in a serialized format" do
     authenticated_api_get(path)
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render(resource, root: "data", **serializer_options))
+    expect(response.body).to eq(serializer.render(resource, root: "data", **options))
   end
 
   context "when the resource does not exist" do


### PR DESCRIPTION
### Context

Now that we have the query and serializer in place, we can flesh out the `index` and `show` actions of the delivery partner APIs.

### Changes proposed in this pull request

- Ignore non-integer cohorts in DeliveryPartners::Query

At the moment it will throw a postgres error when filtering on non-integer contract period values.

Add `integers:` option to `ConditionFormats` so that we can restrict the input.

- Add lead_provider relationship for convenience

To make it a bit cleaner to reference the active lead provider of a delivery partnership.

- Cast serialized cohorts to strings

To be consistent with the lead provider API and the behaviour of the transient cohort logic, we want to cast the cohorts to strings.

- Implement index and show actions for delivery partners

Integrate the query and serializer to flesh out the delivery partner APIs.

Update the shared contexts to allow passing a `lead_provider` to the serializer via `options`.
