### PR TITLE
Grouping induction records for validation

### DIFF
--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -8,10 +8,11 @@ class InductionRecordSanitizer
   class InvalidDateSequenceError < InductionRecordError; end
   class NoInductionRecordsError < InductionRecordError; end
 
-  attr_reader :participant_profile, :error
+  attr_reader :participant_profile, :error, :group_by
 
-  def initialize(participant_profile:)
+  def initialize(participant_profile:, group_by: :none)
     @participant_profile = participant_profile
+    @group_by = group_by.to_sym
     @error = nil
   end
 
@@ -25,11 +26,22 @@ class InductionRecordSanitizer
   end
 
   def validate!
-    # TODO: add more validation checks here as we discover them
     has_induction_records!
-    does_not_have_multiple_blank_end_dates!
-    does_not_have_multiple_active_induction_statuses!
-    induction_record_dates_are_sequential!
+
+    case group_by
+    when :school, :provider
+      induction_records.each do |_subject, induction_record_group|
+        does_not_have_multiple_blank_end_dates!(induction_record_group)
+        does_not_have_multiple_active_induction_statuses!(induction_record_group)
+        # induction_record_dates_are_sequential!(induction_record_group)
+      end
+    when :none
+      does_not_have_multiple_blank_end_dates!(induction_records)
+      does_not_have_multiple_active_induction_statuses!(induction_records)
+      # induction_record_dates_are_sequential!(induction_records)
+    else
+      raise InductionRecordError, "invalid grouping specified [#{group_by}]"
+    end
   end
 
   def validate_and_compress!
@@ -44,18 +56,67 @@ class InductionRecordSanitizer
     end
   end
 
-  def each
+  def each(&block)
     return to_enum(__method__) { induction_records.size } unless block_given?
 
-    induction_records.each do |induction_record|
-      yield Migration::InductionRecordPresenter.new(induction_record)
+    case group_by
+    when :school
+      enumerate_by_school(&block)
+    when :provider
+      enumerate_by_provider(&block)
+    when :none
+      induction_records.each do |induction_record|
+        yield Migration::InductionRecordPresenter.new(induction_record)
+      end
+    else
+      raise InductionRecordError, "invalid grouping specified [#{group_by}]"
     end
+  end
+
+  def induction_records
+    @induction_records ||= ordered_induction_records
   end
 
 private
 
-  def induction_records
-    @induction_records ||= participant_profile.induction_records.includes(induction_programme: [{ school_cohort: [:school] }]).order(start_date: :asc)
+  def ordered_induction_records
+    case group_by
+    when :school
+      participant_profile
+        .induction_records
+        .eager_load(induction_programme: [school_cohort: :school])
+        .order(:start_date, :created_at)
+        .group_by { |ir| ir.induction_programme.school_cohort.school.urn }
+    when :provider
+      participant_profile
+        .induction_records
+        .eager_load(induction_programme: :partnership)
+        .order(:start_date, :created_at)
+        .group_by { |ir| ir.induction_programme.partnership&.lead_provider_id }
+    when :none
+      participant_profile
+        .induction_records
+        .eager_load(induction_programme: [school_cohort: :school])
+        .order(:start_date, :created_at)
+    else
+      raise InductionRecordError, "invalid grouping specified [#{group_by}]"
+    end
+  end
+
+  def enumerate_by_provider
+    induction_records.each do |lead_provider_id, induction_record_group|
+      induction_record_group.each do |induction_record|
+        yield lead_provider_id, Migration::InductionRecordPresenter.new(induction_record)
+      end
+    end
+  end
+
+  def enumerate_by_school
+    induction_records.each do |urn, induction_record_group|
+      induction_record_group.each do |induction_record|
+        yield urn, Migration::InductionRecordPresenter.new(induction_record)
+      end
+    end
   end
 
   def different?(ir1, ir2)
@@ -67,28 +128,29 @@ private
   end
 
   def has_induction_records!
-    raise(NoInductionRecordsError) if induction_records.empty?
+    raise(NoInductionRecordsError) if participant_profile.induction_records.empty?
   end
 
-  def does_not_have_multiple_blank_end_dates!
-    raise(MultipleBlankEndDateError) if induction_records.where(end_date: nil).count > 1
+  def does_not_have_multiple_blank_end_dates!(induction_record_collection)
+    raise(MultipleBlankEndDateError) if induction_record_collection.select { |ir| ir.end_date.nil? }.count > 1
   end
 
-  def does_not_have_multiple_active_induction_statuses!
-    raise(MultipleActiveStatesError) if induction_records.where(induction_status: "active").count > 1
+  def does_not_have_multiple_active_induction_statuses!(induction_record_collection)
+    raise(MultipleActiveStatesError) if induction_record_collection.select { |ir| ir.induction_status == "active" }.count > 1
   end
 
-  def induction_record_dates_are_sequential!
-    previous_end_date = induction_records.first.end_date
+  # NOTE: Ignore the end_date for validation as we will concentrate on the start_date
+  # def induction_record_dates_are_sequential!(induction_record_collection)
+  #   previous_end_date = induction_record_collection.first.end_date
 
-    induction_records.each_with_index do |ir, idx|
-      raise(StartDateAfterEndDateError) if ir.end_date.present? && ir.end_date < ir.start_date
+  #   induction_record_collection.each_with_index do |ir, idx|
+  #     raise(StartDateAfterEndDateError) if ir.end_date.present? && ir.end_date < ir.start_date
 
-      next if idx.zero?
+  #     next if idx.zero?
 
-      raise(InvalidDateSequenceError) if previous_end_date.nil? || ir.start_date < previous_end_date
+  #     raise(InvalidDateSequenceError) if previous_end_date.nil? || ir.start_date < previous_end_date
 
-      previous_end_date = ir.end_date
-    end
-  end
+  #     previous_end_date = ir.end_date
+  #   end
+  # end
 end

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -30,15 +30,17 @@ class InductionRecordSanitizer
 
     case group_by
     when :school, :provider
-      induction_records.each do |_subject, induction_record_group|
+      induction_records.each_value do |induction_record_group|
         does_not_have_multiple_blank_end_dates!(induction_record_group)
         does_not_have_multiple_active_induction_statuses!(induction_record_group)
+        # NOTE: Ignore the end_date for validation as we will concentrate on the start_date
         # induction_record_dates_are_sequential!(induction_record_group)
       end
     when :none
       does_not_have_multiple_blank_end_dates!(induction_records)
       does_not_have_multiple_active_induction_statuses!(induction_records)
-      # induction_record_dates_are_sequential!(induction_records)
+      # NOTE: include end_date checking in "original" ungrouped version
+      induction_record_dates_are_sequential!(induction_records)
     else
       raise InductionRecordError, "invalid grouping specified [#{group_by}]"
     end
@@ -132,25 +134,24 @@ private
   end
 
   def does_not_have_multiple_blank_end_dates!(induction_record_collection)
-    raise(MultipleBlankEndDateError) if induction_record_collection.select { |ir| ir.end_date.nil? }.count > 1
+    raise(MultipleBlankEndDateError) if induction_record_collection.count { |ir| ir.end_date.nil? } > 1
   end
 
   def does_not_have_multiple_active_induction_statuses!(induction_record_collection)
-    raise(MultipleActiveStatesError) if induction_record_collection.select { |ir| ir.induction_status == "active" }.count > 1
+    raise(MultipleActiveStatesError) if induction_record_collection.count { |ir| ir.induction_status == "active" } > 1
   end
 
-  # NOTE: Ignore the end_date for validation as we will concentrate on the start_date
-  # def induction_record_dates_are_sequential!(induction_record_collection)
-  #   previous_end_date = induction_record_collection.first.end_date
+  def induction_record_dates_are_sequential!(induction_record_collection)
+    previous_end_date = induction_record_collection.first.end_date
 
-  #   induction_record_collection.each_with_index do |ir, idx|
-  #     raise(StartDateAfterEndDateError) if ir.end_date.present? && ir.end_date < ir.start_date
+    induction_record_collection.each_with_index do |ir, idx|
+      raise(StartDateAfterEndDateError) if ir.end_date.present? && ir.end_date < ir.start_date
 
-  #     next if idx.zero?
+      next if idx.zero?
 
-  #     raise(InvalidDateSequenceError) if previous_end_date.nil? || ir.start_date < previous_end_date
+      raise(InvalidDateSequenceError) if previous_end_date.nil? || ir.start_date < previous_end_date
 
-  #     previous_end_date = ir.end_date
-  #   end
-  # end
+      previous_end_date = ir.end_date
+    end
+  end
 end

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -134,11 +134,13 @@ private
   end
 
   def does_not_have_multiple_blank_end_dates!(induction_record_collection)
-    raise(MultipleBlankEndDateError) if induction_record_collection.count { |ir| ir.end_date.nil? } > 1
+    # calls to_a to ensure block is used when collection is ActiveRecord Relation
+    raise(MultipleBlankEndDateError) if induction_record_collection.to_a.count { |ir| ir.end_date.nil? } > 1
   end
 
   def does_not_have_multiple_active_induction_statuses!(induction_record_collection)
-    raise(MultipleActiveStatesError) if induction_record_collection.count { |ir| ir.induction_status == "active" } > 1
+    # calls to_a to ensure block is used when collection is ActiveRecord Relation
+    raise(MultipleActiveStatesError) if induction_record_collection.to_a.count { |ir| ir.induction_status == "active" } > 1
   end
 
   def induction_record_dates_are_sequential!(induction_record_collection)

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -14,6 +14,7 @@ class InductionRecordSanitizer
     @participant_profile = participant_profile
     @group_by = group_by.to_sym
     @error = nil
+    raise ArgumentError, "group_by param must be either :school, :provider or :none" unless group_by.in? %i[none school provider]
   end
 
   def valid?

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -39,8 +39,8 @@ module Migrators
 
           # TODO: we could just grab the first entry in each school group
           if sanitizer.valid?
-            sanitizer.induction_records.each do |urn, irs|
-              school_periods << SchoolPeriodExtractor.new(induction_records: irs).school_periods
+            sanitizer.induction_records.each_value do |induction_records_group|
+              school_periods << SchoolPeriodExtractor.new(induction_records: induction_records_group).school_periods
             end
 
             teacher.update!(ecf_ect_profile_id: participant_profile.id)

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -33,13 +33,18 @@ module Migrators
           .mentor
           .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
           .find_each do |participant_profile|
-          induction_records = InductionRecordSanitizer.new(participant_profile:)
+          sanitizer = InductionRecordSanitizer.new(participant_profile:, group_by: :school)
 
-          if induction_records.valid?
-            school_periods = SchoolPeriodExtractor.new(induction_records:)
+          school_periods = []
+
+          # TODO: we could just grab the first entry in each school group
+          if sanitizer.valid?
+            sanitizer.induction_records.each_value do |induction_records_group|
+              school_periods << SchoolPeriodExtractor.new(induction_records: induction_records_group).school_periods
+            end
 
             teacher.update!(ecf_mentor_profile_id: participant_profile.id)
-            result = Builders::Mentor::SchoolPeriods.new(teacher:, school_periods:).build
+            result = Builders::Mentor::SchoolPeriods.new(teacher:, school_periods: school_periods.flatten).build
           else
             ::TeacherMigrationFailure.create!(teacher:,
                                               model: :mentor_at_school_period,

--- a/app/migration/school_period_extractor.rb
+++ b/app/migration/school_period_extractor.rb
@@ -13,14 +13,14 @@ class SchoolPeriodExtractor
     school_periods.each(&block)
   end
 
-private
-
   def school_periods
     @school_periods ||= build_school_periods
   end
 
+private
+
   def build_school_periods
-    periods = build_school_periods_from_induction_records
+    periods = build_school_periods_from_induction_records.flatten
     periods = add_school_mentor_periods_to_school_periods(periods) if mentor?
 
     periods

--- a/spec/migration/induction_record_sanitizer_spec.rb
+++ b/spec/migration/induction_record_sanitizer_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe InductionRecordSanitizer do
+  describe "#validate!" do
+    subject(:sanitizer) { described_class.new(participant_profile:, group_by:) }
+
+    let(:group_by) { :none }
+    let(:participant_profile) { FactoryBot.create(:migration_participant_profile, :ect) }
+    let!(:induction_record) { FactoryBot.create(:migration_induction_record, participant_profile:) }
+
+    it "does not raise an error when the records are correct" do
+      expect {
+        sanitizer.validate!
+      }.not_to raise_error
+    end
+
+    context "when the profile has no induction records" do
+      let!(:induction_record) { nil }
+
+      it "raises a NoInductionRecordsError" do
+        expect {
+          sanitizer.validate!
+        }.to raise_error(InductionRecordSanitizer::NoInductionRecordsError)
+      end
+    end
+
+    context "when there are multiple records with blank end_date values" do
+      let!(:induction_record_2) { FactoryBot.create(:migration_induction_record, participant_profile:) }
+
+      it "raises a MultipleBlankEndDateError" do
+        expect {
+          sanitizer.validate!
+        }.to raise_error(InductionRecordSanitizer::MultipleBlankEndDateError)
+      end
+    end
+
+    context "when there are multiple records with active induction_status values" do
+      let!(:induction_record_2) { FactoryBot.create(:migration_induction_record, participant_profile:, end_date: 1.hour.ago) }
+
+      it "raises a MultipleActiveStatesError" do
+        expect {
+          sanitizer.validate!
+        }.to raise_error(InductionRecordSanitizer::MultipleActiveStatesError)
+      end
+    end
+
+    context "when an induction record has a start_date that is later than the end_date" do
+      let!(:induction_record) { FactoryBot.create(:migration_induction_record, participant_profile:, start_date: 1.hour.ago, end_date: 1.week.ago) }
+
+      it "raises a StartDateAfterEndDateError" do
+        expect {
+          sanitizer.validate!
+        }.to raise_error(InductionRecordSanitizer::StartDateAfterEndDateError)
+      end
+    end
+
+    context "when the induction records have a start_date that is earlier than the previous records end_date" do
+      let!(:induction_record) { FactoryBot.create(:migration_induction_record, participant_profile:, end_date: 1.hour.ago, induction_status: :changed) }
+      let!(:induction_record_2) { FactoryBot.create(:migration_induction_record, participant_profile:, start_date: 1.day.ago) }
+
+      it "raises a InvalidDateSequenceError" do
+        expect {
+          sanitizer.validate!
+        }.to raise_error(InductionRecordSanitizer::InvalidDateSequenceError)
+      end
+    end
+  end
+end

--- a/spec/migration/induction_record_sanitizer_spec.rb
+++ b/spec/migration/induction_record_sanitizer_spec.rb
@@ -4,12 +4,55 @@ RSpec.describe InductionRecordSanitizer do
 
     let(:group_by) { :none }
     let(:participant_profile) { FactoryBot.create(:migration_participant_profile, :ect) }
+    let(:cohort) { participant_profile.school_cohort.cohort }
+    let(:school) { participant_profile.school_cohort.school }
+    let!(:partnership) { FactoryBot.create(:migration_partnership, school:, cohort:) }
     let!(:induction_record) { FactoryBot.create(:migration_induction_record, participant_profile:) }
 
     it "does not raise an error when the records are correct" do
       expect {
         sanitizer.validate!
       }.not_to raise_error
+    end
+
+    context "when group_by is :school" do
+      let(:group_by) { :school }
+      let!(:induction_record) { FactoryBot.create(:migration_induction_record, participant_profile:, end_date: 1.week.ago, induction_status: :changed) }
+      let!(:induction_record_2) { FactoryBot.create(:migration_induction_record, participant_profile:, start_date: 1.week.ago) }
+
+      it "groups the induction records by school" do
+        # 1 school group, 2 records
+        expect(sanitizer.induction_records.size).to eq 1
+        expect(sanitizer.induction_records.values.first.size).to eq 2
+      end
+    end
+
+    context "when group_by is :provider" do
+      let(:group_by) { :provider }
+      let(:partnership) { FactoryBot.create(:migration_partnership, school:, cohort:) }
+      let(:induction_programme) { FactoryBot.create(:migration_induction_programme, partnership:) }
+      let!(:induction_record) { FactoryBot.create(:migration_induction_record, induction_programme:, participant_profile:, end_date: 1.week.ago, induction_status: :changed) }
+      let(:partnership_2) { FactoryBot.create(:migration_partnership, school:, cohort:) }
+      let(:induction_programme_2) { FactoryBot.create(:migration_induction_programme, partnership: partnership_2) }
+      let!(:induction_record_2) { FactoryBot.create(:migration_induction_record, induction_programme: induction_programme_2, participant_profile:, start_date: 1.week.ago) }
+
+      it "groups the induction records by provider" do
+        # 2 provider groups, 1 record each
+        expect(sanitizer.induction_records.size).to eq 2
+        sanitizer.induction_records.each_value do |records|
+          expect(records.count).to eq 1
+        end
+      end
+    end
+
+    context "when group_by is not a valid option" do
+      let(:group_by) { :banana }
+
+      it "raises an error" do
+        expect {
+          sanitizer
+        }.to raise_error(ArgumentError)
+      end
     end
 
     context "when the profile has no induction records" do


### PR DESCRIPTION
### Context

In an attempt to fix some migration errors I've added the ability to validate induction records by group. The group can be by `:school` or `:provider`.  This will segregate the induction records into those groups and perform the validations on each group individually.  This appears to help fix a number of issues with interleaved timelines (e.g. retrospective provider updates) but has only been tested with real data for `ECTAtSchoolPeriod` migrations. This resulted in ~10x reduction in errors raised.  In addition we decided to skip checks regarding to end dates, at least for school periods, because we can focus on when a participant started at a school and any subsequent starts at different schools would close the previous period.  This no doubt has had a big contribution in the reduction in errors observed.

### Changes proposed in this pull request

- Changed `InductionRecordSanitizer` to have the option to group by school or provider
- Skipped checks with `end_date` overlaps and "`start_date` before `end_date`" type errors when grouping
- Updated `ECTATSchoolPeriod` and `MentorAtSchoolPeriod` migrators to use grouping by school

### Guidance to review
