### PR TITLE
Always use `govuk_submit` in forms

### DIFF
--- a/app/components/teachers_index/search_section_component.html.erb
+++ b/app/components/teachers_index/search_section_component.html.erb
@@ -14,7 +14,7 @@
           </div>
           <div class="govuk-grid-column-one-third">
             <div class="govuk-button-group">
-              <%= f.submit("Search", class: "govuk-button govuk-!-margin-left-2") %>
+              <%= f.govuk_submit "Search", class: "govuk-!-margin-left-2" %>
               <%= govuk_button_link_to("Reset", reset_path, secondary: true) %>
             </div>
           </div>

--- a/app/views/admin/finance/adjustments/edit.html.erb
+++ b/app/views/admin/finance/adjustments/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-full">
     <%= form_with model: @adjustment, url: admin_finance_statement_adjustment_path(@statement, @adjustment) do |form| %>
       <%= render "fields", form: %>
-      <%= form.submit "Save changes", class: "govuk-button" %>
+      <%= form.govuk_submit "Save changes" %>
     <% end %>
 
     <%= govuk_link_to "Cancel and return to statement", statement_path %>

--- a/app/views/admin/finance/adjustments/new.html.erb
+++ b/app/views/admin/finance/adjustments/new.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-full">
     <%= form_with model: @adjustment, url: admin_finance_statement_adjustments_path(@statement) do |form| %>
       <%= render "fields", form: %>
-      <%= form.submit "Add adjustment", class: "govuk-button" %>
+      <%= form.govuk_submit "Add adjustment" %>
     <% end %>
 
     <%= govuk_link_to "Cancel and return to statement", statement_path %>

--- a/app/views/admin/induction_periods/new.html.erb
+++ b/app/views/admin/induction_periods/new.html.erb
@@ -39,7 +39,7 @@
         <%= f.govuk_collection_radio_buttons :induction_programme, induction_programme_choices, :identifier, :name, legend: { text: 'Induction programme' }  %>
       <% end %>
 
-      <%= f.submit "Save", class: "govuk-button" %>
+      <%= f.govuk_submit "Save" %>
     <% end %>
   </div>
 </div>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -30,7 +30,7 @@
           <%= hidden_field_tag "appropriate_body_id", persona.appropriate_body_id %>
           <%= hidden_field_tag "school_urn", persona.school_urn %>
           <%= hidden_field_tag "dfe_staff", persona.dfe_staff %>
-          <%= f.submit "Sign-in as #{persona.name}", class: "govuk-button govuk-!-margin-bottom-2" %>
+          <%= f.govuk_submit "Sign-in as #{persona.name}", class: "govuk-!-margin-bottom-2" %>
         <% end %>
       </div>
     </div>

--- a/spec/components/teachers_index/search_section_component_spec.rb
+++ b/spec/components/teachers_index/search_section_component_spec.rb
@@ -95,9 +95,9 @@ RSpec.describe TeachersIndex::SearchSectionComponent, type: :component do
     end
 
     it 'renders submit button with correct styling' do
-      button = rendered.css('input[type="submit"]').first
+      button = rendered.css('button[type="submit"]').first
       expect(button['class']).to include('govuk-button')
-      expect(button['value']).to eq('Search')
+      expect(button.text).to eq('Search')
     end
 
     it 'renders reset button with correct styling' do

--- a/spec/features/admin/teachers/add_induction_period_spec.rb
+++ b/spec/features/admin/teachers/add_induction_period_spec.rb
@@ -196,7 +196,7 @@ private
   end
 
   def and_i_submit_the_form
-    page.locator("input[type=submit]", hasText: "Save").click
+    page.locator("button[type=submit]", hasText: "Save").click
   end
 
   def then_i_see_a_success_message


### PR DESCRIPTION
Rather than adding `govuk-button` classes manually, we can use the `govuk_submit` form element from the Form Builder.

In an ideal world, we might introduce a Cop for this and integrate it with a tool like `erblint`, but that's a problem for another day!

Inspired by #1051