### PR TITLE
Add delivery partner swagger docs

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -31,7 +31,7 @@ paths:
         in: query
         required: false
         schema:
-          "$ref": "#/components/schemas/SortOrder"
+          "$ref": "#/components/schemas/SortingTimestamps"
       responses:
         '200':
           description: A list of delivery partners
@@ -101,7 +101,7 @@ paths:
         in: query
         required: false
         schema:
-          "$ref": "#/components/schemas/SortOrder"
+          "$ref": "#/components/schemas/SortingTimestamps"
       responses:
         '200':
           description: A list of schools scoped to cohort
@@ -263,7 +263,7 @@ components:
             is 3000, if the value is greater that the maximum allowed it will fallback
             to 3000.
           example: 10
-    SortOrder:
+    SortingTimestamps:
       description: Sort records being returned.
       enum:
       - created_at

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -7,6 +7,76 @@ externalDocs:
   description: Find out more about Swagger
   url: https://swagger.io/
 paths:
+  "/api/v3/delivery-partners":
+    get:
+      summary: Retrieve multiple delivery partners
+      tags:
+      - Delivery Partners
+      security:
+      - api_key: []
+      parameters:
+      - name: filter
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/DeliveryPartnersFilter"
+        style: deepObject
+      - name: page
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
+      - name: sort
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/SortOrder"
+      responses:
+        '200':
+          description: A list of delivery partners
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/DeliveryPartnersResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+  "/api/v3/delivery-partners/{id}":
+    get:
+      summary: Retrieve a single a delivery partner
+      tags:
+      - Delivery Partners
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: A single a delivery partner
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/DeliveryPartnerResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
   "/api/v3/schools":
     get:
       summary: Retrieve multiple schools scoped to cohort
@@ -31,7 +101,7 @@ paths:
         in: query
         required: false
         schema:
-          "$ref": "#/components/schemas/SortingOptions"
+          "$ref": "#/components/schemas/SortOrder"
       responses:
         '200':
           description: A list of schools scoped to cohort
@@ -193,7 +263,7 @@ components:
             is 3000, if the value is greater that the maximum allowed it will fallback
             to 3000.
           example: 10
-    SortingOptions:
+    SortOrder:
       description: Sort records being returned.
       enum:
       - created_at
@@ -409,3 +479,71 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Statement"
+    DeliveryPartner:
+      description: A delivery partner.
+      type: object
+      required:
+      - id
+      - type
+      - attributes
+      properties:
+        id:
+          "$ref": "#/components/schemas/IDAttribute"
+        type:
+          description: The data type.
+          type: string
+          example: delivery-partner
+          enum:
+          - delivery-partner
+        attributes:
+          properties:
+            name:
+              description: The name of the delivery partner you are working with.
+              type: string
+              nullable: false
+              example: Awesome Delivery Partner Ltd
+            cohort:
+              description: The cohorts for which you may report school partnerships
+                with this delivery partner.
+              type: array
+              nullable: false
+              example:
+              - '2021'
+              - '2022'
+            created_at:
+              description: The date and time the delivery partner was created.
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+            updated_at:
+              description: The date and time the delivery partner was last updated.
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+    DeliveryPartnersFilter:
+      description: Filter delivery partners to return more specific results
+      type: object
+      properties:
+        cohort:
+          description: Return delivery partners from the specified cohort or cohorts.
+            This is a comma delimited string of years.
+          type: string
+          example: '2021,2022'
+    DeliveryPartnerResponse:
+      description: A delivery partner.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          "$ref": "#/components/schemas/DeliveryPartner"
+    DeliveryPartnersResponse:
+      description: A list of delivery partners.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/DeliveryPartner"

--- a/spec/requests/api/docs/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/docs/v3/delivery_partners_spec.rb
@@ -1,0 +1,27 @@
+require "swagger_helper"
+
+RSpec.describe "Delivery partners endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+  include_context "with authorization for api doc request"
+
+  let(:delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+  let(:resource) { delivery_partnership.delivery_partner }
+
+  it_behaves_like "an API index endpoint documentation",
+                  {
+                    url: "/api/v3/delivery-partners",
+                    tag: "Delivery Partners",
+                    resource_description: "delivery partners",
+                    response_schema_ref: "#/components/schemas/DeliveryPartnersResponse",
+                    filter_schema_ref: "#/components/schemas/DeliveryPartnersFilter",
+                    sorting_schema_ref: "#/components/schemas/SortOrder",
+                  }
+
+  it_behaves_like "an API show endpoint documentation",
+                  {
+                    url: "/api/v3/delivery-partners/{id}",
+                    tag: "Delivery Partners",
+                    resource_description: "a delivery partner",
+                    response_schema_ref: "#/components/schemas/DeliveryPartnerResponse",
+                  } do
+  end
+end

--- a/spec/requests/api/docs/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/docs/v3/delivery_partners_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Delivery partners endpoint", openapi_spec: "v3/swagger.yaml", ty
                     resource_description: "delivery partners",
                     response_schema_ref: "#/components/schemas/DeliveryPartnersResponse",
                     filter_schema_ref: "#/components/schemas/DeliveryPartnersFilter",
-                    sorting_schema_ref: "#/components/schemas/SortOrder",
+                    sorting_schema_ref: "#/components/schemas/SortingTimestamps",
                   }
 
   it_behaves_like "an API show endpoint documentation",

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
                     resource_description: "schools scoped to cohort",
                     response_schema_ref: "#/components/schemas/SchoolsResponse",
                     filter_schema_ref: "#/components/schemas/SchoolsFilter",
-                    sorting_schema_ref: "#/components/schemas/SortOrder",
+                    sorting_schema_ref: "#/components/schemas/SortingTimestamps",
                   }
 
   it_behaves_like "an API show endpoint documentation",

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :reque
                     resource_description: "schools scoped to cohort",
                     response_schema_ref: "#/components/schemas/SchoolsResponse",
                     filter_schema_ref: "#/components/schemas/SchoolsFilter",
-                    default_sortable: true
+                    sorting_schema_ref: "#/components/schemas/SortOrder",
                   }
 
   it_behaves_like "an API show endpoint documentation",

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -24,15 +24,6 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
                 },
                 style: "deepObject"
 
-      if params[:default_sortable]
-        parameter name: :sort,
-                  in: :query,
-                  required: false,
-                  schema: {
-                    "$ref": "#/components/schemas/SortingOptions",
-                  }
-      end
-
       if params[:sorting_schema_ref]
         parameter name: :sort,
                   in: :query,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
           UnauthorisedResponse: UNAUTHORISED_RESPONSE,
           NotFoundResponse: NOT_FOUND_RESPONSE,
           PaginationFilter: PAGINATION_FILTER,
-          SortOrder: SORT_ORDER,
+          SortingTimestamps: SORTING_TIMESTAMPS,
 
           # Schools
           School: SCHOOL,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
           UnauthorisedResponse: UNAUTHORISED_RESPONSE,
           NotFoundResponse: NOT_FOUND_RESPONSE,
           PaginationFilter: PAGINATION_FILTER,
-          SortingOptions: SORTING_OPTIONS,
+          SortOrder: SORT_ORDER,
 
           # Schools
           School: SCHOOL,
@@ -56,6 +56,12 @@ RSpec.configure do |config|
           StatementsFilter: STATEMENTS_FILTER,
           StatementResponse: STATEMENT_RESPONSE,
           StatementsResponse: STATEMENTS_RESPONSE,
+
+          # Delivery Partners
+          DeliveryPartner: DELIVERY_PARTNER,
+          DeliveryPartnersFilter: DELIVERY_PARTNERS_FILTER,
+          DeliveryPartnerResponse: DELIVERY_PARTNER_RESPONSE,
+          DeliveryPartnersResponse: DELIVERY_PARTNERS_RESPONSE,
         }
       }
     }

--- a/spec/swagger_schemas/filters/delivery_partners.rb
+++ b/spec/swagger_schemas/filters/delivery_partners.rb
@@ -1,0 +1,11 @@
+DELIVERY_PARTNERS_FILTER = {
+  description: "Filter delivery partners to return more specific results",
+  type: "object",
+  properties: {
+    cohort: {
+      description: "Return delivery partners from the specified cohort or cohorts. This is a comma delimited string of years.",
+      type: "string",
+      example: "2021,2022",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/filters/sort_order.rb
+++ b/spec/swagger_schemas/filters/sort_order.rb
@@ -1,4 +1,4 @@
-SORTING_OPTIONS = {
+SORT_ORDER = {
   description: "Sort records being returned.",
   enum: [
     "created_at",

--- a/spec/swagger_schemas/models/delivery_partner.rb
+++ b/spec/swagger_schemas/models/delivery_partner.rb
@@ -1,0 +1,46 @@
+DELIVERY_PARTNER = {
+  description: "A delivery partner.",
+  type: :object,
+  required: %i[id type attributes],
+  properties: {
+    id: {
+      "$ref": "#/components/schemas/IDAttribute",
+    },
+    type: {
+      description: "The data type.",
+      type: :string,
+      example: "delivery-partner",
+      enum: %w[
+        delivery-partner
+      ],
+    },
+    attributes: {
+      properties: {
+        name: {
+          description: "The name of the delivery partner you are working with.",
+          type: :string,
+          nullable: false,
+          example: "Awesome Delivery Partner Ltd",
+        },
+        cohort: {
+          description: "The cohorts for which you may report school partnerships with this delivery partner.",
+          type: :array,
+          nullable: false,
+          example: %w[2021 2022],
+        },
+        created_at: {
+          description: "The date and time the delivery partner was created.",
+          type: :string,
+          format: :"date-time",
+          example: "2021-05-31T02:22:32.000Z",
+        },
+        updated_at: {
+          description: "The date and time the delivery partner was last updated.",
+          type: :string,
+          format: :"date-time",
+          example: "2021-05-31T02:22:32.000Z",
+        },
+      },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/delivery_partner.rb
+++ b/spec/swagger_schemas/responses/delivery_partner.rb
@@ -1,0 +1,10 @@
+DELIVERY_PARTNER_RESPONSE = {
+  description: "A delivery partner.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      "$ref": "#/components/schemas/DeliveryPartner",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/delivery_partners.rb
+++ b/spec/swagger_schemas/responses/delivery_partners.rb
@@ -1,0 +1,11 @@
+DELIVERY_PARTNERS_RESPONSE = {
+  description: "A list of delivery partners.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      type: :array,
+      items: { "$ref": "#/components/schemas/DeliveryPartner" },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/sorting/timestamps.rb
+++ b/spec/swagger_schemas/sorting/timestamps.rb
@@ -1,4 +1,4 @@
-SORT_ORDER = {
+SORTING_TIMESTAMPS = {
   description: "Sort records being returned.",
   enum: [
     "created_at",


### PR DESCRIPTION
### Context

We want to add the delivery partner swagger documentation to support the APIs recently added.

### Changes proposed in this pull request

- Add delivery partners swagger documentation

Add request/docs spec for delivery partners `index` and `show` actions.

Add schemas for delivery partners.

Move `SortOptions` schema out of `concerns` and into `filters`.

Update schools specs to use `sorting_schema_ref` instead of `default_sortable`.

- Move and rename sorting schema

To avoid confusion and allow other sorting schemas this is moving to the `sorting` directory and renamed to `SortingTimestamps` so its clearer what its doing.

### Guidance to review

[Link to swagger docs](https://cpd-ec2-review-1059-web.test.teacherservices.cloud/api/docs/v3)