### PR TITLE
Always use `secondary: true` for secondary submit buttons

### DIFF
--- a/app/components/admin/statements/filter_component.html.erb
+++ b/app/components/admin/statements/filter_component.html.erb
@@ -36,6 +36,6 @@
       form_group: { class: 'filter-form-group' }
     %>
 
-    <%= f.govuk_submit "View", class: "govuk-button govuk-button--secondary filter-button" %>
+    <%= f.govuk_submit "View", secondary: true, class: "filter-button" %>
   </div>
 <% end %>

--- a/app/components/admin/statements/selector_component.html.erb
+++ b/app/components/admin/statements/selector_component.html.erb
@@ -27,6 +27,6 @@
       form_group: { class: 'filter-form-group' }
     %>
 
-    <%= f.govuk_submit "View", class: "govuk-button govuk-button--secondary filter-button" %>
+    <%= f.govuk_submit "View", secondary: true, class: "filter-button" %>
   </div>
 <% end %>


### PR DESCRIPTION
Similar to #1056 and also inspired by #1051.

Rather than adding the `govuk-button--secondary` class to submit buttons explicitly, we can rely on the FormBuilder to handle it for us if we pass `secondary: true`.