### PR TITLE
Fix bug where names starting with titles are stripped

### DIFF
--- a/app/services/teachers/full_name_parser.rb
+++ b/app/services/teachers/full_name_parser.rb
@@ -24,7 +24,7 @@ private
   def parse_full_name
     n1 = full_name.strip
     n1 = n1.gsub(/\(.*\)/, "")
-    n1 = n1.gsub(/\A((mrs|miss|mr|ms|dr|)\.?)/i, "")
+    n1 = n1.gsub(/\A((mrs|miss|mr|ms|dr|)\.?) /i, "")
     n1 = n1.strip
     n1.split(/\s/)
   end

--- a/spec/services/teachers/full_name_parser_spec.rb
+++ b/spec/services/teachers/full_name_parser_spec.rb
@@ -7,6 +7,14 @@ describe Teachers::FullNameParser do
     it "returns the first name part" do
       expect(service.first_name).to eq "Alison"
     end
+
+    context "when the first name starts with a title" do
+      let(:full_name) { "Missi Pyle" }
+
+      it "returns the first name intact" do
+        expect(service.first_name).to eq "Missi"
+      end
+    end
   end
 
   describe '#last_name' do


### PR DESCRIPTION
Occasionally we have a failing spec like this:

```
  1) Migrators::Teacher behaves like a migrator #migrate! creates a Teacher records for each ECF TeacherProfile
     Failure/Error: expect(Teachers::Name.new(teacher).full_name).to eq user.full_name

       expected: "Missy Sippy"
            got: "y Sippy"
```

It's because the full name parser strips 'Miss' from the first name (to protect against occasions where a user has accidentally included the title in their first name field).

Some names, e.g., Missy, start with a title. Now the matcher looks for a space after the title.
