### PR TITLE
[2016] - Migrate all ECF schools with partnerships or induction records

### DIFF
--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -28,6 +28,7 @@ module Migration
     scope :eligible_or_cip_only_except_welsh, -> { eligible.or(cip_only_except_welsh) }
     scope :not_cip_only, -> { where.not(id: cip_only) }
     scope :with_induction_records, -> { joins(:induction_records).distinct }
+    scope :with_partnerships, -> { joins(:partnerships).distinct }
 
     def cip_only_type? = GIAS::Types::CIP_ONLY_EXCEPT_WELSH.include?(school_type_name)
 


### PR DESCRIPTION
### Context
[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/2016)

We are importing only open schools from GIAS into RECT. 
Similarly, we are comparing only open, eligible or cip_only schools on ECF1 with those in RECT.

However, other not open schools have partnerships associated and no induction records.
As those partnerships will need to be migrated into RECT, we need their schools to be migrated as well.

### Changes proposed in this pull request

Extend the schools comparison migrator to migrate all ECF schools that have partnerships or induction records.

### Guidance to review