### PR TITLE
Add support for different parity check URLs

### DIFF
--- a/app/migration/parity_check/request_builder.rb
+++ b/app/migration/parity_check/request_builder.rb
@@ -16,7 +16,7 @@ module ParityCheck
     delegate :method, :path, :options, to: :endpoint
 
     def url(app:)
-      parity_check_url(app:) + formatted_path
+      parity_check_url(app:) + formatted_path(app:)
     end
 
     def headers
@@ -51,10 +51,16 @@ module ParityCheck
 
   private
 
-    def formatted_path
-      return path unless path.include?(ID_PLACEHOLDER)
+    def app_specific_path(app:)
+      options[:"#{app}_path"] || path
+    end
 
-      path.sub(ID_PLACEHOLDER, path_id)
+    def formatted_path(app:)
+      app_specific_path = app_specific_path(app:)
+
+      return app_specific_path unless app_specific_path.include?(ID_PLACEHOLDER)
+
+      app_specific_path.sub(ID_PLACEHOLDER, path_id)
     end
 
     def path_id

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -19,36 +19,42 @@ get:
   - "/api/v3/statements/:id":
       id: statement_id
     
-  - "/api/v3/schools/ecf":
+  - "/api/v3/schools":
+      ecf_path: "/api/v3/schools/ecf"
       paginate: true
       query:
         filter:
           cohort: 2022
-  - "/api/v3/schools/ecf":
+  - "/api/v3/schools":
+      ecf_path: "/api/v3/schools/ecf"
       paginate: true
       query:
         filter:
           urn: "102396"
           cohort: 2023
-  - "/api/v3/schools/ecf":
+  - "/api/v3/schools":
+      ecf_path: "/api/v3/schools/ecf"
       paginate: true
       query:
         filter:
           cohort: 2023
           updated_since: "2025-04-13T11:21:55Z"
-  - "/api/v3/schools/ecf":
+  - "/api/v3/schools":
+      ecf_path: "/api/v3/schools/ecf"
       paginate: true
       query:
         cohort: 2021
         sort: "-updated_at"
-  - "/api/v3/schools/ecf":
+  - "/api/v3/schools":
+      ecf_path: "/api/v3/schools/ecf"
       paginate: true
       query:
         filter:
           cohort: "2021,2022"
           urn: "102396"
           updated_since: "2025-04-13T11:21:55Z"
-  - "/api/v3/schools/ecf/:id":
+  - "/api/v3/schools/:id":
+      ecf_path: "/api/v3/schools/ecf/:id"
       id: school_id
 
 post:

--- a/spec/migration/parity_check/request_builder_spec.rb
+++ b/spec/migration/parity_check/request_builder_spec.rb
@@ -61,6 +61,34 @@ RSpec.describe ParityCheck::RequestBuilder do
 
         it { is_expected.to eq("#{ecf_url}/test-path/#{id}") }
       end
+
+      context "when the options specify an ecf-specific path" do
+        let(:app) { :ecf }
+        let(:path) { "/default-path" }
+        let(:options) { { ecf_path: "/ecf-path" } }
+
+        it { is_expected.to eq("#{ecf_url}/ecf-path") }
+
+        context "when the app is rect" do
+          let(:app) { :rect }
+
+          it { is_expected.to eq("#{rect_url}/default-path") }
+        end
+      end
+
+      context "when the options specify a rect-specific path" do
+        let(:app) { :rect }
+        let(:path) { "/default-path" }
+        let(:options) { { rect_path: "/rect-path" } }
+
+        it { is_expected.to eq("#{rect_url}/rect-path") }
+
+        context "when the app is ecf" do
+          let(:app) { :ecf }
+
+          it { is_expected.to eq("#{ecf_url}/default-path") }
+        end
+      end
     end
 
     describe "#headers" do


### PR DESCRIPTION
### Context

On some of the new RECT endpoints we are omitting `ecf` from the path of the endpoint (schools, for example). This means we need to call different endpoints depending on the application.

### Changes proposed in this pull request

- Add support for different parity check URLs

Add support to parity check endpoint options for `ecf_url` or `rect_url` - this will be used with preference over the default URL provided as the key to the check.

### Guidance to review

[Example run](https://cpd-ec2-migration-web.teacherservices.cloud/migration/parity-checks/8)
