### PR TITLE
[1864] allow user to select a different lp than the ect s when registering a new mentor

### DIFF
--- a/app/services/ect_at_school_periods/training.rb
+++ b/app/services/ect_at_school_periods/training.rb
@@ -64,8 +64,6 @@ module ECTAtSchoolPeriods
     # latest_eoi_lead_provider_name
     delegate :name, to: :latest_eoi_lead_provider, allow_nil: true, prefix: true
 
-  private
-
     def latest_eoi_lead_provider
       return unless latest_training_period&.only_expression_of_interest?
 

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -1,0 +1,18 @@
+class MentorAtSchoolPeriods::Finish
+  attr_reader :teacher, :finished_on
+
+  def initialize(teacher:, finished_on:)
+    @teacher = teacher
+    @finished_on = finished_on
+  end
+
+  def finish_existing_at_school_periods!
+    ActiveRecord::Base.transaction do
+      teacher.mentor_at_school_periods.ongoing_on(finished_on).each do |period|
+        period.update!(finished_on:)
+        period.mentorship_periods.ongoing_on(finished_on).update!(finished_on:)
+        period.training_periods.ongoing_on(finished_on).update!(finished_on:)
+      end
+    end
+  end
+end

--- a/app/services/mentor_at_school_periods/latest_registration_choices.rb
+++ b/app/services/mentor_at_school_periods/latest_registration_choices.rb
@@ -10,7 +10,8 @@ module MentorAtSchoolPeriods
       @training_period ||= ::TrainingPeriod
         .includes(mentor_at_school_period: [:teacher])
         .where(teacher: { trn: })
-        .latest_first.first
+        .latest_first
+        .first
     end
 
     delegate :school_partnership, to: :training_period, allow_nil: true

--- a/app/services/mentor_at_school_periods/latest_registration_choices.rb
+++ b/app/services/mentor_at_school_periods/latest_registration_choices.rb
@@ -1,4 +1,4 @@
-module TrainingPeriods
+module MentorAtSchoolPeriods
   class LatestRegistrationChoices
     attr_reader :trn
 

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -23,7 +23,7 @@ module Schools
                    school_urn:,
                    email:,
                    author:,
-                   finish_existing_at_school_periods: nil,
+                   finish_existing_at_school_periods: false,
                    started_on: nil,
                    lead_provider: nil)
       @author = author

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -23,7 +23,7 @@ module Schools
                    school_urn:,
                    email:,
                    author:,
-                   finish_existing_at_school_periods:,
+                   finish_existing_at_school_periods: nil,
                    started_on: nil,
                    lead_provider: nil)
       @author = author

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -82,7 +82,7 @@ module Schools
     end
 
     def finish_existing_at_school_periods!
-      teacher.mentor_at_school_periods.ongoing_on(started_on).update!(finished_on: started_on.prev_day)
+      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: started_on.prev_day).finish_existing_at_school_periods!
     end
 
     def start_at_school!

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -32,7 +32,7 @@ module Schools
       @corrected_name = corrected_name
       @school_urn = school_urn
       @email = email
-      @started_on = started_on || Date.current
+      @started_on = started_on&.to_date || Date.current
       @trn = trn
       @lead_provider = lead_provider
       @finish_existing_at_school_periods = finish_existing_at_school_periods

--- a/app/services/teachers/mentor_funding_eligibility.rb
+++ b/app/services/teachers/mentor_funding_eligibility.rb
@@ -14,5 +14,9 @@ module Teachers
 
       teacher.mentor_became_ineligible_for_funding_reason.blank?
     end
+
+    def ineligible?
+      teacher.mentor_became_ineligible_for_funding_on.present?
+    end
   end
 end

--- a/app/services/teachers/mentor_funding_eligibility.rb
+++ b/app/services/teachers/mentor_funding_eligibility.rb
@@ -6,6 +6,9 @@ module Teachers
       @teacher = Teacher.find_by(trn:)
     end
 
+    # TODO: `mentor_became_ineligible_for_funding_on` is a date,
+    # should we pass in a date to determine eligibility? (Date.today or "mentoring start date")
+
     def eligible?
       return true if teacher.nil?
 

--- a/app/services/teachers/mentor_funding_eligibility.rb
+++ b/app/services/teachers/mentor_funding_eligibility.rb
@@ -16,7 +16,7 @@ module Teachers
     end
 
     def ineligible?
-      teacher.mentor_became_ineligible_for_funding_on.present?
+      !eligible?
     end
   end
 end

--- a/app/services/training_periods/latest_registration_choices.rb
+++ b/app/services/training_periods/latest_registration_choices.rb
@@ -1,0 +1,19 @@
+module TrainingPeriods
+  class LatestRegistrationChoices
+    attr_reader :trn
+
+    def initialize(trn:)
+      @trn = trn
+    end
+
+    def training_period
+      @training_period ||= ::TrainingPeriod
+        .includes(mentor_at_school_period: [:teacher])
+        .where(teacher: { trn: })
+        .latest_first.first
+    end
+
+    delegate :school_partnership, to: :training_period, allow_nil: true
+    delegate :school, :lead_provider, :delivery_partner, to: :school_partnership, allow_nil: true
+  end
+end

--- a/app/validators/lead_provider_validator.rb
+++ b/app/validators/lead_provider_validator.rb
@@ -1,10 +1,10 @@
-class LeadProviderValidator < ActiveModel::Validator
-  def validate(record)
-    if record.lead_provider_id.blank?
-      record.errors.add(:lead_provider_id, "Select which lead provider will be training the ECT")
-    end
-    unless LeadProvider.exists?(record.lead_provider_id)
-      record.errors.add(:lead_provider_id, "Enter the name of a known lead provider")
-    end
+class LeadProviderValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    return if record.errors[attribute].any?
+    return if LeadProvider.find_by(id: value)
+
+    message = options[:message] || "Select a lead provider"
+    record.errors.add(attribute, message)
   end
 end

--- a/app/validators/mentor_start_date_validator.rb
+++ b/app/validators/mentor_start_date_validator.rb
@@ -1,0 +1,12 @@
+class MentorStartDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    start_date = Schools::Validation::MentorStartDate.new(
+      date_as_hash: value,
+      current_date: options[:current_date]
+    )
+
+    unless start_date.valid?
+      record.errors.add(attribute, start_date.error_message)
+    end
+  end
+end

--- a/app/views/schools/register_mentor_wizard/change_lead_provider.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_lead_provider.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "schools/register_mentor_wizard/lead_provider" %>

--- a/app/views/schools/register_mentor_wizard/change_mentoring_at_new_school_only.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_mentoring_at_new_school_only.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "schools/register_mentor_wizard/mentoring_at_new_school_only" %>

--- a/app/views/schools/register_mentor_wizard/change_started_on.html.erb
+++ b/app/views/schools/register_mentor_wizard/change_started_on.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "schools/register_mentor_wizard/started_on" %>

--- a/app/views/schools/register_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/register_mentor_wizard/check_answers.html.erb
@@ -1,40 +1,40 @@
-<%
-  page_data(
-    title: "Check your answers and confirm mentor details",
-    backlink_href: @wizard.previous_step_path
-  )
-%>
-<%=
-  govuk_summary_list do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key(text: 'Teacher reference number (TRN)')
-      row.with_value(text: @mentor.trn)
-    end
+<% page_data(
+  title: "Check your answers and confirm mentor details",
+  backlink_href: @wizard.previous_step_path,
+) %>
+<%= govuk_summary_list do |summary_list|
+  summary_list.with_row do |row|
+    row.with_key(text: "Teacher reference number (TRN)")
+    row.with_value(text: @mentor.trn)
+  end
 
-    summary_list.with_row do |row|
-      row.with_key(text: 'Name')
-      row.with_value(text: @mentor.full_name)
-      row.with_action(text: 'Change',
-                      href: schools_register_mentor_wizard_change_mentor_details_path,
-                      visually_hidden_text: 'name')
-    end
+  summary_list.with_row do |row|
+    row.with_key(text: "Name")
+    row.with_value(text: @mentor.full_name)
+    row.with_action(
+      text: "Change",
+      href: schools_register_mentor_wizard_change_mentor_details_path,
+      visually_hidden_text: "name",
+    )
+  end
 
-    summary_list.with_row do |row|
-      row.with_key(text: 'Email address')
-      row.with_value(text: @mentor.email)
-      row.with_action(text: 'Change',
-                      href: schools_register_mentor_wizard_change_email_address_path,
-                      visually_hidden_text: 'email address')
-    end
+  summary_list.with_row do |row|
+    row.with_key(text: "Email address")
+    row.with_value(text: @mentor.email)
+    row.with_action(
+      text: "Change",
+      href: schools_register_mentor_wizard_change_email_address_path,
+      visually_hidden_text: "email address",
+    )
+  end
 
-    if @wizard.ect.provider_led_training_programme? && @mentor.funding_available?
-      summary_list.with_row do |row|
-        row.with_key(text: 'Lead provider')
-        row.with_value(text: ECTAtSchoolPeriods::Training.new(@wizard.ect).latest_lead_provider_name )
-      end
+  if @wizard.ect.provider_led_training_programme? && @mentor.funding_available?
+    summary_list.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: @mentor.lead_provider.name)
     end
   end
-%>
+end %>
 
 <%= govuk_inset_text(text: "#{@mentor.full_name} will mentor #{@ect_name}") %>
 

--- a/app/views/schools/register_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/register_mentor_wizard/check_answers.html.erb
@@ -34,7 +34,8 @@
       row.with_value(text: @mentor.mentoring_at_new_school_only.capitalize)
       row.with_action(
         text: "Change",
-        href: schools_register_mentor_wizard_mentoring_at_new_school_only_path,
+        href:
+          schools_register_mentor_wizard_change_mentoring_at_new_school_only_path,
         visually_hidden_text: "mentoring only at your school",
       )
     end
@@ -46,7 +47,7 @@
       row.with_value(text: @mentor.started_on.to_date.to_fs(:govuk))
       row.with_action(
         text: "Change",
-        href: schools_register_mentor_wizard_started_on_path,
+        href: schools_register_mentor_wizard_change_started_on_path,
         visually_hidden_text: "mentor start date",
       )
     end
@@ -58,7 +59,7 @@
       row.with_value(text: @mentor.lead_provider.name)
       row.with_action(
         text: "Change",
-        href: (schools_register_mentor_wizard_lead_provider_path),
+        href: (schools_register_mentor_wizard_change_lead_provider_path),
         visually_hidden_text: "lead provider",
       )
     end

--- a/app/views/schools/register_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/register_mentor_wizard/check_answers.html.erb
@@ -28,10 +28,39 @@
     )
   end
 
-  if @wizard.ect.provider_led_training_programme? && @mentor.funding_available?
+  if @mentor.mentoring_at_new_school_only.present?
+    summary_list.with_row do |row|
+      row.with_key(text: "Mentoring only at your school")
+      row.with_value(text: @mentor.mentoring_at_new_school_only.capitalize)
+      row.with_action(
+        text: "Change",
+        href: schools_register_mentor_wizard_mentoring_at_new_school_only_path,
+        visually_hidden_text: "mentoring only at your school",
+      )
+    end
+  end
+
+  if @mentor.started_on
+    summary_list.with_row do |row|
+      row.with_key(text: "Mentor start date")
+      row.with_value(text: @mentor.started_on.to_date.to_fs(:govuk))
+      row.with_action(
+        text: "Change",
+        href: schools_register_mentor_wizard_started_on_path,
+        visually_hidden_text: "mentor start date",
+      )
+    end
+  end
+
+  if @mentor.lead_provider
     summary_list.with_row do |row|
       row.with_key(text: "Lead provider")
       row.with_value(text: @mentor.lead_provider.name)
+      row.with_action(
+        text: "Change",
+        href: (schools_register_mentor_wizard_lead_provider_path),
+        visually_hidden_text: "lead provider",
+      )
     end
   end
 end %>

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -21,7 +21,7 @@ They do not need to provide us with any further details.
 
 <% if @wizard.ect.provider_led_training_programme? %>
 <% if @mentor.funding_available? %>
-We'll pass on their details to <%= ECTAtSchoolPeriods::Training.new(@wizard.ect).latest_lead_provider_name %>
+We'll pass on their details to <%= @mentor.ect_lead_provider&.name %>
  who will contact them to arrange mentor training.
 <% else %>
 They cannot do mentor training according to our records.

--- a/app/views/schools/register_mentor_wizard/eligibility_lead_provider.html.erb
+++ b/app/views/schools/register_mentor_wizard/eligibility_lead_provider.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "schools/register_mentor_wizard/lead_provider" %>

--- a/app/views/schools/register_mentor_wizard/lead_provider.html.erb
+++ b/app/views/schools/register_mentor_wizard/lead_provider.html.erb
@@ -16,7 +16,7 @@
 
   <%= f.govuk_collection_radio_buttons(
     :lead_provider_id,
-    @mentor.active_lead_providers,
+    @mentor.lead_providers_within_contract_period,
     :id,
     :name,
     legend: {

--- a/app/views/schools/register_mentor_wizard/lead_provider.html.erb
+++ b/app/views/schools/register_mentor_wizard/lead_provider.html.erb
@@ -1,0 +1,42 @@
+<% page_data(
+  title:
+    "Which lead provider would you like to contact your school about training #{@mentor.full_name}?",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: @wizard.previous_step_path,
+) %>
+
+<p class="govuk-body">
+  We'll let the lead provider know that your school is interested in working
+  with them. They'll contact your school to discuss this further before you
+  decide if you want to go ahead with the mentor training.
+</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_collection_radio_buttons(
+    :lead_provider_id,
+    @mentor.active_lead_providers,
+    :id,
+    :name,
+    legend: {
+      text: "Select lead provider",
+      hidden: true,
+    },
+  ) %>
+
+  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+    <p class="govuk-body">An appropriate body is responsible for assuring the quality of the
+      statutory induction of ECTs. A lead provider provides the online learning
+      platform used for training ECTs and mentors, while the delivery partner
+      delivers training events.
+    </p>
+
+    <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for
+      example an appropriate body might be the same organisation as the
+      delivery partner.
+    </p>
+  <% end %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb
+++ b/app/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb
@@ -7,7 +7,17 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :mentoring_at_new_school_only, legend: { text: "Our records show that #{@mentor.full_name} is already registered as a mentor at a different school" } do %>
+  <p class="govuk-body">
+    Our records show that
+    <%= @mentor.full_name %>
+    is already registered as a mentor at a different school.
+  </p>
+
+  <%= f.govuk_radio_buttons_fieldset :mentoring_at_new_school_only,
+        legend: {
+          text: "Will #{@mentor.full_name} be mentoring ECTs at your school only?",
+          hidden: true
+        } do %>
     <%= f.govuk_radio_button :mentoring_at_new_school_only,
                          :yes,
                          label: {

--- a/app/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb
+++ b/app/views/schools/register_mentor_wizard/mentoring_at_new_school_only.html.erb
@@ -1,0 +1,26 @@
+<% page_data(
+  title: "Will #{@mentor.full_name} be mentoring ECTs at your school only?",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: @wizard.previous_step_path,
+) %>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_radio_buttons_fieldset :mentoring_at_new_school_only, legend: { text: "Our records show that #{@mentor.full_name} is already registered as a mentor at a different school" } do %>
+    <%= f.govuk_radio_button :mentoring_at_new_school_only,
+                         :yes,
+                         label: {
+                           text: "Yes, they will be mentoring at our school only",
+                         },
+                         link_errors: true %>
+    <%= f.govuk_radio_button :mentoring_at_new_school_only,
+                         :no,
+                         label: {
+                           text:
+                             "No, they will also be mentoring at another school",
+                         } %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
@@ -1,0 +1,44 @@
+<% page_data(
+  title: "#{@mentor.full_name} has been registered before",
+  backlink_href: @wizard.previous_step_path,
+) %>
+
+<%= govuk_summary_card(title: "Previously registered details") do |card|
+  card.with_summary_list(
+    actions: false,
+    rows: [
+      {
+        key: {
+          text: "School name",
+        },
+        value: {
+          text: @mentor.latest_registration_choice.school&.name,
+        },
+      },
+      {
+        key: {
+          text: "Lead provider",
+        },
+        value: {
+          text: @mentor.latest_registration_choice.lead_provider&.name,
+        },
+      },
+      {
+        key: {
+          text: "Delivery partner",
+        },
+        value: {
+          text: @mentor.latest_registration_choice.delivery_partner&.name,
+        },
+      },
+    ],
+  )
+end %>
+
+<p class="govuk-body">You'll be able to tell us what kind of training they'll continue with later.</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
@@ -35,7 +35,7 @@
   )
 end %>
 
-<p class="govuk-body">You'll be able to tell us what kind of training they'll continue with later.</p>
+<p class="govuk-body">You’ll be able to tell us what kind of training they’ll continue with later.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/register_mentor_wizard/programme_choices.html.erb
+++ b/app/views/schools/register_mentor_wizard/programme_choices.html.erb
@@ -22,8 +22,8 @@ end %>
 
 <% unless @mentor.ect_lead_provider %>
   <p class="govuk-body">
-    <%= @mentor.ect_lead_provider&.name %>
-    will confirm if they'll be working with your school and which delivery
+    <%= @mentor.ect_lead_provider.name %>
+    will confirm if they’ll be working with your school and which deliver
     partner will delivery training events.
   </p>
 <% end %>
@@ -31,7 +31,7 @@ end %>
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :use_same_programme_choices, legend: { text: "Do you want to use the same programme choices for #{@mentor.full_name}'s mentor training" }, inline: true do %>
+  <%= f.govuk_radio_buttons_fieldset :use_same_programme_choices, legend: { text: "Do you want to use the same programme choices for #{@mentor.full_name}’s mentor training" }, inline: true do %>
     <%= f.govuk_radio_button :use_same_programme_choices,
                          :yes,
                          label: {

--- a/app/views/schools/register_mentor_wizard/programme_choices.html.erb
+++ b/app/views/schools/register_mentor_wizard/programme_choices.html.erb
@@ -7,22 +7,26 @@
 
 <p class="govuk-body">
   These are the programme choices we have for the ECT who
-  <%= @wizard.mentor.full_name %>
+  <%= @mentor.full_name %>
   will be mentoring.
 </p>
 
 <%= govuk_summary_list do |summary_list|
   summary_list.with_row do |row|
     row.with_key(text: "Lead provider")
-    row.with_value(text: @wizard.ect.lead_provider.name)
+    row.with_value(
+      text: (@mentor.ect_lead_provider || @mentor.ect_eoi_lead_provider).name,
+    )
   end
 end %>
 
-<p class="govuk-body">
-  <%= @wizard.ect.lead_provider.name %>
-  will confirm if they'll be working with your school and which delivery
-  partner will delivery training events.
-</p>
+<% unless @mentor.ect_lead_provider %>
+  <p class="govuk-body">
+    <%= @mentor.ect_lead_provider&.name %>
+    will confirm if they'll be working with your school and which delivery
+    partner will delivery training events.
+  </p>
+<% end %>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/app/views/schools/register_mentor_wizard/programme_choices.html.erb
+++ b/app/views/schools/register_mentor_wizard/programme_choices.html.erb
@@ -1,0 +1,41 @@
+<% page_data(
+  title:
+    "Programme choices used by the ECT who #{@mentor.full_name} will be mentoring",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: @wizard.previous_step_path,
+) %>
+
+<p class="govuk-body">
+  These are the programme choices we have for the ECT who
+  <%= @wizard.mentor.full_name %>
+  will be mentoring.
+</p>
+
+<%= govuk_summary_list do |summary_list|
+  summary_list.with_row do |row|
+    row.with_key(text: "Lead provider")
+    row.with_value(text: @wizard.ect.lead_provider.name)
+  end
+end %>
+
+<p class="govuk-body">
+  <%= @wizard.ect.lead_provider.name %>
+  will confirm if they'll be working with your school and which delivery
+  partner will delivery training events.
+</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_radio_buttons_fieldset :use_same_programme_choices, legend: { text: "Do you want to use the same programme choices for #{@mentor.full_name}'s mentor training" }, inline: true do %>
+    <%= f.govuk_radio_button :use_same_programme_choices,
+                         :yes,
+                         label: {
+                           text: "Yes",
+                         },
+                         link_errors: true %>
+    <%= f.govuk_radio_button :use_same_programme_choices, :no, label: { text: "No" } %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
@@ -1,14 +1,20 @@
-<%
-  page_data(
-    title: "#{@mentor.full_name} can receive mentor training",
-    backlink_href: @wizard.previous_step_path
-  )
-%>
+<% page_data(
+  title: "#{@mentor.full_name} can receive mentor training",
+  backlink_href: @wizard.previous_step_path,
+) %>
 
-<p class="govuk-body">Our records show that <%= @mentor.full_name %> can get up to 20 hours of ECTE mentor training as your school is working with a DfE-funded training provider.</p>
+<p class="govuk-body">Our records show that
+  <%= @mentor.full_name %>
+  can get up to 20 hours of ECTE mentor training as your school is working with
+  a DfE-funded training provider.</p>
 
-<p class="govuk-body">We'll pass on their details to <%= @mentor.ect_lead_provider&.name %> who will contact them to arrange the training.</p>
+<p class="govuk-body">We'll pass on their details to
+  <%= @mentor.ect_lead_provider&.name %>
+  who will contact them to arrange the training.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= f.govuk_submit "Continue" %>
 <% end %>
+
+<%= govuk_link_to "#{@mentor.ect_lead_provider&.name} will not be providing mentor training to #{@mentor.full_name}",
+schools_register_mentor_wizard_eligibility_lead_provider_path %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
@@ -1,13 +1,13 @@
-<% 
+<%
   page_data(
-    title: "#{@mentor.full_name} can receive mentor training", 
+    title: "#{@mentor.full_name} can receive mentor training",
     backlink_href: @wizard.previous_step_path
-  ) 
+  )
 %>
 
 <p class="govuk-body">Our records show that <%= @mentor.full_name %> can get up to 20 hours of ECTE mentor training as your school is working with a DfE-funded training provider.</p>
 
-<p class="govuk-body">We'll pass on their details to <%= ECTAtSchoolPeriods::Training.new(@wizard.ect).latest_lead_provider_name %> who will contact them to arrange the training.</p>
+<p class="govuk-body">We'll pass on their details to <%= @mentor.ect_lead_provider&.name %> who will contact them to arrange the training.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/register_mentor_wizard/started_on.html.erb
+++ b/app/views/schools/register_mentor_wizard/started_on.html.erb
@@ -10,9 +10,8 @@
 
   <%= f.govuk_date_field :started_on,
                      legend: {
-                       text: "Start date",
-                       size: "m",
-                       tag: "h3",
+                       text: "Mentor start date",
+                       hidden: true,
                      },
                      hint: {
                        text: "For example, 27 9 2024",

--- a/app/views/schools/register_mentor_wizard/started_on.html.erb
+++ b/app/views/schools/register_mentor_wizard/started_on.html.erb
@@ -1,0 +1,23 @@
+<% page_data(
+  title:
+    "When did or when will #{@mentor.full_name} start mentoring ECTs at your school?",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: @wizard.previous_step_path,
+) %>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_date_field :started_on,
+                     width: "two-thirds",
+                     legend: {
+                       text: "Start date",
+                       size: "m",
+                       tag: "h3",
+                     },
+                     hint: {
+                       text: "For example, 27 9 2024",
+                     } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/register_mentor_wizard/started_on.html.erb
+++ b/app/views/schools/register_mentor_wizard/started_on.html.erb
@@ -9,7 +9,6 @@
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%= f.govuk_date_field :started_on,
-                     width: "two-thirds",
                      legend: {
                        text: "Start date",
                        size: "m",

--- a/app/wizards/schools/register_ect_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/register_ect_wizard/lead_provider_step.rb
@@ -3,7 +3,9 @@ module Schools
     class LeadProviderStep < Step
       attr_accessor :lead_provider_id
 
-      validates_with LeadProviderValidator
+      validates :lead_provider_id,
+                presence: { message: "Select which lead provider will be training the ECT" },
+                lead_provider: { message: "Enter the name of a known lead provider" }
 
       def self.permitted_params
         %i[lead_provider_id]

--- a/app/wizards/schools/register_mentor_wizard/change_lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/change_lead_provider_step.rb
@@ -1,0 +1,13 @@
+module Schools
+  module RegisterMentorWizard
+    class ChangeLeadProviderStep < LeadProviderStep
+      def next_step
+        :check_answers
+      end
+
+      def previous_step
+        :check_answers
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/change_mentoring_at_new_school_only_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/change_mentoring_at_new_school_only_step.rb
@@ -1,0 +1,13 @@
+module Schools
+  module RegisterMentorWizard
+    class ChangeMentoringAtNewSchoolOnlyStep < MentoringAtNewSchoolOnlyStep
+      def next_step
+        :check_answers
+      end
+
+      def previous_step
+        :check_answers
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/change_started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/change_started_on_step.rb
@@ -1,0 +1,13 @@
+module Schools
+  module RegisterMentorWizard
+    class ChangeStartedOnStep < StartedOnStep
+      def next_step
+        :check_answers
+      end
+
+      def previous_step
+        :check_answers
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/eligibility_lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/eligibility_lead_provider_step.rb
@@ -1,0 +1,13 @@
+module Schools
+  module RegisterMentorWizard
+    class EligibilityLeadProviderStep < LeadProviderStep
+      def next_step
+        :check_answers
+      end
+
+      def previous_step
+        :review_mentor_eligibility
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/email_address_step.rb
@@ -13,7 +13,7 @@ module Schools
         return :cant_use_email if mentor.cant_use_email?
         return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
 
-        return :check_answers unless mentor.has_mentor_at_school_periods?
+        return :check_answers unless mentor.previously_registered_as_mentor?
 
         if mentor.has_open_mentor_at_school_period_at_another_school?
           # Ask school: are they mentoring at new school only?

--- a/app/wizards/schools/register_mentor_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/email_address_step.rb
@@ -13,9 +13,9 @@ module Schools
         return :cant_use_email if mentor.cant_use_email?
         return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
 
-        return :check_answers unless has_mentor_at_school_periods?
+        return :check_answers unless mentor.has_mentor_at_school_periods?
 
-        if has_open_mentor_at_school_period_at_another_school?
+        if mentor.open_mentor_at_school_period_at_another_school?
           # Ask school: are they mentoring at new school only?
           :mentoring_at_new_school_only
         else
@@ -26,23 +26,6 @@ module Schools
 
       def previous_step
         :review_mentor_details
-      end
-
-    private
-
-      def mentor_at_school_periods
-        ::MentorAtSchoolPeriod.includes(:teacher).where(teacher: { trn: mentor.trn })
-      end
-
-      # Does mentor have any previous mentor_at_school_periods (open or closed)?
-      def has_mentor_at_school_periods?
-        mentor_at_school_periods.exists?
-      end
-
-      # Does mentor have an open mentor_at_school_period at another school?
-      def has_open_mentor_at_school_period_at_another_school?
-        finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(Date.tomorrow)
-        mentor_at_school_periods.where.not(school: mentor.school).ongoing.or(finishes_in_the_future_scope).exists?
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/email_address_step.rb
@@ -15,7 +15,7 @@ module Schools
 
         return :check_answers unless mentor.has_mentor_at_school_periods?
 
-        if mentor.open_mentor_at_school_period_at_another_school?
+        if mentor.has_open_mentor_at_school_period_at_another_school?
           # Ask school: are they mentoring at new school only?
           :mentoring_at_new_school_only
         else

--- a/app/wizards/schools/register_mentor_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/email_address_step.rb
@@ -13,11 +13,36 @@ module Schools
         return :cant_use_email if mentor.cant_use_email?
         return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
 
-        :check_answers
+        return :check_answers unless has_mentor_at_school_periods?
+
+        if has_open_mentor_at_school_period_at_another_school?
+          # Ask school: are they mentoring at new school only?
+          :mentoring_at_new_school_only
+        else
+          # Ask school: when will mentor start?
+          :started_on
+        end
       end
 
       def previous_step
         :review_mentor_details
+      end
+
+    private
+
+      def mentor_at_school_periods
+        ::MentorAtSchoolPeriod.includes(:teacher).where(teacher: { trn: mentor.trn })
+      end
+
+      # Does mentor have any previous mentor_at_school_periods (open or closed)?
+      def has_mentor_at_school_periods?
+        mentor_at_school_periods.exists?
+      end
+
+      # Does mentor have an open mentor_at_school_period at another school?
+      def has_open_mentor_at_school_period_at_another_school?
+        finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(Date.tomorrow)
+        mentor_at_school_periods.where.not(school: mentor.school).ongoing.or(finishes_in_the_future_scope).exists?
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/email_address_step.rb
@@ -15,7 +15,7 @@ module Schools
 
         return :check_answers unless mentor.previously_registered_as_mentor?
 
-        if mentor.has_open_mentor_at_school_period_at_another_school?
+        if mentor.currently_mentor_at_another_school?
           # Ask school: are they mentoring at new school only?
           :mentoring_at_new_school_only
         else

--- a/app/wizards/schools/register_mentor_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/lead_provider_step.rb
@@ -1,9 +1,11 @@
 module Schools
   module RegisterMentorWizard
     class LeadProviderStep < Step
-      attr_accessor :lead_provider_id
+      attr_reader :lead_provider_id
 
-      validates_with LeadProviderValidator
+      validates :lead_provider_id,
+                presence: { message: "Select a lead provider to contact your school" },
+                lead_provider: { message: "Select a lead provider to contact your school" }
 
       def self.permitted_params
         %i[lead_provider_id]

--- a/app/wizards/schools/register_mentor_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/lead_provider_step.rb
@@ -1,7 +1,7 @@
 module Schools
   module RegisterMentorWizard
     class LeadProviderStep < Step
-      attr_reader :lead_provider_id
+      attr_accessor :lead_provider_id
 
       validates :lead_provider_id,
                 presence: { message: "Select a lead provider to contact your school" },

--- a/app/wizards/schools/register_mentor_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/lead_provider_step.rb
@@ -1,0 +1,27 @@
+module Schools
+  module RegisterMentorWizard
+    class LeadProviderStep < Step
+      attr_accessor :lead_provider_id
+
+      validates_with LeadProviderValidator
+
+      def self.permitted_params
+        %i[lead_provider_id]
+      end
+
+      def next_step
+        :check_answers
+      end
+
+      def previous_step
+        :programme_choices
+      end
+
+    private
+
+      def persist
+        mentor.update!(lead_provider_id:)
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -76,6 +76,7 @@ module Schools
         @lead_provider ||= LeadProvider.find(lead_provider_id) if lead_provider_id
       end
 
+      # The form submits a symbol (:yes or :no), but Rails stores it as a string ('yes'/'no').
       def finish_existing_at_school_periods
         mentoring_at_new_school_only == "yes"
       end

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -53,6 +53,8 @@ module Schools
                                     school_urn:,
                                     email:,
                                     author:,
+                                    started_on:,
+                                    finish_existing_at_school_periods:,
                                     lead_provider:)
                                .register!
                                .tap { self.registered = true }
@@ -72,6 +74,10 @@ module Schools
 
       def lead_provider
         ECTAtSchoolPeriods::Training.new(ect).latest_lead_provider if ect
+      end
+
+      def finish_existing_at_school_periods
+        mentoring_at_new_school_only == "yes"
       end
 
     private

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -81,7 +81,7 @@ module Schools
       end
 
       def latest_registration_choice
-        @latest_registration_choice ||= TrainingPeriods::LatestRegistrationChoices.new(trn:)
+        @latest_registration_choice ||= MentorAtSchoolPeriods::LatestRegistrationChoices.new(trn:)
       end
 
       # Extract into separate service to get active lead provider for contract period, same for register ECT wizard

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -84,9 +84,14 @@ module Schools
         @latest_registration_choice ||= MentorAtSchoolPeriods::LatestRegistrationChoices.new(trn:)
       end
 
-      # Extract into separate service to get active lead provider for contract period, same for register ECT wizard
-      def active_lead_providers
-        @active_lead_providers ||= LeadProvider.select(:id, :name).all
+      def lead_providers_within_contract_period
+        return [] unless contract_period
+
+        @lead_providers_within_contract_period ||= LeadProviders::Active.in_contract_period(contract_period).select(:id, :name)
+      end
+
+      def contract_period
+        ContractPeriod.containing_date(started_on&.to_date)
       end
 
     private

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -73,11 +73,20 @@ module Schools
       end
 
       def lead_provider
-        ECTAtSchoolPeriods::Training.new(ect).latest_lead_provider if ect
+        @lead_provider ||= LeadProvider.find(lead_provider_id) if lead_provider_id
       end
 
       def finish_existing_at_school_periods
         mentoring_at_new_school_only == "yes"
+      end
+
+      def latest_registration_choice
+        @latest_registration_choice ||= TrainingPeriods::LatestRegistrationChoices.new(trn:)
+      end
+
+      # Extract into separate service to get active lead provider for contract period, same for register ECT wizard
+      def active_lead_providers
+        @active_lead_providers ||= LeadProvider.select(:id, :name).all
       end
 
     private

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -92,7 +92,7 @@ module Schools
       end
 
       def contract_period
-        ContractPeriod.containing_date(started_on&.to_date)
+        ContractPeriod.containing_date(started_on&.to_date || Date.current)
       end
 
       # Does mentor have any previous mentor_at_school_periods (open or closed)?

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -120,7 +120,7 @@ module Schools
       end
 
       def ect_lead_provider
-        ect_training_service.latest_lead_provider
+        ect_training_service.latest_lead_provider if ect
       end
 
       def ect_eoi_lead_provider

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -101,7 +101,7 @@ module Schools
       end
 
       # Does mentor have an open mentor_at_school_period at another school?
-      def has_open_mentor_at_school_period_at_another_school?
+      def currently_mentor_at_another_school?
         previous_school_mentor_at_school_periods.exists?
       end
 

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -96,7 +96,7 @@ module Schools
       end
 
       # Does mentor have any previous mentor_at_school_periods (open or closed)?
-      def has_mentor_at_school_periods?
+      def previously_registered_as_mentor?
         mentor_at_school_periods.exists?
       end
 
@@ -131,7 +131,7 @@ module Schools
     private
 
       def mentor_at_school_periods
-        ::MentorAtSchoolPeriod.includes(:teacher).where(teacher: { trn: })
+        ::MentorAtSchoolPeriods::Search.new.mentor_periods(trn:)
       end
 
       def ect_training_service

--- a/app/wizards/schools/register_mentor_wizard/mentoring_at_new_school_only_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentoring_at_new_school_only_step.rb
@@ -27,7 +27,7 @@ module Schools
     private
 
       def persist
-        mentor.update(mentoring_at_new_school_only:)
+        mentor.update!(mentoring_at_new_school_only:)
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/mentoring_at_new_school_only_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentoring_at_new_school_only_step.rb
@@ -5,7 +5,7 @@ module Schools
 
       validates :mentoring_at_new_school_only,
                 inclusion: { in: %w[yes no],
-                             message: "Select 'Yes' or 'No' to confirm whether they will be mentoring at our school only" }
+                             message: "Select 'Yes' or 'No' to confirm whether they will be mentoring at your school only" }
 
       def self.permitted_params
         %i[mentoring_at_new_school_only]

--- a/app/wizards/schools/register_mentor_wizard/mentoring_at_new_school_only_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentoring_at_new_school_only_step.rb
@@ -1,0 +1,34 @@
+module Schools
+  module RegisterMentorWizard
+    class MentoringAtNewSchoolOnlyStep < Step
+      attr_accessor :mentoring_at_new_school_only
+
+      validates :mentoring_at_new_school_only,
+                inclusion: { in: %w[yes no],
+                             message: "Select 'Yes' or 'No' to confirm whether they will be mentoring at our school only" }
+
+      def self.permitted_params
+        %i[mentoring_at_new_school_only]
+      end
+
+      def next_step
+        # Ask school: are they mentoring at new school only?
+        if mentoring_at_new_school_only == "yes"
+          :started_on
+        else
+          :check_answers
+        end
+      end
+
+      def previous_step
+        :email_address
+      end
+
+    private
+
+      def persist
+        mentor.update(mentoring_at_new_school_only:)
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/previous_training_period_details_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/previous_training_period_details_step.rb
@@ -8,17 +8,6 @@ module Schools
       def previous_step
         :started_on
       end
-
-    private
-
-      def persist
-        ActiveRecord::Base.transaction do
-          AssignMentor.new(ect:, author:, mentor: mentor.register!(author:)).assign!
-        end
-      rescue StandardError => e
-        mentor.registered = false
-        raise e
-      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/previous_training_period_details_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/previous_training_period_details_step.rb
@@ -1,0 +1,24 @@
+module Schools
+  module RegisterMentorWizard
+    class PreviousTrainingPeriodDetailsStep < Step
+      def next_step
+        :programme_choices
+      end
+
+      def previous_step
+        :started_on
+      end
+
+    private
+
+      def persist
+        ActiveRecord::Base.transaction do
+          AssignMentor.new(ect:, author:, mentor: mentor.register!(author:)).assign!
+        end
+      rescue StandardError => e
+        mentor.registered = false
+        raise e
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -18,7 +18,7 @@ module Schools
       end
 
       def previous_step
-        if mentor.latest_registration_choice.training_period
+        if mentor.latest_registration_choice.school_partnership
           :previous_training_period_details
         else
           :started_on

--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -1,0 +1,41 @@
+module Schools
+  module RegisterMentorWizard
+    class ProgrammeChoicesStep < Step
+      attr_accessor :use_same_programme_choices
+
+      validates :use_same_programme_choices,
+                inclusion: { in: %w[yes no],
+                             message: "Select 'Yes' or 'No'" }
+
+      def self.permitted_params
+        %i[use_same_programme_choices]
+      end
+
+      def next_step
+        if use_same_programme_choices == "yes"
+          :check_answers
+        else
+          :lead_provider
+        end
+      end
+
+      def previous_step
+        if mentor.latest_registration_choice.training_period
+          :previous_training_period_details
+        else
+          :started_on
+        end
+      end
+
+    private
+
+      def persist
+        mentor.update!(use_same_programme_choices:, lead_provider_id:)
+      end
+
+      def lead_provider_id
+        ect.lead_provider.id if use_same_programme_choices == "yes"
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -3,9 +3,7 @@ module Schools
     class ProgrammeChoicesStep < Step
       attr_accessor :use_same_programme_choices
 
-      validates :use_same_programme_choices,
-                inclusion: { in: %w[yes no],
-                             message: "Select 'Yes' or 'No'" }
+      validates :use_same_programme_choices, inclusion: { in: %w[yes no], message: "Select 'Yes' or 'No'" }
 
       def self.permitted_params
         %i[use_same_programme_choices]
@@ -34,7 +32,7 @@ module Schools
       end
 
       def lead_provider_id
-        ect.lead_provider.id if use_same_programme_choices == "yes"
+        mentor.ect_lead_provider.id if use_same_programme_choices == "yes"
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -32,7 +32,7 @@ module Schools
       end
 
       def lead_provider_id
-        mentor.ect_lead_provider.id if use_same_programme_choices == "yes"
+        mentor.ect_lead_provider&.id if use_same_programme_choices == "yes"
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -2,7 +2,7 @@ module Schools
   module RegisterMentorWizard
     class ReviewMentorEligibilityStep < Step
       def next_step
-        return :check_answers unless mentor.has_mentor_at_school_periods?
+        return :check_answers unless mentor.previously_registered_as_mentor?
 
         if mentor.has_open_mentor_at_school_period_at_another_school?
           # Ask school: are they mentoring at new school only?

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -4,7 +4,7 @@ module Schools
       def next_step
         return :check_answers unless mentor.previously_registered_as_mentor?
 
-        if mentor.has_open_mentor_at_school_period_at_another_school?
+        if mentor.currently_mentor_at_another_school?
           # Ask school: are they mentoring at new school only?
           :mentoring_at_new_school_only
         else

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -16,6 +16,12 @@ module Schools
       def previous_step
         :email_address
       end
+
+    private
+
+      def persist
+        mentor.update!(lead_provider_id: mentor.ect_lead_provider&.id)
+      end
     end
   end
 end

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -2,9 +2,9 @@ module Schools
   module RegisterMentorWizard
     class ReviewMentorEligibilityStep < Step
       def next_step
-        return :check_answers unless has_mentor_at_school_periods?
+        return :check_answers unless mentor.has_mentor_at_school_periods?
 
-        if has_open_mentor_at_school_period_at_another_school?
+        if mentor.has_open_mentor_at_school_period_at_another_school?
           # Ask school: are they mentoring at new school only?
           :mentoring_at_new_school_only
         else
@@ -15,23 +15,6 @@ module Schools
 
       def previous_step
         :email_address
-      end
-
-    private
-
-      def mentor_at_school_periods
-        ::MentorAtSchoolPeriod.includes(:teacher).where(teacher: { trn: mentor.trn })
-      end
-
-      # Does mentor have any previous mentor_at_school_periods (open or closed)?
-      def has_mentor_at_school_periods?
-        mentor_at_school_periods.exists?
-      end
-
-      # Does mentor have an open mentor_at_school_period at another school?
-      def has_open_mentor_at_school_period_at_another_school?
-        finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(Date.tomorrow)
-        mentor_at_school_periods.where.not(school: mentor.school).ongoing.or(finishes_in_the_future_scope).exists?
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -2,11 +2,36 @@ module Schools
   module RegisterMentorWizard
     class ReviewMentorEligibilityStep < Step
       def next_step
-        :check_answers
+        return :check_answers unless has_mentor_at_school_periods?
+
+        if has_open_mentor_at_school_period_at_another_school?
+          # Ask school: are they mentoring at new school only?
+          :mentoring_at_new_school_only
+        else
+          # Ask school: when will mentor start?
+          :started_on
+        end
       end
 
       def previous_step
         :email_address
+      end
+
+    private
+
+      def mentor_at_school_periods
+        ::MentorAtSchoolPeriod.includes(:teacher).where(teacher: { trn: mentor.trn })
+      end
+
+      # Does mentor have any previous mentor_at_school_periods (open or closed)?
+      def has_mentor_at_school_periods?
+        mentor_at_school_periods.exists?
+      end
+
+      # Does mentor have an open mentor_at_school_period at another school?
+      def has_open_mentor_at_school_period_at_another_school?
+        finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(Date.tomorrow)
+        mentor_at_school_periods.where.not(school: mentor.school).ongoing.or(finishes_in_the_future_scope).exists?
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -15,7 +15,7 @@ module Schools
 
         if mentor.became_ineligible_for_funding?
           :check_answers
-        elsif mentor.latest_registration_choice.training_period
+        elsif mentor.latest_registration_choice.school_partnership
           :previous_training_period_details
         else
           :programme_choices

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -3,16 +3,17 @@ module Schools
     class StartedOnStep < Step
       attribute :started_on, :date
 
-      validates :started_on, presence: { message: "Enter a start date" }
+      validates :started_on, presence: { message: "Enter the date they started or will start ECT mentoring at your school" }
+      validate :started_on_cannot_be_before_previous_started_and_finished_dates, if: :started_on
 
       def self.permitted_params
         %i[started_on]
       end
 
       def next_step
-        return :check_answers unless mentor_assigned_to_provider_led_ect?
+        return :check_answers unless mentor.provider_led_ect?
 
-        if mentor_became_ineligible_for_funding?
+        if mentor.became_ineligible_for_funding?
           :check_answers
         elsif mentor.latest_registration_choice.training_period
           :previous_training_period_details
@@ -31,22 +32,23 @@ module Schools
 
     private
 
-      # Is mentor being assigned to a provider-led ECT?
-      def mentor_assigned_to_provider_led_ect?
-        ect.provider_led?
-      end
-
-      # Does that mentor have a mentor_became_ineligible_for_funding_on?
-      def mentor_became_ineligible_for_funding?
-        ::Teachers::MentorFundingEligibility.new(trn: mentor.trn).ineligible?
-      end
-
       def persist
         mentor.update(started_on:)
       end
 
       def pre_populate_attributes
         self.started_on ||= mentor.started_on
+      end
+
+      def started_on_cannot_be_before_previous_started_and_finished_dates
+        return if errors.any?
+
+        date = mentor.previous_school_mentor_at_school_periods.pluck(:started_on, :finished_on).flatten.compact.max
+        return unless date
+
+        if started_on.before?(date.next_day)
+          errors.add(:started_on, "#{mentor.full_name} was registered as a mentor #{date.to_fs(:govuk)}. Enter a later date.")
+        end
       end
     end
   end

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -12,10 +12,12 @@ module Schools
       def next_step
         return :check_answers unless mentor_assigned_to_provider_led_ect?
 
-        if mentor_eligible_for_funding?
-          raise "needs implementing"
+        if mentor_became_ineligible_for_funding?
+          :check_answers
+        elsif mentor.latest_registration_choice.training_period
+          :previous_training_period_details
         else
-          raise "needs implementing"
+          :programme_choices
         end
       end
 
@@ -35,8 +37,8 @@ module Schools
       end
 
       # Does that mentor have a mentor_became_ineligible_for_funding_on?
-      def mentor_eligible_for_funding?
-        ::Teachers::MentorFundingEligibility.new(urn: mentor.trn).eligible?
+      def mentor_became_ineligible_for_funding?
+        ::Teachers::MentorFundingEligibility.new(trn: mentor.trn).ineligible?
       end
 
       def persist

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -33,7 +33,7 @@ module Schools
     private
 
       def persist
-        mentor.update(started_on:)
+        mentor.update!(started_on:)
       end
 
       def pre_populate_attributes

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -1,0 +1,51 @@
+module Schools
+  module RegisterMentorWizard
+    class StartedOnStep < Step
+      attribute :started_on, :date
+
+      validates :started_on, presence: { message: "Enter a start date" }
+
+      def self.permitted_params
+        %i[started_on]
+      end
+
+      def next_step
+        return :check_answers unless mentor_assigned_to_provider_led_ect?
+
+        if mentor_eligible_for_funding?
+          raise "needs implementing"
+        else
+          raise "needs implementing"
+        end
+      end
+
+      def previous_step
+        if mentor.mentoring_at_new_school_only == "yes"
+          :mentoring_at_new_school_only
+        else
+          :email_address
+        end
+      end
+
+    private
+
+      # Is mentor being assigned to a provider-led ECT?
+      def mentor_assigned_to_provider_led_ect?
+        ect.provider_led?
+      end
+
+      # Does that mentor have a mentor_became_ineligible_for_funding_on?
+      def mentor_eligible_for_funding?
+        ::Teachers::MentorFundingEligibility.new(urn: mentor.trn).eligible?
+      end
+
+      def persist
+        mentor.update(started_on:)
+      end
+
+      def pre_populate_attributes
+        self.started_on ||= mentor.started_on
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -12,7 +12,10 @@ module Schools
             cant_use_changed_email: CantUseChangedEmailStep,
             cant_use_email: CantUseEmailStep,
             change_email_address: ChangeEmailAddressStep,
+            change_lead_provider: ChangeLeadProviderStep,
             change_mentor_details: ChangeMentorDetailsStep,
+            change_mentoring_at_new_school_only: ChangeMentoringAtNewSchoolOnlyStep,
+            change_started_on: ChangeStartedOnStep,
             check_answers: CheckAnswersStep,
             confirmation: ConfirmationStep,
             email_address: EmailAddressStep,
@@ -71,7 +74,7 @@ module Schools
             return steps unless mentor.email
             return steps + %i[change_email_address cant_use_changed_email cant_use_email] if mentor.cant_use_email?
 
-            steps << if mentor.has_open_mentor_at_school_period_at_another_school?
+            steps << if mentor.currently_mentor_at_another_school?
                        :mentoring_at_new_school_only
                      else
                        :started_on
@@ -83,6 +86,9 @@ module Schools
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?
             steps += %i[change_mentor_details change_email_address check_answers]
+            steps << :change_mentoring_at_new_school_only if mentor.mentoring_at_new_school_only.present?
+            steps << :change_started_on if mentor.started_on
+            steps << :change_lead_provider if mentor.lead_provider
 
             steps
           end

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -25,6 +25,9 @@ module Schools
             trn_not_found: TRNNotFoundStep,
             mentoring_at_new_school_only: MentoringAtNewSchoolOnlyStep,
             started_on: StartedOnStep,
+            previous_training_period_details: PreviousTrainingPeriodDetailsStep,
+            programme_choices: ProgrammeChoicesStep,
+            lead_provider: LeadProviderStep,
           }
         ]
       end
@@ -70,6 +73,9 @@ module Schools
 
             steps << :mentoring_at_new_school_only
             steps << :started_on
+            steps << :previous_training_period_details
+            steps << :programme_choices
+            steps << :lead_provider
 
             steps << :review_mentor_eligibility if mentor.funding_available?
             steps += %i[change_mentor_details change_email_address check_answers]

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -17,17 +17,17 @@ module Schools
             confirmation: ConfirmationStep,
             email_address: EmailAddressStep,
             find_mentor: FindMentorStep,
+            lead_provider: LeadProviderStep,
+            mentoring_at_new_school_only: MentoringAtNewSchoolOnlyStep,
             national_insurance_number: NationalInsuranceNumberStep,
             no_trn: NoTRNStep,
             not_found: NotFoundStep,
-            review_mentor_details: ReviewMentorDetailsStep,
-            review_mentor_eligibility: ReviewMentorEligibilityStep,
-            trn_not_found: TRNNotFoundStep,
-            mentoring_at_new_school_only: MentoringAtNewSchoolOnlyStep,
-            started_on: StartedOnStep,
             previous_training_period_details: PreviousTrainingPeriodDetailsStep,
             programme_choices: ProgrammeChoicesStep,
-            lead_provider: LeadProviderStep,
+            review_mentor_details: ReviewMentorDetailsStep,
+            review_mentor_eligibility: ReviewMentorEligibilityStep,
+            started_on: StartedOnStep,
+            trn_not_found: TRNNotFoundStep,
           }
         ]
       end
@@ -71,12 +71,16 @@ module Schools
             return steps unless mentor.email
             return steps + %i[change_email_address cant_use_changed_email cant_use_email] if mentor.cant_use_email?
 
-            steps << :mentoring_at_new_school_only
-            steps << :started_on
-            steps << :previous_training_period_details
-            steps << :programme_choices
-            steps << :lead_provider
+            steps << if mentor.has_open_mentor_at_school_period_at_another_school?
+                       :mentoring_at_new_school_only
+                     else
+                       :started_on
+                     end
 
+            steps << :started_on if mentor.mentoring_at_new_school_only == "yes"
+            steps << :previous_training_period_details if mentor.latest_registration_choice.training_period
+            steps << :programme_choices unless mentor.became_ineligible_for_funding?
+            steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?
             steps += %i[change_mentor_details change_email_address check_answers]
 

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -81,7 +81,7 @@ module Schools
                      end
 
             steps << :started_on if mentor.mentoring_at_new_school_only == "yes"
-            steps << :previous_training_period_details if mentor.latest_registration_choice.training_period
+            steps << :previous_training_period_details if mentor.latest_registration_choice.school_partnership
             steps << :programme_choices unless mentor.became_ineligible_for_funding?
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -23,6 +23,8 @@ module Schools
             review_mentor_details: ReviewMentorDetailsStep,
             review_mentor_eligibility: ReviewMentorEligibilityStep,
             trn_not_found: TRNNotFoundStep,
+            mentoring_at_new_school_only: MentoringAtNewSchoolOnlyStep,
+            started_on: StartedOnStep,
           }
         ]
       end
@@ -65,6 +67,9 @@ module Schools
             steps << :email_address
             return steps unless mentor.email
             return steps + %i[change_email_address cant_use_changed_email cant_use_email] if mentor.cant_use_email?
+
+            steps << :mentoring_at_new_school_only
+            steps << :started_on
 
             steps << :review_mentor_eligibility if mentor.funding_available?
             steps += %i[change_mentor_details change_email_address check_answers]

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -18,6 +18,7 @@ module Schools
             change_started_on: ChangeStartedOnStep,
             check_answers: CheckAnswersStep,
             confirmation: ConfirmationStep,
+            eligibility_lead_provider: EligibilityLeadProviderStep,
             email_address: EmailAddressStep,
             find_mentor: FindMentorStep,
             lead_provider: LeadProviderStep,
@@ -85,6 +86,7 @@ module Schools
             steps << :programme_choices unless mentor.became_ineligible_for_funding?
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?
+            steps << :eligibility_lead_provider if mentor.funding_available?
             steps += %i[change_mentor_details change_email_address check_answers]
             steps << :change_mentoring_at_new_school_only if mentor.mentoring_at_new_school_only.present?
             steps << :change_started_on if mentor.started_on

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,6 +316,12 @@ Rails.application.routes.draw do
       get "review-mentor-eligibility", action: :new
       post "review-mentor-eligibility", action: :create
 
+      get "mentoring-at-new-school-only", action: :new
+      post "mentoring-at-new-school-only", action: :create
+
+      get "started-on", action: :new
+      post "started-on", action: :create
+
       get "check-answers", action: :new
       post "check-answers", action: :create
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,6 +336,8 @@ Rails.application.routes.draw do
       post "lead-provider", action: :create
       get "change-lead-provider", action: :new
       post "change-lead-provider", action: :create
+      get "eligibility-lead-provider", action: :new
+      post "eligibility-lead-provider", action: :create
 
       get "check-answers", action: :new
       post "check-answers", action: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,8 +308,8 @@ Rails.application.routes.draw do
       get "change-email-address", action: :new
       post "change-email-address", action: :create
 
-      get "cant-use-changed_email", action: :new
-      post "cant-use-changed_email", action: :create
+      get "cant-use-changed-email", action: :new
+      post "cant-use-changed-email", action: :create
       get "cant-use-email", action: :new
       post "cant-use-email", action: :create
 
@@ -321,6 +321,15 @@ Rails.application.routes.draw do
 
       get "started-on", action: :new
       post "started-on", action: :create
+
+      get "previous-training-period-details", action: :new
+      post "previous-training-period-details", action: :create
+
+      get "programme-choices", action: :new
+      post "programme-choices", action: :create
+
+      get "lead-provider", action: :new
+      post "lead-provider", action: :create
 
       get "check-answers", action: :new
       post "check-answers", action: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -318,9 +318,13 @@ Rails.application.routes.draw do
 
       get "mentoring-at-new-school-only", action: :new
       post "mentoring-at-new-school-only", action: :create
+      get "change-mentoring-at-new-school-only", action: :new
+      post "change-mentoring-at-new-school-only", action: :create
 
       get "started-on", action: :new
       post "started-on", action: :create
+      get "change-started-on", action: :new
+      post "change-started-on", action: :create
 
       get "previous-training-period-details", action: :new
       post "previous-training-period-details", action: :create
@@ -330,6 +334,8 @@ Rails.application.routes.draw do
 
       get "lead-provider", action: :new
       post "lead-provider", action: :create
+      get "change-lead-provider", action: :new
+      post "change-lead-provider", action: :create
 
       get "check-answers", action: :new
       post "check-answers", action: :create

--- a/lib/schools/validation/mentor_start_date.rb
+++ b/lib/schools/validation/mentor_start_date.rb
@@ -1,0 +1,26 @@
+module Schools
+  module Validation
+    class MentorStartDate < HashDate
+      DATE_MISSING_MESSAGE = "Enter the date they started or will start ECT mentoring at your school".freeze
+      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998".freeze
+
+      def initialize(date_as_hash:, current_date: nil)
+        super(date_as_hash)
+        @current_date = current_date || Time.zone.today
+      end
+
+      # String containing the full month name and year with century. Ex: 'January 2025'
+      def formatted_date
+        value_as_date.strftime(Date::DATE_FORMATS[:govuk])
+      end
+
+    private
+
+      attr_reader :current_date
+
+      def date_missing?
+        super || date_as_hash.values_at(1, 2, 3).all?(&:nil?)
+      end
+    end
+  end
+end

--- a/spec/factories/active_lead_provider_factory.rb
+++ b/spec/factories/active_lead_provider_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association :contract_period
 
     initialize_with do
-      ActiveLeadProvider.find_or_create_by(lead_provider:, contract_period:)
+      ActiveLeadProvider.find_by(lead_provider:, contract_period:) || new(**attributes)
     end
   end
 end

--- a/spec/factories/active_lead_provider_factory.rb
+++ b/spec/factories/active_lead_provider_factory.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory(:active_lead_provider) do
     association :lead_provider
     association :contract_period
+
+    initialize_with do
+      ActiveLeadProvider.find_or_create_by(lead_provider:, contract_period:)
+    end
   end
 end

--- a/spec/factories/mentorship_period_factory.rb
+++ b/spec/factories/mentorship_period_factory.rb
@@ -2,6 +2,9 @@ FactoryBot.define do
   sequence(:base_mentorship_date) { |n| 3.years.ago.to_date + (2 * n).days }
 
   factory(:mentorship_period) do
+    association :mentee, factory: :ect_at_school_period
+    association :mentor, factory: :mentor_at_school_period
+
     started_on { generate(:base_mentorship_date) }
     finished_on { started_on + 1.day }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -3,11 +3,13 @@ RSpec.describe 'Registering a mentor', :js do
 
   let(:trn) { '3002586' }
 
-  scenario 'happy path' do
+  scenario 'mentor has existing mentorship and is not mentoring at new school only' do
     given_there_is_a_school_in_the_service
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_mentor_has_existing_mentorship_at_another_school
     and_i_sign_in_as_that_school_user
     and_i_am_on_the_schools_landing_page
+
     when_i_click_to_assign_a_mentor_to_the_ect
     then_i_am_in_the_requirements_page
 
@@ -27,56 +29,16 @@ RSpec.describe 'Registering a mentor', :js do
     and_i_click_continue
     then_i_should_be_taken_to_the_review_mentor_eligibility_page
     and_i_click_continue
+
+    then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    when_i_select_no_they_will_also_be_mentoring_at_another_school
+
     then_i_should_be_taken_to_the_check_answers_page
     and_i_should_see_all_the_mentor_data_on_the_page
 
     when_i_click_confirm_details
     then_i_should_be_taken_to_the_confirmation_page
-
-    when_i_click_on_back_to_ects
-    then_i_should_be_taken_to_the_ects_page
-    and_the_ect_is_shown_linked_to_the_mentor_just_registered
-  end
-
-  scenario 'check your answers' do
-    given_there_is_a_school_in_the_service
-    and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    and_i_sign_in_as_that_school_user
-    and_i_am_on_the_schools_landing_page
-    when_i_click_to_assign_a_mentor_to_the_ect
-    then_i_am_in_the_requirements_page
-
-    when_i_click_continue
-    then_i_should_be_taken_to_the_find_mentor_page
-
-    when_i_submit_the_find_mentor_form
-    then_i_should_be_taken_to_the_review_mentor_details_page
-    and_i_should_see_the_mentor_details_in_the_review_page
-
-    when_i_select_that_my_mentor_name_is_incorrect
-    and_i_enter_the_corrected_name
-    and_i_click_confirm_and_continue
-    then_i_should_be_taken_to_the_email_address_page
-
-    when_i_enter_the_mentor_email_address
-    and_i_click_continue
-    then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    and_i_should_see_mentor_funding_on_the_page
-    and_i_click_continue
-    then_i_should_be_taken_to_the_check_answers_page
-    and_i_should_see_all_the_mentor_data_on_the_page
-
-    when_i_try_to_change_the_name
-    then_i_should_be_taken_to_the_change_mentor_details_page
-    and_i_should_see_the_corrected_name
-    and_i_click_confirm_and_continue
-    then_i_should_be_taken_to_the_check_answers_page
-
-    when_i_try_to_change_the_email
-    then_i_should_be_taken_to_the_change_email_address_page
-    and_i_should_see_the_current_email
-    and_i_click_continue
-    then_i_should_be_taken_to_the_check_answers_page
+    and_mentor_has_mentorship_with_new_school
   end
 
   def given_there_is_a_school_in_the_service
@@ -88,10 +50,16 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider:, school: @school)
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider: @lead_provider, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_mentor_has_existing_mentorship_at_another_school
+    another_school = FactoryBot.create(:school, urn: "7654321")
+    @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: another_school, teacher: @teacher)
   end
 
   def and_i_am_on_the_schools_landing_page
@@ -160,41 +128,21 @@ RSpec.describe 'Registering a mentor', :js do
     page.get_by_label('email').fill('example@example.com')
   end
 
-  def and_i_click_continue
-    page.get_by_role('button', name: "Continue").click
-  end
-
-  def when_i_try_to_change_the_name
-    page.get_by_role('link', name: 'Change').first.click
-  end
-
-  def then_i_should_be_taken_to_the_change_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/change-mentor-details')
-  end
-
-  def and_i_should_see_the_corrected_name
-    expect(page.get_by_label('Enter the correct full name').input_value).to eq('Kirk Van Damme')
-  end
-
-  def when_i_try_to_change_the_email
-    page.get_by_role('link', name: 'Change email address').last.click
-  end
-
-  def then_i_should_be_taken_to_the_change_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/change-email-address')
-  end
-
-  def and_i_should_see_the_current_email
-    expect(page.get_by_label('email').input_value).to eq('example@example.com')
-  end
-
   def then_i_should_be_taken_to_the_review_mentor_eligibility_page
     expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
   end
 
-  def and_i_should_see_mentor_funding_on_the_page
-    expect(page.get_by_text("Our records show that Kirk Van Damme can get up to 20 hours of ECTE mentor training as your school is working with a DfE-funded training provider.")).to be_visible
-    expect(page.get_by_text("We'll pass on their details to Xavier's School for Gifted Youngsters who will contact them to arrange the training.")).to be_visible
+  def and_i_click_continue
+    page.get_by_role('button', name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+  end
+
+  def when_i_select_no_they_will_also_be_mentoring_at_another_school
+    page.get_by_role(:radio, name: "No, they will also be mentoring at another school").check
+    page.get_by_role(:button, name: 'Continue').click
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
@@ -208,6 +156,8 @@ RSpec.describe 'Registering a mentor', :js do
     expect(page.locator('dd', hasText: 'Kirk Van Damme')).to be_visible
     expect(page.locator('dt', hasText: 'Email address')).to be_visible
     expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentoring only at your school')).to be_visible
+    expect(page.locator('dd', hasText: 'No')).to be_visible
   end
 
   def when_i_click_confirm_details
@@ -218,16 +168,13 @@ RSpec.describe 'Registering a mentor', :js do
     expect(page.url).to end_with('/school/register-mentor/confirmation')
   end
 
-  def when_i_click_on_back_to_ects
-    page.get_by_role('link', name: 'Back to ECTs').click
-  end
+  def and_mentor_has_mentorship_with_new_school
+    expect(@existing_mentor_at_school_period.reload.finished_on).to be_nil
+    expect(@teacher.mentor_at_school_periods.count).to eq(2)
 
-  def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
-  end
-
-  def and_the_ect_is_shown_linked_to_the_mentor_just_registered
-    expect(page.get_by_text("Kirk Van Damme")).to be_visible
-    expect(page.get_by_text(@ect_name)).to be_visible
+    new_mentor_at_school_period = @teacher.mentor_at_school_periods.excluding(@existing_mentor_at_school_period).last
+    expect(new_mentor_at_school_period.started_on).to eq(Date.current)
+    expect(new_mentor_at_school_period.finished_on).to be_nil
+    expect(new_mentor_at_school_period.training_periods.count).to eq(1)
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_registered_at_another_school_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_registered_at_another_school_provider_led_ect_spec.rb
@@ -1,0 +1,172 @@
+RSpec.describe 'Registering a mentor', :js do
+  include_context 'test trs api client'
+
+  let(:trn) { '3002586' }
+
+  scenario 'provider-led ect, mentor not registered at another school, can receive mentor training' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_find_mentor_form
+    then_i_should_be_taken_to_the_review_mentor_details_page
+    and_i_should_see_the_mentor_details_in_the_review_page
+
+    when_i_select_that_my_mentor_name_is_incorrect
+    and_i_enter_the_corrected_name
+    and_i_click_confirm_and_continue
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_the_mentor_email_address
+    and_i_click_continue
+    then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    and_i_click_choose_another_provider_link
+
+    then_i_should_be_taken_to_eligibility_lead_provider_page
+    when_i_select_a_different_lead_provider
+
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_should_see_all_the_mentor_data_on_the_page
+
+    when_i_click_confirm_details
+    then_i_should_be_taken_to_the_confirmation_page
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    contract_period = FactoryBot.create(:contract_period, year: Date.current.year)
+
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period:)
+
+    @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
+    FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period:)
+
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :active, lead_provider: @lead_provider, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_submit_the_find_mentor_form
+    if ActiveModel::Type::Boolean.new.cast(ENV.fetch('TEST_GUIDANCE', false))
+      page.get_by_role(:row, name: trn).get_by_role(:button, name: "Select").first.click
+    else
+      page.get_by_label('trn').fill(trn)
+      page.get_by_label('day').fill('3')
+      page.get_by_label('month').fill('2')
+      page.get_by_label('year').fill('1977')
+    end
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+  end
+
+  def and_i_should_see_the_mentor_details_in_the_review_page
+    expect(page.get_by_text(trn)).to be_visible
+    expect(page.get_by_text("Kirk Van Houten")).to be_visible
+    expect(page.get_by_text("3 February 1977")).to be_visible
+  end
+
+  def when_i_select_that_my_mentor_name_is_incorrect
+    page.get_by_label("No, they changed their name or it's spelt wrong").check
+  end
+
+  def and_i_enter_the_corrected_name
+    page.get_by_label('Enter the correct full name').fill('Kirk Van Damme')
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role('button', name: 'Confirm and continue').click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page.url).to end_with('/school/register-mentor/email-address')
+  end
+
+  def when_i_enter_the_mentor_email_address
+    page.get_by_label('email').fill('example@example.com')
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+  end
+
+  def and_i_click_continue
+    page.get_by_role('button', name: "Continue").click
+  end
+
+  def and_i_click_choose_another_provider_link
+    page.get_by_role('link', name: "#{@lead_provider.name} will not be providing mentor training to Kirk Van Damme").click
+  end
+
+  def then_i_should_be_taken_to_eligibility_lead_provider_page
+    expect(page.url).to end_with('/school/register-mentor/eligibility-lead-provider')
+  end
+
+  def when_i_select_a_different_lead_provider
+    page.get_by_role(:radio, name: @another_lead_provider.name).check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page.url).to end_with('/school/register-mentor/check-answers')
+  end
+
+  def and_i_should_see_all_the_mentor_data_on_the_page
+    expect(page.locator('dt', hasText: 'Teacher reference number (TRN)')).to be_visible
+    expect(page.locator('dd', hasText: trn)).to be_visible
+    expect(page.locator('dt', hasText: 'Name')).to be_visible
+    expect(page.locator('dd', hasText: 'Kirk Van Damme')).to be_visible
+    expect(page.locator('dt', hasText: 'Email address')).to be_visible
+    expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
+    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
+    expect(page.locator('dd', hasText: @another_lead_provider.name)).to be_visible
+  end
+
+  def when_i_click_confirm_details
+    page.get_by_role('button', name: 'Confirm details').click
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page.url).to end_with('/school/register-mentor/confirmation')
+  end
+end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -1,0 +1,247 @@
+RSpec.describe 'Registering a mentor', :js do
+  include_context 'test trs api client'
+
+  let(:trn) { '3002586' }
+
+  scenario 'mentor has existing mentorship, mentoring at new school only and is eligible for funding with provider-led ect' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_mentor_has_existing_mentorship_at_another_school
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_find_mentor_form
+    then_i_should_be_taken_to_the_review_mentor_details_page
+    and_i_should_see_the_mentor_details_in_the_review_page
+
+    when_i_select_that_my_mentor_name_is_incorrect
+    and_i_enter_the_corrected_name
+    and_i_click_confirm_and_continue
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_the_mentor_email_address
+    and_i_click_continue
+    then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    and_i_click_continue
+
+    then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    when_i_select_yes_they_will_be_mentoring_at_our_school_only
+
+    then_i_should_be_taken_to_mentor_start_date_page
+    when_i_enter_mentor_start_date
+    and_i_click_continue
+
+    then_i_should_be_taken_to_previous_training_period_details_page
+    and_i_should_see_previous_training_period_details
+    and_i_click_continue
+
+    then_i_should_be_taken_to_programme_choices_page
+    when_i_select_no_choose_lead_provider
+
+    then_i_should_be_taken_to_lead_provider_page
+    when_i_select_a_different_lead_provider
+
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_should_see_all_the_mentor_data_on_the_page
+
+    when_i_click_confirm_details
+    then_i_should_be_taken_to_the_confirmation_page
+    and_mentor_has_mentorship_with_new_school
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    contract_period = FactoryBot.create(:contract_period, year: Date.current.year)
+
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period:)
+
+    @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
+    FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period:)
+
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :active, lead_provider: @lead_provider, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_mentor_has_existing_mentorship_at_another_school
+    another_school = FactoryBot.create(:school, urn: "7654321")
+    @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: another_school, teacher: @teacher)
+    @training_period = FactoryBot.create(:training_period, :for_mentor, :with_school_partnership, :active, started_on: @existing_mentor_at_school_period.started_on, mentor_at_school_period: @existing_mentor_at_school_period)
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_submit_the_find_mentor_form
+    if ActiveModel::Type::Boolean.new.cast(ENV.fetch('TEST_GUIDANCE', false))
+      page.get_by_role(:row, name: trn).get_by_role(:button, name: "Select").first.click
+    else
+      page.get_by_label('trn').fill(trn)
+      page.get_by_label('day').fill('3')
+      page.get_by_label('month').fill('2')
+      page.get_by_label('year').fill('1977')
+    end
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+  end
+
+  def and_i_should_see_the_mentor_details_in_the_review_page
+    expect(page.get_by_text(trn)).to be_visible
+    expect(page.get_by_text("Kirk Van Houten")).to be_visible
+    expect(page.get_by_text("3 February 1977")).to be_visible
+  end
+
+  def when_i_select_that_my_mentor_name_is_incorrect
+    page.get_by_label("No, they changed their name or it's spelt wrong").check
+  end
+
+  def and_i_enter_the_corrected_name
+    page.get_by_label('Enter the correct full name').fill('Kirk Van Damme')
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role('button', name: 'Confirm and continue').click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page.url).to end_with('/school/register-mentor/email-address')
+  end
+
+  def when_i_enter_the_mentor_email_address
+    page.get_by_label('email').fill('example@example.com')
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+  end
+
+  def and_i_click_continue
+    page.get_by_role('button', name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+  end
+
+  def when_i_select_yes_they_will_be_mentoring_at_our_school_only
+    page.get_by_role(:radio, name: "Yes, they will be mentoring at our school only").check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_mentor_start_date_page
+    expect(page.url).to end_with('/school/register-mentor/started-on')
+  end
+
+  def when_i_enter_mentor_start_date
+    @mentor_start_date = Date.current
+    page.get_by_label('Day').fill(@mentor_start_date.day.to_s)
+    page.get_by_label('Month').fill(@mentor_start_date.month.to_s)
+    page.get_by_label('Year').fill(@mentor_start_date.year.to_s)
+  end
+
+  def then_i_should_be_taken_to_previous_training_period_details_page
+    expect(page.url).to end_with('/school/register-mentor/previous-training-period-details')
+  end
+
+  def and_i_should_see_previous_training_period_details
+    expect(page.locator('dt', hasText: 'School name')).to be_visible
+    expect(page.locator('dd', hasText: @training_period.school_partnership.school.name)).to be_visible
+    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
+    expect(page.locator('dd', hasText: @training_period.school_partnership.lead_provider.name)).to be_visible
+    expect(page.locator('dt', hasText: 'Delivery partner')).to be_visible
+    expect(page.locator('dd', hasText: @training_period.school_partnership.delivery_partner.name)).to be_visible
+  end
+
+  def then_i_should_be_taken_to_programme_choices_page
+    expect(page.url).to end_with('/school/register-mentor/programme-choices')
+  end
+
+  def when_i_select_no_choose_lead_provider
+    page.get_by_role(:radio, name: "No").check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_lead_provider_page
+    expect(page.url).to end_with('/school/register-mentor/lead-provider')
+  end
+
+  def when_i_select_a_different_lead_provider
+    page.get_by_role(:radio, name: @another_lead_provider.name).check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page.url).to end_with('/school/register-mentor/check-answers')
+  end
+
+  def and_i_should_see_all_the_mentor_data_on_the_page
+    expect(page.locator('dt', hasText: 'Teacher reference number (TRN)')).to be_visible
+    expect(page.locator('dd', hasText: trn)).to be_visible
+    expect(page.locator('dt', hasText: 'Name')).to be_visible
+    expect(page.locator('dd', hasText: 'Kirk Van Damme')).to be_visible
+    expect(page.locator('dt', hasText: 'Email address')).to be_visible
+    expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentoring only at your school')).to be_visible
+    expect(page.locator('dd', hasText: 'Yes')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentor start date')).to be_visible
+    expect(page.locator('dd', hasText: @mentor_start_date.to_fs(:govuk))).to be_visible
+    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
+    expect(page.locator('dd', hasText: @another_lead_provider.name)).to be_visible
+  end
+
+  def when_i_click_confirm_details
+    page.get_by_role('button', name: 'Confirm details').click
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page.url).to end_with('/school/register-mentor/confirmation')
+  end
+
+  def and_mentor_has_mentorship_with_new_school
+    expect(@existing_mentor_at_school_period.reload.finished_on).not_to be_nil
+    expect(@teacher.mentor_at_school_periods.count).to eq(2)
+
+    new_mentor_at_school_period = @teacher.mentor_at_school_periods.excluding(@existing_mentor_at_school_period).last
+    expect(new_mentor_at_school_period.started_on).to eq(@mentor_start_date)
+    expect(new_mentor_at_school_period.finished_on).to be_nil
+    expect(new_mentor_at_school_period.training_periods.count).to eq(1)
+  end
+end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -1,0 +1,229 @@
+RSpec.describe 'Registering a mentor', :js do
+  include_context 'test trs api client'
+
+  let(:trn) { '3002586' }
+
+  scenario 'mentor has existing mentorship, mentoring at new school only and is eligible for funding with provider-led ect' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_mentor_has_existing_mentorship_at_another_school
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_find_mentor_form
+    then_i_should_be_taken_to_the_review_mentor_details_page
+    and_i_should_see_the_mentor_details_in_the_review_page
+
+    when_i_select_that_my_mentor_name_is_incorrect
+    and_i_enter_the_corrected_name
+    and_i_click_confirm_and_continue
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_the_mentor_email_address
+    and_i_click_continue
+    then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    and_i_click_continue
+
+    then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    when_i_select_yes_they_will_be_mentoring_at_our_school_only
+
+    then_i_should_be_taken_to_mentor_start_date_page
+    when_i_enter_mentor_start_date
+    and_i_click_continue
+
+    then_i_should_be_taken_to_previous_training_period_details_page
+    and_i_should_see_previous_training_period_details
+    and_i_click_continue
+
+    then_i_should_be_taken_to_programme_choices_page
+    when_i_select_yes_use_same_programme_choices
+
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_should_see_all_the_mentor_data_on_the_page
+
+    when_i_click_confirm_details
+    then_i_should_be_taken_to_the_confirmation_page
+    and_mentor_has_mentorship_with_new_school
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :active, lead_provider: @lead_provider, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_mentor_has_existing_mentorship_at_another_school
+    another_school = FactoryBot.create(:school, urn: "7654321")
+    @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: another_school, teacher: @teacher)
+    @training_period = FactoryBot.create(:training_period, :for_mentor, :with_school_partnership, :active, started_on: @existing_mentor_at_school_period.started_on, mentor_at_school_period: @existing_mentor_at_school_period)
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = '/schools/home/ects'
+    page.goto path
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role('link', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = '/school/register-mentor/find-mentor'
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_submit_the_find_mentor_form
+    if ActiveModel::Type::Boolean.new.cast(ENV.fetch('TEST_GUIDANCE', false))
+      page.get_by_role(:row, name: trn).get_by_role(:button, name: "Select").first.click
+    else
+      page.get_by_label('trn').fill(trn)
+      page.get_by_label('day').fill('3')
+      page.get_by_label('month').fill('2')
+      page.get_by_label('year').fill('1977')
+    end
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+  end
+
+  def and_i_should_see_the_mentor_details_in_the_review_page
+    expect(page.get_by_text(trn)).to be_visible
+    expect(page.get_by_text("Kirk Van Houten")).to be_visible
+    expect(page.get_by_text("3 February 1977")).to be_visible
+  end
+
+  def when_i_select_that_my_mentor_name_is_incorrect
+    page.get_by_label("No, they changed their name or it's spelt wrong").check
+  end
+
+  def and_i_enter_the_corrected_name
+    page.get_by_label('Enter the correct full name').fill('Kirk Van Damme')
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role('button', name: 'Confirm and continue').click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page.url).to end_with('/school/register-mentor/email-address')
+  end
+
+  def when_i_enter_the_mentor_email_address
+    page.get_by_label('email').fill('example@example.com')
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+  end
+
+  def and_i_click_continue
+    page.get_by_role('button', name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+  end
+
+  def when_i_select_yes_they_will_be_mentoring_at_our_school_only
+    page.get_by_role(:radio, name: "Yes, they will be mentoring at our school only").check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_mentor_start_date_page
+    expect(page.url).to end_with('/school/register-mentor/started-on')
+  end
+
+  def when_i_enter_mentor_start_date
+    @mentor_start_date = Date.current
+    page.get_by_label('Day').fill(@mentor_start_date.day.to_s)
+    page.get_by_label('Month').fill(@mentor_start_date.month.to_s)
+    page.get_by_label('Year').fill(@mentor_start_date.year.to_s)
+  end
+
+  def then_i_should_be_taken_to_previous_training_period_details_page
+    expect(page.url).to end_with('/school/register-mentor/previous-training-period-details')
+  end
+
+  def and_i_should_see_previous_training_period_details
+    expect(page.locator('dt', hasText: 'School name')).to be_visible
+    expect(page.locator('dd', hasText: @training_period.school_partnership.school.name)).to be_visible
+    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
+    expect(page.locator('dd', hasText: @training_period.school_partnership.lead_provider.name)).to be_visible
+    expect(page.locator('dt', hasText: 'Delivery partner')).to be_visible
+    expect(page.locator('dd', hasText: @training_period.school_partnership.delivery_partner.name)).to be_visible
+  end
+
+  def then_i_should_be_taken_to_programme_choices_page
+    expect(page.url).to end_with('/school/register-mentor/programme-choices')
+  end
+
+  def when_i_select_yes_use_same_programme_choices
+    page.get_by_role(:radio, name: "Yes").check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page.url).to end_with('/school/register-mentor/check-answers')
+  end
+
+  def and_i_should_see_all_the_mentor_data_on_the_page
+    expect(page.locator('dt', hasText: 'Teacher reference number (TRN)')).to be_visible
+    expect(page.locator('dd', hasText: trn)).to be_visible
+    expect(page.locator('dt', hasText: 'Name')).to be_visible
+    expect(page.locator('dd', hasText: 'Kirk Van Damme')).to be_visible
+    expect(page.locator('dt', hasText: 'Email address')).to be_visible
+    expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentoring only at your school')).to be_visible
+    expect(page.locator('dd', hasText: 'Yes')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentor start date')).to be_visible
+    expect(page.locator('dd', hasText: @mentor_start_date.to_fs(:govuk))).to be_visible
+    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
+    expect(page.locator('dd', hasText: @lead_provider.name)).to be_visible
+  end
+
+  def when_i_click_confirm_details
+    page.get_by_role('button', name: 'Confirm details').click
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page.url).to end_with('/school/register-mentor/confirmation')
+  end
+
+  def and_mentor_has_mentorship_with_new_school
+    expect(@existing_mentor_at_school_period.reload.finished_on).not_to be_nil
+    expect(@teacher.mentor_at_school_periods.count).to eq(2)
+
+    new_mentor_at_school_period = @teacher.mentor_at_school_periods.excluding(@existing_mentor_at_school_period).last
+    expect(new_mentor_at_school_period.started_on).to eq(@mentor_start_date)
+    expect(new_mentor_at_school_period.finished_on).to be_nil
+    expect(new_mentor_at_school_period.training_periods.count).to eq(1)
+  end
+end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -3,11 +3,13 @@ RSpec.describe 'Registering a mentor', :js do
 
   let(:trn) { '3002586' }
 
-  scenario 'happy path' do
+  scenario 'mentor has existing mentorship and mentoring at new school only with school-led ect' do
     given_there_is_a_school_in_the_service
-    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
+    and_mentor_has_existing_mentorship_at_another_school
     and_i_sign_in_as_that_school_user
     and_i_am_on_the_schools_landing_page
+
     when_i_click_to_assign_a_mentor_to_the_ect
     then_i_am_in_the_requirements_page
 
@@ -25,58 +27,20 @@ RSpec.describe 'Registering a mentor', :js do
 
     when_i_enter_the_mentor_email_address
     and_i_click_continue
-    then_i_should_be_taken_to_the_review_mentor_eligibility_page
+
+    then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    when_i_select_yes_they_will_be_mentoring_at_our_school_only
+
+    then_i_should_be_taken_to_mentor_start_date_page
+    when_i_enter_mentor_start_date
     and_i_click_continue
+
     then_i_should_be_taken_to_the_check_answers_page
     and_i_should_see_all_the_mentor_data_on_the_page
 
     when_i_click_confirm_details
     then_i_should_be_taken_to_the_confirmation_page
-
-    when_i_click_on_back_to_ects
-    then_i_should_be_taken_to_the_ects_page
-    and_the_ect_is_shown_linked_to_the_mentor_just_registered
-  end
-
-  scenario 'check your answers' do
-    given_there_is_a_school_in_the_service
-    and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    and_i_sign_in_as_that_school_user
-    and_i_am_on_the_schools_landing_page
-    when_i_click_to_assign_a_mentor_to_the_ect
-    then_i_am_in_the_requirements_page
-
-    when_i_click_continue
-    then_i_should_be_taken_to_the_find_mentor_page
-
-    when_i_submit_the_find_mentor_form
-    then_i_should_be_taken_to_the_review_mentor_details_page
-    and_i_should_see_the_mentor_details_in_the_review_page
-
-    when_i_select_that_my_mentor_name_is_incorrect
-    and_i_enter_the_corrected_name
-    and_i_click_confirm_and_continue
-    then_i_should_be_taken_to_the_email_address_page
-
-    when_i_enter_the_mentor_email_address
-    and_i_click_continue
-    then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    and_i_should_see_mentor_funding_on_the_page
-    and_i_click_continue
-    then_i_should_be_taken_to_the_check_answers_page
-    and_i_should_see_all_the_mentor_data_on_the_page
-
-    when_i_try_to_change_the_name
-    then_i_should_be_taken_to_the_change_mentor_details_page
-    and_i_should_see_the_corrected_name
-    and_i_click_confirm_and_continue
-    then_i_should_be_taken_to_the_check_answers_page
-
-    when_i_try_to_change_the_email
-    then_i_should_be_taken_to_the_change_email_address_page
-    and_i_should_see_the_current_email
-    and_i_click_continue
-    then_i_should_be_taken_to_the_check_answers_page
+    and_mentor_has_mentorship_with_new_school
   end
 
   def given_there_is_a_school_in_the_service
@@ -87,11 +51,15 @@ RSpec.describe 'Registering a mentor', :js do
     sign_in_as_school_user(school: @school)
   end
 
-  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider:, school: @school)
+  def and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :school_led, :active, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_mentor_has_existing_mentorship_at_another_school
+    another_school = FactoryBot.create(:school, urn: "7654321")
+    @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: another_school, teacher: @teacher)
   end
 
   def and_i_am_on_the_schools_landing_page
@@ -164,37 +132,24 @@ RSpec.describe 'Registering a mentor', :js do
     page.get_by_role('button', name: "Continue").click
   end
 
-  def when_i_try_to_change_the_name
-    page.get_by_role('link', name: 'Change').first.click
+  def then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
   end
 
-  def then_i_should_be_taken_to_the_change_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/change-mentor-details')
+  def when_i_select_yes_they_will_be_mentoring_at_our_school_only
+    page.get_by_role(:radio, name: "Yes, they will be mentoring at our school only").check
+    page.get_by_role(:button, name: 'Continue').click
   end
 
-  def and_i_should_see_the_corrected_name
-    expect(page.get_by_label('Enter the correct full name').input_value).to eq('Kirk Van Damme')
+  def then_i_should_be_taken_to_mentor_start_date_page
+    expect(page.url).to end_with('/school/register-mentor/started-on')
   end
 
-  def when_i_try_to_change_the_email
-    page.get_by_role('link', name: 'Change email address').last.click
-  end
-
-  def then_i_should_be_taken_to_the_change_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/change-email-address')
-  end
-
-  def and_i_should_see_the_current_email
-    expect(page.get_by_label('email').input_value).to eq('example@example.com')
-  end
-
-  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
-  end
-
-  def and_i_should_see_mentor_funding_on_the_page
-    expect(page.get_by_text("Our records show that Kirk Van Damme can get up to 20 hours of ECTE mentor training as your school is working with a DfE-funded training provider.")).to be_visible
-    expect(page.get_by_text("We'll pass on their details to Xavier's School for Gifted Youngsters who will contact them to arrange the training.")).to be_visible
+  def when_i_enter_mentor_start_date
+    @mentor_start_date = Date.current
+    page.get_by_label('Day').fill(@mentor_start_date.day.to_s)
+    page.get_by_label('Month').fill(@mentor_start_date.month.to_s)
+    page.get_by_label('Year').fill(@mentor_start_date.year.to_s)
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
@@ -208,6 +163,10 @@ RSpec.describe 'Registering a mentor', :js do
     expect(page.locator('dd', hasText: 'Kirk Van Damme')).to be_visible
     expect(page.locator('dt', hasText: 'Email address')).to be_visible
     expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentoring only at your school')).to be_visible
+    expect(page.locator('dd', hasText: 'Yes')).to be_visible
+    expect(page.locator('dt', hasText: 'Mentor start date')).to be_visible
+    expect(page.locator('dd', hasText: @mentor_start_date.to_fs(:govuk))).to be_visible
   end
 
   def when_i_click_confirm_details
@@ -218,16 +177,13 @@ RSpec.describe 'Registering a mentor', :js do
     expect(page.url).to end_with('/school/register-mentor/confirmation')
   end
 
-  def when_i_click_on_back_to_ects
-    page.get_by_role('link', name: 'Back to ECTs').click
-  end
+  def and_mentor_has_mentorship_with_new_school
+    expect(@existing_mentor_at_school_period.reload.finished_on).not_to be_nil
+    expect(@teacher.mentor_at_school_periods.count).to eq(2)
 
-  def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
-  end
-
-  def and_the_ect_is_shown_linked_to_the_mentor_just_registered
-    expect(page.get_by_text("Kirk Van Damme")).to be_visible
-    expect(page.get_by_text(@ect_name)).to be_visible
+    new_mentor_at_school_period = @teacher.mentor_at_school_periods.excluding(@existing_mentor_at_school_period).last
+    expect(new_mentor_at_school_period.started_on).to eq(@mentor_start_date)
+    expect(new_mentor_at_school_period.finished_on).to be_nil
+    expect(new_mentor_at_school_period.training_periods.count).to eq(0)
   end
 end

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -208,8 +208,6 @@ RSpec.describe 'Registering a mentor', :js do
     expect(page.locator('dd', hasText: 'Kirk Van Damme')).to be_visible
     expect(page.locator('dt', hasText: 'Email address')).to be_visible
     expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
-    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
-    expect(page.locator('dd', hasText: "Xavier's School for Gifted Youngsters")).to be_visible
   end
 
   def when_i_click_confirm_details

--- a/spec/lib/schools/validation/mentor_start_date_spec.rb
+++ b/spec/lib/schools/validation/mentor_start_date_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Schools::Validation::MentorStartDate do
+  describe '#valid?' do
+    subject { described_class.new(date_as_hash:) }
+
+    let(:date_as_hash) { {} }
+
+    context 'when date is empty' do
+      it 'returns error' do
+        expect(subject).not_to be_valid
+        expect(subject.error_message).to eq("Enter the date they started or will start ECT mentoring at your school")
+      end
+    end
+
+    context 'when the date is valid' do
+      let(:date_as_hash) { { 1 => 2024, 2 => 6, 3 => 1 } }
+
+      it 'is valid and has no error message' do
+        expect(subject).to be_valid
+        expect(subject.error_message).to be_blank
+      end
+    end
+
+    context 'when day is missing' do
+      let(:date_as_hash) { { 1 => 2024, 2 => 6, 3 => nil } }
+
+      it 'returns error' do
+        expect(subject).not_to be_valid
+        expect(subject.error_message).to eq("Enter the date in the correct format, for example 12 03 1998")
+      end
+    end
+
+    context 'when month is missing' do
+      let(:date_as_hash) { { 1 => 2024, 2 => nil, 3 => 1 } }
+
+      it 'returns error' do
+        expect(subject).not_to be_valid
+        expect(subject.error_message).to eq("Enter the date in the correct format, for example 12 03 1998")
+      end
+    end
+
+    context 'when year is missing' do
+      let(:date_as_hash) { { 1 => nil, 2 => 6, 3 => 1 } }
+
+      it 'returns error' do
+        expect(subject).not_to be_valid
+        expect(subject.error_message).to eq("Enter the date in the correct format, for example 12 03 1998")
+      end
+    end
+  end
+end

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -1,0 +1,26 @@
+describe MentorAtSchoolPeriods::Finish do
+  subject { MentorAtSchoolPeriods::Finish.new(teacher:, finished_on:) }
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:started_on) { 3.months.ago.to_date }
+  let(:finished_on) { Date.current }
+
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:, started_on:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :active, mentor_at_school_period:, started_on:) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on:) }
+  let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :active, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
+
+  describe '#finish_existing_at_school_periods!' do
+    it "finishes all the associated periods" do
+      expect(training_period.finished_on).to be_nil
+      expect(mentorship_period.finished_on).to be_nil
+      expect(mentor_at_school_period.finished_on).to be_nil
+
+      subject.finish_existing_at_school_periods!
+
+      expect(training_period.reload.finished_on).not_to be_nil
+      expect(mentorship_period.reload.finished_on).not_to be_nil
+      expect(mentor_at_school_period.reload.finished_on).not_to be_nil
+    end
+  end
+end

--- a/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
+++ b/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
@@ -4,7 +4,7 @@ describe MentorAtSchoolPeriods::LatestRegistrationChoices do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:school_partnership) { FactoryBot.create(:school_partnership) }
   let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:) }
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, school_partnership:, mentor_at_school_period:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :active, school_partnership:, started_on: mentor_at_school_period.started_on, mentor_at_school_period:) }
 
   describe '#school' do
     it { expect(subject.school).to eq(school_partnership.school) }

--- a/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
+++ b/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
@@ -1,0 +1,20 @@
+describe MentorAtSchoolPeriods::LatestRegistrationChoices do
+  subject { MentorAtSchoolPeriods::LatestRegistrationChoices.new(trn: teacher.trn) }
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, school_partnership:, mentor_at_school_period:) }
+
+  describe '#school' do
+    it { expect(subject.school).to eq(school_partnership.school) }
+  end
+
+  describe '#lead_provider' do
+    it { expect(subject.lead_provider).to eq(school_partnership.lead_provider) }
+  end
+
+  describe '#delivery_partner' do
+    it { expect(subject.delivery_partner).to eq(school_partnership.delivery_partner) }
+  end
+end

--- a/spec/services/teachers/mentor_funding_eligibility_spec.rb
+++ b/spec/services/teachers/mentor_funding_eligibility_spec.rb
@@ -22,18 +22,21 @@ describe Teachers::MentorFundingEligibility do
   describe 'checking eligibility' do
     context 'when the teacher is missing' do
       it { is_expected.to be_eligible }
+      it { is_expected.not_to be_ineligible }
     end
 
     context 'when the teacher has an ineligibility reason and date set' do
       let!(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding, trn:) }
 
       it { is_expected.not_to be_eligible }
+      it { is_expected.to be_ineligible }
     end
 
     context 'when the teacher has no ineligibility reason or date set' do
       let!(:teacher) { FactoryBot.create(:teacher, trn:) }
 
       it { is_expected.to be_eligible }
+      it { is_expected.not_to be_ineligible }
     end
   end
 end

--- a/spec/validators/lead_provider_validator_spec.rb
+++ b/spec/validators/lead_provider_validator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe LeadProvider, type: :validator do
 
     it "adds a default error message" do
       expect(subject.valid?).to be(false)
-      expect(subject.errors[:lead_provider_id]).to include("Enter the name of a known lead provider")
+      expect(subject.errors[:lead_provider_id]).to include("Select a lead provider")
     end
   end
 

--- a/spec/validators/lead_provider_validator_spec.rb
+++ b/spec/validators/lead_provider_validator_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe LeadProvider, type: :validator do
+  subject { model_class.new(lead_provider_id:) }
+
+  let(:model_class) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :lead_provider_id
+
+      validates :lead_provider_id, lead_provider: true
+    end
+  end
+
+  context "when lead_provider_id is nil" do
+    let(:lead_provider_id) { nil }
+
+    it "does not add an error" do
+      expect(subject.valid?).to be(true)
+      expect(subject.errors[:lead_provider_id]).to be_empty
+    end
+  end
+
+  context "when lead_provider_id is valid" do
+    let(:lead_provider_id) { FactoryBot.create(:lead_provider).id }
+
+    it "does not add an error" do
+      expect(subject.valid?).to be(true)
+      expect(subject.errors[:lead_provider_id]).to be_empty
+    end
+  end
+
+  context "when lead_provider_id is invalid" do
+    let(:lead_provider_id) { 9999 }
+
+    it "adds a default error message" do
+      expect(subject.valid?).to be(false)
+      expect(subject.errors[:lead_provider_id]).to include("Enter the name of a known lead provider")
+    end
+  end
+
+  context "with a custom error message" do
+    let(:lead_provider_id) { 9999 }
+    let(:model_class) do
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :lead_provider_id
+
+        validates :lead_provider_id, lead_provider: { message: "custom validation message" }
+      end
+    end
+
+    it "uses the custom message" do
+      expect(subject.valid?).to be(false)
+      expect(subject.errors[:lead_provider_id]).to include("custom validation message")
+    end
+  end
+end

--- a/spec/validators/mentor_start_date_validator_spec.rb
+++ b/spec/validators/mentor_start_date_validator_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe MentorStartDateValidator, type: :model do
+  context "when date is in an invalid format" do
+    subject { test_class.new(start_date:) }
+
+    let(:start_date) { { 1 => "invalid year", 2 => "invalid month", 3 => 'invalid day' } }
+    let(:test_class) do
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :start_date
+
+        validates :start_date, mentor_start_date: { current_date: Time.zone.today }
+      end
+    end
+
+    it "adds an error" do
+      subject.valid?
+      expect(subject.errors[:start_date]).to include("Enter the date in the correct format, for example 12 03 1998")
+    end
+  end
+
+  context "when the start date has invalid values" do
+    subject { test_class.new(start_date:) }
+
+    let(:error_message) { "Enter the date in the correct format, for example 12 03 1998" }
+    let(:test_class) do
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :start_date
+
+        validates :start_date, mentor_start_date: true
+      end
+    end
+
+    context "when the month is outside the range 1-12" do
+      let(:start_date) { { 1 => "2024", 2 => "13", 3 => "1" } }
+
+      it "adds an error" do
+        subject.valid?
+        expect(subject.errors[:start_date]).to include(error_message)
+      end
+    end
+
+    context "when the year is non-integer" do
+      # "abcd".to_i == 0 and and therefore a valid date year but it is not valid
+      let(:start_date) { { 1 => "abcd", 2 => "07", 3 => "1" } }
+
+      it "adds an error" do
+        subject.valid?
+        expect(subject.errors[:start_date]).to include(error_message)
+      end
+    end
+
+    context "when the month is non-integer" do
+      let(:start_date) { { 1 => "2024", 2 => "abcd", 3 => "1" } }
+
+      it "adds an error" do
+        subject.valid?
+        expect(subject.errors[:start_date]).to include(error_message)
+      end
+    end
+
+    context "when the day is not an integer" do
+      let(:start_date) { { 1 => "2024", 2 => "07", 3 => "abcd" } }
+
+      it "adds an error" do
+        subject.valid?
+        expect(subject.errors[:start_date]).to include(error_message)
+      end
+    end
+  end
+end

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -92,8 +92,6 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
         expect(rendered).to have_element(:dd, text: "Jim Wayne")
         expect(rendered).to have_element(:dt, text: "Email address")
         expect(rendered).to have_element(:dd, text: "john.wayne@example.com")
-        expect(rendered).to have_element(:dt, text: "Lead provider")
-        expect(rendered).to have_element(:dd, text: "FraggleRock")
       end
     end
 

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
   let(:ect) { FactoryBot.create(:ect_at_school_period, :with_training_period, :active, teacher:, lead_provider:) }
 
   let(:store) do
-    double(
-      trn: '0000007',
-      trs_first_name: "John",
-      trs_last_name: "Wayne",
-      change_name: 'no',
-      corrected_name: nil,
-      already_active_at_school:,
-      eligible_for_mentor_funding?: true
-    )
+    FactoryBot.build(:session_repository,
+                     trn: '0000007',
+                     trs_first_name: "John",
+                     trs_last_name: "Wayne",
+                     change_name: 'no',
+                     corrected_name: nil,
+                     already_active_at_school:,
+                     eligible_for_mentor_funding?: true,
+                     ect_id: ect.id)
   end
 
   let(:wizard) do

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -205,6 +205,20 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
   end
 
+  describe '#finish_existing_at_school_periods' do
+    context "when mentoring_at_new_school_only set to yes" do
+      before { store.mentoring_at_new_school_only = "yes" }
+
+      it { expect(mentor.finish_existing_at_school_periods).to be(true) }
+    end
+
+    context "when mentoring_at_new_school_only set to no" do
+      before { store.mentoring_at_new_school_only = "no" }
+
+      it { expect(mentor.finish_existing_at_school_periods).to be(false) }
+    end
+  end
+
   describe '#lead_providers_within_contract_period' do
     let!(:contract_period) { FactoryBot.create(:contract_period, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 12, 31)) }
     let!(:lp_in) { FactoryBot.create(:lead_provider) }

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -235,7 +235,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
 
     context 'when no contract period matches the started_on' do
-      before { store.started_on = nil }
+      before { store.started_on = "2020-01-01" }
 
       it 'returns an empty array' do
         expect(mentor.lead_providers_within_contract_period).to eq([])

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -204,4 +204,28 @@ describe Schools::RegisterMentorWizard::Mentor do
       expect(mentor.trn).to eq("3002586")
     end
   end
+
+  describe '#lead_providers_within_contract_period' do
+    let!(:contract_period) { FactoryBot.create(:contract_period, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 12, 31)) }
+    let!(:lp_in) { FactoryBot.create(:lead_provider) }
+    let!(:lp_out) { FactoryBot.create(:lead_provider) }
+
+    before do
+      FactoryBot.create(:active_lead_provider, contract_period:, lead_provider: lp_in)
+      store.started_on = "2025-05-01"
+    end
+
+    it 'returns lead providers active in the contract period' do
+      expect(mentor.lead_providers_within_contract_period).to include(lp_in)
+      expect(mentor.lead_providers_within_contract_period).not_to include(lp_out)
+    end
+
+    context 'when no contract period matches the started_on' do
+      before { store.started_on = nil }
+
+      it 'returns an empty array' do
+        expect(mentor.lead_providers_within_contract_period).to eq([])
+      end
+    end
+  end
 end

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -242,6 +242,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility
+                                   eligibility_lead_provider
                                    change_mentor_details
                                    change_email_address
                                    check_answers])
@@ -292,6 +293,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility
+                                   eligibility_lead_provider
                                    change_mentor_details
                                    change_email_address
                                    check_answers])

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -238,6 +238,11 @@ describe Schools::RegisterMentorWizard::Wizard do
           expect(subject).to eq(%i[find_mentor
                                    review_mentor_details
                                    email_address
+                                   mentoring_at_new_school_only
+                                   started_on
+                                   previous_training_period_details
+                                   programme_choices
+                                   lead_provider
                                    review_mentor_eligibility
                                    change_mentor_details
                                    change_email_address
@@ -285,6 +290,11 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    national_insurance_number
                                    review_mentor_details
                                    email_address
+                                   mentoring_at_new_school_only
+                                   started_on
+                                   previous_training_period_details
+                                   programme_choices
+                                   lead_provider
                                    review_mentor_eligibility
                                    change_mentor_details
                                    change_email_address

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -238,9 +238,7 @@ describe Schools::RegisterMentorWizard::Wizard do
           expect(subject).to eq(%i[find_mentor
                                    review_mentor_details
                                    email_address
-                                   mentoring_at_new_school_only
                                    started_on
-                                   previous_training_period_details
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility
@@ -290,9 +288,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    national_insurance_number
                                    review_mentor_details
                                    email_address
-                                   mentoring_at_new_school_only
                                    started_on
-                                   previous_training_period_details
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility


### PR DESCRIPTION
### Context

Branches off: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/950
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1864

### Changes proposed in this pull request

* New wizard step `EligibilityLeadProviderStep`, copying from `LeadProviderStep`
* Feature test

### Guidance to review
