### PR TITLE
Fix 'a' typo in Swagger docs for delivery partners

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -47,7 +47,7 @@ paths:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
   "/api/v3/delivery-partners/{id}":
     get:
-      summary: Retrieve a single a delivery partner
+      summary: Retrieve a single delivery partner
       tags:
       - Delivery Partners
       security:
@@ -60,7 +60,7 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: A single a delivery partner
+          description: A single delivery partner
           content:
             application/json:
               schema:

--- a/spec/requests/api/docs/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/docs/v3/delivery_partners_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Delivery partners endpoint", openapi_spec: "v3/swagger.yaml", ty
                   {
                     url: "/api/v3/delivery-partners/{id}",
                     tag: "Delivery Partners",
-                    resource_description: "a delivery partner",
+                    resource_description: "delivery partner",
                     response_schema_ref: "#/components/schemas/DeliveryPartnerResponse",
                   } do
   end


### PR DESCRIPTION
I noticed when reviewing this there was a typo.