### PR TITLE
Rework listing card component to accept teacher and training period

### DIFF
--- a/app/components/schools/ects/listing_card_component.html.erb
+++ b/app/components/schools/ects/listing_card_component.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h3 class="govuk-summary-card__title govuk-!-font-size-24">
-      <strong><%= link_to_ect(ect) %></strong>
+      <strong><%= link_to_ect(ect_at_school_period) %></strong>
     </h3>
   </div>
   <div class="govuk-summary-card__content">

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -4,10 +4,12 @@ module Schools
       include TeacherHelper
       include ECTHelper
 
-      attr_reader :ect_at_school_period
+      attr_reader :teacher, :ect_at_school_period, :training_period
 
-      def initialize(ect_at_school_period:)
+      def initialize(teacher:, ect_at_school_period:, training_period:)
+        @teacher = teacher
         @ect_at_school_period = ect_at_school_period
+        @training_period = training_period
       end
 
     private
@@ -35,7 +37,7 @@ module Schools
       end
 
       def delivery_partner_display_text
-        if latest_training_period_only_expression_of_interest?
+        if training_period_only_expression_of_interest?
           'Their lead provider will confirm this'
         else
           latest_delivery_partner_name(ect_at_school_period)
@@ -43,15 +45,15 @@ module Schools
       end
 
       def lead_provider_display_text
-        if latest_training_period_only_expression_of_interest?
+        if training_period_only_expression_of_interest?
           latest_eoi_lead_provider_name(ect_at_school_period)
         else
           latest_lead_provider_name(ect_at_school_period)
         end
       end
 
-      def latest_training_period_only_expression_of_interest?
-        ECTAtSchoolPeriods::Training.new(ect_at_school_period).latest_training_period&.only_expression_of_interest?
+      def training_period_only_expression_of_interest?
+        training_period&.only_expression_of_interest?
       end
 
       def left_rows
@@ -83,7 +85,7 @@ module Schools
       end
 
       def trn_row
-        { key: { text: 'TRN' }, value: { text: ect_at_school_period.trn } }
+        { key: { text: 'TRN' }, value: { text: teacher.trn } }
       end
     end
   end

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -19,7 +19,7 @@ module Schools
       end
 
       def delivery_partner_row
-        return if ect_at_school_period.school_led_training_programme?
+        return if training_period&.school_led_training_programme?
 
         {
           key: { text: 'Delivery partner' },
@@ -28,7 +28,7 @@ module Schools
       end
 
       def lead_provider_row
-        return if ect_at_school_period.school_led_training_programme?
+        return if training_period&.school_led_training_programme?
 
         {
           key: { text: 'Lead provider' },
@@ -61,7 +61,7 @@ module Schools
       end
 
       def left_start_date_row
-        start_date_row if ect_at_school_period.provider_led_training_programme?
+        start_date_row if training_period&.provider_led_training_programme?
       end
 
       def mentor_row
@@ -73,7 +73,7 @@ module Schools
       end
 
       def right_start_date_row
-        start_date_row if ect_at_school_period.school_led_training_programme?
+        start_date_row if training_period&.school_led_training_programme?
       end
 
       def start_date_row

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -4,20 +4,20 @@ module Schools
       include TeacherHelper
       include ECTHelper
 
-      attr_reader :ect
+      attr_reader :ect_at_school_period
 
-      def initialize(ect:)
-        @ect = ect
+      def initialize(ect_at_school_period:)
+        @ect_at_school_period = ect_at_school_period
       end
 
     private
 
       def appropriate_body_row
-        { key: { text: 'Appropriate body' }, value: { text: ect.school_reported_appropriate_body_name } }
+        { key: { text: 'Appropriate body' }, value: { text: ect_at_school_period.school_reported_appropriate_body_name } }
       end
 
       def delivery_partner_row
-        return if ect.school_led_training_programme?
+        return if ect_at_school_period.school_led_training_programme?
 
         {
           key: { text: 'Delivery partner' },
@@ -26,7 +26,7 @@ module Schools
       end
 
       def lead_provider_row
-        return if ect.school_led_training_programme?
+        return if ect_at_school_period.school_led_training_programme?
 
         {
           key: { text: 'Lead provider' },
@@ -38,20 +38,20 @@ module Schools
         if latest_training_period_only_expression_of_interest?
           'Their lead provider will confirm this'
         else
-          latest_delivery_partner_name(ect)
+          latest_delivery_partner_name(ect_at_school_period)
         end
       end
 
       def lead_provider_display_text
         if latest_training_period_only_expression_of_interest?
-          latest_eoi_lead_provider_name(ect)
+          latest_eoi_lead_provider_name(ect_at_school_period)
         else
-          latest_lead_provider_name(ect)
+          latest_lead_provider_name(ect_at_school_period)
         end
       end
 
       def latest_training_period_only_expression_of_interest?
-        ECTAtSchoolPeriods::Training.new(ect).latest_training_period&.only_expression_of_interest?
+        ECTAtSchoolPeriods::Training.new(ect_at_school_period).latest_training_period&.only_expression_of_interest?
       end
 
       def left_rows
@@ -59,11 +59,11 @@ module Schools
       end
 
       def left_start_date_row
-        start_date_row if ect.provider_led_training_programme?
+        start_date_row if ect_at_school_period.provider_led_training_programme?
       end
 
       def mentor_row
-        { key: { text: 'Mentor', classes: %w[mentor-key] }, value: { text: ect_mentor_details(ect) } }
+        { key: { text: 'Mentor', classes: %w[mentor-key] }, value: { text: ect_mentor_details(ect_at_school_period) } }
       end
 
       def right_rows
@@ -71,19 +71,19 @@ module Schools
       end
 
       def right_start_date_row
-        start_date_row if ect.school_led_training_programme?
+        start_date_row if ect_at_school_period.school_led_training_programme?
       end
 
       def start_date_row
-        { key: { text: 'School start date' }, value: { text: ect.started_on.to_fs(:govuk) } }
+        { key: { text: 'School start date' }, value: { text: ect_at_school_period.started_on.to_fs(:govuk) } }
       end
 
       def status_row
-        { key: { text: 'Status' }, value: { text: ect_status(ect) } }
+        { key: { text: 'Status' }, value: { text: ect_status(ect_at_school_period) } }
       end
 
       def trn_row
-        { key: { text: 'TRN' }, value: { text: ect.trn } }
+        { key: { text: 'TRN' }, value: { text: ect_at_school_period.trn } }
       end
     end
   end

--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -3,7 +3,9 @@ module Schools
     layout "full"
 
     def index
-      @pagy, @filtered_teachers = pagy_array(Teachers::Search.new(ect_at_school: school, query_string: params[:q]).search)
+      search = Teachers::Search.new(ect_at_school: school, query_string: params[:q]).search
+      @pagy, @filtered_teachers = pagy(search)
+
       @number_of_teachers = Teachers::Search.new(ect_at_school: school).count
     end
 

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -19,6 +19,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :ect_at_school_period
   has_many :mentor_at_school_periods, through: :teacher
   has_many :events
+  has_one :current_training_period, -> { ongoing_today_or_starting_tomorrow_or_after }, class_name: 'TrainingPeriod'
 
   touch -> { school }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -21,6 +21,7 @@ class Teacher < ApplicationRecord
 
   has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body
+  has_one :current_ect_at_school_period, -> { ongoing_today_or_starting_tomorrow_or_after }, class_name: 'ECTAtSchoolPeriod'
 
   has_many :events
 

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -22,8 +22,12 @@
       <% if @filtered_teachers.count.zero? %>
         <p class="govuk-body">There are no ECTs that match your search.</p>
       <% else %>
-        <% @filtered_teachers.to_a.map { |t| t.ect_at_school_periods.first }.each do |ect_at_school_period| %>
-          <%= render Schools::ECTs::ListingCardComponent.new(ect_at_school_period:) %>
+        <% @filtered_teachers.each do |teacher| %>
+          <%= render Schools::ECTs::ListingCardComponent.new(
+            teacher:,
+            ect_at_school_period: teacher.current_ect_at_school_period,
+            training_period: teacher.current_ect_at_school_period&.current_training_period)
+          %>
         <% end %>
       <% end %>
       <%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -22,8 +22,8 @@
       <% if @filtered_teachers.count.zero? %>
         <p class="govuk-body">There are no ECTs that match your search.</p>
       <% else %>
-        <% @filtered_teachers.to_a.map { |t| t.ect_at_school_periods.first }.each do |ect| %>
-          <%= render Schools::ECTs::ListingCardComponent.new(ect:) %>
+        <% @filtered_teachers.to_a.map { |t| t.ect_at_school_periods.first }.each do |ect_at_school_period| %>
+          <%= render Schools::ECTs::ListingCardComponent.new(ect_at_school_period:) %>
         <% end %>
       <% end %>
       <%= govuk_pagination(pagy: @pagy) %>

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -70,20 +70,22 @@ def describe_induction_period(ip)
 end
 
 def describe_training_period(tp)
-  suffix = "(training period)"
+  prefix = (tp.started_on.future?) ? 'will be' : 'was'
 
-  if tp.school_partnership.present?
+  case
+  when tp.provider_led_training_programme? && tp.school_partnership.present?
+    suffix = "(training period - provider-led)"
     lpdp = tp.school_partnership.lead_provider_delivery_partnership
     lead_provider_name = lpdp.active_lead_provider.lead_provider.name
     delivery_partner_name = lpdp.delivery_partner.name
-
-    prefix = (tp.started_on.future?) ? 'will be' : 'was'
-
-    print_seed_info("* #{prefix} trained by #{lead_provider_name} (LP) and #{delivery_partner_name} #{describe_period_duration(tp)} #{suffix}", indent: 4)
-  else
+    print_seed_info("* #{prefix} trained by #{lead_provider_name} (LP) and #{delivery_partner_name} (DP) #{describe_period_duration(tp)} #{suffix}", indent: 4)
+  when tp.provider_led_training_programme? && tp.expression_of_interest.present?
+    suffix = "(training period - provider-led)"
     lead_provider_name = tp.expression_of_interest.lead_provider.name
-
-    print_seed_info("* was registered with an expression of interest with #{lead_provider_name}", indent: 4)
+    print_seed_info("* #{prefix} trained by #{lead_provider_name} (LP) #{describe_period_duration(tp)} providing the EOI is accepted #{suffix}", indent: 4)
+  when tp.school_led_training_programme?
+    suffix = "(training period - school-led)"
+    print_seed_info("* #{prefix} trained #{describe_period_duration(tp)} #{suffix}", indent: 4)
   end
 end
 
@@ -305,9 +307,8 @@ hugh_grant_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: hugh_grant_ect_at_abbey_grove,
   started_on: 2.years.ago,
-  finished_on: 1.week.ago,
-  expression_of_interest: ambitious_artisan_2022,
-  school_partnership: ambitious_artisan_partnership_2022,
+  expression_of_interest: nil,
+  school_partnership: nil,
   training_programme: 'school_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -351,7 +352,6 @@ abbey_grove_school.update!(last_chosen_lead_provider: nil,
 TrainingPeriod.create!(
   ect_at_school_period: colin_firth_ect_at_abbey_grove,
   started_on: 2.years.ago,
-  finished_on: 1.week.ago,
   school_partnership: ambitious_artisan_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when provider led chosen' do
-    let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: ect_at_school_period, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :provider_led, ect_at_school_period:, started_on:) }
 
     it "renders their latest providers" do
       render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
@@ -63,7 +63,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when school led chosen' do
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :school_led, teacher:, school:, started_on:, finished_on: nil) }
+    let(:training_period) { FactoryBot.create(:training_period, :ongoing, :school_led) }
 
     it "don't render providers" do
       render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -3,12 +3,13 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   let(:started_on) { Date.new(2023, 9, 1) }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil) }
+  let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:, started_on:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: nil) }
 
   context 'when the ECT has a mentor assigned' do
     before do
       FactoryBot.create(:mentorship_period, :ongoing, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
-      render_inline(described_class.new(ect_at_school_period:))
+      render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
     end
 
     it "renders 'Registered' status" do
@@ -18,7 +19,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when the ECT has no mentor assigned' do
-    before { render_inline(described_class.new(ect_at_school_period:)) }
+    before { render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:)) }
 
     it "renders 'Mentor required' status" do
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Status')
@@ -27,21 +28,21 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   it "renders the TRN" do
-    render_inline(described_class.new(ect_at_school_period:))
+    render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
 
     expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'TRN')
     expect(rendered_content).to have_text(ect_at_school_period.trn)
   end
 
   it "renders the school start date" do
-    render_inline(described_class.new(ect_at_school_period:))
+    render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
 
     expect(rendered_content).to have_selector(".govuk-summary-list__row", text: "School start date")
     expect(rendered_content).to have_text('1 September 2023')
   end
 
   it "renders the school reported appropriate body name" do
-    render_inline(described_class.new(ect_at_school_period:))
+    render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
 
     expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Appropriate body')
     expect(rendered_content).to have_text(ect_at_school_period.school_reported_appropriate_body_name)
@@ -51,7 +52,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: ect_at_school_period, started_on:) }
 
     it "renders their latest providers" do
-      render_inline(described_class.new(ect_at_school_period:))
+      render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
 
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
       expect(rendered_content).to have_text(training_period.delivery_partner_name)
@@ -65,7 +66,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :school_led, teacher:, school:, started_on:, finished_on: nil) }
 
     it "don't render providers" do
-      render_inline(described_class.new(ect_at_school_period:))
+      render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
 
       expect(rendered_content).not_to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
       expect(rendered_content).not_to have_selector('.govuk-summary-list__row', text: 'Lead provider')
@@ -74,26 +75,27 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
 
   context 'when latest training period is an expression of interest only' do
     let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Jimmy Provider') }
-    let(:ect_at_school_period) do
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+    let(:training_period) do
       FactoryBot.create(
-        :ect_at_school_period,
+        :training_period,
         :ongoing,
-        :with_eoi_only_training_period,
-        lead_provider:,
-        school:,
-        started_on:
+        :with_no_school_partnership,
+        ect_at_school_period:,
+        started_on:,
+        expression_of_interest: active_lead_provider
       )
     end
 
     it 'renders lead provider name on the EOI' do
-      render_inline(described_class.new(ect_at_school_period:))
+      render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
 
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Lead provider')
       expect(rendered_content).to have_text('Jimmy Provider')
     end
 
     it 'renders the delivery partner fallback text' do
-      render_inline(described_class.new(ect_at_school_period:))
+      render_inline(described_class.new(teacher:, ect_at_school_period:, training_period:))
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
       expect(rendered_content).to have_text('Their lead provider will confirm this')
     end

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -2,13 +2,13 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { Date.new(2023, 9, 1) }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Naruto', trs_last_name: 'Uzumaki') }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: nil) }
 
   context 'when the ECT has a mentor assigned' do
     before do
-      FactoryBot.create(:mentorship_period, :ongoing, started_on: ect.started_on, mentee: ect, mentor:)
-      render_inline(described_class.new(ect:))
+      FactoryBot.create(:mentorship_period, :ongoing, started_on: ect_at_school_period.started_on, mentee: ect_at_school_period, mentor:)
+      render_inline(described_class.new(ect_at_school_period:))
     end
 
     it "renders 'Registered' status" do
@@ -18,7 +18,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when the ECT has no mentor assigned' do
-    before { render_inline(described_class.new(ect:)) }
+    before { render_inline(described_class.new(ect_at_school_period:)) }
 
     it "renders 'Mentor required' status" do
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Status')
@@ -27,31 +27,31 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   it "renders the TRN" do
-    render_inline(described_class.new(ect:))
+    render_inline(described_class.new(ect_at_school_period:))
 
     expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'TRN')
-    expect(rendered_content).to have_text(ect.trn)
+    expect(rendered_content).to have_text(ect_at_school_period.trn)
   end
 
   it "renders the school start date" do
-    render_inline(described_class.new(ect:))
+    render_inline(described_class.new(ect_at_school_period:))
 
     expect(rendered_content).to have_selector(".govuk-summary-list__row", text: "School start date")
     expect(rendered_content).to have_text('1 September 2023')
   end
 
   it "renders the school reported appropriate body name" do
-    render_inline(described_class.new(ect:))
+    render_inline(described_class.new(ect_at_school_period:))
 
     expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Appropriate body')
-    expect(rendered_content).to have_text(ect.school_reported_appropriate_body_name)
+    expect(rendered_content).to have_text(ect_at_school_period.school_reported_appropriate_body_name)
   end
 
   context 'when provider led chosen' do
-    let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: ect, started_on:) }
+    let!(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: ect_at_school_period, started_on:) }
 
     it "renders their latest providers" do
-      render_inline(described_class.new(ect:))
+      render_inline(described_class.new(ect_at_school_period:))
 
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
       expect(rendered_content).to have_text(training_period.delivery_partner_name)
@@ -62,10 +62,10 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   end
 
   context 'when school led chosen' do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :school_led, teacher:, school:, started_on:, finished_on: nil) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :school_led, teacher:, school:, started_on:, finished_on: nil) }
 
     it "don't render providers" do
-      render_inline(described_class.new(ect:))
+      render_inline(described_class.new(ect_at_school_period:))
 
       expect(rendered_content).not_to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
       expect(rendered_content).not_to have_selector('.govuk-summary-list__row', text: 'Lead provider')
@@ -74,7 +74,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
 
   context 'when latest training period is an expression of interest only' do
     let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Jimmy Provider') }
-    let(:ect) do
+    let(:ect_at_school_period) do
       FactoryBot.create(
         :ect_at_school_period,
         :ongoing,
@@ -86,14 +86,14 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     end
 
     it 'renders lead provider name on the EOI' do
-      render_inline(described_class.new(ect:))
+      render_inline(described_class.new(ect_at_school_period:))
 
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Lead provider')
       expect(rendered_content).to have_text('Jimmy Provider')
     end
 
     it 'renders the delivery partner fallback text' do
-      render_inline(described_class.new(ect:))
+      render_inline(described_class.new(ect_at_school_period:))
       expect(rendered_content).to have_selector('.govuk-summary-list__row', text: 'Delivery partner')
       expect(rendered_content).to have_text('Their lead provider will confirm this')
     end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
       association :school_partnership
     end
 
+    trait :with_no_school_partnership do
+      school_partnership { nil }
+    end
+
     trait :with_expression_of_interest do
       association :expression_of_interest, factory: :active_lead_provider
     end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -9,6 +9,16 @@ FactoryBot.define do
     started_on { generate(:base_training_date) }
     finished_on { started_on + 1.day }
 
+    trait :not_started_yet do
+      started_on { 2.weeks.from_now }
+      finished_on { nil }
+    end
+
+    trait :finished do
+      started_on { 1.year.ago }
+      finished_on { 2.weeks.ago }
+    end
+
     trait(:school_led) do
       training_programme { 'school_led' }
       school_partnership { nil }

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -25,6 +25,30 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to have_many(:training_periods) }
     it { is_expected.to have_many(:mentors).through(:mentorship_periods).source(:mentor) }
     it { is_expected.to have_many(:events) }
+
+    describe '.current_training_period' do
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+
+      it { is_expected.to have_one(:current_training_period).class_name('TrainingPeriod') }
+
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+
+      context 'when there is a current period' do
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
+
+        it 'returns the current ect_at_school_period' do
+          expect(ect_at_school_period.current_training_period).to eql(training_period)
+        end
+      end
+
+      context 'when there is no current period' do
+        let!(:training_period) { FactoryBot.create(:training_period, :finished, ect_at_school_period:) }
+
+        it 'returns nil' do
+          expect(ect_at_school_period.current_training_period).to be_nil
+        end
+      end
+    end
   end
 
   describe "validations" do

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -31,8 +31,6 @@ describe ECTAtSchoolPeriod do
 
       it { is_expected.to have_one(:current_training_period).class_name('TrainingPeriod') }
 
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-
       context 'when there is a current period' do
         let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -8,9 +8,9 @@ describe Teacher do
     it { is_expected.to have_many(:events) }
 
     describe '.current_ect_at_school_period' do
-      it { is_expected.to have_one(:current_ect_at_school_period).class_name('ECTAtSchoolPeriod') }
-
       let(:teacher) { FactoryBot.create(:teacher) }
+
+      it { is_expected.to have_one(:current_ect_at_school_period).class_name('ECTAtSchoolPeriod') }
 
       context 'when there is a current period' do
         let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -14,6 +14,7 @@ describe Teacher do
 
       context 'when there is a current period' do
         let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+        let!(:finished_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 10.years.ago, finished_on: 8.year.ago, teacher:) }
 
         it 'returns the current ect_at_school_period' do
           expect(teacher.current_ect_at_school_period).to eql(ect_at_school_period)

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -7,6 +7,28 @@ describe Teacher do
     it { is_expected.to have_many(:induction_extensions) }
     it { is_expected.to have_many(:events) }
 
+    describe '.current_ect_at_school_period' do
+      it { is_expected.to have_one(:current_ect_at_school_period).class_name('ECTAtSchoolPeriod') }
+
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      context 'when there is a current period' do
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+
+        it 'returns the current ect_at_school_period' do
+          expect(teacher.current_ect_at_school_period).to eql(ect_at_school_period)
+        end
+      end
+
+      context 'when there is no current period' do
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :finished, teacher:) }
+
+        it 'returns nil' do
+          expect(teacher.current_ect_at_school_period).to be_nil
+        end
+      end
+    end
+
     it "returns the appropriate body from the ongoing induction period" do
       teacher = FactoryBot.create(:teacher)
       other_appropriate_body = FactoryBot.create(:appropriate_body)

--- a/spec/views/schools/ects/index.html.erb_spec.rb
+++ b/spec/views/schools/ects/index.html.erb_spec.rb
@@ -33,11 +33,12 @@ RSpec.describe 'schools/ects/index.html.erb' do
 
   context 'when there are teachers' do
     let(:teacher) { FactoryBot.create(:teacher, trs_first_name: 'Johnnie', trs_last_name: 'Walker') }
-    let(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+    let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
     before do
       assign(:filtered_teachers, [teacher])
-      assign(:ects, [ect_period])
+      assign(:ects, [ect_at_school_period])
       assign(:number_of_teachers, 1)
       assign(:school, school)
       render
@@ -54,7 +55,7 @@ RSpec.describe 'schools/ects/index.html.erb' do
     context 'when the filtered teachers is empty' do
       before do
         assign(:filtered_teachers, [])
-        assign(:ects, [ect_period])
+        assign(:ects, [ect_at_school_period])
         assign(:number_of_teachers, 1)
         assign(:school, school)
         render


### PR DESCRIPTION
The `Schools::ECTs::ListingCardComponent` currently recives one object, an `ECTAtSchoolPeriod` when being initialised and then uses `ECTatSchoolPeriods::Training` to determine the training information. This made sense when we weren't concerned about future periods but now we need to take that into consideration.

To hopefully simplify things, there are now `has_one` relationships that retrieve the `current_ect_at_school_period` from the `Teacher`, and the `current_training_period` from the `ECTatSchoolPeriod`.

This means we can pass into the listing component all of the objects we will need, and use them directly.

## Notes

The moving of `training_programme` from `ECTAtSchoolPeriod` to `TrainingPeriod` means there's a chance we'll have teachers who are neither `school-led` or `provider-led`. We'll need to address this in a later change.

## Changes

- **Rename ect variable to ect_at_school_period**
- **Add has_one relationships for current period**
- **Pass relevant objects into listing card component**
- **Use training period as source for training programme**
