### PR TITLE
Bulk claim error logic

### DIFF
--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -55,26 +55,25 @@ module AppropriateBodies
           capture_error(trs_error)
           true
         elsif teacher
-          if induction_periods.last_induction_period&.outcome.eql?('pass')
+          if already_passed?
             capture_error("#{name} has already passed their induction")
             true
-          elsif induction_periods.last_induction_period&.outcome.eql?('fail')
+          elsif already_failed?
             capture_error("#{name} has already failed their induction")
             true
           elsif claimed_by_another_ab?
             capture_error("#{name} is already claimed by another appropriate body")
             true
-          elsif overlapping_with_induction_period?
-            capture_error('Induction start date must not overlap with any other induction periods')
-            true
           elsif !claimed_by_another_ab?
             capture_error("#{name} is already claimed by your appropriate body")
             true
+          elsif induction_periods.none?
+            false
           end
         elsif prohibited_from_teaching?
           capture_error("#{name} is prohibited from teaching")
           true
-        elsif pending_induction_submission.trs_qts_awarded_on.blank?
+        elsif no_qts?
           capture_error("#{name} does not have their qualified teacher status (QTS)")
           true
         elsif predates_qts_award?
@@ -83,6 +82,21 @@ module AppropriateBodies
         else
           false
         end
+      end
+
+      # @return [Boolean]
+      def no_qts?
+        pending_induction_submission.trs_qts_awarded_on.blank?
+      end
+
+      # @return [Boolean]
+      def already_passed?
+        induction_periods.last_induction_period&.outcome.eql?('pass')
+      end
+
+      # @return [Boolean]
+      def already_failed?
+        induction_periods.last_induction_period&.outcome.eql?('fail')
       end
 
       # @return [Boolean]

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -372,28 +372,6 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
       end
     end
 
-    context 'when the submission overlaps an earlier induction period' do
-      include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
-
-      let(:started_on) { 15.days.ago.to_date.to_s }
-
-      let(:teacher) { FactoryBot.create(:teacher, trn:) }
-
-      before do
-        FactoryBot.create(:induction_period, teacher:,
-                                             appropriate_body:,
-                                             started_on: 30.days.ago.to_date,
-                                             finished_on: 1.day.ago.to_date)
-        service.process!
-      end
-
-      describe 'submission error messages' do
-        subject { submission.error_messages }
-
-        it { is_expected.to eq ['Induction start date must not overlap with any other induction periods'] }
-      end
-    end
-
     context 'start date before QTS' do
       include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 


### PR DESCRIPTION
### Context

Claim bug party identified the wrong error

### Changes proposed in this pull request

- teachers with no induction pass precheck
- "already claimed by your appropriate body" covers "induction overlap" which has been removed

### Guidance to review

Heirarchy of errors when there is a teacher:

1. already passed their induction
2. already failed their induction
3. already claimed by another appropriate body
4. already claimed by your appropriate body

A teacher with no inductions should be claimable