### PR TITLE
Bulk action error logic

### DIFF
--- a/app/services/appropriate_bodies/process_batch/action.rb
+++ b/app/services/appropriate_bodies/process_batch/action.rb
@@ -54,17 +54,21 @@ module AppropriateBodies
         elsif (trs_error = fetch_trs_details!)
           capture_error(trs_error)
           true
+        elsif teacher
+          if passed? || failed?
+            capture_error("#{name} has already completed their induction")
+            true
+          elsif no_ongoing_induction_period?
+            capture_error("#{name} does not have an open induction")
+            true
+          elsif claimed_by_another_ab?
+            capture_error("#{name} is completing their induction with another appropriate body")
+            true
+          else
+            false # can be claimed
+          end
         elsif teacher.blank?
           capture_error("#{name} has not yet been claimed")
-          true
-        elsif passed? || failed?
-          capture_error("#{name} has already completed their induction")
-          true
-        elsif no_ongoing_induction_period?
-          capture_error("#{name} does not have an open induction")
-          true
-        elsif claimed_by_another_ab?
-          capture_error("#{name} is completing their induction with another appropriate body")
           true
         else
           false # can be claimed

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -362,10 +362,9 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         end
       end
 
-      context 'with a completed induction' do
+      context 'with a passed or failed outcome' do
         let!(:induction_period) do
           FactoryBot.create(:induction_period, :pass,
-                            appropriate_body:,
                             teacher:)
         end
 


### PR DESCRIPTION
### Context

Nest error hierarchy block similar to claims

### Changes proposed in this pull request

### Guidance to review

A teacher who has already completed an induction with an outcome of pass or fail should see an error message in a bulk actions upload.

> "#{name} has already completed their induction"
