### PR TITLE
[2116] Refactor schools query service

### DIFF
--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -4,14 +4,26 @@ module API
       filter_validation required_filters: %i[cohort]
 
       def index
-        render json: to_json(paginate(schools_query.schools))
+        render json: to_json(schools)
       end
 
       def show
-        render json: to_json(schools_query.school_by_api_id(api_id))
+        render json: to_json(school)
       end
 
     private
+
+      def paginated_results
+        paginate(schools_query.schools_for_pagination)
+      end
+
+      def schools
+        @schools ||= schools_query.schools_from(paginated_results)
+      end
+
+      def school
+        @school ||= schools_query.school_by_api_id(api_id)
+      end
 
       def schools_query
         conditions = {

--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -27,7 +27,7 @@ module ParityCheck
     def school_id
       contract_period_id = ContractPeriod.order("RANDOM()").pick(:year)
       Schools::Query.new(lead_provider_id: lead_provider.id, contract_period_id:)
-        .schools
+        .schools_for_pagination
         .distinct(false)
         .includes(:gias_school)
         .reorder("RANDOM()")

--- a/app/models/concerns/gias_helpers.rb
+++ b/app/models/concerns/gias_helpers.rb
@@ -2,7 +2,7 @@ module GIASHelpers
   extend ActiveSupport::Concern
 
   included do
-    scope :in_gias_schools, -> { includes(:gias_school).references(:gias_schools) }
+    scope :in_gias_schools, -> { joins(:gias_school) }
     scope :eligible, -> { in_gias_schools.where(gias_school: { funding_eligibility: :eligible_for_fip }) }
     scope :cip_only, -> { in_gias_schools.where(gias_school: { funding_eligibility: :eligible_for_cip }) }
     scope :not_cip_only, -> { where.not(id: cip_only) }

--- a/spec/serializers/school_serializer_spec.rb
+++ b/spec/serializers/school_serializer_spec.rb
@@ -40,11 +40,11 @@ describe SchoolSerializer, type: :serializer do
 
   context "when serialiser input is a query scope" do
     subject(:response) do
-      JSON.parse(described_class.render(scope))
+      JSON.parse(described_class.render(scope)).first
     end
 
     let(:query) { Schools::Query.new(lead_provider_id: lead_provider.id, contract_period_id: contract_period.id) }
-    let(:scope) { query.school(school.id) }
+    let(:scope) { query.schools_from(School.all) }
 
     describe "core attributes" do
       it "serializes `id`" do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2116

Query service select all schools with all transient fields.. which is taking a long time. 

### Changes proposed in this pull request

- Schools records are selected by the query service and then a much smaller result set of schools to be paginated will be sent back to the query service to have transient fields added to it.
- Query service now selects plain schools records in separate then send it back to the query service to enrich the much smaller result set with transient fields required for `SchoolSerializer`.
- School endpoint response time tested with this branch deployed to the migration env and comparing main branch with this branch:
  - For 10 records - down from ~1.8s to ~110ms.
  - For 100 records - down from ~1.7s to ~120ms.
  - For 500 records - down from ~1.9s to ~240ms.
  - For 1000 records - down from ~2s to ~390ms
  - For 3000 records - down from ~2.4s to ~900ms
- Still far from ideal response times, but numbers have improved considerably.
- Benchmark results using a view instead and same logic as this branch ([PR#1031](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1031))
  - For 10 records - ~100ms.
  - For 100 records - ~130ms.
  - For 500 records - ~200ms.
  - For 1000 records - ~320ms
  - For 3000 records - ~720ms

### Guidance to review

Review app