### PR TITLE
Only support filtering on `index` actions

### DIFF
--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -4,7 +4,8 @@ module API
       filter_validation required_filters: %i[cohort]
 
       def index
-        render json: to_json(paginate(schools_query.schools))
+        conditions = { updated_since:, urn:, sort: }
+        render json: to_json(paginate(schools_query(conditions:).schools))
       end
 
       def show
@@ -13,15 +14,9 @@ module API
 
     private
 
-      def schools_query
-        conditions = {
-          lead_provider_id: current_lead_provider.id,
-          contract_period_id: contract_period&.id,
-          updated_since:,
-          urn:,
-          sort:,
-        }
-
+      def schools_query(conditions: {})
+        conditions[:lead_provider_id] = current_lead_provider.id
+        conditions[:contract_period_id] = contract_period&.id
         Schools::Query.new(**conditions.compact)
       end
 

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -2,7 +2,8 @@ module API
   module V3
     class StatementsController < BaseController
       def index
-        render json: to_json(paginate(statements_query.statements))
+        conditions = { contract_period_years:, updated_since: }
+        render json: to_json(paginate(statements_query(conditions:).statements))
       end
 
       def show
@@ -11,13 +12,8 @@ module API
 
     private
 
-      def statements_query
-        conditions = {
-          lead_provider: current_lead_provider,
-          contract_period_years:,
-          updated_since:,
-        }
-
+      def statements_query(conditions: {})
+        conditions[:lead_provider] = current_lead_provider
         Statements::Query.new(**conditions.compact)
       end
 

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -30,5 +30,6 @@ RSpec.describe "Delivery partners API", type: :request do
 
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "a show endpoint"
+    it_behaves_like "a does not filter by cohort endpoint"
   end
 end

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -34,5 +34,6 @@ RSpec.describe "Schools API", type: :request do
 
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "a show endpoint"
+    it_behaves_like "a does not filter by updated_since endpoint"
   end
 end

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -30,5 +30,6 @@ RSpec.describe "Statements API", type: :request do
 
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "a show endpoint"
+    it_behaves_like "a does not filter by cohort endpoint"
   end
 end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -138,3 +138,27 @@ RSpec.shared_examples "a filter by urn endpoint" do
     expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
   end
 end
+
+RSpec.shared_examples "a does not filter by cohort endpoint" do
+  it "returns the resources, ignoring the `cohort`" do
+    different_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)
+    authenticated_api_get(path, params: { filter: { cohort: different_contract_period.year.to_s } })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render(resource, root: "data", **serializer_options))
+  end
+end
+
+RSpec.shared_examples "a does not filter by updated_since endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
+
+  it "returns the resources, ignoring the `updated_since`" do
+    updated_since_after_resource_updated_at = (resource.updated_at + 1.day).utc.iso8601
+    authenticated_api_get(path, params: { filter: { updated_since: updated_since_after_resource_updated_at } })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render(resource, root: "data", **serializer_options))
+  end
+end


### PR DESCRIPTION
### Context

Currently the filtering will also be applied to the `show` action; we don't allow/document this, so we want to restrict filtering to the `index` endpoint only.

### Changes proposed in this pull request

- Only support filtering on `index` actions

Restrict the query conditions so that filters only get passed in on `index` actions (apart from filtering on `contract_period_id` for the schools `show` action as we allow this).
