### PR TITLE
Rename `:active` traits to `:ongoing`

### DIFF
--- a/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
       let!(:induction_period) do
         FactoryBot.create(
           :induction_period,
-          :active,
+          :ongoing,
           teacher:,
           appropriate_body: other_appropriate_body
         )

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
 
   context 'when the ECT has a mentor assigned' do
     before do
-      FactoryBot.create(:mentorship_period, :active, started_on: ect.started_on, mentee: ect, mentor:)
+      FactoryBot.create(:mentorship_period, :ongoing, started_on: ect.started_on, mentee: ect, mentor:)
       render_inline(described_class.new(ect:))
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
     let(:ect) do
       FactoryBot.create(
         :ect_at_school_period,
-        :active,
+        :ongoing,
         :with_eoi_only_training_period,
         lead_provider:,
         school:,

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
   context 'when there are multiple mentors' do
     let(:second_mentor) { FactoryBot.create(:teacher, trs_first_name: 'Sasuke', trs_last_name: 'Uchiha') }
     let!(:second_mentor_at_school_period) do
-      FactoryBot.create(:mentor_at_school_period, :active, teacher: second_mentor, school:, started_on:)
+      FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: second_mentor, school:, started_on:)
     end
 
     let(:ect1_teacher) { FactoryBot.create(:teacher, trs_first_name: 'Konohamaru', trs_last_name: 'Sarutobi') }

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
 
   let(:school_led_ect) do
-    FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:)
+    FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, school_reported_appropriate_body:)
   end
 
   let(:provider_led_ect) do
     FactoryBot.create(:ect_at_school_period,
                       :with_training_period,
-                      :active,
+                      :ongoing,
                       :provider_led,
                       school_reported_appropriate_body:,
                       lead_provider:,
@@ -87,7 +87,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
   end
 
   context 'when data is reported by the appropriate body' do
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, school_reported_appropriate_body:) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, school_reported_appropriate_body:) }
 
     before do
       FactoryBot.create(:induction_period, teacher: ect.teacher, started_on: '2023-01-01')
@@ -141,7 +141,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
 
   context 'when no training periods exist for a provider-led ECT' do
     let(:provider_led_ect_without_training_periods) do
-      FactoryBot.create(:ect_at_school_period, :with_training_period, :active, :provider_led, school_reported_appropriate_body:, lead_provider:)
+      FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, :provider_led, school_reported_appropriate_body:, lead_provider:)
     end
 
     before { render_inline(described_class.new(title: 'Reported to us by your lead provider', ect: provider_led_ect_without_training_periods, data_source: :lead_provider)) }

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,16 +1,16 @@
 RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
   let(:mentee_teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'Kakarot', trs_last_name: 'SSJ') }
   let(:mentor_teacher) { FactoryBot.create(:teacher, trn: '987654', trs_first_name: 'Naruto', trs_last_name: 'Ninetails') }
-  let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher, started_on: 3.years.ago) }
+  let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
+  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher, started_on: 3.years.ago) }
   let(:mentee) do
-    FactoryBot.create(:ect_at_school_period, :active, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
-                                                      email: 'foobarect@madeup.com', working_pattern: 'full_time')
+    FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
+                                                       email: 'foobarect@madeup.com', working_pattern: 'full_time')
   end
 
   before do
-    FactoryBot.create(:mentorship_period, :active, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago)
-    FactoryBot.create(:mentorship_period, :active, mentee:, mentor: current_mentor, started_on: 2.years.ago)
+    FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago)
+    FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: current_mentor, started_on: 2.years.ago)
     render_inline(described_class.new(mentee))
   end
 

--- a/spec/components/teachers/details/current_induction_period_component_spec.rb
+++ b/spec/components/teachers/details/current_induction_period_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
   context "when teacher has a current induction period" do
     let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: "Test AB") }
     let!(:current_period) do
-      FactoryBot.create(:induction_period, :active,
+      FactoryBot.create(:induction_period, :ongoing,
                         teacher:,
                         appropriate_body:,
                         started_on: '2025-06-30',
@@ -94,7 +94,7 @@ RSpec.describe Teachers::Details::CurrentInductionPeriodComponent, type: :compon
 
         context "when the induction period has an outcome" do
           let!(:current_period) do
-            FactoryBot.create(:induction_period, :active,
+            FactoryBot.create(:induction_period, :ongoing,
                               teacher:,
                               appropriate_body:,
                               started_on: 6.months.ago,

--- a/spec/components/teachers/details/induction_outcome_actions_component_spec.rb
+++ b/spec/components/teachers/details/induction_outcome_actions_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Teachers::Details::InductionOutcomeActionsComponent, type: :compo
 
   context "with active induction period" do
     before do
-      FactoryBot.create(:induction_period, :active, teacher:)
+      FactoryBot.create(:induction_period, :ongoing, teacher:)
       render_inline(component)
     end
 

--- a/spec/components/teachers_index/table_section_component_spec.rb
+++ b/spec/components/teachers_index/table_section_component_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe TeachersIndex::TableSectionComponent, type: :component do
 
     let!(:teacher_1) do
       teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
       teacher
     end
 
     let!(:teacher_2) do
       teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 4, 1))
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2024, 4, 1))
       teacher
     end
 
@@ -252,7 +252,7 @@ RSpec.describe TeachersIndex::TableSectionComponent, type: :component do
 
     let!(:integration_teacher) do
       teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2024, 3, 15))
       teacher
     end
 

--- a/spec/components/teachers_index_component_spec.rb
+++ b/spec/components/teachers_index_component_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe TeachersIndexComponent, type: :component do
 
   let!(:teacher_1) do
     teacher = FactoryBot.create(:teacher, trs_first_name: "Alice", trs_last_name: "Smith", trn: "1234567")
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 3.months.ago)
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 3.months.ago)
     teacher
   end
 
   let!(:teacher_2) do
     teacher = FactoryBot.create(:teacher, trs_first_name: "Bob", trs_last_name: "Jones", trn: "2345678")
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 2.months.ago)
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 2.months.ago)
     teacher
   end
 
@@ -32,7 +32,7 @@ RSpec.describe TeachersIndexComponent, type: :component do
 
   let!(:teacher_4_other_ab) do
     teacher = FactoryBot.create(:teacher, trs_first_name: "David", trs_last_name: "Wilson", trn: "4567890")
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_appropriate_body, started_on: 1.month.ago)
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body: other_appropriate_body, started_on: 1.month.ago)
     teacher
   end
 

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
       finished_on { 2.weeks.ago }
     end
 
-    trait :active do
+    trait :ongoing do
       started_on { generate(:base_ect_date) + 1.year }
       finished_on { nil }
     end

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     induction_programme { "fip" }
     training_programme { 'provider_led' }
 
-    trait :active do
+    trait :ongoing do
       finished_on { nil }
       number_of_terms { nil }
     end

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     finished_on { started_on + 1.day }
     email { Faker::Internet.email }
 
-    trait :active do
+    trait :ongoing do
       started_on { generate(:base_mentor_date) + 1.year }
       finished_on { nil }
     end

--- a/spec/factories/mentorship_period_factory.rb
+++ b/spec/factories/mentorship_period_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     started_on { generate(:base_mentorship_date) }
     finished_on { started_on + 1.day }
 
-    trait :active do
+    trait :ongoing do
       finished_on { nil }
     end
   end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
       association :expression_of_interest, factory: :active_lead_provider
     end
 
-    trait :active do
+    trait :ongoing do
       finished_on { nil }
     end
 

--- a/spec/features/admin/teachers/delete_induction_period_spec.rb
+++ b/spec/features/admin/teachers/delete_induction_period_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Admin deletes an induction period" do
   end
 
   context "when it is the only induction period" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
 
     scenario "TRS status is reset" do
       given_i_am_on_the_ect_page(teacher)
@@ -27,8 +27,8 @@ RSpec.describe "Admin deletes an induction period" do
   end
 
   context "when there are multiple induction periods" do
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
+    let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
 
     scenario "TRS start date is updated to next earliest period" do
       given_i_am_on_the_ect_page(teacher)
@@ -45,8 +45,8 @@ RSpec.describe "Admin deletes an induction period" do
   end
 
   context "when deleting the later induction period" do
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
+    let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 2) }
+    let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 2) }
 
     scenario "TRS start date remains unchanged" do
       given_i_am_on_the_ect_page(teacher)

--- a/spec/features/admin/teachers/edit_induction_period_spec.rb
+++ b/spec/features/admin/teachers/edit_induction_period_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Admin amending number of terms of an induction period" do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :active,
+    FactoryBot.create(:induction_period, :ongoing,
                       teacher:,
                       appropriate_body:,
                       started_on: Date.new(2024, 1, 1))

--- a/spec/features/admin/teachers/record_failed_outcome_spec.rb
+++ b/spec/features/admin/teachers/record_failed_outcome_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Admin recording a failed outcome for an ECT" do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/admin/teachers/record_passed_outcome_spec.rb
+++ b/spec/features/admin/teachers/record_passed_outcome_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Admin recording a passed outcome for an ECT" do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Claiming an ECT' do
     include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
     before do
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_body)
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body: other_body)
     end
 
     scenario 'Button is hidden when induction is ongoing' do

--- a/spec/features/appropriate_bodies/edit_induction_period_spec.rb
+++ b/spec/features/appropriate_bodies/edit_induction_period_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Appropriate body editing an induction period" do
   let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
 
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:)
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:)
   end
 
   before do

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Recording a failed outcome for an ECT" do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Recording a passed outcome for an ECT" do
   let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Releasing an ECT' do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:today) { Time.zone.today }
   let(:number_of_completed_terms) { 4 }

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def and_an_ongoing_ect_is_assigned_to_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Registering an ECT' do
 
   def and_an_ect_has_already_registered_at_my_school
     teacher = FactoryBot.create(:teacher, trn: '9876543')
-    FactoryBot.create(:ect_at_school_period, :active, teacher:, school:)
+    FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
   end
 
   def when_i_click_continue

--- a/spec/features/schools/ects/search_spec.rb
+++ b/spec/features/schools/ects/search_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe 'Searching for an ECT', type: :feature do
     @school = FactoryBot.create(:school)
 
     @matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Jimmy', trs_last_name: 'Searchable')
-    FactoryBot.create(:ect_at_school_period, :active, teacher: @matching_teacher, school: @school)
+    FactoryBot.create(:ect_at_school_period, :ongoing, teacher: @matching_teacher, school: @school)
 
     @non_matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Invisible')
-    FactoryBot.create(:ect_at_school_period, :active, teacher: @non_matching_teacher, school: @school)
+    FactoryBot.create(:ect_at_school_period, :ongoing, teacher: @non_matching_teacher, school: @school)
   end
 
   def and_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe 'Registering a mentor', :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
     teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe 'Registering a mentor', :js do
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
     teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_an_active_mentor_registered_at_the_school
     teacher = FactoryBot.create(:teacher, trs_first_name: 'Kirk', trs_last_name: 'Van Houten', corrected_name: nil)
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, teacher:)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, teacher:)
     @mentor_name = Teachers::Name.new(teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
     contract_period = FactoryBot.create(:contract_period, year: Date.current.year)
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider:, contract_period:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, contract_period:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/search_spec.rb
+++ b/spec/features/schools/mentors/search_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe 'Searching for a mentor', type: :feature do
     @school = FactoryBot.create(:school)
 
     @matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Jimmy', trs_last_name: 'Searchable')
-    FactoryBot.create(:mentor_at_school_period, :active, teacher: @matching_teacher, school: @school)
+    FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: @matching_teacher, school: @school)
 
     @non_matching_teacher = FactoryBot.create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Invisible')
-    FactoryBot.create(:mentor_at_school_period, :active, teacher: @non_matching_teacher, school: @school)
+    FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: @non_matching_teacher, school: @school)
   end
 
   def and_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/mentorship/add_a_mentor_to_an_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_an_ect_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe 'Add a mentor to an ECT' do
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :active, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school, started_on: @ect.started_on)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school, started_on: @ect.started_on)
     @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
   end
 

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
     FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :active, lead_provider:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
-    @mentor = FactoryBot.create(:mentor_at_school_period, :active, school: @school)
+    @mentor = FactoryBot.create(:mentor_at_school_period, :ongoing, school: @school)
     @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
   end
 

--- a/spec/helpers/ect_helper_spec.rb
+++ b/spec/helpers/ect_helper_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe ECTHelper, type: :helper do
     let(:ect_teacher) { FactoryBot.create(:teacher, trs_induction_status:) }
     let(:trs_induction_status) { nil }
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, teacher: ect_teacher, school:, started_on:) }
-    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, school:, started_on:) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:, started_on:) }
+    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
 
     context "when the ECT has a TRS induction status" do
       context "when the status is Passed" do
@@ -36,7 +36,7 @@ RSpec.describe ECTHelper, type: :helper do
 
     context "when the ECT has an empty TRS induction status" do
       context "when the ECT has a current mentor" do
-        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :active, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
+        let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:) }
 
         it "returns a green 'Registered' tag" do
           expect(helper.ect_status(ect_at_school_period)).to have_css('strong.govuk-tag.govuk-tag--green', text: 'Registered')

--- a/spec/helpers/induction_helper_spec.rb
+++ b/spec/helpers/induction_helper_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe InductionHelper, type: :helper do
   describe '#claiming_body?' do
     let(:teacher) { FactoryBot.create(:teacher) }
-    let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
     let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
 
     it 'returns true when the current induction is with the claiming body' do

--- a/spec/migration/builders/mentorship_periods_spec.rb
+++ b/spec/migration/builders/mentorship_periods_spec.rb
@@ -4,16 +4,16 @@ describe Builders::MentorshipPeriods do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:started_on) { 2.years.ago.to_date }
   let(:finished_on) { 6.months.ago.to_date }
-  let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :active, teacher:, started_on:, finished_on:) }
+  let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, started_on:, finished_on:) }
   let(:mentor_period_1) do
     FactoryBot.create(:mentor_at_school_period,
-                      :active,
+                      :ongoing,
                       school: ect_period.school,
                       started_on: started_on + 1.day)
   end
   let(:mentor_period_2) do
     FactoryBot.create(:mentor_at_school_period,
-                      :active,
+                      :ongoing,
                       school: ect_period.school,
                       started_on: started_on - 1.week)
   end
@@ -87,7 +87,7 @@ describe Builders::MentorshipPeriods do
     end
 
     context "when the mentor does not have a MentorAtSchoolPeriod at the same school" do
-      let(:mentor_period_1) { FactoryBot.create(:mentor_at_school_period, :active, started_on: started_on + 1.day) }
+      let(:mentor_period_1) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: started_on + 1.day) }
 
       it "creates a TeacherMigrationFailure record" do
         expect {

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe InductionPeriod do
     end
 
     describe "started_on_not_in_future" do
-      subject { FactoryBot.build(:induction_period, :active, appropriate_body:, started_on:) }
+      subject { FactoryBot.build(:induction_period, :ongoing, appropriate_body:, started_on:) }
 
       context "when started_on is today" do
         let(:started_on) { Date.current }
@@ -136,7 +136,7 @@ RSpec.describe InductionPeriod do
 
     describe "number_of_terms" do
       context "when finished_on is empty" do
-        subject { FactoryBot.build(:induction_period, :active, appropriate_body:) }
+        subject { FactoryBot.build(:induction_period, :ongoing, appropriate_body:) }
 
         it { is_expected.not_to validate_presence_of(:number_of_terms) }
       end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -16,8 +16,8 @@ describe MentorshipPeriod do
       )
     end
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 2.years.ago) }
-    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 2.years.ago) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.years.ago) }
+    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 2.years.ago) }
     let(:started_on) { 2.months.ago }
     let(:finished_on) { nil }
 
@@ -119,8 +119,8 @@ describe MentorshipPeriod do
         subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
         let!(:teacher) { ect_at_school_period.teacher }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
         it 'add a base error' do
           subject.valid?
@@ -132,8 +132,8 @@ describe MentorshipPeriod do
       context 'when mentor and mentee are different teachers' do
         subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
 
         it 'do not add an error' do
           subject.valid?
@@ -145,8 +145,8 @@ describe MentorshipPeriod do
       context 'when mentor or mentee are not set yet' do
         subject { FactoryBot.build(:mentorship_period, mentor: mentor_at_school_period) }
 
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
-        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
 
         it 'do not add an error' do
           subject.valid?
@@ -174,12 +174,12 @@ describe MentorshipPeriod do
   describe "#siblings" do
     subject { period_1.siblings }
 
-    let!(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
-    let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: '2021-01-01') }
+    let!(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: '2021-01-01') }
     let!(:period_1) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-01-01', finished_on: '2022-06-01') }
     let!(:period_2) { FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
-    let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:unrelated_mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: '2021-01-01') }
     let!(:unrelated_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: unrelated_mentee, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
     it "only returns records that belong to the same mentee" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -1,7 +1,7 @@
 describe TrainingPeriod do
   describe "declarative touch" do
     let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, school: target, started_on: '2021-01-01') }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: target, started_on: '2021-01-01') }
     let(:instance) { FactoryBot.create(:training_period, :with_expression_of_interest, :for_mentor, mentor_at_school_period:) }
     let(:target) { FactoryBot.create(:school) }
 
@@ -240,12 +240,12 @@ describe TrainingPeriod do
   describe "#siblings" do
     subject { training_period_1.siblings }
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01') }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: '2021-01-01') }
     let!(:training_period_1) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: '2022-01-01', finished_on: '2022-06-01') }
     let!(:training_period_2) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: '2022-06-01', finished_on: '2023-01-01') }
 
     let!(:unrelated_ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :active, started_on: '2021-01-01')
+      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: '2021-01-01')
     end
 
     let!(:unrelated_training_period) do

--- a/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
+++ b/spec/requests/admin/appropriate_bodies/appropriate_bodies/current_ects/index_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe 'Listing and searching ECTs belonging to an appropriate body' do
       let!(:teacher_1) { FactoryBot.create(:teacher, trs_first_name: "Pam", trs_last_name: "Ferris") }
       let!(:teacher_2) { FactoryBot.create(:teacher, trs_first_name: "Felicity", trs_last_name: "Kendall") }
 
-      let!(:induction_period_1) { FactoryBot.create(:induction_period, :active, teacher: teacher_1, appropriate_body:) }
-      let!(:induction_period_2) { FactoryBot.create(:induction_period, :active, teacher: teacher_2, appropriate_body:) }
+      let!(:induction_period_1) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher_1, appropriate_body:) }
+      let!(:induction_period_2) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher_2, appropriate_body:) }
 
       it 'shows lists current ECTs' do
         get "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects"

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe 'Admin editing an active induction period', type: :request do
 
   describe "DELETE /admin/induction_periods/:id" do
     context "when it is the only induction period" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
+      let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
       let(:trs_api_client) { instance_double(TRS::APIClient) }
 
       before do
@@ -687,8 +687,8 @@ RSpec.describe 'Admin editing an active induction period', type: :request do
     end
 
     context "when there are multiple induction periods" do
-      let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 9.months.ago, number_of_terms: 2) }
-      let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 3.months.ago, number_of_terms: 2) }
+      let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 1.year.ago, finished_on: 9.months.ago, number_of_terms: 2) }
+      let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 3.months.ago, number_of_terms: 2) }
       let(:trs_api_client) { instance_double(TRS::APIClient) }
 
       before do
@@ -712,7 +712,7 @@ RSpec.describe 'Admin editing an active induction period', type: :request do
     end
 
     context "when deletion fails" do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
+      let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 6.months.ago, finished_on: 1.month.ago, number_of_terms: 2) }
 
       before do
         service = instance_double(InductionPeriods::DeleteInductionPeriod)

--- a/spec/requests/admin/teachers/index_spec.rb
+++ b/spec/requests/admin/teachers/index_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe "Admin teachers index", type: :request do
 
           FactoryBot.create(
             :induction_period,
-            :active,
+            :ongoing,
             teacher:,
             started_on: 1.month.ago.to_date,
             induction_programme: 'fip'
           )
           FactoryBot.create(
             :induction_period,
-            :active,
+            :ongoing,
             teacher: other_teacher,
             started_on: 1.month.ago.to_date,
             induction_programme: 'fip'
@@ -50,14 +50,14 @@ RSpec.describe "Admin teachers index", type: :request do
 
           FactoryBot.create(
             :induction_period,
-            :active,
+            :ongoing,
             teacher:,
             started_on: 1.month.ago.to_date,
             induction_programme: 'fip'
           )
           FactoryBot.create(
             :induction_period,
-            :active,
+            :ongoing,
             teacher: other_teacher,
             started_on: 1.month.ago.to_date,
             induction_programme: 'fip'

--- a/spec/requests/admin/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_outcome_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Admin recording a failed outcome for a teacher' do
   let!(:induction_period) do
     FactoryBot.create(
       :induction_period,
-      :active,
+      :ongoing,
       teacher:,
       appropriate_body:,
       started_on: 1.month.ago,

--- a/spec/requests/admin/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_outcome_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Admin recording a passed outcome for a teacher' do
   let!(:induction_period) do
     FactoryBot.create(
       :induction_period,
-      :active,
+      :ongoing,
       teacher:,
       appropriate_body:,
       started_on: 1.month.ago,

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Admin::Teachers#show", type: :request do
   include ActionView::Helpers::SanitizeHelper
 
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
 
   describe "GET /admin/teachers/:id" do
     it "redirects to sign in path" do

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
 
       context "when the ECT has an ongoing induction period with another appropriate body" do
         let!(:preexisting_teacher) { FactoryBot.create(:teacher, trn: pending_induction_submission.trn) }
-        let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher: preexisting_teacher) }
+        let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: preexisting_teacher) }
 
         it 'redirects to the ECT already claimed by another AB early exit page' do
           patch(

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :active,
+            :ongoing,
             appropriate_body: FactoryBot.create(:appropriate_body),
             teacher:,
             started_on: Date.parse("2 October 2022")
@@ -128,7 +128,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
         let!(:induction_period) do
           FactoryBot.create(
             :induction_period,
-            :active,
+            :ongoing,
             appropriate_body:,
             teacher:,
             started_on: Date.parse("2 October 2022")

--- a/spec/requests/appropriate_bodies/induction_periods_spec.rb
+++ b/spec/requests/appropriate_bodies/induction_periods_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Appropriate body editing an active induction period', type: :req
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
   let!(:induction_period) do
-    FactoryBot.create(:induction_period, :active, teacher:, started_on: 9.months.ago)
+    FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: 9.months.ago)
   end
 
   describe "GET /appropriate-body/teachers/:teacher_id/induction-periods/:id/edit" do

--- a/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/edit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Appropriate Body teacher extensions edit", type: :request do
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
   let(:extension) { FactoryBot.create(:induction_extension, teacher:, number_of_terms: 2) }
 

--- a/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Appropriate Body teacher extensions index", type: :request do
   include AuthHelper
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
 
   describe 'when not signed in' do
     it 'redirects to the root page' do

--- a/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/new_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Appropriate Body teacher extensions new", type: :request do
   include AuthHelper
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
   let!(:user) { sign_in_as(:appropriate_body_user, appropriate_body:) }
 
   describe 'GET /appropriate-body/teachers/:id/extensions/new' do

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
         let!(:additional_teachers) do
           FactoryBot.create_list(:teacher, 51, trs_first_name: "John", trs_last_name: "Smith").tap do |teachers|
             teachers.each do |teacher|
-              FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:)
+              FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:)
             end
           end
         end
@@ -36,19 +36,19 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
       context "with open and closed induction filtering" do
         let!(:alice_johnson) do
           FactoryBot.create(:teacher, trs_first_name: 'Alice', trs_last_name: 'Johnson', trn: '1000001', trs_induction_status: 'InProgress').tap do |teacher|
-            FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 3.months.ago)
+            FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 3.months.ago)
           end
         end
 
         let!(:bob_williams) do
           FactoryBot.create(:teacher, trs_first_name: 'Bob', trs_last_name: 'Williams', trn: '1000002', trs_induction_status: 'RequiredToComplete').tap do |teacher|
-            FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 2.months.ago)
+            FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 2.months.ago)
           end
         end
 
         let!(:charlie_brown) do
           FactoryBot.create(:teacher, trs_first_name: 'Charlie', trs_last_name: 'Brown', trn: '1000003', trs_induction_status: 'InProgress').tap do |teacher|
-            FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: 1.month.ago)
+            FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: 1.month.ago)
           end
         end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
   let!(:induction_period) do
     FactoryBot.create(
       :induction_period,
-      :active,
+      :ongoing,
       teacher:,
       appropriate_body:,
       started_on: 1.month.ago,

--- a/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
   let!(:induction_period) do
     FactoryBot.create(
       :induction_period,
-      :active,
+      :ongoing,
       teacher:,
       appropriate_body:,
       started_on: 1.month.ago,

--- a/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
 
       context 'and a teacher actively training' do
         before do
-          FactoryBot.create(:induction_period, :active, appropriate_body:, teacher:)
+          FactoryBot.create(:induction_period, :ongoing, appropriate_body:, teacher:)
         end
 
         it 'instantiates a new PendingInductionSubmission and renders the page' do
@@ -55,7 +55,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
         end
 
         let!(:induction_period) do
-          FactoryBot.create(:induction_period, :active, appropriate_body:, teacher:, started_on: "2022-09-01")
+          FactoryBot.create(:induction_period, :ongoing, appropriate_body:, teacher:, started_on: "2022-09-01")
         end
 
         let(:release_params) do

--- a/spec/requests/appropriate_bodies/teachers/show_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/show_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Appropriate Body teacher show page", type: :request do
   include AuthHelper
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+  let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
 
   describe 'GET /appropriate-body/teachers/:id' do
     context 'when not signed in' do

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'Create mentorship of an ECT to a mentor' do
   include ActionView::Helpers::SanitizeHelper
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, school:) }
-  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school:) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
   let(:school) { FactoryBot.create(:school, :independent) }
 
   describe 'GET /school/ects/:id/mentorship/new' do

--- a/spec/serializers/school_serializer_spec.rb
+++ b/spec/serializers/school_serializer_spec.rb
@@ -10,7 +10,7 @@ describe SchoolSerializer, type: :serializer do
   let(:lead_provider) { school_partnership.lead_provider }
   let(:ect_at_school_period) do
     FactoryBot.create(:ect_at_school_period,
-                      :active,
+                      :ongoing,
                       :provider_led,
                       school:,
                       started_on: '2021-01-01')
@@ -24,7 +24,7 @@ describe SchoolSerializer, type: :serializer do
   end
   let(:another_ect_at_school_period) do
     FactoryBot.create(:ect_at_school_period,
-                      :active,
+                      :ongoing,
                       :school_led,
                       school:,
                       started_on: '2021-01-01')

--- a/spec/services/admin/current_teachers_spec.rb
+++ b/spec/services/admin/current_teachers_spec.rb
@@ -10,7 +10,7 @@ describe Admin::CurrentTeachers do
       before do
         FactoryBot.create(
           :induction_period,
-          :active,
+          :ongoing,
           teacher: teacher_1,
           appropriate_body: appropriate_body_1,
           started_on: 1.month.ago.to_date,
@@ -18,7 +18,7 @@ describe Admin::CurrentTeachers do
         )
         FactoryBot.create(
           :induction_period,
-          :active,
+          :ongoing,
           teacher: teacher_2,
           appropriate_body: appropriate_body_2,
           started_on: 1.month.ago.to_date,
@@ -47,7 +47,7 @@ describe Admin::CurrentTeachers do
       before do
         FactoryBot.create(
           :induction_period,
-          :active,
+          :ongoing,
           teacher: teacher_1,
           started_on: 1.month.ago.to_date,
           induction_programme: 'fip'
@@ -73,7 +73,7 @@ describe Admin::CurrentTeachers do
       before do
         FactoryBot.create(
           :induction_period,
-          :active,
+          :ongoing,
           teacher: teacher_1,
           appropriate_body: appropriate_body_1,
           started_on: 1.month.ago.to_date,

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
       let(:teacher) { FactoryBot.create(:teacher) }
       let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :active, appropriate_body:, teacher:, started_on: Date.parse("2 October 2022"))
+        FactoryBot.create(:induction_period, :ongoing, appropriate_body:, teacher:, started_on: Date.parse("2 October 2022"))
       end
 
       context "when the induction period is with another AB" do

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       let(:other_body) { FactoryBot.create(:appropriate_body) }
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :active,
+        FactoryBot.create(:induction_period, :ongoing,
                           appropriate_body: other_body,
                           teacher:,
                           started_on: '2024-1-1')
@@ -302,7 +302,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
 
     context 'with an ongoing induction' do
       let!(:induction_period) do
-        FactoryBot.create(:induction_period, :active,
+        FactoryBot.create(:induction_period, :ongoing,
                           appropriate_body:,
                           teacher:,
                           started_on: '2024-1-1')

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
       let(:teacher) { FactoryBot.create(:teacher, trn:) }
 
       before do
-        FactoryBot.create(:induction_period, :active, teacher:, appropriate_body: other_body)
+        FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body: other_body)
         service.process!
       end
 

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let(:induction_period) do
-    FactoryBot.create(:induction_period, :active,
+    FactoryBot.create(:induction_period, :ongoing,
                       appropriate_body:,
                       teacher:,
                       started_on: '2024-1-1')

--- a/spec/services/appropriate_bodies/release_ect_spec.rb
+++ b/spec/services/appropriate_bodies/release_ect_spec.rb
@@ -9,7 +9,7 @@ describe AppropriateBodies::ReleaseECT do
     )
   end
 
-  let(:induction_period) { FactoryBot.create(:induction_period, :active) }
+  let(:induction_period) { FactoryBot.create(:induction_period, :ongoing) }
   let(:appropriate_body) { induction_period.appropriate_body }
   let(:pending_induction_submission) do
     FactoryBot.create(

--- a/spec/services/ect_at_school_periods/mentorship_spec.rb
+++ b/spec/services/ect_at_school_periods/mentorship_spec.rb
@@ -2,8 +2,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#current_mentorship_period" do
     subject { described_class.new(mentee).current_mentorship_period }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -19,7 +19,7 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at a school" do
       let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:) }
-      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee:, mentor:) }
+      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:) }
 
       it { is_expected.to eq(ongoing_mentorship) }
     end
@@ -28,8 +28,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#current_mentor" do
     subject { described_class.new(mentee).current_mentor }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -46,7 +46,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(mentor) }
@@ -56,8 +56,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#current_mentor_name" do
     subject { described_class.new(mentee).current_mentor_name }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -74,7 +74,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor:, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(Teachers::Name.new(mentor.teacher).full_name) }
@@ -84,8 +84,8 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#latest_mentorship_period" do
     subject { described_class.new(mentee).latest_mentorship_period }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -99,7 +99,7 @@ describe ECTAtSchoolPeriods::Mentorship do
 
     context "when the ect has an ongoing mentorship at the school" do
       let!(:old_mentorship) { FactoryBot.create(:mentorship_period, mentee:, mentor:) }
-      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee:, mentor:) }
+      let!(:ongoing_mentorship) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:) }
 
       it { is_expected.to eq(ongoing_mentorship) }
     end
@@ -108,9 +108,9 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#latest_mentor" do
     subject { described_class.new(mentee).latest_mentor }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-    let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -128,7 +128,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(mentor) }
@@ -138,9 +138,9 @@ describe ECTAtSchoolPeriods::Mentorship do
   describe "#latest_mentor_name" do
     subject { described_class.new(mentee).latest_mentor_name }
 
-    let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-    let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
+    let(:old_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no mentorships ever" do
       it { is_expected.to be_nil }
@@ -158,7 +158,7 @@ describe ECTAtSchoolPeriods::Mentorship do
     context "when the ect has an ongoing mentorship at a school" do
       before do
         FactoryBot.create(:mentorship_period, mentee:, mentor: old_mentor, started_on: 2.years.ago)
-        FactoryBot.create(:mentorship_period, :active, mentee:, mentor:, started_on: 1.year.ago)
+        FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago)
       end
 
       it { is_expected.to eql(Teachers::Name.new(mentor.teacher).full_name) }

--- a/spec/services/ect_at_school_periods/training_spec.rb
+++ b/spec/services/ect_at_school_periods/training_spec.rb
@@ -2,7 +2,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_training_period" do
     subject { described_class.new(ect_at_school_period).current_training_period }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -18,7 +18,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training) }
     end
@@ -27,7 +27,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_delivery_partner" do
     subject { described_class.new(ect_at_school_period).current_delivery_partner }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -43,7 +43,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
@@ -52,7 +52,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_delivery_partner_name" do
     subject { described_class.new(ect_at_school_period).current_delivery_partner_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -68,7 +68,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
@@ -77,7 +77,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_lead_provider" do
     subject { described_class.new(ect_at_school_period).current_lead_provider }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -93,7 +93,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
@@ -102,7 +102,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#current_lead_provider_name" do
     subject { described_class.new(ect_at_school_period).current_lead_provider_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -118,7 +118,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
@@ -127,7 +127,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_training_period" do
     subject { described_class.new(ect_at_school_period).latest_training_period }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -141,7 +141,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training) }
     end
@@ -150,7 +150,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_delivery_partner" do
     subject { described_class.new(ect_at_school_period).latest_delivery_partner }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -164,7 +164,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
@@ -173,7 +173,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_delivery_partner_name" do
     subject { described_class.new(ect_at_school_period).latest_delivery_partner_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -187,7 +187,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
@@ -196,7 +196,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_lead_provider" do
     subject { described_class.new(ect_at_school_period).latest_lead_provider }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -210,7 +210,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
@@ -219,7 +219,7 @@ describe ECTAtSchoolPeriods::Training do
   describe "#latest_lead_provider_name" do
     subject { described_class.new(ect_at_school_period).latest_lead_provider_name }
 
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 
     context "when the ect has had no training ever" do
       it { is_expected.to be_nil }
@@ -233,7 +233,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :active, :for_ect, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end
@@ -244,7 +244,7 @@ describe ECTAtSchoolPeriods::Training do
 
     context 'when the latest training period is an expression of interest' do
       let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Jimmy Provider') }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, :with_eoi_only_training_period, lead_provider:) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_eoi_only_training_period, lead_provider:) }
 
       it 'returns the lead provider name from the EOI' do
         expect(subject).to eq('Jimmy Provider')
@@ -271,7 +271,7 @@ describe ECTAtSchoolPeriods::Training do
       let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'EOI Provider') }
 
       let(:ect_at_school_period) do
-        FactoryBot.create(:ect_at_school_period, :active).tap do |ect|
+        FactoryBot.create(:ect_at_school_period, :ongoing).tap do |ect|
           FactoryBot.create(:training_period, :for_ect, ect_at_school_period: ect, started_on: ect.started_on + 1.week, finished_on: ect.started_on + 10.days)
 
           FactoryBot.create(
@@ -295,7 +295,7 @@ describe ECTAtSchoolPeriods::Training do
       let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Old EOI Provider') }
 
       let(:ect_at_school_period) do
-        FactoryBot.create(:ect_at_school_period, :active, :with_eoi_only_training_period, lead_provider:)
+        FactoryBot.create(:ect_at_school_period, :ongoing, :with_eoi_only_training_period, lead_provider:)
       end
 
       let!(:confirmed_period) do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Events::Record do
     end
 
     it 'assigns and saves attributes correctly' do
-      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :active, started_on: 3.weeks.ago)
-      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.weeks.ago)
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.weeks.ago)
+      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.weeks.ago)
 
       attributes = {
         author:,
@@ -51,7 +51,7 @@ RSpec.describe Events::Record do
         lead_provider: FactoryBot.create(:lead_provider),
         delivery_partner: FactoryBot.create(:delivery_partner),
         user: FactoryBot.create(:user),
-        training_period: FactoryBot.create(:training_period, :active, ect_at_school_period:, started_on: 1.week.ago),
+        training_period: FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: 1.week.ago),
         mentorship_period: FactoryBot.create(
           :mentorship_period,
           mentor: mentor_at_school_period,
@@ -362,7 +362,7 @@ RSpec.describe Events::Record do
   describe '.record_induction_period_updated_event!' do
     let(:three_weeks_ago) { 3.weeks.ago.to_date }
     let(:two_weeks_ago) { 2.weeks.ago.to_date }
-    let(:induction_period) { FactoryBot.create(:induction_period, :active, started_on: three_weeks_ago) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, started_on: three_weeks_ago) }
 
     it 'queues a RecordEventJob with the correct values' do
       induction_period.assign_attributes(started_on: two_weeks_ago)
@@ -665,8 +665,8 @@ RSpec.describe Events::Record do
     let(:started_on_param) { { started_on: 2.years.ago.to_date } }
     let(:school) { FactoryBot.create(:school) }
     let(:mentee) { FactoryBot.create(:teacher, trs_first_name: 'Steffan', trs_last_name: 'Rhodri') }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, teacher: mentee, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:, school:, **started_on_param) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentee, school:, **started_on_param) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:, **started_on_param) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
 
     it 'queues a RecordEventJob with the correct values' do
@@ -692,8 +692,8 @@ RSpec.describe Events::Record do
     let(:started_on_param) { { started_on: 2.years.ago.to_date } }
     let(:school) { FactoryBot.create(:school) }
     let(:mentor) { FactoryBot.create(:teacher, trs_first_name: 'Steffan', trs_last_name: 'Rhodri') }
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, teacher:, school:, **started_on_param) }
-    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor, school:, **started_on_param) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, **started_on_param) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor, school:, **started_on_param) }
     let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on: 2.days.ago.to_date) }
 
     it 'queues a RecordEventJob with the correct values' do

--- a/spec/services/induction_periods/delete_induction_period_spec.rb
+++ b/spec/services/induction_periods/delete_induction_period_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
   end
 
   context "when it is the only induction period" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:) }
+    let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
 
     before do
       allow(trs_client).to receive(:reset_teacher_induction!)
@@ -79,8 +79,8 @@ RSpec.describe InductionPeriods::DeleteInductionPeriod do
   end
 
   context "when there are other induction periods" do
-    let!(:earliest_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 3) }
-    let!(:later_period) { FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 3) }
+    let!(:earliest_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 3) }
+    let!(:later_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 3) }
 
     before do
       allow(trs_client).to receive(:reset_teacher_induction!)

--- a/spec/services/schools/assign_mentor_form_spec.rb
+++ b/spec/services/schools/assign_mentor_form_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       context "when the mentor is not registered at the ect's school" do
         subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
 
         before do
           subject.valid?
@@ -36,8 +36,8 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
       context "when the mentor is not eligible for the ect" do
         subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
-        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school: ect.school, teacher: ect.teacher) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school, teacher: ect.teacher) }
 
         before do
           subject.valid?
@@ -54,9 +54,9 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
     context "when the mentor is eligible to mentor the ect at the same school" do
       subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
       let(:author) { FactoryBot.create(:school_user, school_urn: ect.school.urn) }
-      let(:mentor) { FactoryBot.create(:mentor_at_school_period, :active, school: ect.school) }
+      let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
 
       it 'adds a new mentorship for the ect and the mentor starting today' do
         expect(ECTAtSchoolPeriods::Mentorship.new(ect).current_mentor).to be_nil

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Schools::AssignMentor do
     described_class.new(author:, ect: mentee, mentor: new_mentor, started_on:)
   end
 
-  let(:mentee) { FactoryBot.create(:ect_at_school_period, :active, started_on: 3.years.ago) }
-  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
-  let!(:current_mentorship) { FactoryBot.create(:mentorship_period, :active, mentee:, mentor: current_mentor) }
-  let(:new_mentor) { FactoryBot.create(:mentor_at_school_period, :active, started_on: 3.years.ago) }
+  let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
+  let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
+  let!(:current_mentorship) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: current_mentor) }
+  let(:new_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }
   let(:started_on) { Date.yesterday }
   let(:author) { FactoryBot.create(:school_user, school_urn: mentee.school.urn) }
 

--- a/spec/services/schools/eligible_mentors_spec.rb
+++ b/spec/services/schools/eligible_mentors_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Schools::EligibleMentors do
   end
 
   let(:school) { FactoryBot.create(:school) }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, started_on: 2.years.ago) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.years.ago) }
 
   describe '#for_ect' do
     context "when the school has no active mentors" do
@@ -12,7 +12,7 @@ RSpec.describe Schools::EligibleMentors do
     end
 
     context "when the school has active mentors registered" do
-      let!(:active_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :active, school:, started_on: 2.years.ago) }
+      let!(:active_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :ongoing, school:, started_on: 2.years.ago) }
 
       it "returns those mentors" do
         expect(subject.to_a).to match_array(active_mentors)
@@ -20,10 +20,10 @@ RSpec.describe Schools::EligibleMentors do
     end
 
     context "when the ect is also a mentor at the school" do
-      let!(:mentors_excluding_ect) { FactoryBot.create_list(:mentor_at_school_period, 2, :active, school:, started_on: 2.years.ago) }
+      let!(:mentors_excluding_ect) { FactoryBot.create_list(:mentor_at_school_period, 2, :ongoing, school:, started_on: 2.years.ago) }
 
       before do
-        FactoryBot.create(:mentor_at_school_period, :active, school:, teacher: ect.teacher, started_on: 2.years.ago)
+        FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: ect.teacher, started_on: 2.years.ago)
       end
 
       it "returns those mentors excluding themself" do

--- a/spec/services/schools/home_spec.rb
+++ b/spec/services/schools/home_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe Schools::Home do
   let(:mentor) { FactoryBot.create(:teacher, corrected_name: nil) }
 
   let(:mentor_period) do
-    FactoryBot.create(:mentor_at_school_period, :active,
+    FactoryBot.create(:mentor_at_school_period, :ongoing,
                       school:,
                       teacher: mentor,
                       started_on: 2.years.ago)
   end
 
   let(:ect_period) do
-    FactoryBot.create(:ect_at_school_period, :active,
+    FactoryBot.create(:ect_at_school_period, :ongoing,
                       school:,
                       teacher: ect,
                       started_on: 2.years.ago)
   end
 
   before do
-    FactoryBot.create(:training_period, :active,
+    FactoryBot.create(:training_period, :ongoing,
                       mentor_at_school_period: mentor_period,
                       ect_at_school_period: nil,
                       started_on: 1.year.ago)
@@ -30,7 +30,7 @@ RSpec.describe Schools::Home do
                       mentee: ect_period,
                       started_on: 2.years.ago,
                       finished_on: 1.year.ago)
-    FactoryBot.create(:mentorship_period, :active,
+    FactoryBot.create(:mentorship_period, :ongoing,
                       mentor: mentor_period,
                       mentee: ect_period,
                       started_on: 1.year.ago)

--- a/spec/services/schools/query_spec.rb
+++ b/spec/services/schools/query_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Schools::Query do
         let!(:school1) { FactoryBot.create(:school, :eligible, updated_at: 2.days.ago) }
         let!(:school2) { FactoryBot.create(:school, :eligible, updated_at: 10.minutes.ago) }
 
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :for_ect) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_ect) }
         let!(:school3) { training_period.school_partnership.school }
 
         let(:contract_period_id) { training_period.contract_period.id }
@@ -250,7 +250,7 @@ RSpec.describe Schools::Query do
       it { expect(returned_school).not_to be_transient_mentors_at_school }
 
       context "when there is any mentors with expression of interest for the given school and contract period" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_only_expression_of_interest, :for_mentor) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, :for_mentor) }
         let(:contract_period_id) { training_period.expression_of_interest.contract_period.id }
 
         before do
@@ -261,7 +261,7 @@ RSpec.describe Schools::Query do
       end
 
       context "when there is any mentors in training for the given school and contract period" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_school_partnership, :for_mentor) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_school_partnership, :for_mentor) }
         let(:contract_period_id) { training_period.contract_period.id }
 
         before do
@@ -282,7 +282,7 @@ RSpec.describe Schools::Query do
       it { expect(returned_school).not_to be_transient_ects_at_school_training_programme }
 
       context "when there is any ects with expression of interest for the given school and contract period" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_only_expression_of_interest, :for_ect) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, :for_ect) }
         let(:contract_period_id) { training_period.expression_of_interest.contract_period.id }
 
         before do
@@ -293,7 +293,7 @@ RSpec.describe Schools::Query do
       end
 
       context "when there is any ects in training for the given school and contract period" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_school_partnership, :for_ect) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_school_partnership, :for_ect) }
         let(:contract_period_id) { training_period.contract_period.id }
 
         before do
@@ -336,7 +336,7 @@ RSpec.describe Schools::Query do
       it { expect(returned_school).not_to be_transient_expression_of_interest_ects }
 
       context "when there is any expression of interest from an ect for the given school/contract period/lead provider" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_only_expression_of_interest, :for_ect) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, :for_ect) }
         let(:lead_provider_id) { training_period.expression_of_interest.lead_provider.id }
         let(:contract_period_id) { training_period.expression_of_interest.contract_period.id }
 
@@ -348,7 +348,7 @@ RSpec.describe Schools::Query do
       end
 
       context "when there is any expression of interest from a mentor for the given school/contract period/lead provider" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_only_expression_of_interest, :for_mentor) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, :for_mentor) }
         let(:lead_provider_id) { training_period.expression_of_interest.lead_provider.id }
         let(:contract_period_id) { training_period.expression_of_interest.contract_period.id }
 
@@ -377,7 +377,7 @@ RSpec.describe Schools::Query do
       it { expect(returned_school).not_to be_transient_expression_of_interest_mentors }
 
       context "when there is any expression of interest from a mentor for the given school/contract period/lead provider" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_only_expression_of_interest, :for_mentor) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, :for_mentor) }
         let(:lead_provider_id) { training_period.expression_of_interest.lead_provider.id }
         let(:contract_period_id) { training_period.expression_of_interest.contract_period.id }
 
@@ -389,7 +389,7 @@ RSpec.describe Schools::Query do
       end
 
       context "when there is any expression of interest from an ect for the given school/contract period/lead provider" do
-        let!(:training_period) { FactoryBot.create(:training_period, :active, :with_only_expression_of_interest, :for_ect) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :with_only_expression_of_interest, :for_ect) }
         let(:lead_provider_id) { training_period.expression_of_interest.lead_provider.id }
         let(:contract_period_id) { training_period.expression_of_interest.contract_period.id }
 

--- a/spec/services/schools/teacher_email_spec.rb
+++ b/spec/services/schools/teacher_email_spec.rb
@@ -2,10 +2,10 @@ describe Schools::TeacherEmail do
   subject { described_class.new(email:, trn:) }
 
   let(:finished_ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
-  let(:ongoing_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ongoing_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
 
   let(:finished_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
-  let(:ongoing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :active) }
+  let(:ongoing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
 
   let(:trn) { '123456' }
 

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -21,7 +21,7 @@ describe Schools::TrainingProgramme do
         context "when school has at least one mentor in training" do
           let(:mentor_at_school_period) do
             FactoryBot.create(:mentor_at_school_period,
-                              :active,
+                              :ongoing,
                               school:,
                               started_on: '2021-01-01')
           end
@@ -41,19 +41,19 @@ describe Schools::TrainingProgramme do
         context "when school has mentors not in training (only mentoring)" do
           let(:mentor_at_school_period) do
             FactoryBot.create(:mentor_at_school_period,
-                              :active,
+                              :ongoing,
                               school:,
                               started_on: '2021-01-01')
           end
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :active,
+                              :ongoing,
                               school:,
                               started_on: '2021-01-01')
           end
           let!(:mentorship_period) do
             FactoryBot.create(:mentorship_period,
-                              :active,
+                              :ongoing,
                               started_on: mentor_at_school_period.started_on,
                               mentor: mentor_at_school_period,
                               mentee: ect_at_school_period)
@@ -67,7 +67,7 @@ describe Schools::TrainingProgramme do
         context "when school has at least one expression of interest for training from a mentor" do
           let(:mentor_at_school_period) do
             FactoryBot.create(:mentor_at_school_period,
-                              :active,
+                              :ongoing,
                               school:,
                               started_on: '2021-01-01')
           end
@@ -89,7 +89,7 @@ describe Schools::TrainingProgramme do
           context "when there is only `provider_led` as the ects training programmes" do
             let(:ect_at_school_period) do
               FactoryBot.create(:ect_at_school_period,
-                                :active,
+                                :ongoing,
                                 school:,
                                 started_on: '2021-01-01')
             end
@@ -110,7 +110,7 @@ describe Schools::TrainingProgramme do
           context "when there is only `school_led` as the ects training programmes" do
             let(:ect_at_school_period) do
               FactoryBot.create(:ect_at_school_period,
-                                :active,
+                                :ongoing,
                                 school:,
                                 started_on: '2021-01-01')
             end
@@ -131,7 +131,7 @@ describe Schools::TrainingProgramme do
           context "when there is a mix of `provider_led` and `school_led` as the ects training programmes" do
             let(:ect_at_school_period_1) do
               FactoryBot.create(:ect_at_school_period,
-                                :active,
+                                :ongoing,
                                 school:,
                                 started_on: '2021-01-01')
             end
@@ -146,7 +146,7 @@ describe Schools::TrainingProgramme do
 
             let(:ect_at_school_period_2) do
               FactoryBot.create(:ect_at_school_period,
-                                :active,
+                                :ongoing,
                                 school:,
                                 started_on: '2021-01-01')
             end
@@ -168,7 +168,7 @@ describe Schools::TrainingProgramme do
         context "when school has at least one expression of interest for training from an ect" do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :active,
+                              :ongoing,
                               school:,
                               started_on: '2021-01-01')
           end
@@ -204,7 +204,7 @@ describe Schools::TrainingProgramme do
       context "`transient_mentors_at_school` is true" do
         let(:mentor_at_school_period) do
           FactoryBot.create(:mentor_at_school_period,
-                            :active,
+                            :ongoing,
                             school:,
                             started_on: '2021-01-01')
         end
@@ -225,7 +225,7 @@ describe Schools::TrainingProgramme do
         context "when `transient_ects_at_school_training_programme` is present" do
           let(:ect_at_school_period) do
             FactoryBot.create(:ect_at_school_period,
-                              :active,
+                              :ongoing,
                               school:,
                               started_on: '2021-01-01')
           end

--- a/spec/services/teachers/induction_period_spec.rb
+++ b/spec/services/teachers/induction_period_spec.rb
@@ -36,7 +36,7 @@ describe Teachers::InductionPeriod do
 
     context "with ongoing induction period" do
       let!(:ongoing_induction_period) do
-        FactoryBot.create(:induction_period, :active, teacher:, started_on: '2023-10-3')
+        FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: '2023-10-3')
       end
 
       it 'returns the active open induction period' do

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Teachers::Induction do
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let(:induction_period_unfinished) do
-    FactoryBot.create(:induction_period, :active, teacher:, started_on: 6.months.ago)
+    FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: 6.months.ago)
   end
 
   let(:induction_period_finished_one_year_ago) do
@@ -92,7 +92,7 @@ RSpec.describe Teachers::Induction do
 
   describe "#with_appropriate_body?" do
     let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
-    let(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+    let(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
 
     it "returns true when the current induction is with the body" do
       expect(service.with_appropriate_body?(induction_period.appropriate_body)).to be true

--- a/spec/services/teachers/induction_status_spec.rb
+++ b/spec/services/teachers/induction_status_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Teachers::InductionStatus do
       context 'with an ongoing induction period' do
         let(:induction_periods) do
           [
-            FactoryBot.create(:induction_period, :active, teacher:)
+            FactoryBot.create(:induction_period, :ongoing, teacher:)
           ]
         end
 
@@ -108,7 +108,7 @@ RSpec.describe Teachers::InductionStatus do
         context "when there is an open induction period" do
           let(:induction_periods) do
             [
-              FactoryBot.create(:induction_period, :active)
+              FactoryBot.create(:induction_period, :ongoing)
             ]
           end
 

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -24,8 +24,8 @@ describe Teachers::Search do
     let(:teacher2) { FactoryBot.create(:teacher) }
     let(:teacher3) { FactoryBot.create(:teacher) }
 
-    let!(:induction_period1) { FactoryBot.create(:induction_period, :active, teacher: teacher1, appropriate_body: ab1) }
-    let!(:induction_period2) { FactoryBot.create(:induction_period, :active, teacher: teacher2, appropriate_body: ab2) }
+    let!(:induction_period1) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher1, appropriate_body: ab1) }
+    let!(:induction_period2) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher2, appropriate_body: ab2) }
 
     describe 'belonging to appropriate bodies' do
       context 'when one appropriate body is provided' do
@@ -43,7 +43,7 @@ describe Teachers::Search do
       context 'when multiple appropriate bodies are provided' do
         subject { Teachers::Search.new(appropriate_bodies: [ab1, ab3]) }
 
-        let!(:induction_period3) { FactoryBot.create(:induction_period, :active, teacher: teacher3, appropriate_body: ab3) }
+        let!(:induction_period3) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher3, appropriate_body: ab3) }
 
         it 'includes teachers with ongoing induction periods with the specified appropriate bodies' do
           expect(subject.search).to include(teacher1, teacher3)
@@ -76,7 +76,7 @@ describe Teachers::Search do
       let(:teacher_with_completed_induction) { FactoryBot.create(:teacher) }
       let(:teacher_with_no_induction) { FactoryBot.create(:teacher) }
 
-      let!(:open_induction_period) { FactoryBot.create(:induction_period, :active, teacher: teacher_with_open_induction, appropriate_body: ab1) }
+      let!(:open_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: teacher_with_open_induction, appropriate_body: ab1) }
       let!(:completed_induction_period) { FactoryBot.create(:induction_period, :pass, teacher: teacher_with_completed_induction, appropriate_body: ab1) }
 
       context 'when status is "open"' do
@@ -237,7 +237,7 @@ describe Teachers::Search do
           end
 
           context 'when currently an ECT at the school' do
-            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :active, school:, teacher:) }
+            let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher:) }
 
             it 'returns the teacher' do
               expect(Teachers::Search.new(ect_at_school: school).search).to include(teacher)
@@ -278,13 +278,13 @@ describe Teachers::Search do
         let(:mentored_teacher2) { FactoryBot.create(:teacher) }
 
         # unmentored
-        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :active, teacher: teacher1, school: school1, started_on:, created_at: 2.days.ago) }
-        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :active, teacher: teacher2, school: school1, started_on:, created_at: 1.day.ago) }
+        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher1, school: school1, started_on:, created_at: 2.days.ago) }
+        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher2, school: school1, started_on:, created_at: 1.day.ago) }
 
         # mentored
-        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :active, teacher: teacher3, school: school1, started_on:) }
-        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :active, teacher: mentored_teacher1, school: school1, started_on:, created_at: 2.days.ago) }
-        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :active, teacher: mentored_teacher2, school: school1, started_on:, created_at: 1.day.ago) }
+        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: teacher3, school: school1, started_on:) }
+        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher1, school: school1, started_on:, created_at: 2.days.ago) }
+        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher2, school: school1, started_on:, created_at: 1.day.ago) }
 
         let!(:mentorship_period1) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on:) }
         let!(:mentorship_period2) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on:) }

--- a/spec/support/shared_contexts/csv_file.rb
+++ b/spec/support/shared_contexts/csv_file.rb
@@ -16,7 +16,7 @@ RSpec.shared_context '1 valid and 1 invalid claim' do
 
   before do
     already_claimed_teacher = FactoryBot.create(:teacher, trn: '1234567')
-    FactoryBot.create(:induction_period, :active, teacher: already_claimed_teacher)
+    FactoryBot.create(:induction_period, :ongoing, teacher: already_claimed_teacher)
   end
 end
 
@@ -34,7 +34,7 @@ RSpec.shared_context '3 valid actions' do
   before do
     data.map do |row|
       teacher = FactoryBot.create(:teacher, trn: row[:trn])
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:, started_on: '2024-12-01')
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: '2024-12-01')
     end
   end
 end
@@ -52,9 +52,9 @@ RSpec.shared_context '1 valid and 2 invalid actions' do
 
   before do
     valid_teacher = FactoryBot.create(:teacher, trn: '1234567')
-    FactoryBot.create(:induction_period, :active, teacher: valid_teacher, appropriate_body:, started_on: '2024-12-01')
+    FactoryBot.create(:induction_period, :ongoing, teacher: valid_teacher, appropriate_body:, started_on: '2024-12-01')
     teacher_at_another_body = FactoryBot.create(:teacher, trn: '7654321')
-    FactoryBot.create(:induction_period, :active, teacher: teacher_at_another_body, started_on: '2024-12-01')
+    FactoryBot.create(:induction_period, :ongoing, teacher: teacher_at_another_body, started_on: '2024-12-01')
     FactoryBot.create(:teacher, trn: '0000007')
   end
 end

--- a/spec/views/admin/induction_period/edit.html.erb_spec.rb
+++ b/spec/views/admin/induction_period/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'admin/induction_periods/edit.html.erb' do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:back_path) { admin_teacher_path(ect.teacher) }
   let(:induction_period) { FactoryBot.create(:induction_period, teacher: ect.teacher) }
 

--- a/spec/views/admin/induction_period/new.html.erb_spec.rb
+++ b/spec/views/admin/induction_period/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'admin/induction_periods/new.html.erb' do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:back_path) { admin_teacher_path(ect.teacher) }
   let(:induction_period) { FactoryBot.build(:induction_period, teacher: ect.teacher) }
 

--- a/spec/views/admin/teachers/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'admin/teachers/show.html.erb' do
   let(:teacher) { FactoryBot.create(:teacher, trn: '1234567', trs_first_name: 'Floella', trs_last_name: 'Benjamin') }
 
   before do
-    FactoryBot.create(:induction_period, :active, teacher:)
+    FactoryBot.create(:induction_period, :ongoing, teacher:)
     assign(:teacher, Admin::TeacherPresenter.new(teacher))
     render
   end

--- a/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/claim_an_ect/check_ect/edit.html.erb_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
     end
 
     context 'when the ECT has an ongoing induction period with another appropriate body' do
-      let!(:induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+      let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
 
       before { assign(:current_appropriate_body, appropriate_body) }
 
@@ -62,7 +62,7 @@ RSpec.describe 'appropriate_bodies/claim_an_ect/check_ect/edit.html.erb' do
 
   describe 'induction periods' do
     context 'when the ECT has past induction periods' do
-      let!(:current_induction_period) { FactoryBot.create(:induction_period, :active, teacher:) }
+      let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
 
       it 'shows the current induction period' do
         render

--- a/spec/views/appropriate_bodies/induction_period/edit.html.erb_spec.rb
+++ b/spec/views/appropriate_bodies/induction_period/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'appropriate_bodies/induction_periods/edit.html.erb' do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:back_path) { ab_teacher_path(ect.teacher) }
   let(:induction_period) { FactoryBot.create(:induction_period, teacher: ect.teacher) }
 

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe 'schools/ects/show.html.erb' do
       context 'when assigned' do
         before do
           mentor = FactoryBot.create(:teacher, trs_first_name: 'Moby', trs_last_name: 'Dick')
-          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :active, school: current_school, teacher: mentor)
+          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, school: current_school, teacher: mentor)
 
-          FactoryBot.create(:mentorship_period, :active,
+          FactoryBot.create(:mentorship_period, :ongoing,
                             started_on: current_ect_period.started_on,
                             mentee: current_ect_period,
                             mentor: mentor_at_school_period)
@@ -101,7 +101,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
 
   describe 'ECTE training details' do
     before do
-      FactoryBot.create(:induction_period, :active, teacher:, appropriate_body:)
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:)
 
       render
     end

--- a/spec/views/schools/mentorships/new.html.erb_spec.rb
+++ b/spec/views/schools/mentorships/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/mentorships/new.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:ect_name) { Teachers::Name.new(ect.teacher).full_name }
   let(:mentor) { double("mentor_at_school_period", full_name: 'Peter Times', id: 7) }
   let(:mentor_id) { mentor.id }

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   end
 
   let(:ect) do
-    FactoryBot.create(:ect_at_school_period, :with_training_period, :active, teacher:, lead_provider:)
+    FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, teacher:, lead_provider:)
   end
 
   let(:store) do
@@ -74,7 +74,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   describe 'summary' do
     context 'with school led ect' do
       let(:ect) do
-        FactoryBot.create(:ect_at_school_period, :active, :school_led, teacher:)
+        FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, teacher:)
       end
 
       it 'hides lead provider' do

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
   let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :with_training_period, :active, teacher:, lead_provider:) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, teacher:, lead_provider:) }
 
   let(:store) do
     double(
@@ -54,7 +54,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       end
 
       context 'when the ect is not provider_led' do
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, teacher:) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, teacher:) }
 
         it { expect(rendered).not_to have_content("We’ll pass on their details to FraggleRock") }
       end
@@ -71,7 +71,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       end
 
       context 'when the ect is not provider_led' do
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led, teacher:) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, teacher:) }
 
         it { expect(rendered).not_to have_content('They cannot do mentor training according to our records.') }
       end

--- a/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/find_mentor.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "schools/register_mentor_wizard/find_mentor.html.erb" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:back_path) { schools_register_mentor_wizard_start_path(ect_id: ect.id) }
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, ect_id: ect.id) }

--- a/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led) }
   let(:ect_name) { Teachers::Name.new(ect.teacher).full_name }
 
   before do
@@ -29,7 +29,7 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
       let(:back_path) { new_schools_ect_mentorship_path(ect) }
 
       before do
-        FactoryBot.create(:mentor_at_school_period, :active, school: ect.school)
+        FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school)
         render
       end
 

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
 
     context 'when the ECT has an ongoing ECT record at the school' do
-      let!(:existing_ect_record) { FactoryBot.create(:ect_at_school_period, :active, school:, teacher:) }
+      let!(:existing_ect_record) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher:) }
 
       it 'returns the ECT record' do
         expect(ect.active_record_at_school(school.urn)).to eq(existing_ect_record)
@@ -45,7 +45,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     let(:teacher) { FactoryBot.create(:teacher, trn: ect.trn) }
 
     it 'returns true if the ECT is active at the given school' do
-      FactoryBot.create(:ect_at_school_period, :active, teacher:, school:)
+      FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:)
 
       expect(ect.active_at_school?(school.urn)).to be_truthy
     end

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -87,7 +87,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     context 'when the ect is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :active, teacher:, school:) }
+      let(:active_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :ongoing, teacher:, school:) }
 
       before do
         wizard.store.update!(school_urn: active_ect_period.school.urn)

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -1,7 +1,7 @@
 describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
   subject { wizard.current_step }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :provider_led) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led) }
   let(:training_programme) { 'provider_led' }
   let(:use_previous_ect_choices) { true }
   let(:store) { FactoryBot.build(:session_repository) }
@@ -24,7 +24,7 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
         end
 
         context 'when the ect is not provider led' do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led) }
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led) }
 
           it { expect(subject.previous_step).to eq(:email_address) }
         end

--- a/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
@@ -31,7 +31,7 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
     it_behaves_like 'an email step', current_step: :email_address,
                                      previous_step: :review_mentor_details,
                                      next_step: :check_answers do
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :school_led) }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led) }
     end
   end
 end

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -61,7 +61,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
   describe '#next_step' do
     subject { wizard.current_step }
 
-    let(:ect) { FactoryBot.create(:ect_at_school_period, :active) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
     let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :find_mentor, step_params:, ect_id: ect.id) }
     let(:step_params) do
       ActionController::Parameters.new(
@@ -87,7 +87,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context 'when the mentor trn matches that of the ECT' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher:) }
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
 
       before do
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
@@ -123,7 +123,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context 'when the mentor is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
       before do
         wizard.store.update!(school_urn: active_mentor_period.school.urn)

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -19,7 +19,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
 
     context 'when the mentor has an ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :active, school:, teacher:) }
+      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
 
       it 'returns true' do
         expect(mentor.active_at_school?).to be(true)
@@ -39,7 +39,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
 
     context 'when the mentor has an ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :active, school:, teacher:) }
+      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
 
       it 'returns the mentor record' do
         expect(mentor.active_record_at_school).to eq(existing_mentor_record)

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -82,7 +82,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context 'when the mentor is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
       before do
         wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
@@ -97,7 +97,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context 'when the mentor is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher:) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
       before do
         wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_step:|
   subject { described_class.new(wizard:) }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, :provider_led) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led) }
   let(:store) do
     FactoryBot.build(:session_repository,
                      trn: "1234567",

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -1,7 +1,7 @@
 describe Schools::RegisterMentorWizard::Wizard do
   let(:current_step) { :find_mentor }
   let(:ect_teacher) { FactoryBot.create(:teacher, trn: "7654321") }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :active, teacher: ect_teacher) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher) }
   let(:ect_id) { ect.id }
   let(:mentor_trn) { "1234567" }
   let(:mentor_date_of_birth) { "1977-02-03" }
@@ -68,7 +68,7 @@ describe Schools::RegisterMentorWizard::Wizard do
 
       context 'when the mentor is already active at the school' do
         let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
         let(:school_urn) { active_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor already_active_at_school]) }
@@ -110,7 +110,7 @@ describe Schools::RegisterMentorWizard::Wizard do
 
       context 'when the mentor is already active at the school' do
         let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
         let(:school_urn) { active_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor national_insurance_number already_active_at_school]) }
@@ -129,7 +129,7 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context 'when only TRN, DoB and already active at school have been set' do
       let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
       let(:school_urn) { active_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do
@@ -150,7 +150,7 @@ describe Schools::RegisterMentorWizard::Wizard do
     context 'when only TRN, DoB, Nino and already active at school have been set' do
       let(:mentor_date_of_birth) { "2000-01-01" }
       let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :active, teacher: mentor_teacher) }
+      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
       let(:school_urn) { active_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do


### PR DESCRIPTION
We have a bunch of `Period` models that use `ongoing` scopes.

The corresponding factories tend to use `:active` traits to create "ongoing" records, though.

This mismatch is a little confusing, so this aligns them.

Closes #1057.