### PR TITLE
Add delivery partners APIs to parity check

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -34,6 +34,14 @@ module ParityCheck
         .pick(gias_school: :api_id)
     end
 
+    def delivery_partner_id
+      DeliveryPartners::Query.new(lead_provider:)
+        .delivery_partners
+        .distinct(false)
+        .reorder("RANDOM()")
+        .pick(:api_id)
+    end
+
     # Request body methods
 
     def example_body

--- a/app/migration/parity_check/request_builder.rb
+++ b/app/migration/parity_check/request_builder.rb
@@ -92,10 +92,10 @@ module ParityCheck
     end
 
     def pages_remain?(previous_response)
-      return nil unless pagination_enabled?
+      return false unless pagination_enabled?
 
-      [previous_response.ecf_body, previous_response.rect_body].any? do |body|
-        JSON.parse(body)["data"]&.size == PAGINATION_PER_PAGE
+      [previous_response.ecf_body_hash, previous_response.rect_body_hash].compact.any? do |body|
+        body[:data]&.size == PAGINATION_PER_PAGE
       rescue JSON::ParserError
         false
       end

--- a/app/models/parity_check/filter/response_body.rb
+++ b/app/models/parity_check/filter/response_body.rb
@@ -100,11 +100,13 @@ module ParityCheck::Filter
       @ecf_key_hash ||= nested_key_hash(ecf_body_hash)
     end
 
-    def nested_key_hash(hash)
+    def nested_key_hash(item)
       result = {}
 
-      hash.keys.sort.each do |key|
-        value = hash[key]
+      return result unless item.is_a?(Hash)
+
+      item.keys.sort.each do |key|
+        value = item[key]
         result[key] = if value.is_a?(Hash) && value.any?
                         nested_key_hash(value)
                       elsif value.is_a?(Array) && value.any?

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -69,7 +69,6 @@ get:
       query:
         sort: "-updated_at"
   - "/api/v3/delivery-partners":
-      ecf_path: "/api/v3/schools/ecf"
       paginate: true
       query:
         filter:

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -57,6 +57,27 @@ get:
       ecf_path: "/api/v3/schools/ecf/:id"
       id: school_id
 
+  - "/api/v3/delivery-partners":
+      paginate: true
+  - "/api/v3/delivery-partners":
+      paginate: true
+      query:
+        filter:
+          cohort: 2023
+  - "/api/v3/delivery-partners":
+      paginate: true
+      query:
+        sort: "-updated_at"
+  - "/api/v3/delivery-partners":
+      ecf_path: "/api/v3/schools/ecf"
+      paginate: true
+      query:
+        filter:
+          cohort: 2023
+        sort: "+created_at"
+  - "/api/v3/delivery-partners/:id":
+      id: delivery_partner_id
+
 post:
   - "/api/v3/partnerships/ecf":
       body: example_body

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe ParityCheck::DynamicRequestContent do
       it { is_expected.to eq(school.api_id) }
     end
 
+    context "when fetching delivery_partner_id" do
+      let(:identifier) { :delivery_partner_id }
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+      let!(:delivery_partner) { lead_provider_delivery_partnership.delivery_partner }
+
+      before do
+        # Delivery partner for different lead provider should not be used.
+        FactoryBot.create(:delivery_partner)
+      end
+
+      it { is_expected.to eq(delivery_partner.api_id) }
+    end
+
     context "when fetching example_body" do
       let(:identifier) { :example_body }
 

--- a/spec/migration/parity_check/request_builder_spec.rb
+++ b/spec/migration/parity_check/request_builder_spec.rb
@@ -204,6 +204,24 @@ RSpec.describe ParityCheck::RequestBuilder do
             expect(instance.page).to eq(1)
           end
         end
+
+        context "when there the response bodies are nil" do
+          let(:previous_response) { FactoryBot.build(:parity_check_response, ecf_body: nil, rect_body: nil) }
+
+          it "returns false and does not increment the page number" do
+            expect(advance_page).to be_falsy
+            expect(instance.page).to eq(1)
+          end
+        end
+
+        context "when there the response bodies do not return JSON" do
+          let(:previous_response) { FactoryBot.build(:parity_check_response, ecf_body: "bad response", rect_body: "bad response") }
+
+          it "returns false and does not increment the page number" do
+            expect(advance_page).to be_falsy
+            expect(instance.page).to eq(1)
+          end
+        end
       end
 
       context "when pagination is disabled" do

--- a/spec/models/parity_check/filter/response_body_spec.rb
+++ b/spec/models/parity_check/filter/response_body_spec.rb
@@ -76,6 +76,21 @@ describe ParityCheck::Filter::ResponseBody do
           )
         end
       end
+
+      context "when the JSON contains arrays of values" do
+        let(:ecf_body) { { key1: [{ subkey: "value1", other_subkey: %w[value4 value5] }] }.to_json }
+        let(:rect_body) { { key2: "value" }.to_json }
+
+        it "returns a hash of the key structure" do
+          expect(key_hash).to eq(
+            key1: {
+              subkey: {},
+              other_subkey: {}
+            },
+            key2: {}
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

We want to run the delivery partner APIs on the parity check now that they are complete to find any differences/issues.

### Changes proposed in this pull request

- Add delivery partner API requests to the parity check.

Update `DynamicRequestContent` to retrieve a `delivery_partner_id`.

- Support response bodies with arrays of values

Currently we expect all arrays to contain objects (which can be mapped into a hash). When we return `cohort` for delivery partners, however, it is an array of strings and trips up the `ParityCheck::Filter::ResponseBody` logic.

Ignore nested items in the key hash mapping unless they are also a hash.

### Guidance to review

[Run in migration](https://cpd-ec2-migration-web.teacherservices.cloud/migration/parity-checks/31)

From the most part it looks like the updated_at/created_at are different and a handful of `cohort` entries (some are just ordered differently but there are some that are a small handful that have different content).