### PR TITLE
Capture ERD rake task output in test instead of printing to shell

### DIFF
--- a/spec/lib/tasks/mermaid_erd_spec.rb
+++ b/spec/lib/tasks/mermaid_erd_spec.rb
@@ -12,7 +12,7 @@ describe 'ERD tasks' do
 
       expect(generator).to receive(:generate)
 
-      Rake::Task['erd:generate'].invoke
+      expect { Rake::Task['erd:generate'].invoke }.to output(/\[✔\] Mermaid ERD diagram added to:/).to_stdout
     end
   end
 end


### PR DESCRIPTION
#### Context

Since the test stubs `Rails.env` to development and invokes the `erd:generate` task, the success message is printed to stdout, which is noisy in CI.

Use an `expect { ... }.to output(...).to_stdout` block to capture and assert the message instead, keeping CI logs clean while verifying the behaviour.