### PR TITLE
Migrate the ECF schools timestamps to RECT schools

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -37,8 +37,11 @@ module Migrators
       migrate(self.class.schools) do |ecf_school|
         gias_school = find_gias_school(urn: ecf_school.urn.to_i) || migrate_school!(ecf_school)
         if check_gias_school(gias_school:, ecf_school:)
-          [compare_fields(gias_school:, ecf_school:),
-           update_gias_school!(gias_school:, api_id: ecf_school.id)].all?
+          [
+            compare_fields(gias_school:, ecf_school:),
+            update_gias_school!(gias_school:, api_id: ecf_school.id),
+            update_school!(school: gias_school.school, ecf_school:),
+          ].all?
         end
       end
     end
@@ -84,5 +87,13 @@ module Migrators
     def open_school_with_partnerships?(ecf_school) = ecf_school.open? && ecf_school.partnerships.exists?
 
     def update_gias_school!(gias_school:, api_id:) = gias_school.update!(api_id:)
+
+    def update_school!(school:, ecf_school:)
+      timestamp_attrs = {
+        created_at: ecf_school.created_at,
+        updated_at: ecf_school.updated_at
+      }
+      school.update_columns(timestamp_attrs)
+    end
   end
 end

--- a/spec/factories/gias/school_factory.rb
+++ b/spec/factories/gias/school_factory.rb
@@ -113,5 +113,9 @@ FactoryBot.define do
     trait(:state_school_type) do
       type_name { GIAS::Types::STATE_SCHOOL_TYPES.sample }
     end
+
+    trait(:with_school) do
+      school { build_school }
+    end
   end
 end

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -15,7 +15,7 @@ describe Migrators::School do
   end
 
   def create_gias_school(ecf_school)
-    FactoryBot.create(:gias_school,
+    FactoryBot.create(:gias_school, :with_school,
                       urn: ecf_school.urn,
                       administrative_district_name: 'AD1',
                       funding_eligibility: 'eligible_for_fip',
@@ -102,7 +102,7 @@ describe Migrators::School do
       end
 
       let!(:gias_school) do
-        FactoryBot.create(:gias_school,
+        FactoryBot.create(:gias_school, :with_school,
                           urn: ecf_school.urn,
                           administrative_district_name: 'AAD1',
                           funding_eligibility: 'eligible_for_cip',
@@ -147,6 +147,13 @@ describe Migrators::School do
       it "sets api_id to be the id of the school on ECF" do
         expect(data_migration.reload.failure_count).to eq(0)
         expect(gias_school.reload.api_id).to eq(ecf_school.id)
+      end
+
+      it "syncs the timestamps from the ECF school to the RECT school" do
+        expect(data_migration.reload.failure_count).to eq(0)
+        gias_school.reload
+        expect(gias_school.school.created_at).to eq(ecf_school.created_at)
+        expect(gias_school.school.updated_at).to eq(ecf_school.updated_at)
       end
     end
   end


### PR DESCRIPTION
### Context

To preserve the current API experience for providers, we need to ensure the School timestamps match their corresponding ECF values.

### Changes proposed in this pull request
- Update the school migrator to set the `created_at` and `updated_at` timestamps using  the corresponding ECF values
- Use `update_columns` to avoid Active Record overriding the `updated_at`

### Guidance to review

