### PR TITLE
Fix flaky test for `ECTAtSchoolPeriod#current_training_period`

### DIFF
--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -15,8 +15,8 @@ FactoryBot.define do
     end
 
     trait :finished do
-      started_on { 1.year.ago }
-      finished_on { 2.weeks.ago }
+      started_on  { ect_at_school_period&.started_on || 1.year.ago }
+      finished_on { ect_at_school_period&.started_on&.+(1.month) || 2.weeks.ago }
     end
 
     trait(:school_led) do


### PR DESCRIPTION
### Context

The `:finished` TrainingPeriod trait used absolute dates (1.year.ago/2.weeks.ago), which could fall outside the associated `ECTAtSchoolPeriod` and trigger the validation:

- Date range is not contained by the period the trainee is at the school

Which caused a flaky failure in:

`spec/models/ect_at_school_period_spec.rb:45`

The factory now uses a date within the parent `ECTAtSchoolPeriod` if present, falling back to the absolute dates if it's not.