### PR TITLE
Update ongoing period variable names in tests

### DIFF
--- a/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
 
     context "when teacher is registered with another appropriate body" do
       let(:other_appropriate_body) { FactoryBot.create(:appropriate_body) }
-      let!(:induction_period) do
+      let!(:ongoing_induction_period) do
         FactoryBot.create(
           :induction_period,
           :ongoing,

--- a/spec/components/teachers/details/induction_outcome_actions_component_spec.rb
+++ b/spec/components/teachers/details/induction_outcome_actions_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Teachers::Details::InductionOutcomeActionsComponent, type: :compo
   let(:mode) { :admin }
   let(:teacher) { FactoryBot.create(:teacher) }
 
-  context "without active induction period" do
+  context "without ongoing induction period" do
     it "does not render" do
       expect(component.render?).to be false
       render_inline(component)
@@ -12,7 +12,7 @@ RSpec.describe Teachers::Details::InductionOutcomeActionsComponent, type: :compo
     end
   end
 
-  context "with active induction period" do
+  context "with ongoing induction period" do
     before do
       FactoryBot.create(:induction_period, :ongoing, teacher:)
       render_inline(component)

--- a/spec/components/teachers_index_component_spec.rb
+++ b/spec/components/teachers_index_component_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe TeachersIndexComponent, type: :component do
   describe 'real data integration' do
     it 'correctly counts open inductions for the appropriate body' do
       rendered = render_inline(component)
-      # teacher_1 and teacher_2 both have active inductions with this appropriate body
+      # teacher_1 and teacher_2 both have ongoing inductions with this appropriate body
       expect(rendered.css('h2').text).to include('2 open induction')
     end
 

--- a/spec/requests/admin/induction_periods_spec.rb
+++ b/spec/requests/admin/induction_periods_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Admin editing an active induction period', type: :request do
+RSpec.describe 'Admin::InductionPeriodsController', type: :request do
   include_context 'sign in as DfE user'
 
   let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
         end
       end
 
-      context "when the submission is valid but ECT has an active induction period with another AB" do
+      context "when the submission is valid but ECT has an ongoing induction period with another AB" do
         let(:teacher) { FactoryBot.create(:teacher, trn:) }
         let!(:induction_period) do
           FactoryBot.create(
@@ -122,7 +122,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
         end
       end
 
-      context "when the submission is valid but ECT has an active induction period with the current AB" do
+      context "when the submission is valid but ECT has an ongoing induction period with the current AB" do
         let(:teacher) { FactoryBot.create(:teacher, trn:) }
         let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
         let!(:induction_period) do

--- a/spec/requests/appropriate_bodies/induction_periods_spec.rb
+++ b/spec/requests/appropriate_bodies/induction_periods_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Appropriate body editing an active induction period', type: :request do
+RSpec.describe 'AppropriateBodies::InductionPeriodsController', type: :request do
   include_context 'sign in as non-DfE user'
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
       it "assigns the incoming attributes to the pending_induction_submission and returns it"
     end
 
-    context "when there is a match and the teacher has an active induction period" do
+    context "when there is a match and the teacher has an ongoing induction period" do
       let(:teacher) { FactoryBot.create(:teacher) }
       let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
       let!(:induction_period) do

--- a/spec/services/schools/eligible_mentors_spec.rb
+++ b/spec/services/schools/eligible_mentors_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Schools::EligibleMentors do
       it { is_expected.to be_empty }
     end
 
-    context "when the school has active mentors registered" do
-      let!(:active_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :ongoing, school:, started_on: 2.years.ago) }
+    context "when the school has ongoing mentors registered" do
+      let!(:ongoing_mentors) { FactoryBot.create_list(:mentor_at_school_period, 2, :ongoing, school:, started_on: 2.years.ago) }
 
       it "returns those mentors" do
-        expect(subject.to_a).to match_array(active_mentors)
+        expect(subject.to_a).to match_array(ongoing_mentors)
       end
     end
 

--- a/spec/services/teachers/induction_period_spec.rb
+++ b/spec/services/teachers/induction_period_spec.rb
@@ -39,7 +39,7 @@ describe Teachers::InductionPeriod do
         FactoryBot.create(:induction_period, :ongoing, teacher:, started_on: '2023-10-3')
       end
 
-      it 'returns the active open induction period' do
+      it 'returns the ongoing induction period' do
         expect(service.ongoing_induction_period).to eq(ongoing_induction_period)
       end
     end

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Teachers::Induction do
         induction_period_finished_one_year_ago
       end
 
-      it "returns the current active induction period" do
+      it "returns the current induction period" do
         expect(service.current_induction_period).to eq(induction_period_unfinished)
       end
     end

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -87,10 +87,10 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
 
     context 'when the ect is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :ongoing, teacher:, school:) }
+      let(:ongoing_ect_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, :ongoing, teacher:, school:) }
 
       before do
-        wizard.store.update!(school_urn: active_ect_period.school.urn)
+        wizard.store.update!(school_urn: ongoing_ect_period.school.urn)
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -123,10 +123,10 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
 
     context 'when the mentor is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
       before do
-        wizard.store.update!(school_urn: active_mentor_period.school.urn)
+        wizard.store.update!(school_urn: ongoing_mentor_period.school.urn)
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -19,7 +19,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
 
     context 'when the mentor has an ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
+      let!(:ongoing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
 
       it 'returns true' do
         expect(mentor.active_at_school?).to be(true)
@@ -27,7 +27,7 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
 
     context 'when the mentor has no ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, school:, teacher:) }
+      let!(:ongoing_mentor_record) { FactoryBot.create(:mentor_at_school_period, school:, teacher:) }
 
       it 'returns false' do
         expect(mentor.active_at_school?).to be(false)
@@ -39,10 +39,10 @@ describe Schools::RegisterMentorWizard::Mentor do
     let(:teacher) { FactoryBot.create(:teacher, trn: '3002586') }
 
     context 'when the mentor has an ongoing mentor record at the school' do
-      let!(:existing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
+      let!(:ongoing_mentor_record) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
 
       it 'returns the mentor record' do
-        expect(mentor.active_record_at_school).to eq(existing_mentor_record)
+        expect(mentor.active_record_at_school).to eq(ongoing_mentor_record)
       end
     end
 

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -82,10 +82,10 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context 'when the mentor is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
       before do
-        wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
+        wizard.store.update!(trn: '1234568', school_urn: ongoing_mentor_period.school.urn)
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end
@@ -97,10 +97,10 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
 
     context 'when the mentor is already active at the school' do
       let(:teacher) { FactoryBot.create(:teacher, trn: '1234568') }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
 
       before do
-        wizard.store.update!(trn: '1234568', school_urn: active_mentor_period.school.urn)
+        wizard.store.update!(trn: '1234568', school_urn: ongoing_mentor_period.school.urn)
         allow(::TRS::APIClient).to receive(:new).and_return(TRS::TestAPIClient.new)
         subject.save!
       end

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -68,8 +68,8 @@ describe Schools::RegisterMentorWizard::Wizard do
 
       context 'when the mentor is already active at the school' do
         let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
-        let(:school_urn) { active_mentor_period.school.urn }
+        let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+        let(:school_urn) { ongoing_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor already_active_at_school]) }
       end
@@ -110,8 +110,8 @@ describe Schools::RegisterMentorWizard::Wizard do
 
       context 'when the mentor is already active at the school' do
         let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-        let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
-        let(:school_urn) { active_mentor_period.school.urn }
+        let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+        let(:school_urn) { ongoing_mentor_period.school.urn }
 
         it { is_expected.to eq(%i[find_mentor national_insurance_number already_active_at_school]) }
       end
@@ -129,8 +129,8 @@ describe Schools::RegisterMentorWizard::Wizard do
 
     context 'when only TRN, DoB and already active at school have been set' do
       let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
-      let(:school_urn) { active_mentor_period.school.urn }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+      let(:school_urn) { ongoing_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do
         FactoryBot.build(:session_repository,
@@ -150,8 +150,8 @@ describe Schools::RegisterMentorWizard::Wizard do
     context 'when only TRN, DoB, Nino and already active at school have been set' do
       let(:mentor_date_of_birth) { "2000-01-01" }
       let(:mentor_teacher) { FactoryBot.create(:teacher, trn: mentor_trn) }
-      let(:active_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
-      let(:school_urn) { active_mentor_period.school.urn }
+      let(:ongoing_mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher) }
+      let(:school_urn) { ongoing_mentor_period.school.urn }
       let(:already_active_at_school) { true }
       let(:store) do
         FactoryBot.build(:session_repository,


### PR DESCRIPTION
Following on from feedback in #1083, this updates some of the language used to describe ongoing periods in tests (from "active").