### PR TITLE
Rename `contract_period_id` to `contract_period_year`

### DIFF
--- a/app/components/admin/statements/filter_component.html.erb
+++ b/app/components/admin/statements/filter_component.html.erb
@@ -9,12 +9,12 @@
       form_group: { class: 'filter-form-group' }
     %>
 
-    <%= f.govuk_collection_select :contract_period_id,
+    <%= f.govuk_collection_select :contract_period_year,
       contract_periods,
       :id,
       :year,
       label: { text: "Contract year" },
-      options: { selected: contract_period_id, include_blank: "All" },
+      options: { selected: contract_period_year, include_blank: "All" },
       form_group: { class: 'filter-form-group' }
     %>
 

--- a/app/components/admin/statements/filter_component.rb
+++ b/app/components/admin/statements/filter_component.rb
@@ -19,8 +19,8 @@ module Admin
         ContractPeriod.order(year: :asc)
       end
 
-      def contract_period_id
-        params[:contract_period_id]
+      def contract_period_year
+        params[:contract_period_year]
       end
 
       def statement_dates

--- a/app/components/admin/statements/selector_component.html.erb
+++ b/app/components/admin/statements/selector_component.html.erb
@@ -9,12 +9,12 @@
       form_group: { class: 'filter-form-group' }
     %>
 
-    <%= f.govuk_collection_select :contract_period_id,
+    <%= f.govuk_collection_select :contract_period_year,
       contract_periods,
       :id,
       :year,
       label: { text: "Contract year" },
-      options: { selected: contract_period_id, include_blank: false },
+      options: { selected: contract_period_year, include_blank: false },
       form_group: { class: 'filter-form-group' }
     %>
 

--- a/app/components/admin/statements/selector_component.rb
+++ b/app/components/admin/statements/selector_component.rb
@@ -17,8 +17,8 @@ module Admin
         ContractPeriod.order(year: :asc)
       end
 
-      def contract_period_id
-        @statement.active_lead_provider.contract_period_id
+      def contract_period_year
+        @statement.active_lead_provider.contract_period_year
       end
 
       def statement_dates

--- a/app/controllers/admin/finance/statements_controller.rb
+++ b/app/controllers/admin/finance/statements_controller.rb
@@ -57,7 +57,7 @@ module Admin::Finance
     end
 
     def contract_period_years
-      filter_params[:contract_period_id].presence
+      filter_params[:contract_period_year].presence
     end
 
     def statement_date
@@ -78,7 +78,7 @@ module Admin::Finance
     end
 
     def filter_params
-      params.permit(:lead_provider_id, :contract_period_id, :statement_date, :statement_type)
+      params.permit(:lead_provider_id, :contract_period_year, :statement_date, :statement_type)
     end
 
     helper_method :filter_params

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -16,7 +16,7 @@ module Builders
           next unless period.training_programme == "full_induction_programme"
 
           lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
-          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_id: period.cohort_year)
+          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: period.cohort_year)
           delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
           lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
 

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -16,7 +16,7 @@ module Builders
           next unless period.training_programme == "full_induction_programme"
 
           lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
-          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_id: period.cohort_year)
+          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: period.cohort_year)
           delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
           lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
 

--- a/app/migration/migrators/active_lead_provider.rb
+++ b/app/migration/migrators/active_lead_provider.rb
@@ -28,7 +28,7 @@ module Migrators
 
         ::ActiveLeadProvider.find_or_create_by!(
           lead_provider_id:,
-          contract_period_id: ecf_active_lead_provider.start_year
+          contract_period_year: ecf_active_lead_provider.start_year
         )
       end
     end

--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -121,8 +121,8 @@ module Migrators
       lead_provider_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find LeadProvider")
     end
 
-    def find_active_lead_provider_id!(lead_provider_id:, contract_period_id:)
-      active_lead_provider_ids_by_lead_provider_and_contract_period["#{lead_provider_id} #{contract_period_id}"] || raise(ActiveRecord::RecordNotFound, "Couldn't find ActiveLeadProvider")
+    def find_active_lead_provider_id!(lead_provider_id:, contract_period_year:)
+      active_lead_provider_ids_by_lead_provider_and_contract_period["#{lead_provider_id} #{contract_period_year}"] || raise(ActiveRecord::RecordNotFound, "Couldn't find ActiveLeadProvider")
     end
 
   private
@@ -174,7 +174,7 @@ module Migrators
     end
 
     def active_lead_provider_ids_by_lead_provider_and_contract_period
-      @active_lead_provider_ids_by_lead_provider_and_contract_period ||= ::ActiveLeadProvider.pluck(:lead_provider_id, :contract_period_id, :id).to_h { |s| ["#{s[0]} #{s[1]}", s[2]] }
+      @active_lead_provider_ids_by_lead_provider_and_contract_period ||= ::ActiveLeadProvider.pluck(:lead_provider_id, :contract_period_year, :id).to_h { |s| ["#{s[0]} #{s[1]}", s[2]] }
     end
   end
 end

--- a/app/migration/migrators/lead_provider_delivery_partnership.rb
+++ b/app/migration/migrators/lead_provider_delivery_partnership.rb
@@ -27,7 +27,7 @@ module Migrators
         partnership = ::LeadProviderDeliveryPartnership.find_or_initialize_by(ecf_id: provider_relationship.id)
         partnership.active_lead_provider = ::ActiveLeadProvider.find_by!(
           lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
-          contract_period_id: ::ContractPeriod.find(provider_relationship.cohort.start_year)
+          contract_period_year: ::ContractPeriod.find(provider_relationship.cohort.start_year)
         )
         partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
         partnership.created_at = provider_relationship.created_at

--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -27,10 +27,10 @@ module Migrators
         statement = ::Statement.find_or_initialize_by(api_id: ecf_statement.id)
 
         lead_provider_id = find_lead_provider_id!(ecf_id: ecf_statement.lead_provider.id)
-        contract_period_id = ecf_statement.cohort.start_year
+        contract_period_year = ecf_statement.cohort.start_year
 
         statement.update!(
-          active_lead_provider_id: find_active_lead_provider_id!(lead_provider_id:, contract_period_id:),
+          active_lead_provider_id: find_active_lead_provider_id!(lead_provider_id:, contract_period_year:),
           month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]),
           year: ecf_statement.name.split[1],
           deadline_date: ecf_statement.deadline_date,

--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -7,12 +7,12 @@ class ActiveLeadProvider < ApplicationRecord
   has_many :expressions_of_interest, class_name: 'TrainingPeriod', foreign_key: 'expression_of_interest_id', inverse_of: :expression_of_interest
   has_many :events
 
-  validates :contract_period_id,
+  validates :contract_period_year,
             presence: { message: 'Choose a contract period' },
             uniqueness: { scope: :lead_provider_id, message: 'Contract period and lead provider must be unique' }
 
   validates :lead_provider_id, presence: { message: 'Choose a lead provider' }
 
-  scope :for_contract_period, ->(year) { where(contract_period_id: year) }
+  scope :for_contract_period, ->(year) { where(contract_period_year: year) }
   scope :for_lead_provider, ->(lead_provider_id) { where(lead_provider_id:) }
 end

--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -1,5 +1,5 @@
 class ActiveLeadProvider < ApplicationRecord
-  belongs_to :contract_period, inverse_of: :active_lead_providers
+  belongs_to :contract_period, inverse_of: :active_lead_providers, foreign_key: :contract_period_year
   belongs_to :lead_provider, inverse_of: :active_lead_providers
   has_many :lead_provider_delivery_partnerships
   has_many :delivery_partners, through: :lead_provider_delivery_partnerships

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -114,7 +114,7 @@ class School < ApplicationRecord
 
   def to_param = urn
 
-  def training_programme_for(contract_period_id)
-    Schools::TrainingProgramme.new(school: self, contract_period_id:).training_programme
+  def training_programme_for(contract_period_year)
+    Schools::TrainingProgramme.new(school: self, contract_period_year:).training_programme
   end
 end

--- a/app/serializers/delivery_partner_serializer.rb
+++ b/app/serializers/delivery_partner_serializer.rb
@@ -11,7 +11,7 @@ class DeliveryPartnerSerializer < Blueprinter::Base
           .lead_provider_delivery_partnerships
           .joins(:active_lead_provider)
           .where(active_lead_providers: { lead_provider_id: options[:lead_provider].id })
-          .pluck("active_lead_providers.contract_period_id")
+          .pluck("active_lead_providers.contract_period_year")
           .map(&:to_s)
       end
     end

--- a/app/serializers/school_serializer.rb
+++ b/app/serializers/school_serializer.rb
@@ -5,13 +5,13 @@ class SchoolSerializer < Blueprinter::Base
     field :name
     field(:urn) { |school, _| school.urn.to_s }
     field(:cohort) do |school, options|
-      school_contract_period_id(school, options)
+      school_contract_period_year(school, options)
     end
     field(:in_partnership) do |school, options|
       in_partnership?(school, options)
     end
     field(:induction_programme_choice) do |school, options|
-      school.training_programme_for(school_contract_period_id(school, options))
+      school.training_programme_for(school_contract_period_year(school, options))
     end
     field(:expression_of_interest) do |school, options|
       expressions_of_interest?(school, options)
@@ -20,7 +20,7 @@ class SchoolSerializer < Blueprinter::Base
     field(:api_updated_at, name: :updated_at)
 
     class << self
-      def school_contract_period_id(school, options)
+      def school_contract_period_year(school, options)
         if school.respond_to?(:transient_contract_period_year)
           school.transient_contract_period_year
         else

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -40,11 +40,11 @@ module DeliveryPartners
       <<~SQL.squish
         (
           SELECT ARRAY(
-            SELECT DISTINCT active_lead_providers.contract_period_id::text
+            SELECT DISTINCT active_lead_providers.contract_period_year::text
             FROM lead_provider_delivery_partnerships
             INNER JOIN active_lead_providers ON active_lead_providers.id = lead_provider_delivery_partnerships.active_lead_provider_id
             WHERE lead_provider_delivery_partnerships.delivery_partner_id = delivery_partners.id #{lead_provider_where_clause}
-            ORDER BY active_lead_providers.contract_period_id::text
+            ORDER BY active_lead_providers.contract_period_year::text
           )
         ) AS transient_cohorts
       SQL

--- a/app/services/lead_providers/active.rb
+++ b/app/services/lead_providers/active.rb
@@ -13,7 +13,7 @@ module LeadProviders
     def self.in_contract_period(contract_period)
       LeadProvider
         .joins(:active_lead_providers)
-        .where(active_lead_providers: { contract_period_id: contract_period.id })
+        .where(active_lead_providers: { contract_period_year: contract_period.id })
     end
   end
 end

--- a/app/services/sandbox_seed_data/delivery_partners.rb
+++ b/app/services/sandbox_seed_data/delivery_partners.rb
@@ -17,7 +17,7 @@ module SandboxSeedData
         NUMBER_OF_RECORDS_PER_LEAD_PROVIDER.times do
           delivery_partner = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:).delivery_partner
 
-          log_seed_info("#{delivery_partner.name} -> #{active_lead_provider.lead_provider.name} / #{active_lead_provider.contract_period_id}", colour: Colourize::COLOURS.keys.sample)
+          log_seed_info("#{delivery_partner.name} -> #{active_lead_provider.lead_provider.name} / #{active_lead_provider.contract_period_year}", colour: Colourize::COLOURS.keys.sample)
         end
       end
     end

--- a/app/services/schools/training_programme.rb
+++ b/app/services/schools/training_programme.rb
@@ -1,8 +1,8 @@
 module Schools
   class TrainingProgramme
-    def initialize(school:, contract_period_id:)
+    def initialize(school:, contract_period_year:)
       @school = school
-      @contract_period_id = contract_period_id.to_i
+      @contract_period_year = contract_period_year.to_i
     end
 
     def training_programme
@@ -13,22 +13,22 @@ module Schools
 
   private
 
-    attr_reader :school, :contract_period_id
+    attr_reader :school, :contract_period_year
 
     def ects_expressions_of_interest
-      @ects_expressions_of_interest ||= school.ect_at_school_periods.with_expressions_of_interest_for_contract_period(contract_period_id)
+      @ects_expressions_of_interest ||= school.ect_at_school_periods.with_expressions_of_interest_for_contract_period(contract_period_year)
     end
 
     def mentors_expressions_of_interest
-      @mentors_expressions_of_interest ||= school.mentor_at_school_periods.with_expressions_of_interest_for_contract_period(contract_period_id)
+      @mentors_expressions_of_interest ||= school.mentor_at_school_periods.with_expressions_of_interest_for_contract_period(contract_period_year)
     end
 
     def ect_at_school_periods
-      @ect_at_school_periods ||= school.ect_at_school_periods.with_partnerships_for_contract_period(contract_period_id)
+      @ect_at_school_periods ||= school.ect_at_school_periods.with_partnerships_for_contract_period(contract_period_year)
     end
 
     def mentors_at_school_periods
-      @mentors_at_school_periods ||= school.mentor_at_school_periods.with_partnerships_for_contract_period(contract_period_id)
+      @mentors_at_school_periods ||= school.mentor_at_school_periods.with_partnerships_for_contract_period(contract_period_year)
     end
 
     def mentors_at_school?

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -401,7 +401,7 @@
   :active_lead_providers:
   - id
   - lead_provider_id
-  - contract_period_id
+  - contract_period_year
   - created_at
   - updated_at
   :statement_adjustments:

--- a/db/migrate/20250806082156_rename_contract_period_id_to_year.rb
+++ b/db/migrate/20250806082156_rename_contract_period_id_to_year.rb
@@ -1,0 +1,5 @@
+class RenameContractPeriodIdToYear < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :active_lead_providers, :contract_period_year, :contract_period_year
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_06_082156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -40,11 +40,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
 
   create_table "active_lead_providers", force: :cascade do |t|
     t.bigint "lead_provider_id", null: false
-    t.bigint "contract_period_id", null: false
+    t.bigint "contract_period_year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["contract_period_id"], name: "index_active_lead_providers_on_contract_period_id"
-    t.index ["lead_provider_id", "contract_period_id"], name: "idx_on_lead_provider_id_contract_period_id_0083722692", unique: true
+    t.index ["contract_period_year"], name: "index_active_lead_providers_on_contract_period_year"
+    t.index ["lead_provider_id", "contract_period_year"], name: "idx_on_lead_provider_id_contract_period_year_e442ca2260", unique: true
     t.index ["lead_provider_id"], name: "index_active_lead_providers_on_lead_provider_id"
   end
 
@@ -724,7 +724,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_28_110140) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "active_lead_providers", "contract_periods", primary_key: "year"
+  add_foreign_key "active_lead_providers", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "active_lead_providers", "lead_providers"
   add_foreign_key "dfe_roles", "users"
   add_foreign_key "ect_at_school_periods", "appropriate_bodies", column: "school_reported_appropriate_body_id"

--- a/spec/components/admin/statements/filter_component_spec.rb
+++ b/spec/components/admin/statements/filter_component_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".contract_period_id" do
-    let(:filter_params) { { contract_period_id: 2025 } }
+  context ".contract_period_year" do
+    let(:filter_params) { { contract_period_year: 2025 } }
 
-    it "returns filter param contract_period_id" do
-      expect(component.contract_period_id).to eq(2025)
+    it "returns filter param contract_period_year" do
+      expect(component.contract_period_year).to eq(2025)
     end
   end
 

--- a/spec/components/admin/statements/selector_component_spec.rb
+++ b/spec/components/admin/statements/selector_component_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
     end
   end
 
-  context ".contract_period_id" do
-    it "returns contract_period_id from statement" do
-      expect(component.contract_period_id).to eq(statement.active_lead_provider.contract_period_id)
+  context ".contract_period_year" do
+    it "returns contract_period_year from statement" do
+      expect(component.contract_period_year).to eq(statement.active_lead_provider.contract_period_year)
     end
   end
 

--- a/spec/migration/migrators/active_lead_provider_spec.rb
+++ b/spec/migration/migrators/active_lead_provider_spec.rb
@@ -25,7 +25,7 @@ describe Migrators::ActiveLeadProvider do
 
         active_lead_provider = ActiveLeadProvider.find_by(
           lead_provider_id: LeadProvider.find_by_ecf_id(migration_resource1.id).id,
-          contract_period_id: migration_resource1.cohorts.first.start_year
+          contract_period_year: migration_resource1.cohorts.first.start_year
         )
         expect(active_lead_provider).to be_present
       end

--- a/spec/migration/migrators/school_partnership_spec.rb
+++ b/spec/migration/migrators/school_partnership_spec.rb
@@ -30,7 +30,7 @@ describe Migrators::SchoolPartnership do
           school_partnership = SchoolPartnership.find_by!(api_id: partnership.id)
 
           lead_provider = school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider
-          year = school_partnership.lead_provider_delivery_partnership.active_lead_provider.contract_period_id
+          year = school_partnership.lead_provider_delivery_partnership.active_lead_provider.contract_period_year
           delivery_partner = school_partnership.lead_provider_delivery_partnership.delivery_partner
           school = school_partnership.school
 

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -1,6 +1,6 @@
 describe ActiveLeadProvider do
   describe "associations" do
-    it { is_expected.to belong_to(:contract_period) }
+    it { is_expected.to belong_to(:contract_period).with_foreign_key(:contract_period_year) }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to have_many(:statements) }
     it { is_expected.to have_many(:lead_provider_delivery_partnerships) }

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -13,8 +13,8 @@ describe ActiveLeadProvider do
     subject { FactoryBot.create(:active_lead_provider) }
 
     it { is_expected.to validate_presence_of(:lead_provider_id).with_message("Choose a lead provider") }
-    it { is_expected.to validate_presence_of(:contract_period_id).with_message("Choose a contract period") }
-    it { is_expected.to validate_uniqueness_of(:contract_period_id).scoped_to(:lead_provider_id).with_message("Contract period and lead provider must be unique") }
+    it { is_expected.to validate_presence_of(:contract_period_year).with_message("Choose a contract period") }
+    it { is_expected.to validate_uniqueness_of(:contract_period_year).scoped_to(:lead_provider_id).with_message("Contract period and lead provider must be unique") }
   end
 
   describe "scopes" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -135,15 +135,15 @@ describe School do
   end
 
   describe "#training_programme_for" do
-    subject(:training_programme_for) { school.training_programme_for(contract_period_id) }
+    subject(:training_programme_for) { school.training_programme_for(contract_period_year) }
 
     let(:school) { FactoryBot.build(:school) }
-    let(:contract_period_id) { FactoryBot.build(:contract_period).id }
+    let(:contract_period_year) { FactoryBot.build(:contract_period).id }
 
     it "calls Schools::TrainingProgramme service with correct params" do
       training_programma_service = instance_double(Schools::TrainingProgramme)
 
-      allow(Schools::TrainingProgramme).to receive(:new).with(school:, contract_period_id:).and_return(training_programma_service)
+      allow(Schools::TrainingProgramme).to receive(:new).with(school:, contract_period_year:).and_return(training_programma_service)
       expect(training_programma_service).to receive(:training_programme)
 
       training_programme_for

--- a/spec/services/schools/query_spec.rb
+++ b/spec/services/schools/query_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Schools::Query do
     end
 
     describe "filtering" do
-      describe "by `contract_period_id`" do
+      describe "by `contract_period_year`" do
         let!(:school1) { FactoryBot.create(:school, :eligible) }
         let!(:school2) { FactoryBot.create(:school) }
         let!(:school3) { FactoryBot.create(:school) }
@@ -60,17 +60,17 @@ RSpec.describe Schools::Query do
           }
         end
 
-        it "filters by `contract_period_id`" do
+        it "filters by `contract_period_year`" do
           expect(query.schools).to contain_exactly(school1, school3)
         end
 
-        context "when `contract_period_id` param is omitted" do
+        context "when `contract_period_year` param is omitted" do
           it "returns no schools" do
             expect(described_class.new.schools).to be_empty
           end
         end
 
-        context "when no `contract_period_id` is found" do
+        context "when no `contract_period_year` is found" do
           let!(:contract_period_year) { "0000" }
 
           it "returns no schools" do
@@ -78,7 +78,7 @@ RSpec.describe Schools::Query do
           end
         end
 
-        context "when `contract_period_id` param is blank" do
+        context "when `contract_period_year` param is blank" do
           let!(:contract_period_year) { " " }
 
           it "returns no schools" do
@@ -124,7 +124,7 @@ RSpec.describe Schools::Query do
           end
         end
 
-        context "when `contract_period_id` param is blank" do
+        context "when `contract_period_year` param is blank" do
           let!(:updated_since) { " " }
 
           it "returns all eligible schools" do

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -1,9 +1,9 @@
 describe Schools::TrainingProgramme do
-  subject { described_class.new(school:, contract_period_id:) }
+  subject { described_class.new(school:, contract_period_year:) }
 
   let(:school) { FactoryBot.create(:school, urn: "123456") }
   let(:contract_period) { FactoryBot.create(:contract_period) }
-  let(:contract_period_id) { contract_period.id }
+  let(:contract_period_year) { contract_period.id }
 
   describe "#training_programme" do
     context "when no transient values are available" do
@@ -190,7 +190,7 @@ describe Schools::TrainingProgramme do
     end
 
     context "when transient values are available" do
-      subject { described_class.new(school: scope, contract_period_id:) }
+      subject { described_class.new(school: scope, contract_period_year:) }
 
       let(:lead_provider) { FactoryBot.create(:lead_provider) }
       let(:query) { Schools::Query.new(lead_provider_id: lead_provider.id, contract_period_year: contract_period.id) }


### PR DESCRIPTION
### Context

The primary key of `contract_periods` is called `year` rather than ID, as there is one per year and we don't need to generate them using a sequence.

The foreign key from `active_lead_providers` was called `contract_period_id`, which is confusing. It should be `contract_period_year`.

This PR makes the change in the database, model and switches all references to `contract_period_id` to `contract_period_year`.
