### PR TITLE
Bump migration resources

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -21,6 +21,10 @@ migration:
       threads: 3
       processes: 3
       polling_interval: 0.1
+    - queues: [migration]
+      threads: 2
+      processes: 1
+      polling_interval: 0.1
 
 review:
   <<: *default

--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -3,7 +3,9 @@
     "namespace": "cpd-production",
     "environment": "migration",
     "enable_logit": true,
-    "worker_replicas": 6,
-    "worker_memory_max": "2Gi",
+    "worker_memory_max": "4Gi",
+    "webapp_memory_max": "2Gi",
+    "worker_replicas": 20,
+    "webapp_replicas": 6,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }


### PR DESCRIPTION
### Context
We need to bump resources for migration to try to see if we can run things faster

### Changes proposed in this pull request
- Lower processes and threads on the migration queues: We don't want too many jobs running on a pod, limit this to 2 jobs (threads) per process, so 2 jobs per pod for migration queue
- Bump web/worker memory and pods on migration: This makes sure that we don't lose out on jobs running but we're giving them more memory. Web apps bump is for parity checks

### Guidance to review
I'll bump db resources later in the week