### PR TITLE
Fix incorrect migration

### DIFF
--- a/db/migrate/20250806082156_rename_contract_period_id_to_year.rb
+++ b/db/migrate/20250806082156_rename_contract_period_id_to_year.rb
@@ -1,5 +1,5 @@
 class RenameContractPeriodIdToYear < ActiveRecord::Migration[8.0]
   def change
-    rename_column :active_lead_providers, :contract_period_year, :contract_period_year
+    rename_column :active_lead_providers, :contract_period_id, :contract_period_year
   end
 end


### PR DESCRIPTION
I accidentally broke the migration in my last PR while doing a subsequent find and replace. This should fix it, it was renaming the column to itself 🫣
