### PR TITLE
Seed delivery partners/partnerships to sandbox environment

### DIFF
--- a/app/services/sandbox_seed_data/delivery_partners.rb
+++ b/app/services/sandbox_seed_data/delivery_partners.rb
@@ -1,25 +1,28 @@
 module SandboxSeedData
   class DeliveryPartners < Base
-    NUMBER_OF_RECORDS_PER_LEAD_PROVIDER = 5
+    NUMBER_OF_RECORDS = 50
 
     def plant
       return unless plantable?
 
       log_plant_info("delivery partners")
 
-      create_delivery_partners
+      NUMBER_OF_RECORDS.times { create_delivery_partner }
     end
 
   private
 
-    def create_delivery_partners
-      ActiveLeadProvider.find_each do |active_lead_provider|
-        NUMBER_OF_RECORDS_PER_LEAD_PROVIDER.times do
-          delivery_partner = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:).delivery_partner
-
-          log_seed_info("#{delivery_partner.name} -> #{active_lead_provider.lead_provider.name} / #{active_lead_provider.contract_period_year}", colour: Colourize::COLOURS.keys.sample)
-        end
+    def create_delivery_partner
+      delivery_partner = FactoryBot.build(:delivery_partner).tap do
+        random_date = rand(1..100).days.ago
+        it.update!(
+          created_at: random_date,
+          updated_at: random_date,
+          api_updated_at: random_date
+        )
       end
+
+      log_seed_info(delivery_partner.name, indent: 2)
     end
   end
 end

--- a/app/services/sandbox_seed_data/lead_provider_delivery_partnerships.rb
+++ b/app/services/sandbox_seed_data/lead_provider_delivery_partnerships.rb
@@ -1,0 +1,116 @@
+module SandboxSeedData
+  class LeadProviderDeliveryPartnerships < Base
+    DELIVERY_PARTNERS_PER_LEAD_PROVIDER = 30
+    SHARED_DELIVERY_PARTNERS_PER_LEAD_PROVIDER = 5
+    APPLICABLE_CONTRACT_PERIOD_YEARS = (2021..2025).to_a.freeze
+    COL_WIDTHS = {
+      lead_provider_name: 40,
+      delivery_partner_name: 40,
+      year: 6,
+    }.freeze
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("lead provider delivery partnerships")
+
+      active_lead_providers.find_each do |active_lead_provider|
+        DELIVERY_PARTNERS_PER_LEAD_PROVIDER.times { create_lead_provider_delivery_partnership(active_lead_provider) }
+        SHARED_DELIVERY_PARTNERS_PER_LEAD_PROVIDER.times do |index|
+          delivery_partner = shared_delivery_partner(index)
+          create_lead_provider_delivery_partnership(active_lead_provider, delivery_partner:)
+        end
+      end
+
+      log_delivery_partnerships_info
+      log_shared_delivery_partner_info
+    end
+
+  private
+
+    def log_shared_delivery_partner_info
+      log_seed_info("Shared delivery partners", indent: 2, blank_lines_before: 1)
+
+      SHARED_DELIVERY_PARTNERS_PER_LEAD_PROVIDER.times do |index|
+        delivery_partner = shared_delivery_partner(index)
+
+        delivery_partner_name = delivery_partner.name.ljust(COL_WIDTHS[:delivery_partner_name])
+        delivery_partner_api_id = Colourize.text(delivery_partner.api_id, :green)
+
+        log_seed_info("#{delivery_partner_name}(#{delivery_partner_api_id})", indent: 4)
+      end
+    end
+
+    def log_delivery_partnerships_info
+      LeadProvider.find_each do |lead_provider|
+        log_header_info(lead_provider)
+        log_row_info(lead_provider)
+      end
+    end
+
+    def log_header_info(lead_provider)
+      name_header = lead_provider.name.ljust(COL_WIDTHS[:lead_provider_name])
+      years_header = APPLICABLE_CONTRACT_PERIOD_YEARS.map { |year| year.to_s.rjust(COL_WIDTHS[:year]) }.join
+
+      log_seed_info(name_header + years_header, indent: 2)
+    end
+
+    def log_row_info(lead_provider)
+      count_by_contract_period_year = LeadProviderDeliveryPartnership
+        .joins(active_lead_provider: :lead_provider)
+        .where(active_lead_provider: { lead_provider: })
+        .group("active_lead_provider.contract_period_year")
+        .order("active_lead_provider.contract_period_year")
+        .count
+
+      name_space = " " * COL_WIDTHS[:lead_provider_name]
+      years_info = APPLICABLE_CONTRACT_PERIOD_YEARS.map do |year|
+        count = count_by_contract_period_year[year] || 0
+        format_year_count(count)
+      end
+
+      log_seed_info(name_space + years_info.join, indent: 2)
+    end
+
+    def format_year_count(count)
+      coloured_count = if count.positive?
+                         Colourize.text(count, :blue)
+                       else
+                         Colourize.text(0, :red)
+                       end
+
+      # The colourizing characters affect the length so offset the rjust.
+      offset = coloured_count.length - count.to_s.length
+      coloured_count.rjust(COL_WIDTHS[:year] + offset)
+    end
+
+    def create_lead_provider_delivery_partnership(active_lead_provider, delivery_partner: nil)
+      delivery_partner ||= find_random_available_delivery_partner(active_lead_provider)
+
+      return if active_lead_provider.lead_provider_delivery_partnerships.exists?(delivery_partner:)
+
+      FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+    end
+
+    def find_random_available_delivery_partner(active_lead_provider)
+      existing_delivery_partners = active_lead_provider.lead_provider_delivery_partnerships.pluck(:delivery_partner_id)
+
+      DeliveryPartner
+        .where.not(id: existing_delivery_partners)
+        .order("RANDOM()")
+        .first
+    end
+
+    def shared_delivery_partner(index)
+      DeliveryPartner.order(:name).offset(index).limit(1).first
+    end
+
+    def active_lead_providers
+      ActiveLeadProvider.where(contract_period: relevant_contract_periods)
+    end
+
+    def relevant_contract_periods
+      ContractPeriod.where(year: APPLICABLE_CONTRACT_PERIOD_YEARS)
+    end
+  end
+end

--- a/lib/tasks/sandbox_seed_data.rake
+++ b/lib/tasks/sandbox_seed_data.rake
@@ -7,6 +7,7 @@ namespace :sandbox_seed_data do
       SandboxSeedData::Statements,
       SandboxSeedData::Schools,
       SandboxSeedData::DeliveryPartners,
+      SandboxSeedData::LeadProviderDeliveryPartnerships,
       SandboxSeedData::SchoolPartnerships,
     ]
 

--- a/spec/services/sandbox_seed_data/lead_provider_delivery_partnerships_spec.rb
+++ b/spec/services/sandbox_seed_data/lead_provider_delivery_partnerships_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe SandboxSeedData::LeadProviderDeliveryPartnerships do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  before do
+    allow(Rails).to receive(:env) { environment.inquiry }
+    allow(Logger).to receive(:new).with($stdout) { logger }
+
+    FactoryBot.create_list(:delivery_partner, described_class::DELIVERY_PARTNERS_PER_LEAD_PROVIDER * 2)
+  end
+
+  describe "#plant" do
+    let(:year) { described_class::APPLICABLE_CONTRACT_PERIOD_YEARS.sample }
+    let(:contract_period) { FactoryBot.create(:contract_period, year:) }
+    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+
+    it "creates the correct number of lead provider delivery partnerships" do
+      minimum_records = described_class::DELIVERY_PARTNERS_PER_LEAD_PROVIDER
+      maximum_records = minimum_records + described_class::SHARED_DELIVERY_PARTNERS_PER_LEAD_PROVIDER
+      expect { instance.plant }.to(change(LeadProviderDeliveryPartnership, :count).by(minimum_records..maximum_records))
+    end
+
+    it "creates lead provider delivery partnerships with the correct attributes" do
+      instance.plant
+
+      LeadProviderDeliveryPartnership.find_each do |partnership|
+        expect(partnership).to have_attributes(
+          active_lead_provider:,
+          delivery_partner: be_present
+        )
+      end
+    end
+
+    it "logs the creation of lead provider delivery partnerships" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting lead provider delivery partnerships/).once
+
+      described_class::APPLICABLE_CONTRACT_PERIOD_YEARS.each do |year|
+        expect(logger).to have_received(:info).with(/#{year}/).exactly(LeadProvider.count).times
+      end
+
+      LeadProvider.find_each do |lead_provider|
+        expect(logger).to have_received(:info).with(/#{lead_provider.name}/).once
+      end
+
+      expect(logger).to have_received(:info).with(/Shared delivery partners/).once
+    end
+
+    context "when there are multiple active lead providers" do
+      let!(:another_active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+
+      it "creates shared delivery partners between lead providers" do
+        instance.plant
+
+        delivery_partner_ids_1 = active_lead_provider.lead_provider_delivery_partnerships.pluck(:delivery_partner_id)
+        delivery_partner_ids_2 = another_active_lead_provider.lead_provider_delivery_partnerships.pluck(:delivery_partner_id)
+
+        overlapping_ids = delivery_partner_ids_1 & delivery_partner_ids_2
+        expect(overlapping_ids.size).to be >= described_class::SHARED_DELIVERY_PARTNERS_PER_LEAD_PROVIDER
+      end
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any delivery partners" do
+        expect { instance.plant }.not_to change(DeliveryPartner, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to seed delivery partners and partnerships to the sandbox environment so that lead providers have data to test with.

### Changes proposed in this pull request

- Seed delivery partners/partnerships to sandbox environment

Split out the `delivery_partners` seed to have a separate `lead_provider_delivery_partnerships` and seed 30 delivery partners per lead provider/contract period.

Only seed for the 21->25 contract periods.

Ensure there are always at least 5 shared delivery partners across all lead providers.

Vary the `api_updated_at` dates for delivery partners.

### Guidance to review

<img width="604" height="336" alt="Screenshot 2025-08-07 at 12 15 22" src="https://github.com/user-attachments/assets/afd9121f-246e-4c94-9b1b-87798f53f1f6" />
