### PR TITLE
Amend Migration queues

### DIFF
--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -56,7 +56,7 @@ module Migrators
       end
 
       def records_per_worker
-        5_000
+        3_000
       end
 
       def reset!

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -13,7 +13,7 @@ migration:
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: [mailers, events, migration, parity_check_requests, trs_sync, dfe_analytics, "*"]
+    - queues: [mailers, events, parity_check_requests, trs_sync, dfe_analytics]
       threads: 3
       processes: 3
       polling_interval: 0.1
@@ -22,7 +22,7 @@ migration:
       processes: 3
       polling_interval: 0.1
     - queues: [migration]
-      threads: 2
+      threads: 1
       processes: 1
       polling_interval: 0.1
 

--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -5,7 +5,7 @@
     "enable_logit": true,
     "worker_memory_max": "4Gi",
     "webapp_memory_max": "2Gi",
-    "worker_replicas": 20,
+    "worker_replicas": 10,
     "webapp_replicas": 6,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }


### PR DESCRIPTION
We noticed that the "*" and "migration" was including migration jobs and creating 3 threads per process, which hammered the db with 20 workers.

Remove "migration" and "*" from the queue so it respects 1 thread 1 process.

Bump record number to 3000 and drop workers to see if this helps with the speed of the migration