### PR TITLE
Bump memory for sandbox as its alerting

### DIFF
--- a/config/terraform/application/config/sandbox.tfvars.json
+++ b/config/terraform/application/config/sandbox.tfvars.json
@@ -7,5 +7,7 @@
     "enable_monitoring": true,
     "external_url": "https://sandbox.register-early-career-teachers.education.gov.uk/healthcheck",
     "webapp_replicas": 2,
-    "worker_replicas": 2
+    "worker_replicas": 2,
+    "worker_memory_max": "2Gi",
+    "webapp_memory_max": "2Gi"
 }


### PR DESCRIPTION
### Context
We bumped the pods but we need to also bump memory

### Changes proposed in this pull request
Bump worker memory as its hovering at 96%, bumping web as well just because this is provider facing for testing

### Guidance to review
keep on monitoring