### PR TITLE
Fix query attribute on `DyanmicRequestContent`

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -35,7 +35,7 @@ module ParityCheck
     end
 
     def delivery_partner_id
-      DeliveryPartners::Query.new(lead_provider:)
+      DeliveryPartners::Query.new(lead_provider_id: lead_provider.id)
         .delivery_partners
         .distinct(false)
         .reorder("RANDOM()")


### PR DESCRIPTION
I think this got lost in the big refactor PR yesterday; the tests are failing on `main` now.
