### PR TITLE
Add metadata service and school handler

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -117,4 +117,10 @@ class School < ApplicationRecord
   def training_programme_for(contract_period_year)
     Schools::TrainingProgramme.new(school: self, contract_period_year:).training_programme
   end
+
+  def expression_of_interest_for?(lead_provider_id, contract_period_year)
+    [ect_at_school_periods, mentor_at_school_periods].any? do |periods|
+      periods.with_expressions_of_interest_for_lead_provider_and_contract_period(contract_period_year, lead_provider_id).exists?
+    end
+  end
 end

--- a/app/serializers/school_serializer.rb
+++ b/app/serializers/school_serializer.rb
@@ -43,8 +43,7 @@ class SchoolSerializer < Blueprinter::Base
               school.transient_expression_of_interest_mentors
         end
 
-        school.ect_at_school_periods.with_expressions_of_interest_for_lead_provider_and_contract_period(options[:contract_period_year], options[:lead_provider_id]).exists? ||
-          school.mentor_at_school_periods.with_expressions_of_interest_for_lead_provider_and_contract_period(options[:contract_period_year], options[:lead_provider_id]).exists?
+        school.expression_of_interest_for?(options[:lead_provider_id], options[:contract_period_year])
       end
     end
   end

--- a/app/services/metadata/handlers/school.rb
+++ b/app/services/metadata/handlers/school.rb
@@ -35,7 +35,7 @@ module Metadata::Handlers
           contract_period_year:
         )
 
-        expression_of_interest = expression_of_interest_for?(lead_provider_id, contract_period_year)
+        expression_of_interest = school.expression_of_interest_for?(lead_provider_id, contract_period_year)
 
         upsert(metadata, expression_of_interest:)
       end
@@ -52,12 +52,6 @@ module Metadata::Handlers
 
     def contract_period_years
       @contract_period_years ||= ContractPeriod.pluck(:year)
-    end
-
-    def expression_of_interest_for?(lead_provider_id, contract_period_year)
-      [school.ect_at_school_periods, school.mentor_at_school_periods].any? do |periods|
-        periods.with_expressions_of_interest_for_lead_provider_and_contract_period(contract_period_year, lead_provider_id).exists?
-      end
     end
   end
 end

--- a/app/services/metadata/handlers/school.rb
+++ b/app/services/metadata/handlers/school.rb
@@ -1,0 +1,63 @@
+module Metadata::Handlers
+  class School
+    attr_reader :school
+
+    def initialize(school)
+      @school = school
+    end
+
+    def refresh_metadata!
+      upsert_contract_period_metadata!
+      upsert_lead_provider_contract_period_metadata!
+    end
+
+  private
+
+    def upsert_contract_period_metadata!
+      contract_period_years.each do |contract_period_year|
+        metadata = Metadata::SchoolContractPeriod.find_or_initialize_by(
+          school:,
+          contract_period_year:
+        )
+
+        in_partnership = school.school_partnerships.for_contract_period(contract_period_year).exists?
+        induction_programme_choice = school.training_programme_for(contract_period_year)
+
+        upsert(metadata, in_partnership:, induction_programme_choice:)
+      end
+    end
+
+    def upsert_lead_provider_contract_period_metadata!
+      lead_provider_id_contract_period_years.each do |lead_provider_id, contract_period_year|
+        metadata = Metadata::SchoolLeadProviderContractPeriod.find_or_initialize_by(
+          school:,
+          lead_provider_id:,
+          contract_period_year:
+        )
+
+        expression_of_interest = expression_of_interest_for?(lead_provider_id, contract_period_year)
+
+        upsert(metadata, expression_of_interest:)
+      end
+    end
+
+    def upsert(metadata, attributes)
+      metadata.assign_attributes(attributes)
+      metadata.save! if metadata.changed?
+    end
+
+    def lead_provider_id_contract_period_years
+      @lead_provider_id_contract_period_years ||= LeadProvider.pluck(:id).product(contract_period_years)
+    end
+
+    def contract_period_years
+      @contract_period_years ||= ContractPeriod.pluck(:year)
+    end
+
+    def expression_of_interest_for?(lead_provider_id, contract_period_year)
+      [school.ect_at_school_periods, school.mentor_at_school_periods].any? do |periods|
+        periods.with_expressions_of_interest_for_lead_provider_and_contract_period(contract_period_year, lead_provider_id).exists?
+      end
+    end
+  end
+end

--- a/app/services/metadata/manager.rb
+++ b/app/services/metadata/manager.rb
@@ -1,0 +1,13 @@
+module Metadata
+  class Manager
+    def refresh_metadata!(objects)
+      Array.wrap(objects).each { resolve_handler(it).refresh_metadata! }
+    end
+
+  private
+
+    def resolve_handler(object)
+      Metadata::Resolver.resolve_handler(object)
+    end
+  end
+end

--- a/app/services/metadata/resolver.rb
+++ b/app/services/metadata/resolver.rb
@@ -1,0 +1,12 @@
+module Metadata
+  class Resolver
+    def self.resolve_handler(object)
+      class_name = object.class.name
+      handler_class = "Metadata::Handlers::#{class_name}".safe_constantize
+
+      raise ArgumentError, "No metadata handler found for #{class_name}" unless handler_class
+
+      handler_class.new(object)
+    end
+  end
+end

--- a/spec/services/metadata/handlers/school_spec.rb
+++ b/spec/services/metadata/handlers/school_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe Metadata::Handlers::School do
+  let(:instance) { described_class.new(school) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, school:) }
+  let!(:lead_provider) { school_partnership.lead_provider }
+  let!(:contract_period) { school_partnership.contract_period }
+
+  describe "#refresh_metadata!" do
+    subject(:refresh_metadata) { instance.refresh_metadata! }
+
+    describe "SchoolContractPeriod" do
+      it "creates metadata for the school and contract period" do
+        expect { refresh_metadata }.to change(Metadata::SchoolContractPeriod, :count).by(1)
+
+        created_metadata = Metadata::SchoolContractPeriod.last
+
+        expect(created_metadata).to have_attributes(
+          school:,
+          contract_period:,
+          in_partnership: true,
+          induction_programme_choice: "not_yet_known"
+        )
+      end
+
+      it "creates metadata for all combinations of the school and contract periods" do
+        FactoryBot.create_list(:contract_period, 3)
+
+        expect { refresh_metadata }.to change(Metadata::SchoolContractPeriod, :count).by(ContractPeriod.count)
+      end
+
+      context "when metadata already exists for a school and contract period" do
+        let!(:metadata) { FactoryBot.create(:school_contract_period_metadata, school:, contract_period:, in_partnership: true, induction_programme_choice: "not_yet_known") }
+
+        it "does not create metadata" do
+          expect { refresh_metadata }.not_to change(Metadata::SchoolContractPeriod, :count)
+        end
+
+        it "updates the metadata when the partnership changes" do
+          Metadata::SchoolContractPeriod.bypass_update_restrictions { metadata.update!(in_partnership: false) }
+
+          expect { refresh_metadata }.to change { metadata.reload.in_partnership }.from(false).to(true)
+        end
+
+        it "updates the metadata when the induction programme choice changes" do
+          Metadata::SchoolContractPeriod.bypass_update_restrictions { metadata.update!(induction_programme_choice: "provider_led") }
+
+          expect { refresh_metadata }.to change { metadata.reload.induction_programme_choice }.from("provider_led").to("not_yet_known")
+        end
+
+        it "does not update the metadata if no changes are made" do
+          expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
+        end
+      end
+    end
+
+    describe "SchoolLeadProviderContractPeriod" do
+      it "creates metadata for the school, lead provider and contract period" do
+        expect { refresh_metadata }.to change(Metadata::SchoolLeadProviderContractPeriod, :count).by(1)
+
+        created_metadata = Metadata::SchoolLeadProviderContractPeriod.last
+
+        expect(created_metadata).to have_attributes(
+          school:,
+          lead_provider:,
+          contract_period:,
+          expression_of_interest: false
+        )
+      end
+
+      it "creates metadata for all combinations of the school, lead providers and contract periods" do
+        FactoryBot.create_list(:contract_period, 3)
+        FactoryBot.create_list(:lead_provider, 2)
+
+        expect { refresh_metadata }.to change(Metadata::SchoolLeadProviderContractPeriod, :count).by(LeadProvider.count * ContractPeriod.count)
+      end
+
+      context "when metadata already exists for a school, lead provider and contract period" do
+        let!(:metadata) { FactoryBot.create(:school_lead_provider_contract_period_metadata, school:, lead_provider:, contract_period:, expression_of_interest: false) }
+
+        it "does not create metadata" do
+          expect { refresh_metadata }.not_to change(Metadata::SchoolLeadProviderContractPeriod, :count)
+        end
+
+        it "updates the metadata when the partnership changes" do
+          Metadata::SchoolLeadProviderContractPeriod.bypass_update_restrictions { metadata.update!(expression_of_interest: true) }
+
+          expect { refresh_metadata }.to change { metadata.reload.expression_of_interest }.from(true).to(false)
+        end
+
+        it "does not update the metadata if no changes are made" do
+          expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
+        end
+      end
+    end
+  end
+end

--- a/spec/services/metadata/manager_spec.rb
+++ b/spec/services/metadata/manager_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Metadata::Manager do
+  let(:instance) { described_class.new }
+  let(:objects) { FactoryBot.build_list(:school, 2) }
+  let(:handler) { instance_double(Metadata::Handlers::School) }
+
+  describe "#refresh_metadata!" do
+    subject(:refresh_metadata) { instance.refresh_metadata!(objects) }
+
+    it "calls refresh_metadata! on the resolved handler for all objects" do
+      objects.each do
+        handler = instance_double(Metadata::Handlers::School)
+
+        allow(Metadata::Handlers::School).to receive(:new).with(it) { handler }
+        expect(handler).to receive(:refresh_metadata!).once
+      end
+
+      refresh_metadata
+    end
+
+    context "when given a single object" do
+      let(:objects) { FactoryBot.build(:school) }
+
+      it "calls refresh_metadata! on the resolved handler for the single object" do
+        handler = instance_double(Metadata::Handlers::School)
+
+        allow(Metadata::Handlers::School).to receive(:new).with(objects) { handler }
+        expect(handler).to receive(:refresh_metadata!).once
+
+        refresh_metadata
+      end
+    end
+  end
+end

--- a/spec/services/metadata/resolver_spec.rb
+++ b/spec/services/metadata/resolver_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Metadata::Resolver do
+  describe ".resolve_handler" do
+    it "returns the correct handler for a known object type" do
+      object = School.new
+      handler = Metadata::Resolver.resolve_handler(object)
+      expect(handler).to be_a(Metadata::Handlers::School)
+      expect(handler.school).to eq(object)
+    end
+
+    it "raises an error for an unknown object type" do
+      unknown_object = Class.new
+      expect {
+        Metadata::Resolver.resolve_handler(unknown_object)
+      }.to raise_error(ArgumentError, "No metadata handler found for Class")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Now that we have metadata models for `SchoolContractPeriod` and `SchoolLeadProviderContractPeriod` we want to implement the core service for managing the refreshing of metadata, starting with schools.

### Changes proposed in this pull request

- Add metadata service and school handler

Add the foundations for the metadata service, consisting of:

- `Metadata::Manager`
- `Metadata::Resolver`
- `Metadata::Handlers`

Add the `Metadata::Handlers::School` handler that will refresh school metadata for both `SchoolContractPeriod` and `SchoolLeadProviderContractPeriod`.

### Guidance to review

Testing this on migration to do a full sync of schools would be ~3 hours. I think performance-wise its probably OK for small/individual updates, but I'm going to look at optimising batch updates as part of [this ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/2166) to keep the changes here to a minimum.