### PR TITLE
[2133] Add missing data-turbo attribute

### DIFF
--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -2,7 +2,7 @@
 <%= govuk_html_element do %>
   <%= render partial: "layouts/shared/head" %>
 
-  <body class="govuk-template__body api-guidance">
+  <body class="govuk-template__body api-guidance" data-turbo="false">
     <%= render partial: "layouts/shared/js_enabled" %>
 
     <%= govuk_skip_link %>


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2133

Swagger docs page is not loading properly after clicking on `Swagger documentation` link from the guidance page.

### Changes proposed in this pull request

- Add missing data-turbo attribute to the guidance template.

### Guidance to review

[Review app](https://cpd-ec2-review-1110-web.test.teacherservices.cloud/api/guidance/swagger-api-documentation)