### PR TITLE
Use AB name in error messages when validating claims and outcomes

### DIFF
--- a/app/services/appropriate_bodies/process_batch/action.rb
+++ b/app/services/appropriate_bodies/process_batch/action.rb
@@ -62,7 +62,7 @@ module AppropriateBodies
             capture_error("#{name} does not have an open induction")
             true
           elsif claimed_by_another_ab?
-            capture_error("#{name} is completing their induction with another appropriate body")
+            capture_error("#{name} is completing their induction with another appropriate body (#{teacher.current_appropriate_body.name})")
             true
           else
             false # can be claimed

--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -69,7 +69,7 @@ module AppropriateBodies
               false # can be claimed
             end
           elsif claimed_by_another_ab?
-            capture_error("#{name} is already claimed by another appropriate body")
+            capture_error("#{name} is already claimed by another appropriate body (#{teacher.current_appropriate_body.name})")
             true
           elsif !claimed_by_another_ab?
             capture_error("#{name} is already claimed by your appropriate body")

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
     end
 
     context 'with an ongoing induction at another Appropriate Body' do
-      let(:other_body) { FactoryBot.create(:appropriate_body) }
+      let(:other_body) { FactoryBot.create(:appropriate_body, name: 'Acme') }
 
       let!(:induction_period) do
         FactoryBot.create(:induction_period, :ongoing,
@@ -296,7 +296,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
       before { service.process! }
 
       it 'captures error message' do
-        expect(submission.error_messages).to eq ['Kirk Van Houten is completing their induction with another appropriate body']
+        expect(submission.error_messages).to eq ['Kirk Van Houten is completing their induction with another appropriate body (Acme)']
       end
     end
 

--- a/spec/services/appropriate_bodies/process_batch/claim_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/claim_spec.rb
@@ -452,7 +452,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
     context 'when the ECT is already claimed by another body' do
       include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
-      let(:other_body) { FactoryBot.create(:appropriate_body) }
+      let(:other_body) { FactoryBot.create(:appropriate_body, name: 'Acme') }
       let(:teacher) { FactoryBot.create(:teacher, trn:) }
 
       before do
@@ -469,7 +469,7 @@ RSpec.describe AppropriateBodies::ProcessBatch::Claim do
       describe 'submission error messages' do
         subject { submission.error_messages }
 
-        it { is_expected.to eq ['Kirk Van Houten is already claimed by another appropriate body'] }
+        it { is_expected.to eq ['Kirk Van Houten is already claimed by another appropriate body (Acme)'] }
       end
     end
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Replace

- `#{name} is already claimed by another appropriate body`
- `#{name} is completing their induction with another appropriate body`

With 

- `#{name} is already claimed by another appropriate body (#{ab.name})`
- `#{name} is completing their induction with another appropriate body (#{ab.name})`

### Guidance to review
