### PR TITLE
Bulk reporting to Sentry

### DIFF
--- a/app/services/appropriate_bodies/process_batch/action.rb
+++ b/app/services/appropriate_bodies/process_batch/action.rb
@@ -15,8 +15,10 @@ module AppropriateBodies
 
           true
         rescue StandardError => e
-          capture_error("Something went wrong. You’ll need to try again later")
+          Rails.logger.info(e.message)
           Sentry.capture_exception(e)
+          capture_error("Something went wrong. You’ll need to try again later")
+
           next(false)
         end
 

--- a/app/services/appropriate_bodies/process_batch/base.rb
+++ b/app/services/appropriate_bodies/process_batch/base.rb
@@ -25,8 +25,10 @@ module AppropriateBodies
 
           validate_submission!
         rescue StandardError => e
-          capture_error("Something went wrong. You’ll need to try again later")
+          Rails.logger.info(e.message)
           Sentry.capture_exception(e)
+          capture_error("Something went wrong. You’ll need to try again later")
+
           next
         end
 

--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -17,8 +17,10 @@ module AppropriateBodies
           )
           true
         rescue StandardError => e
-          capture_error("Something went wrong. You’ll need to try again later")
+          Rails.logger.info(e.message)
           Sentry.capture_exception(e)
+          capture_error("Something went wrong. You’ll need to try again later")
+
           next(false)
         end
 


### PR DESCRIPTION
### Context

Bulk upload row error messages can surface internal errors. 
Though not expected, it has been observed when a worker crashes.

### Changes proposed in this pull request

- Do not capture rescued errors use something generic
- Report exception to Sentry

### Guidance to review
