### PR TITLE
Bulk passed/failed errors

### DIFF
--- a/app/services/appropriate_bodies/process_batch/action.rb
+++ b/app/services/appropriate_bodies/process_batch/action.rb
@@ -55,8 +55,11 @@ module AppropriateBodies
           capture_error(trs_error)
           true
         elsif teacher
-          if passed? || failed?
-            capture_error("#{name} has already completed their induction")
+          if passed?
+            capture_error("#{name} has already passed their induction")
+            true
+          elsif failed?
+            capture_error("#{name} has already failed their induction")
             true
           elsif no_ongoing_induction_period?
             capture_error("#{name} does not have an open induction")

--- a/spec/services/appropriate_bodies/process_batch/action_spec.rb
+++ b/spec/services/appropriate_bodies/process_batch/action_spec.rb
@@ -362,16 +362,27 @@ RSpec.describe AppropriateBodies::ProcessBatch::Action do
         end
       end
 
-      context 'with a passed or failed outcome' do
+      context 'with a passed outcome' do
         let!(:induction_period) do
-          FactoryBot.create(:induction_period, :pass,
-                            teacher:)
+          FactoryBot.create(:induction_period, :pass, teacher:)
         end
 
         before { service.process! }
 
         it 'captures an error message' do
-          expect(submission.error_messages).to eq ['Kirk Van Houten has already completed their induction']
+          expect(submission.error_messages).to eq ['Kirk Van Houten has already passed their induction']
+        end
+      end
+
+      context 'with a failed outcome' do
+        let!(:induction_period) do
+          FactoryBot.create(:induction_period, :fail, teacher:)
+        end
+
+        before { service.process! }
+
+        it 'captures an error message' do
+          expect(submission.error_messages).to eq ['Kirk Van Houten has already failed their induction']
         end
       end
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Replace 

- `#{name} has already completed their induction`

With 

- `#{name} has already passed their induction`
- `#{name} has already failed their induction`

### Guidance to review
