### PR TITLE
[1864] Allow users to select a different lead provider than the ECTs when registering a new mentor

### DIFF
--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -271,12 +271,12 @@ module Events
 
     # ECT and mentor events
 
-    def self.record_teacher_registered_as_mentor_event!(author:, mentor_at_school_period:, teacher:, school:, training_period:, happened_at: Time.zone.now)
+    def self.record_teacher_registered_as_mentor_event!(author:, mentor_at_school_period:, teacher:, school:, training_period:, lead_provider:, happened_at: Time.zone.now)
       event_type = :teacher_registered_as_mentor
       teacher_name = Teachers::Name.new(teacher).full_name
       heading = "#{teacher_name} was registered as a mentor at #{school.name}"
 
-      new(event_type:, author:, heading:, mentor_at_school_period:, teacher:, school:, training_period:, happened_at:).record_event!
+      new(event_type:, author:, heading:, mentor_at_school_period:, teacher:, school:, training_period:, lead_provider:, happened_at:).record_event!
     end
 
     def self.record_teacher_registered_as_ect_event!(author:, ect_at_school_period:, teacher:, school:, training_period:, happened_at: Time.zone.now)

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -90,7 +90,7 @@ module Schools
     end
 
     def record_event!
-      Events::Record.record_teacher_registered_as_mentor_event!(author:, mentor_at_school_period:, teacher:, school:, training_period:)
+      Events::Record.record_teacher_registered_as_mentor_event!(author:, mentor_at_school_period:, teacher:, school:, training_period:, lead_provider:)
     end
   end
 end

--- a/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
@@ -32,8 +32,8 @@ end %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset :change_name, legend: { text: "Are these details correct for the mentor?" } do %>
-    <%= f.govuk_radio_button :change_name, :no, label: { text: "Yes" }, link_errors: true %>
-    <%= f.govuk_radio_button :change_name, :yes, label: { text: "No, they changed their name or it's spelt wrong" } do %>
+    <%= f.govuk_radio_button :change_name, :yes, label: { text: "Yes" }, link_errors: true %>
+    <%= f.govuk_radio_button :change_name, :no, label: { text: "No, they changed their name or it's spelt wrong" } do %>
       <%= f.govuk_text_field :corrected_name,
                              label: {
                                text: "Enter the correct full name"

--- a/app/views/schools/register_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/register_mentor_wizard/check_answers.html.erb
@@ -52,10 +52,10 @@
     end
   end
 
-  if @mentor.lead_provider
+  if @mentor.provider_led_ect?
     summary_list.with_row do |row|
       row.with_key(text: "Lead provider")
-      row.with_value(text: @mentor.lead_provider.name)
+      row.with_value(text: @mentor.lead_provider&.name || @mentor.ect_lead_provider&.name)
       row.with_action(
         text: "Change",
         href: schools_register_mentor_wizard_change_lead_provider_path,

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -21,7 +21,7 @@ They do not need to provide us with any further details.
 
 <% if @wizard.ect.provider_led_training_programme? %>
 <% if @mentor.funding_available? %>
-  We'll pass on their details to <%= @mentor.ect_lead_provider&.name %> who will contact them to arrange mentor training.
+  We'll pass on their details to <%= @mentor.lead_provider&.name || @mentor.ect_lead_provider&.name %> who will contact them to arrange mentor training.
 <% else %>
 They cannot do mentor training according to our records.
 This could be because they've undertaken it before.

--- a/app/views/schools/register_mentor_wizard/eligibility_lead_provider.html.erb
+++ b/app/views/schools/register_mentor_wizard/eligibility_lead_provider.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "schools/register_mentor_wizard/lead_provider" %>

--- a/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
@@ -12,3 +12,6 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= f.govuk_submit "Continue" %>
 <% end %>
+
+<%= govuk_link_to "#{@mentor.ect_lead_provider&.name} will not be providing mentor training to #{@mentor.full_name}",
+schools_register_mentor_wizard_eligibility_lead_provider_path %>

--- a/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
@@ -6,9 +6,15 @@ module Schools
       end
 
       def previous_step
-        return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
+        if wizard.store.back_to == 'eligibility_lead_provider'
+          wizard.store.back_to = nil
+          :eligibility_lead_provider
+        else
 
-        :email_address
+          return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
+
+          :email_address
+        end
       end
 
     private

--- a/app/wizards/schools/register_mentor_wizard/eligibility_lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/eligibility_lead_provider_step.rb
@@ -1,0 +1,13 @@
+module Schools
+  module RegisterMentorWizard
+    class EligibilityLeadProviderStep < LeadProviderStep
+      def next_step
+        :check_answers
+      end
+
+      def previous_step
+        :review_mentor_eligibility
+      end
+    end
+  end
+end

--- a/app/wizards/schools/register_mentor_wizard/eligibility_lead_provider_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/eligibility_lead_provider_step.rb
@@ -2,6 +2,7 @@ module Schools
   module RegisterMentorWizard
     class EligibilityLeadProviderStep < LeadProviderStep
       def next_step
+        wizard.store.back_to = 'eligibility_lead_provider'
         :check_answers
       end
 

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -92,7 +92,7 @@ module Schools
       end
 
       def contract_period
-        ContractPeriod.containing_date(started_on&.to_date)
+        ContractPeriod.containing_date(started_on&.to_date || Date.current)
       end
 
       # Does mentor have any previous mentor_at_school_periods (open or closed)?
@@ -112,7 +112,7 @@ module Schools
 
       # Is mentor being assigned to a provider-led ECT?
       def provider_led_ect?
-        ect.provider_led?
+        ect&.provider_led?
       end
 
       # Does that mentor have a mentor_became_ineligible_for_funding_on?

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_details_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_details_step.rb
@@ -7,7 +7,7 @@ module Schools
                 inclusion: { in: %w[yes no],
                              message: "Select 'Yes' or 'No' to confirm whether the details are correct" }
 
-      validates :corrected_name, corrected_name: true, if: -> { change_name == 'yes' }
+      validates :corrected_name, corrected_name: true, if: -> { change_name == 'no' }
 
       def self.permitted_params
         %i[change_name corrected_name]
@@ -26,7 +26,7 @@ module Schools
     private
 
       def formatted_name
-        return nil if change_name == "no"
+        return nil if change_name == "yes"
 
         Schools::Validation::CorrectedName.new(corrected_name).formatted_name
       end

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -18,6 +18,7 @@ module Schools
             change_started_on: ChangeStartedOnStep,
             check_answers: CheckAnswersStep,
             confirmation: ConfirmationStep,
+            eligibility_lead_provider: EligibilityLeadProviderStep,
             email_address: EmailAddressStep,
             find_mentor: FindMentorStep,
             lead_provider: LeadProviderStep,
@@ -85,6 +86,7 @@ module Schools
             steps << :programme_choices unless mentor.became_ineligible_for_funding?
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?
+            steps << :eligibility_lead_provider if mentor.funding_available?
             steps += %i[change_mentor_details change_email_address check_answers]
             steps << :change_mentoring_at_new_school_only if mentor.mentoring_at_new_school_only.present?
             steps << :change_started_on if mentor.started_on

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,6 +340,9 @@ Rails.application.routes.draw do
       get "change-lead-provider", action: :new
       post "change-lead-provider", action: :create
 
+      get "eligibility-lead-provider", action: :new
+      post "eligibility-lead-provider", action: :create
+
       get "check-answers", action: :new
       post "check-answers", action: :create
 

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -1,0 +1,130 @@
+RSpec.describe 'Selecting a different lead provider' do
+  include_context 'test trs api client'
+
+  scenario 'Registering a new mentor' do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_i_sign_in_as_that_school_user
+    and_i_click_to_assign_a_mentor_to_the_ect
+    and_i_click_continue('link')
+    and_i_submit_the_find_mentor_form
+    and_i_choose_that_the_details_are_correct
+    and_i_click_confirm_and_continue
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_the_mentor_email_address
+    and_i_click_continue('button')
+    then_i_should_be_taken_to_the_review_mentor_eligibility_page
+
+    when_i_click_choose_another_provider_link
+    then_i_should_be_taken_to_eligibility_lead_provider_page
+
+    when_i_select_a_different_lead_provider
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_should_see_all_the_mentor_data_on_the_page
+
+    when_i_click_confirm_details
+    then_i_should_be_taken_to_the_confirmation_page
+  end
+
+  def and_i_choose_that_the_details_are_correct
+    page.get_by_label('Yes').check
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    contract_period = FactoryBot.create(:contract_period, year: Date.current.year)
+
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period:)
+
+    @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
+    FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period:)
+
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+  end
+
+  def and_i_click_continue(link_or_button)
+    page.get_by_role(link_or_button, name: 'Continue').click
+  end
+
+  def and_i_submit_the_find_mentor_form
+    page.get_by_label('Teacher reference number (TRN)').fill(trn)
+    page.get_by_label('day').fill('3')
+    page.get_by_label('month').fill('2')
+    page.get_by_label('year').fill('1977')
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role('button', name: 'Confirm and continue').click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page.url).to end_with('/school/register-mentor/email-address')
+  end
+
+  def when_i_enter_the_mentor_email_address
+    page.get_by_label('email').fill('example@example.com')
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
+    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+  end
+
+  def when_i_click_choose_another_provider_link
+    page.get_by_role('link', name: "#{@lead_provider.name} will not be providing mentor training to Kirk Van Houten").click
+  end
+
+  def then_i_should_be_taken_to_eligibility_lead_provider_page
+    expect(page.url).to end_with('/school/register-mentor/eligibility-lead-provider')
+  end
+
+  def when_i_select_a_different_lead_provider
+    page.get_by_role(:radio, name: @another_lead_provider.name).check
+    page.get_by_role(:button, name: 'Continue').click
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page.url).to end_with('/school/register-mentor/check-answers')
+  end
+
+  def and_i_should_see_all_the_mentor_data_on_the_page
+    expect(page.locator('dt', hasText: 'Teacher reference number (TRN)')).to be_visible
+    expect(page.locator('dd', hasText: trn)).to be_visible
+    expect(page.locator('dt', hasText: 'Name')).to be_visible
+    expect(page.locator('dd', hasText: 'Kirk Van Houten')).to be_visible
+    expect(page.locator('dt', hasText: 'Email address')).to be_visible
+    expect(page.locator('dd', hasText: 'example@example.com')).to be_visible
+    expect(page.locator('dt', hasText: 'Lead provider')).to be_visible
+    expect(page.locator('dd', hasText: @another_lead_provider.name)).to be_visible
+  end
+
+  def when_i_click_confirm_details
+    page.get_by_role('button', name: 'Confirm details').click
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page.url).to end_with('/school/register-mentor/confirmation')
+  end
+
+  def trn
+    '3002586'
+  end
+end

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -22,9 +22,14 @@ RSpec.describe 'Selecting a different lead provider' do
     when_i_select_a_different_lead_provider
     then_i_should_be_taken_to_the_check_answers_page
     and_i_should_see_all_the_mentor_data_on_the_page
+    and_the_back_link_points_to_the_eligibility_lead_provider_page
 
     when_i_click_confirm_details
     then_i_should_be_taken_to_the_confirmation_page
+  end
+
+  def and_the_back_link_points_to_the_eligibility_lead_provider_page
+    expect(page.get_by_role('link', name: 'Back', exact: true).get_attribute('href')).to end_with('/school/register-mentor/eligibility-lead-provider')
   end
 
   def and_i_choose_that_the_details_are_correct

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -620,9 +620,11 @@ RSpec.describe Events::Record do
       )
     end
 
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
-        Events::Record.record_teacher_registered_as_mentor_event!(author:, teacher:, mentor_at_school_period:, school:, training_period:)
+        Events::Record.record_teacher_registered_as_mentor_event!(author:, teacher:, mentor_at_school_period:, school:, training_period:, lead_provider:)
 
         expect(RecordEventJob).to have_received(:perform_later).with(
           teacher:,
@@ -632,6 +634,7 @@ RSpec.describe Events::Record do
           heading: "Rhys Ifans was registered as a mentor at #{school.name}",
           event_type: :teacher_registered_as_mentor,
           happened_at: Time.zone.now,
+          lead_provider:,
           **author_params
         )
       end

--- a/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/review_mentor_details_view.rb
@@ -35,7 +35,7 @@ RSpec.shared_examples "a review mentor details step view" do |current_step:,
   end
 
   it "prefixes the page with 'Error:' when any step data is invalid" do
-    store.change_name = 'yes'
+    store.change_name = 'no'
     store.corrected_name = 'a' * 100
     wizard.valid_step?
 

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -237,8 +237,21 @@ describe Schools::RegisterMentorWizard::Mentor do
     context 'when no contract period matches the started_on' do
       before { store.started_on = nil }
 
+      it 'falls back to today and returns providers in the current contract period' do
+        travel_to(Date.new(2025, 5, 1)) do
+          expect(mentor.lead_providers_within_contract_period).to include(lp_in)
+          expect(mentor.lead_providers_within_contract_period).not_to include(lp_out)
+        end
+      end
+    end
+
+    context 'when today is outside any contract period' do
+      before { store.started_on = nil }
+
       it 'returns an empty array' do
-        expect(mentor.lead_providers_within_contract_period).to eq([])
+        travel_to(Date.new(2024, 6, 1)) do
+          expect(mentor.lead_providers_within_contract_period).to eq([])
+        end
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
@@ -44,8 +44,8 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
                        .with_message("Select 'Yes' or 'No' to confirm whether the details are correct")
     end
 
-    context "when change_name is 'yes'" do
-      subject { described_class.new(change_name: 'yes') }
+    context "when change_name is 'no'" do
+      subject { described_class.new(change_name: 'no') }
 
       it { is_expected.to allow_value('Rick Collins').for(:corrected_name) }
 
@@ -54,8 +54,8 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
       end
     end
 
-    context "when change_name is not 'yes'" do
-      subject { described_class.new(change_name: 'no') }
+    context "when change_name is not 'no'" do
+      subject { described_class.new(change_name: 'yes') }
 
       ['Rick Collins', 'a' * 71, ' ', nil].each do |value|
         it { is_expected.to allow_value(value).for(:corrected_name) }
@@ -94,7 +94,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
       let(:step_params) do
         ActionController::Parameters.new(
           current_step.to_s => {
-            "change_name" => 'yes',
+            "change_name" => 'no',
             "corrected_name" => "Paul Saints",
           }
         )
@@ -105,7 +105,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
           .to change(subject.mentor, :corrected_name)
                 .from(nil).to('Paul Saints')
                 .and change(subject.mentor, :change_name)
-                       .from(nil).to('yes')
+                       .from(nil).to('no')
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -242,6 +242,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility
+                                   eligibility_lead_provider
                                    change_mentor_details
                                    change_email_address
                                    check_answers])
@@ -292,6 +293,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility
+                                   eligibility_lead_provider
                                    change_mentor_details
                                    change_email_address
                                    check_answers])


### PR DESCRIPTION
## Summary

This PR adds support for selecting a different lead provider during the mentor registration flow.

Previously:
- Users could only continue with the ECT’s existing lead provider.
- The CYA page showed only the previous lead provider

Now:
- Users can choose an alternative lead provider from the list of LPs active in the mentor’s contract year.
- The CYA page shows the previous lead provider or the newly chosen lead provider, depending on the option chosen

---

## Changes

- Added **Eligibility Lead Provider** step:
  - Lists lead providers active in the relevant contract period.
  - Includes validation
  - Includes correct back link handling (returns to CYA if reached from CYA).
  - Linked from "Mentor can receive mentor training" page when user clicks  
  **"[ECT’s LP name] will not be providing mentor training to [Mentor name]"**.

> [!IMPORTANT]
>The Review mentor details radios were flipped:  "Yes" had the value "No"  and vice-versa.
Swapped the :yes and :no options so:
Yes → details are correct (no extra field)
No  → show ‘corrected_name’ input
---

## Behaviour

- If the user selects a different lead provider and clicks **Continue**, they proceed to CYA with the updated provider.
- Lead provider list is filtered by:
  - Mentor's `started_on` date (if set)  
  - Or **today’s date** if `started_on` is not set.

## Guidance to review

Login as Bob and assign a new mentor to Colin Firth. When you get to the "receive mentor training" page, click the new link "Ambitious Institute will not be providing mentor training to Chloe Nolan".

## Screenshots

<img width="1128" height="268" alt="image" src="https://github.com/user-attachments/assets/3bfd0b9a-de61-479c-b937-7bbffda502df" />

---
