### PR TITLE
Retry background jobs when the TRS API errors

### DIFF
--- a/app/jobs/begin_ect_induction_job.rb
+++ b/app/jobs/begin_ect_induction_job.rb
@@ -1,4 +1,6 @@
 class BeginECTInductionJob < ApplicationJob
+  include TRS::RetryableClient
+
   def perform(trn:, start_date:, pending_induction_submission_id: nil)
     ActiveRecord::Base.transaction do
       api_client.begin_induction!(trn:, start_date:)
@@ -7,11 +9,5 @@ class BeginECTInductionJob < ApplicationJob
         PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
       end
     end
-  end
-
-private
-
-  def api_client
-    TRS::APIClient.build
   end
 end

--- a/app/jobs/pass_ect_induction_job.rb
+++ b/app/jobs/pass_ect_induction_job.rb
@@ -1,17 +1,14 @@
 class PassECTInductionJob < ApplicationJob
+  include TRS::RetryableClient
+
   def perform(trn:, start_date:, completed_date:, pending_induction_submission_id:)
     ActiveRecord::Base.transaction do
       api_client.pass_induction!(trn:, start_date:, completed_date:)
 
       PendingInductionSubmission.find(pending_induction_submission_id).update!(delete_at: 24.hours.from_now)
 
-      Teachers::RefreshTRSAttributes.new(Teacher.find_by!(trn:)).refresh!
+      teacher = Teacher.find_by!(trn:)
+      Teachers::RefreshTRSAttributes.new(teacher, api_client:).refresh!
     end
-  end
-
-private
-
-  def api_client
-    TRS::APIClient.build
   end
 end

--- a/app/jobs/reopen_induction_job.rb
+++ b/app/jobs/reopen_induction_job.rb
@@ -1,11 +1,7 @@
 class ReopenInductionJob < ApplicationJob
+  include TRS::RetryableClient
+
   def perform(trn:, start_date:)
     api_client.reopen_teacher_induction!(trn:, start_date:)
-  end
-
-private
-
-  def api_client
-    TRS::APIClient.build
   end
 end

--- a/app/jobs/reset_induction_job.rb
+++ b/app/jobs/reset_induction_job.rb
@@ -1,11 +1,7 @@
 class ResetInductionJob < ApplicationJob
+  include TRS::RetryableClient
+
   def perform(trn:)
     api_client.reset_teacher_induction!(trn:)
-  end
-
-private
-
-  def api_client
-    TRS::APIClient.build
   end
 end

--- a/app/jobs/teachers/sync_teacher_with_trs_job.rb
+++ b/app/jobs/teachers/sync_teacher_with_trs_job.rb
@@ -1,9 +1,11 @@
 module Teachers
   class SyncTeacherWithTRSJob < ApplicationJob
+    include TRS::RetryableClient
+
     queue_as :trs_sync
 
     def perform(teacher:)
-      Teachers::RefreshTRSAttributes.new(teacher).refresh!
+      Teachers::RefreshTRSAttributes.new(teacher, api_client:).refresh!
     end
   end
 end

--- a/app/models/concerns/trs/retryable_client.rb
+++ b/app/models/concerns/trs/retryable_client.rb
@@ -1,0 +1,17 @@
+module TRS
+  module RetryableClient
+    extend ActiveSupport::Concern
+
+    included do
+      retry_on Errors::APIRequestError,
+               wait: ->(executions) { 2**executions },
+               attempts: 15
+    end
+
+  private
+
+    def api_client
+      @api_client ||= TRS::APIClient.build
+    end
+  end
+end

--- a/app/services/teachers/refresh_trs_attributes.rb
+++ b/app/services/teachers/refresh_trs_attributes.rb
@@ -2,8 +2,9 @@ module Teachers
   class RefreshTRSAttributes
     attr_reader :teacher
 
-    def initialize(teacher)
+    def initialize(teacher, api_client: TRS::APIClient.build)
       @teacher = teacher
+      @api_client = api_client
     end
 
     def refresh!
@@ -11,7 +12,7 @@ module Teachers
       # overwrite existing teacher data, so we skip the refresh.
       return unless Rails.application.config.enable_trs_teacher_refresh
 
-      trs_teacher = TRS::APIClient.build.find_teacher(trn: teacher.trn)
+      trs_teacher = @api_client.find_teacher(trn: teacher.trn)
 
       Teacher.transaction do
         manage_teacher.update_name!(trs_first_name: trs_teacher.first_name, trs_last_name: trs_teacher.last_name)

--- a/spec/jobs/fail_ect_induction_job_spec.rb
+++ b/spec/jobs/fail_ect_induction_job_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe FailECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
-  let(:start_date) { "2023-11-13" }
-  let(:completed_date) { "2024-01-13" }
+  let(:start_date) { Date.parse("2023-11-13") }
+  let(:completed_date) { Date.parse("2024-01-13") }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
@@ -10,7 +10,10 @@ RSpec.describe FailECTInductionJob, type: :job do
 
   before do
     allow(TRS::APIClient).to receive(:new).and_return(api_client)
-    allow(Teachers::RefreshTRSAttributes).to receive(:new).with(teacher).and_return(refresh_service)
+    allow(Teachers::RefreshTRSAttributes)
+      .to receive(:new)
+      .with(teacher, api_client:)
+      .and_return(refresh_service)
     allow(refresh_service).to receive(:refresh!)
   end
 

--- a/spec/jobs/pass_ect_induction_job_spec.rb
+++ b/spec/jobs/pass_ect_induction_job_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe PassECTInductionJob, type: :job do
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
-  let(:start_date) { "2023-11-13" }
-  let(:completed_date) { "2024-01-13" }
+  let(:start_date) { Date.parse("2023-11-13") }
+  let(:completed_date) { Date.parse("2024-01-13") }
   let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let!(:pending_induction_submission_id) { pending_induction_submission.id }
   let(:api_client) { instance_double(TRS::APIClient) }
@@ -10,7 +10,10 @@ RSpec.describe PassECTInductionJob, type: :job do
 
   before do
     allow(TRS::APIClient).to receive(:new).and_return(api_client)
-    allow(Teachers::RefreshTRSAttributes).to receive(:new).with(teacher).and_return(refresh_service)
+    allow(Teachers::RefreshTRSAttributes)
+      .to receive(:new)
+      .with(teacher, api_client:)
+      .and_return(refresh_service)
     allow(refresh_service).to receive(:refresh!)
   end
 

--- a/spec/jobs/teachers/sync_teacher_with_trs_job_spec.rb
+++ b/spec/jobs/teachers/sync_teacher_with_trs_job_spec.rb
@@ -1,10 +1,18 @@
 RSpec.describe Teachers::SyncTeacherWithTRSJob, type: :job do
   describe "#perform" do
     let(:teacher) { FactoryBot.create(:teacher) }
+    let(:api_client) { instance_double(TRS::APIClient) }
     let(:refresh_service) { instance_double(Teachers::RefreshTRSAttributes) }
 
+    before do
+      allow(TRS::APIClient).to receive(:new).and_return(api_client)
+      allow(Teachers::RefreshTRSAttributes)
+        .to receive(:new)
+        .with(teacher, api_client:)
+        .and_return(refresh_service)
+    end
+
     it "calls the RefreshTRSAttributes service with the correct teacher" do
-      allow(Teachers::RefreshTRSAttributes).to receive(:new).with(teacher).and_return(refresh_service)
       expect(refresh_service).to receive(:refresh!)
 
       described_class.perform_now(teacher:)


### PR DESCRIPTION
As part of [this investigation] into mismatched TRS induction statuses, we identified that our background jobs are not retrying by default.

That meant that any intermittent API error (e.g service unavailability) would result in some jobs failing, and the corresponding updates *never happening*.

Now, in jobs that use the TRS API, we retry on API request errors. As part of this change, the `Teachers::RefreshTRSAttributes` service has been refactored so we can use a single `api_client` in a job, rather than instantiating several.

[this investigation]: https://github.com/DFE-Digital/register-ects-project-board/issues/2134