### PR TITLE
Filter out teachers with nil TRNs from migrations

### DIFF
--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.ect_teachers
-      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect).distinct
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect).where.not(trn: nil).distinct
     end
 
     def self.dependencies

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.mentor_teachers
-      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.mentor).distinct
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.mentor).where.not(trn: nil).distinct
     end
 
     def self.dependencies

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.teachers
-      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect_or_mentor).distinct
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect_or_mentor).where.not(trn: nil).distinct
     end
 
     def self.reset!

--- a/app/migration/migrators/training_period.rb
+++ b/app/migration/migrators/training_period.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.teachers
-      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect_or_mentor).distinct
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(Migration::ParticipantProfile.ect_or_mentor).where.not(trn: nil).distinct
     end
 
     def self.dependencies

--- a/spec/migration/migrators/ect_at_school_period_spec.rb
+++ b/spec/migration/migrators/ect_at_school_period_spec.rb
@@ -30,5 +30,19 @@ RSpec.describe Migrators::ECTAtSchoolPeriod do
         end
       end
     end
+
+    describe ".ect_teachers" do
+      it "excludes teacher profiles with nil TRN" do
+        teacher_profile_with_nil_trn = FactoryBot.create(:migration_teacher_profile, trn: nil)
+        FactoryBot.create(:migration_participant_profile, :ect, teacher_profile: teacher_profile_with_nil_trn, user: teacher_profile_with_nil_trn.user)
+
+        teacher_profile_with_valid_trn = FactoryBot.create(:migration_teacher_profile)
+        FactoryBot.create(:migration_participant_profile, :ect, teacher_profile: teacher_profile_with_valid_trn, user: teacher_profile_with_valid_trn.user)
+
+        ect_teachers = described_class.ect_teachers
+        expect(ect_teachers).to include(teacher_profile_with_valid_trn)
+        expect(ect_teachers).not_to include(teacher_profile_with_nil_trn)
+      end
+    end
   end
 end

--- a/spec/migration/migrators/mentor_at_school_period_spec.rb
+++ b/spec/migration/migrators/mentor_at_school_period_spec.rb
@@ -30,5 +30,19 @@ RSpec.describe Migrators::MentorAtSchoolPeriod do
         end
       end
     end
+
+    describe ".mentor_teachers" do
+      it "excludes teacher profiles with nil TRN" do
+        teacher_profile_with_nil_trn = FactoryBot.create(:migration_teacher_profile, trn: nil)
+        FactoryBot.create(:migration_participant_profile, :mentor, teacher_profile: teacher_profile_with_nil_trn, user: teacher_profile_with_nil_trn.user)
+
+        teacher_profile_with_valid_trn = FactoryBot.create(:migration_teacher_profile)
+        FactoryBot.create(:migration_participant_profile, :mentor, teacher_profile: teacher_profile_with_valid_trn, user: teacher_profile_with_valid_trn.user)
+
+        mentor_teachers = described_class.mentor_teachers
+        expect(mentor_teachers).to include(teacher_profile_with_valid_trn)
+        expect(mentor_teachers).not_to include(teacher_profile_with_nil_trn)
+      end
+    end
   end
 end

--- a/spec/migration/migrators/teacher_spec.rb
+++ b/spec/migration/migrators/teacher_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Migrators::Teacher do
     end
 
     def setup_failure_state
-      teacher_profile = FactoryBot.create(:migration_teacher_profile, trn: nil)
+      invalid_trn = '123'
+      teacher_profile = FactoryBot.create(:migration_teacher_profile, trn: invalid_trn)
       FactoryBot.create(:migration_participant_profile, :ect, teacher_profile:, user: teacher_profile.user)
     end
 
@@ -25,6 +26,20 @@ RSpec.describe Migrators::Teacher do
           expect(teacher.created_at).to be_within(1.second).of teacher_profile.created_at
           expect(teacher.updated_at).to be_within(1.second).of teacher_profile.updated_at
         end
+      end
+    end
+
+    describe ".teachers" do
+      it "excludes teacher profiles with nil TRN" do
+        teacher_profile_with_nil_trn = FactoryBot.create(:migration_teacher_profile, trn: nil)
+        FactoryBot.create(:migration_participant_profile, :ect, teacher_profile: teacher_profile_with_nil_trn, user: teacher_profile_with_nil_trn.user)
+
+        teacher_profile_with_valid_trn = FactoryBot.create(:migration_teacher_profile)
+        FactoryBot.create(:migration_participant_profile, :ect, teacher_profile: teacher_profile_with_valid_trn, user: teacher_profile_with_valid_trn.user)
+
+        teachers = described_class.teachers
+        expect(teachers).to include(teacher_profile_with_valid_trn)
+        expect(teachers).not_to include(teacher_profile_with_nil_trn)
       end
     end
   end

--- a/spec/migration/migrators/training_period_spec.rb
+++ b/spec/migration/migrators/training_period_spec.rb
@@ -50,5 +50,19 @@ describe Migrators::TrainingPeriod do
         end
       end
     end
+
+    describe ".teachers" do
+      it "excludes teacher profiles with nil TRN" do
+        teacher_profile_with_nil_trn = FactoryBot.create(:migration_teacher_profile, trn: nil)
+        FactoryBot.create(:migration_participant_profile, :ect, teacher_profile: teacher_profile_with_nil_trn, user: teacher_profile_with_nil_trn.user)
+
+        teacher_profile_with_valid_trn = FactoryBot.create(:migration_teacher_profile)
+        FactoryBot.create(:migration_participant_profile, :ect, teacher_profile: teacher_profile_with_valid_trn, user: teacher_profile_with_valid_trn.user)
+
+        teachers = described_class.teachers
+        expect(teachers).to include(teacher_profile_with_valid_trn)
+        expect(teachers).not_to include(teacher_profile_with_nil_trn)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2006

We don't need to migrate teachers without TRNs.

### Changes proposed in this pull request
- Update the Teacher and teacher periods migrators to filter out teachers with nil TRNs
