### PR TITLE
[2053] Add partnership serialiser

### DIFF
--- a/app/serializers/partnership_serializer.rb
+++ b/app/serializers/partnership_serializer.rb
@@ -1,0 +1,46 @@
+class PartnershipSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field :cohort do |partnership, _options|
+      partnership.active_lead_provider.contract_period_year.to_s
+    end
+
+    field :urn do |partnership, _options|
+      partnership.school.urn
+    end
+
+    field :school_id do |partnership, _options|
+      partnership.school.api_id
+    end
+
+    field :delivery_partner_id do |partnership, _options|
+      partnership.delivery_partner.api_id
+    end
+
+    field :delivery_partner_name do |partnership, _options|
+      partnership.delivery_partner.name
+    end
+
+    field :induction_tutor_name do |partnership, _options|
+      partnership.school.induction_tutor_name
+    end
+
+    field :induction_tutor_email do |partnership, _options|
+      partnership.school.induction_tutor_email
+    end
+
+    field :created_at
+
+    # TODO: Replace with `api_updated_at` when the field is available
+    field :updated_at
+    # field(:api_updated_at, name: :updated_at)
+  end
+
+  identifier :api_id, name: :id
+  field(:type) { "partnership" }
+
+  association :attributes, blueprint: AttributesSerializer do |partnership|
+    partnership
+  end
+end

--- a/spec/serializers/partnership_serializer_spec.rb
+++ b/spec/serializers/partnership_serializer_spec.rb
@@ -1,0 +1,63 @@
+describe PartnershipSerializer, type: :serializer do
+  subject(:response) do
+    JSON.parse(described_class.render(partnership))
+  end
+
+  let(:partnership) { FactoryBot.create(:school_partnership) }
+  let(:school) { partnership.school }
+  let(:delivery_partner) { partnership.delivery_partner }
+  let(:contract_period) { partnership.contract_period }
+
+  describe "core attributes" do
+    it "serializes `id`" do
+      expect(response["id"]).to eq(partnership.api_id)
+    end
+
+    it "serializes `type`" do
+      expect(response["type"]).to eq("partnership")
+    end
+  end
+
+  describe "nested attributes" do
+    subject(:attributes) { response["attributes"] }
+
+    it "serializes `cohort`" do
+      expect(attributes["cohort"]).to eq(contract_period.year.to_s)
+    end
+
+    it "serializes `urn`" do
+      expect(attributes["urn"]).to eq(school.urn)
+    end
+
+    it "serializes `school_id`" do
+      expect(attributes["school_id"]).to eq(school.api_id)
+    end
+
+    it "serializes `delivery_partner_id`" do
+      expect(attributes["delivery_partner_id"]).to eq(delivery_partner.api_id)
+    end
+
+    it "serializes `delivery_partner_name`" do
+      expect(attributes["delivery_partner_name"]).to eq(delivery_partner.name)
+    end
+
+    it "serializes `induction_tutor_name`" do
+      expect(attributes["induction_tutor_name"]).to eq(school.induction_tutor_name)
+    end
+
+    it "serializes `induction_tutor_email`" do
+      expect(attributes["induction_tutor_email"]).to eq(school.induction_tutor_email)
+    end
+
+    it "serializes `created_at`" do
+      expect(attributes["created_at"]).to eq(partnership.created_at.utc.rfc3339)
+    end
+
+    it "serializes `updated_at`" do
+      # TODO: Replace with `api_updated_at` when the field is available
+      expect(attributes["updated_at"]).to eq(partnership.updated_at.utc.rfc3339)
+      # partnership.update!(api_updated_at: 3.days.ago)
+      # expect(attributes["updated_at"]).to eq(partnership.api_updated_at.utc.rfc3339)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2053

We need a serialiser to be created for the partnership endpoints.

### Changes proposed in this pull request

- Add partnership serialiser

### Guidance to review

Example of data/fields returned by the serialiser.
```
{
  "data": [
    {
      "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
      "type": "partnership",
      "attributes": {
        "cohort": 2021,
        "urn": "123456",
        "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
        "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
        "delivery_partner_name": "Delivery Partner Example",
        "induction_tutor_name": "John Doe",
        "induction_tutor_email": "john.doe@example.com",
        "updated_at": "2021-05-31T02:22:32.000Z",
        "created_at": "2021-05-31T02:22:32.000Z"
      }
    }
  ]
}
```
