### PR TITLE
Allow to add GIAS Schools with blank establishment number

### DIFF
--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -28,7 +28,7 @@ class GIAS::School < ApplicationRecord
 
   # Validations
   validates :establishment_number,
-            numericality: { only_integer: true }
+            numericality: { only_integer: true, allow_nil: true }
 
   validates :local_authority_code,
             numericality: { only_integer: true }

--- a/db/migrate/20250811143143_allow_null_establishment_number_in_gias_schools.rb
+++ b/db/migrate/20250811143143_allow_null_establishment_number_in_gias_schools.rb
@@ -1,0 +1,5 @@
+class AllowNullEstablishmentNumberInGIASSchools < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :gias_schools, :establishment_number, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_07_063339) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_11_143143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -277,7 +277,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_07_063339) do
     t.string "administrative_district_name"
     t.integer "local_authority_code", null: false
     t.string "local_authority_name"
-    t.integer "establishment_number", null: false
+    t.integer "establishment_number"
     t.string "phase_name"
     t.boolean "section_41_approved", null: false
     t.string "type_name", null: false

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -12,7 +12,7 @@ describe GIAS::School do
     it { is_expected.to have_db_column(:administrative_district_name).of_type(:string) }
     it { is_expected.to have_db_column(:closed_on).of_type(:date) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
-    it { is_expected.to have_db_column(:establishment_number).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:establishment_number).of_type(:integer) }
     it { is_expected.to have_db_column(:funding_eligibility).of_type(:enum).with_options(null: false) }
     it { is_expected.to have_db_column(:induction_eligibility).of_type(:boolean).with_options(null: false) }
     it { is_expected.to have_db_column(:in_england).of_type(:boolean).with_options(null: false) }
@@ -78,7 +78,7 @@ describe GIAS::School do
 
     it { is_expected.to validate_numericality_of(:local_authority_code).only_integer }
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_numericality_of(:establishment_number).only_integer }
+    it { is_expected.to validate_numericality_of(:establishment_number).only_integer.allow_nil }
 
     it {
       is_expected.to validate_inclusion_of(:type_name)


### PR DESCRIPTION
### Context
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2207

With the inclusion of type 47 schools the `GIAS::Importer` is failing because not all of these have an `establishment_number` which is required in the RECT schema.

As we want these schools included we should relax the requirement for the `establishment_number` on the `GIAS::School` record. This was never imported in ECF and is not currently used in RECT.

### Changes proposed in this pull request
- Update the validation for the establishment_number to allow `nil` values
- Remove the `null: false` restriction from the schema

### Guidance to review
Trigger the gias import with ```bin/rails gias:import```. It should be working fine and also importing schools with blank establishment number.