### PR TITLE
Add recurring job to clear finished solid queue jobs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,8 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue
   # config.active_job.queue_name_prefix = "ecf2_production"
+  # Remove finished solid queue jobs from database after a week
+  config.solid_queue.clear_finished_jobs_after = 1.week
 
   # GOVUK Notify
   config.action_mailer.delivery_method = :notify

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -14,11 +14,24 @@ production:
     queue: default
     schedule: Every hour
 
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+
+sandbox:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+
 staging:
   purge_pending_induction_submissions:
     class: PurgePendingInductionSubmissionsJob
     queue: default
     schedule: Every hour
+
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
 
 review:
   purge_pending_induction_submissions:


### PR DESCRIPTION
### Context
We would like to clear jobs from the database when they are successfully finished. The number currently is at 7million in production as there has been no recurring job in place to cull those jobs.

### Changes proposed in this pull request
Add job that clears finished jobs every hour on the 12th minute in batches.
This job was taken from solid queue: https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings

I've changed the defaults for `clear_finished_jobs_after` from 1 day to a week instead in production.

### Guidance to review
I'm going to test this in migration env, even though the job runs deletions in batches it's worth monitoring deleting 7 million jobs at once and might require an initial manual task first