### PR TITLE
Admins must confirm before reopening an induction

### DIFF
--- a/app/assets/stylesheets/admin/button-group.scss
+++ b/app/assets/stylesheets/admin/button-group.scss
@@ -1,0 +1,7 @@
+// when Rails' button_to is used (via govuk_button_to it renders
+// a <form> with a <button> element in it, which breaks alignment.
+//
+// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods#grid_and_display_contents
+.govuk-button-group > form {
+  display: contents;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $govuk-assets-path: "/";
 @import "bulk_upload";
 @import "search";
 @import "admin/filter";
+@import "admin/button-group";
 
 // library styles
 @import "accessible-autocomplete/src/autocomplete";

--- a/app/controllers/admin/teachers/reopen_induction_controller.rb
+++ b/app/controllers/admin/teachers/reopen_induction_controller.rb
@@ -1,22 +1,34 @@
 module Admin
   module Teachers
     class ReopenInductionController < AdminController
+      before_action :set_teacher
+
+      before_action -> do
+        redirect_to admin_teacher_path(@teacher),
+                    notice: "No completed induction period found"
+      end, unless: :induction_complete_with_outcome?
+
       def update
+        Admin::ReopenInductionPeriod.new(
+          author: current_user,
+          induction_period: @teacher.last_induction_period
+        ).reopen_induction_period!
+
+        redirect_to admin_teacher_path(@teacher),
+                    alert: "Induction was successfully reopened"
+      end
+
+    private
+
+      def set_teacher
         @teacher = Teacher
           .includes(:last_induction_period)
           .find(params[:teacher_id])
+      end
 
-        last_induction_period = @teacher.last_induction_period
-
-        if last_induction_period.blank? ||
-            last_induction_period.ongoing? ||
-            last_induction_period.outcome.blank?
-          return redirect_to admin_teacher_path(@teacher), notice: "No completed induction period found"
-        end
-
-        Admin::ReopenInductionPeriod.new(author: current_user, induction_period: last_induction_period).reopen_induction_period!
-
-        redirect_to admin_teacher_path(@teacher)
+      def induction_complete_with_outcome?
+        @teacher.last_induction_period&.complete? &&
+          @teacher.last_induction_period.outcome?
       end
     end
   end

--- a/app/jobs/reopen_induction_job.rb
+++ b/app/jobs/reopen_induction_job.rb
@@ -2,6 +2,10 @@ class ReopenInductionJob < ApplicationJob
   include TRS::RetryableClient
 
   def perform(trn:, start_date:)
+    teacher = Teacher.find_by!(trn:)
+
     api_client.reopen_teacher_induction!(trn:, start_date:)
+
+    Teachers::RefreshTRSAttributes.new(teacher, api_client:).refresh!
   end
 end

--- a/app/views/admin/teachers/reopen_induction/confirm.html.erb
+++ b/app/views/admin/teachers/reopen_induction/confirm.html.erb
@@ -1,0 +1,49 @@
+<%
+  page_data(
+    title: "Reopen induction for #{teacher_full_name(@teacher)}",
+    backlink_href: admin_teacher_path(@teacher)
+  )
+%>
+
+<%= govuk_warning_text do %>
+  Are you sure you want to reopen this induction?<br>
+  This action cannot be undone.
+<% end %>
+
+<p class="govuk-body">
+  The following data will be deleted from the latest induction period,
+  and the ECT's induction status will be updated to "In Progress".
+</p>
+
+<%= govuk_summary_list do |list| %>
+  <%= list.with_row do |row| %>
+    <%= row.with_key { "End date" } %>
+    <%= row.with_value { @teacher.last_induction_period.finished_on.to_fs(:govuk) } %>
+  <% end %>
+
+  <%= list.with_row do |row| %>
+    <%= row.with_key { "Number of terms" } %>
+    <%= row.with_value { @teacher.last_induction_period.number_of_terms.to_s } %>
+  <% end %>
+
+  <%= list.with_row do |row| %>
+    <%= row.with_key { "Outcome" } %>
+    <%= row.with_value do %>
+      <%= govuk_tag(
+            text: @teacher.last_induction_period.outcome.humanize,
+            colour: @teacher.last_induction_period.outcome == "pass" ? "green" : "red"
+          ) %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= form_with url: admin_teacher_reopen_induction_path(@teacher), method: :patch do |f| %>
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Reopen induction", warning: true %>
+    <%= govuk_button_link_to(
+          "Cancel",
+          admin_teacher_path(@teacher),
+          secondary: true
+        ) %>
+  </div>
+<% end %>

--- a/app/views/admin/teachers/reopen_induction/confirm.html.erb
+++ b/app/views/admin/teachers/reopen_induction/confirm.html.erb
@@ -37,13 +37,16 @@
   <% end %>
 <% end %>
 
-<%= form_with url: admin_teacher_reopen_induction_path(@teacher), method: :patch do |f| %>
-  <div class="govuk-button-group">
-    <%= f.govuk_submit "Reopen induction", warning: true %>
-    <%= govuk_button_link_to(
-          "Cancel",
-          admin_teacher_path(@teacher),
-          secondary: true
-        ) %>
-  </div>
-<% end %>
+<div class="govuk-button-group">
+  <%= govuk_button_to(
+        "Reopen induction",
+        admin_teacher_reopen_induction_path(@teacher),
+        method: :patch,
+        warning: true
+      ) %>
+  <%= govuk_button_link_to(
+        "Cancel",
+        admin_teacher_path(@teacher),
+        secondary: true
+      ) %>
+</div>

--- a/app/views/admin/teachers/show.html.erb
+++ b/app/views/admin/teachers/show.html.erb
@@ -9,7 +9,7 @@
 %>
 
 <% if admin_latest_induction_complete_with_outcome?(@teacher) %>
-  <%= govuk_button_to "Reopen induction", admin_teacher_reopen_induction_path(@teacher), method: :put, warning: true %>
+  <%= govuk_button_link_to "Reopen induction", confirm_admin_teacher_reopen_induction_path(@teacher), warning: true %>
 <% end %>
 
 <%= render Teachers::DetailsComponent.new(mode: :admin, teacher: @teacher) do |component|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,9 @@ Rails.application.routes.draw do
       end
       resource :record_passed_outcome, only: %i[new create show], path: 'record-passed-outcome', controller: 'teachers/record_passed_outcome'
       resource :record_failed_outcome, only: %i[new create show], path: 'record-failed-outcome', controller: 'teachers/record_failed_outcome'
-      resource :reopen_induction, only: %i[update], path: 'reopen-induction', controller: 'teachers/reopen_induction'
+      resource :reopen_induction, only: %i[update], path: 'reopen-induction', controller: 'teachers/reopen_induction' do
+        member { get :confirm }
+      end
       resources :extensions, only: %i[index new create edit update destroy], controller: 'teachers/extensions' do
         member do
           get :confirm_delete

--- a/spec/features/admin/teachers/reopen_induction_spec.rb
+++ b/spec/features/admin/teachers/reopen_induction_spec.rb
@@ -1,0 +1,50 @@
+describe "Admins can reopen a teacher's closed induction" do
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  before do
+    FactoryBot.create(:induction_period, :pass, teacher:)
+    sign_in_as_dfe_user(role: :admin)
+  end
+
+  it "reopens the induction period" do
+    when_i_go_to_the_teacher_page
+    then_there_is_no_current_induction_period
+
+    when_i_reopen_the_induction
+    and_i_am_sure_i_want_to_reopen_the_induction
+    then_the_induction_is_successfully_reopened
+    and_there_is_a_current_induction_period
+  end
+
+private
+
+  def when_i_go_to_the_teacher_page
+    page.goto(admin_teacher_path(teacher))
+  end
+
+  def then_there_is_no_current_induction_period
+    expect(page.locator("h2", hasText: "Current induction period"))
+      .not_to be_visible
+  end
+
+  def when_i_reopen_the_induction
+    page.get_by_role("link", name: "Reopen induction").click
+  end
+
+  def and_i_am_sure_i_want_to_reopen_the_induction
+    expect(page.locator(".govuk-warning-text"))
+      .to have_text("Are you sure you want to reopen this induction?")
+
+    page.get_by_role("button", name: "Reopen induction").click
+  end
+
+  def then_the_induction_is_successfully_reopened
+    expect(page.locator(".govuk-notification-banner__content"))
+      .to have_text("Induction was successfully reopened")
+  end
+
+  def and_there_is_a_current_induction_period
+    expect(page.locator("h2", hasText: "Current induction period"))
+      .to be_visible
+  end
+end

--- a/spec/jobs/reopen_induction_job_spec.rb
+++ b/spec/jobs/reopen_induction_job_spec.rb
@@ -1,16 +1,32 @@
 RSpec.describe ReopenInductionJob, type: :job do
   describe "#perform" do
-    let(:trn) { "1234567" }
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:trn) { teacher.trn }
     let(:start_date) { 1.year.ago }
     let(:trs_client) { instance_double(TRS::APIClient) }
+    let(:refresh_service) { instance_double(Teachers::RefreshTRSAttributes) }
 
     before do
       allow(TRS::APIClient).to receive(:new).and_return(trs_client)
+      allow(Teachers::RefreshTRSAttributes)
+        .to receive(:new)
+        .with(teacher, api_client: trs_client)
+        .and_return(refresh_service)
       allow(trs_client).to receive(:reopen_teacher_induction!)
+      allow(refresh_service).to receive(:refresh!)
     end
 
     it "calls the TRS API to reopen the teacher's induction" do
-      expect(trs_client).to receive(:reopen_teacher_induction!).with(trn:, start_date:)
+      expect(trs_client)
+        .to receive(:reopen_teacher_induction!)
+        .with(trn:, start_date:)
+
+      described_class.new.perform(trn:, start_date:)
+    end
+
+    it "refreshes the teacher's TRS attributes" do
+      expect(refresh_service).to receive(:refresh!)
+
       described_class.new.perform(trn:, start_date:)
     end
   end

--- a/spec/requests/admin/teachers/reopen_induction_spec.rb
+++ b/spec/requests/admin/teachers/reopen_induction_spec.rb
@@ -1,5 +1,4 @@
 describe "Admin::Teachers::ReopenInductionController" do
-  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }
 
   let(:reopen_service) { instance_double(Admin::ReopenInductionPeriod) }
@@ -8,6 +7,74 @@ describe "Admin::Teachers::ReopenInductionController" do
     allow(Admin::ReopenInductionPeriod)
       .to receive(:new)
       .and_return(reopen_service)
+  end
+
+  describe "GET confirm" do
+    context "when not signed in" do
+      it "redirects to the sign in page" do
+        get confirm_admin_teacher_reopen_induction_path(teacher)
+
+        expect(response).to redirect_to(sign_in_path)
+      end
+    end
+
+    context "when signed in as a non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "returns unauthorized" do
+        get confirm_admin_teacher_reopen_induction_path(teacher)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when signed in as a DfE user" do
+      include_context "sign in as DfE user"
+
+      context "when there is no last induction period" do
+        it "redirects to the teacher page" do
+          get confirm_admin_teacher_reopen_induction_path(teacher)
+
+          expect(response).to redirect_to(admin_teacher_path(teacher))
+        end
+      end
+
+      context "when the last induction period is ongoing" do
+        let!(:induction_period) do
+          FactoryBot.create(:induction_period, :ongoing, teacher:)
+        end
+
+        it "redirects to the teacher page" do
+          get confirm_admin_teacher_reopen_induction_path(teacher)
+
+          expect(response).to redirect_to(admin_teacher_path(teacher))
+        end
+      end
+
+      context "when the last induction period is completed without an outcome" do
+        let!(:induction_period) do
+          FactoryBot.create(:induction_period, teacher:)
+        end
+
+        it "redirects to the teacher page" do
+          get confirm_admin_teacher_reopen_induction_path(teacher)
+
+          expect(response).to redirect_to(admin_teacher_path(teacher))
+        end
+      end
+
+      context "when the last induction period is completed with an outcome" do
+        let!(:induction_period) do
+          FactoryBot.create(:induction_period, :pass, teacher:)
+        end
+
+        it "renders the confirm page" do
+          get confirm_admin_teacher_reopen_induction_path(teacher)
+
+          expect(response.body).to include("Are you sure you want to reopen this induction?")
+        end
+      end
+    end
   end
 
   describe "PATCH update" do
@@ -22,7 +89,7 @@ describe "Admin::Teachers::ReopenInductionController" do
     context "when signed in as a non-DfE user" do
       include_context "sign in as non-DfE user"
 
-      it "redirects to the sign in page" do
+      it "returns unauthorized" do
         patch admin_teacher_reopen_induction_path(teacher)
 
         expect(response).to have_http_status(:unauthorized)

--- a/spec/views/admin/teachers/show.html.erb_spec.rb
+++ b/spec/views/admin/teachers/show.html.erb_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'admin/teachers/show.html.erb' do
     end
 
     it "displays a button to reopen induction" do
-      expect(rendered).to have_button("Reopen induction")
+      expect(rendered).to have_link("Reopen induction")
     end
   end
 
@@ -72,8 +72,8 @@ RSpec.describe 'admin/teachers/show.html.erb' do
       FactoryBot.create(:induction_period, outcome: nil, teacher:)
     end
 
-    it "does not display a button to reopen induction" do
-      expect(rendered).not_to have_button("Reopen induction")
+    it "does not display a link to reopen induction" do
+      expect(rendered).not_to have_link("Reopen induction")
     end
   end
 
@@ -82,8 +82,8 @@ RSpec.describe 'admin/teachers/show.html.erb' do
       FactoryBot.create(:induction_period, :ongoing, teacher:)
     end
 
-    it "does not display a button to reopen induction" do
-      expect(rendered).not_to have_button("Reopen induction")
+    it "does not display a link to reopen induction" do
+      expect(rendered).not_to have_link("Reopen induction")
     end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2142

### Changes proposed in this pull request

Before, reopening a Teacher's induction was a one-click action.

We've seen some mistakes since launching this feature, so we think we've made it too easy to use accidentally. Especially considering the action is destructive and irreversible.

This adds some friction to the journey by introducing a confirmation screen.

Now, admins must confirm they are sure before then can reopen a Teacher's induction.

### Guidance to review

https://github.com/user-attachments/assets/55445094-5c7e-43b1-afde-f099e3ba546e



