### PR TITLE
Add input to ignore jobs tables during backups

### DIFF
--- a/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
@@ -5,6 +5,10 @@ inputs:
   environment:
     description: The name of the environment
     required: true
+  exclude-jobs:
+    description: Exclude jobs tables
+    type: boolean
+    default: false
   azure-client-id:
     description: Azure service principal or managed identity client ID when using OIDC
     required: true
@@ -61,7 +65,22 @@ runs:
     - name: Backup database
       shell: bash
       run: |
-        bin/konduit.sh -n ${{ env.NAMESPACE }} cpd-ec2-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
+        # Build up exclude arguments based on flags
+        EXCLUDE_ARGS=""
+
+        if [ "${{ inputs.exclude-jobs }}" = "true" ]; then
+          EXCLUDE_ARGS="$EXCLUDE_ARGS \
+            --exclude-table-data=solid_queue_jobs \
+            --exclude-table-data=solid_queue_ready_executions \
+            --exclude-table-data=solid_queue_claimed_executions \
+            --exclude-table-data=solid_queue_blocked_executions \
+            --exclude-table-data=solid_queue_failed_executions \
+            --exclude-table-data=solid_queue_processes"
+        fi
+
+        echo "Excluding tables (if any): $EXCLUDE_ARGS"
+
+        bin/konduit.sh -n ${{ env.NAMESPACE }} cpd-ec2-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists $EXCLUDE_ARGS --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
 
     - name: Restore snapshot database
       shell: bash

--- a/.github/actions/refresh-migration-database/action.yml
+++ b/.github/actions/refresh-migration-database/action.yml
@@ -5,6 +5,10 @@ inputs:
   environment:
     description: The name of the environment
     required: true
+  exclude-jobs:
+    description: Exclude jobs tables
+    type: boolean
+    default: true
   azure-client-id:
     description: Azure Client ID
     required: true
@@ -56,7 +60,22 @@ runs:
     - name: Backup production DB
       shell: bash
       run: |
-        bin/konduit.sh -n ${{ env.NAMESPACE }} cpd-ec2-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
+        # Build up exclude arguments based on flags
+        EXCLUDE_ARGS=""
+
+        if [ "${{ inputs.exclude-jobs }}" = "true" ]; then
+          EXCLUDE_ARGS="$EXCLUDE_ARGS \
+            --exclude-table-data=solid_queue_jobs \
+            --exclude-table-data=solid_queue_ready_executions \
+            --exclude-table-data=solid_queue_claimed_executions \
+            --exclude-table-data=solid_queue_blocked_executions \
+            --exclude-table-data=solid_queue_failed_executions \
+            --exclude-table-data=solid_queue_processes"
+        fi
+
+        echo "Excluding tables (if any): $EXCLUDE_ARGS"
+
+        bin/konduit.sh -n ${{ env.NAMESPACE }} cpd-ec2-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists $EXCLUDE_ARGS --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
 
     - name: Restore to migration DB
       shell: bash

--- a/.github/workflows/directly-copy-main-db-into-snapshot-db.yml
+++ b/.github/workflows/directly-copy-main-db-into-snapshot-db.yml
@@ -11,6 +11,10 @@ on:
           - staging
           - production
         required: true
+      exclude-jobs:
+        description: Exclude jobs tables
+        type: boolean
+        default: false
 
 env:
   SERVICE_NAME: cpd-ec2
@@ -65,3 +69,4 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           app-name: ${{ env.SERVICE_NAME }}-${{ inputs.environment || 'production' }}-web
           slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
+          exclude-jobs: ${{ inputs.exclude-jobs }}

--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -9,6 +9,10 @@ on:
         options:
           - production
         required: true
+      exclude-jobs:
+        description: Exclude jobs tables
+        type: boolean
+        default: true
 
 jobs:
   refresh-migration-db:
@@ -28,6 +32,7 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          exclude-jobs: ${{ inputs.exclude-jobs }}
 
       - name: Login
         uses: azure/login@v2


### PR DESCRIPTION
### Context

We want to have the option to exclude jobs tables when doing backups of the production database for the snapshot and migration environments so that the backups run quicker.

### Changes proposed in this pull request

Add inputs to the migration/snapshot database refresh jobs so that we can ignore job tables and backup more quickly.

Include the jobs tables by default in snapshot.

Exclude the jobs tables by default in migration.

Tables excluded:

solid_queue_jobs – the master record of every enqueued job (active, scheduled, or finished) 
solid_queue_ready_executions – jobs ready to run now 
solid_queue_claimed_executions – jobs actively being worked on by a worker 
solid_queue_blocked_executions – jobs blocked due to concurrency limits 
solid_queue_failed_executions – failed job logs
solid_queue_processes – background process monitoring

Tables retained:

solid_queue_scheduled_executions – jobs waiting until a scheduled time before execution
solid_queue_recurring_tasks – definitions of recurring jobs (their key, schedule, arguments, etc.) 
solid_queue_recurring_executions – history/future runs of recurring jobs (can be rebuilt, but useful to keep) 
solid_queue_semaphores – concurrency and resource control settings solid_queue_pauses – paused queue definitions

### Guidance to review

[Snapshot refresh - with jobs](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/16937646823)
[Snapshot refresh - without jobs](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/16958201793)

[Migration refresh - without jobs](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/16938073608)
[Migration refresh - with jobs](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/16938255279)

Without jobs:

```
register-early-career-teachers(migration)> SolidQueue::Job.count
=> 0
```

With jobs:

```
register-early-career-teachers(migration)> SolidQueue::Job.count
register-early-career-teachers(migration)> 
=> 460838
```

I haven't changed the backup/restore to/from azure actions as they appear to use a generic DfE action for doing the backup so we can't hook into it (the snapshot refresh above is the direct copy workflow).