### PR TITLE
[2055] Add partnership api endpoints

### DIFF
--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -1,10 +1,44 @@
 module API
   module V3
     class PartnershipsController < BaseController
+      def index
+        conditions = { contract_period_years:, updated_since:, delivery_partner_api_ids:, sort: }
+        render json: to_json(paginate(partnerships_query(conditions:).school_partnerships))
+      end
+
+      def show
+        render json: to_json(partnerships_query.school_partnership_by_api_id(api_id))
+      end
+
       def create = head(:method_not_allowed)
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
       def update = head(:method_not_allowed)
+
+    private
+
+      def partnerships_query(conditions: {})
+        conditions[:lead_provider_id] = current_lead_provider.id
+        SchoolPartnerships::Query.new(**conditions.compact)
+      end
+
+      def partnerships_params
+        params.permit(:api_id, :sort, filter: %i[delivery_partner_id])
+      end
+
+      def api_id
+        partnerships_params[:api_id]
+      end
+
+      def sort
+        partnerships_params[:sort]
+      end
+
+      def delivery_partner_api_ids
+        partnerships_params.dig(:filter, :delivery_partner_id)
+      end
+
+      def to_json(obj)
+        PartnershipSerializer.render(obj, root: "data")
+      end
     end
   end
 end

--- a/app/controllers/concerns/api/paginatable.rb
+++ b/app/controllers/concerns/api/paginatable.rb
@@ -14,11 +14,11 @@ module API
     end
 
     def per_page
-      [params.dig(:page, :per_page).to_i.nonzero? || Pagy::DEFAULT[:api_per_page], Pagy::DEFAULT[:api_max_per_page]].min
+      [(params.dig(:page, :per_page) || Pagy::DEFAULT[:api_per_page]).to_i, Pagy::DEFAULT[:api_max_per_page]].min
     end
 
     def page
-      params.dig(:page, :page).to_i.nonzero? || 1
+      (params.dig(:page, :page) || 1).to_i
     end
 
     def raise_as_bad_request!

--- a/app/controllers/concerns/api/paginatable.rb
+++ b/app/controllers/concerns/api/paginatable.rb
@@ -14,11 +14,11 @@ module API
     end
 
     def per_page
-      [(params.dig(:page, :per_page) || Pagy::DEFAULT[:api_per_page]).to_i, Pagy::DEFAULT[:api_max_per_page]].min
+      [params.dig(:page, :per_page)&.to_i || Pagy::DEFAULT[:api_per_page], Pagy::DEFAULT[:api_max_per_page]].min
     end
 
     def page
-      (params.dig(:page, :page) || 1).to_i
+      params.dig(:page, :page)&.to_i || 1
     end
 
     def raise_as_bad_request!

--- a/app/models/lead_provider_delivery_partnership.rb
+++ b/app/models/lead_provider_delivery_partnership.rb
@@ -10,8 +10,6 @@ class LeadProviderDeliveryPartnership < ApplicationRecord
 
   touch -> { delivery_partner }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
 
-  delegate :lead_provider, :contract_period, to: :active_lead_provider
-
   validates :active_lead_provider_id, presence: { message: 'Select an active lead provider' }
   validates :delivery_partner_id,
             presence: { message: 'Select a delivery partner' },

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -6,10 +6,9 @@ class SchoolPartnership < ApplicationRecord
   belongs_to :school
   has_many :events
   has_one :active_lead_provider, through: :lead_provider_delivery_partnership
+  has_one :delivery_partner, through: :lead_provider_delivery_partnership
   has_one :contract_period, through: :active_lead_provider
-
-  # delegates
-  delegate :lead_provider, :delivery_partner, :contract_period, to: :lead_provider_delivery_partnership
+  has_one :lead_provider, through: :active_lead_provider
 
   touch -> { self }, when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at
 

--- a/app/serializers/partnership_serializer.rb
+++ b/app/serializers/partnership_serializer.rb
@@ -7,7 +7,7 @@ class PartnershipSerializer < Blueprinter::Base
     end
 
     field :urn do |partnership, _options|
-      partnership.school.urn
+      partnership.school.urn.to_s
     end
 
     field :school_id do |partnership, _options|

--- a/app/services/school_partnerships/query.rb
+++ b/app/services/school_partnerships/query.rb
@@ -82,11 +82,9 @@ module SchoolPartnerships
     def default_scope
       SchoolPartnership
         .eager_load(
+          :delivery_partner,
           school: :gias_school,
-          lead_provider_delivery_partnership: [
-            :delivery_partner,
-            { active_lead_provider: %i[lead_provider contract_period] }
-          ]
+          active_lead_provider: :lead_provider
         )
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -378,7 +378,7 @@ Rails.application.routes.draw do
 
         resources :statements, only: %i[index show], param: :api_id
         resources :delivery_partners, only: %i[index show], path: "delivery-partners", param: :api_id
-        resources :partnerships, only: %i[show index create update]
+        resources :partnerships, only: %i[show index create update], param: :api_id
         resources :schools, only: %i[index show], param: :api_id
         resources :unfunded_mentors, only: %i[index show], path: "unfunded-mentors"
       end

--- a/spec/models/lead_provider_delivery_partnership_spec.rb
+++ b/spec/models/lead_provider_delivery_partnership_spec.rb
@@ -125,11 +125,6 @@ describe LeadProviderDeliveryPartnership do
     end
   end
 
-  describe "delegate methods" do
-    it { is_expected.to delegate_method(:lead_provider).to(:active_lead_provider) }
-    it { is_expected.to delegate_method(:contract_period).to(:active_lead_provider) }
-  end
-
   describe "declarative touch" do
     let(:instance) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner:) }
     let(:delivery_partner) { FactoryBot.create(:delivery_partner) }

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -18,7 +18,9 @@ describe SchoolPartnership do
     it { is_expected.to belong_to(:school) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_one(:active_lead_provider).through(:lead_provider_delivery_partnership) }
+    it { is_expected.to have_one(:delivery_partner).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
+    it { is_expected.to have_one(:lead_provider).through(:active_lead_provider) }
   end
 
   describe "validations" do
@@ -44,11 +46,5 @@ describe SchoolPartnership do
         expect(described_class.for_contract_period(contract_period_2.id)).to contain_exactly(school_partnership_2)
       end
     end
-  end
-
-  describe "delegate methods" do
-    it { is_expected.to delegate_method(:lead_provider).to(:lead_provider_delivery_partnership) }
-    it { is_expected.to delegate_method(:delivery_partner).to(:lead_provider_delivery_partnership) }
-    it { is_expected.to delegate_method(:contract_period).to(:lead_provider_delivery_partnership) }
   end
 end

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Partnerships API", type: :request do
 
     it_behaves_like "a paginated endpoint"
     it_behaves_like "a token authenticated endpoint", :get
-    it_behaves_like "a filter by a single cohort (contract_period year) endpoint"
+    it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
     it_behaves_like "a filter by updated_since endpoint"
     it_behaves_like "a filter by delivery_partner_id endpoint"
     it_behaves_like "an index endpoint"

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -1,33 +1,49 @@
 RSpec.describe "Partnerships API", type: :request do
-  describe "#create" do
+  let(:serializer) { PartnershipSerializer }
+  let(:serializer_options) { { lead_provider: } }
+  let(:query) { SchoolPartnerships::Query }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:lead_provider) { active_lead_provider.lead_provider }
+
+  def create_resource(active_lead_provider:)
+    lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+  end
+
+  describe "#index" do
+    let(:path) { api_v3_partnerships_path }
+
+    def apply_expected_order(resources)
+      resources.sort_by(&:created_at)
+    end
+
+    it_behaves_like "a paginated endpoint"
+    it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "a filter by a single cohort (contract_period year) endpoint"
+    it_behaves_like "a filter by updated_since endpoint"
+    it_behaves_like "a filter by delivery_partner_id endpoint"
+    it_behaves_like "an index endpoint"
+    it_behaves_like "a sortable endpoint"
+  end
+
+  describe "#show" do
+    let(:resource) { create_resource(active_lead_provider:) }
+    let(:path_id) { resource.api_id }
+    let(:path) { api_v3_partnership_path(path_id) }
+
+    it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "a show endpoint"
+    it_behaves_like "a does not filter by cohort endpoint"
+    it_behaves_like "a does not filter by updated_since endpoint"
+  end
+
+  describe "# create" do
     let(:path) { api_v3_partnerships_path }
 
     it_behaves_like "a token authenticated endpoint", :get
 
     it "returns method not allowed" do
       authenticated_api_post path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#index" do
-    let(:path) { api_v3_partnerships_path }
-
-    it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#show" do
-    let(:path) { api_v3_partnership_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
       expect(response).to be_method_not_allowed
     end
   end

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Partnerships API", type: :request do
     it_behaves_like "a show endpoint"
     it_behaves_like "a does not filter by cohort endpoint"
     it_behaves_like "a does not filter by updated_since endpoint"
+    it_behaves_like "a does not filter by delivery_partner_id endpoint"
   end
 
   describe "# create" do

--- a/spec/serializers/partnership_serializer_spec.rb
+++ b/spec/serializers/partnership_serializer_spec.rb
@@ -26,7 +26,7 @@ describe PartnershipSerializer, type: :serializer do
     end
 
     it "serializes `urn`" do
-      expect(attributes["urn"]).to eq(school.urn)
+      expect(attributes["urn"]).to eq(school.urn.to_s)
     end
 
     it "serializes `school_id`" do

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -162,3 +162,33 @@ RSpec.shared_examples "a does not filter by updated_since endpoint" do
     expect(response.body).to eq(serializer.render(resource, root: "data", **serializer_options))
   end
 end
+
+RSpec.shared_examples "a filter by delivery_partner_id endpoint" do
+  it "returns only resources for the specified delivery_partner_id" do
+    resource = create_resource(active_lead_provider:)
+
+    # Resource with another delivery_partner_id should not be included.
+    create_resource(active_lead_provider:)
+
+    params = { filter: { delivery_partner_id: resource.lead_provider_delivery_partnership.delivery_partner.api_id } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
+  end
+
+  it "ignores invalid delivery partner ids" do
+    resource = create_resource(active_lead_provider:)
+
+    # Resource with another delivery_partner_id should not be included.
+    create_resource(active_lead_provider:)
+
+    params = { filter: { delivery_partner_id: "#{resource.lead_provider_delivery_partnership.delivery_partner.api_id},invalid" } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
+  end
+end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -170,7 +170,7 @@ RSpec.shared_examples "a filter by delivery_partner_id endpoint" do
     # Resource with another delivery_partner_id should not be included.
     create_resource(active_lead_provider:)
 
-    params = { filter: { delivery_partner_id: resource.lead_provider_delivery_partnership.delivery_partner.api_id } }
+    params = { filter: { delivery_partner_id: resource.delivery_partner.api_id } }
     authenticated_api_get(path, params:)
 
     expect(response).to have_http_status(:ok)
@@ -184,11 +184,27 @@ RSpec.shared_examples "a filter by delivery_partner_id endpoint" do
     # Resource with another delivery_partner_id should not be included.
     create_resource(active_lead_provider:)
 
-    params = { filter: { delivery_partner_id: "#{resource.lead_provider_delivery_partnership.delivery_partner.api_id},invalid" } }
+    params = { filter: { delivery_partner_id: "#{resource.delivery_partner.api_id},invalid" } }
     authenticated_api_get(path, params:)
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
     expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
+  end
+end
+
+RSpec.shared_examples "a does not filter by delivery_partner_id endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
+
+  it "returns the resources, ignoring the `delivery_partner_id`" do
+    # Use of a filter with a different delivery_partner_id should not change the resource returned.
+    different_resource = create_resource(active_lead_provider:)
+
+    params = { filter: { delivery_partner_id: different_resource.delivery_partner.api_id } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render(resource, root: "data", **serializer_options))
   end
 end

--- a/spec/support/shared_contexts/api/paginated_endpoint.rb
+++ b/spec/support/shared_contexts/api/paginated_endpoint.rb
@@ -32,6 +32,14 @@ shared_examples "a paginated endpoint" do
     expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number" }] }.to_json)
   end
 
+  it "returns error when requesting page is invalid" do
+    authenticated_api_get(path, params: { page: { per_page: 100, page: 0.8 } })
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number" }] }.to_json)
+  end
+
   it "returns error when requesting per_page is invalid" do
     authenticated_api_get(path, params: { page: { per_page: "abc", page: 1 } })
 

--- a/spec/support/shared_contexts/api/paginated_endpoint.rb
+++ b/spec/support/shared_contexts/api/paginated_endpoint.rb
@@ -31,4 +31,12 @@ shared_examples "a paginated endpoint" do
     expect(response.content_type).to eql("application/json; charset=utf-8")
     expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number" }] }.to_json)
   end
+
+  it "returns error when requesting per_page is invalid" do
+    authenticated_api_get(path, params: { page: { per_page: "abc", page: 1 } })
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number" }] }.to_json)
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2055

We need to allow Lead Providers to view all partnerships they manage, or just view details of a specific partnership.

### Changes proposed in this pull request

- Add partnership api endpoints
- Return cohort value as a string in partnership endpoint
- Fix n+1 queries in partnership query service

### Guidance to review

- Postman calls to the review app url:
  - GET `https://cpd-ec2-review-1148-web.test.teacherservices.cloud/api/v3/partnerships`
  - GET `https://cpd-ec2-review-1148-web.test.teacherservices.cloud/api/v3/partnerships/{id}`
  - Use the available filter options (`cohort`, `updated_since` and `delivery_partner_id`)
  - Use the sort option
  - Use the pagination option