### PR TITLE
WIP - Analytics debugging

### DIFF
--- a/config/terraform/application/config/review.tfvars.json
+++ b/config/terraform/application/config/review.tfvars.json
@@ -5,5 +5,5 @@
     "enable_postgres_ssl": false,
     "enable_logit": true,
     "gcp_table_deletion_protection": false,
-    "create_bigquery_dataset": false
+    "create_bigquery_dataset": true
 }

--- a/config/terraform/application/config/review.yml
+++ b/config/terraform/application/config/review.yml
@@ -13,7 +13,7 @@ TEST_GUIDANCE: true
 ENABLE_SENTRY: false
 SENTRY_ENVIRONMENT: review
 ENABLE_BLAZER: true
-DFE_ANALYTICS_ENABLED: false
+DFE_ANALYTICS_ENABLED: true
 TRS_API_BASE_URL: 'https://preprod.teacher-qualifications-api.education.gov.uk'
 TRS_API_VERSION: '20250203'
 ENCRYPTION_PRIMARY_KEY: review_primary_key

--- a/lib/dfe_analytics/active_job_extensions.rb
+++ b/lib/dfe_analytics/active_job_extensions.rb
@@ -2,11 +2,13 @@ module DfEAnalytics
   module ActiveJobExtensions
     def serialize
       request_id = RequestLocals.fetch(:dfe_analytics_request_id) { nil } # rubocop:disable Style/RedundantFetchBlock
+      Rails.logger.info("Serializing job with DfE Analytics request ID: #{request_id}")
       super.merge("dfe_analytics_request_id" => request_id)
     end
 
     def deserialize(job_data)
-      request_id = job_data.delete("dfe_analytics_request_id")
+      request_id = job_data["dfe_analytics_request_id"]
+      Rails.logger.info("Setting DfE Analytics request ID: #{request_id}")
       RequestLocals.store[:dfe_analytics_request_id] = request_id
       super(job_data)
     end


### PR DESCRIPTION
We want to know more about what's going on with our DfE Analytics tracking of request UUIDs via background jobs.

This enables DfE Analytics in the review app and adds some extra logging.
