### PR TITLE
Fix training period builder specs

### DIFF
--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -22,8 +22,9 @@ module Builders
 
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first
+          school = ect_at_school_period&.school
 
-          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school: ect_at_school_period.school)
+          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
 
           training_period = ::TrainingPeriod.find_or_initialize_by(ecf_start_induction_record_id: period.start_source_id)
           training_period.ect_at_school_period = ect_at_school_period

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -23,7 +23,8 @@ module Builders
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first
 
-          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school: mentor_at_school_period.school)
+          school = mentor_at_school_period&.school
+          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
 
           training_period = ::TrainingPeriod.find_or_initialize_by(ecf_start_induction_record_id: period.start_source_id)
           training_period.mentor_at_school_period = mentor_at_school_period

--- a/spec/factories/lead_provider_delivery_partnership_factory.rb
+++ b/spec/factories/lead_provider_delivery_partnership_factory.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory(:lead_provider_delivery_partnership) do
-    association :active_lead_provider
+    transient do
+      contract_year { Random.rand(2021..2120) }
+    end
+
+    active_lead_provider do
+      FactoryBot.create(:active_lead_provider, contract_period: (ContractPeriod.find_by(year: contract_year) || FactoryBot.create(:contract_period, year: contract_year)))
+    end
+
     association :delivery_partner
   end
 end

--- a/spec/factories/school_partnership_factory.rb
+++ b/spec/factories/school_partnership_factory.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory(:school_partnership) do
-    association :lead_provider_delivery_partnership
+    transient do
+      contract_year { Random.rand(2021..2120) }
+    end
+
+    lead_provider_delivery_partnership { FactoryBot.create(:lead_provider_delivery_partnership, contract_year:) }
     association :school
   end
 end

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -1,11 +1,11 @@
 describe Builders::ECT::TrainingPeriods do
   subject(:service) { described_class.new(teacher:, training_period_data:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, contract_period:) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, contract_period:) }
   let(:school_1) { FactoryBot.create(:school, :independent, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, :independent, urn: "987654") }
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+  let(:partnership_1) { FactoryBot.create(:school_partnership, contract_year: contract_period.year, school: school_1) }
+  let(:partnership_2) { FactoryBot.create(:school_partnership, contract_year: contract_period.year, school: school_2) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let!(:school_period_1) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
   let!(:school_period_2) { FactoryBot.create(:ect_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
@@ -13,7 +13,7 @@ describe Builders::ECT::TrainingPeriods do
   let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
-  describe "#build", pending: "will be reworked once EOI schema is done" do
+  describe "#build" do
     it "creates TrainingPeriod records for the school periods" do
       expect {
         service.build

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -1,11 +1,11 @@
 describe Builders::Mentor::TrainingPeriods do
   subject(:service) { described_class.new(teacher:, training_period_data:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period) }
-  let(:partnership_1) { FactoryBot.create(:school_partnership, contract_period:) }
-  let(:partnership_2) { FactoryBot.create(:school_partnership, contract_period:) }
   let(:school_1) { FactoryBot.create(:school, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, urn: "987654") }
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+  let(:partnership_1) { FactoryBot.create(:school_partnership, contract_year: contract_period.year, school: school_1) }
+  let(:partnership_2) { FactoryBot.create(:school_partnership, contract_year: contract_period.year, school: school_2) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let!(:school_period_1) { FactoryBot.create(:mentor_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
   let!(:school_period_2) { FactoryBot.create(:mentor_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
@@ -13,7 +13,7 @@ describe Builders::Mentor::TrainingPeriods do
   let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
-  describe "#build", pending: "will be reworked once EOI schema is done" do
+  describe "#build" do
     it "creates TrainingPeriod records for the school periods" do
       expect {
         service.build


### PR DESCRIPTION
### Context

The specs for the `TrainingPeriod` builders for migration have been marked as pending for a while due to model changes.  This fixes the specs.

### Changes proposed in this pull request

Using transients in the factories to pass contract_year along up the chain
Fix issues causing specs to fail when `ECTAtSchoolPeriod` not found

### Guidance to review
