### PR TITLE
[2056] Add partnership endpoints to swagger

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -77,6 +77,76 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
+  "/api/v3/partnerships":
+    get:
+      summary: Retrieve multiple partnerships
+      tags:
+      - Partnerships
+      security:
+      - api_key: []
+      parameters:
+      - name: filter
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/PartnershipsFilter"
+        style: deepObject
+      - name: page
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
+      - name: sort
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/SortingTimestamps"
+      responses:
+        '200':
+          description: A list of partnerships
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PartnershipsResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+  "/api/v3/partnerships/{id}":
+    get:
+      summary: Retrieve a single partnership
+      tags:
+      - Partnerships
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: A single partnership
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PartnershipResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
   "/api/v3/schools":
     get:
       summary: Retrieve multiple schools scoped to cohort
@@ -547,3 +617,106 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/DeliveryPartner"
+    Partnership:
+      description: A partnership.
+      type: object
+      required:
+      - id
+      - type
+      - attributes
+      properties:
+        id:
+          "$ref": "#/components/schemas/IDAttribute"
+        type:
+          description: The data type.
+          type: string
+          example: partnership
+          enum:
+          - partnership
+        attributes:
+          properties:
+            cohort:
+              description: The cohort for which you are reporting the partnership
+              type: string
+              example: 2021
+            urn:
+              description: The Unique Reference Number (URN) of the school you are
+                partnered with
+              type: string
+              example: '123456'
+            school_id:
+              description: The unique ID of the school you are partnered with
+              type: string
+              format: uuid
+              example: dd4a11347-7308-4879-942a-c4a70ced400v
+            delivery_partner_id:
+              description: The unique ID of the delivery partner you are working with
+                for this partnership
+              type: string
+              format: uuid
+              example: cd3a12347-7308-4879-942a-c4a70ced400a
+            delivery_partner_name:
+              description: The name of the delivery partner you are working with for
+                this partnership
+              type: string
+              example: Delivery Partner Example
+            induction_tutor_name:
+              description: The name of the induction tutor at the school you are in
+                partnership with
+              type: string
+              nullable: true
+              example: John Doe
+            induction_tutor_email:
+              description: The email address of the induction tutor at the school
+                you are in partnership with
+              type: string
+              nullable: true
+              example: john.doe@example.com
+            updated_at:
+              description: The date the partnership was last updated
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+            created_at:
+              description: The date the partnership was reported by you
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+    PartnershipsFilter:
+      description: Filter partnerships to return more specific results
+      type: object
+      properties:
+        cohort:
+          description: Return partnerships within the specified cohorts. This is a
+            comma delimited string of years.
+          type: string
+          example: '2021,2022'
+        updated_since:
+          description: Return only records that have been updated since this date
+            and time (ISO 8601 date format)
+          type: string
+          example: '2021-05-13T11:21:55Z'
+        delivery_partner_id:
+          description: Return partnerships associated to the specified delivery partner
+            or delivery partners. This is a comma delimited string of delivery partner
+            IDs.
+          type: string
+          example: 42a9ef2f-9059-400a-92ff-4830a629d0c5,92f6e54b-57fe-4a62-89cc-e83d6b0f734b
+    PartnershipResponse:
+      description: A single partnership.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          "$ref": "#/components/schemas/Partnership"
+    PartnershipsResponse:
+      description: A list of partnerships.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Partnership"

--- a/spec/requests/api/docs/v3/partnerships_spec.rb
+++ b/spec/requests/api/docs/v3/partnerships_spec.rb
@@ -1,0 +1,27 @@
+require "swagger_helper"
+
+RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+  include_context "with authorization for api doc request"
+
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+  let(:resource) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+
+  it_behaves_like "an API index endpoint documentation",
+                  {
+                    url: "/api/v3/partnerships",
+                    tag: "Partnerships",
+                    resource_description: "partnerships",
+                    response_schema_ref: "#/components/schemas/PartnershipsResponse",
+                    filter_schema_ref: "#/components/schemas/PartnershipsFilter",
+                    sorting_schema_ref: "#/components/schemas/SortingTimestamps",
+                  }
+
+  it_behaves_like "an API show endpoint documentation",
+                  {
+                    url: "/api/v3/partnerships/{id}",
+                    tag: "Partnerships",
+                    resource_description: "partnership",
+                    response_schema_ref: "#/components/schemas/PartnershipResponse",
+                  } do
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -62,6 +62,12 @@ RSpec.configure do |config|
           DeliveryPartnersFilter: DELIVERY_PARTNERS_FILTER,
           DeliveryPartnerResponse: DELIVERY_PARTNER_RESPONSE,
           DeliveryPartnersResponse: DELIVERY_PARTNERS_RESPONSE,
+
+          # Partnerships
+          Partnership: PARTNERSHIP,
+          PartnershipsFilter: PARTNERSHIPS_FILTER,
+          PartnershipResponse: PARTNERSHIP_RESPONSE,
+          PartnershipsResponse: PARTNERSHIPS_RESPONSE,
         }
       }
     }

--- a/spec/swagger_schemas/filters/partnerships.rb
+++ b/spec/swagger_schemas/filters/partnerships.rb
@@ -1,0 +1,21 @@
+PARTNERSHIPS_FILTER = {
+  description: "Filter partnerships to return more specific results",
+  type: "object",
+  properties: {
+    cohort: {
+      description: "Return partnerships within the specified cohorts. This is a comma delimited string of years.",
+      type: "string",
+      example: "2021,2022",
+    },
+    updated_since: {
+      description: "Return only records that have been updated since this date and time (ISO 8601 date format)",
+      type: "string",
+      example: "2021-05-13T11:21:55Z",
+    },
+    delivery_partner_id: {
+      description: "Return partnerships associated to the specified delivery partner or delivery partners. This is a comma delimited string of delivery partner IDs.",
+      type: "string",
+      example: "42a9ef2f-9059-400a-92ff-4830a629d0c5,92f6e54b-57fe-4a62-89cc-e83d6b0f734b",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/models/partnership.rb
+++ b/spec/swagger_schemas/models/partnership.rb
@@ -1,0 +1,73 @@
+PARTNERSHIP = {
+  description: "A partnership.",
+  type: :object,
+  required: %i[id type attributes],
+  properties: {
+    id: {
+      "$ref": "#/components/schemas/IDAttribute",
+    },
+    type: {
+      description: "The data type.",
+      type: :string,
+      example: "partnership",
+      enum: %w[
+        partnership
+      ],
+    },
+    attributes: {
+      properties: {
+        cohort: {
+          description: "The cohort for which you are reporting the partnership",
+          type: "string",
+          example: 2021
+        },
+        urn: {
+          description: "The Unique Reference Number (URN) of the school you are partnered with",
+          type: "string",
+          example: "123456"
+        },
+        school_id: {
+          description: "The unique ID of the school you are partnered with",
+          type: "string",
+          format: "uuid",
+          example: "dd4a11347-7308-4879-942a-c4a70ced400v"
+        },
+        delivery_partner_id: {
+          description: "The unique ID of the delivery partner you are working with for this partnership",
+          type: "string",
+          format: "uuid",
+          example: "cd3a12347-7308-4879-942a-c4a70ced400a"
+        },
+        delivery_partner_name: {
+          description: "The name of the delivery partner you are working with for this partnership",
+          type: "string",
+          example: "Delivery Partner Example"
+        },
+        induction_tutor_name: {
+          description: "The name of the induction tutor at the school you are in partnership with",
+          type: "string",
+          nullable: true,
+          example: "John Doe"
+        },
+        induction_tutor_email: {
+          description: "The email address of the induction tutor at the school you are in partnership with",
+          type: "string",
+          nullable: true,
+          example: "john.doe@example.com"
+        },
+        updated_at: {
+          description: "The date the partnership was last updated",
+          type: "string",
+          format: "date-time",
+          example: "2021-05-31T02:22:32.000Z"
+        },
+        created_at: {
+          description: "The date the partnership was reported by you",
+          type: "string",
+          format: "date-time",
+          example: "2021-05-31T02:22:32.000Z"
+        }
+      },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/partnership.rb
+++ b/spec/swagger_schemas/responses/partnership.rb
@@ -1,0 +1,10 @@
+PARTNERSHIP_RESPONSE = {
+  description: "A single partnership.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      "$ref": "#/components/schemas/Partnership",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/partnerships.rb
+++ b/spec/swagger_schemas/responses/partnerships.rb
@@ -1,0 +1,11 @@
+PARTNERSHIPS_RESPONSE = {
+  description: "A list of partnerships.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      type: :array,
+      items: { "$ref": "#/components/schemas/Partnership" },
+    },
+  },
+}.freeze


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2056

Swagger documentation allows for LP developer and integrations team to read the API structure based off of our libraries.

### Changes proposed in this pull request

- Add partnership endpoints to swagger

### Guidance to review

- [Review app swagger docs](https://cpd-ec2-review-1153-web.test.teacherservices.cloud/api/docs/v3)