### PR TITLE
Fix N+1 queries in parity check

### DIFF
--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -26,7 +26,7 @@ class Migration::ParityChecksController < ::AdminController
   end
 
   def show
-    @run = ParityCheck::Run.completed.find(params[:run_id])
+    @run = ParityCheck::Run.includes(requests: %i[lead_provider responses]).completed.find(params[:run_id])
     @breadcrumbs = {
       "Run a parity check" => new_migration_parity_check_path,
       "Completed parity checks" => completed_migration_parity_checks_path,
@@ -49,7 +49,8 @@ private
   end
 
   def load_completed_runs
-    @pagy, @completed_runs = pagy(ParityCheck::Run.completed)
+    completed_runs = ParityCheck::Run.includes(requests: %i[endpoint responses]).completed
+    @pagy, @completed_runs = pagy(completed_runs)
   end
 
   def runner_params

--- a/app/views/migration/parity_checks/show.html.erb
+++ b/app/views/migration/parity_checks/show.html.erb
@@ -36,7 +36,7 @@
         end
       end
 
-      grouped_requests(@run.requests.with_lead_provider(lead_provider)).each do |group_name, requests|
+      grouped_requests(@run.requests.select { it.lead_provider == lead_provider}).each do |group_name, requests|
         table.with_body do |body|
           requests.each do |request|  
             body.with_row do |row|


### PR DESCRIPTION
### Context

The parity check views have a few N+1 queries where we need to preload associations of the runs.

There was also a view that was re-querying grouped requests instead of operating on the already in-memory results.

Update `dispatch_requests` to batch-queue jobs to avoid an N+1 in SolidQueue.

### Changes proposed in this pull request

- Fix N+1 queries in parity check