### PR TITLE
Switch to using real lead provider names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ECF is a framework of standards to help early career teachers succeed at the sta
 * [Parity check](./documentation/parity-check.md)
 * [CSV processing](./documentation/csv-processing.md)
 * [Metadata](./documentation/metadata.md)
+* [API tokens](./documentation/api-tokens.md)
 
 ## Repository setup
 

--- a/db/seeds/lead_provider_delivery_partnerships.rb
+++ b/db/seeds/lead_provider_delivery_partnerships.rb
@@ -3,40 +3,40 @@ def describe_lead_provider_delivery_partnership(lpdp)
   print_seed_info("#{lpdp.delivery_partner.name} are working with #{alp.lead_provider.name} in #{alp.contract_period.year}")
 end
 
-ambitious_institute = LeadProvider.find_by!(name: 'Ambitious Institute')
-teach_fast = LeadProvider.find_by!(name: 'Teach Fast')
-better_practice_network = LeadProvider.find_by!(name: 'Better Practice Network')
+ambition_institute = LeadProvider.find_by!(name: 'Ambition Institute')
+teach_first = LeadProvider.find_by!(name: 'Teach First')
+best_practice_network = LeadProvider.find_by!(name: 'Best Practice Network')
 
 active_lead_providers = ActiveLeadProvider
   .eager_load(:contract_period, :lead_provider)
   .index_by { |alp| [alp.lead_provider, alp.contract_period.year] }
 
-ambitious_institute_2022 = active_lead_providers.fetch([ambitious_institute, 2022])
-ambitious_institute_2023 = active_lead_providers.fetch([ambitious_institute, 2023])
-ambitious_institute_2024 = active_lead_providers.fetch([ambitious_institute, 2024])
-ambitious_institute_2026 = active_lead_providers.fetch([ambitious_institute, 2026])
-teach_fast_2022 = active_lead_providers.fetch([teach_fast, 2022])
-teach_fast_2023 = active_lead_providers.fetch([teach_fast, 2023])
-teach_fast_2024 = active_lead_providers.fetch([teach_fast, 2024])
-teach_fast_2025 = active_lead_providers.fetch([teach_fast, 2025])
-better_practice_network_2023 = active_lead_providers.fetch([better_practice_network, 2023])
-better_practice_network_2024 = active_lead_providers.fetch([better_practice_network, 2024])
+ambition_institute_2022 = active_lead_providers.fetch([ambition_institute, 2022])
+ambition_institute_2023 = active_lead_providers.fetch([ambition_institute, 2023])
+ambition_institute_2024 = active_lead_providers.fetch([ambition_institute, 2024])
+ambition_institute_2026 = active_lead_providers.fetch([ambition_institute, 2026])
+teach_first_2022 = active_lead_providers.fetch([teach_first, 2022])
+teach_first_2023 = active_lead_providers.fetch([teach_first, 2023])
+teach_first_2024 = active_lead_providers.fetch([teach_first, 2024])
+teach_first_2025 = active_lead_providers.fetch([teach_first, 2025])
+best_practice_network_2023 = active_lead_providers.fetch([best_practice_network, 2023])
+best_practice_network_2024 = active_lead_providers.fetch([best_practice_network, 2024])
 
 artisan = DeliveryPartner.find_by!(name: "Artisan Education Group")
 grain = DeliveryPartner.find_by!(name: "Grain Teaching School Hub")
 rising_minds = DeliveryPartner.find_by!(name: "Rising Minds Network")
 
 [
-  { active_lead_provider: ambitious_institute_2022, delivery_partner: artisan },
-  { active_lead_provider: ambitious_institute_2023, delivery_partner: artisan },
-  { active_lead_provider: ambitious_institute_2024, delivery_partner: artisan },
-  { active_lead_provider: ambitious_institute_2026, delivery_partner: artisan },
-  { active_lead_provider: teach_fast_2022, delivery_partner: grain },
-  { active_lead_provider: teach_fast_2023, delivery_partner: grain },
-  { active_lead_provider: teach_fast_2024, delivery_partner: grain },
-  { active_lead_provider: teach_fast_2025, delivery_partner: grain },
-  { active_lead_provider: better_practice_network_2023, delivery_partner: rising_minds },
-  { active_lead_provider: better_practice_network_2024, delivery_partner: rising_minds }
+  { active_lead_provider: ambition_institute_2022, delivery_partner: artisan },
+  { active_lead_provider: ambition_institute_2023, delivery_partner: artisan },
+  { active_lead_provider: ambition_institute_2024, delivery_partner: artisan },
+  { active_lead_provider: ambition_institute_2026, delivery_partner: artisan },
+  { active_lead_provider: teach_first_2022, delivery_partner: grain },
+  { active_lead_provider: teach_first_2023, delivery_partner: grain },
+  { active_lead_provider: teach_first_2024, delivery_partner: grain },
+  { active_lead_provider: teach_first_2025, delivery_partner: grain },
+  { active_lead_provider: best_practice_network_2023, delivery_partner: rising_minds },
+  { active_lead_provider: best_practice_network_2024, delivery_partner: rising_minds }
 ].each do |data|
   LeadProviderDeliveryPartnership.find_or_create_by!(
     active_lead_provider: data[:active_lead_provider],

--- a/db/seeds/lead_providers.rb
+++ b/db/seeds/lead_providers.rb
@@ -9,11 +9,13 @@ def describe_lead_provider(lead_provider, years)
 end
 
 lead_providers_data = [
-  { name: 'Ambitious Institute', years: [2022, 2023, 2024, 2025, 2026] },
-  { name: 'Capitan', years: [2021, 2022, 2023] },
-  { name: 'Teach Fast', years: [2022, 2023, 2024, 2025] },
-  { name: 'International Institute of Teaching', years: [2021] },
-  { name: 'Better Practice Network', years: [2022, 2023, 2024, 2025] },
+  { name: 'Ambition Institute', years: [2022, 2023, 2024, 2025, 2026] },
+  { name: 'Best Practice Network', years: [2022, 2023, 2024, 2025] },
+  { name: 'Capita', years: [2021, 2022, 2023] },
+  { name: 'Education Development Trust', years: [2021, 2022, 2023, 2024, 2025] },
+  { name: 'National Institute of Teaching', years: [2021] },
+  { name: 'Teach First', years: [2022, 2023, 2024, 2025] },
+  { name: 'UCL Institute of Education', years: [2021, 2022, 2023, 2024, 2025] },
 ]
 
 lead_providers_data.each do |data|

--- a/db/seeds/school_partnerships.rb
+++ b/db/seeds/school_partnerships.rb
@@ -28,23 +28,23 @@ rp2022 = ContractPeriod.find_by(year: 2022)
 rp2023 = ContractPeriod.find_by(year: 2023)
 rp2025 = ContractPeriod.find_by(year: 2025)
 
-ambitious_institute = LeadProvider.find_by!(name: 'Ambitious Institute')
-teach_fast = LeadProvider.find_by!(name: 'Teach Fast')
+ambition_institute = LeadProvider.find_by!(name: 'Ambition Institute')
+teach_first = LeadProvider.find_by!(name: 'Teach First')
 
 artisan = DeliveryPartner.find_by!(name: "Artisan Education Group")
 grain = DeliveryPartner.find_by!(name: "Grain Teaching School Hub")
 
-ambitious_institute__artisan__2022 = find_lead_provider_delivery_partnership(delivery_partner: artisan, lead_provider: ambitious_institute, contract_period: rp2022)
-ambitious_institute__artisan__2023 = find_lead_provider_delivery_partnership(delivery_partner: artisan, lead_provider: ambitious_institute, contract_period: rp2023)
-teach_fast__grain__2022 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_fast, contract_period: rp2022)
-teach_fast__grain__2023 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_fast, contract_period: rp2023)
-teach_fast__grain__2025 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_fast, contract_period: rp2025)
+ambition_institute__artisan__2022 = find_lead_provider_delivery_partnership(delivery_partner: artisan, lead_provider: ambition_institute, contract_period: rp2022)
+ambition_institute__artisan__2023 = find_lead_provider_delivery_partnership(delivery_partner: artisan, lead_provider: ambition_institute, contract_period: rp2023)
+teach_first__grain__2022 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_first, contract_period: rp2022)
+teach_first__grain__2023 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_first, contract_period: rp2023)
+teach_first__grain__2025 = find_lead_provider_delivery_partnership(delivery_partner: grain, lead_provider: teach_first, contract_period: rp2025)
 [
-  { school: abbey_grove_school, lead_provider_delivery_partnership: ambitious_institute__artisan__2022 },
-  { school: abbey_grove_school, lead_provider_delivery_partnership: ambitious_institute__artisan__2023 },
-  { school: abbey_grove_school, lead_provider_delivery_partnership: teach_fast__grain__2023 },
-  { school: abbey_grove_school, lead_provider_delivery_partnership: teach_fast__grain__2025 },
-  { school: ackley_bridge, lead_provider_delivery_partnership: ambitious_institute__artisan__2023 },
-  { school: mallory_towers, lead_provider_delivery_partnership: teach_fast__grain__2022 },
-  { school: brookfield_school, lead_provider_delivery_partnership: teach_fast__grain__2022 },
+  { school: abbey_grove_school, lead_provider_delivery_partnership: ambition_institute__artisan__2022 },
+  { school: abbey_grove_school, lead_provider_delivery_partnership: ambition_institute__artisan__2023 },
+  { school: abbey_grove_school, lead_provider_delivery_partnership: teach_first__grain__2023 },
+  { school: abbey_grove_school, lead_provider_delivery_partnership: teach_first__grain__2025 },
+  { school: ackley_bridge, lead_provider_delivery_partnership: ambition_institute__artisan__2023 },
+  { school: mallory_towers, lead_provider_delivery_partnership: teach_first__grain__2022 },
+  { school: brookfield_school, lead_provider_delivery_partnership: teach_first__grain__2022 },
 ].each { |kwargs| SchoolPartnership.create!(**kwargs).tap { |sp| describe_school_partnership(sp) } }

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -101,9 +101,9 @@ def describe_mentor_at_school_period(sp)
   print_seed_info("* was a mentor at #{sp.school.name} from #{sp.started_on} #{describe_period_duration(sp)} #{suffix}", indent: 4)
 end
 
-ambitious_institute = LeadProvider.find_by!(name: 'Ambitious Institute')
-teach_fast = LeadProvider.find_by!(name: 'Teach Fast')
-better_practice_network = LeadProvider.find_by!(name: 'Better Practice Network')
+ambition_institute = LeadProvider.find_by!(name: 'Ambition Institute')
+teach_first = LeadProvider.find_by!(name: 'Teach First')
+best_practice_network = LeadProvider.find_by!(name: 'Best Practice Network')
 
 abbey_grove_school = School.find_by!(urn: 1_759_427)
 ackley_bridge = School.find_by!(urn: 3_375_958)
@@ -131,29 +131,29 @@ cp_2023 = ContractPeriod.find_by(year: 2023)
 _cp_2024 = ContractPeriod.find_by(year: 2024)
 cp_2025 = ContractPeriod.find_by(year: 2025)
 
-ambitious_artisan_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: ambitious_institute)
-ambitious_artisan_2023 = ActiveLeadProvider.find_by!(contract_period: cp_2023, lead_provider: ambitious_institute)
-teach_fast_grain_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: teach_fast)
-teach_fast_grain_2025 = ActiveLeadProvider.find_by!(contract_period: cp_2025, lead_provider: teach_fast)
+ambition_artisan_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: ambition_institute)
+ambition_artisan_2023 = ActiveLeadProvider.find_by!(contract_period: cp_2023, lead_provider: ambition_institute)
+teach_first_grain_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: teach_first)
+teach_first_grain_2025 = ActiveLeadProvider.find_by!(contract_period: cp_2025, lead_provider: teach_first)
 
-ambitious_artisan_partnership_2022 = find_school_partnership(
-  lead_provider: ambitious_institute,
+ambition_artisan_partnership_2022 = find_school_partnership(
+  lead_provider: ambition_institute,
   delivery_partner: artisan_education_group,
   contract_period: ContractPeriod.find_by!(year: 2022)
 )
-ambitious_artisan_partnership_2023 = find_school_partnership(
-  lead_provider: ambitious_institute,
+ambition_artisan_partnership_2023 = find_school_partnership(
+  lead_provider: ambition_institute,
   delivery_partner: artisan_education_group,
   contract_period: ContractPeriod.find_by!(year: 2023)
 )
-teach_fast_grain_partnership_2022 = find_school_partnership(
+teach_first_grain_partnership_2022 = find_school_partnership(
   contract_period: ContractPeriod.find_by!(year: 2022),
-  lead_provider: teach_fast,
+  lead_provider: teach_first,
   delivery_partner: grain_teaching_school_hub
 )
-teach_fast_grain_partnership_2025 = find_school_partnership(
+teach_first_grain_partnership_2025 = find_school_partnership(
   contract_period: ContractPeriod.find_by!(year: 2025),
-  lead_provider: teach_fast,
+  lead_provider: teach_first,
   delivery_partner: grain_teaching_school_hub
 )
 
@@ -171,8 +171,8 @@ TrainingPeriod.create!(
   mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
   started_on: 3.years.ago,
   finished_on: 140.weeks.ago,
-  expression_of_interest: ambitious_artisan_2022,
-  school_partnership: ambitious_artisan_partnership_2022,
+  expression_of_interest: ambition_artisan_2022,
+  school_partnership: ambition_artisan_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -182,7 +182,7 @@ TrainingPeriod.create!(
   mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
   started_on: 130.weeks.ago,
   finished_on: nil,
-  school_partnership: ambitious_artisan_partnership_2022,
+  school_partnership: ambition_artisan_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -202,8 +202,8 @@ kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: kate_winslet_ect_at_ackley_bridge,
   started_on: 1.year.ago,
-  expression_of_interest: ambitious_artisan_2023,
-  school_partnership: ambitious_artisan_partnership_2023,
+  expression_of_interest: ambition_artisan_2023,
+  school_partnership: ambition_artisan_partnership_2023,
   training_programme: 'school_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -238,8 +238,8 @@ hugh_laurie_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: hugh_laurie_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
-  expression_of_interest: teach_fast_grain_2022,
-  school_partnership: teach_fast_grain_partnership_2022,
+  expression_of_interest: teach_first_grain_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -256,14 +256,14 @@ alan_rickman_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
   training_programme: 'provider_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
-ackley_bridge.update!(last_chosen_lead_provider: better_practice_network,
+ackley_bridge.update!(last_chosen_lead_provider: best_practice_network,
                       last_chosen_appropriate_body: golden_leaf_teaching_school_hub,
                       last_chosen_training_programme: 'provider_led')
 
 TrainingPeriod.create!(
   ect_at_school_period: alan_rickman_ect_at_ackley_bridge,
   started_on: 2.years.ago + 1.month,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -352,7 +352,7 @@ abbey_grove_school.update!(last_chosen_lead_provider: nil,
 TrainingPeriod.create!(
   ect_at_school_period: colin_firth_ect_at_abbey_grove,
   started_on: 2.years.ago,
-  school_partnership: ambitious_artisan_partnership_2022,
+  school_partnership: ambition_artisan_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -442,7 +442,7 @@ imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: imogen_stubbs_at_malory_towers,
   started_on: 1.year.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'school_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -473,14 +473,14 @@ gemma_jones_at_malory_towers = ECTAtSchoolPeriod.create!(
   training_programme: 'provider_led'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
-mallory_towers.update!(last_chosen_lead_provider: better_practice_network,
+mallory_towers.update!(last_chosen_lead_provider: best_practice_network,
                        last_chosen_appropriate_body: golden_leaf_teaching_school_hub,
                        last_chosen_training_programme: 'provider_led')
 
 TrainingPeriod.create!(
   ect_at_school_period: gemma_jones_at_malory_towers,
   started_on: 20.months.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -502,7 +502,7 @@ andre_roussimoff_mentoring_at_ackley_bridge = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: andre_roussimoff_mentoring_at_ackley_bridge,
   started_on: 1.year.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -522,7 +522,7 @@ anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: anthony_hopkins_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -539,14 +539,14 @@ stephen_fry_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
   working_pattern: 'part_time'
 ).tap { |sp| describe_ect_at_school_period(sp) }
 
-brookfield_school.update!(last_chosen_lead_provider: teach_fast,
+brookfield_school.update!(last_chosen_lead_provider: teach_first,
                           last_chosen_appropriate_body: south_yorkshire_studio_hub,
                           last_chosen_training_programme: 'provider_led')
 
 TrainingPeriod.create!(
   ect_at_school_period: stephen_fry_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -564,7 +564,7 @@ harriet_walter_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: harriet_walter_ect_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -581,7 +581,7 @@ helen_mirren_mentoring_at_brookfield_school = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: helen_mirren_mentoring_at_brookfield_school,
   started_on: 2.years.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -598,7 +598,7 @@ john_withers_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   mentor_at_school_period: john_withers_mentoring_at_abbey_grove,
   started_on: 2.years.ago,
-  school_partnership: teach_fast_grain_partnership_2022,
+  school_partnership: teach_first_grain_partnership_2022,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -617,7 +617,7 @@ dominic_west_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: dominic_west_ect_at_brookfield_school,
   started_on: 18.months.ago,
-  expression_of_interest: ambitious_artisan_2023,
+  expression_of_interest: ambition_artisan_2023,
   training_programme: 'provider_led'
 ).tap { |tp| describe_training_period(tp) }
 
@@ -636,9 +636,9 @@ peter_davison_at_abbey_grove_school = ECTAtSchoolPeriod.create!(
 TrainingPeriod.create!(
   ect_at_school_period: peter_davison_at_abbey_grove_school,
   started_on: 2.weeks.from_now,
-  school_partnership: teach_fast_grain_partnership_2025,
+  school_partnership: teach_first_grain_partnership_2025,
   training_programme: 'provider_led',
-  expression_of_interest: teach_fast_grain_2025
+  expression_of_interest: teach_first_grain_2025
 ).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Adding mentorships:")

--- a/documentation/api-tokens.md
+++ b/documentation/api-tokens.md
@@ -1,0 +1,27 @@
+# API tokens
+
+## Development/review
+
+We generate tokens for each lead provider in the review apps (via the development database seeds) to make testing easier. The tokens are the lead provider names, lower case and hyphenated:
+
+```
+Ambition Institute              => ambition-institute
+Best Practice Network           => best-practice-network
+Capita                          => capita
+Education Development Trust     => education-development-trust
+National Institute of Teaching  => national-institute-of-teaching
+Teach First                     => teach-first
+UCL Institute of Education      => ucl-institute-of-education
+```
+
+## Staging
+
+The staging tokens are currently configured as above; the lead provider name lower case and hyphenated.  
+
+## Sandbox
+
+The sandbox tokens have been distributed to lead providers via galaxkey and are also available in [this spreadsheet](https://educationgovuk.sharepoint.com/:x:/r/sites/TeacherServices/Shared%20Documents/Teacher%20Continuing%20Professional%20Development/Teacher%20CPD%20Team/Register%20early%20career%20teachers/Beta/Dev/RECT%20API%20tokens.xlsx?d=w645914cfeed84fddbeb4a31e1ade1bbf&csf=1&web=1&e=VPmgan).
+
+## Production
+
+At the time of writing, there are no lead provider records in production as we have not yet migrated the data across from ECF.


### PR DESCRIPTION
### Context

Originally we used similar but different lead provider names in development and review. This was in an effort to reduce the risk of changing something in an environment accidentally, however its caused more issues and confusion than we expected so we are going to use the normal/real lead provider names everywhere.

### Changes proposed in this pull request

- Switch to using real lead provider names

### Guidance to review

I've also added some missing lead providers from the review/development seeds.
