### PR TITLE
Group induction records by provider for training period migration

### DIFF
--- a/app/migration/builders/builder_helpers.rb
+++ b/app/migration/builders/builder_helpers.rb
@@ -1,0 +1,11 @@
+module Builders
+  module BuilderHelpers
+    def find_school_partnership!(training_period_data, school)
+      lead_provider = ::LeadProvider.find_by!(name: training_period_data.lead_provider)
+      active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: training_period_data.cohort_year)
+      delivery_partner = ::DeliveryPartner.find_by!(name: training_period_data.delivery_partner)
+      lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
+      ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
+    end
+  end
+end

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -13,32 +13,41 @@ module Builders
         period_date = Data.define(:started_on, :finished_on)
 
         training_period_data.each do |period|
-          next unless period.training_programme == "full_induction_programme"
-
-          lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
-          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: period.cohort_year)
-          delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
-          lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
-
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
-          ect_at_school_period = teacher.ect_at_school_periods.containing_period(period_dates).first
-          school = ect_at_school_period&.school
+          school = School.find_by!(urn: period.school_urn)
 
-          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
+          ect_at_school_period = teacher
+            .ect_at_school_periods
+            .where(school_id: school.id)
+            .containing_period(period_dates)
+            .first
 
           training_period = ::TrainingPeriod.find_or_initialize_by(ecf_start_induction_record_id: period.start_source_id)
+          training_period.training_programme = period.training_programme
           training_period.ect_at_school_period = ect_at_school_period
-          training_period.school_partnership = school_partnership
           training_period.started_on = period.start_date
           training_period.finished_on = period.end_date
           training_period.ecf_end_induction_record_id = period.end_source_id
-          training_period.training_programme = period.training_programme.in?(%w[core_induction_programme design_our_own]) ? "school_led" : "provider_led"
+
+          training_period.school_partnership = if period.training_programme == "provider_led"
+                                                 training_period.school_partnership = find_partnership!(period, school)
+                                               else
+                                                 nil
+                                               end
           training_period.save!
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, model: :training_period, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")
           success = false
         end
         success
+      end
+
+      def find_partnership!(period, school)
+        lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
+        active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: period.cohort_year)
+        delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
+        lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
+        ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
       end
     end
   end

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -32,8 +32,6 @@ module Builders
 
           training_period.school_partnership = if period.training_programme == "provider_led"
                                                  find_school_partnership!(period, school)
-                                               else
-                                                 nil
                                                end
           training_period.save!
         rescue ActiveRecord::ActiveRecordError => e

--- a/app/migration/builders/ect/training_periods.rb
+++ b/app/migration/builders/ect/training_periods.rb
@@ -1,6 +1,8 @@
 module Builders
   module ECT
     class TrainingPeriods
+      include Builders::BuilderHelpers
+
       attr_reader :teacher, :training_period_data
 
       def initialize(teacher:, training_period_data:)
@@ -11,7 +13,6 @@ module Builders
       def build
         success = true
         period_date = Data.define(:started_on, :finished_on)
-
         training_period_data.each do |period|
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           school = School.find_by!(urn: period.school_urn)
@@ -30,7 +31,7 @@ module Builders
           training_period.ecf_end_induction_record_id = period.end_source_id
 
           training_period.school_partnership = if period.training_programme == "provider_led"
-                                                 training_period.school_partnership = find_partnership!(period, school)
+                                                 find_school_partnership!(period, school)
                                                else
                                                  nil
                                                end
@@ -40,14 +41,6 @@ module Builders
           success = false
         end
         success
-      end
-
-      def find_partnership!(period, school)
-        lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
-        active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: period.cohort_year)
-        delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
-        lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
-        ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
       end
     end
   end

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -1,6 +1,8 @@
 module Builders
   module Mentor
     class TrainingPeriods
+      include Builders::BuilderHelpers
+
       attr_reader :teacher, :training_period_data
 
       def initialize(teacher:, training_period_data:)
@@ -13,26 +15,28 @@ module Builders
         period_date = Data.define(:started_on, :finished_on)
 
         training_period_data.each do |period|
-          next unless period.training_programme == "full_induction_programme"
-
-          lead_provider = ::LeadProvider.find_by!(name: period.lead_provider)
-          active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period_year: period.cohort_year)
-          delivery_partner = ::DeliveryPartner.find_by!(name: period.delivery_partner)
-          lead_provider_delivery_partnership = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
-
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
-          mentor_at_school_period = teacher.mentor_at_school_periods.containing_period(period_dates).first
-
-          school = mentor_at_school_period&.school
-          school_partnership = ::SchoolPartnership.find_by!(lead_provider_delivery_partnership:, school:)
+          school = School.find_by!(urn: period.school_urn)
+          
+          mentor_at_school_period = teacher
+            .mentor_at_school_periods
+            .where(school_id: school.id)
+            .containing_period(period_dates)
+            .first
 
           training_period = ::TrainingPeriod.find_or_initialize_by(ecf_start_induction_record_id: period.start_source_id)
+          training_period.training_programme = period.training_programme
           training_period.mentor_at_school_period = mentor_at_school_period
-          training_period.school_partnership = school_partnership
           training_period.started_on = period.start_date
           training_period.finished_on = period.end_date
           training_period.ecf_end_induction_record_id = period.end_source_id
-          training_period.training_programme = period.training_programme.in?(%w[core_induction_programme design_our_own]) ? "school_led" : "provider_led"
+
+          training_period.school_partnership = if period.training_programme == "provider_led"
+                                                 find_school_partnership!(period, school)
+                                               else
+                                                 nil
+                                               end
+
           training_period.save!
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, model: :training_period, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")

--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -17,7 +17,7 @@ module Builders
         training_period_data.each do |period|
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           school = School.find_by!(urn: period.school_urn)
-          
+
           mentor_at_school_period = teacher
             .mentor_at_school_periods
             .where(school_id: school.id)
@@ -33,8 +33,6 @@ module Builders
 
           training_period.school_partnership = if period.training_programme == "provider_led"
                                                  find_school_partnership!(period, school)
-                                               else
-                                                 nil
                                                end
 
           training_period.save!

--- a/app/migration/induction_record_sanitizer.rb
+++ b/app/migration/induction_record_sanitizer.rb
@@ -95,7 +95,7 @@ private
         .induction_records
         .eager_load(induction_programme: :partnership)
         .order(:start_date, :created_at)
-        .group_by { |ir| ir.induction_programme.partnership&.lead_provider_id }
+        .group_by { |ir| [rect_training_type(ir.induction_programme.training_programme), ir.induction_programme.partnership&.lead_provider_id] }
     when :none
       participant_profile
         .induction_records
@@ -104,6 +104,10 @@ private
     else
       raise InductionRecordError, "invalid grouping specified [#{group_by}]"
     end
+  end
+
+  def rect_training_type(ecf_training_programme)
+    Mappers::TrainingProgrammeMapper.new(ecf_training_programme).mapped_value
   end
 
   def enumerate_by_provider

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -48,7 +48,7 @@ module Migrators
           else
             ::TeacherMigrationFailure.create!(teacher:,
                                               model: :ect_at_school_period,
-                                              message: induction_records.error,
+                                              message: sanitizer.error,
                                               migration_item_id: participant_profile.id,
                                               migration_item_type: participant_profile.class.name)
             result = false

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -48,7 +48,7 @@ module Migrators
           else
             ::TeacherMigrationFailure.create!(teacher:,
                                               model: :mentor_at_school_period,
-                                              message: induction_records.error,
+                                              message: sanitizer.error,
                                               migration_item_id: participant_profile.id,
                                               migration_item_type: participant_profile.class.name)
             result = false

--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -71,6 +71,7 @@ private
 
     return false unless last_type == "school_led"
     return false if last_programme.school_cohort.school_id != next_programme.school_cohort.school_id
+
     last_type == next_type
   end
 end

--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -11,11 +11,11 @@ class TrainingPeriodExtractor
     training_periods.each(&block)
   end
 
-private
-
   def training_periods
     @training_periods ||= build_training_periods
   end
+
+private
 
   def build_training_periods
     current_period = nil
@@ -31,14 +31,20 @@ private
         # is that the correct approach?
         next if record_programme.training_programme == "full_induction_programme" && record_programme.partnership.nil?
 
+        # if we have e.g. CIP and switch to DIY it is still a school_led programme so don't need to create a new period
+        # often this appears to be the SIT unsure what option to choose
+        next if current_programme.present? && school_led_and_not_changing_type?(current_programme, record_programme)
+
         current_programme = record_programme
 
+        training_programme = mapped_training_programme(current_programme.training_programme)
         lead_provider = current_programme.partnership&.lead_provider&.name
         delivery_partner = current_programme.partnership&.delivery_partner&.name
         core_materials = current_programme.core_induction_programme&.name
+        school_urn = current_programme.school_cohort.school.urn
 
-        # TODO: check - should we skip CIP without materials?
-        current_period = Migration::TrainingPeriodData.new(training_programme: current_programme.training_programme,
+        current_period = Migration::TrainingPeriodData.new(training_programme:,
+                                                           school_urn:,
                                                            lead_provider:,
                                                            delivery_partner:,
                                                            core_materials:,
@@ -53,5 +59,18 @@ private
         current_period.end_source_id = induction_record.id
       end
     end
+  end
+
+  def mapped_training_programme(ecf_training)
+    Mappers::TrainingProgrammeMapper.new(ecf_training).mapped_value
+  end
+
+  def school_led_and_not_changing_type?(last_programme, next_programme)
+    last_type = mapped_training_programme(last_programme.training_programme)
+    next_type = mapped_training_programme(next_programme.training_programme)
+
+    return false unless last_type == "school_led"
+    return false if last_programme.school_cohort.school_id != next_programme.school_cohort.school_id
+    last_type == next_type
   end
 end

--- a/app/models/migration/training_period_data.rb
+++ b/app/models/migration/training_period_data.rb
@@ -4,11 +4,12 @@ module Migration
   #       multiple places and make it easier to test the code that uses it
   class TrainingPeriodData
     attr_accessor :training_programme, :lead_provider, :delivery_partner, :core_materials, :cohort_year,
-                  :start_date, :end_date, :start_source_id, :end_source_id
+                  :school_urn, :start_date, :end_date, :start_source_id, :end_source_id
 
-    def initialize(training_programme:, lead_provider:, delivery_partner:, core_materials:,
+    def initialize(training_programme:, school_urn:, lead_provider:, delivery_partner:, core_materials:,
                    cohort_year:, start_date:, end_date:, start_source_id:, end_source_id:)
       @training_programme = training_programme
+      @school_urn = school_urn
       @lead_provider = lead_provider
       @delivery_partner = delivery_partner
       @core_materials = core_materials

--- a/spec/factories/migration/training_period_factory.rb
+++ b/spec/factories/migration/training_period_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :training_period_data, class: "Migration::TrainingPeriodData" do
     school_urn { FactoryBot.create(:school).urn }
-    training_programme { "full_induction_programme" }
+    training_programme { "provider_led" }
     lead_provider { "Ace Provider" }
     delivery_partner { "Whizzy Delivery" }
     core_materials { nil }

--- a/spec/factories/migration/training_period_factory.rb
+++ b/spec/factories/migration/training_period_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :training_period_data, class: "Migration::TrainingPeriodData" do
+    school_urn { FactoryBot.create(:school).urn }
     training_programme { "full_induction_programme" }
     lead_provider { "Ace Provider" }
     delivery_partner { "Whizzy Delivery" }

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -11,10 +11,12 @@ describe Builders::ECT::TrainingPeriods do
   let(:partnership_2) { make_partnership_for(school_2, contract_period) }
 
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:school_period_1) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
-  let!(:school_period_2) { FactoryBot.create(:ect_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
-  let(:training_period_1) { FactoryBot.build(:training_period_data, school_urn: school_1.urn, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:training_period_2) { FactoryBot.build(:training_period_data, school_urn: school_2.urn, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:started_on) { contract_period.started_on }
+
+  let!(:school_period_1) { FactoryBot.create(:ect_at_school_period, started_on:, finished_on: started_on + 10.months, teacher:, school: school_1) }
+  let!(:school_period_2) { FactoryBot.create(:ect_at_school_period, started_on: started_on + 11.months, finished_on: nil, teacher:, school: school_2) }
+  let(:training_period_1) { FactoryBot.build(:training_period_data, school_urn: school_1.urn, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: school_period_1.started_on, end_date: school_period_1.finished_on) }
+  let(:training_period_2) { FactoryBot.build(:training_period_data, school_urn: school_2.urn, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: school_period_2.started_on, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
   describe "#build" do

--- a/spec/migration/builders/ect/training_periods_spec.rb
+++ b/spec/migration/builders/ect/training_periods_spec.rb
@@ -13,8 +13,8 @@ describe Builders::ECT::TrainingPeriods do
   let(:teacher) { FactoryBot.create(:teacher) }
   let!(:school_period_1) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
   let!(:school_period_2) { FactoryBot.create(:ect_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
-  let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:training_period_1) { FactoryBot.build(:training_period_data, school_urn: school_1.urn, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
+  let(:training_period_2) { FactoryBot.build(:training_period_data, school_urn: school_2.urn, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
   describe "#build" do

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -10,10 +10,12 @@ describe Builders::Mentor::TrainingPeriods do
   let(:partnership_2) { make_partnership_for(school_2, contract_period) }
 
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:school_period_1) { FactoryBot.create(:mentor_at_school_period, started_on: 1.year.ago.to_date, finished_on: 1.month.ago.to_date, teacher:, school: school_1) }
-  let!(:school_period_2) { FactoryBot.create(:mentor_at_school_period, started_on: 1.month.ago.to_date, finished_on: nil, teacher:, school: school_2) }
-  let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
-  let(:training_period_2) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: 1.month.ago.to_date, end_date: nil) }
+  let(:started_on) { contract_period.started_on }
+
+  let!(:school_period_1) { FactoryBot.create(:mentor_at_school_period, started_on:, finished_on: started_on + 10.months, teacher:, school: school_1) }
+  let!(:school_period_2) { FactoryBot.create(:mentor_at_school_period, started_on: started_on + 12.months, finished_on: nil, teacher:, school: school_2) }
+  let(:training_period_1) { FactoryBot.build(:training_period_data, school_urn: school_1.urn, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: school_period_1.started_on, end_date: school_period_1.finished_on) }
+  let(:training_period_2) { FactoryBot.build(:training_period_data, school_urn: school_2.urn, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, start_date: school_period_2.started_on, end_date: nil) }
   let(:training_period_data) { [training_period_1, training_period_2] }
 
   describe "#build" do


### PR DESCRIPTION
### Context

For the `ECTAtSchoolPeriod` and `MentorAtSchoolPeriod` we've had good results by grouping the participant's ECF `InductionRecord`s by school.  This PR was original a spike to check if we could get better results (i.e. less validation errors) when migrating `TrainingPeriod` by grouping the `InductionRecord`s by the provider.  This has yielded an improvement (albeit not as big as for the school periods) so is worth pursuing further.

### Changes proposed in this pull request

Group participant's induction records by provider when parsing and validating them.

### Guidance to review
