### PR TITLE
Remove training programme enum from ect at school periods

### DIFF
--- a/app/components/schools/mentors/ect_mentor_training_details_component.rb
+++ b/app/components/schools/mentors/ect_mentor_training_details_component.rb
@@ -11,7 +11,7 @@ module Schools
       end
 
       def render?
-        assigned_ects.any?(&:provider_led?)
+        assigned_ects.any?(&:provider_led_training_programme?)
       end
 
       def eligible_for_training?

--- a/app/components/schools/summary_card_component.rb
+++ b/app/components/schools/summary_card_component.rb
@@ -53,7 +53,7 @@ module Schools
     def school_rows
       [
         { key: { text: 'Appropriate body' }, value: { text: @ect_at_school_period.school_reported_appropriate_body_name } },
-        { key: { text: 'Training programme' }, value: { text: training_programme_name(@ect_at_school_period.training_programme) } }
+        { key: { text: 'Training programme' }, value: { text: training_programme_name(@training_period.training_programme) } }
       ].tap do |rows|
         rows << { key: { text: 'Lead provider' }, value: { text: @training_period.lead_provider_name } } if @training_period&.provider_led_training_programme?
       end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -1,13 +1,6 @@
 class ECTAtSchoolPeriod < ApplicationRecord
   include Interval
 
-  # Enums
-  enum :training_programme,
-       { provider_led: "provider_led",
-         school_led: "school_led" },
-       validate: { message: "Must be provider-led or school-led" },
-       suffix: :training_programme
-
   # Associations
   belongs_to :school, inverse_of: :ect_at_school_periods
   belongs_to :teacher, inverse_of: :ect_at_school_periods
@@ -62,16 +55,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
     .where(expression_of_interest: { lead_provider_id: })
   }
 
-  # Instance methods
-
-  def provider_led?
-    training_programme == 'provider_led'
-  end
-
-  def school_led?
-    training_programme == 'school_led'
-  end
-
   def school_reported_appropriate_body_name = school_reported_appropriate_body&.name
 
   def school_reported_appropriate_body_type = school_reported_appropriate_body&.body_type
@@ -83,6 +66,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   end
 
   delegate :trn, to: :teacher
+  delegate :provider_led_training_programme?, to: :current_training_period, allow_nil: true
+  delegate :school_led_training_programme?, to: :current_training_period, allow_nil: true
 
 private
 

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -95,7 +95,6 @@ module Schools
     def start_at_school!
       teacher.ect_at_school_periods.build(school_reported_appropriate_body:,
                                           email:,
-                                          training_programme:,
                                           school:,
                                           started_on:,
                                           working_pattern:) do |ect|

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -14,8 +14,8 @@
     ) %>
 
     <%= render Schools::Mentors::ECTMentorTrainingDetailsComponent.new(
-          teacher: @teacher,
-          mentor: @mentor
-        ) %>
+      teacher: @teacher,
+      mentor: @mentor
+    ) %>
   </div>
 </div>

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -97,7 +97,7 @@ module Schools
       end
 
       def previous_provider_led?
-        previous_ect_at_school_period&.provider_led_training_programme?
+        previous_training_period&.provider_led_training_programme?
       end
 
       def previous_school

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -108,7 +108,7 @@ module Schools
       delegate :name, to: :previous_school, prefix: true, allow_nil: true
 
       def previous_training_programme
-        previous_ect_at_school_period&.training_programme
+        previous_training_period&.training_programme
       end
 
       def provider_led?

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -112,7 +112,7 @@ module Schools
 
       # Is mentor being assigned to a provider-led ECT?
       def provider_led_ect?
-        ect&.provider_led?
+        ect&.provider_led_training_programme?
       end
 
       # Does that mentor have a mentor_became_ineligible_for_funding_on?

--- a/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
+++ b/spec/components/schools/mentors/ect_mentor_training_details_component_spec.rb
@@ -3,6 +3,9 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
   let(:mentor_start_date) { Date.new(2023, 1, 1) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date, finished_on: nil) }
   let(:teacher) { FactoryBot.create(:teacher, mentor_became_ineligible_for_funding_on: nil) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
 
   context 'when teacher is eligible and there is a provider-led ECT with a lead provider' do
     let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Hidden leaf village') }
@@ -14,13 +17,13 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
                         teacher: ect_teacher,
                         school:,
                         lead_provider:,
-                        training_programme: 'provider_led',
                         started_on: ect_start_date,
                         finished_on: nil)
     end
 
     before do
       FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+      FactoryBot.create(:training_period, :ongoing, :provider_led, school_partnership:, ect_at_school_period: ect)
     end
 
     it 'renders the summary cards' do
@@ -44,13 +47,13 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
       FactoryBot.create(:ect_at_school_period,
                         teacher: ect_teacher,
                         school:,
-                        training_programme: 'provider_led',
                         started_on: ect_start_date,
                         finished_on: nil)
     end
 
     before do
       FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: ect_start_date, finished_on: nil)
+      FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect)
     end
 
     it 'renders the ineligible message' do
@@ -65,7 +68,6 @@ RSpec.describe Schools::Mentors::ECTMentorTrainingDetailsComponent, type: :compo
       FactoryBot.create(:ect_at_school_period,
                         teacher: ect_teacher,
                         school:,
-                        training_programme: 'school_led',
                         started_on: mentor_start_date + 1.month,
                         finished_on: nil)
     end

--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
   factory(:contract_period) do
     year { generate(:base_contract_period) }
 
+    trait :current do
+      year { Time.zone.today.year }
+    end
+
     started_on { Date.new(year, 6, 1) }
     finished_on { Date.new(year.next, 5, 31) }
 

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     association :teacher
 
     independent_school
-    provider_led
 
     started_on { generate(:base_ect_date) }
     finished_on { started_on + 1.day }
@@ -25,14 +24,6 @@ FactoryBot.define do
     trait :ongoing do
       started_on { generate(:base_ect_date) + 1.year }
       finished_on { nil }
-    end
-
-    trait :provider_led do
-      training_programme { 'provider_led' }
-    end
-
-    trait :school_led do
-      training_programme { 'school_led' }
     end
 
     trait :independent_school do

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   scenario 'mentor has existing mentorship and is not mentoring at new school only' do
     given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
     and_mentor_has_existing_mentorship_at_another_school
     and_i_sign_in_as_that_school_user
@@ -45,14 +46,22 @@ RSpec.describe 'Registering a mentor', :js do
     @school = FactoryBot.create(:school, urn: "1234567")
   end
 
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period = FactoryBot.create(:contract_period, :current)
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: @contract_period, lead_provider: @lead_provider)
+    @lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: @active_lead_provider)
+    @school_partnership = FactoryBot.create(:school_partnership, school: @school, lead_provider_delivery_partnership: @lead_provider_delivery_partnership)
+  end
+
   def and_i_sign_in_as_that_school_user
     sign_in_as_school_user(school: @school)
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
     @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
+    @training_period = FactoryBot.create(:training_period, :ongoing, :provider_led, school_partnership: @school_partnership, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe 'Registering a mentor', :js do
     @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
     FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period:)
 
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
+    @training_period = FactoryBot.create(:training_period, :ongoing, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   scenario 'mentor has existing mentorship, mentoring at new school only and is eligible for funding with provider-led ect' do
     given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
     and_mentor_has_existing_mentorship_at_another_school
     and_i_sign_in_as_that_school_user
@@ -60,10 +61,18 @@ RSpec.describe 'Registering a mentor', :js do
     sign_in_as_school_user(school: @school)
   end
 
-  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period = FactoryBot.create(:contract_period, :current)
     @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: @contract_period, lead_provider: @lead_provider)
+    @lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: @active_lead_provider)
+    @school_partnership = FactoryBot.create(:school_partnership, school: @school, lead_provider_delivery_partnership: @lead_provider_delivery_partnership)
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @training_period = FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: @ect, school_partnership: @school_partnership)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :school_led, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @training_period = FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   scenario 'happy path' do
     given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
     and_i_sign_in_as_that_school_user
     and_i_am_on_the_schools_landing_page
@@ -40,6 +41,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   scenario 'check your answers' do
     given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
     and_i_sign_in_as_that_school_user
     and_i_am_on_the_schools_landing_page
@@ -83,14 +85,22 @@ RSpec.describe 'Registering a mentor', :js do
     @school = FactoryBot.create(:school, urn: "1234567")
   end
 
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period = FactoryBot.create(:contract_period, :current)
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: @contract_period, lead_provider: @lead_provider)
+    @lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: @active_lead_provider)
+    @school_partnership = FactoryBot.create(:school_partnership, school: @school, lead_provider_delivery_partnership: @lead_provider_delivery_partnership)
+  end
+
   def and_i_sign_in_as_that_school_user
     sign_in_as_school_user(school: @school)
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
     contract_period = FactoryBot.create(:contract_period, year: Date.current.year)
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, contract_period:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, contract_period:, school: @school)
+    @training_period = FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe 'Selecting a different lead provider' do
 
   scenario 'Registering a new mentor' do
     given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
     and_i_sign_in_as_that_school_user
     and_i_click_to_assign_a_mentor_to_the_ect
@@ -28,6 +29,14 @@ RSpec.describe 'Selecting a different lead provider' do
     then_i_should_be_taken_to_the_confirmation_page
   end
 
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period = FactoryBot.create(:contract_period, :current)
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: @contract_period, lead_provider: @lead_provider)
+    @lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: @active_lead_provider)
+    @school_partnership = FactoryBot.create(:school_partnership, school: @school, lead_provider_delivery_partnership: @lead_provider_delivery_partnership)
+  end
+
   def and_the_back_link_points_to_the_eligibility_lead_provider_page
     expect(page.get_by_role('link', name: 'Back', exact: true).get_attribute('href')).to end_with('/school/register-mentor/eligibility-lead-provider')
   end
@@ -47,13 +56,11 @@ RSpec.describe 'Selecting a different lead provider' do
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     contract_period = FactoryBot.create(:contract_period, year: Date.current.year)
 
-    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period:)
-
     @another_lead_provider = FactoryBot.create(:lead_provider, name: "Another lead provider")
     FactoryBot.create(:active_lead_provider, lead_provider: @another_lead_provider, contract_period:)
 
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :provider_led, :ongoing, lead_provider: @lead_provider, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @training_period = FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -27,13 +27,13 @@ private
     @ect_teacher = FactoryBot.create(:teacher, trs_first_name: 'Boruto', trs_last_name: 'Uzumaki')
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :provider_led,
       teacher: @ect_teacher,
       school: @school,
       started_on: start_date,
       finished_on: nil
     )
 
+    FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect)
     FactoryBot.create(:mentorship_period, mentor: @mentor, mentee: @ect, started_on: start_date, finished_on: nil)
   end
 

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
 
   scenario 'happy path' do
     given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
     and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
     and_i_sign_in_as_that_school_user
@@ -46,15 +47,23 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
     @school = FactoryBot.create(:school, urn: "1234567")
   end
 
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period = FactoryBot.create(:contract_period, :current)
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: @contract_period, lead_provider: @lead_provider)
+    @lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: @active_lead_provider)
+    @school_partnership = FactoryBot.create(:school_partnership, school: @school, lead_provider_delivery_partnership: @lead_provider_delivery_partnership)
+  end
+
   def and_i_sign_in_as_that_school_user
     sign_in_as_school_user(school: @school)
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    lead_provider = FactoryBot.create(:lead_provider, name: "Xavier's School for Gifted Youngsters")
-    FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: FactoryBot.create(:contract_period, year: Date.current.year))
-    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider:, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, lead_provider: @lead_provider, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
+
+    FactoryBot.create(:training_period, :ongoing, school_partnership: @school_partnership, ect_at_school_period: @ect)
   end
 
   def and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -1,15 +1,4 @@
 describe ECTAtSchoolPeriod do
-  describe "enums" do
-    it do
-      is_expected.to define_enum_for(:training_programme)
-                       .with_values({ provider_led: "provider_led",
-                                      school_led: "school_led" })
-                       .validating
-                       .with_suffix(:training_programme)
-                       .backed_by_column_of_type(:enum)
-    end
-  end
-
   describe "associations" do
     it { is_expected.to belong_to(:school).inverse_of(:ect_at_school_periods) }
     it { is_expected.to belong_to(:teacher).inverse_of(:ect_at_school_periods) }
@@ -201,16 +190,6 @@ describe ECTAtSchoolPeriod do
             end
           end
         end
-      end
-    end
-
-    context "training_programme" do
-      subject { FactoryBot.build(:ect_at_school_period) }
-
-      it do
-        is_expected.to validate_inclusion_of(:training_programme)
-                         .in_array(%w[provider_led school_led])
-                         .with_message("Must be provider-led or school-led")
       end
     end
   end

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe 'ECT summary' do
   let(:ect) { FactoryBot.create(:ect_at_school_period, school:) }
   let(:school) { FactoryBot.create(:school) }
 
+  before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect) }
+
   describe '#show' do
     context 'when signed in as school user' do
       before do

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe Schools::RegisterECT do
           expect(ect_at_school_period.working_pattern).to eq(working_pattern)
           expect(ect_at_school_period.email).to eq(email)
           expect(ect_at_school_period.school_reported_appropriate_body_id).to eq(school_reported_appropriate_body.id)
-          expect(ect_at_school_period.training_programme).to eq(training_programme)
         end
 
         describe 'recording an event' do

--- a/spec/views/schools/mentors/show.html.erb_spec.rb
+++ b/spec/views/schools/mentors/show.html.erb_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe 'schools/mentors/show.html.erb' do
     FactoryBot.create(:mentorship_period, mentor: mentor_period, mentee: ect_period, started_on: start_date, finished_on: nil)
   end
 
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:) }
+
+  let!(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      ect_at_school_period: ect_period,
+      started_on: ect_period.started_on,
+      finished_on: nil,
+      school_partnership:
+    )
+  end
+
   before do
     assign(:mentor, mentor_period)
     assign(:teacher, mentor_teacher)
@@ -100,7 +114,11 @@ RSpec.describe 'schools/mentors/show.html.erb' do
 
   context 'when all ECTs are school-led' do
     let(:ect_period) do
-      FactoryBot.create(:ect_at_school_period, :school_led, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
+      FactoryBot.create(:ect_at_school_period, teacher: ect_teacher, school:, started_on: start_date, finished_on: nil)
+    end
+
+    let!(:training_period) do
+      FactoryBot.create(:training_period, :school_led, ect_at_school_period: ect_period, started_on: ect_period.started_on)
     end
 
     before do

--- a/spec/views/schools/register_ect_wizard/registered_before.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/registered_before.html.erb_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
       finished_on: nil,
       school:,
       teacher:,
-      started_on: Date.new(2023, 9, 1),
-      training_programme: 'provider_led'
+      started_on: Date.new(2023, 9, 1)
     )
   end
 
@@ -40,32 +39,33 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
 
   let(:wizard_ect) { Schools::RegisterECTWizard::ECT.new(store) }
 
-  before do
-    FactoryBot.create(
-      :training_period,
-      ect_at_school_period:,
-      started_on: Date.new(2023, 9, 1),
-      finished_on: Date.new(2024, 7, 31),
-      school_partnership:
-    )
-
-    FactoryBot.create(
-      :induction_period,
-      teacher:,
-      appropriate_body:,
-      started_on: Date.new(2023, 9, 1),
-      finished_on: Date.new(2024, 7, 31)
-    )
-
-    FactoryBot.create(:gias_school, school:, name: "Really cool school")
-
-    assign(:school, school)
-    assign(:ect, wizard_ect)
-    assign(:wizard, wizard)
-    render
-  end
-
   context 'Provider-led' do
+    before do
+      FactoryBot.create(
+        :training_period,
+        :provider_led,
+        ect_at_school_period:,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 7, 31),
+        school_partnership:
+      )
+
+      FactoryBot.create(
+        :induction_period,
+        teacher:,
+        appropriate_body:,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 7, 31)
+      )
+
+      FactoryBot.create(:gias_school, school:, name: "Really cool school")
+
+      assign(:school, school)
+      assign(:ect, wizard_ect)
+      assign(:wizard, wizard)
+      render
+    end
+
     it 'renders the full name in the page title' do
       expect(view.content_for(:page_title)).to include('Konohamaru Sarutobi has been registered before')
     end
@@ -102,15 +102,30 @@ RSpec.describe 'schools/register_ect_wizard/registered_before.html.erb' do
   end
 
   context 'School-led' do
-    let(:ect_at_school_period) do
+    before do
       FactoryBot.create(
-        :ect_at_school_period,
+        :training_period,
+        :school_led,
+        ect_at_school_period:,
         started_on: Date.new(2023, 9, 1),
-        finished_on: nil,
-        school:,
-        teacher:,
-        training_programme: 'school_led'
+        finished_on: Date.new(2024, 7, 31),
+        school_partnership:
       )
+
+      FactoryBot.create(
+        :induction_period,
+        teacher:,
+        appropriate_body:,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 7, 31)
+      )
+
+      FactoryBot.create(:gias_school, school:, name: "Really cool school")
+
+      assign(:school, school)
+      assign(:ect, wizard_ect)
+      assign(:wizard, wizard)
+      render
     end
 
     it 'renders the full name in the page title' do

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -1,12 +1,19 @@
 RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'FraggleRock') }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership) }
 
   let(:teacher) do
     FactoryBot.create(:teacher, trn: '1234568')
   end
 
   let(:ect) do
-    FactoryBot.create(:ect_at_school_period, :with_training_period, :ongoing, teacher:, lead_provider:)
+    FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+  end
+
+  let!(:training_period) do
+    FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, school_partnership:)
   end
 
   let(:store) do
@@ -45,7 +52,9 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
     context 'without exemption' do
       before { render }
 
-      it { expect(backlink).to have_link('Back', href: schools_register_mentor_wizard_review_mentor_eligibility_path) }
+      it do
+        expect(backlink).to have_link('Back', href: schools_register_mentor_wizard_review_mentor_eligibility_path)
+      end
     end
 
     context 'with legacy exemption' do
@@ -74,7 +83,11 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
   describe 'summary' do
     context 'with school led ect' do
       let(:ect) do
-        FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, teacher:)
+        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+      end
+
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect)
       end
 
       it 'hides lead provider' do

--- a/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/start.html.erb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   let(:continue_path) { schools_register_mentor_wizard_find_mentor_path }
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:ect_name) { Teachers::Name.new(ect.teacher).full_name }
 
   before do
@@ -46,7 +46,9 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   end
 
   context 'when the ect has chosen a provider led training programme' do
-    let(:ect) { FactoryBot.build(:ect_at_school_period, :provider_led) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+
+    before { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect) }
 
     it 'informs the user about the mentor training programme requirements' do
       render
@@ -56,7 +58,9 @@ RSpec.describe "schools/register_mentor_wizard/start.html.erb" do
   end
 
   context 'when the ect has chosen a school led training programme' do
-    let(:ect) { FactoryBot.build(:ect_at_school_period, :school_led) }
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+
+    before { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: ect) }
 
     it 'does not inform the user about the mentor training programme requirements' do
       render

--- a/spec/wizards/schools/register_ect_wizard/ect_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/ect_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
                      email: "dusty@rhodes.com",
                      appropriate_body_id: appropriate_body.id,
                      training_programme: "school_led",
-                     start_date: 'January 2025',
+                     start_date: 'January 2025', # FIXME: this should be a Date?
                      trn: "3002586",
                      trs_first_name: "Dusty",
                      trs_last_name: "Rhodes",
@@ -377,8 +377,10 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     describe '#previous_training_programme' do
       context 'when the teacher has ECTAtSchoolPeriods' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :school_led, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          school_led_ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
+          FactoryBot.create(:training_period, training_programme: :school_led, ect_at_school_period: school_led_ect_at_school_period, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
+          provider_led_ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          FactoryBot.create(:training_period, training_programme: :provider_led, ect_at_school_period: provider_led_ect_at_school_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
         end
 
         it 'returns the training programme from the latest ECTAtSchoolPeriod by started_on' do
@@ -396,7 +398,8 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
     describe '#previous_provider_led?' do
       context 'when the latest ECTAtSchoolPeriod is provider-led' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          provider_led_ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :provider_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          FactoryBot.create(:training_period, training_programme: :provider_led, ect_at_school_period: provider_led_ect_at_school_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
         end
 
         it 'returns true' do
@@ -406,7 +409,8 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
       context 'when the latest ECTAtSchoolPeriod is school-led' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, training_programme: :school_led, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 6, 1))
+          school_led_ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
+          FactoryBot.create(:training_period, training_programme: :school_led, ect_at_school_period: school_led_ect_at_school_period, started_on: Date.new(2023, 10, 1), finished_on: Date.new(2023, 12, 1))
         end
 
         it 'returns false' do
@@ -507,24 +511,38 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
 
     describe '#lead_provider_has_confirmed_partnership_for_contract_period?' do
       let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Confirmed LP') }
+      let(:contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
       let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
       let(:school) { FactoryBot.create(:school) }
+      let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:) }
+
       let(:teacher) { FactoryBot.create(:teacher) }
-      let(:contract_period) { FactoryBot.create(:contract_period, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 12, 31)) }
 
       context 'when everything is valid' do
         let!(:ect_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :provider_led,
             :with_training_period,
             teacher:,
             school:,
-            started_on: Date.new(2025, 3, 10),
-            finished_on: Date.new(2025, 10, 10),
+            started_on: Date.new(2024, 9, 10),
+            finished_on: Date.new(2025, 3, 10),
             lead_provider:,
             delivery_partner:,
             contract_period:
+          )
+        end
+
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :provider_led,
+            started_on: ect_period.started_on,
+            finished_on: ect_period.finished_on,
+            ect_at_school_period: ect_period,
+            school_partnership:
           )
         end
 
@@ -552,7 +570,6 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         let!(:ect_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :provider_led,
             :with_training_period,
             teacher:,
             school:,
@@ -577,7 +594,6 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         let!(:ect_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :provider_led,
             :with_training_period,
             teacher:,
             school:,
@@ -614,7 +630,6 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         let!(:ect_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :provider_led,
             school:,
             teacher:,
             started_on: Date.new(2025, 3, 10)
@@ -648,7 +663,6 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         let!(:ect_period) do
           FactoryBot.create(
             :ect_at_school_period,
-            :provider_led,
             school:,
             teacher:,
             started_on: Date.new(2025, 3, 10)
@@ -658,6 +672,7 @@ RSpec.describe Schools::RegisterECTWizard::ECT do
         let!(:training_period) do
           FactoryBot.create(
             :training_period,
+            :provider_led,
             :for_ect,
             ect_at_school_period: ect_period,
             started_on: Date.new(2025, 3, 10),

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -1,7 +1,7 @@
 describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
   subject { wizard.current_step }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:training_programme) { 'provider_led' }
   let(:use_previous_ect_choices) { true }
   let(:store) { FactoryBot.build(:session_repository) }
@@ -15,16 +15,20 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
 
     describe '#previous_step' do
       context 'when the mentor is available for funding' do
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+
         before do
           allow(wizard.mentor).to receive(:funding_available?).and_return(true)
         end
 
         context 'when the ect is provider led' do
+          let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect) }
+
           it { expect(subject.previous_step).to eq(:review_mentor_eligibility) }
         end
 
         context 'when the ect is not provider led' do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led) }
+          let!(:training_period) { FactoryBot.create(:training_period, :school_led, :ongoing, ect_at_school_period: ect) }
 
           it { expect(subject.previous_step).to eq(:email_address) }
         end

--- a/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
@@ -14,7 +14,8 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
   context 'with provider_led ect and without funding exemption' do
     it_behaves_like 'an email step', current_step: :email_address,
                                      previous_step: :review_mentor_details,
-                                     next_step: :review_mentor_eligibility
+                                     next_step: :review_mentor_eligibility,
+                                     training_programme: :provider_led
   end
 
   context 'with funding exemption' do
@@ -30,8 +31,7 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
   context 'with school_led ect' do
     it_behaves_like 'an email step', current_step: :email_address,
                                      previous_step: :review_mentor_details,
-                                     next_step: :check_answers do
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led) }
-    end
+                                     next_step: :check_answers,
+                                     training_programme: :school_led
   end
 end

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/email_step.rb
@@ -1,7 +1,7 @@
-RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_step:|
+RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_step:, training_programme: :provider_led|
   subject { described_class.new(wizard:) }
 
-  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
   let(:store) do
     FactoryBot.build(:session_repository,
                      trn: "1234567",
@@ -12,6 +12,8 @@ RSpec.shared_examples "an email step" do |current_step:, previous_step:, next_st
                      email: 'initial@email.com')
   end
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:, ect_id: ect.id) }
+
+  before { FactoryBot.create(:training_period, training_programme, :ongoing, ect_at_school_period: ect) }
 
   describe '#initialize' do
     subject { described_class.new(wizard:, **params) }


### PR DESCRIPTION
This is quite a far-reaching change as it impacted a lot of tests, but this removes the training programme enum from `ECTAtSchoolPeriod`, we should be using the corresponding one on `TrainingPeriod` from now on.