### PR TITLE
[2191] Add delivery partner lead provider metadata table

### DIFF
--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -5,6 +5,7 @@ class DeliveryPartner < ApplicationRecord
   has_many :lead_provider_delivery_partnerships, inverse_of: :delivery_partner
   has_many :school_partnerships, through: :lead_provider_delivery_partnerships
   has_many :events
+  has_many :lead_provider_metadata, class_name: "Metadata::DeliveryPartnerLeadProvider"
 
   # Validations
   validates :name,

--- a/app/models/metadata/base.rb
+++ b/app/models/metadata/base.rb
@@ -1,5 +1,7 @@
 module Metadata
   class Base < ApplicationRecord
+    include DeclarativeTouch
+
     class UpdateRestrictedError < StandardError; end
 
     self.abstract_class = true

--- a/app/models/metadata/delivery_partner_lead_provider.rb
+++ b/app/models/metadata/delivery_partner_lead_provider.rb
@@ -1,0 +1,15 @@
+module Metadata
+  class DeliveryPartnerLeadProvider < Metadata::Base
+    self.table_name = :metadata_delivery_partners_lead_providers
+
+    belongs_to :delivery_partner
+    belongs_to :lead_provider
+
+    validates :delivery_partner, presence: true
+    validates :lead_provider, presence: true
+    validates :contract_period_years,
+              presence: true,
+              inclusion: { in: (2021..Date.current.year).to_a }
+    validates :contract_period_years, uniqueness: { scope: %i[delivery_partner_id lead_provider_id] }
+  end
+end

--- a/app/models/metadata/school_contract_period.rb
+++ b/app/models/metadata/school_contract_period.rb
@@ -1,7 +1,5 @@
 module Metadata
   class SchoolContractPeriod < Metadata::Base
-    include DeclarativeTouch
-
     self.table_name = :metadata_schools_contract_periods
 
     enum :induction_programme_choice, {

--- a/app/models/metadata/school_lead_provider_contract_period.rb
+++ b/app/models/metadata/school_lead_provider_contract_period.rb
@@ -1,7 +1,5 @@
 module Metadata
   class SchoolLeadProviderContractPeriod < Metadata::Base
-    include DeclarativeTouch
-
     self.table_name = :metadata_schools_lead_providers_contract_periods
 
     belongs_to :school

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -481,3 +481,10 @@
   - induction_programme_choice
   - created_at
   - updated_at
+  :metadata_delivery_partners_lead_providers:
+  - id
+  - delivery_partner_id
+  - lead_provider_id
+  - contract_period_years
+  - created_at
+  - updated_at

--- a/db/migrate/20250815122130_create_join_table_metadata_delivery_partners_lead_providers.rb
+++ b/db/migrate/20250815122130_create_join_table_metadata_delivery_partners_lead_providers.rb
@@ -1,0 +1,13 @@
+class CreateJoinTableMetadataDeliveryPartnersLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :metadata_delivery_partners_lead_providers do |t|
+      t.references :delivery_partner, null: false, foreign_key: true, index: true
+      t.references :lead_provider, null: false, foreign_key: true, index: true
+      t.integer :contract_period_years, array: true, null: false, default: []
+
+      t.timestamps
+    end
+
+    add_index :metadata_delivery_partners_lead_providers, %i[delivery_partner_id lead_provider_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_12_092336) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_15_122130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -370,6 +370,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_092336) do
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
     t.index ["mentor_at_school_period_id", "ect_at_school_period_id", "started_on"], name: "idx_on_mentor_at_school_period_id_ect_at_school_per_d69dffeecc", unique: true
     t.index ["mentor_at_school_period_id"], name: "index_mentorship_periods_on_mentor_at_school_period_id"
+  end
+
+  create_table "metadata_delivery_partners_lead_providers", force: :cascade do |t|
+    t.bigint "delivery_partner_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.integer "contract_period_years", default: [], null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["delivery_partner_id", "lead_provider_id"], name: "idx_on_delivery_partner_id_lead_provider_id_a83df5ed0c", unique: true
+    t.index ["delivery_partner_id"], name: "idx_on_delivery_partner_id_d734fa500e"
+    t.index ["lead_provider_id"], name: "idx_on_lead_provider_id_b318746369"
   end
 
   create_table "metadata_schools_contract_periods", force: :cascade do |t|
@@ -785,6 +796,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_092336) do
   add_foreign_key "mentor_at_school_periods", "teachers"
   add_foreign_key "mentorship_periods", "ect_at_school_periods"
   add_foreign_key "mentorship_periods", "mentor_at_school_periods"
+  add_foreign_key "metadata_delivery_partners_lead_providers", "delivery_partners"
+  add_foreign_key "metadata_delivery_partners_lead_providers", "lead_providers"
   add_foreign_key "metadata_schools_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "metadata_schools_contract_periods", "schools"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -316,4 +316,14 @@ erDiagram
   }
   Metadata_SchoolContractPeriod }o--|| School : belongs_to
   Metadata_SchoolContractPeriod }o--|| ContractPeriod : belongs_to
+  Metadata_DeliveryPartnerLeadProvider {
+    integer id
+    integer delivery_partner_id
+    integer lead_provider_id
+    array[int] contract_period_years
+    datetime created_at
+    datetime updated_at
+  }
+  Metadata_DeliveryPartnerLeadProvider }o--|| DeliveryPartner : belongs_to
+  Metadata_DeliveryPartnerLeadProvider }o--|| LeadProvider : belongs_to
 ```

--- a/spec/factories/metadata/delivery_partner_lead_provider_factory.rb
+++ b/spec/factories/metadata/delivery_partner_lead_provider_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory(:delivery_partner_lead_provider_metadata, class: "Metadata::DeliveryPartnerLeadProvider") do
+    association :delivery_partner
+    association :lead_provider
+    contract_period_years { (2021..Date.current.year).to_a.sample(rand(1..2)) }
+
+    updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+  end
+end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -3,6 +3,7 @@ describe DeliveryPartner do
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:lead_provider_delivery_partnerships).inverse_of(:delivery_partner) }
     it { is_expected.to have_many(:school_partnerships).through(:lead_provider_delivery_partnerships) }
+    it { is_expected.to have_many(:lead_provider_metadata).class_name("Metadata::DeliveryPartnerLeadProvider") }
   end
 
   describe "validations" do

--- a/spec/models/metadata/delivery_partner_lead_provider_spec.rb
+++ b/spec/models/metadata/delivery_partner_lead_provider_spec.rb
@@ -1,0 +1,18 @@
+describe Metadata::DeliveryPartnerLeadProvider do
+  include_context "restricts updates to the Metadata namespace", :delivery_partner_lead_provider_metadata
+
+  describe "associations" do
+    it { is_expected.to belong_to(:delivery_partner) }
+    it { is_expected.to belong_to(:lead_provider) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:delivery_partner_lead_provider_metadata) }
+
+    it { is_expected.to validate_presence_of(:delivery_partner) }
+    it { is_expected.to validate_presence_of(:lead_provider) }
+    it { is_expected.to validate_presence_of(:contract_period_years) }
+    it { is_expected.to allow_values((2021..Date.current.year).to_a).for(:contract_period_years) }
+    it { is_expected.to validate_uniqueness_of(:contract_period_years).scoped_to(:delivery_partner_id, :lead_provider_id) }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2191

In order to implement the solution for delivery partner metadata, we need to first add the tables for the delivery partner endpoint.

### Changes proposed in this pull request

- Add delivery partner lead provider metadata table;
- Add metadata model for delivery partner lead provider
- Add new metadata table to analytics blocklist yml file
- Update domain model mermaid diagram with the new metadata table

### Guidance to review
