### PR TITLE
Fix flakey school partnership touch spec

### DIFF
--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -5,11 +5,8 @@ describe SchoolPartnership do
     context "target school_partnership" do
       let(:target) { instance }
 
-      def generate_new_value(attribute_to_change:)
-        case attribute_to_change
-        when :lead_provider_delivery_partnership_id
-          FactoryBot.create(:lead_provider_delivery_partnership).id
-        end
+      def will_change_attribute(attribute_to_change:, new_value:)
+        FactoryBot.create(:lead_provider_delivery_partnership, id: new_value) if attribute_to_change == :lead_provider_delivery_partnership
       end
 
       it_behaves_like "a declarative touch model", when_changing: %i[lead_provider_delivery_partnership_id], timestamp_attribute: :api_updated_at


### PR DESCRIPTION
I can't see why its flakey, but we have another test that is similar but uses a different format for the new value (it creates the associated object with the generated ID value instead of overriding the `generate_new_value` method).

Changing this spec to be inline with that one to see if it resolves the flakiness.
