### PR TITLE
Allow bypass filter logging in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -71,4 +71,7 @@ Rails.application.configure do
   config.enable_migration_testing = false
 
   config.active_job.queue_adapter = :test
+
+  # Custom config
+  config.bypass_filter_parameter_logging = ENV.fetch("ENABLE_BYPASS_FILTER_PARAMETER_LOGGING", false)
 end


### PR DESCRIPTION
This makes debugging failing tests that little bit easier 😅
