### PR TITLE
Admins must add context when deleting an induction period

### DIFF
--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -124,11 +124,11 @@ module Events
       new(event_type:, modifications:, author:, appropriate_body:, induction_period:, teacher:, heading:, happened_at:).record_event!
     end
 
-    def self.record_induction_period_deleted_event!(author:, modifications:, teacher:, appropriate_body:, body: nil, happened_at: Time.zone.now)
+    def self.record_induction_period_deleted_event!(author:, modifications:, teacher:, appropriate_body:, body: nil, zendesk_ticket_id: nil, happened_at: Time.zone.now)
       event_type = :induction_period_deleted
       heading = 'Induction period deleted by admin'
 
-      new(event_type:, modifications:, author:, appropriate_body:, teacher:, heading:, happened_at:, body:).record_event!
+      new(event_type:, modifications:, author:, appropriate_body:, teacher:, heading:, happened_at:, body:, zendesk_ticket_id:).record_event!
     end
 
     # Teacher Status Events

--- a/app/views/admin/induction_periods/confirm_delete.html.erb
+++ b/app/views/admin/induction_periods/confirm_delete.html.erb
@@ -47,12 +47,17 @@
 %>
 
 <%= form_with(
-  url: admin_teacher_induction_period_path(@induction_period.teacher, @induction_period),
-  method: :delete,
-  class: "govuk-!-margin-bottom-8"
-) do |f| %>
+      model: @delete_induction,
+      url: admin_teacher_induction_period_path(@teacher, @induction_period),
+      method: :delete,
+      class: "govuk-!-margin-bottom-8"
+    ) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= render "admin/shared/auditable_fields", form: f %>
+
   <div class="govuk-button-group">
     <%= f.govuk_submit "Delete induction period", warning: true %>
-    <%= govuk_button_link_to "Cancel", admin_teacher_path(@induction_period.teacher), secondary: true %>
+    <%= govuk_button_link_to "Cancel", admin_teacher_path(@teacher), secondary: true %>
   </div>
 <% end %>

--- a/spec/features/admin/teachers/delete_induction_period_spec.rb
+++ b/spec/features/admin/teachers/delete_induction_period_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Admin deletes an induction period" do
   include ActiveJob::TestHelper
+
   include_context "test trs api client"
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
@@ -18,11 +19,21 @@ RSpec.describe "Admin deletes an induction period" do
       when_i_click_delete_link
       then_i_should_see_the_delete_confirmation_page
 
-      when_i_confirm_deletion
+      when_i_do_not_add_any_extra_information
+      and_i_confirm_deletion
+      then_there_is_an_error_message
+
+      when_i_add_a_zendesk_ticket_id
+      and_i_add_a_note("This is a test reason for deleting")
+      and_i_confirm_deletion
       then_i_should_be_on_the_success_page
       and_the_induction_period_should_be_deleted(induction_period)
       and_an_event_should_have_been_recorded
       and_trs_status_should_be_reset
+
+      when_i_go_to_the_timeline_page
+      then_i_can_see_the_note("This is a test reason for deleting")
+      and_i_can_see_the_zendesk_url
     end
   end
 
@@ -36,11 +47,21 @@ RSpec.describe "Admin deletes an induction period" do
       when_i_click_delete_link_for(induction_period1)
       then_i_should_see_the_delete_confirmation_page
 
-      when_i_confirm_deletion
+      when_i_do_not_add_any_extra_information
+      and_i_confirm_deletion
+      then_there_is_an_error_message
+
+      when_i_add_a_zendesk_ticket_id
+      and_i_add_a_note("This is a test reason for deleting")
+      and_i_confirm_deletion
       then_i_should_be_on_the_success_page
       and_the_induction_period_should_be_deleted(induction_period1)
       and_an_event_should_have_been_recorded
       and_trs_status_should_not_be_reset
+
+      when_i_go_to_the_timeline_page
+      then_i_can_see_the_note("This is a test reason for deleting")
+      and_i_can_see_the_zendesk_url
     end
   end
 
@@ -54,11 +75,21 @@ RSpec.describe "Admin deletes an induction period" do
       when_i_click_delete_link_for(induction_period2)
       then_i_should_see_the_delete_confirmation_page
 
-      when_i_confirm_deletion
+      when_i_do_not_add_any_extra_information
+      and_i_confirm_deletion
+      then_there_is_an_error_message
+
+      when_i_add_a_zendesk_ticket_id
+      and_i_add_a_note("This is a test reason for deleting")
+      and_i_confirm_deletion
       then_i_should_be_on_the_success_page
       and_the_induction_period_should_be_deleted(induction_period2)
       and_an_event_should_have_been_recorded
       and_trs_status_should_not_be_reset
+
+      when_i_go_to_the_timeline_page
+      then_i_can_see_the_note("This is a test reason for deleting")
+      and_i_can_see_the_zendesk_url
     end
   end
 
@@ -89,7 +120,26 @@ RSpec.describe "Admin deletes an induction period" do
     expect(page.get_by_role('button', name: 'Delete induction period')).to be_visible
   end
 
-  def when_i_confirm_deletion
+  def when_i_do_not_add_any_extra_information = nil
+
+  def then_there_is_an_error_message
+    expect(page.locator(".govuk-error-summary"))
+      .to have_text("There is a problem")
+  end
+
+  def when_i_add_a_zendesk_ticket_id
+    page.locator("fieldset", hasText: "Explain why you're making this change")
+      .get_by_label("Enter the Zendesk ID")
+      .fill("123")
+  end
+
+  def and_i_add_a_note(reason)
+    page.locator("fieldset", hasText: "Explain why you're making this change")
+      .get_by_label("Add a note to explain why you're making this change")
+      .fill(reason)
+  end
+
+  def and_i_confirm_deletion
     perform_enqueued_jobs do
       page.get_by_role('button', name: 'Delete induction period').click
     end
@@ -117,5 +167,24 @@ RSpec.describe "Admin deletes an induction period" do
 
   def and_trs_status_should_not_be_reset
     expect(teacher.induction_periods.count).to eq(1)
+  end
+
+  def when_i_go_to_the_timeline_page
+    page.goto(admin_teacher_timeline_path(teacher))
+  end
+
+  def then_i_can_see_the_note(reason)
+    description = page
+      .locator(".app-timeline__item", hasText: "Induction period deleted")
+      .locator(".app-timeline__description")
+    expect(description).to have_text(reason)
+  end
+
+  def and_i_can_see_the_zendesk_url
+    description = page
+      .locator(".app-timeline__item", hasText: "Induction period deleted")
+      .locator(".app-timeline__description")
+    expect(description.get_by_role("link", name: "Zendesk ticket (opens in new tab)"))
+      .to be_visible
   end
 end

--- a/spec/services/induction_periods/delete_induction_period_spec.rb
+++ b/spec/services/induction_periods/delete_induction_period_spec.rb
@@ -1,181 +1,230 @@
 RSpec.describe InductionPeriods::DeleteInductionPeriod do
+  include ActiveJob::TestHelper
+
   subject(:service) do
-    described_class.new(
-      author:,
-      induction_period:
-    )
+    described_class.new(author:, induction_period:, note:, zendesk_ticket_id:)
   end
 
   include_context 'test trs api client'
-  include ActiveJob::TestHelper
+
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
+  let(:note) { "Induction period created in error" }
+  let(:zendesk_ticket_id) { 123 }
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:user) { FactoryBot.create(:user) }
-  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
   let(:trs_client) { instance_double(TRS::APIClient) }
+
+  let!(:induction_period) do
+    FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:)
+  end
 
   before do
     allow(TRS::APIClient).to receive(:new).and_return(trs_client)
+    allow(trs_client).to receive(:reset_teacher_induction!)
+    allow(trs_client).to receive(:begin_induction!)
   end
 
   context "when it is the only induction period" do
-    let!(:induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:) }
-
-    before do
-      allow(trs_client).to receive(:reset_teacher_induction!)
-      allow(trs_client).to receive(:begin_induction!)
-      allow(Events::Record).to receive(:record_induction_period_deleted_event!)
-      allow(Events::Record).to receive(:record_teacher_induction_status_reset_event!)
-      allow(Events::Record).to receive(:record_teacher_trs_induction_start_date_updated_event!)
-    end
-
     it "destroys the induction period" do
-      expect { service.delete_induction_period! }.to change(InductionPeriod, :count).by(-1)
+      expect { service.delete_induction_period! }
+        .to change(InductionPeriod, :count).by(-1)
     end
 
     it "resets the TRS status" do
-      service.delete_induction_period!
+      expect(trs_client)
+        .to receive(:reset_teacher_induction!)
+        .with(trn: teacher.trn)
 
-      expect(trs_client).to have_received(:reset_teacher_induction!).with(trn: teacher.trn)
+      service.delete_induction_period!
     end
 
     it "does not update the TRS start date" do
-      service.delete_induction_period!
+      expect(trs_client).not_to receive(:begin_induction!)
 
-      expect(trs_client).not_to have_received(:begin_induction!)
+      service.delete_induction_period!
     end
 
     it "records a delete event with the correct parameters" do
-      service.delete_induction_period!
+      expect(Events::Record)
+        .to receive(:record_induction_period_deleted_event!)
+        .with(
+          author:,
+          body: note,
+          zendesk_ticket_id:,
+          modifications: hash_including("id" => [induction_period.id, nil]),
+          teacher:,
+          appropriate_body:,
+          happened_at: instance_of(ActiveSupport::TimeWithZone)
+        )
 
-      expect(Events::Record).to have_received(:record_induction_period_deleted_event!).with(
-        author:,
-        modifications: hash_including("id" => [induction_period.id, nil]),
-        teacher:,
-        appropriate_body:,
-        happened_at: instance_of(ActiveSupport::TimeWithZone)
-      )
+      service.delete_induction_period!
     end
 
     it "does not record a TRS induction start date updated event" do
+      expect(Events::Record)
+        .not_to receive(:record_teacher_trs_induction_start_date_updated_event!)
+
       service.delete_induction_period!
-      expect(Events::Record).not_to have_received(:record_teacher_trs_induction_start_date_updated_event!)
     end
 
     context "when the induction period has an outcome" do
       before { induction_period.update!(outcome: "pass") }
 
       it "raises ActiveRecord::RecordInvalid and does not delete or fire events" do
-        expect {
-          expect { service.delete_induction_period! }.to raise_error(ActiveRecord::RecordInvalid)
-        }.not_to change(InductionPeriod, :count)
-        expect(Events::Record).not_to have_received(:record_induction_period_deleted_event!)
-        expect(Events::Record).not_to have_received(:record_teacher_trs_induction_start_date_updated_event!)
-        expect(trs_client).not_to have_received(:reset_teacher_induction!)
-        expect(trs_client).not_to have_received(:begin_induction!)
+        expect { service.delete_induction_period! }
+          .to raise_error(ActiveRecord::RecordInvalid)
+          .and(not_change(InductionPeriod, :count))
+
+        expect(Events::Record)
+          .not_to receive(:record_induction_period_deleted_event!)
+        expect(Events::Record)
+          .not_to receive(:record_teacher_trs_induction_start_date_updated_event!)
+        expect(trs_client).not_to receive(:reset_teacher_induction!)
+        expect(trs_client).not_to receive(:begin_induction!)
       end
     end
   end
 
   context "when there are other induction periods" do
-    let!(:earliest_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2020, 1, 1), finished_on: Date.new(2020, 12, 31), number_of_terms: 3) }
-    let!(:later_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2021, 1, 1), finished_on: Date.new(2021, 12, 31), number_of_terms: 3) }
+    let!(:earliest_period) do
+      FactoryBot.create(
+        :induction_period,
+        :ongoing,
+        teacher:,
+        appropriate_body:,
+        started_on: Date.new(2020, 1, 1),
+        finished_on: Date.new(2020, 12, 31),
+        number_of_terms: 3
+      )
+    end
 
-    before do
-      allow(trs_client).to receive(:reset_teacher_induction!)
-      allow(trs_client).to receive(:begin_induction!)
-      allow(Events::Record).to receive(:record_induction_period_deleted_event!)
-      allow(Events::Record).to receive(:record_teacher_induction_status_reset_event!)
-      allow(Events::Record).to receive(:record_teacher_trs_induction_start_date_updated_event!)
+    let!(:later_period) do
+      FactoryBot.create(
+        :induction_period,
+        :ongoing,
+        teacher:,
+        appropriate_body:,
+        started_on: Date.new(2021, 1, 1),
+        finished_on: Date.new(2021, 12, 31),
+        number_of_terms: 3
+      )
     end
 
     context "when deleting the earliest period" do
-      subject(:service) do
-        described_class.new(
-          author:,
-          induction_period: earliest_period
-        )
-      end
+      let(:induction_period) { earliest_period }
 
       it "destroys the induction period" do
-        expect { service.delete_induction_period! }.to change(InductionPeriod, :count).by(-1)
+        expect { service.delete_induction_period! }
+          .to change(InductionPeriod, :count).by(-1)
       end
 
       it "updates the TRS start date to the next earliest period" do
-        service.delete_induction_period!
+        expect(trs_client)
+          .to receive(:begin_induction!)
+          .with(
+            trn: teacher.trn,
+            start_date: later_period.started_on
+          )
 
-        expect(trs_client).to have_received(:begin_induction!).with(
-          trn: teacher.trn,
-          start_date: later_period.started_on
-        )
+        service.delete_induction_period!
       end
 
       it "does not reset the TRS status" do
-        service.delete_induction_period!
+        expect(trs_client).not_to receive(:reset_teacher_induction!)
 
-        expect(trs_client).not_to have_received(:reset_teacher_induction!)
+        service.delete_induction_period!
       end
 
       it "records a TRS induction start date updated event with the correct parameters" do
-        service.delete_induction_period!
+        expect(Events::Record)
+          .to receive(:record_teacher_trs_induction_start_date_updated_event!)
+          .with(
+            author:,
+            teacher:,
+            appropriate_body:,
+            induction_period: later_period
+          )
 
-        expect(Events::Record).to have_received(:record_teacher_trs_induction_start_date_updated_event!).with(
-          author:,
-          teacher:,
-          appropriate_body:,
-          induction_period: later_period
-        )
+        service.delete_induction_period!
       end
 
       it "records a delete event with the correct parameters" do
+        expect(Events::Record)
+          .to receive(:record_induction_period_deleted_event!)
+          .with(
+            author:,
+            body: note,
+            zendesk_ticket_id:,
+            modifications: hash_including("id" => [earliest_period.id, nil]),
+            teacher:,
+            appropriate_body:,
+            happened_at: instance_of(ActiveSupport::TimeWithZone)
+          )
+
         service.delete_induction_period!
-        expect(Events::Record).to have_received(:record_induction_period_deleted_event!).with(
-          author:,
-          modifications: hash_including("id" => [earliest_period.id, nil]),
-          teacher:,
-          appropriate_body:,
-          happened_at: instance_of(ActiveSupport::TimeWithZone)
-        )
       end
     end
 
     context "when deleting a later period" do
-      subject(:service) do
-        described_class.new(
-          author:,
-          induction_period: later_period
-        )
-      end
+      let(:induction_period) { later_period }
 
       it "destroys the induction period" do
-        expect { service.delete_induction_period! }.to change(InductionPeriod, :count).by(-1)
+        expect { service.delete_induction_period! }
+          .to change(InductionPeriod, :count).by(-1)
       end
 
       it "does not update the TRS start date" do
+        expect(trs_client).not_to receive(:begin_induction!)
         service.delete_induction_period!
-        expect(trs_client).not_to have_received(:begin_induction!)
       end
 
       it "does not reset the TRS status" do
+        expect(trs_client).not_to receive(:reset_teacher_induction!)
         service.delete_induction_period!
-        expect(trs_client).not_to have_received(:reset_teacher_induction!)
       end
 
       it "does not record a TRS induction start date updated event" do
+        expect(Events::Record).not_to receive(:record_teacher_trs_induction_start_date_updated_event!)
         service.delete_induction_period!
-        expect(Events::Record).not_to have_received(:record_teacher_trs_induction_start_date_updated_event!)
       end
 
       it "records a delete event with the correct parameters" do
+        expect(Events::Record)
+          .to receive(:record_induction_period_deleted_event!)
+          .with(
+            author:,
+            body: note,
+            zendesk_ticket_id:,
+            modifications: hash_including("id" => [later_period.id, nil]),
+            teacher:,
+            appropriate_body:,
+            happened_at: instance_of(ActiveSupport::TimeWithZone)
+          )
+
         service.delete_induction_period!
-        expect(Events::Record).to have_received(:record_induction_period_deleted_event!).with(
-          author:,
-          modifications: hash_including("id" => [later_period.id, nil]),
-          teacher:,
-          appropriate_body:,
-          happened_at: instance_of(ActiveSupport::TimeWithZone)
-        )
+      end
+    end
+
+    context "when the note and Zendesk ticket ID are blank" do
+      let(:note) { "" }
+      let(:zendesk_ticket_id) { "" }
+
+      it "raises an error" do
+        expect { service.delete_induction_period! }
+          .to raise_error(ActiveModel::ValidationError)
+          .with_message("Validation failed: Enter a Zendesk ID or add a note")
+      end
+    end
+
+    context "when the Zendesk ticket ID is invalid" do
+      let(:zendesk_ticket_id) { "invalid_url" }
+
+      it "raises an error" do
+        expect { service.delete_induction_period! }
+          .to raise_error(ActiveModel::ValidationError)
+          .with_message("Validation failed: Zendesk ticket ID must be a number")
       end
     end
   end


### PR DESCRIPTION
Building on #1176, this ensures Admin users provide extra information (in the form of a support ticket URL or a note) when they delete an induction period.