### PR TITLE
Add `Metadata::Handlers::DeliveryPartner`

### DIFF
--- a/app/models/metadata/delivery_partner_lead_provider.rb
+++ b/app/models/metadata/delivery_partner_lead_provider.rb
@@ -15,8 +15,10 @@ module Metadata
     def contract_period_years_is_an_array_of_valid_years
       if contract_period_years.nil? || !contract_period_years.is_a?(Array)
         errors.add(:contract_period_years, "must be an array")
-      elsif contract_period_years.present? && contract_period_years.any? { |year| !year.between?(2021, Date.current.year) }
-        errors.add(:contract_period_years, "must contain valid years between 2021 and the current year")
+      elsif contract_period_years.uniq.count != contract_period_years.count
+        errors.add(:contract_period_years, "must not contain duplicate years")
+      elsif ContractPeriod.where(year: contract_period_years).pluck(:year).count != contract_period_years.count
+        errors.add(:contract_period_years, "must contain valid years")
       end
     end
   end

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -1,0 +1,26 @@
+module Metadata::Handlers
+  class Base
+    BATCH_SIZE = 100
+
+    class << self
+      def refresh_all_metadata!(async: false)
+        job_method = async ? :perform_later : :perform_now
+        object_type = name.demodulize.constantize
+        object_type.order(:created_at).in_batches(of: BATCH_SIZE) do |objects|
+          RefreshMetadataJob.send(job_method, object_type:, object_ids: objects.pluck(:id))
+        end
+      end
+    end
+
+  protected
+
+    def upsert(metadata, attributes)
+      metadata.assign_attributes(attributes)
+      metadata.save! if metadata.changed?
+    end
+
+    def lead_provider_ids
+      @lead_provider_ids ||= LeadProvider.pluck(:id)
+    end
+  end
+end

--- a/app/services/metadata/handlers/delivery_partner.rb
+++ b/app/services/metadata/handlers/delivery_partner.rb
@@ -1,0 +1,34 @@
+module Metadata::Handlers
+  class DeliveryPartner < Base
+    attr_reader :delivery_partner
+
+    def initialize(delivery_partner)
+      @delivery_partner = delivery_partner
+    end
+
+    def refresh_metadata!
+      upsert_lead_provider_metadata!
+    end
+
+  private
+
+    def upsert_lead_provider_metadata!
+      lead_provider_ids.each do |lead_provider_id|
+        metadata = Metadata::DeliveryPartnerLeadProvider.find_or_initialize_by(
+          delivery_partner:,
+          lead_provider_id:
+        )
+
+        upsert(metadata, contract_period_years: contract_period_years(lead_provider_id))
+      end
+    end
+
+    def contract_period_years(lead_provider_id)
+      delivery_partner
+        .lead_provider_delivery_partnerships
+        .joins(:active_lead_provider)
+        .where(active_lead_providers: { lead_provider_id: })
+        .pluck("active_lead_providers.contract_period_year")
+    end
+  end
+end

--- a/app/services/metadata/resolver.rb
+++ b/app/services/metadata/resolver.rb
@@ -15,6 +15,7 @@ module Metadata
           .constants
           .map { Handlers.const_get(it) }
           .select { it.is_a?(Class) }
+          .reject { it == Metadata::Handlers::Base }
       end
     end
   end

--- a/spec/factories/metadata/delivery_partner_lead_provider_factory.rb
+++ b/spec/factories/metadata/delivery_partner_lead_provider_factory.rb
@@ -2,7 +2,12 @@ FactoryBot.define do
   factory(:delivery_partner_lead_provider_metadata, class: "Metadata::DeliveryPartnerLeadProvider") do
     association :delivery_partner
     association :lead_provider
-    contract_period_years { (2021..Date.current.year).to_a.sample(rand(1..2)) }
+    contract_period_years do
+      years = (2021..Time.current.year).to_a
+      random_years = years.shuffle.take(rand(1..years.size))
+      random_years.each { FactoryBot.create(:contract_period, year: it) }
+      random_years
+    end
 
     updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
   end

--- a/spec/models/metadata/delivery_partner_lead_provider_spec.rb
+++ b/spec/models/metadata/delivery_partner_lead_provider_spec.rb
@@ -7,13 +7,19 @@ describe Metadata::DeliveryPartnerLeadProvider do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:delivery_partner_lead_provider_metadata) }
+    subject { FactoryBot.create(:delivery_partner_lead_provider_metadata, contract_period_years: [2021, 2023]) }
+
+    before do
+      FactoryBot.create(:contract_period, year: 2021)
+      FactoryBot.create(:contract_period, year: 2023)
+    end
 
     it { is_expected.to validate_presence_of(:delivery_partner) }
     it { is_expected.to validate_presence_of(:lead_provider) }
-    it { is_expected.to allow_values((2021..Date.current.year).to_a).for(:contract_period_years) }
+    it { is_expected.to allow_values([], [2021, 2023]).for(:contract_period_years) }
     it { is_expected.not_to allow_value(nil, false, 2022).for(:contract_period_years).with_message("must be an array") }
-    it { is_expected.not_to allow_value([2020], [2019, 2022]).for(:contract_period_years).with_message("must contain valid years between 2021 and the current year") }
+    it { is_expected.not_to allow_value([2020], [2019, 2022]).for(:contract_period_years).with_message("must contain valid years") }
+    it { is_expected.not_to allow_value([2021, 2021]).for(:contract_period_years).with_message("must not contain duplicate years") }
     it { is_expected.to validate_uniqueness_of(:delivery_partner_id).scoped_to(:lead_provider_id) }
   end
 end

--- a/spec/services/metadata/handlers/delivery_partner_spec.rb
+++ b/spec/services/metadata/handlers/delivery_partner_spec.rb
@@ -41,9 +41,11 @@ RSpec.describe Metadata::Handlers::DeliveryPartner do
         end
 
         it "updates the metadata when the partnership changes" do
-          Metadata::DeliveryPartnerLeadProvider.bypass_update_restrictions { metadata.update!(contract_period_years: [2022, 2023]) }
+          changed_contract_period = FactoryBot.create(:contract_period, year: 2022)
 
-          expect { refresh_metadata }.to change { metadata.reload.contract_period_years }.from([2022, 2023]).to(contract_period_years)
+          Metadata::DeliveryPartnerLeadProvider.bypass_update_restrictions { metadata.update!(contract_period_years: [changed_contract_period.year]) }
+
+          expect { refresh_metadata }.to change { metadata.reload.contract_period_years }.from([changed_contract_period.year]).to(contract_period_years)
         end
 
         it "does not update the metadata if no changes are made" do

--- a/spec/services/metadata/handlers/delivery_partner_spec.rb
+++ b/spec/services/metadata/handlers/delivery_partner_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Metadata::Handlers::DeliveryPartner do
+  let(:instance) { described_class.new(delivery_partner) }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner:, active_lead_provider:) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+  let(:contract_period) { FactoryBot.create(:contract_period, year: 2021) }
+  let(:contract_period_years) { [contract_period.year] }
+  let(:lead_provider) { active_lead_provider.lead_provider }
+
+  include_context "supports refreshing all metadata", :delivery_partner, DeliveryPartner do
+    let(:object) { delivery_partner }
+  end
+
+  describe "#refresh_metadata!" do
+    subject(:refresh_metadata) { instance.refresh_metadata! }
+
+    describe "DeliveryPartnerLeadProvider" do
+      it "creates metadata for the delivery partner and lead provider" do
+        expect { refresh_metadata }.to change(Metadata::DeliveryPartnerLeadProvider, :count).by(1)
+
+        created_metadata = Metadata::DeliveryPartnerLeadProvider.last
+
+        expect(created_metadata).to have_attributes(
+          delivery_partner:,
+          lead_provider:,
+          contract_period_years:
+        )
+      end
+
+      it "creates metadata for all combinations of the delivery partner and lead providers" do
+        FactoryBot.create_list(:lead_provider, 2)
+
+        expect { refresh_metadata }.to change(Metadata::DeliveryPartnerLeadProvider, :count).by(LeadProvider.count)
+      end
+
+      context "when metadata already exists for a delivery partner and lead provider" do
+        let!(:metadata) { FactoryBot.create(:delivery_partner_lead_provider_metadata, delivery_partner:, lead_provider:, contract_period_years:) }
+
+        it "does not create metadata" do
+          expect { refresh_metadata }.not_to change(Metadata::DeliveryPartnerLeadProvider, :count)
+        end
+
+        it "updates the metadata when the partnership changes" do
+          Metadata::DeliveryPartnerLeadProvider.bypass_update_restrictions { metadata.update!(contract_period_years: [2022, 2023]) }
+
+          expect { refresh_metadata }.to change { metadata.reload.contract_period_years }.from([2022, 2023]).to(contract_period_years)
+        end
+
+        it "does not update the metadata if no changes are made" do
+          expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
+        end
+      end
+    end
+  end
+end

--- a/spec/services/metadata/handlers/school_spec.rb
+++ b/spec/services/metadata/handlers/school_spec.rb
@@ -5,45 +5,8 @@ RSpec.describe Metadata::Handlers::School do
   let!(:lead_provider) { school_partnership.lead_provider }
   let!(:contract_period) { school_partnership.contract_period }
 
-  describe ".refresh_all_metadata!" do
-    subject(:refresh_all_metadata) { described_class.refresh_all_metadata!(async:) }
-
-    let(:async) { true }
-    let(:school_ids) { [school.id] + FactoryBot.create_list(:school, 2, :eligible).map(&:id) }
-
-    before { stub_const("Metadata::Handlers::School::BATCH_SIZE", 2) }
-
-    it "enqueues jobs to refresh metadata for all eligible schools in batches" do
-      expect(RefreshMetadataJob).to receive(:perform_later).with(
-        object_type: School,
-        object_ids: school_ids[0..1]
-      )
-
-      expect(RefreshMetadataJob).to receive(:perform_later).with(
-        object_type: School,
-        object_ids: school_ids[2..2]
-      )
-
-      refresh_all_metadata
-    end
-
-    context "when async is false" do
-      let(:async) { false }
-
-      it "enqueues jobs to refresh metadata for all eligible schools in batches" do
-        expect(RefreshMetadataJob).to receive(:perform_now).with(
-          object_type: School,
-          object_ids: school_ids[0..1]
-        )
-
-        expect(RefreshMetadataJob).to receive(:perform_now).with(
-          object_type: School,
-          object_ids: school_ids[2..2]
-        )
-
-        refresh_all_metadata
-      end
-    end
+  include_context "supports refreshing all metadata", :school, School do
+    let(:object) { school }
   end
 
   describe "#refresh_metadata!" do

--- a/spec/services/metadata/resolver_spec.rb
+++ b/spec/services/metadata/resolver_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe Metadata::Resolver do
   describe ".all_handlers" do
     subject { described_class.all_handlers }
 
-    it { is_expected.to contain_exactly(Metadata::Handlers::School) }
+    it { is_expected.to contain_exactly(Metadata::Handlers::School, Metadata::Handlers::DeliveryPartner) }
   end
 end

--- a/spec/support/shared_examples/metadata_support.rb
+++ b/spec/support/shared_examples/metadata_support.rb
@@ -31,3 +31,46 @@ RSpec.shared_examples "restricts updates to the Metadata namespace" do |factory|
     expect { model.class.bypass_update_restrictions { OtherNamespace::TestUpdater.perform(model) } }.not_to raise_error
   end
 end
+
+RSpec.shared_examples "supports refreshing all metadata" do |factory, object_type|
+  describe ".refresh_all_metadata!" do
+    subject(:refresh_all_metadata) { described_class.refresh_all_metadata!(async:) }
+
+    let(:async) { true }
+    let(:object_ids) { [object.id] + FactoryBot.create_list(factory, 2).map(&:id) }
+
+    before { stub_const("Metadata::Handlers::Base::BATCH_SIZE", 2) }
+
+    it "enqueues jobs to refresh metadata for all #{factory} in batches" do
+      expect(RefreshMetadataJob).to receive(:perform_later).with(
+        object_type:,
+        object_ids: object_ids[0..1]
+      )
+
+      expect(RefreshMetadataJob).to receive(:perform_later).with(
+        object_type:,
+        object_ids: object_ids[2..2]
+      )
+
+      refresh_all_metadata
+    end
+
+    context "when async is false" do
+      let(:async) { false }
+
+      it "enqueues jobs to refresh metadata for all #{factory} in batches" do
+        expect(RefreshMetadataJob).to receive(:perform_now).with(
+          object_type:,
+          object_ids: object_ids[0..1]
+        )
+
+        expect(RefreshMetadataJob).to receive(:perform_now).with(
+          object_type:,
+          object_ids: object_ids[2..2]
+        )
+
+        refresh_all_metadata
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to add the metadata handler for populating `DeliveryPartnerLeadProvider` metadata, so that we simplify our `DeliveryPartners::Query` and `DeliveryPartnerSerializer`.

### Changes proposed in this pull request

- Add `Metadata::Handlers::DeliveryPartner`

Add a handler for delivery partners so that we can populate the `DeliveryPartnerLeadProviderMetadata`.

Extract shared logic into `Metadata::Handlers::Base` and DRY up specs with a shared context.

- Improve contract_period_years validation

We were getting validation errors due to some `ContractPeriod` records that are created for future years (2026). To make this more robust we can check that the `ContractPeriod` for each year exists in the database. It will be a bit slower, but the numbers should be fairly low for `DeliveryPartnerLeadProvider`.

### Guidance to review

It wasn't part of this ticket, but with a bit of refactoring we get the backfill/refresh all metadata behaviour for free. The review app contains the metadata:

```
Metadata::DeliveryPartnerLeadProvider.count
=> 49
```