### PR TITLE
[1834] update journey for school led mentor being assigned to a provider led ECT for the first time

### DIFF
--- a/app/controllers/schools/assign_existing_mentor_wizard_controller.rb
+++ b/app/controllers/schools/assign_existing_mentor_wizard_controller.rb
@@ -1,0 +1,55 @@
+class Schools::AssignExistingMentorWizardController < SchoolsController
+  before_action :initialize_wizard, only: %i[new create]
+  before_action :check_allowed_step, only: %i[new create]
+
+  WIZARD_CLASS = Schools::AssignExistingMentorWizard::Wizard
+
+  def new
+    render current_step
+  end
+
+  def create
+    if @wizard.valid_step?
+      @wizard.current_step.save!
+      redirect_to @wizard.next_step_path
+    else
+      render current_step
+    end
+  end
+
+private
+
+  def check_allowed_step
+    redirect_to @wizard.allowed_step_path unless @wizard.allowed_step?
+  end
+
+  def store
+    @store ||= SessionRepository.new(session:, form_key: :assign_existing_mentor_wizard)
+  end
+
+  def current_step
+    @current_step ||= begin
+      step = step_name_from_path
+      return :not_found unless WIZARD_CLASS.step?(step)
+
+      step
+    end
+  end
+
+  def step_name_from_path
+    request.path.split("/").last.underscore.to_sym
+  end
+
+  def initialize_wizard
+    redirect_to(root_path) unless store.ect_id && store.mentor_period_id
+
+    @wizard = WIZARD_CLASS.new(
+      current_step:,
+      step_params: params,
+      author: current_user,
+      ect_id: store.ect_id,
+      mentor_period_id: store.mentor_period_id,
+      store:
+    )
+  end
+end

--- a/app/controllers/schools/mentorships_controller.rb
+++ b/app/controllers/schools/mentorships_controller.rb
@@ -5,10 +5,17 @@ module Schools
 
     def new
       @mentor_form = AssignMentorForm.new(ect:)
+
+      assign_previously_chosen_mentor_id
     end
 
     def create
       @mentor_form = AssignMentorForm.new(ect:, mentor_id:)
+
+      if mentor_at_school_period.present? && provider_led_and_eligible_for_funding?
+        kickoff_assign_existing_wizard!(ect_id: ect.id, mentor_period_id: mentor_at_school_period.id)
+        return redirect_to schools_assign_existing_mentor_wizard_review_mentor_eligibility_path
+      end
 
       if @mentor_form.save(author: current_user)
         redirect_to confirmation_schools_ect_mentorship_path(@ect)
@@ -29,6 +36,24 @@ module Schools
       @mentor_id ||= params.dig(:schools_assign_mentor_form, :mentor_id)
     end
 
+    def assign_previously_chosen_mentor_id
+      return if params[:preselect].blank?
+
+      @mentor_form.mentor_id = params[:preselect]
+    end
+
+    def mentor_at_school_period
+      @mentor_at_school_period ||= school.mentor_at_school_periods.find_by(id: mentor_id)
+    end
+
+    def provider_led_and_eligible_for_funding?
+      ect&.provider_led? &&
+        mentor_at_school_period&.teacher &&
+        Teachers::MentorFundingEligibility
+          .new(trn: mentor_at_school_period.teacher.trn)
+          .eligible?
+    end
+
     def register_mentor
       redirect_to schools_register_mentor_wizard_start_path(ect_id: ect.id)
     end
@@ -40,6 +65,14 @@ module Schools
     def set_ect
       @ect ||= school.ect_at_school_periods.find_by_id(params[:ect_id])
       @ect_name = Teachers::Name.new(@ect.teacher).full_name if @ect
+    end
+
+    def store
+      @store ||= SessionRepository.new(session:, form_key: :assign_existing_mentor_wizard)
+    end
+
+    def kickoff_assign_existing_wizard!(ect_id:, mentor_period_id:)
+      store.update!(ect_id:, mentor_period_id:)
     end
   end
 end

--- a/app/controllers/schools/mentorships_controller.rb
+++ b/app/controllers/schools/mentorships_controller.rb
@@ -47,7 +47,7 @@ module Schools
     end
 
     def provider_led_and_eligible_for_funding?
-      ect&.provider_led? &&
+      ect&.provider_led_training_programme? &&
         mentor_at_school_period&.teacher &&
         Teachers::MentorFundingEligibility
           .new(trn: mentor_at_school_period.teacher.trn)

--- a/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
@@ -1,0 +1,19 @@
+---
+title: You've assigned <%= @wizard.context.mentor_teacher_full_name %> as a mentor
+header: false
+---
+
+<%= govuk_panel(title_text: "You’ve assigned #{@wizard.context.mentor_teacher_full_name} as a mentor") do %>
+for
+<br>
+<strong><%= @wizard.context.ect_teacher_full_name %></strong>
+<% end %>
+
+You have successfully registered <%= @wizard.context.ect_teacher_full_name %> for training.
+
+They do not need to provide us with any further details.
+
+We'll pass on their details to <%= @wizard.context.user_selected_lead_provider&.name || @wizard.context.ect_lead_provider&.name %> 
+who will contact them to arrange mentor training.
+
+<%= govuk_link_to 'Back to your ECTs', schools_ects_home_path %>

--- a/app/views/schools/assign_existing_mentor_wizard/lead_provider.html.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/lead_provider.html.erb
@@ -1,0 +1,41 @@
+<% page_data(
+  title:
+    "Which lead provider would you like to contact your school about training #{@wizard.context.mentor_teacher_full_name}?",
+  error: @wizard.current_step.errors.present?,
+  backlink_href: schools_assign_existing_mentor_wizard_review_mentor_eligibility_path
+) %>
+
+<p class="govuk-body">
+  We’ll let the lead provider know that your school is interested in working
+  with them. They’ll contact your school to discuss this further before you
+  decide if you want to go ahead with the mentor training.
+</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+  <%= f.govuk_collection_radio_buttons(
+    :lead_provider_id,
+    @wizard.context.lead_providers_within_contract_period,
+    :id,
+    :name,
+    legend: {
+      text: "Select lead provider",
+      hidden: true,
+    },
+  ) %>
+
+  <%= govuk_details(summary_text: 'What are the roles of an appropriate body, lead provider and delivery partner?') do %>
+    <p class="govuk-body">An appropriate body is responsible for assuring the quality of the
+      statutory induction of ECTs. A lead provider provides the online learning
+      platform used for training ECTs and mentors, while the delivery partner
+      delivers training events.
+    </p>
+
+    <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for
+      example an appropriate body might be the same organisation as the
+      delivery partner.
+    </p>
+  <% end %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/assign_existing_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/review_mentor_eligibility.html.erb
@@ -1,0 +1,17 @@
+<%
+  page_data(
+    title: "#{@wizard.context.mentor_teacher_full_name} can receive mentor training",
+    backlink_href: new_schools_ect_mentorship_path(@wizard.context.ect_at_school_period, preselect: @wizard.mentor_period_id)
+  )
+%>
+
+<p class="govuk-body">Our records show that <%= @wizard.context.mentor_teacher_full_name %> can get up to 20 hours of ECTE mentor training as your school is working with a DfE-funded training provider.</p>
+
+<p class="govuk-body">We’ll pass on their details to <%= @wizard.context.ect_lead_provider&.name %> who will contact them to arrange the training.</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= f.govuk_submit "Continue" %>
+<% end %>
+
+<%= govuk_link_to "#{@wizard.context.ect_lead_provider&.name} will not be providing mentor training to #{@wizard.context.mentor_teacher_full_name}",
+schools_assign_existing_mentor_wizard_lead_provider_path %>

--- a/app/views/schools/assign_existing_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/review_mentor_eligibility.html.erb
@@ -13,5 +13,7 @@
   <%= f.govuk_submit "Continue" %>
 <% end %>
 
-<%= govuk_link_to "#{@wizard.context.ect_lead_provider&.name} will not be providing mentor training to #{@wizard.context.mentor_teacher_full_name}",
-schools_assign_existing_mentor_wizard_lead_provider_path %>
+<p class="govuk-body">
+  <%= govuk_link_to "#{@wizard.context.ect_lead_provider&.name} will not be providing mentor training to #{@wizard.context.mentor_teacher_full_name}",
+  schools_assign_existing_mentor_wizard_lead_provider_path %>
+</p>

--- a/app/wizards/schools/assign_existing_mentor_wizard/confirmation_step.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/confirmation_step.rb
@@ -1,0 +1,6 @@
+module Schools
+  module AssignExistingMentorWizard
+    class ConfirmationStep < Step
+    end
+  end
+end

--- a/app/wizards/schools/assign_existing_mentor_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/lead_provider_step.rb
@@ -1,0 +1,31 @@
+module Schools
+  module AssignExistingMentorWizard
+    class LeadProviderStep < Step
+      attr_accessor :lead_provider_id
+
+      validates :lead_provider_id,
+                presence: { message: 'Select a lead provider to contact your school' },
+                lead_provider: { message: 'Select a lead provider to contact your school' }
+
+      def self.permitted_params = %i[lead_provider_id]
+
+      def previous_step = :review_mentor_eligibility
+
+      def next_step = :confirmation
+
+    private
+
+      def persist
+        store.lead_provider_id = lead_provider_id
+
+        AssignMentor.new(
+          ect: wizard.context.ect_at_school_period,
+          mentor: wizard.context.mentor_at_school_period,
+          author: wizard.author
+        ).assign!
+
+        # TODO: Update the LP if there is a confirmed partnership, if not add an EOI
+      end
+    end
+  end
+end

--- a/app/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step.rb
@@ -1,0 +1,20 @@
+module Schools
+  module AssignExistingMentorWizard
+    class ReviewMentorEligibilityStep < Step
+      # previous step is outside wizard
+      def next_step = :confirmation
+
+    private
+
+      def persist
+        AssignMentor.new(
+          ect: wizard.context.ect_at_school_period,
+          mentor: wizard.context.mentor_at_school_period,
+          author: wizard.author
+        ).assign!
+
+        # TODO: Update the LP if there is a confirmed partnership, if not add an EOI
+      end
+    end
+  end
+end

--- a/app/wizards/schools/assign_existing_mentor_wizard/step.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/step.rb
@@ -1,0 +1,27 @@
+module Schools
+  module AssignExistingMentorWizard
+    class Step < ApplicationWizardStep
+      def self.permitted_params = []
+
+      def save!
+        persist if wizard.valid_step?
+      end
+
+    private
+
+      def pre_populate_attributes
+        # Pre-populate form fields from the MentorAssignmentContext object
+        # Currently not used but implemented, once the wizard grows it should "just work"
+        return unless wizard.context
+
+        self.class.permitted_params.each do |key|
+          public_send("#{key}=", wizard.context.send(key)) if wizard.context.respond_to?(key)
+        end
+      end
+
+      def step_params
+        @step_params ||= wizard.step_params.to_h.slice(*self.class.permitted_params.map(&:to_s))
+      end
+    end
+  end
+end

--- a/app/wizards/schools/assign_existing_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/assign_existing_mentor_wizard/wizard.rb
@@ -1,0 +1,44 @@
+module Schools
+  module AssignExistingMentorWizard
+    class Wizard < DfE::Wizard::Base
+      attr_accessor :store, :ect_id, :mentor_period_id, :author
+
+      steps do
+        [{
+          review_mentor_eligibility: ReviewMentorEligibilityStep,
+          lead_provider: LeadProviderStep,
+          confirmation: ConfirmationStep
+        }]
+      end
+
+      def self.step?(step_name) = Array(steps).first[step_name].present?
+
+      def allowed_step?(step_name = current_step_name)
+        allowed_steps.include?(step_name)
+      end
+
+      def mentor_assignment_context
+        # Convenience accessors for key objects used throughout the wizard
+        @mentor_assignment_context ||= Shared::MentorAssignmentContext.new(
+          store:,
+          mentor_at_school_period:,
+          ect_at_school_period:
+        )
+      end
+
+      alias_method :context, :mentor_assignment_context
+
+    private
+
+      def allowed_steps = %i[review_mentor_eligibility lead_provider confirmation]
+
+      def mentor_at_school_period
+        @mentor_at_school_period ||= MentorAtSchoolPeriod.find(mentor_period_id)
+      end
+
+      def ect_at_school_period
+        @ect_at_school_period ||= ECTAtSchoolPeriod.find(ect_id)
+      end
+    end
+  end
+end

--- a/app/wizards/schools/shared/mentor_assignment_context.rb
+++ b/app/wizards/schools/shared/mentor_assignment_context.rb
@@ -1,0 +1,52 @@
+module Schools
+  module Shared
+    class MentorAssignmentContext
+      def initialize(store:, mentor_at_school_period:, ect_at_school_period:)
+        @store = store
+        @mentor_at_school_period = mentor_at_school_period
+        @ect_at_school_period = ect_at_school_period
+      end
+
+      attr_reader :mentor_at_school_period, :ect_at_school_period
+
+      def ect_teacher_full_name
+        Teachers::Name.new(@ect_at_school_period.teacher).full_name
+      end
+
+      def mentor_teacher_full_name
+        Teachers::Name.new(@mentor_at_school_period.teacher).full_name
+      end
+
+      def already_active_at_school?
+        @mentor_at_school_period.school_id == @ect_at_school_period.school_id
+      end
+
+      def funding_available?
+        Teachers::MentorFundingEligibility.new(trn: @mentor_at_school_period.teacher.trn).eligible?
+      end
+
+      def user_selected_lead_provider
+        id = @store.lead_provider_id
+        @user_selected_lead_provider ||= LeadProvider.find_by(id:) if id
+      end
+
+      def ect_lead_provider
+        @ect_lead_provider ||= ECTAtSchoolPeriods::CurrentTraining.new(@ect_at_school_period)&.lead_provider
+      end
+
+      def lead_providers_within_contract_period
+        return [] unless contract_period
+
+        @lead_providers_within_contract_period ||= LeadProviders::Active
+          .in_contract_period(contract_period)
+          .select(:id, :name)
+      end
+
+    private
+
+      def contract_period
+        ContractPeriod.containing_date(@ect_at_school_period&.started_on&.to_date)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -350,6 +350,16 @@ Rails.application.routes.draw do
 
       get "confirmation", action: :new
     end
+
+    namespace :assign_existing_mentor_wizard, path: 'assign-existing-mentor' do
+      get 'review-mentor-eligibility', action: :new
+      post 'review-mentor-eligibility', action: :create
+
+      get 'lead-provider', action: :new
+      post 'lead-provider', action: :create
+
+      get 'confirmation', action: :new
+    end
   end
 
   constraints -> { Rails.application.config.enable_api } do

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -1,0 +1,153 @@
+RSpec.describe 'Add a mentor to a provider led ECT' do
+  before do
+    given_there_is_a_school_in_the_service
+    and_the_school_has_a_provider_led_ect_with_no_mentor
+    and_the_school_has_a_mentor_eligible_to_mentor_the_ect
+    and_i_sign_in_as_that_school_user
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_on_the_who_will_mentor_page
+  end
+
+  scenario 'Same lead provider' do
+    given_i_select_the_mentor
+    and_i_click_continue
+    then_i_should_be_taken_to_the_eligibility_page
+
+    given_i_click_the_back_link
+    and_i_am_back_on_the_who_will_mentor_page
+    then_the_mentor_i_previously_selected_is_still_selected
+
+    given_i_click_continue
+    and_i_click_continue
+    then_i_should_be_taken_to_the_mentorship_confirmation_page
+
+    given_i_click_on_back_to_your_ects
+    then_i_should_be_taken_to_the_ects_page
+    and_the_ect_is_shown_linked_to_the_mentor_just_registered
+  end
+
+  scenario 'New lead provider' do
+    given_i_select_the_mentor
+    and_i_click_continue
+    then_i_should_be_taken_to_the_eligibility_page
+
+    given_i_click_the_back_link
+    and_i_am_back_on_the_who_will_mentor_page
+    then_the_mentor_i_previously_selected_is_still_selected
+
+    given_i_click_continue
+    and_i_click_on_the_my_lead_provider_is_not_providing_mentor_training_link
+    and_the_back_link_links_to_the_eligibility_page
+    and_i_choose_the_lead_provider_vegeta
+    and_i_click_continue
+    then_i_should_be_taken_to_the_mentorship_confirmation_page
+
+    given_i_click_on_back_to_your_ects
+    then_i_should_be_taken_to_the_ects_page
+    and_the_ect_is_shown_linked_to_the_mentor_just_registered
+  end
+
+  def and_the_back_link_links_to_the_who_will_mentor_page
+    expect(page.get_by_role(:link, name: 'Back').get_attribute('href')).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+  end
+
+  def and_the_back_link_links_to_the_eligibility_page
+    expect(page.get_by_role(:link, name: 'Back').get_attribute('href')).to end_with("/school/assign-existing-mentor/review-mentor-eligibility")
+  end
+
+  def and_i_choose_the_lead_provider_vegeta
+    page.get_by_role(:radio, name: @lead_provider_2.name).check
+  end
+
+  def and_i_click_on_the_my_lead_provider_is_not_providing_mentor_training_link
+    page.get_by_role('link', name: "#{@lead_provider.name} will not be providing mentor training to #{@mentor_name}").click
+  end
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_the_school_has_a_provider_led_ect_with_no_mentor
+    @cp_2023 = FactoryBot.create(:contract_period, year: 2023)
+
+    @lead_provider = FactoryBot.create(:lead_provider, name: "Goku")
+    @lead_provider_2 = FactoryBot.create(:lead_provider, name: "Vegeta")
+
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider,   contract_period: @cp_2023)
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider_2, contract_period: @cp_2023)
+
+    @ect = FactoryBot.create(
+      :ect_at_school_period,
+      :provider_led,
+      :ongoing,
+      :with_training_period,
+      school: @school,
+      started_on: Date.new(2023, 9, 1),
+      lead_provider: @lead_provider,
+      contract_period: @cp_2023
+    )
+
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_the_school_has_a_mentor_eligible_to_mentor_the_ect
+    @mentor = FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school: @school,
+      started_on: Date.new(2023, 9, 1)
+    )
+
+    @mentor_name = Teachers::Name.new(@mentor.teacher).full_name
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role(:link, name: 'assign a mentor or register a new one').click
+  end
+
+  def then_i_am_on_the_who_will_mentor_page
+    expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
+    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+  end
+
+  def and_i_am_back_on_the_who_will_mentor_page
+    expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
+    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new?preselect=#{@mentor.id}")
+  end
+
+  def given_i_select_the_mentor
+    page.get_by_role(:radio, name: @mentor_name).check
+  end
+
+  def then_the_mentor_i_previously_selected_is_still_selected
+    expect(page.get_by_role(:radio, name: @mentor_name)).to be_checked
+  end
+
+  def then_i_should_be_taken_to_the_eligibility_page
+    expect(page.url).to end_with("assign-existing-mentor/review-mentor-eligibility")
+    expect(page.get_by_text("#{@mentor_name} can receive mentor training")).to be_visible
+  end
+
+  def then_i_should_be_taken_to_the_mentorship_confirmation_page
+    expect(page.url).to end_with("/school/assign-existing-mentor/confirmation")
+    expect(page.get_by_text("You’ve assigned #{@mentor_name} as a mentor for #{@ect_name}")).to be_visible
+  end
+
+  def given_i_click_on_back_to_your_ects
+    page.get_by_role(:link, name: 'Back to your ECTs').click
+  end
+
+  def then_i_should_be_taken_to_the_ects_page
+    expect(page.url).to end_with('/schools/home/ects')
+  end
+
+  def and_the_ect_is_shown_linked_to_the_mentor_just_registered
+    expect(page.get_by_role(:link, name: @ect_name)).to be_visible
+    expect(page.locator('dt', hasText: 'Mentor')).to be_visible
+    expect(page.locator('dd', hasText: @mentor_name)).to be_visible
+  end
+end

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Add a mentor to a provider led ECT' do
   end
 
   def and_the_back_link_links_to_the_eligibility_page
-    expect(page.get_by_role(:link, name: 'Back').get_attribute('href')).to end_with("/school/assign-existing-mentor/review-mentor-eligibility")
+    expect(page.get_by_role(:link, name: 'Back', exact: true).get_attribute('href')).to end_with('/school/assign-existing-mentor/review-mentor-eligibility')
   end
 
   def and_i_choose_the_lead_provider_vegeta

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -77,21 +77,22 @@ RSpec.describe 'Add a mentor to a provider led ECT' do
     @lead_provider = FactoryBot.create(:lead_provider, name: "Goku")
     @lead_provider_2 = FactoryBot.create(:lead_provider, name: "Vegeta")
 
-    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider,   contract_period: @cp_2023)
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: @cp_2023)
+    @lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: @active_lead_provider)
+    @school_partnership = FactoryBot.create(:school_partnership, school: @school, lead_provider_delivery_partnership: @lead_provider_delivery_partnership)
+
     FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider_2, contract_period: @cp_2023)
 
     @ect = FactoryBot.create(
       :ect_at_school_period,
-      :provider_led,
       :ongoing,
-      :with_training_period,
       school: @school,
-      started_on: Date.new(2023, 9, 1),
-      lead_provider: @lead_provider,
-      contract_period: @cp_2023
+      started_on: Date.new(2023, 9, 1)
     )
 
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
+
+    FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: @ect, school_partnership: @school_partnership)
   end
 
   def and_the_school_has_a_mentor_eligible_to_mentor_the_ect

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
@@ -1,7 +1,7 @@
-RSpec.describe 'Add a mentor to an ECT' do
+RSpec.describe 'Add a mentor to a school led ECT' do
   scenario 'happy path' do
     given_there_is_a_school_in_the_service
-    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
     and_there_is_a_mentor_registered_at_the_school_eligible_to_mentor_the_ect
     and_i_sign_in_as_that_school_user
     and_i_am_on_the_schools_landing_page
@@ -24,8 +24,8 @@ RSpec.describe 'Add a mentor to an ECT' do
     sign_in_as_school_user(school: @school)
   end
 
-  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+  def and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :school_led, :ongoing, school: @school)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'Add a mentor to a school led ECT' do
   end
 
   def and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school
-    @ect = FactoryBot.create(:ect_at_school_period, :school_led, :ongoing, school: @school)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @training_period = FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: @ect)
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 

--- a/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
+++ b/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe 'Assign existing mentor wizard', type: :request do
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect)    { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led, school:) }
+  let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+
+  def kickoff_wizard!
+    allow(Teachers::MentorFundingEligibility).to receive(:new)
+      .with(trn: mentor.teacher.trn)
+      .and_return(instance_double(Teachers::MentorFundingEligibility, eligible?: true))
+
+    post(
+      "/school/ects/#{ect.id}/mentorship",
+      params: { schools_assign_mentor_form: { mentor_id: mentor.id } }
+    )
+  end
+
+  describe 'GET /school/assign-existing-mentor/:step' do
+    context 'when signed in as a school user' do
+      before { sign_in_as(:school_user, school:) }
+
+      context 'when the wizard is not yet started' do
+        it 'redirects to the root path' do
+          get schools_assign_existing_mentor_wizard_review_mentor_eligibility_path
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'when the mentor is eligible for funding' do
+        before { kickoff_wizard! }
+
+        it 'renders the review_mentor_eligibility step' do
+          get schools_assign_existing_mentor_wizard_review_mentor_eligibility_path
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'renders the lead_provider step' do
+          get schools_assign_existing_mentor_wizard_lead_provider_path
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context 'when visiting an invalid step' do
+        it 'renders a 404 page' do
+          get '/school/assign-existing-mentor/fake-step'
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+
+  describe 'POST /school/assign-existing-mentor/:step' do
+    before { sign_in_as(:school_user, school:) }
+
+    context 'when the wizard is not started' do
+      it 'redirects to the root path' do
+        post schools_assign_existing_mentor_wizard_review_mentor_eligibility_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when mentor is eligible for funding' do
+      before { kickoff_wizard! }
+
+      it 'redirects to the confirmation step' do
+        post schools_assign_existing_mentor_wizard_review_mentor_eligibility_path
+        expect(response).to redirect_to(schools_assign_existing_mentor_wizard_confirmation_path)
+      end
+    end
+
+    context 'when visiting an invalid step' do
+      it 'renders a 404 page' do
+        post '/school/assign-existing-mentor/fake-step'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
+++ b/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
@@ -1,7 +1,11 @@
 RSpec.describe 'Assign existing mentor wizard', type: :request do
   let(:school) { FactoryBot.create(:school) }
-  let(:ect)    { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led, school:) }
+  let(:ect)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
+
+  before do
+    FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect)
+  end
 
   def kickoff_wizard!
     allow(Teachers::MentorFundingEligibility).to receive(:new)

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -72,8 +72,12 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
       end
 
       context 'when a valid mentor has been selected for the school led ect mentorship' do
+        before do
+          FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: ect)
+        end
+
         let(:params) { { schools_assign_mentor_form: { mentor_id: mentor.id } } }
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :school_led, school:) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
 
         it 'creates the mentorship and redirects the user to the confirmation page' do
           allow(Schools::AssignMentorForm).to receive(:new).and_call_original
@@ -88,8 +92,12 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
       end
 
       context 'provider led ECT mentorship' do
+        before do
+          FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect)
+        end
+
         let(:params) { { schools_assign_mentor_form: { mentor_id: mentor.id } } }
-        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, :provider_led, school:) }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
 
         context 'when the mentor is eligible for funding' do
           before do

--- a/spec/support/features/view_helpers.rb
+++ b/spec/support/features/view_helpers.rb
@@ -6,5 +6,12 @@ module Features
 
     alias_method :when_i_click_the_back_link, :given_i_click_the_back_link
     alias_method :and_i_click_the_back_link, :given_i_click_the_back_link
+
+    def given_i_click_continue
+      page.get_by_role('button', name: "Continue").click
+    end
+
+    alias_method :when_i_click_continue, :given_i_click_continue
+    alias_method :and_i_click_continue, :given_i_click_continue
   end
 end

--- a/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Schools::AssignExistingMentorWizard::LeadProviderStep do
+  subject(:step) { described_class.new(wizard:, lead_provider_id:) }
+
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:lead_provider_id) { lead_provider.id }
+  let(:ect_at_school_period) { instance_double(ECTAtSchoolPeriod) }
+  let(:mentor_at_school_period) { instance_double(MentorAtSchoolPeriod) }
+  let(:author) { instance_double(User) }
+
+  let(:context) do
+    instance_double(
+      Schools::Shared::MentorAssignmentContext,
+      ect_at_school_period:,
+      mentor_at_school_period:
+    )
+  end
+
+  let(:wizard) do
+    instance_double(
+      Schools::AssignExistingMentorWizard::Wizard,
+      context:,
+      author:
+    )
+  end
+
+  describe '#valid?' do
+    context 'when lead_provider_id is nil' do
+      let(:lead_provider_id) { nil }
+
+      it 'is invalid with correct error' do
+        expect(step).not_to be_valid
+        expect(step.errors[:lead_provider_id]).to include('Select a lead provider to contact your school')
+      end
+    end
+
+    context 'when lead_provider_id is present' do
+      it 'is valid' do
+        expect(step).to be_valid
+      end
+    end
+  end
+
+  describe '#next_step' do
+    it { expect(step.next_step).to eq(:confirmation) }
+  end
+
+  describe '#previous_step' do
+    it { expect(step.previous_step).to eq(:review_mentor_eligibility) }
+  end
+
+  describe '#save' do
+    let(:store) { OpenStruct.new(lead_provider_id: nil) }
+    let(:assign_mentor_double) { instance_double(Schools::AssignMentor, assign!: true) }
+
+    let(:wizard) do
+      instance_double(
+        Schools::AssignExistingMentorWizard::Wizard,
+        context:,
+        author:,
+        store:,
+        valid_step?: true
+      )
+    end
+
+    before do
+      allow(Schools::AssignMentor).to receive(:new).and_return(assign_mentor_double)
+    end
+
+    it 'persists the selected lead_provider_id to the store' do
+      expect { step.save! }.to change(store, :lead_provider_id).from(nil).to(lead_provider_id)
+    end
+  end
+end

--- a/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Schools::AssignExistingMentorWizard::ReviewMentorEligibilityStep do
+  subject(:step) { described_class.new(wizard:) }
+
+  let(:ect_at_school_period) { instance_double(ECTAtSchoolPeriod) }
+  let(:mentor_at_school_period) { instance_double(MentorAtSchoolPeriod) }
+  let(:author) { instance_double(User) }
+
+  let(:context) do
+    instance_double(Schools::Shared::MentorAssignmentContext,
+                    ect_at_school_period:,
+                    mentor_at_school_period:)
+  end
+
+  let(:wizard) do
+    instance_double(
+      Schools::AssignExistingMentorWizard::Wizard,
+      context:,
+      author:
+    )
+  end
+
+  describe '#next_step' do
+    it 'returns :confirmation' do
+      expect(step.next_step).to eq(:confirmation)
+    end
+  end
+end

--- a/spec/wizards/schools/assign_existing_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/wizard_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Schools::AssignExistingMentorWizard::Wizard do
+  describe '.step?' do
+    it 'returns true for a valid step name' do
+      expect(described_class.step?(:confirmation)).to be(true)
+    end
+
+    it 'returns false for an invalid step name' do
+      expect(described_class.step?(:fake_step)).to be(false)
+    end
+  end
+
+  describe '#allowed_step?' do
+    let(:wizard) do
+      described_class.new(
+        current_step: :review_mentor_eligibility,
+        store: instance_double(SessionRepository),
+        mentor_period_id: 1,
+        ect_id: 2,
+        author: instance_double(User)
+      )
+    end
+
+    it 'returns true for allowed steps' do
+      expect(wizard.allowed_step?(:review_mentor_eligibility)).to be(true)
+    end
+
+    it 'returns false for an unlisted step' do
+      expect(wizard.allowed_step?(:some_other_step)).to be(false)
+    end
+  end
+end

--- a/spec/wizards/schools/shared/mentor_assignment_context_spec.rb
+++ b/spec/wizards/schools/shared/mentor_assignment_context_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe Schools::Shared::MentorAssignmentContext do
+  subject(:context) do
+    described_class.new(
+      store:,
+      mentor_at_school_period:,
+      ect_at_school_period:
+    )
+  end
+
+  let(:school) { FactoryBot.create(:school) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:store) { FactoryBot.build(:session_repository, lead_provider_id: lead_provider.id) }
+
+  let(:mentor_teacher) { FactoryBot.create(:teacher, trn: '1234567', trs_first_name: 'Goku', trs_last_name: 'Saiyan', mentor_became_ineligible_for_funding_reason: nil) }
+  let(:ect_teacher) { FactoryBot.create(:teacher, trs_first_name: 'King', trs_last_name: 'Vegeta') }
+
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: mentor_teacher) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(:ect_at_school_period, :provider_led, school:, teacher: ect_teacher, started_on: Date.new(2025, 5, 1))
+  end
+
+  describe '#ect_teacher_full_name' do
+    it 'returns the ECTs full name' do
+      expect(context.ect_teacher_full_name).to eq('King Vegeta')
+    end
+  end
+
+  describe '#mentor_teacher_full_name' do
+    it 'returns the mentors full name' do
+      expect(context.mentor_teacher_full_name).to eq('Goku Saiyan')
+    end
+  end
+
+  describe "#already_active_at_school" do
+    it 'returns true when both ECT and mentor are at the same school' do
+      expect(context.already_active_at_school?).to be(true)
+    end
+  end
+
+  describe '#funding_available?' do
+    it 'returns true if mentor_became_ineligible_for_funding_reason is nil' do
+      expect(context.funding_available?).to be(true)
+    end
+  end
+
+  describe '#user_selected_lead_provider' do
+    it 'returns the lead provider from the store' do
+      expect(context.user_selected_lead_provider).to eq(lead_provider)
+    end
+  end
+
+  describe '#ect_lead_provider' do
+    let(:started_on) { 2.days.ago.to_date }
+    let(:finished_on) { 2.days.from_now.to_date }
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period, :provider_led, :with_training_period, started_on:, finished_on:, school:, teacher: ect_teacher, lead_provider:)
+    end
+
+    it 'returns the ECT lead provider using CurrentTraining service' do
+      expect(context.ect_lead_provider).to eq(lead_provider)
+    end
+  end
+
+  describe '#lead_providers_within_contract_period' do
+    let!(:in_contract_period) do
+      FactoryBot.create(:contract_period, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 12, 31))
+    end
+
+    let!(:out_of_contract_period) do
+      FactoryBot.create(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 12, 31))
+    end
+
+    let!(:lead_provider_1) { FactoryBot.create(:lead_provider) }
+    let!(:lead_provider_2) { FactoryBot.create(:lead_provider) }
+    let!(:excluded_provider) { FactoryBot.create(:lead_provider) }
+
+    before do
+      FactoryBot.create(:active_lead_provider, contract_period: in_contract_period, lead_provider: lead_provider_1)
+      FactoryBot.create(:active_lead_provider, contract_period: in_contract_period, lead_provider: lead_provider_2)
+      FactoryBot.create(:active_lead_provider, contract_period: out_of_contract_period, lead_provider: excluded_provider)
+    end
+
+    it 'returns only lead providers within the ECTs contract period' do
+      expect(context.lead_providers_within_contract_period).to contain_exactly(lead_provider_1, lead_provider_2)
+    end
+  end
+end

--- a/spec/wizards/schools/shared/mentor_assignment_context_spec.rb
+++ b/spec/wizards/schools/shared/mentor_assignment_context_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Schools::Shared::MentorAssignmentContext do
 
   let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: mentor_teacher) }
   let(:ect_at_school_period) do
-    FactoryBot.create(:ect_at_school_period, :provider_led, school:, teacher: ect_teacher, started_on: Date.new(2025, 5, 1))
+    FactoryBot.create(:ect_at_school_period, school:, teacher: ect_teacher, started_on: Date.new(2025, 5, 1))
   end
 
   describe '#ect_teacher_full_name' do
@@ -52,8 +52,27 @@ RSpec.describe Schools::Shared::MentorAssignmentContext do
   describe '#ect_lead_provider' do
     let(:started_on) { 2.days.ago.to_date }
     let(:finished_on) { 2.days.from_now.to_date }
+
+    let(:school_partnership) do
+      active_lp = FactoryBot.create(:active_lead_provider, lead_provider:)
+      lpdp = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lp)
+      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp)
+    end
+
     let(:ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :provider_led, :with_training_period, started_on:, finished_on:, school:, teacher: ect_teacher, lead_provider:)
+      FactoryBot.create(:ect_at_school_period, started_on:, finished_on:, school:, teacher: ect_teacher)
+    end
+
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :provider_led,
+        :ongoing,
+        ect_at_school_period:,
+        started_on:,
+        finished_on:,
+        school_partnership:
+      )
     end
 
     it 'returns the ECT lead provider using CurrentTraining service' do


### PR DESCRIPTION
### Context

Introduce a mini wizard into the mentor assignment flow. This will allows us to handle new questions in a structured way and makes the flow easier to extend or adjust in future.

### Changes proposed in this pull request

- Add a **mentor eligible page** leading onto the confirmation step
- Add **lead provider selection page**, accessible from the eligibility step
- Add a **confirmation page** for completing the flow
- Introduce `Schools::Shared::MentorAssignmentContext` PORO to encapsulate wizard logic

### Screenshots

<img width="1941" height="673" alt="image" src="https://github.com/user-attachments/assets/0a905552-de86-47d6-b544-7cc9303b6f1a" />

### Guidance to review

Login as **Serena** and assign a mentor to **Harriet Walter**, choose **Dame Helen Mirren**. You will then be on the new journey. Click the link below the continue button to get to the Lead provider selection page.

