### PR TITLE
User FactoryBot in creating lead providers in seeds

### DIFF
--- a/db/seeds/lead_providers.rb
+++ b/db/seeds/lead_providers.rb
@@ -19,10 +19,10 @@ lead_providers_data = [
 ]
 
 lead_providers_data.each do |data|
-  lead_provider = LeadProvider.create!(name: data[:name])
+  lead_provider = FactoryBot.create(:lead_provider, name: data[:name])
   data[:years].each do |year|
     contract_period = ContractPeriod.find_by!(year:)
-    ActiveLeadProvider.create!(contract_period:, lead_provider:)
+    FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:)
   end
 
   describe_lead_provider(lead_provider, data[:years])


### PR DESCRIPTION
### Context
Lead providers are currently set up in seeds without `ecf_id` which doesn't allow the parity check page to appear properly as it relies on  lead providers with ECF id

### Changes proposed in this pull request
- Use the existing factories to create lead providers where we always generate an ecf id, also use factories for active lead provider
- We have a ticket to move all entity creation to factories in seeds coming soon, so doing this just for the lead provider seeds for now