### PR TITLE
Remove `SampleJob`

### DIFF
--- a/app/jobs/sample_job.rb
+++ b/app/jobs/sample_job.rb
@@ -1,5 +1,0 @@
-class SampleJob < ApplicationJob
-  def perform(*args)
-    Rails.logger.info "SampleJob#perform with arguments: #{args.inspect}"
-  end
-end


### PR DESCRIPTION
We're not using this, so I figured we can remove it.