### PR TITLE
Explicitly set Delivery Partner name in test to avoid mismatches

### DIFF
--- a/spec/requests/admin/delivery_partners_spec.rb
+++ b/spec/requests/admin/delivery_partners_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Admin delivery partners", type: :request do
   end
 
   describe "GET /admin/organisations/delivery-partners/:id" do
-    let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+    let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: "Test College Delivery Partner") }
     let(:show_path) { admin_delivery_partner_path(delivery_partner) }
 
     it "redirects to sign in path" do


### PR DESCRIPTION
When Faker returns names such as O'Reilly for a name, they will be rendered as "O&#39;Reilly" which will fail the spec as the name cannot be found.

Explicitly set a delivery partner name to avoid mismatches in spec expectations on names
