### PR TITLE
Ensure ukprn generation in GIAS school factory is unique

### DIFF
--- a/spec/factories/gias/school_factory.rb
+++ b/spec/factories/gias/school_factory.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     establishment_number { Faker::Number.unique.within(range: 1..9_999) }
     phase_name { "Phase one" }
     urn { Faker::Number.unique.within(range: 10_000..9_999_999) }
-    ukprn { rand(1_000_000..99_999_999).to_s }
+    ukprn { Faker::Number.unique.within(range: 1_000_000..99_999_999).to_s }
 
     # eligibility to be registered in the service
     trait(:eligible_for_registration) do


### PR DESCRIPTION
### Context

Trying to fix multiple flakey tests:
```
Failures:

  1) SandboxSeedData::SchoolPartnerships#plant logs the creation of school partnerships
     Failure/Error: gias_school { association :gias_school, :open, :independent_school_type, :eligible_for_cip, urn: }

     ActiveRecord::RecordInvalid:
       Validation failed: Ukprn has already been taken
     # ./spec/factories/school_factory.rb:7:in 'block (4 levels) in <main>'
     # ./spec/services/sandbox_seed_data/school_partnerships_spec.rb:18:in 'block (3 levels) in <main>'
     # ./spec/support/rack_attack.rb:17:in 'block (2 levels) in <main>'

Finished in 3 minutes 32 seconds (files took 10.31 seconds to load)
5047 examples, 1 failure, 5 pending

Failed examples:

rspec ./spec/services/sandbox_seed_data/school_partnerships_spec.rb:33 # SandboxSeedData::SchoolPartnerships#plant logs the creation of school partnerships
```


### Changes proposed in this pull request
- ensure `ukprn` is unique in factory bot
- reduce number of schools created for test, as 100 is not required

### Guidance to review
