### PR TITLE
Update ECT details page (2nd attempt)

### DIFF
--- a/app/components/schools/ect_induction_details_component.rb
+++ b/app/components/schools/ect_induction_details_component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Schools
+  class ECTInductionDetailsComponent < ViewComponent::Base
+    include TeacherHelper
+
+    def initialize(ect)
+      @ect = ect
+    end
+
+    def call
+      safe_join([
+        tag.h2('Induction details', class: 'govuk-heading-m'),
+        govuk_summary_list(rows:)
+      ])
+    end
+
+  private
+
+    def rows
+      [
+        appropriate_body_row,
+        induction_start_date_row
+      ]
+    end
+
+    def appropriate_body_row
+      { key: { text: 'Appropriate body' }, value: { text: @ect.school_reported_appropriate_body_name } }
+    end
+
+    def induction_start_date_row
+      date = induction_start_date
+      if date.present?
+        {
+          key: { text: 'Induction start date' },
+          value: { text: induction_start_date_with_suffix(date) }
+        }
+      else
+        {
+          key: { text: 'Induction start date' },
+          value: { text: 'Yet to be reported by the appropriate body' }
+        }
+      end
+    end
+
+    def induction_start_date
+      Teachers::Induction.new(@ect.teacher).induction_start_date&.to_fs(:govuk)
+    end
+
+    def induction_start_date_with_suffix(date)
+      safe_join([
+        date,
+        tag.br,
+        tag.span("This has been reported by an appropriate body", class: 'govuk-hint')
+      ])
+    end
+  end
+end

--- a/app/components/schools/ect_training_details_component.rb
+++ b/app/components/schools/ect_training_details_component.rb
@@ -92,14 +92,7 @@ module Schools
     end
 
     def training_programme_display_name
-      case training_period.training_programme
-      when 'provider_led'
-        'Provider-led'
-      when 'school_led'
-        'School-led'
-      else
-        training_period.training_programme&.humanize || 'Unknown'
-      end
+      TRAINING_PROGRAMME.fetch(training_period.training_programme, 'Unknown')
     end
   end
 end

--- a/app/components/schools/ect_training_details_component.rb
+++ b/app/components/schools/ect_training_details_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Schools
+  class ECTTrainingDetailsComponent < ViewComponent::Base
+    include ProgrammeHelper
+
+    def initialize(ect)
+      @ect = ect
+    end
+
+    def call
+      safe_join([
+        tag.h2('Training details', class: 'govuk-heading-m'),
+        govuk_summary_list(rows:)
+      ])
+    end
+
+  private
+
+    def training
+      @training ||= ECTAtSchoolPeriods::CurrentTraining.new(@ect)
+    end
+
+    def rows
+      base_rows = [training_programme_row]
+
+      if training.provider_led?
+        base_rows << lead_provider_row
+        base_rows << delivery_partner_row
+      end
+
+      base_rows
+    end
+
+    def training_programme_row
+      { key: { text: 'Training programme' }, value: { text: training_programme_display_name } }
+    end
+
+    def lead_provider_row
+      {
+        key: { text: 'Lead provider' },
+        value: { text: lead_provider_display_text }
+      }
+    end
+
+    def delivery_partner_row
+      {
+        key: { text: 'Delivery partner' },
+        value: { text: delivery_partner_display_text }
+      }
+    end
+
+    def lead_provider_display_text
+      return fallback_lead_provider_name unless partnership_confirmed? || training.expression_of_interest?
+
+      if partnership_confirmed?
+        provider_name = training.lead_provider_name
+        status_text = "Confirmed by #{provider_name}"
+      else
+        provider_name = training.expression_of_interest_lead_provider_name
+        status_text = "Awaiting confirmation by #{provider_name}"
+      end
+
+      return 'Not available' if provider_name.blank?
+
+      safe_join([
+        provider_name,
+        tag.br,
+        tag.span(status_text, class: 'govuk-hint')
+      ])
+    end
+
+    def delivery_partner_display_text
+      return yet_to_be_reported_message unless partnership_confirmed? && training.delivery_partner_name.present?
+
+      safe_join([
+        training.delivery_partner_name,
+        tag.br,
+        tag.span("To change the delivery partner, you must contact the lead provider", class: 'govuk-hint')
+      ])
+    end
+
+    def partnership_confirmed?
+      training.school_partnership.present?
+    end
+
+    def fallback_lead_provider_name
+      training.lead_provider_name || training.expression_of_interest_lead_provider_name || 'Not available'
+    end
+
+    def yet_to_be_reported_message
+      'Yet to be reported by the lead provider'
+    end
+
+    def training_programme_display_name
+      case training.training_programme
+      when 'provider_led'
+        'Provider-led'
+      when 'school_led'
+        'School-led'
+      else
+        training.training_programme&.humanize || 'Unknown'
+      end
+    end
+  end
+end

--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -1,0 +1,33 @@
+<h2 class="govuk-heading-m">ECT details</h2>
+
+<%= govuk_summary_list do |list| %>
+  <% list.with_row do |row| %>
+    <% row.with_key { "Name" } %>
+    <% row.with_value { teacher_full_name(@ect.teacher) } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <% row.with_key { "Email address" } %>
+    <% row.with_value { @ect.email } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <% row.with_key { "Mentor" } %>
+    <% row.with_value { ect_mentor_details(@ect) } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <% row.with_key { "Status" } %>
+    <% row.with_value { ect_status_tag } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <% row.with_key { "School start date" } %>
+    <% row.with_value { ect_start_date(@ect) } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <% row.with_key { "Working pattern" } %>
+    <% row.with_value { @ect.working_pattern&.humanize } %>
+  <% end %>
+<% end %>

--- a/app/components/schools/teacher_profile_summary_list_component.rb
+++ b/app/components/schools/teacher_profile_summary_list_component.rb
@@ -7,40 +7,29 @@ module Schools
       @ect = ect
     end
 
-    def rows
-      [
-        name_row,
-        email_row,
-        mentor_row,
-        school_start_date_row,
-        working_pattern_row
-      ]
-    end
-
-    def call
-      safe_join([tag.h2('ECT details', class: 'govuk-heading-m'), govuk_summary_list(rows:)])
-    end
-
   private
 
-    def name_row
-      { key: { text: 'Name' }, value: { text: teacher_full_name(@ect.teacher) } }
+    def ect_status_tag
+      induction_status = @ect.teacher.trs_induction_status
+
+      case induction_status
+      when "Passed"
+        govuk_tag(text: "Completed induction", colour: "blue")
+      when "Failed"
+        govuk_tag(text: "Failed induction", colour: "pink")
+      when "Exempt"
+        govuk_tag(text: "Exempt", colour: "grey")
+      else
+        if current_mentor_name(@ect)
+          govuk_tag(text: "Registered", colour: "green")
+        else
+          govuk_tag(text: "Mentor required", colour: "red")
+        end
+      end
     end
 
-    def email_row
-      { key: { text: 'Email address' }, value: { text: @ect.email } }
-    end
-
-    def mentor_row
-      { key: { text: 'Mentor' }, value: { text: ect_mentor_details(@ect) } }
-    end
-
-    def school_start_date_row
-      { key: { text: 'School start date' }, value: { text: ect_start_date(@ect) } }
-    end
-
-    def working_pattern_row
-      { key: { text: 'Working pattern' }, value: { text: @ect.working_pattern&.humanize } }
+    def current_mentor_name(ect)
+      ECTAtSchoolPeriods::Mentorship.new(ect).current_mentor_name
     end
   end
 end

--- a/app/services/ect_at_school_periods/current_training.rb
+++ b/app/services/ect_at_school_periods/current_training.rb
@@ -43,5 +43,12 @@ module ECTAtSchoolPeriods
 
     # expression_of_interest_lead_provider_name
     delegate :name, to: :expression_of_interest_lead_provider, allow_nil: true, prefix: :expression_of_interest_lead_provider
+
+    # training_programme
+    delegate :training_programme, to: :current_training_period, allow_nil: true
+
+    def provider_led?
+      current_training_period&.provider_led_training_programme?
+    end
   end
 end

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -9,13 +9,6 @@
 
 <%= render Schools::TeacherProfileSummaryListComponent.new(@ect_at_school_period) %>
 
-<h2 class="govuk-heading-m">ECTE training details</h2>
+<%= render Schools::ECTInductionDetailsComponent.new(@ect_at_school_period) %>
 
-<%= render Schools::SummaryCardComponent.new(title: 'Reported to us by your school', ect_at_school_period: @ect_at_school_period, training_period: @training_period, data_source: :school) %>
-
-<% if @training_period&.provider_led_training_programme? %>
-  <%= render Schools::SummaryCardComponent.new(title: 'Reported to us by your lead provider', ect_at_school_period: @ect_at_school_period, training_period: @training_period, data_source: :lead_provider) %>
-<% end %>
-
-
-<%= render Schools::SummaryCardComponent.new(title: 'Reported to us by your appropriate body', ect_at_school_period: @ect_at_school_period, training_period: @training_period, data_source: :appropriate_body) %>
+<%= render Schools::ECTTrainingDetailsComponent.new(@ect_at_school_period) %>

--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -11,4 +11,4 @@
 
 <%= render Schools::ECTInductionDetailsComponent.new(@ect_at_school_period) %>
 
-<%= render Schools::ECTTrainingDetailsComponent.new(@ect_at_school_period) %>
+<%= render Schools::ECTTrainingDetailsComponent.new(ect_at_school_period: @ect_at_school_period, training_period: @training_period) %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -8,7 +8,7 @@ STATUTORY_INDUCTION_ROLLOUT_DATE = Date.new(1999, 9, 1).freeze
 TRAINING_PROGRAMME = {
   provider_led: 'Provider-led',
   school_led: 'School-led'
-}.freeze
+}.with_indifferent_access.freeze
 
 # Old types (induction periods and pending induction submissions) to be deprecated
 INDUCTION_PROGRAMMES = {

--- a/spec/components/schools/ect_induction_details_component_spec.rb
+++ b/spec/components/schools/ect_induction_details_component_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: 'Alpha Teaching School Hub') }
+  let(:teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'John', trs_last_name: 'Doe') }
+  let(:ect) do
+    FactoryBot.create(:ect_at_school_period,
+                      teacher:,
+                      school_reported_appropriate_body: appropriate_body,
+                      started_on: Date.new(2023, 9, 1))
+  end
+
+  before do
+    render_inline(described_class.new(ect))
+  end
+
+  it "renders the section heading" do
+    expect(page).to have_selector('h2.govuk-heading-m', text: 'Induction details')
+  end
+
+  it "renders the appropriate body row" do
+    expect(page).to have_selector('.govuk-summary-list__key', text: 'Appropriate body')
+    expect(page).to have_selector('.govuk-summary-list__value', text: 'Alpha Teaching School Hub')
+  end
+
+  context 'when induction start date is available' do
+    let!(:induction_period) do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body:, started_on: Date.new(2023, 9, 1))
+    end
+
+    before do
+      teacher.reload # Reload to pick up the new induction period
+      render_inline(described_class.new(ect))
+    end
+
+    it "renders the induction start date with appropriate text" do
+      expect(page).to have_selector('.govuk-summary-list__key', text: 'Induction start date')
+      expect(page).to have_selector('.govuk-summary-list__value', text: '1 September 2023')
+      expect(page).to have_text('This has been reported by an appropriate body')
+    end
+  end
+
+  context 'when induction start date is not available' do
+    it "renders the appropriate message" do
+      expect(page).to have_selector('.govuk-summary-list__key', text: 'Induction start date')
+      expect(page).to have_selector('.govuk-summary-list__value', text: 'Yet to be reported by the appropriate body')
+    end
+  end
+end

--- a/spec/components/schools/ect_training_details_component_spec.rb
+++ b/spec/components/schools/ect_training_details_component_spec.rb
@@ -1,0 +1,172 @@
+RSpec.describe Schools::ECTTrainingDetailsComponent, type: :component do
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: 'Ambition Institute') }
+  let(:delivery_partner) { FactoryBot.create(:delivery_partner, name: 'Test Delivery Partner') }
+  let(:teacher) { FactoryBot.create(:teacher, trn: '9876543', trs_first_name: 'John', trs_last_name: 'Doe') }
+  let(:ect) do
+    FactoryBot.create(:ect_at_school_period,
+                      teacher:,
+                      training_programme: 'provider_led')
+  end
+
+  before do
+    render_inline(described_class.new(ect))
+  end
+
+  it "renders the section heading" do
+    expect(page).to have_selector('h2.govuk-heading-m', text: 'Training details')
+  end
+
+  it "renders the training programme row" do
+    expect(page).to have_selector('.govuk-summary-list__key', text: 'Training programme')
+  end
+
+  context 'when provider-led training' do
+    let(:ect) do
+      FactoryBot.create(:ect_at_school_period,
+                        :ongoing,
+                        :with_training_period,
+                        teacher:,
+                        training_programme: 'provider_led',
+                        lead_provider:,
+                        delivery_partner:)
+    end
+
+    it "shows lead provider and delivery partner fields" do
+      expect(page).to have_selector('.govuk-summary-list__key', text: 'Lead provider')
+      expect(page).to have_selector('.govuk-summary-list__key', text: 'Delivery partner')
+    end
+
+    context 'with confirmed partnership' do
+      it "shows lead provider information" do
+        expect(page).to have_selector('.govuk-summary-list__key', text: 'Lead provider')
+        expect(page).to have_selector('.govuk-summary-list__value')
+      end
+    end
+
+    context 'with expression of interest only' do
+      let(:ect) do
+        FactoryBot.create(:ect_at_school_period,
+                          :ongoing,
+                          teacher:,
+                          training_programme: 'provider_led')
+      end
+
+      before do
+        # Create an EOI training period that matches the ongoing scope
+        active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:)
+        FactoryBot.create(:training_period,
+                          :provider_led,
+                          :ongoing,
+                          ect_at_school_period: ect,
+                          school_partnership: nil,
+                          expression_of_interest: active_lead_provider,
+                          started_on: Date.current,
+                          finished_on: nil)
+        ect.reload # Ensure association cache is cleared
+        render_inline(described_class.new(ect))
+      end
+
+      it "shows lead provider information" do
+        expect(page).to have_selector('.govuk-summary-list__key', text: 'Lead provider')
+        expect(page).to have_selector('.govuk-summary-list__value')
+      end
+
+      it "shows appropriate message for delivery partner" do
+        expect(page).to have_text('Yet to be reported by the lead provider')
+      end
+    end
+  end
+
+  context 'when school-led training' do
+    let(:ect) do
+      FactoryBot.create(:ect_at_school_period,
+                        :ongoing,
+                        teacher:,
+                        training_programme: 'school_led')
+    end
+
+    before do
+      # Create a school-led training period since the factory doesn't create one automatically for school-led
+      FactoryBot.create(:training_period,
+                        :school_led,
+                        :ongoing,
+                        ect_at_school_period: ect,
+                        started_on: Date.current,
+                        finished_on: nil)
+      render_inline(described_class.new(ect))
+    end
+
+    it "does not show lead provider and delivery partner fields" do
+      expect(page).not_to have_selector('.govuk-summary-list__key', text: 'Lead provider')
+      expect(page).not_to have_selector('.govuk-summary-list__key', text: 'Delivery partner')
+    end
+  end
+
+  describe '#training_programme_display_name' do
+    context 'when training programme is provider_led' do
+      let(:ect) do
+        FactoryBot.create(:ect_at_school_period,
+                          :ongoing,
+                          :with_training_period,
+                          teacher:,
+                          training_programme: 'provider_led')
+      end
+      let(:component) { described_class.new(ect) }
+
+      it 'returns Provider-led' do
+        expect(component.send(:training_programme_display_name)).to eq('Provider-led')
+      end
+    end
+
+    context 'when training programme is school_led' do
+      let(:ect) do
+        FactoryBot.create(:ect_at_school_period,
+                          :ongoing,
+                          teacher:,
+                          training_programme: 'school_led')
+      end
+      let(:component) { described_class.new(ect) }
+
+      before do
+        # Create a school-led training period that matches the ongoing scope
+        FactoryBot.create(:training_period,
+                          :school_led,
+                          :ongoing,
+                          ect_at_school_period: ect,
+                          started_on: Date.current,
+                          finished_on: nil)
+        ect.reload # Ensure association cache is cleared
+      end
+
+      it 'returns School-led' do
+        expect(component.send(:training_programme_display_name)).to eq('School-led')
+      end
+    end
+
+    context 'when training programme is an unknown value' do
+      it 'returns the humanized value' do
+        ect_double = instance_double(ECTAtSchoolPeriod)
+        training_period_double = instance_double(TrainingPeriod)
+
+        allow(ect_double).to receive(:current_training_period).and_return(training_period_double)
+        allow(training_period_double).to receive(:training_programme).and_return('some_other_value')
+
+        component = described_class.new(ect_double)
+
+        expect(component.send(:training_programme_display_name)).to eq('Some other value')
+      end
+    end
+
+    context 'when training programme is nil' do
+      it 'returns Unknown' do
+        ect_double = instance_double(ECTAtSchoolPeriod)
+
+        allow(ect_double).to receive(:current_training_period).and_return(nil)
+
+        component = described_class.new(ect_double)
+
+        expect(component.send(:training_programme_display_name)).to eq('Unknown')
+      end
+    end
+  end
+end

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -43,9 +43,12 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     expect(page).to have_text('Full time')
   end
 
-  describe '#rows' do
-    it 'returns the correct number of rows' do
-      expect(described_class.new(mentee).rows.count).to eq(5)
-    end
+  it "renders the status row with correct value" do
+    expect(page).to have_selector(".govuk-summary-list__row", text: "Status")
+    expect(page).to have_selector('.govuk-tag', text: 'Registered')
+  end
+
+  it 'renders all expected rows' do
+    expect(page).to have_selector('.govuk-summary-list__row', count: 6)
   end
 end

--- a/spec/initializers/constants_spec.rb
+++ b/spec/initializers/constants_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Constants" do
   end
 
   describe "TRAINING_PROGRAMME" do
-    it { expect(TRAINING_PROGRAMME).to eq({ provider_led: 'Provider-led', school_led: 'School-led' }) }
+    it { expect(TRAINING_PROGRAMME).to eq({ 'provider_led' => 'Provider-led', 'school_led' => 'School-led' }) }
   end
 
   describe "INDUCTION_PROGRAMMES" do


### PR DESCRIPTION
This is #1139 re-reverted so we can fix some failing tests around training programme and its new location in `training_periods`.