### PR TITLE
[1249] Redirect to `has been registered before` page when applicable (`#MentorRegistrationFlow`)

### DIFF
--- a/app/services/mentor_at_school_periods/latest_registration_choices.rb
+++ b/app/services/mentor_at_school_periods/latest_registration_choices.rb
@@ -14,7 +14,21 @@ module MentorAtSchoolPeriods
         .first
     end
 
+    def lead_provider
+      school_partnership&.lead_provider || expression_of_interest&.lead_provider
+    end
+
+    def school
+      school_partnership&.school || training_period&.mentor_at_school_period&.school
+    end
+
+  private
+
+    delegate :delivery_partner, to: :school_partnership, allow_nil: true
     delegate :school_partnership, to: :training_period, allow_nil: true
-    delegate :school, :lead_provider, :delivery_partner, to: :school_partnership, allow_nil: true
+
+    def expression_of_interest
+      training_period&.expression_of_interest
+    end
   end
 end

--- a/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
@@ -12,7 +12,7 @@
           text: "School name",
         },
         value: {
-          text: @mentor.latest_registration_choice.school&.name,
+          text: @mentor.latest_registration_choice.school&.name || 'Not confirmed', # AC 9a
         },
       },
       {
@@ -20,7 +20,7 @@
           text: "Lead provider",
         },
         value: {
-          text: @mentor.latest_registration_choice.lead_provider&.name,
+          text: @mentor.latest_registration_choice.lead_provider&.name || 'Not confirmed',
         },
       },
       {
@@ -28,7 +28,7 @@
           text: "Delivery partner",
         },
         value: {
-          text: @mentor.latest_registration_choice.delivery_partner&.name,
+          text: @mentor.latest_registration_choice.delivery_partner&.name || 'Not confirmed',
         },
       },
     ],

--- a/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/previous_training_period_details.html.erb
@@ -12,7 +12,7 @@
           text: "School name",
         },
         value: {
-          text: @mentor.latest_registration_choice.school&.name || 'Not confirmed', # AC 9a
+          text: @mentor.latest_registration_choice.school&.name || 'Not confirmed', # MentorRegistrationFlow: AC 9a
         },
       },
       {

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -85,6 +85,10 @@ module Schools
         @latest_registration_choice ||= MentorAtSchoolPeriods::LatestRegistrationChoices.new(trn:)
       end
 
+      def previous_training_period
+        latest_registration_choice.training_period
+      end
+
       def lead_providers_within_contract_period
         return [] unless contract_period
 

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -124,6 +124,10 @@ module Schools
         ::Teachers::MentorFundingEligibility.new(trn:).ineligible?
       end
 
+      def eligible_for_funding?
+        ::Teachers::MentorFundingEligibility.new(trn:).eligible?
+      end
+
       def ect_lead_provider
         ect_training_service.lead_provider if ect
       end

--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -18,11 +18,7 @@ module Schools
       end
 
       def previous_step
-        if mentor.latest_registration_choice.school_partnership
-          :previous_training_period_details
-        else
-          :started_on
-        end
+        :started_on
       end
 
     private

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -14,6 +14,8 @@ module Schools
         # AC6a, AC6b + AC7: school-led or ineligible mentors go straight to CYA
         if mentor.became_ineligible_for_funding? || !mentor.provider_led_ect?
           :check_answers
+        elsif mentor.previous_training_period.blank?
+          :programme_choices # if previous registration school led
         else
           :previous_training_period_details # AC8
         end

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -11,14 +11,11 @@ module Schools
       end
 
       def next_step
-        return :check_answers unless mentor.provider_led_ect?
-
-        if mentor.became_ineligible_for_funding?
+        # AC6a, AC6b + AC7: school-led or ineligible mentors go straight to CYA
+        if mentor.became_ineligible_for_funding? || !mentor.provider_led_ect?
           :check_answers
-        elsif mentor.latest_registration_choice.school_partnership
-          :previous_training_period_details
         else
-          :programme_choices
+          :previous_training_period_details # AC8
         end
       end
 

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -11,7 +11,7 @@ module Schools
       end
 
       def next_step
-        # AC6a, AC6b + AC7: school-led or ineligible mentors go straight to CYA
+        # MentorRegistrationFlow: AC6a, AC6b + AC7, school-led or ineligible mentors go straight to CYA
         if mentor.became_ineligible_for_funding? || !mentor.provider_led_ect?
           :check_answers
         elsif mentor.previous_training_period.blank?

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -82,7 +82,7 @@ module Schools
                      end
 
             steps << :started_on if mentor.mentoring_at_new_school_only == "yes"
-            steps << :previous_training_period_details if mentor.latest_registration_choice.school_partnership
+            steps << :previous_training_period_details if !mentor.became_ineligible_for_funding? || mentor.provider_led_ect?
             steps << :programme_choices unless mentor.became_ineligible_for_funding?
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -82,7 +82,7 @@ module Schools
                      end
 
             steps << :started_on if mentor.mentoring_at_new_school_only == "yes"
-            steps << :previous_training_period_details if !mentor.became_ineligible_for_funding? || mentor.provider_led_ect?
+            steps << :previous_training_period_details if mentor.eligible_for_funding? || mentor.provider_led_ect?
             steps << :programme_choices unless mentor.became_ineligible_for_funding?
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"
             steps << :review_mentor_eligibility if mentor.funding_available?

--- a/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
+++ b/spec/services/mentor_at_school_periods/latest_registration_choices_spec.rb
@@ -17,4 +17,48 @@ describe MentorAtSchoolPeriods::LatestRegistrationChoices do
   describe '#delivery_partner' do
     it { expect(subject.delivery_partner).to eq(school_partnership.delivery_partner) }
   end
+
+  context 'when the latest training period has an EOI (no partnership)' do
+    let(:school) { FactoryBot.create(:school) }
+    let!(:mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        teacher:,
+        school:
+      )
+    end
+
+    let(:lp_from_eoi) { FactoryBot.create(:lead_provider, name: "EOI LP") }
+    let(:expression_of_interest) { FactoryBot.create(:active_lead_provider, lead_provider: lp_from_eoi) }
+
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :for_mentor,
+        :ongoing,
+        mentor_at_school_period:,
+        school_partnership: nil,
+        expression_of_interest:,
+        training_programme: 'provider_led'
+      )
+    end
+
+    describe '#school' do
+      it 'returns the school from the mentor_at_school_period when only an EOI exists' do
+        expect(subject.school).to eq(school)
+      end
+    end
+
+    describe '#lead_provider' do
+      it "returns the lead provider from the expression of interest (EOI)" do
+        expect(subject.lead_provider).to eq(lp_from_eoi)
+      end
+    end
+
+    describe '#delivery_partner' do
+      it 'returns nil' do
+        expect(subject.delivery_partner).to be_nil
+      end
+    end
+  end
 end

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -165,6 +165,16 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
   end
 
+  describe '#previous_training_period' do
+    let(:teacher) { FactoryBot.create(:teacher, trn: mentor.trn) }
+    let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 3, 1)) }
+    let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on: Date.new(2025, 1, 1)) }
+
+    it 'returns the latest training period for the mentor' do
+      expect(mentor.previous_training_period).to eq(training_period)
+    end
+  end
+
   describe '#register!' do
     let(:teacher) { Teacher.first }
     let(:mentor_at_school_period) { teacher.mentor_at_school_periods.first }

--- a/spec/wizards/schools/register_mentor_wizard/programme_choices_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/programme_choices_step_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Schools::RegisterMentorWizard::ProgrammeChoicesStep do
+  subject(:step) { described_class.new(wizard:, use_same_programme_choices:) }
+
+  let(:wizard) do
+    instance_double(Schools::RegisterMentorWizard::Wizard)
+  end
+
+  let(:use_same_programme_choices) { 'yes' }
+
+  describe '#previous_step' do
+    it { expect(step.previous_step).to eq(:started_on) }
+  end
+end

--- a/spec/wizards/schools/register_mentor_wizard/started_on_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/started_on_step_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Schools::RegisterMentorWizard::StartedOnStep do
       'Schools::RegisterMentorWizard::Mentor',
       mentoring_at_new_school_only: mentoring_only,
       became_ineligible_for_funding?: ineligible,
-      provider_led_ect?: provider_led
+      provider_led_ect?: provider_led,
+      previous_training_period:
     )
   end
 
@@ -21,6 +22,7 @@ RSpec.describe Schools::RegisterMentorWizard::StartedOnStep do
   let(:ineligible) { false }
   let(:provider_led) { true }
   let(:started_on) { { 'day' => '10', 'month' => '9', 'year' => '2025' } }
+  let(:previous_training_period) { FactoryBot.build(:training_period) }
 
   describe '#next_step' do
     context 'when mentor is ineligible for funding' do
@@ -37,6 +39,12 @@ RSpec.describe Schools::RegisterMentorWizard::StartedOnStep do
 
     context 'when mentor is eligible and ECT is provider-led' do
       it { expect(step.next_step).to eq(:previous_training_period_details) }
+    end
+
+    context 'when there is no previous training period' do
+      let(:previous_training_period) { nil }
+
+      it { expect(step.next_step).to eq(:programme_choices) }
     end
   end
 

--- a/spec/wizards/schools/register_mentor_wizard/started_on_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/started_on_step_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe Schools::RegisterMentorWizard::StartedOnStep do
+  subject(:step) { described_class.new(wizard:, started_on:) }
+
+  let(:wizard) do
+    instance_double(
+      Schools::RegisterMentorWizard::Wizard,
+      mentor:
+    )
+  end
+
+  let(:mentor) do
+    double(
+      'Schools::RegisterMentorWizard::Mentor',
+      mentoring_at_new_school_only: mentoring_only,
+      became_ineligible_for_funding?: ineligible,
+      provider_led_ect?: provider_led
+    )
+  end
+
+  let(:mentoring_only) { 'no' }
+  let(:ineligible) { false }
+  let(:provider_led) { true }
+  let(:started_on) { { 'day' => '10', 'month' => '9', 'year' => '2025' } }
+
+  describe '#next_step' do
+    context 'when mentor is ineligible for funding' do
+      let(:ineligible) { true }
+
+      it { expect(step.next_step).to eq(:check_answers) }
+    end
+
+    context 'when ECT is school-led' do
+      let(:provider_led) { false }
+
+      it { expect(step.next_step).to eq(:check_answers) }
+    end
+
+    context 'when mentor is eligible and ECT is provider-led' do
+      it { expect(step.next_step).to eq(:previous_training_period_details) }
+    end
+  end
+
+  describe '#previous_step' do
+    context "when mentoring_at_new_school_only is 'yes'" do
+      let(:mentoring_only) { 'yes' }
+
+      it { expect(step.previous_step).to eq(:mentoring_at_new_school_only) }
+    end
+
+    context "when mentoring_at_new_school_only is 'no'" do
+      it { expect(step.previous_step).to eq(:email_address) }
+    end
+  end
+end

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -239,6 +239,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    review_mentor_details
                                    email_address
                                    started_on
+                                   previous_training_period_details
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility
@@ -290,6 +291,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                                    review_mentor_details
                                    email_address
                                    started_on
+                                   previous_training_period_details
                                    programme_choices
                                    lead_provider
                                    review_mentor_eligibility


### PR DESCRIPTION
## Context

When re-registering a mentor who has previously been registered, we show the previous registration details (school name, lead provider, and delivery partner) if their previous training period was `provider_led` and they are eligible for funding.

This step appears after the `started_on` step, if applicable.

---

## Changes proposed

- Adds logic to render previous registration details (`school`, `lead provider`, and `delivery partner`) on the `has been registered before` page
  - Falls back to `"Not confirmed"` if LP/DP/School is missing
- Redirect to `check_answers` if:
  - `school_led` or  not eligible for funding

- Pre-fills with:
  - school partnership (if present)
  - or expression of interest (EOI)


<img width="1203" height="821" alt="image" src="https://github.com/user-attachments/assets/c05c42d3-2905-4ff0-8b06-359b5a7543a0" />


---

## Notes

- The `MentorAtSchoolPeriods::LatestRegistrationChoices` service encapsulates logic for looking up the most recent mentor training period and associated details.

---

## Acceptance criteria

**The following ACs from the epic/card are now satisfied:** ☑️

AC comments are to help with cross-checking with the card and will be removed once the epic is considered complete.

<img width="673" height="473" alt="image" src="https://github.com/user-attachments/assets/e3f587eb-bd06-4752-95d4-ac8bbed1a8cd" />

