### PR TITLE
Add swagger docs for POST /api/v3/partnerships

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -115,6 +115,43 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
+    post:
+      summary: Creates a partnership
+      tags:
+      - Partnerships
+      security:
+      - api_key: []
+      parameters: []
+      responses:
+        '200':
+          description: The created partnership
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PartnershipResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/PartnershipRequest"
   "/api/v3/partnerships/{id}":
     get:
       summary: Retrieve a single partnership
@@ -318,6 +355,36 @@ components:
           description: Resource not found
       example:
         error: Resource not found
+    BadRequestResponse:
+      description: The request body did not match the expected payload.
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+                example: Bad request
+              detail:
+                type: string
+                example: correct json data structure required. See API docs for reference
+    UnprocessableContentResponse:
+      description: The payload was not valid. See the errors for more information.
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+                example: example_attribute
+              detail:
+                type: string
+                example: An '#/example_attribute' must be specified.
     PaginationFilter:
       description: Pagination options to navigate through the list of results.
       type: object
@@ -710,6 +777,52 @@ components:
       properties:
         data:
           "$ref": "#/components/schemas/Partnership"
+    PartnershipRequest:
+      description: A partnership request
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          description: A partnership
+          type: object
+          required:
+          - type
+          - attributes
+          properties:
+            type:
+              type: string
+              required: true
+              enum:
+              - partnership
+              example: partnership
+            attributes:
+              description: A partnership request attributes
+              type: object
+              required:
+              - cohort
+              - delivery_partner_id
+              - school_id
+              properties:
+                cohort:
+                  description: The cohort for which you are reporting the partnership
+                  required: true
+                  nullable: false
+                  type: string
+                  example: '2022'
+                school_id:
+                  description: The Unique ID of the school you are partnering with
+                  required: true
+                  nullable: false
+                  type: string
+                  example: 24b61d1c-ad95-4000-aee0-afbdd542294a
+                delivery_partner_id:
+                  description: The unique ID of the delivery partner you will work
+                    with for this school partnership
+                  required: true
+                  nullable: false
+                  type: string
+                  example: db2fbf67-b7b7-454f-a1b7-0020411e2314
     PartnershipsResponse:
       description: A list of partnerships.
       type: object

--- a/spec/requests/api/docs/v3/partnerships_spec.rb
+++ b/spec/requests/api/docs/v3/partnerships_spec.rb
@@ -22,6 +22,39 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                     tag: "Partnerships",
                     resource_description: "partnership",
                     response_schema_ref: "#/components/schemas/PartnershipResponse",
+                  }
+
+  it_behaves_like "an API create endpoint documentation",
+                  {
+                    url: "/api/v3/partnerships",
+                    tag: "Partnerships",
+                    resource_description: "partnership",
+                    request_schema_ref: "#/components/schemas/PartnershipRequest",
+                    response_schema_ref: "#/components/schemas/PartnershipResponse",
                   } do
-  end
+                    let(:params) do
+                      {
+                        data: {
+                          type: "partnership",
+                          attributes: {
+                            cohort: lead_provider_delivery_partnership.contract_period.year,
+                            school_id: FactoryBot.create(:school, :eligible).api_id,
+                            delivery_partner_id: lead_provider_delivery_partnership.delivery_partner.api_id,
+                          },
+                        },
+                      }
+                    end
+
+                    let(:invalid_params) do
+                      {
+                        data: {
+                          type: "partnership",
+                          attributes: {
+                            cohort: 2020,
+                            school_id: SecureRandom.uuid,
+                          },
+                        },
+                      }
+                    end
+                  end
 end

--- a/spec/support/shared_contexts/api/docs/api_create_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_create_endpoint_documentation_support.rb
@@ -1,0 +1,48 @@
+RSpec.shared_context "an API create endpoint documentation", :exceptions_app do |options = {}|
+  path options[:url] do
+    post "Creates a #{options[:resource_description]}" do
+      tags options[:tag]
+      consumes "application/json"
+      produces "application/json"
+      security [api_key: []]
+
+      parameter name: :params,
+                in: :body,
+                style: :deepObject,
+                required: false,
+                schema: {
+                  "$ref": options[:request_schema_ref],
+                }
+
+      response "200", "The created #{options[:resource_description]}" do
+        schema({ "$ref": options[:response_schema_ref] })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:token) { "invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+
+      response "400", "Bad request" do
+        let(:params) { { data: {} } }
+
+        schema({ "$ref": "#/components/schemas/BadRequestResponse" })
+
+        run_test!
+      end
+
+      response "422", "Unprocessable entity" do
+        let(:params) { invalid_params }
+
+        schema({ "$ref": "#/components/schemas/UnprocessableContentResponse" })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -41,6 +41,8 @@ RSpec.configure do |config|
           IDAttribute: ID_ATTRIBUTE,
           UnauthorisedResponse: UNAUTHORISED_RESPONSE,
           NotFoundResponse: NOT_FOUND_RESPONSE,
+          BadRequestResponse: BAD_REQUEST_RESPONSE,
+          UnprocessableContentResponse: UNPROCESSABLE_CONTENT_RESPONSE,
           PaginationFilter: PAGINATION_FILTER,
           SortingTimestamps: SORTING_TIMESTAMPS,
 
@@ -67,6 +69,7 @@ RSpec.configure do |config|
           Partnership: PARTNERSHIP,
           PartnershipsFilter: PARTNERSHIPS_FILTER,
           PartnershipResponse: PARTNERSHIP_RESPONSE,
+          PartnershipRequest: PARTNERSHIP_REQUEST,
           PartnershipsResponse: PARTNERSHIPS_RESPONSE,
         }
       }

--- a/spec/swagger_schemas/requests/partnership.rb
+++ b/spec/swagger_schemas/requests/partnership.rb
@@ -1,0 +1,50 @@
+PARTNERSHIP_REQUEST = {
+  description: "A partnership request",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "A partnership",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[
+            partnership
+          ],
+          example: "partnership",
+        },
+        attributes: {
+          description: "A partnership request attributes",
+          type: :object,
+          required: %i[cohort delivery_partner_id school_id],
+          properties: {
+            cohort: {
+              description: "The cohort for which you are reporting the partnership",
+              required: true,
+              nullable: false,
+              type: :string,
+              example: "2022",
+            },
+            school_id: {
+              description: "The Unique ID of the school you are partnering with",
+              required: true,
+              nullable: false,
+              type: :string,
+              example: "24b61d1c-ad95-4000-aee0-afbdd542294a",
+            },
+            delivery_partner_id: {
+              description: "The unique ID of the delivery partner you will work with for this school partnership",
+              required: true,
+              nullable: false,
+              type: :string,
+              example: "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+            },
+          },
+        },
+      },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/bad_request.rb
+++ b/spec/swagger_schemas/responses/bad_request.rb
@@ -1,0 +1,22 @@
+BAD_REQUEST_RESPONSE = {
+  description: "The request body did not match the expected payload.",
+  type: :object,
+  properties: {
+    errors: {
+      type: :array,
+      items: {
+        type: :object,
+        properties: {
+          title: {
+            type: :string,
+            example: "Bad request",
+          },
+          detail: {
+            type: :string,
+            example: "correct json data structure required. See API docs for reference",
+          },
+        },
+      },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/unprocessable_content.rb
+++ b/spec/swagger_schemas/responses/unprocessable_content.rb
@@ -1,0 +1,22 @@
+UNPROCESSABLE_CONTENT_RESPONSE = {
+  description: "The payload was not valid. See the errors for more information.",
+  type: :object,
+  properties: {
+    errors: {
+      type: :array,
+      items: {
+        type: :object,
+        properties: {
+          title: {
+            type: :string,
+            example: "example_attribute",
+          },
+          detail: {
+            type: :string,
+            example: "An '#/example_attribute' must be specified.",
+          },
+        },
+      },
+    },
+  },
+}.freeze


### PR DESCRIPTION
### Context

We want to add the swagger docs for the POST /api/v3/partnerships endpoint.

### Changes proposed in this pull request

- Add API documentations for POST /api/v3/partnerships

Add the swagger documentation for POST /api/v3/partnerships.

Use shared context so that we can re-use it for other POST requests.

Add needed response schemas.

### Guidance to review

[Swagger docs](https://cpd-ec2-review-1202-web.test.teacherservices.cloud/api/docs/v3)

Note the attribute names in the error response will be incorrect for the time being; these will be fixed when we address the general API/RECT error message/terminology consistency issues.