### PR TITLE
Make the review mentor eligibilty screen show the relevant lead provider

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -20,8 +20,8 @@ class TrainingPeriod < ApplicationRecord
   has_one :contract_period, through: :active_lead_provider
 
   belongs_to :expression_of_interest, class_name: 'ActiveLeadProvider'
-  has_one :expression_of_interest_lead_provider, through: :expression_of_interest, class_name: 'LeadProvider', source: :lead_provider
-  has_one :expression_of_interest_contract_period, through: :expression_of_interest, class_name: 'ContractPeriod', source: :contract_period
+  has_one :expression_of_interest_lead_provider, through: :expression_of_interest, source: :lead_provider
+  has_one :expression_of_interest_contract_period, through: :expression_of_interest, source: :contract_period
 
   has_many :declarations, inverse_of: :training_period
   has_many :events

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -12,12 +12,16 @@ class TrainingPeriod < ApplicationRecord
   belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :training_periods
   belongs_to :mentor_at_school_period, inverse_of: :training_periods
   belongs_to :school_partnership
-  belongs_to :expression_of_interest, class_name: 'ActiveLeadProvider'
+
   has_one :lead_provider_delivery_partnership, through: :school_partnership
   has_one :active_lead_provider, through: :lead_provider_delivery_partnership
   has_one :lead_provider, through: :active_lead_provider
   has_one :delivery_partner, through: :lead_provider_delivery_partnership
   has_one :contract_period, through: :active_lead_provider
+
+  belongs_to :expression_of_interest, class_name: 'ActiveLeadProvider'
+  has_one :expression_of_interest_lead_provider, through: :expression_of_interest, class_name: 'LeadProvider', source: :lead_provider
+  has_one :expression_of_interest_contract_period, through: :expression_of_interest, class_name: 'LeadProvider', source: :contract_period
 
   has_many :declarations, inverse_of: :training_period
   has_many :events

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -21,7 +21,7 @@ class TrainingPeriod < ApplicationRecord
 
   belongs_to :expression_of_interest, class_name: 'ActiveLeadProvider'
   has_one :expression_of_interest_lead_provider, through: :expression_of_interest, class_name: 'LeadProvider', source: :lead_provider
-  has_one :expression_of_interest_contract_period, through: :expression_of_interest, class_name: 'LeadProvider', source: :contract_period
+  has_one :expression_of_interest_contract_period, through: :expression_of_interest, class_name: 'ContractPeriod', source: :contract_period
 
   has_many :declarations, inverse_of: :training_period
   has_many :events

--- a/app/services/ect_at_school_periods/current_training.rb
+++ b/app/services/ect_at_school_periods/current_training.rb
@@ -11,8 +11,9 @@ module ECTAtSchoolPeriods
       school_partnership.blank? && expression_of_interest.present?
     end
 
-    # FIXME: do we need another method here to pick whichever lead provider is present, be it
-    #        an EOI or partnership based one?
+    def lead_provider_via_school_partnership_or_eoi
+      lead_provider || expression_of_interest_lead_provider
+    end
 
     # school_partnership
     delegate :school_partnership, to: :current_training_period, allow_nil: true

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -25,19 +25,19 @@
       summary_list.with_row do |row|
         row.with_key(text: 'Delivery partner')
         row.with_value(text: @ect.previous_delivery_partner_name)
-      end 
+      end
     else
       summary_list.with_row do |row|
         row.with_key(text: 'Lead provider')
-        row.with_value(text: @ect.previous_eoi_lead_provider_name)
-      end 
-    end 
-  end 
+        row.with_value(text: @ect.previous_eoi_lead_provider_name || @school.last_chosen_lead_provider&.name)
+      end
+    end
+  end
 end %>
 
 <% if @school.provider_led_training_programme_chosen? && !@ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
   <p class="govuk-body">
-    <%= @ect.previous_eoi_lead_provider_name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
+    <%= @ect.previous_eoi_lead_provider_name || @school.last_chosen_lead_provider&.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
   </p>
 <% end %>
 

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -37,7 +37,7 @@ end %>
 
 <% if @school.provider_led_training_programme_chosen? && !@ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
   <p class="govuk-body">
-    <%= @ect.previous_eoi_lead_provider_name || @school.last_chosen_lead_provider&.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
+    <%= @ect.previous_eoi_lead_provider_name || @school.last_chosen_lead_provider.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
   </p>
 <% end %>
 

--- a/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
+++ b/app/views/schools/register_mentor_wizard/review_mentor_eligibility.html.erb
@@ -7,11 +7,11 @@
 
 <p class="govuk-body">Our records show that <%= @mentor.full_name %> can get up to 20 hours of ECTE mentor training as your school is working with a DfE-funded training provider.</p>
 
-<p class="govuk-body">We'll pass on their details to <%= @mentor.ect_lead_provider&.name %> who will contact them to arrange the training.</p>
+<p class="govuk-body">We'll pass on their details to <%= @mentor.ect_lead_provider.name %> who will contact them to arrange the training.</p>
 
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= f.govuk_submit "Continue" %>
 <% end %>
 
-<%= govuk_link_to "#{@mentor.ect_lead_provider&.name} will not be providing mentor training to #{@mentor.full_name}",
+<%= govuk_link_to "#{@mentor.ect_lead_provider.name} will not be providing mentor training to #{@mentor.full_name}",
 schools_register_mentor_wizard_eligibility_lead_provider_path %>

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -129,11 +129,7 @@ module Schools
       end
 
       def ect_lead_provider
-        ect_training_service.lead_provider if ect
-      end
-
-      def ect_eoi_lead_provider
-        ect_training_service.expression_of_interest_lead_provider
+        ect_training_service.lead_provider_via_school_partnership_or_eoi
       end
 
     private

--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -29,7 +29,7 @@ module Schools
 
       def lead_provider_id
         if use_same_programme_choices == "yes"
-          mentor.ect_lead_provider&.id || mentor.ect_eoi_lead_provider&.id
+          mentor.ect_lead_provider.id
         end
       end
     end

--- a/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/review_mentor_eligibility_step.rb
@@ -20,7 +20,7 @@ module Schools
     private
 
       def persist
-        mentor.update!(lead_provider_id: mentor.ect_lead_provider&.id)
+        mentor.update!(lead_provider_id: mentor.ect_lead_provider.id)
       end
     end
   end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -14,7 +14,6 @@ describe TrainingPeriod do
     it { is_expected.to belong_to(:ect_at_school_period).class_name("ECTAtSchoolPeriod").inverse_of(:training_periods) }
     it { is_expected.to belong_to(:mentor_at_school_period).inverse_of(:training_periods) }
     it { is_expected.to belong_to(:school_partnership) }
-    it { is_expected.to belong_to(:expression_of_interest).class_name('ActiveLeadProvider') }
     it { is_expected.to have_many(:declarations).inverse_of(:training_period) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_one(:lead_provider_delivery_partnership).through(:school_partnership) }
@@ -22,6 +21,9 @@ describe TrainingPeriod do
     it { is_expected.to have_one(:lead_provider).through(:active_lead_provider) }
     it { is_expected.to have_one(:delivery_partner).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
+    it { is_expected.to belong_to(:expression_of_interest).class_name('ActiveLeadProvider') }
+    it { is_expected.to have_one(:expression_of_interest_lead_provider).through(:expression_of_interest).class_name('LeadProvider').source(:lead_provider) }
+    it { is_expected.to have_one(:expression_of_interest_contract_period).through(:expression_of_interest).class_name('LeadProvider').source(:contract_period) }
   end
 
   describe "validations" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -22,8 +22,8 @@ describe TrainingPeriod do
     it { is_expected.to have_one(:delivery_partner).through(:lead_provider_delivery_partnership) }
     it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
     it { is_expected.to belong_to(:expression_of_interest).class_name('ActiveLeadProvider') }
-    it { is_expected.to have_one(:expression_of_interest_lead_provider).through(:expression_of_interest).class_name('LeadProvider').source(:lead_provider) }
-    it { is_expected.to have_one(:expression_of_interest_contract_period).through(:expression_of_interest).class_name('ContractPeriod').source(:contract_period) }
+    it { is_expected.to have_one(:expression_of_interest_lead_provider).through(:expression_of_interest).source(:lead_provider) }
+    it { is_expected.to have_one(:expression_of_interest_contract_period).through(:expression_of_interest).source(:contract_period) }
   end
 
   describe "validations" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -23,7 +23,7 @@ describe TrainingPeriod do
     it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
     it { is_expected.to belong_to(:expression_of_interest).class_name('ActiveLeadProvider') }
     it { is_expected.to have_one(:expression_of_interest_lead_provider).through(:expression_of_interest).class_name('LeadProvider').source(:lead_provider) }
-    it { is_expected.to have_one(:expression_of_interest_contract_period).through(:expression_of_interest).class_name('LeadProvider').source(:contract_period) }
+    it { is_expected.to have_one(:expression_of_interest_contract_period).through(:expression_of_interest).class_name('ContractPeriod').source(:contract_period) }
   end
 
   describe "validations" do


### PR DESCRIPTION
### Context

This (hopefully) fixes DFE-Digital/register-ects-project-board#2213 where the lead provider name wasn't shown because there was only an EOI lead provider present and not one via school partnership.

It also adds new relationships to `TrainingPeriod` that allow us to find the lead provider and contract period via the expression of interest as well as via school partnership.

For now the:

* the _confirmed_ relations are unprefixed as they are the _actual_ values
* the _expression of interest_ relations are prefixed as they aren't yet official

We may make both prefixed for extra explicitness if this is still confusing!

### Changes proposed in this pull request

- **Add expression_of_interest prefixed relationships**
- **Add method to select relevant lead provider**

### Notes

The changes made in `_use_previous_ect_choices.html.erb` aren't great, but this needs to be reworked as described in DFE-Digital/register-ects-project-board#2309
