### PR TITLE
[1195] Remove frozen string comments and redundant `.freeze`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,8 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 3.4.4
+  TargetRubyVersion: 3.4
+  StringLiteralsFrozenByDefault: true
 
 require:
   - ./.rubocop/cop/rspec_cops

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,10 @@ Style/SignalException:
 
 Style/StringConcatenation:
   Enabled: false
+  
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: never
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: always

--- a/.rubocop/cop/rspec/require_rails_helper.rb
+++ b/.rubocop/cop/rspec/require_rails_helper.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module RuboCop
   module Cop

--- a/app/components/api/guidance/sidebar_component.rb
+++ b/app/components/api/guidance/sidebar_component.rb
@@ -1,7 +1,7 @@
 module API
   module Guidance
     class SidebarComponent < ViewComponent::Base
-      GUIDANCE_PREFIX = "guidance-for-lead-providers".freeze
+      GUIDANCE_PREFIX = "guidance-for-lead-providers"
       GUIDANCE_PAGES = [
         { title: "API IDs explained", path: "api-ids-explained" },
         { title: "API data states", path: "api-data-states" },

--- a/app/components/appropriate_bodies/claim_ect_actions_component.rb
+++ b/app/components/appropriate_bodies/claim_ect_actions_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module AppropriateBodies
   class ClaimECTActionsComponent < ViewComponent::Base
     def initialize(teacher:, pending_induction_submission:, current_appropriate_body:)

--- a/app/components/schools/summary_card_component.rb
+++ b/app/components/schools/summary_card_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   class SummaryCardComponent < ViewComponent::Base
     include AppropriateBodyHelper

--- a/app/controllers/schools/register_ect_wizard_controller.rb
+++ b/app/controllers/schools/register_ect_wizard_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   class RegisterECTWizardController < SchoolsController
     before_action :initialize_wizard, only: %i[new create]

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,3 @@
 class ApplicationMailer < Mail::Notify::Mailer
-  NOTIFY_TEMPLATE_ID = "c437a1cb-9e1c-49ff-83ee-967c92f95637".freeze
+  NOTIFY_TEMPLATE_ID = "c437a1cb-9e1c-49ff-83ee-967c92f95637"
 end

--- a/app/services/appropriate_bodies/search.rb
+++ b/app/services/appropriate_bodies/search.rb
@@ -1,6 +1,6 @@
 module AppropriateBodies
   class Search
-    ISTIP = 'Independent Schools Teacher Induction Panel (ISTIP)'.freeze
+    ISTIP = 'Independent Schools Teacher Induction Panel (ISTIP)'
 
     def initialize(query_string = nil)
       @scope = AppropriateBody

--- a/app/services/gias/importer.rb
+++ b/app/services/gias/importer.rb
@@ -3,8 +3,8 @@ require "csv"
 
 module GIAS
   class Importer
-    SCHOOLS_FILENAME = "ecf_tech.csv".freeze
-    SCHOOL_LINKS_FILENAME = "links.csv".freeze
+    SCHOOLS_FILENAME = "ecf_tech.csv"
+    SCHOOL_LINKS_FILENAME = "links.csv"
 
     def fetch
       import_only? ? fetch_and_import_only : fetch_and_update

--- a/app/services/migration/induction_sequence_exporter.rb
+++ b/app/services/migration/induction_sequence_exporter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "csv"
 
 module Migration

--- a/app/services/migration/induction_sequence_formatter.rb
+++ b/app/services/migration/induction_sequence_formatter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # rubocop:disable Rails/Output
 module Migration
   # Formats and displays induction sequence analysis results to the console

--- a/app/wizards/schools/register_ect_wizard/email_address_step.rb
+++ b/app/wizards/schools/register_ect_wizard/email_address_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterECTWizard
     class EmailAddressStep < Step

--- a/app/wizards/schools/register_ect_wizard/find_ect_step.rb
+++ b/app/wizards/schools/register_ect_wizard/find_ect_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterECTWizard
     class FindECTStep < Step

--- a/app/wizards/schools/register_ect_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_ect_wizard/national_insurance_number_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterECTWizard
     class NationalInsuranceNumberStep < Step

--- a/app/wizards/schools/register_ect_wizard/review_ect_details_step.rb
+++ b/app/wizards/schools/register_ect_wizard/review_ect_details_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterECTWizard
     class ReviewECTDetailsStep < Step

--- a/app/wizards/schools/register_ect_wizard/wizard.rb
+++ b/app/wizards/schools/register_ect_wizard/wizard.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterECTWizard
     class Wizard < DfE::Wizard::Base

--- a/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Schools
   module RegisterMentorWizard
     class NationalInsuranceNumberStep < Step

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if Rails.application.config.enable_sentry
   Sentry.init do |config|
     config.dsn = Rails.application.config.sentry_dsn

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,8 +10,8 @@ end
 
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 port ENV.fetch("PORT", 3000)
-environment ENV.fetch("RAILS_ENV") { "development" }
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+environment ENV.fetch("RAILS_ENV", "development")
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/db/scripts/fix_mismatched_induction_statuses.rb
+++ b/db/scripts/fix_mismatched_induction_statuses.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
 # This script finds teachers whose latest induction period has a pass/fail outcome
 # but their TRS status is still 'InProgress'. It then:

--- a/lib/schools/validation/date_of_birth.rb
+++ b/lib/schools/validation/date_of_birth.rb
@@ -1,10 +1,10 @@
 module Schools
   module Validation
     class DateOfBirth < HashDate
-      DATE_MISSING_MESSAGE   = "Enter a date of birth".freeze
-      INVALID_FORMAT_MESSAGE = "Enter the date of birth in the correct format, for example 12 03 1998".freeze
-      TOO_OLD_MESSAGE        = "The teacher cannot be more than 100 years old".freeze
-      TOO_YOUNG_MESSAGE      = "The teacher cannot be less than 18 years old".freeze
+      DATE_MISSING_MESSAGE   = "Enter a date of birth"
+      INVALID_FORMAT_MESSAGE = "Enter the date of birth in the correct format, for example 12 03 1998"
+      TOO_OLD_MESSAGE        = "The teacher cannot be more than 100 years old"
+      TOO_YOUNG_MESSAGE      = "The teacher cannot be less than 18 years old"
 
     private
 

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -1,8 +1,8 @@
 module Schools
   module Validation
     class ECTStartDate < HashDate
-      DATE_MISSING_MESSAGE = "Enter the date the ECT started or will start teaching at your school".freeze
-      INVALID_FORMAT_MESSAGE = "Enter the start date using the correct format, for example, 17 09 1999".freeze
+      DATE_MISSING_MESSAGE = "Enter the date the ECT started or will start teaching at your school"
+      INVALID_FORMAT_MESSAGE = "Enter the start date using the correct format, for example, 17 09 1999"
 
       def initialize(date_as_hash:, current_date: nil)
         super(date_as_hash)

--- a/lib/schools/validation/hash_date.rb
+++ b/lib/schools/validation/hash_date.rb
@@ -1,8 +1,8 @@
 module Schools
   module Validation
     class HashDate
-      DATE_MISSING_MESSAGE = "Enter a date".freeze
-      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 30 06 2001".freeze
+      DATE_MISSING_MESSAGE = "Enter a date"
+      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 30 06 2001"
 
       attr_reader :date_as_hash, :error_message
 

--- a/lib/schools/validation/mentor_start_date.rb
+++ b/lib/schools/validation/mentor_start_date.rb
@@ -1,8 +1,8 @@
 module Schools
   module Validation
     class MentorStartDate < HashDate
-      DATE_MISSING_MESSAGE = "Enter the date they started or will start ECT mentoring at your school".freeze
-      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998".freeze
+      DATE_MISSING_MESSAGE = "Enter the date they started or will start ECT mentoring at your school"
+      INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998"
 
       def initialize(date_as_hash:, current_date: nil)
         super(date_as_hash)

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -1,6 +1,6 @@
 module TRS
   class Teacher
-    PROHIBITED_FROM_TEACHING_CATEGORY_ID = 'b2b19019-b165-47a3-8745-3297ff152581'.freeze
+    PROHIBITED_FROM_TEACHING_CATEGORY_ID = 'b2b19019-b165-47a3-8745-3297ff152581'
 
     attr_reader :trn,
                 :first_name,

--- a/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
+++ b/spec/components/appropriate_bodies/claim_ect_actions_component_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe AppropriateBodies::ClaimECTActionsComponent, type: :component do
   subject(:component) do
     described_class.new(

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Rack::Attack.enabled = false
 
 RSpec.configure do |config|

--- a/spec/support/rspec_playwright.rb
+++ b/spec/support/rspec_playwright.rb
@@ -5,7 +5,7 @@ module RSpecPlaywright
   class PlaywrightMajorVersionMismatch < StandardError; end
 
   DEFAULT_TIMEOUT = 3_000
-  PLAYWRIGHT_CLI_EXECUTABLE_PATH = "./node_modules/.bin/playwright".freeze
+  PLAYWRIGHT_CLI_EXECUTABLE_PATH = "./node_modules/.bin/playwright"
 
   def self.start_browser
     Playwright.create(playwright_cli_executable_path: PLAYWRIGHT_CLI_EXECUTABLE_PATH)

--- a/spec/support/shared_examples/declarative_touch.rb
+++ b/spec/support/shared_examples/declarative_touch.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.shared_examples "a declarative touch model" do |when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, target_optional: true|
   def generate_new_value(attribute_to_change:)
     column = instance.class.columns_hash[attribute_to_change.to_s]

--- a/spec/support/shared_examples/rate_limiting_support.rb
+++ b/spec/support/shared_examples/rate_limiting_support.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.shared_examples "a rate limited endpoint", :rack_attack do |desc|
   describe desc do
     subject { response }


### PR DESCRIPTION
### Context

Ruby 3.4 [freezes string literals by default](https://www.ruby-lang.org/en/news/2024/05/16/ruby-3-4-0-preview1-released/), making the magic comment and `.freeze` on strings redundant.

### Changes proposed

- Enable `StringLiteralsFrozenByDefault` in RuboCop
- Set `TargetRubyVersion` to 3.4
- Remove magic comments and `.freeze` from string literals
- Keep `.freeze` on arrays, hashes, and non literals
- Simplify `ENV.fetch` defaults in Puma config
- Disallow `# frozen_string_literal` comments via RuboCop

### Guidance to review

Commit by commit.
