### PR TITLE
Add `Partnerships::Update` service

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,7 @@ class Event < ApplicationRecord
     lead_provider_api_token_revoked
     lead_provider_delivery_partnership_added
     school_partnership_created
+    school_partnership_updated
     statement_adjustment_added
     statement_adjustment_deleted
     statement_adjustment_updated

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -369,7 +369,7 @@ module Events
       ).record_event!
     end
 
-    def self.record_school_partnership_updated_event!(author:, school_partnership:, previous_delivery_partner:)
+    def self.record_school_partnership_updated_event!(author:, school_partnership:, previous_delivery_partner:, modifications:)
       event_type = :school_partnership_updated
       school = school_partnership.school
       delivery_partner = school_partnership.delivery_partner
@@ -378,7 +378,6 @@ module Events
       heading = "#{school.name} changed partnership from #{previous_delivery_partner.name} to #{delivery_partner.name} (via #{lead_provider.name}) for #{contract_period.year}"
       metadata = {
         contract_period_year: contract_period.year,
-        previous_delivery_partner_id: previous_delivery_partner.id,
       }
 
       new(
@@ -390,7 +389,8 @@ module Events
         school:,
         lead_provider:,
         happened_at: Time.zone.now,
-        metadata:
+        metadata:,
+        modifications:
       ).record_event!
     end
 

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -369,6 +369,31 @@ module Events
       ).record_event!
     end
 
+    def self.record_school_partnership_updated_event!(author:, school_partnership:, previous_delivery_partner:)
+      event_type = :school_partnership_updated
+      school = school_partnership.school
+      delivery_partner = school_partnership.delivery_partner
+      lead_provider = school_partnership.lead_provider
+      contract_period = school_partnership.contract_period
+      heading = "#{school.name} changed partnership from #{previous_delivery_partner.name} to #{delivery_partner.name} (via #{lead_provider.name}) for #{contract_period.year}"
+      metadata = {
+        contract_period_year: contract_period.year,
+        previous_delivery_partner_id: previous_delivery_partner.id,
+      }
+
+      new(
+        event_type:,
+        author:,
+        heading:,
+        school_partnership:,
+        delivery_partner:,
+        school:,
+        lead_provider:,
+        happened_at: Time.zone.now,
+        metadata:
+      ).record_event!
+    end
+
     # Statement Adjustment Events
 
     def self.record_statement_adjustment_added_event!(author:, statement_adjustment:)

--- a/app/services/school_partnerships/update.rb
+++ b/app/services/school_partnerships/update.rb
@@ -1,0 +1,72 @@
+module SchoolPartnerships
+  class Update
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :school_partnership_id
+    attribute :delivery_partner_api_id
+
+    validates :school_partnership_id, presence: { message: "Enter a '#/partnership'." }
+    validates :delivery_partner_api_id, presence: { message: "Enter a '#/delivery_partner_id'." }
+    validate :delivery_partner_exists
+    validate :school_partnership_exists
+    validate :lead_provider_delivery_partnership_exists
+    validate :does_not_cause_duplicate_school_partnership
+
+    def update
+      return false unless valid?
+
+      school_partnership.tap do |school_partnership|
+        previous_delivery_partner = school_partnership.delivery_partner
+        school_partnership.update!(lead_provider_delivery_partnership:)
+        Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:, previous_delivery_partner:)
+      end
+    end
+
+  private
+
+    def school_partnership
+      @school_partnership ||= SchoolPartnership.find_by(id: school_partnership_id) if school_partnership_id
+    end
+
+    def delivery_partner
+      @delivery_partner ||= DeliveryPartner.find_by(api_id: delivery_partner_api_id) if delivery_partner_api_id
+    end
+
+    def lead_provider
+      @lead_provider ||= school_partnership&.lead_provider
+    end
+
+    def active_lead_provider
+      @active_lead_provider ||= school_partnership&.active_lead_provider
+    end
+
+    def lead_provider_delivery_partnership
+      return unless active_lead_provider && delivery_partner
+
+      @lead_provider_delivery_partnership ||= delivery_partner.lead_provider_delivery_partnerships.find_by(active_lead_provider:, delivery_partner:)
+    end
+
+    def delivery_partner_exists
+      errors.add(:delivery_partner_api_id, "The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again.") unless delivery_partner
+    end
+
+    def school_partnership_exists
+      errors.add(:school_partnership_id, "The '#/partnership' you have entered is invalid. Check partnership details and try again.") unless school_partnership
+    end
+
+    def lead_provider_delivery_partnership_exists
+      return unless active_lead_provider && delivery_partner
+
+      errors.add(:delivery_partner_api_id, "The entered delivery partner is not recognised to be working in partnership with you for the given cohort. Contact the DfE for more information.") unless lead_provider_delivery_partnership
+    end
+
+    def does_not_cause_duplicate_school_partnership
+      return unless school_partnership && lead_provider_delivery_partnership
+
+      existing_school_partnership = school_partnership.school.school_partnerships.exists?(lead_provider_delivery_partnership:)
+
+      errors.add(:delivery_partner_api_id, "We are unable to process this request. You are already confirmed to be in partnership with the entered delivery partner. Contact the DfE for support.") if existing_school_partnership
+    end
+  end
+end

--- a/app/services/school_partnerships/update.rb
+++ b/app/services/school_partnerships/update.rb
@@ -19,7 +19,8 @@ module SchoolPartnerships
       school_partnership.tap do |school_partnership|
         previous_delivery_partner = school_partnership.delivery_partner
         school_partnership.update!(lead_provider_delivery_partnership:)
-        Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:, previous_delivery_partner:)
+        modifications = school_partnership.saved_changes
+        Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:, previous_delivery_partner:, modifications:)
       end
     end
 

--- a/app/services/school_partnerships/update.rb
+++ b/app/services/school_partnerships/update.rb
@@ -16,11 +16,13 @@ module SchoolPartnerships
     def update
       return false unless valid?
 
-      school_partnership.tap do |school_partnership|
-        previous_delivery_partner = school_partnership.delivery_partner
-        school_partnership.update!(lead_provider_delivery_partnership:)
-        modifications = school_partnership.saved_changes
-        Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:, previous_delivery_partner:, modifications:)
+      ActiveRecord::Base.transaction do
+        school_partnership.tap do |school_partnership|
+          previous_delivery_partner = school_partnership.delivery_partner
+          school_partnership.update!(lead_provider_delivery_partnership:)
+          modifications = school_partnership.saved_changes
+          Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:, previous_delivery_partner:, modifications:)
+        end
       end
     end
 

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -857,11 +857,11 @@ RSpec.describe Events::Record do
 
     it 'queues a RecordEventJob with the correct values' do
       freeze_time do
-        previous_delivery_partner = FactoryBot.create(:delivery_partner)
-        Events::Record.record_school_partnership_updated_event!(author:, school_partnership:, previous_delivery_partner:)
+        previous_delivery_partner = school_partnership.delivery_partner
+        school_partnership.update!(lead_provider_delivery_partnership: FactoryBot.create(:lead_provider_delivery_partnership))
+        Events::Record.record_school_partnership_updated_event!(author:, school_partnership:, previous_delivery_partner:, modifications: school_partnership.saved_changes)
         metadata = {
           contract_period_year: school_partnership.contract_period.year,
-          previous_delivery_partner_id: previous_delivery_partner.id,
         }
 
         expect(RecordEventJob).to have_received(:perform_later).with(
@@ -873,6 +873,7 @@ RSpec.describe Events::Record do
           event_type: :school_partnership_updated,
           happened_at: Time.zone.now,
           metadata:,
+          modifications: [/Lead provider delivery partnership changed from '\d+' to '\d+'/],
           **author_params
         )
       end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -852,6 +852,33 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe '.record_school_partnership_updated_event!' do
+    let(:school_partnership) { FactoryBot.create(:school_partnership) }
+
+    it 'queues a RecordEventJob with the correct values' do
+      freeze_time do
+        previous_delivery_partner = FactoryBot.create(:delivery_partner)
+        Events::Record.record_school_partnership_updated_event!(author:, school_partnership:, previous_delivery_partner:)
+        metadata = {
+          contract_period_year: school_partnership.contract_period.year,
+          previous_delivery_partner_id: previous_delivery_partner.id,
+        }
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          heading: "#{school_partnership.school.name} changed partnership from #{previous_delivery_partner.name} to #{school_partnership.delivery_partner.name} (via #{school_partnership.lead_provider.name}) for #{school_partnership.contract_period.year}",
+          school_partnership:,
+          school: school_partnership.school,
+          delivery_partner: school_partnership.delivery_partner,
+          lead_provider: school_partnership.lead_provider,
+          event_type: :school_partnership_updated,
+          happened_at: Time.zone.now,
+          metadata:,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe '.record_statement_adjustment_updated_event!' do
     let(:statement) { FactoryBot.create(:statement) }
     let(:statement_adjustment) { FactoryBot.create(:statement_adjustment, statement:) }

--- a/spec/services/school_partnerships/update_spec.rb
+++ b/spec/services/school_partnerships/update_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe SchoolPartnerships::Update, type: :model do
+  let(:service) do
+    described_class.new(
+      school_partnership_id:,
+      delivery_partner_api_id:
+    )
+  end
+
+  let!(:school_partnership) { FactoryBot.create(:school_partnership) }
+  let(:school_partnership_id) { school_partnership.id }
+  let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: school_partnership.active_lead_provider) }
+  let(:delivery_partner_api_id) { lead_provider_delivery_partnership.delivery_partner.api_id }
+
+  describe "validations" do
+    subject { service }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:school_partnership_id).with_message("Enter a '#/partnership'.") }
+    it { is_expected.to validate_presence_of(:delivery_partner_api_id).with_message("Enter a '#/delivery_partner_id'.") }
+
+    context "when the delivery partner does not exist" do
+      let(:delivery_partner_api_id) { SecureRandom.uuid }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_api_id]).to include("The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again.")
+      end
+    end
+
+    context "when the school partnership does not exist" do
+      let(:school_partnership_id) { -1 }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:school_partnership_id]).to include("The '#/partnership' you have entered is invalid. Check partnership details and try again.")
+      end
+    end
+
+    context "when the lead provider delivery partnership does not exist" do
+      let(:delivery_partner_api_id) { FactoryBot.create(:delivery_partner).api_id }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_api_id]).to include("The entered delivery partner is not recognised to be working in partnership with you for the given cohort. Contact the DfE for more information.")
+      end
+    end
+
+    context "when the change in delivery partner would result in a duplicate school partnership" do
+      before { FactoryBot.create(:school_partnership, school: school_partnership.school, lead_provider_delivery_partnership:) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:delivery_partner_api_id]).to include("We are unable to process this request. You are already confirmed to be in partnership with the entered delivery partner. Contact the DfE for support.")
+      end
+    end
+  end
+
+  describe "#update" do
+    subject(:update_school_partnership) { service.update }
+
+    it "updates the delivery partner of the school partnership" do
+      updated_school_partnership = nil
+
+      expect { updated_school_partnership = service.update }.to(change { school_partnership.reload.attributes })
+
+      expect(updated_school_partnership).to have_attributes(lead_provider_delivery_partnership:)
+    end
+
+    it "records a school partnership updated event" do
+      allow(Events::Record).to receive(:record_school_partnership_updated_event!).once.and_call_original
+
+      previous_delivery_partner = school_partnership.delivery_partner
+      school_partnership = update_school_partnership
+
+      expect(Events::Record).to have_received(:record_school_partnership_updated_event!).once.with(
+        hash_including(
+          {
+            school_partnership:,
+            author: kind_of(Events::LeadProviderAPIAuthor),
+            previous_delivery_partner:
+          }
+        )
+      )
+    end
+
+    context "when invalid" do
+      let(:delivery_partner_api_id) { SecureRandom.uuid }
+
+      it { is_expected.to be(false) }
+      it { expect { update_school_partnership }.not_to(change { school_partnership.reload.attributes }) }
+    end
+  end
+end

--- a/spec/services/school_partnerships/update_spec.rb
+++ b/spec/services/school_partnerships/update_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe SchoolPartnerships::Update, type: :model do
           {
             school_partnership:,
             author: kind_of(Events::LeadProviderAPIAuthor),
-            previous_delivery_partner:
+            previous_delivery_partner:,
+            modifications: school_partnership.saved_changes
           }
         )
       )


### PR DESCRIPTION
### Context

We want to add a service that will enable school partnerships to change delivery partner in order to support the `PUT /api/v3/partnerships/:id` endpoint.

### Changes proposed in this pull request

- Add `Partnerships::Update` service

Add service to update the delivery partner for a given partnership.

Send an update event that tracks the change (including the previous delivery partner in the metadata).

In order to perform an update, there must: 

- be a school partnership and delivery partner matching the provided ids.
- be a lead provider delivery partnership for the lead provider and delivery 
partner.
- not already be a partnership with the same lead provider and delivery partner.

### Guidance to review

We don't appear to need to refresh any metadata off the back of a partnership update.