### PR TITLE
Replace RECT terminology with ECF terminology in API error messages

### DIFF
--- a/app/services/api/errors/mapper.rb
+++ b/app/services/api/errors/mapper.rb
@@ -1,0 +1,31 @@
+module API
+  module Errors
+    class Mapper
+      class MappingsFileNotFoundError < RuntimeError; end
+
+      YAML_FILE_PATH = "config/api_error_mappings.yml"
+
+      attr_reader :mappings_file, :mappings
+
+      def initialize
+        @mappings = load_mappings!
+      end
+
+      def map_error(title:, detail:)
+        { title:, detail: }.transform_values { replace(it) }
+      end
+
+    private
+
+      def load_mappings!
+        raise MappingsFileNotFoundError, "Mappings file not found: #{YAML_FILE_PATH}" unless File.exist?(YAML_FILE_PATH)
+
+        YAML.load_file(YAML_FILE_PATH) || {}
+      end
+
+      def replace(text)
+        mappings.reduce(text.to_s) { |t, (from, to)| t.gsub(from.to_s, to.to_s) }
+      end
+    end
+  end
+end

--- a/app/services/api/errors/response.rb
+++ b/app/services/api/errors/response.rb
@@ -9,7 +9,7 @@ module API
       end
 
       def call
-        messages.map { |detail| { title:, detail: }.freeze }
+        messages.map { |detail| mapper.map_error(title:, detail:).freeze }
       end
 
       def self.from(service)
@@ -18,6 +18,12 @@ module API
             new(title:, messages:).call
           end
         }
+      end
+
+    private
+
+      def mapper
+        @mapper ||= API::Errors::Mapper.new
       end
     end
   end

--- a/app/services/school_partnerships/create.rb
+++ b/app/services/school_partnerships/create.rb
@@ -10,10 +10,10 @@ module SchoolPartnerships
     attribute :school_api_id
     attribute :delivery_partner_api_id
 
-    validates :contract_period_year, presence: { message: "Enter a '#/cohort'." }
-    validates :school_api_id, presence: { message: "Enter a '#/school_id'." }
+    validates :contract_period_year, presence: { message: "Enter a '#/contract_period_year'." }
+    validates :school_api_id, presence: { message: "Enter a '#/school_api_id'." }
     validates :lead_provider_id, presence: { message: "Enter a '#/lead_provider_id'." }
-    validates :delivery_partner_api_id, presence: { message: "Enter a '#/delivery_partner_id'." }
+    validates :delivery_partner_api_id, presence: { message: "Enter a '#/delivery_partner_api_id'." }
     validate :contract_period_exists
     validate :contract_period_enabled
     validate :lead_provider_exists
@@ -62,11 +62,11 @@ module SchoolPartnerships
     end
 
     def contract_period_exists
-      errors.add(:contract_period_year, "The '#/cohort' you have entered is invalid. Check cohort details and try again.") unless contract_period
+      errors.add(:contract_period_year, "The '#/contract_period_year' you have entered is invalid. Check contract period details and try again.") unless contract_period
     end
 
     def contract_period_enabled
-      errors.add(:contract_period_year, "You cannot create this partnership until the cohort has started.") unless contract_period&.enabled?
+      errors.add(:contract_period_year, "You cannot create this partnership until the contract period has started.") unless contract_period&.enabled?
     end
 
     def lead_provider_exists
@@ -74,7 +74,7 @@ module SchoolPartnerships
     end
 
     def school_exists
-      errors.add(:school_api_id, "The '#/school_id' you have entered is invalid. Check school details and try again. Contact the DfE for support if you are unable to find the '#/school_id'.") unless school
+      errors.add(:school_api_id, "The '#/school_api_id' you have entered is invalid. Check school details and try again. Contact the DfE for support if you are unable to find the '#/school_api_id'.") unless school
     end
 
     def school_is_not_cip_only
@@ -93,11 +93,11 @@ module SchoolPartnerships
         .joins(:lead_provider_delivery_partnership)
         .exists?(lead_provider_delivery_partnerships: { active_lead_provider: })
 
-      errors.add(:school_api_id, "You are already in a confirmed partnership with this school for the entered cohort.") if existing_school_partnership
+      errors.add(:school_api_id, "You are already in a confirmed partnership with this school for the entered contract period.") if existing_school_partnership
     end
 
     def delivery_partner_exists
-      errors.add(:delivery_partner_api_id, "The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again.") unless delivery_partner
+      errors.add(:delivery_partner_api_id, "The '#/delivery_partner_api_id' you have entered is invalid. Check delivery partner details and try again.") unless delivery_partner
     end
 
     def active_lead_provider
@@ -115,7 +115,7 @@ module SchoolPartnerships
     def lead_provider_delivery_partnership_exists
       return unless lead_provider && delivery_partner
 
-      errors.add(:delivery_partner_api_id, "The entered delivery partner is not recognised to be working in partnership with you for the given cohort. Contact the DfE for more information.") unless lead_provider_delivery_partnership
+      errors.add(:delivery_partner_api_id, "The entered delivery partner is not recognised to be working in partnership with you for the given contract period. Contact the DfE for more information.") unless lead_provider_delivery_partnership
     end
 
     def metadata

--- a/app/services/school_partnerships/create.rb
+++ b/app/services/school_partnerships/create.rb
@@ -1,5 +1,3 @@
-# TODO: error messages are currently consistent with ECF, however we want them to use RECT
-# terminology in the service and will look to map between them somehow in a future PR.
 module SchoolPartnerships
   class Create
     include ActiveModel::Model

--- a/app/services/school_partnerships/update.rb
+++ b/app/services/school_partnerships/update.rb
@@ -6,8 +6,8 @@ module SchoolPartnerships
     attribute :school_partnership_id
     attribute :delivery_partner_api_id
 
-    validates :school_partnership_id, presence: { message: "Enter a '#/partnership'." }
-    validates :delivery_partner_api_id, presence: { message: "Enter a '#/delivery_partner_id'." }
+    validates :school_partnership_id, presence: { message: "Enter a '#/school_partnership_id'." }
+    validates :delivery_partner_api_id, presence: { message: "Enter a '#/delivery_partner_api_id'." }
     validate :delivery_partner_exists
     validate :school_partnership_exists
     validate :lead_provider_delivery_partnership_exists
@@ -51,17 +51,17 @@ module SchoolPartnerships
     end
 
     def delivery_partner_exists
-      errors.add(:delivery_partner_api_id, "The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again.") unless delivery_partner
+      errors.add(:delivery_partner_api_id, "The '#/delivery_partner_api_id' you have entered is invalid. Check delivery partner details and try again.") unless delivery_partner
     end
 
     def school_partnership_exists
-      errors.add(:school_partnership_id, "The '#/partnership' you have entered is invalid. Check partnership details and try again.") unless school_partnership
+      errors.add(:school_partnership_id, "The '#/school_partnership_id' you have entered is invalid. Check partnership details and try again.") unless school_partnership
     end
 
     def lead_provider_delivery_partnership_exists
       return unless active_lead_provider && delivery_partner
 
-      errors.add(:delivery_partner_api_id, "The entered delivery partner is not recognised to be working in partnership with you for the given cohort. Contact the DfE for more information.") unless lead_provider_delivery_partnership
+      errors.add(:delivery_partner_api_id, "The entered delivery partner is not recognised to be working in partnership with you for the given contract period. Contact the DfE for more information.") unless lead_provider_delivery_partnership
     end
 
     def does_not_cause_duplicate_school_partnership

--- a/config/api_error_mappings.yml
+++ b/config/api_error_mappings.yml
@@ -1,0 +1,5 @@
+"contract_period_year": "cohort"
+"contract period": "cohort"
+"api_id": "id"
+"school_partnership_id": "partnership"
+"delivery_partner_api_id": "delivery_partner_id"

--- a/spec/fixtures/files/api_error_mappings.yml
+++ b/spec/fixtures/files/api_error_mappings.yml
@@ -1,0 +1,1 @@
+rect_term: ecf_term

--- a/spec/services/api/errors/mapper_spec.rb
+++ b/spec/services/api/errors/mapper_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe API::Errors::Mapper do
+  let(:instance) { described_class.new }
+
+  before { stub_const("#{described_class}::YAML_FILE_PATH", file_fixture("api_error_mappings.yml")) }
+
+  describe "#map_error" do
+    subject(:map_error) { instance.map_error(**error) }
+
+    let(:error) { { title: "a title with a rect_term", detail: "a message with a rect_term" } }
+
+    it "maps error keys using the YAML mappings" do
+      result = map_error
+
+      expect(result[:title]).to eql("a title with a ecf_term")
+      expect(result[:detail]).to eql("a message with a ecf_term")
+    end
+
+    context "when there are multiple occurrences of mappable terms" do
+      let(:error) { { title: "rect_term and rect_term", detail: "rect_term or rect_term" } }
+
+      it "replaces all occurrences" do
+        result = map_error
+
+        expect(result[:title]).to eql("ecf_term and ecf_term")
+        expect(result[:detail]).to eql("ecf_term or ecf_term")
+      end
+    end
+
+    context "when the mappings file is missing" do
+      before { stub_const("#{described_class}::YAML_FILE_PATH", "non_existent_file.yml") }
+
+      it { expect { map_error }.to raise_error(API::Errors::Mapper::MappingsFileNotFoundError, "Mappings file not found: non_existent_file.yml") }
+    end
+  end
+end

--- a/spec/services/api/errors/response_spec.rb
+++ b/spec/services/api/errors/response_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe API::Errors::Response do
         expect(result[0][:detail]).to eql("Error 1")
       end
     end
+
+    context "when the errors contain RECT terms" do
+      before { stub_const("API::Errors::Mapper::YAML_FILE_PATH", file_fixture("api_error_mappings.yml")) }
+
+      let(:title) { "a rect_term error title" }
+      let(:messages) do
+        [
+          "a rect_term message",
+          "another rect_term message",
+        ]
+      end
+
+      it "maps the errors using the YAML mappings" do
+        result = subject.call
+
+        expect(result[0][:title]).to eql("a ecf_term error title")
+        expect(result[0][:detail]).to eql("a ecf_term message")
+
+        expect(result[1][:title]).to eql("a ecf_term error title")
+        expect(result[1][:detail]).to eql("another ecf_term message")
+      end
+    end
   end
 
   describe ".from" do
@@ -43,8 +65,8 @@ RSpec.describe API::Errors::Response do
 
     it "returns a hash with formatted errors" do
       expect(response[:errors]).to include(
-        { title: :contract_period_year, detail: "Enter a '#/cohort'." },
-        { title: :school_api_id, detail: "Enter a '#/school_id'." }
+        { title: "cohort", detail: "Enter a '#/cohort'." },
+        { title: "school_id", detail: "Enter a '#/school_id'." }
       )
     end
   end

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe SchoolPartnerships::Create, type: :model do
 
     it { is_expected.to be_valid }
 
-    it { is_expected.to validate_presence_of(:contract_period_year).with_message("Enter a '#/cohort'.") }
-    it { is_expected.to validate_presence_of(:school_api_id).with_message("Enter a '#/school_id'.") }
+    it { is_expected.to validate_presence_of(:contract_period_year).with_message("Enter a '#/contract_period_year'.") }
+    it { is_expected.to validate_presence_of(:school_api_id).with_message("Enter a '#/school_api_id'.") }
     it { is_expected.to validate_presence_of(:lead_provider_id).with_message("Enter a '#/lead_provider_id'.") }
-    it { is_expected.to validate_presence_of(:delivery_partner_api_id).with_message("Enter a '#/delivery_partner_id'.") }
+    it { is_expected.to validate_presence_of(:delivery_partner_api_id).with_message("Enter a '#/delivery_partner_api_id'.") }
 
     context "when the contract period year does not exist" do
       let(:contract_period_year) { contract_period.year - 1 }
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:contract_period_year]).to include("The '#/cohort' you have entered is invalid. Check cohort details and try again.")
+        expect(service.errors[:contract_period_year]).to include("The '#/contract_period_year' you have entered is invalid. Check contract period details and try again.")
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe SchoolPartnerships::Create, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:contract_period_year]).to include("You cannot create this partnership until the cohort has started.")
+        expect(service.errors[:contract_period_year]).to include("You cannot create this partnership until the contract period has started.")
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe SchoolPartnerships::Create, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:school_api_id]).to include("The '#/school_id' you have entered is invalid. Check school details and try again. Contact the DfE for support if you are unable to find the '#/school_id'.")
+        expect(service.errors[:school_api_id]).to include("The '#/school_api_id' you have entered is invalid. Check school details and try again. Contact the DfE for support if you are unable to find the '#/school_api_id'.")
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe SchoolPartnerships::Create, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:school_api_id]).to include("You are already in a confirmed partnership with this school for the entered cohort.")
+        expect(service.errors[:school_api_id]).to include("You are already in a confirmed partnership with this school for the entered contract period.")
       end
     end
 
@@ -127,7 +127,7 @@ RSpec.describe SchoolPartnerships::Create, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:delivery_partner_api_id]).to include("The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again.")
+        expect(service.errors[:delivery_partner_api_id]).to include("The '#/delivery_partner_api_id' you have entered is invalid. Check delivery partner details and try again.")
       end
     end
 
@@ -136,7 +136,7 @@ RSpec.describe SchoolPartnerships::Create, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:delivery_partner_api_id]).to include("The entered delivery partner is not recognised to be working in partnership with you for the given cohort. Contact the DfE for more information.")
+        expect(service.errors[:delivery_partner_api_id]).to include("The entered delivery partner is not recognised to be working in partnership with you for the given contract period. Contact the DfE for more information.")
       end
     end
 

--- a/spec/services/school_partnerships/update_spec.rb
+++ b/spec/services/school_partnerships/update_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe SchoolPartnerships::Update, type: :model do
 
     it { is_expected.to be_valid }
 
-    it { is_expected.to validate_presence_of(:school_partnership_id).with_message("Enter a '#/partnership'.") }
-    it { is_expected.to validate_presence_of(:delivery_partner_api_id).with_message("Enter a '#/delivery_partner_id'.") }
+    it { is_expected.to validate_presence_of(:school_partnership_id).with_message("Enter a '#/school_partnership_id'.") }
+    it { is_expected.to validate_presence_of(:delivery_partner_api_id).with_message("Enter a '#/delivery_partner_api_id'.") }
 
     context "when the delivery partner does not exist" do
       let(:delivery_partner_api_id) { SecureRandom.uuid }
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:delivery_partner_api_id]).to include("The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again.")
+        expect(service.errors[:delivery_partner_api_id]).to include("The '#/delivery_partner_api_id' you have entered is invalid. Check delivery partner details and try again.")
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe SchoolPartnerships::Update, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:school_partnership_id]).to include("The '#/partnership' you have entered is invalid. Check partnership details and try again.")
+        expect(service.errors[:school_partnership_id]).to include("The '#/school_partnership_id' you have entered is invalid. Check partnership details and try again.")
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe SchoolPartnerships::Update, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:delivery_partner_api_id]).to include("The entered delivery partner is not recognised to be working in partnership with you for the given cohort. Contact the DfE for more information.")
+        expect(service.errors[:delivery_partner_api_id]).to include("The entered delivery partner is not recognised to be working in partnership with you for the given contract period. Contact the DfE for more information.")
       end
     end
 


### PR DESCRIPTION
### Context

We need to be able to swap out the RECT terminology used in the service errors and attribute names with ECF terminology that lead providers are familiar with.

### Changes proposed in this pull request

- Update school partnership service errors to use RECT terminology

At the moment we use RECT attribute names and ECF error messages. Going forward we're going to keep the service using RECT terminology and swap out the errors in the API responses.

- Add API error mapping service

Add `API::Errors::Mapper` service that will transform RECT terms to ECF.

Hook into the `API::Errors::Response` service to replace error messages.

### Guidance to review

Initially I thought we would be replacing whole error messages and was worried about how we would catch changes to error messages in the service, but as we're only replacing terms I don't think it will be as big of an issue.

Example response from the API:

```
{
    "errors": [
        {
            "title": "cohort",
            "detail": "The '#/cohort' you have entered is invalid. Check cohort details and try again."
        },
        {
            "title": "cohort",
            "detail": "You cannot create this partnership until the cohort has started."
        },
        {
            "title": "school_id",
            "detail": "The '#/school_id' you have entered is invalid. Check school details and try again. Contact the DfE for support if you are unable to find the '#/school_id'."
        },
        {
            "title": "school_id",
            "detail": "The school you have entered is currently ineligible for DfE funding. Contact the school for more information."
        },
        {
            "title": "delivery_partner_id",
            "detail": "The '#/delivery_partner_id' you have entered is invalid. Check delivery partner details and try again."
        }
    ]
}
```