### PR TITLE
Add PUT /partnerships/:id endpoint 

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -14,5 +14,15 @@ module API
     def current_user
       current_lead_provider
     end
+
+  protected
+
+    def respond_with_service(service:, action:)
+      if service.valid?
+        render json: to_json(service.send(action))
+      else
+        render json: API::Errors::Response.from(service), status: :unprocessable_content
+      end
+    end
   end
 end

--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -35,17 +35,11 @@ module API
     private
 
       def create_partnership_params
-        params
-          .require(:data)
-          .require(:attributes)
-          .permit(:cohort, :school_id, :delivery_partner_id)
+        params.require(:data).expect({ attributes: %i[cohort school_id delivery_partner_id] })
       end
 
       def update_partnership_params
-        params
-          .require(:data)
-          .require(:attributes)
-          .permit(:delivery_partner_id)
+        params.require(:data).expect({ attributes: %i[delivery_partner_id] })
       end
 
       def partnerships_query(conditions: {})

--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -18,14 +18,19 @@ module API
           delivery_partner_api_id: create_partnership_params[:delivery_partner_id],
         })
 
-        if service.valid?
-          render json: to_json(service.create)
-        else
-          render json: API::Errors::Response.from(service), status: :unprocessable_content
-        end
+        respond_with_service(service:, action: :create)
       end
 
-      def update = head(:method_not_allowed)
+      def update
+        school_partnership = partnerships_query.school_partnership_by_api_id(api_id)
+
+        service = SchoolPartnerships::Update.new({
+          school_partnership_id: school_partnership.id,
+          delivery_partner_api_id: update_partnership_params[:delivery_partner_id],
+        })
+
+        respond_with_service(service:, action: :update)
+      end
 
     private
 
@@ -34,6 +39,13 @@ module API
           .require(:data)
           .require(:attributes)
           .permit(:cohort, :school_id, :delivery_partner_id)
+      end
+
+      def update_partnership_params
+        params
+          .require(:data)
+          .require(:attributes)
+          .permit(:delivery_partner_id)
       end
 
       def partnerships_query(conditions: {})

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -70,13 +70,33 @@ RSpec.describe "Partnerships API", type: :request do
   end
 
   describe "#update" do
-    let(:path) { api_v3_partnership_path(123) }
+    let(:path) { api_v3_partnership_path(resource.api_id) }
+    let(:service) { SchoolPartnerships::Update }
+    let(:resource_type) { SchoolPartnership }
+    let(:resource) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+    let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+    let(:other_delivery_partner) do
+      other_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+      other_delivery_partnership.delivery_partner
+    end
+    let(:service_args) do
+      {
+        school_partnership_id: resource.id,
+        delivery_partner_api_id: other_delivery_partner.api_id,
+      }
+    end
+    let(:params) do
+      {
+        data: {
+          type: "partnership",
+          attributes: {
+            delivery_partner_id: other_delivery_partner.api_id,
+          }
+        }
+      }
+    end
 
     it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
+    it_behaves_like "an API update endpoint"
   end
 end

--- a/spec/support/shared_contexts/update_endpoint.rb
+++ b/spec/support/shared_contexts/update_endpoint.rb
@@ -1,0 +1,49 @@
+RSpec.shared_examples "an API update endpoint" do
+  let(:options) { defined?(serializer_options) ? serializer_options : {} }
+
+  it "creates and returns the resource in a serialized format" do
+    authenticated_api_put(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render(resource_type.last, root: "data", **options))
+  end
+
+  it "calls the service with the correct arguments" do
+    allow(service).to receive(:new).and_call_original
+
+    authenticated_api_put(path, params:)
+
+    expect(service).to have_received(:new).with(service_args)
+  end
+
+  it "returns a 422 response if the service has errors" do
+    errors = instance_double(ActiveModel::Errors, messages: { attr: %w[message] })
+    service_double = instance_double(service, valid?: false, errors:)
+    allow(service).to receive(:new).and_return(service_double)
+
+    authenticated_api_put(path, params:)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq({ errors: [{ title: "attr", detail: "message" }] }.to_json)
+  end
+
+  it "returns a 400 response if the request body is malformed" do
+    authenticated_api_put(path, params: { not_a_valid: :body })
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "Correct json data structure required. See API docs for reference." }] }.to_json)
+  end
+
+  it "returns a 404 response if the resource does not belong to the lead provider" do
+    resource.update!(active_lead_provider: FactoryBot.create(:active_lead_provider))
+
+    authenticated_api_put(path, params:)
+
+    expect(response).to have_http_status(:not_found)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq({ errors: [{ title: "Resource not found", detail: "Nothing could be found for the provided details" }] }.to_json)
+  end
+end


### PR DESCRIPTION
### Context

Now that we have the `SchoolPartnerships::Update` service, we want to connect it to the `PUT /partnerships/:id` endpoint to allow lead providers to create partnerships.

### Changes proposed in this pull request

- Add PUT /api/v3/partnerships/:id endpoint

Call the `SchoolPartnerships::Update` service from the `update` action of the `PartnershipsController`.

Add shared context for testing `update` actions.

- Switch partnerships controller to use params.expect

Note we need to still `require(:data)` as the result of `expect(data: { attributes: %i[attr] })` is a hash of `{ attributes: ... }` when we just want the bottom-level attributes.

### Guidance to review
