### PR TITLE
Add swagger docs for PUT /api/v3/partnerships/:id

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -116,7 +116,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
     post:
-      summary: Creates a partnership
+      summary: Create a partnership
       tags:
       - Partnerships
       security:
@@ -184,6 +184,54 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
+    put:
+      summary: Update a partnership
+      tags:
+      - Partnerships
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The updated partnership
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PartnershipResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/PartnershipUpdateRequest"
   "/api/v3/schools":
     get:
       summary: Retrieve multiple schools scoped to cohort
@@ -777,7 +825,7 @@ components:
       properties:
         data:
           "$ref": "#/components/schemas/Partnership"
-    PartnershipRequest:
+    PartnershipCreateRequest:
       description: A partnership request
       type: object
       required:
@@ -816,6 +864,38 @@ components:
                   nullable: false
                   type: string
                   example: 24b61d1c-ad95-4000-aee0-afbdd542294a
+                delivery_partner_id:
+                  description: The unique ID of the delivery partner you will work
+                    with for this school partnership
+                  required: true
+                  nullable: false
+                  type: string
+                  example: db2fbf67-b7b7-454f-a1b7-0020411e2314
+    PartnershipUpdateRequest:
+      description: A partnership update request
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          description: A partnership update
+          type: object
+          required:
+          - type
+          - attributes
+          properties:
+            type:
+              type: string
+              required: true
+              enum:
+              - partnership
+              example: partnership
+            attributes:
+              description: A partnership update request attributes
+              type: object
+              required:
+              - delivery_partner_id
+              properties:
                 delivery_partner_id:
                   description: The unique ID of the delivery partner you will work
                     with for this school partnership

--- a/spec/requests/api/docs/v3/partnerships_spec.rb
+++ b/spec/requests/api/docs/v3/partnerships_spec.rb
@@ -57,4 +57,38 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                       }
                     end
                   end
+
+  it_behaves_like "an API update endpoint documentation",
+                  {
+                    url: "/api/v3/partnerships/{id}",
+                    tag: "Partnerships",
+                    resource_description: "partnership",
+                    request_schema_ref: "#/components/schemas/PartnershipUpdateRequest",
+                    response_schema_ref: "#/components/schemas/PartnershipResponse",
+                  } do
+                    let(:params) do
+                      other_lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+                      other_delivery_partner = other_lead_provider_delivery_partnership.delivery_partner
+
+                      {
+                        data: {
+                          type: "partnership",
+                          attributes: {
+                            delivery_partner_id: other_delivery_partner.api_id,
+                          },
+                        },
+                      }
+                    end
+
+                    let(:invalid_params) do
+                      {
+                        data: {
+                          type: "partnership",
+                          attributes: {
+                            delivery_partner_id: SecureRandom.uuid,
+                          },
+                        },
+                      }
+                    end
+                  end
 end

--- a/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
@@ -1,10 +1,17 @@
-RSpec.shared_context "an API create endpoint documentation", :exceptions_app do |options = {}|
+RSpec.shared_context "an API update endpoint documentation", :exceptions_app do |options = {}|
   path options[:url] do
-    post "Create a #{options[:resource_description]}" do
+    put "Update a #{options[:resource_description]}" do
       tags options[:tag]
       consumes "application/json"
       produces "application/json"
       security [api_key: []]
+
+      parameter name: :id,
+                in: :path,
+                required: true,
+                schema: {
+                  "$ref": "#/components/schemas/IDAttribute",
+                }
 
       parameter name: :params,
                 in: :body,
@@ -14,7 +21,9 @@ RSpec.shared_context "an API create endpoint documentation", :exceptions_app do 
                   "$ref": options[:request_schema_ref],
                 }
 
-      response "200", "The created #{options[:resource_description]}" do
+      let(:id) { resource.api_id }
+
+      response "200", "The updated #{options[:resource_description]}" do
         schema({ "$ref": options[:response_schema_ref] })
 
         run_test!
@@ -40,6 +49,14 @@ RSpec.shared_context "an API create endpoint documentation", :exceptions_app do 
         let(:params) { invalid_params }
 
         schema({ "$ref": "#/components/schemas/UnprocessableContentResponse" })
+
+        run_test!
+      end
+
+      response "404", "Not found" do
+        let(:id) { SecureRandom.uuid }
+
+        schema({ "$ref": "#/components/schemas/NotFoundResponse" })
 
         run_test!
       end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -69,7 +69,8 @@ RSpec.configure do |config|
           Partnership: PARTNERSHIP,
           PartnershipsFilter: PARTNERSHIPS_FILTER,
           PartnershipResponse: PARTNERSHIP_RESPONSE,
-          PartnershipRequest: PARTNERSHIP_REQUEST,
+          PartnershipCreateRequest: PARTNERSHIP_CREATE_REQUEST,
+          PartnershipUpdateRequest: PARTNERSHIP_UPDATE_REQUEST,
           PartnershipsResponse: PARTNERSHIPS_RESPONSE,
         }
       }

--- a/spec/swagger_schemas/requests/partnership_create.rb
+++ b/spec/swagger_schemas/requests/partnership_create.rb
@@ -1,0 +1,50 @@
+PARTNERSHIP_CREATE_REQUEST = {
+  description: "A partnership request",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "A partnership",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[
+            partnership
+          ],
+          example: "partnership",
+        },
+        attributes: {
+          description: "A partnership request attributes",
+          type: :object,
+          required: %i[cohort delivery_partner_id school_id],
+          properties: {
+            cohort: {
+              description: "The cohort for which you are reporting the partnership",
+              required: true,
+              nullable: false,
+              type: :string,
+              example: "2022",
+            },
+            school_id: {
+              description: "The Unique ID of the school you are partnering with",
+              required: true,
+              nullable: false,
+              type: :string,
+              example: "24b61d1c-ad95-4000-aee0-afbdd542294a",
+            },
+            delivery_partner_id: {
+              description: "The unique ID of the delivery partner you will work with for this school partnership",
+              required: true,
+              nullable: false,
+              type: :string,
+              example: "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+            },
+          },
+        },
+      },
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/requests/partnership_update.rb
+++ b/spec/swagger_schemas/requests/partnership_update.rb
@@ -1,10 +1,10 @@
-PARTNERSHIP_REQUEST = {
-  description: "A partnership request",
+PARTNERSHIP_UPDATE_REQUEST = {
+  description: "A partnership update request",
   type: :object,
   required: %w[data],
   properties: {
     data: {
-      description: "A partnership",
+      description: "A partnership update",
       type: :object,
       required: %w[type attributes],
       properties: {
@@ -17,24 +17,10 @@ PARTNERSHIP_REQUEST = {
           example: "partnership",
         },
         attributes: {
-          description: "A partnership request attributes",
+          description: "A partnership update request attributes",
           type: :object,
-          required: %i[cohort delivery_partner_id school_id],
+          required: %i[delivery_partner_id],
           properties: {
-            cohort: {
-              description: "The cohort for which you are reporting the partnership",
-              required: true,
-              nullable: false,
-              type: :string,
-              example: "2022",
-            },
-            school_id: {
-              description: "The Unique ID of the school you are partnering with",
-              required: true,
-              nullable: false,
-              type: :string,
-              example: "24b61d1c-ad95-4000-aee0-afbdd542294a",
-            },
             delivery_partner_id: {
               description: "The unique ID of the delivery partner you will work with for this school partnership",
               required: true,


### PR DESCRIPTION
### Context

We want to add the swagger docs for the PUT /api/v3/partnerships/:id endpoint.

### Changes proposed in this pull request

- Add API documentations for PUT /api/v3/partnerships/:id

Add the swagger documentation for PUT api/v3/partnerships/:id.

Use shared context so that we can re-use it for other PUT requests.

### Guidance to review

[Swagger docs](https://cpd-ec2-review-1221-web.test.teacherservices.cloud/api/docs/v3)

Note the attribute names in the error response will be incorrect for the time being; these will be fixed when we address the general API/RECT error message/terminology consistency issues.