### PR TITLE
Add POST/PUT partnership parity check endpoints

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -112,6 +112,8 @@ module ParityCheck
     def random_contract_period(lead_provider:)
       lead_provider
         .lead_provider_delivery_partnerships
+        .joins(:contract_period)
+        .where(contract_period: { enabled: true })
         .order("RANDOM()")
         .first
         &.contract_period

--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -54,15 +54,83 @@ module ParityCheck
 
     # Request body methods
 
-    def example_body
+    def partnership_create_body
+      contract_period = random_contract_period(lead_provider:)
+      return unless contract_period
+
+      lead_provider_delivery_partnerships = lead_provider_delivery_partnerships(lead_provider:, contract_period:)
+      return unless lead_provider_delivery_partnerships.any?
+
+      school = random_other_eligible_school(lead_provider_delivery_partnerships:)
+      return unless school
+
+      delivery_partner = lead_provider_delivery_partnerships.map(&:delivery_partner).uniq.sample
+
       {
         data: {
-          type: "statements",
+          type: "partnerships",
           attributes: {
-            content: "This is an example request body.",
+            cohort: contract_period.year,
+            school_id: school.api_id,
+            delivery_partner_id: delivery_partner.api_id,
           },
         },
       }
+    end
+
+    def partnership_update_body
+      school_partnership = random_school_partnership(lead_provider:)
+      return unless school_partnership
+
+      contract_period = school_partnership.contract_period
+      lead_provider_delivery_partnership = school_partnership.lead_provider_delivery_partnership
+      lead_provider_delivery_partnerships = lead_provider_delivery_partnerships(lead_provider:, contract_period:).where.not(id: lead_provider_delivery_partnership.id)
+      return unless lead_provider_delivery_partnerships.any?
+
+      delivery_partner = lead_provider_delivery_partnerships.sample.delivery_partner
+
+      {
+        data: {
+          type: "partnerships",
+          attributes: {
+            delivery_partner_id: delivery_partner.api_id,
+          },
+        },
+      }
+    end
+
+    # Helpers
+
+    def random_school_partnership(lead_provider:)
+      SchoolPartnership
+        .joins(lead_provider_delivery_partnership: :active_lead_provider)
+        .where(active_lead_provider: { lead_provider: })
+        .order("RANDOM()")
+        .first
+    end
+
+    def random_contract_period(lead_provider:)
+      lead_provider
+        .lead_provider_delivery_partnerships
+        .order("RANDOM()")
+        .first
+        &.contract_period
+    end
+
+    def lead_provider_delivery_partnerships(lead_provider:, contract_period:)
+      lead_provider
+        .lead_provider_delivery_partnerships
+        .joins(:active_lead_provider)
+        .where(active_lead_provider: { contract_period: })
+    end
+
+    def random_other_eligible_school(lead_provider_delivery_partnerships:)
+      existing_school_ids = lead_provider_delivery_partnerships
+        .joins(school_partnerships: :school)
+        .pluck(:school_id)
+        .uniq
+
+      School.where.not(id: existing_school_ids).eligible.not_cip_only.first
     end
   end
 end

--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -10,6 +10,7 @@ class ContractPeriod < ApplicationRecord
 
   # Scopes
   scope :most_recent_first, -> { order(year: :desc, started_on: :desc) }
+  scope :enabled, -> { where(enabled: true) }
 
   # Validations
   validates :year,

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -153,10 +153,12 @@ get:
       id: ":partnership_id"
 
 post:
-  - "/api/v3/partnerships/ecf":
-      body: example_body
+  - "/api/v3/partnerships":
+      ecf_path: "/api/v3/partnerships/ecf"
+      body: partnership_create_body
 
 put:
-  - "/api/v3/participant-declarations/:id":
-      id: ":example_id"
-      body: example_body
+  - "/api/v3/partnerships/:id":
+      ecf_path: "/api/v3/partnerships/ecf/:id"
+      id: ":partnership_id"
+      body: partnership_update_body

--- a/spec/factories/parity_check/endpoint_factory.rb
+++ b/spec/factories/parity_check/endpoint_factory.rb
@@ -10,12 +10,12 @@ FactoryBot.define do
 
     trait :post do
       add_attribute(:method) { :post }
-      options { { body: :example_body } }
+      options { { body: :partnership_create_body } }
     end
 
     trait :put do
       add_attribute(:method) { :put }
-      options { { body: :example_body } }
+      options { { body: :partnership_update_body } }
     end
 
     trait :with_query_parameters do

--- a/spec/features/migration/run_parity_check_spec.rb
+++ b/spec/features/migration/run_parity_check_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe "Run parity check" do
   let(:ecf_url) { "https://ecf.example.com" }
   let(:rect_url) { "https://rect.example.com" }
-  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:lead_provider) { active_lead_provider.lead_provider }
   let!(:get_endpoint) { FactoryBot.create(:parity_check_endpoint, :get, path: "/api/v1/statements") }
   let!(:post_endpoint) { FactoryBot.create(:parity_check_endpoint, :post, path: "/api/v1/statements") }
   let!(:put_endpoint) { FactoryBot.create(:parity_check_endpoint, :put, path: "/api/v3/users") }
@@ -71,6 +72,7 @@ RSpec.describe "Run parity check" do
   end
 
   scenario "Running a parity check when there are no lead providers" do
+    ActiveLeadProvider.destroy_all
     LeadProvider.destroy_all
 
     page.goto(new_migration_parity_check_path)

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -74,7 +74,11 @@ RSpec.describe ParityCheck::DynamicRequestContent do
       let!(:school) { FactoryBot.create(:school, :eligible, :not_cip_only) }
 
       before do
-        # Different lead provider.
+        # Disabled contract period
+        disabled_contract_period = FactoryBot.create(:contract_period, enabled: false)
+        other_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: disabled_contract_period)
+        FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: other_active_lead_provider)
+        # Different lead provider
         FactoryBot.create(:lead_provider_delivery_partnership)
         # Ineligible school
         FactoryBot.create(:school, :ineligible)

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -98,6 +98,16 @@ describe ContractPeriod do
         expect(result.last).to eq(period_2022)
       end
     end
+
+    describe ".enabled" do
+      subject { described_class.enabled }
+
+      let!(:enabled_period) { FactoryBot.create(:contract_period, enabled: true) }
+
+      before { FactoryBot.create(:contract_period, enabled: false) }
+
+      it { is_expected.to contain_exactly(enabled_period) }
+    end
   end
 
   describe "#started_on_or_before_today?" do


### PR DESCRIPTION
### Context

We want to include the POST and PUT partnership endpoints in the parity check so that we can verify it behaves consistently with ECF.

### Changes proposed in this pull request

- Add partnerships POST/PUT endpoints to parity check

Add the POST and PUT endpoints to the parity check endpoints config file.

Update the `DynamicRequestContent` with the relevant request body methods.

Fallback to returning a `nil` body if required data can't be found to make a valid request; this will result in a 422 in the parity check, which should be fine and will prevent it from just falling over.

### Guidance to review

Tested in migration - a few things identified that will be raised as new tickets.