### PR TITLE
Add ability to migrate single entity

### DIFF
--- a/app/migration/migrate_entity.rb
+++ b/app/migration/migrate_entity.rb
@@ -1,0 +1,99 @@
+class MigrateEntity
+  # NOTE: the assumption is that the School records are present already having been populated via
+  # the GIAS::Importer
+  #
+
+  attr_reader :logger
+
+  def initialize(logger = Rails.logger)
+    @logger = logger
+  end
+
+  # migrate a school partnership and all the dependencies
+  def school_partnership(ecf_partnership:)
+    # active lead provider (will add lead provider and all their contract periods)
+    active_lead_provider(ecf_lead_provider: ecf_partnership.lead_provider)
+
+    # need to migrate DP as it is a dependency
+    Migrators::DeliveryPartner.new.migrate_one!(ecf_partnership.delivery_partner)
+
+    # lead_provider_delivery_partnership
+    ecf_lpdp = Migration::ProviderRelationship.find_by!(lead_provider: ecf_partnership.lead_provider,
+                                                        delivery_partner: ecf_partnership.delivery_partner,
+                                                        cohort: ecf_partnership.cohort)
+
+    Migrators::LeadProviderDeliveryPartnership.new.migrate_one!(ecf_lpdp)
+
+    # school_partnership
+    Migrators::SchoolPartnership.new.migrate_one!(ecf_partnership)
+  rescue StandardError => e
+    logger.error(e.message)
+  end
+
+  # migrate a lead_provider and their active cohorts
+  def active_lead_provider(ecf_lead_provider:)
+    Migrators::LeadProvider.new.migrate_one!(ecf_lead_provider)
+
+    alp = Data.define(:id, :start_year)
+    ecf_lead_provider.cohorts.order(:start_year).each do |cohort|
+      Migrators::ContractPeriod.new.migrate_one!(cohort)
+      Migrators::ActiveLeadProvider.new.migrate_one!(alp.new(id: ecf_lead_provider.id, start_year: cohort.start_year))
+    end
+  rescue StandardError => e
+    logger.error(e.message)
+  end
+
+  # migrate a teacher and their dependencies
+  def teacher(trn:)
+    teacher_profile = Migration::TeacherProfile
+      .where(trn:)
+      .joins(:participant_profiles)
+      .eager_load(participant_profiles: [
+        induction_records: [
+          induction_programme: [
+            school_cohort: :school,
+            partnership: %i[
+              lead_provider delivery_partner
+            ]
+          ]
+        ]
+      ]).first
+
+    teacher = Migrators::Teacher.new.migrate_one!(teacher_profile)
+
+    Migrators::ECTAtSchoolPeriod.new.migrate_one!(teacher_profile) if teacher_profile.participant_profiles.ect.any?
+    Migrators::MentorAtSchoolPeriod.new.migrate_one!(teacher_profile) if teacher_profile.participant_profiles.mentor.any?
+
+    teacher_profile.participant_profiles.each do |participant_profile|
+      fetch_partnerships(participant_profile:).each do |ecf_partnership|
+        # create school partnerships and all their dependencies
+        school_partnership(ecf_partnership:)
+      end
+
+      next unless participant_profile.ect?
+
+      fetch_mentors(participant_profile:).each do |ecf_mentor|
+        # create mentors
+        teacher(trn: ecf_mentor.teacher_profile.trn)
+      end
+
+      Migrators::MentorshipPeriod.new.migrate_one!(participant_profile)
+    end
+
+    Migrators::TrainingPeriod.new.migrate_one!(teacher_profile)
+
+    teacher
+  rescue StandardError => e
+    logger.error(e.message)
+  end
+
+private
+
+  def fetch_partnerships(participant_profile:)
+    Migration::Partnership.where(id: participant_profile.induction_records.joins(induction_programme: :partnership).select(:partnership_id))
+  end
+
+  def fetch_mentors(participant_profile:)
+    Migration::ParticipantProfile.mentor.where(id: participant_profile.induction_records.select(:mentor_profile_id))
+  end
+end

--- a/app/migration/migrators/active_lead_provider.rb
+++ b/app/migration/migrators/active_lead_provider.rb
@@ -24,13 +24,17 @@ module Migrators
 
     def migrate!
       migrate(self.class.active_lead_providers) do |ecf_active_lead_provider|
-        lead_provider_id = find_lead_provider_id!(ecf_id: ecf_active_lead_provider.id)
-
-        ::ActiveLeadProvider.find_or_create_by!(
-          lead_provider_id:,
-          contract_period_year: ecf_active_lead_provider.start_year
-        )
+        migrate_one!(ecf_active_lead_provider)
       end
+    end
+
+    def migrate_one!(ecf_active_lead_provider)
+      lead_provider_id = find_lead_provider_id!(ecf_id: ecf_active_lead_provider.id)
+
+      ::ActiveLeadProvider.find_or_create_by!(
+        lead_provider_id:,
+        contract_period_year: ecf_active_lead_provider.start_year
+      )
     end
   end
 end

--- a/app/migration/migrators/contract_period.rb
+++ b/app/migration/migrators/contract_period.rb
@@ -20,16 +20,22 @@ module Migrators
 
     def migrate!
       migrate(self.class.cohorts) do |cohort|
-        contract_period = ::ContractPeriod.find_or_initialize_by(year: cohort.start_year)
-
-        contract_period.update!(
-          started_on: cohort.registration_start_date,
-          finished_on: finished_on_for(cohort),
-          enabled: contract_period_enabled?(cohort),
-          created_at: cohort.created_at,
-          updated_at: cohort.updated_at
-        )
+        migrate_one!(cohort)
       end
+    end
+
+    def migrate_one!(cohort)
+      contract_period = ::ContractPeriod.find_or_initialize_by(year: cohort.start_year)
+
+      contract_period.update!(
+        started_on: cohort.registration_start_date,
+        finished_on: finished_on_for(cohort),
+        enabled: contract_period_enabled?(cohort),
+        created_at: cohort.created_at,
+        updated_at: cohort.updated_at
+      )
+
+      contract_period
     end
 
   private

--- a/app/migration/migrators/delivery_partner.rb
+++ b/app/migration/migrators/delivery_partner.rb
@@ -20,12 +20,17 @@ module Migrators
 
     def migrate!
       migrate(self.class.delivery_partners) do |delivery_partner|
-        dp = ::DeliveryPartner.find_or_initialize_by(api_id: delivery_partner.id)
-        dp.name = delivery_partner.name
-        dp.created_at = delivery_partner.created_at
-        dp.updated_at = delivery_partner.updated_at
-        dp.save!
+        migrate_one!(delivery_partner)
       end
+    end
+
+    def migrate_one!(delivery_partner)
+      dp = ::DeliveryPartner.find_or_initialize_by(api_id: delivery_partner.id)
+      dp.name = delivery_partner.name
+      dp.created_at = delivery_partner.created_at
+      dp.updated_at = delivery_partner.updated_at
+      dp.save!
+      dp
     end
   end
 end

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -24,15 +24,20 @@ module Migrators
 
     def migrate!
       migrate(self.class.ect_teachers.eager_load(:user)) do |teacher_profile|
-        teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+        migrate_one!(teacher_profile)
+      end
+    end
 
-        result = true
+    def migrate_one!(teacher_profile)
+      teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
 
-        teacher_profile
-          .participant_profiles
-          .ect
-          .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
-          .find_each do |participant_profile|
+      result = true
+
+      teacher_profile
+        .participant_profiles
+        .ect
+        .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
+        .find_each do |participant_profile|
           sanitizer = InductionRecordSanitizer.new(participant_profile:, group_by: :school)
 
           school_periods = []
@@ -54,9 +59,7 @@ module Migrators
             result = false
           end
         end
-
-        result
-      end
+      result
     end
   end
 end

--- a/app/migration/migrators/lead_provider.rb
+++ b/app/migration/migrators/lead_provider.rb
@@ -20,13 +20,18 @@ module Migrators
 
     def migrate!
       migrate(self.class.lead_providers) do |lead_provider|
-        lp = ::LeadProvider.find_or_initialize_by(ecf_id: lead_provider.id)
-
-        lp.name = lead_provider.name
-        lp.created_at = lead_provider.created_at
-        lp.updated_at = lead_provider.updated_at
-        lp.save!
+        migrate_one!(lead_provider)
       end
+    end
+
+    def migrate_one!(lead_provider)
+      lp = ::LeadProvider.find_or_initialize_by(ecf_id: lead_provider.id)
+
+      lp.name = lead_provider.name
+      lp.created_at = lead_provider.created_at
+      lp.updated_at = lead_provider.updated_at
+      lp.save!
+      lp
     end
   end
 end

--- a/app/migration/migrators/lead_provider_delivery_partnership.rb
+++ b/app/migration/migrators/lead_provider_delivery_partnership.rb
@@ -24,17 +24,22 @@ module Migrators
 
     def migrate!
       migrate(self.class.provider_relationships.includes(:lead_provider, :delivery_partner, :cohort)) do |provider_relationship|
-        partnership = ::LeadProviderDeliveryPartnership.find_or_initialize_by(ecf_id: provider_relationship.id)
-        partnership.active_lead_provider = ::ActiveLeadProvider.find_by!(
-          lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
-          contract_period_year: ::ContractPeriod.find(provider_relationship.cohort.start_year)
-        )
-        partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
-        partnership.created_at = provider_relationship.created_at
-        partnership.updated_at = provider_relationship.updated_at
-
-        partnership.save!
+        migrate_one!(provider_relationship)
       end
+    end
+
+    def migrate_one!(provider_relationship)
+      partnership = ::LeadProviderDeliveryPartnership.find_or_initialize_by(ecf_id: provider_relationship.id)
+      partnership.active_lead_provider = ::ActiveLeadProvider.find_by!(
+        lead_provider_id: ::LeadProvider.find_by!(ecf_id: provider_relationship.lead_provider_id),
+        contract_period_year: ::ContractPeriod.find(provider_relationship.cohort.start_year)
+      )
+      partnership.delivery_partner = ::DeliveryPartner.find_by!(api_id: provider_relationship.delivery_partner_id)
+      partnership.created_at = provider_relationship.created_at
+      partnership.updated_at = provider_relationship.updated_at
+
+      partnership.save!
+      partnership
     end
   end
 end

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -24,15 +24,20 @@ module Migrators
 
     def migrate!
       migrate(self.class.mentor_teachers.eager_load(:user)) do |teacher_profile|
-        teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+        migrate_one!(teacher_profile)
+      end
+    end
 
-        result = true
+    def migrate_one!(teacher_profile)
+      teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
 
-        teacher_profile
-          .participant_profiles
-          .mentor
-          .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
-          .find_each do |participant_profile|
+      result = true
+
+      teacher_profile
+        .participant_profiles
+        .mentor
+        .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
+        .find_each do |participant_profile|
           sanitizer = InductionRecordSanitizer.new(participant_profile:, group_by: :school)
 
           school_periods = []
@@ -54,9 +59,7 @@ module Migrators
             result = false
           end
         end
-
-        result
-      end
+      result
     end
   end
 end

--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -24,25 +24,29 @@ module Migrators
 
     def migrate!
       migrate(self.class.ects) do |participant_profile|
-        teacher = ::Teacher.find_by!(ecf_ect_profile_id: participant_profile.id)
-
-        success = true
-        induction_records = InductionRecordSanitizer.new(participant_profile:)
-
-        if induction_records.valid?
-          mentorship_period_data = MentorshipPeriodExtractor.new(induction_records:)
-          success = Builders::MentorshipPeriods.new(teacher:, mentorship_period_data:).build
-        else
-          ::TeacherMigrationFailure.create!(teacher:,
-                                            model: :mentorship_period,
-                                            message: induction_records.error,
-                                            migration_item_id: participant_profile.id,
-                                            migration_item_type: participant_profile.class.name)
-          success = false
-        end
-
-        success
+        migrate_one!(participant_profile)
       end
+    end
+
+    def migrate_one!(participant_profile)
+      teacher = ::Teacher.find_by!(ecf_ect_profile_id: participant_profile.id)
+
+      success = true
+      induction_records = InductionRecordSanitizer.new(participant_profile:)
+
+      if induction_records.valid?
+        mentorship_period_data = MentorshipPeriodExtractor.new(induction_records:)
+        success = Builders::MentorshipPeriods.new(teacher:, mentorship_period_data:).build
+      else
+        ::TeacherMigrationFailure.create!(teacher:,
+                                          model: :mentorship_period,
+                                          message: induction_records.error,
+                                          migration_item_id: participant_profile.id,
+                                          migration_item_type: participant_profile.class.name)
+        success = false
+      end
+
+      success
     end
   end
 end

--- a/app/migration/migrators/reconcile_adjustment.rb
+++ b/app/migration/migrators/reconcile_adjustment.rb
@@ -25,17 +25,22 @@ module Migrators
 
     def migrate!
       migrate(self.class.statements_with_adjustments) do |statement|
-        statement_adjustment = ::Statement::Adjustment.find_or_initialize_by(api_id: statement.id)
-
-        statement_adjustment.statement = ::Statement.find_by!(api_id: statement.id)
-        statement_adjustment.payment_type = "Reconcile amounts pre-adjustments feature"
-        statement_adjustment.amount = statement.reconcile_amount
-
-        statement_adjustment.created_at = statement.created_at
-        statement_adjustment.updated_at = statement.updated_at
-
-        statement_adjustment.save!
+        migrate_one!(statement)
       end
+    end
+
+    def migrate_one!(statement_with_adjustment)
+      statement_adjustment = ::Statement::Adjustment.find_or_initialize_by(api_id: statement_with_adjustment.id)
+
+      statement_adjustment.statement = ::Statement.find_by!(api_id: statement_with_adjustment.id)
+      statement_adjustment.payment_type = "Reconcile amounts pre-adjustments feature"
+      statement_adjustment.amount = statement_with_adjustment.reconcile_amount
+
+      statement_adjustment.created_at = statement_with_adjustment.created_at
+      statement_adjustment.updated_at = statement_with_adjustment.updated_at
+
+      statement_adjustment.save!
+      statement_adjustment
     end
   end
 end

--- a/app/migration/migrators/school_partnership.rb
+++ b/app/migration/migrators/school_partnership.rb
@@ -25,17 +25,22 @@ module Migrators
 
     def migrate!
       migrate(self.class.partnerships.includes(:lead_provider, :delivery_partner, :cohort, :school)) do |partnership|
-        lead_provider = ::LeadProvider.find_by!(ecf_id: partnership.lead_provider_id)
-        delivery_partner = ::DeliveryPartner.find_by!(api_id: partnership.delivery_partner_id)
-        contract_period = ::ContractPeriod.find(partnership.cohort.start_year)
-        active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period:)
-        lpdp = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
-        school_partnership = ::SchoolPartnership.find_or_initialize_by(api_id: partnership.id)
-
-        school_partnership.lead_provider_delivery_partnership = lpdp
-        school_partnership.school = ::School.find_by!(urn: partnership.school.urn)
-        school_partnership.save!
+        migrate_one!(partnership)
       end
+    end
+
+    def migrate_one!(partnership)
+      lead_provider = ::LeadProvider.find_by!(ecf_id: partnership.lead_provider_id)
+      delivery_partner = ::DeliveryPartner.find_by!(api_id: partnership.delivery_partner_id)
+      contract_period = ::ContractPeriod.find(partnership.cohort.start_year)
+      active_lead_provider = ::ActiveLeadProvider.find_by!(lead_provider:, contract_period:)
+      lpdp = ::LeadProviderDeliveryPartnership.find_by!(active_lead_provider:, delivery_partner:)
+      school_partnership = ::SchoolPartnership.find_or_initialize_by(api_id: partnership.id)
+
+      school_partnership.lead_provider_delivery_partnership = lpdp
+      school_partnership.school = ::School.find_by!(urn: partnership.school.urn)
+      school_partnership.save!
+      school_partnership
     end
   end
 end

--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -24,24 +24,30 @@ module Migrators
 
     def migrate!
       migrate(self.class.statements) do |ecf_statement|
-        statement = ::Statement.find_or_initialize_by(api_id: ecf_statement.id)
-
-        lead_provider_id = find_lead_provider_id!(ecf_id: ecf_statement.lead_provider.id)
-        contract_period_year = ecf_statement.cohort.start_year
-
-        statement.update!(
-          active_lead_provider_id: find_active_lead_provider_id!(lead_provider_id:, contract_period_year:),
-          month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]),
-          year: ecf_statement.name.split[1],
-          deadline_date: ecf_statement.deadline_date,
-          payment_date: ecf_statement.payment_date,
-          marked_as_paid_at: ecf_statement.marked_as_paid_at,
-          fee_type: fee_type(ecf_statement),
-          status: status(ecf_statement),
-          created_at: ecf_statement.created_at,
-          updated_at: ecf_statement.updated_at
-        )
+        migrate_one!(ecf_statement)
       end
+    end
+
+    def migrate_one!(ecf_statement)
+      statement = ::Statement.find_or_initialize_by(api_id: ecf_statement.id)
+
+      lead_provider_id = find_lead_provider_id!(ecf_id: ecf_statement.lead_provider.id)
+      contract_period_year = ecf_statement.cohort.start_year
+
+      statement.update!(
+        active_lead_provider_id: find_active_lead_provider_id!(lead_provider_id:, contract_period_year:),
+        month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]),
+        year: ecf_statement.name.split[1],
+        deadline_date: ecf_statement.deadline_date,
+        payment_date: ecf_statement.payment_date,
+        marked_as_paid_at: ecf_statement.marked_as_paid_at,
+        fee_type: fee_type(ecf_statement),
+        status: status(ecf_statement),
+        created_at: ecf_statement.created_at,
+        updated_at: ecf_statement.updated_at
+      )
+
+      statement
     end
 
   private

--- a/app/migration/migrators/statement_adjustment.rb
+++ b/app/migration/migrators/statement_adjustment.rb
@@ -24,16 +24,21 @@ module Migrators
 
     def migrate!
       migrate(self.class.statement_adjustments) do |adjustment|
-        statement_adjustment = ::Statement::Adjustment.find_or_initialize_by(api_id: adjustment.id)
-
-        statement_adjustment.statement = ::Statement.find_by!(api_id: adjustment.statement_id)
-        statement_adjustment.payment_type = adjustment.payment_type
-        statement_adjustment.amount = adjustment.amount
-        statement_adjustment.created_at = adjustment.created_at
-        statement_adjustment.updated_at = adjustment.updated_at
-
-        statement_adjustment.save!
+        migrate_one!(adjustment)
       end
+    end
+
+    def migrate_one!(ecf_adjustment)
+      statement_adjustment = ::Statement::Adjustment.find_or_initialize_by(api_id: ecf_adjustment.id)
+
+      statement_adjustment.statement = ::Statement.find_by!(api_id: ecf_adjustment.statement_id)
+      statement_adjustment.payment_type = ecf_adjustment.payment_type
+      statement_adjustment.amount = ecf_adjustment.amount
+      statement_adjustment.created_at = ecf_adjustment.created_at
+      statement_adjustment.updated_at = ecf_adjustment.updated_at
+
+      statement_adjustment.save!
+      statement_adjustment
     end
   end
 end

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -20,23 +20,28 @@ module Migrators
 
     def migrate!
       migrate(self.class.teachers.eager_load(:user)) do |teacher_profile|
-        teacher = ::Teacher.find_or_initialize_by(trn: teacher_profile.trn)
-        user = teacher_profile.user
-
-        if teacher.persisted? && name_does_not_match?(teacher, user.full_name)
-          teacher.corrected_name = user.full_name
-        else
-          # FIXME: we should look these up in TRS but this will hammer it
-          parser = Teachers::FullNameParser.new(full_name: user.full_name)
-          teacher.trs_first_name = parser.first_name
-          teacher.trs_last_name = parser.last_name
-        end
-
-        teacher.ecf_user_id = user.id
-        teacher.created_at = user.created_at
-        teacher.updated_at = user.updated_at
-        teacher.save!
+        migrate_one!(teacher_profile)
       end
+    end
+
+    def migrate_one!(teacher_profile)
+      teacher = ::Teacher.find_or_initialize_by(trn: teacher_profile.trn)
+      user = teacher_profile.user
+
+      if teacher.persisted? && name_does_not_match?(teacher, user.full_name)
+        teacher.corrected_name = user.full_name
+      else
+        # FIXME: we should look these up in TRS but this will hammer it
+        parser = Teachers::FullNameParser.new(full_name: user.full_name)
+        teacher.trs_first_name = parser.first_name
+        teacher.trs_last_name = parser.last_name
+      end
+
+      teacher.ecf_user_id = user.id
+      teacher.created_at = user.created_at
+      teacher.updated_at = user.updated_at
+      teacher.save!
+      teacher
     end
 
   private

--- a/app/migration/migrators/training_period.rb
+++ b/app/migration/migrators/training_period.rb
@@ -24,15 +24,20 @@ module Migrators
 
     def migrate!
       migrate(self.class.teachers.eager_load(:user)) do |teacher_profile|
-        teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
+        migrate_one!(teacher_profile)
+      end
+    end
 
-        result = true
+    def migrate_one!(teacher_profile)
+      teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
 
-        teacher_profile
-          .participant_profiles
-          .ect_or_mentor
-          .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
-          .find_each do |participant_profile|
+      result = true
+
+      teacher_profile
+        .participant_profiles
+        .ect_or_mentor
+        .eager_load(induction_records: [induction_programme: [school_cohort: :school]])
+        .find_each do |participant_profile|
           sanitizer = InductionRecordSanitizer.new(participant_profile:, group_by: :provider)
 
           training_period_data = []
@@ -59,8 +64,7 @@ module Migrators
           end
         end
 
-        result
-      end
+      result
     end
   end
 end

--- a/spec/migration/migrate_entity_spec.rb
+++ b/spec/migration/migrate_entity_spec.rb
@@ -1,0 +1,109 @@
+RSpec.describe MigrateEntity do
+  subject(:service) { described_class.new }
+
+  describe "#school_partnership" do
+    let(:ecf_lead_provider) { FactoryBot.create(:migration_lead_provider, :active) }
+    let(:ecf_cohort) { ecf_lead_provider.cohorts.first }
+    let(:ecf_delivery_partner) { FactoryBot.create(:migration_delivery_partner) }
+    let!(:ecf_provider_relationship) do
+      FactoryBot.create(:migration_provider_relationship,
+                        lead_provider: ecf_lead_provider,
+                        delivery_partner: ecf_delivery_partner,
+                        cohort: ecf_cohort)
+    end
+    let!(:ecf_partnership) { FactoryBot.create(:migration_partnership, lead_provider: ecf_lead_provider, delivery_partner: ecf_delivery_partner, cohort: ecf_cohort) }
+    let!(:school) { FactoryBot.create(:school, :eligible, urn: ecf_partnership.school.urn) }
+
+    it "creates a school_partnership from the ECF partnership" do
+      expect {
+        service.school_partnership(ecf_partnership:)
+      }.to change(SchoolPartnership, :count).by(1).and \
+        change(LeadProviderDeliveryPartnership, :count).by(1).and \
+          change(DeliveryPartner, :count).by(1).and \
+            change(ActiveLeadProvider, :count).by(1).and \
+              change(LeadProvider, :count).by(1)
+    end
+
+    it "migrates the correct school_partnership values" do
+      school_partnership = service.school_partnership(ecf_partnership:)
+      expect(school_partnership.lead_provider_delivery_partnership.lead_provider.name).to eq ecf_lead_provider.name
+      expect(school_partnership.lead_provider_delivery_partnership.delivery_partner.name).to eq ecf_delivery_partner.name
+      expect(school_partnership.lead_provider_delivery_partnership.contract_period.year).to eq ecf_cohort.start_year
+      expect(school_partnership.school).to eq school
+    end
+  end
+
+  describe "#active_lead_provider" do
+    let(:ecf_lead_provider) { FactoryBot.create(:migration_lead_provider) }
+
+    before do
+      3.times { ecf_lead_provider.cohorts << FactoryBot.create(:migration_cohort, :with_sequential_start_year) }
+    end
+
+    it "creates active_lead_provider records from the ECF lead_provider and active cohorts" do
+      expect {
+        service.active_lead_provider(ecf_lead_provider:)
+      }.to change(ActiveLeadProvider, :count).by(3).and \
+        change(LeadProvider, :count).by(1).and \
+          change(ContractPeriod, :count).by(3)
+    end
+
+    it "migrates the correct values" do
+      service.active_lead_provider(ecf_lead_provider:)
+
+      lead_provider = LeadProvider.find_by!(name: ecf_lead_provider.name)
+      expect(lead_provider.name).to eq ecf_lead_provider.name
+
+      ecf_lead_provider.cohorts.each do |cohort|
+        expect(ActiveLeadProvider).to exist(lead_provider:, contract_period: ContractPeriod.find(cohort.start_year))
+      end
+    end
+  end
+
+  describe "#teacher" do
+    let(:ect_profile) { FactoryBot.create(:migration_participant_profile, :ect) }
+    let(:trn) { ect_profile.teacher_profile.trn }
+    let(:school_cohort) { ect_profile.school_cohort }
+    let(:cohort) { school_cohort.cohort }
+    let(:ecf_school) { school_cohort.school }
+    let(:mentor_profile) { FactoryBot.create(:migration_participant_profile, :mentor, school_cohort:) }
+    let!(:ect_induction_record) { FactoryBot.create(:migration_induction_record, participant_profile: ect_profile, mentor_profile:) }
+    let!(:mentor_induction_record) { FactoryBot.create(:migration_induction_record, participant_profile: mentor_profile) }
+    let(:lead_provider) { FactoryBot.create(:migration_lead_provider) }
+    let(:delivery_partner) { FactoryBot.create(:migration_delivery_partner) }
+    let!(:provider_relationship) { FactoryBot.create(:migration_provider_relationship, lead_provider:, delivery_partner:, cohort:) }
+    let!(:ecf_partnership) { FactoryBot.create(:migration_partnership, lead_provider:, delivery_partner:, cohort:, school: ecf_school) }
+    let!(:school) { FactoryBot.create(:school, :eligible, urn: ecf_school.urn) }
+
+    before do
+      lead_provider.cohorts << cohort
+      school_cohort.default_induction_programme.update!(partnership: ecf_partnership)
+    end
+
+    it "creates a teacher record and dependencies from the matching ECF TRN" do
+      expect {
+        service.teacher(trn:)
+      }.to change(Teacher, :count).by(2).and \
+        change(ECTAtSchoolPeriod, :count).by(1).and \
+          change(MentorAtSchoolPeriod, :count).by(1).and \
+            change(MentorshipPeriod, :count).by(1).and \
+              change(TrainingPeriod, :count).by(2).and \
+                change(SchoolPartnership, :count).by(1).and \
+                  change(LeadProviderDeliveryPartnership, :count).by(1).and \
+                    change(DeliveryPartner, :count).by(1).and \
+                      change(ActiveLeadProvider, :count).by(1).and \
+                        change(LeadProvider, :count).by(1).and \
+                          change(ContractPeriod, :count).by(1)
+    end
+
+    it "migrates the correct values" do
+      teacher = service.teacher(trn:)
+
+      parser = Teachers::FullNameParser.new(full_name: ect_profile.teacher_profile.user.full_name)
+      expect(Teachers::Name.new(teacher).full_name).to eq [parser.first_name, parser.last_name].join(" ")
+
+      expect(teacher.ect_at_school_periods.first.mentors.first.teacher).to eq Teacher.find_by(trn: mentor_profile.teacher_profile.trn)
+      expect(teacher.ect_at_school_periods.first.training_periods.first.lead_provider.name).to eq lead_provider.name
+    end
+  end
+end


### PR DESCRIPTION
### Context

Often when testing we need a small amount of known data to work with. Currently the only way to get everything is to do a full migration which takes around 5 hours.

This PR adds the ability to migrate a teacher, school partnership and active lead provider with all of their dependencies from the console.

The only dependency expected to already exist in your DB (ie. that won't get migrated) is the `School` as we import these from GIAS.

This could be expanded to other entities however the addition of `migrate_one!` to the migrators allows a simple migration of a single entity via the migrator (as long as any dependencies exist in this case).

### Changes proposed in this pull request

Add `MigrateEntity` class
Adds `migrate_one!` to existing migrators

### Guidance to review

From the Rails console:

```
MigrateEntity.new.teacher(trn:)
```

or

```
MigrateEntity.new.school_partnership(ecf_partnership:)
```

or

```
MigrateEntity.new.active_lead_provider(ecf_lead_provider:)
```