### PR TITLE
Update _training_programme.html.erb

### DIFF
--- a/app/views/schools/register_ect_wizard/_training_programme.html.erb
+++ b/app/views/schools/register_ect_wizard/_training_programme.html.erb
@@ -16,7 +16,7 @@
     <%= f.govuk_radio_button :training_programme,
                              :school_led,
                              label: { text: "School-led" },
-                             hint: { text: "Your school will design and deliver your own training based on the initial teacher training and early career framework" }
+                             hint: { text: "Your school will design and deliver its own training based on the initial teacher training and early career framework" }
     %>
   <% end %>
 

--- a/app/views/schools/register_ect_wizard/_training_programme.html.erb
+++ b/app/views/schools/register_ect_wizard/_training_programme.html.erb
@@ -1,5 +1,5 @@
 <% page_data(
-    title: "What training programme will #{@ect.full_name} follow?",
+    title: "Which training programme will #{@ect.full_name} follow?",
     error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path,
 ) %>
@@ -7,16 +7,16 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset :training_programme, legend: { text: "What training programme will #{@ect.full_name} follow?", hidden: true} do %>
+  <%= f.govuk_radio_buttons_fieldset :training_programme, legend: { text: "Which training programme will #{@ect.full_name} follow?", hidden: true} do %>
     <%= f.govuk_radio_button :training_programme,
                              :provider_led,
                              label: { text: "Provider-led" },
-                             hint: { text: "Your school will work with providers who will deliver early career framework based training funded by the Department for Education." },
+                             hint: { text: "Your school will use DfE funded providers to design and deliver training based on the initial teacher training and early career framework" },
                              link_errors: true %>
     <%= f.govuk_radio_button :training_programme,
                              :school_led,
                              label: { text: "School-led" },
-                             hint: { text: "Your school will deliver training based on the early career framework." }
+                             hint: { text: "Your school will design and deliver your own training based on the initial teacher training and early career framework" }
     %>
   <% end %>
 

--- a/spec/views/schools/register_ect_wizard/shared_examples/training_programme_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/training_programme_view.rb
@@ -15,10 +15,10 @@ RSpec.shared_examples "a training programme view" do |current_step:, back_path:,
     assign(:ect, ect)
   end
 
-  it "sets the page title to 'What training programme will John Smith follow?'" do
+  it "sets the page title to 'Which training programme will John Smith follow?'" do
     render
 
-    expect(sanitize(view.content_for(:page_title))).to eql("What training programme will John Smith follow?")
+    expect(sanitize(view.content_for(:page_title))).to eql("Which training programme will John Smith follow?")
   end
 
   context "when the training programme is invalid" do


### PR DESCRIPTION
Update hint text to include reference to the initial teacher training and early career framework.

### Context
ECT training is now based on the initial teacher training and early career framework (previously, just the early career framework). This is a policy change.

### Changes proposed in this pull request
Updating the existing radio hint text to reflect this policy change.

### Guidance to review
Code and visual check.

Note that the removal of the full stop from the existing text is intended, as per GDS guidance.
