### PR TITLE
Change API params to use expect

### DIFF
--- a/app/controllers/api/v3/delivery_partners_controller.rb
+++ b/app/controllers/api/v3/delivery_partners_controller.rb
@@ -23,7 +23,7 @@ module API
       end
 
       def delivery_partner_params
-        params.permit(:api_id, :sort)
+        params.expect(:api_id, :sort)
       end
 
       def api_id

--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -42,7 +42,7 @@ module API
       end
 
       def partnerships_params
-        params.permit(:api_id, :sort, filter: %i[delivery_partner_id])
+        params.expect(:api_id, :sort, filter: %i[delivery_partner_id])
       end
 
       def api_id

--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -30,10 +30,7 @@ module API
     private
 
       def create_partnership_params
-        params
-          .require(:data)
-          .require(:attributes)
-          .permit(:cohort, :school_id, :delivery_partner_id)
+        params.require(:data).expect({ attributes: %i[cohort school_id delivery_partner_id] })
       end
 
       def partnerships_query(conditions: {})

--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -26,7 +26,7 @@ module API
       end
 
       def school_params
-        params.permit(:api_id, :sort, filter: %i[urn])
+        params.expect(:api_id, :sort, filter: %i[urn])
       end
 
       def api_id

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -18,7 +18,7 @@ module API
       end
 
       def statement_params
-        params.permit(:api_id)
+        params.expect(:api_id)
       end
 
       def api_id


### PR DESCRIPTION
### Context

To make consistent with rest of repository, use expect instead of permit params

### Changes proposed in this pull request
- use expect instead of permit params
- from @ethax-ross: use `require(:data)` as the result of `expect(data: { attributes: %i[attr] })` is a hash of `{ attributes: ... }` when we just want the bottom-level attributes.

### Guidance to review
We are aware some providers will send extra params in their requests, before permit used to ignore those, now they will fail. We're going to monitor and see what the response is