### PR TITLE
Run local migrations in single threaded processes

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -37,6 +37,15 @@ sandbox:
 
 development:
   <<: *default
+  workers:
+    - queues: [mailers, process_batch, events, metadata, parity_check_requests, trs_sync, dfe_analytics]
+      threads: 3
+      processes: 3
+      polling_interval: 0.1
+    - queues: [migration]
+      threads: 1
+      processes: <%= ENV.fetch('MIGRATION_QUEUE_PROCESSES', 3) %>
+      polling_interval: 0.1
 
 test:
   <<: *default


### PR DESCRIPTION
### Context
This PR Aligns the migration queue config in development with the migration environment by using single-threaded processes.


### Changes proposed in this pull request
- Set migration queue to 3 single-threaded processes in development
- Add `MIGRATION_QUEUE_PROCESSES` env var to adjust the number of the processes

