### PR TITLE
[BUG] Schools ECT page renders even when there is no training period

### DIFF
--- a/app/components/schools/ect_training_details_component.rb
+++ b/app/components/schools/ect_training_details_component.rb
@@ -9,6 +9,8 @@ module Schools
       @training_period = training_period
     end
 
+    def render? = @training_period.present?
+
     def call
       safe_join([
         tag.h2('Training details', class: 'govuk-heading-m'),

--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -10,7 +10,7 @@ module Schools
     end
 
     def show
-      @ect_at_school_period = ::ECTAtSchoolPeriod.find_by!(id: params[:id], school_id: school.id)
+      @ect_at_school_period = @school.ect_at_school_periods.find(params[:id])
       @training_period = @ect_at_school_period.current_training_period
       @teacher = @ect_at_school_period.teacher
     end

--- a/spec/components/schools/ect_training_details_component_spec.rb
+++ b/spec/components/schools/ect_training_details_component_spec.rb
@@ -17,21 +17,47 @@ RSpec.describe Schools::ECTTrainingDetailsComponent, type: :component do
   end
 
   it "renders the training programme row" do
-    expect(page).to have_selector('.govuk-summary-list__key', text: 'Training programme')
+    expect(page).to have_summary_list_row("Training programme")
+  end
+
+  context "when there is no training period" do
+    let(:training_period) { nil }
+
+    it "renders nothing" do
+      expect(page).to have_no_selector("body")
+    end
   end
 
   context 'when provider-led training' do
     let(:training_period) { FactoryBot.build(:training_period, :provider_led, ect_at_school_period:) }
 
-    it "shows lead provider and delivery partner fields" do
-      expect(page).to have_selector('.govuk-summary-list__key', text: 'Lead provider')
-      expect(page).to have_selector('.govuk-summary-list__key', text: 'Delivery partner')
+    it "shows lead provider information" do
+      expect(page).to have_summary_list_row(
+        "Lead provider",
+        value: "Not available"
+      )
+    end
+
+    it "shows delivery partner information" do
+      expect(page).to have_summary_list_row(
+        "Delivery partner",
+        value: "Yet to be reported by the lead provider"
+      )
     end
 
     context 'with confirmed partnership' do
       it "shows lead provider information" do
-        expect(page).to have_selector('.govuk-summary-list__key', text: 'Lead provider')
-        expect(page).to have_selector('.govuk-summary-list__value')
+        expect(page).to have_summary_list_row(
+          "Lead provider",
+          value: "Not available"
+        )
+      end
+
+      it "shows delivery partner information" do
+        expect(page).to have_summary_list_row(
+          "Delivery partner",
+          value: "Yet to be reported by the lead provider"
+        )
       end
     end
 
@@ -39,12 +65,17 @@ RSpec.describe Schools::ECTTrainingDetailsComponent, type: :component do
       let(:training_period) { FactoryBot.build(:training_period, :provider_led, ect_at_school_period:) }
 
       it "shows lead provider information" do
-        expect(page).to have_selector('.govuk-summary-list__key', text: 'Lead provider')
-        expect(page).to have_selector('.govuk-summary-list__value')
+        expect(page).to have_summary_list_row(
+          "Lead provider",
+          value: "Not available"
+        )
       end
 
-      it "shows appropriate message for delivery partner" do
-        expect(page).to have_text('Yet to be reported by the lead provider')
+      it "shows delivery partner information" do
+        expect(page).to have_summary_list_row(
+          "Delivery partner",
+          value: "Yet to be reported by the lead provider"
+        )
       end
     end
   end
@@ -52,9 +83,12 @@ RSpec.describe Schools::ECTTrainingDetailsComponent, type: :component do
   context 'when school-led training' do
     let(:training_period) { FactoryBot.build(:training_period, :school_led, ect_at_school_period:) }
 
-    it "does not show lead provider and delivery partner fields" do
-      expect(page).not_to have_selector('.govuk-summary-list__key', text: 'Lead provider')
-      expect(page).not_to have_selector('.govuk-summary-list__key', text: 'Delivery partner')
+    it "does not show lead provider information" do
+      expect(page).not_to have_summary_list_row("Lead provider")
+    end
+
+    it "does not show delivery partner information" do
+      expect(page).not_to have_summary_list_row("Delivery partner")
     end
   end
 
@@ -62,24 +96,33 @@ RSpec.describe Schools::ECTTrainingDetailsComponent, type: :component do
     context 'when training programme is provider_led' do
       let(:training_period) { FactoryBot.build(:training_period, :provider_led, ect_at_school_period:) }
 
-      it 'returns Provider-led' do
-        expect(component.send(:training_programme_display_name)).to eq('Provider-led')
+      it 'displays Provider-led' do
+        expect(page).to have_summary_list_row(
+          "Training programme",
+          value: "Provider-led"
+        )
       end
     end
 
     context 'when training programme is school_led' do
       let(:training_period) { FactoryBot.build(:training_period, :school_led, ect_at_school_period:) }
 
-      it 'returns School-led' do
-        expect(component.send(:training_programme_display_name)).to eq('School-led')
+      it 'displays School-led' do
+        expect(page).to have_summary_list_row(
+          "Training programme",
+          value: "School-led"
+        )
       end
     end
 
     context 'when training programme is nil' do
       let(:training_period) { FactoryBot.build(:training_period, ect_at_school_period:, training_programme: nil) }
 
-      it 'returns Unknown' do
-        expect(component.send(:training_programme_display_name)).to eq('Unknown')
+      it 'displays Unknown' do
+        expect(page).to have_summary_list_row(
+          "Training programme",
+          value: "Unknown"
+        )
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Features::ViewHelpers, type: :feature
   config.include APIHelper, type: :request
+  config.include HaveSummaryListRow, type: :component
 
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/support/matchers/have_summary_list_row.rb
+++ b/spec/support/matchers/have_summary_list_row.rb
@@ -1,0 +1,53 @@
+module HaveSummaryListRow
+  class Matcher
+    def initialize(key, value: "")
+      @key = key
+      @value = value
+    end
+
+    def matches?(page)
+      @page = page
+      @rows = @page.find_all("dl.govuk-summary-list dt.govuk-summary-list__key")
+      @matching_row = @rows.find { |it| it.text == @key }
+
+      if @value.blank?
+        @matching_row && @matching_row.text == @key
+      else
+        @sibling = @matching_row&.sibling("dd.govuk-summary-list__value")
+        @sibling && @sibling.text == @value
+      end
+    end
+
+    def failure_message
+      [generic_failure_message, matching_row_failure_message, sibling_failure_message]
+        .compact
+        .join("\n\n")
+    end
+
+  private
+
+    def generic_failure_message
+      <<~TXT.squish
+        Expected page to have summary list pair with key: "#{@key}" and value:
+        "#{@value}", but it did not.
+      TXT
+    end
+
+    def matching_row_failure_message
+      if @rows.present? && @matching_row.blank?
+        <<~TXT.squish
+          Found #{@rows.size} #{'summary list row'.pluralize(@rows.size)} with
+          keys: #{@rows.map { "\"#{it.text}\"" }.join(', ')}.
+        TXT
+      end
+    end
+
+    def sibling_failure_message
+      if @matching_row.present?
+        "Found matching summary list row, but its value is \"#{@sibling.text}\"."
+      end
+    end
+  end
+
+  def have_summary_list_row(key, value: "") = Matcher.new(key, value:)
+end


### PR DESCRIPTION
## Context

Broken out of https://github.com/DFE-Digital/register-ects-project-board/issues/2098 and driven by [this Slack conversation](https://ukgovernmentdfe.slack.com/archives/C06V31R0Z17/p1756383838236039)

## Changes in this pull request

Before, visiting a schools ECT page where there was no current training period would result in an error.

Since it is possible for an ECT to have no training period, this seemed like a reasonable edge case we should handle.

This updates the `Schools::ECTTrainingDetailsComponent` so it only renders when the training period is present.

As part of this change, I have introduced a `have_summary_list_row` matcher, which I think improves the ergonomics of asserting against key <> value pairs in summary lists.

## Guidance to review

- [ ] View an ECT page as a school when the ECT has no training period