### PR TITLE
[1249] Skip `:review_mentor_eligibility` step for previously registered mentors (#MentorRegistrationFlow)

### DIFF
--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -114,6 +114,16 @@ module Schools
         mentor_at_school_periods.where.not(school:).ongoing.or(finishes_in_the_future_scope)
       end
 
+      def mentorship_status
+        if mentor_at_school_periods.any?(&:ongoing?)
+          :currently_a_mentor
+        elsif mentor_at_school_periods.any?
+          :previously_a_mentor
+        else
+          raise 'Unexpected state: no mentor_at_school_periods found for previously registered mentor'
+        end
+      end
+
       # Is mentor being assigned to a provider-led ECT?
       def provider_led_ect?
         ect&.provider_led_training_programme?

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -80,7 +80,7 @@ module Schools
                        :started_on
                      end
 
-            steps << :started_on if mentor.mentoring_at_new_school_only == "yes"
+            steps << :started_on if mentor.mentoring_at_new_school_only == "yes" || mentor.previous_school_closed_mentor_at_school_periods?
             steps << :previous_training_period_details if mentor.eligible_for_funding? || mentor.provider_led_ect?
             steps << :programme_choices unless mentor.became_ineligible_for_funding?
             steps << :lead_provider unless mentor.use_same_programme_choices == "yes"

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -29,9 +29,6 @@ RSpec.describe 'Registering a mentor', :js do
 
     when_i_enter_the_mentor_email_address
     and_i_click_continue
-    then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    and_i_click_continue
-
     then_i_should_be_taken_to_mentoring_at_your_school_only_page
     when_i_select_no_they_will_also_be_mentoring_at_another_school
 
@@ -137,10 +134,6 @@ RSpec.describe 'Registering a mentor', :js do
 
   def when_i_enter_the_mentor_email_address
     page.get_by_label('email').fill('example@example.com')
-  end
-
-  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
   end
 
   def and_i_click_continue

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -27,9 +27,6 @@ RSpec.describe 'Registering a mentor', :js do
 
     when_i_enter_the_mentor_email_address
     and_i_click_continue
-    then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    and_i_click_continue
-
     then_i_should_be_taken_to_mentoring_at_your_school_only_page
     when_i_select_yes_they_will_be_mentoring_at_our_school_only
 
@@ -148,10 +145,6 @@ RSpec.describe 'Registering a mentor', :js do
 
   def when_i_enter_the_mentor_email_address
     page.get_by_label('email').fill('example@example.com')
-  end
-
-  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
   end
 
   def and_i_click_continue

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -29,9 +29,6 @@ RSpec.describe 'Registering a mentor', :js do
 
     when_i_enter_the_mentor_email_address
     and_i_click_continue
-    then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    and_i_click_continue
-
     then_i_should_be_taken_to_mentoring_at_your_school_only_page
     when_i_select_yes_they_will_be_mentoring_at_our_school_only
 
@@ -146,10 +143,6 @@ RSpec.describe 'Registering a mentor', :js do
 
   def when_i_enter_the_mentor_email_address
     page.get_by_label('email').fill('example@example.com')
-  end
-
-  def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
   end
 
   def and_i_click_continue

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe 'Registering a mentor', :js do
 
     then_i_should_be_taken_to_mentoring_at_your_school_only_page
     when_i_select_yes_they_will_be_mentoring_at_our_school_only
-
     then_i_should_be_taken_to_mentor_start_date_page
     when_i_enter_mentor_start_date
     and_i_click_continue

--- a/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/email_address_step_spec.rb
@@ -34,4 +34,56 @@ describe Schools::RegisterMentorWizard::EmailAddressStep, type: :model do
                                      next_step: :check_answers,
                                      training_programme: :school_led
   end
+
+  context 'provider-led, eligible for funding, previously registered, previously a mentor' do
+    before do
+      allow(wizard.mentor).to receive_messages(cant_use_email?: false, funding_available?: true, previously_registered_as_mentor?: true, mentorship_status: :previously_a_mentor)
+    end
+
+    it_behaves_like 'an email step',
+                    current_step: :email_address,
+                    previous_step: :review_mentor_details,
+                    next_step: :started_on,
+                    training_programme: :provider_led
+  end
+
+  context 'provider-led, eligible for funding, previously registered, currently a mentor' do
+    before do
+      allow(wizard.mentor).to receive_messages(cant_use_email?: false, funding_available?: true, previously_registered_as_mentor?: true, mentorship_status: :currently_a_mentor)
+    end
+
+    it_behaves_like 'an email step',
+                    current_step: :email_address,
+                    previous_step: :review_mentor_details,
+                    next_step: :mentoring_at_new_school_only,
+                    training_programme: :provider_led
+  end
+
+  context 'previously registered with unexpected mentorship_status' do
+    let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+    let(:store) do
+      FactoryBot.build(:session_repository,
+                       trn: "1234567",
+                       trs_first_name: "Naruto",
+                       trs_last_name: "Uzumaki",
+                       corrected_name: "9 tails fox",
+                       date_of_birth: "01/01/1990",
+                       email: 'uchiha@clan.com')
+    end
+    let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :email_address, store:, ect_id: ect.id) }
+
+    before do
+      FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period: ect)
+      allow(wizard.mentor).to receive_messages(
+        cant_use_email?: false,
+        previously_registered_as_mentor?: true,
+        mentorship_status: :unknown_state
+      )
+    end
+
+    it 'raises InvalidMentorshipStatus' do
+      expect { described_class.new(wizard:).next_step }
+        .to raise_error(described_class::InvalidMentorshipStatus, /Unexpected status: :unknown_state/)
+    end
+  end
 end

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -289,4 +289,40 @@ describe Schools::RegisterMentorWizard::Mentor do
       end
     end
   end
+
+  describe '#mentorship_status' do
+    let(:teacher) { FactoryBot.create(:teacher, trn: mentor.trn) }
+
+    context 'when there is an ongoing mentor_at_school_period' do
+      let!(:ongoing_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
+
+      it 'returns :currently_a_mentor' do
+        expect(mentor.mentorship_status).to eq(:currently_a_mentor)
+      end
+    end
+
+    context 'when there are past mentor_at_school_periods but none ongoing' do
+      let!(:closed_period) { FactoryBot.create(:mentor_at_school_period, school:, teacher:) }
+
+      it 'returns :previously_a_mentor' do
+        expect(mentor.mentorship_status).to eq(:previously_a_mentor)
+      end
+    end
+
+    context 'when there are past mentor_at_school_periods and some ongoing' do
+      let!(:closed_period) { FactoryBot.create(:mentor_at_school_period, school:, teacher:) }
+      let!(:ongoing_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:) }
+
+      it 'returns :currently_a_mentor' do
+        expect(mentor.mentorship_status).to eq(:currently_a_mentor)
+      end
+    end
+
+    context 'when there are no mentor_at_school_periods' do
+      it 'raises an error' do
+        expect { mentor.mentorship_status }
+          .to raise_error(RuntimeError, /no mentor_at_school_periods/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Previously registered mentors no longer go through the `:review_mentor_eligibility` step.  
Instead, their next step is determined by `mentorship_status`:

- **Currently a mentor elsewhere** -> `:mentoring_at_new_school_only`
- **Previously a mentor (not currently)** -> `:started_on`
- **Anything else** -> raises `InvalidMentorshipStatus`

Open (ongoing) mentorship periods always take precedence over closed ones.

## Lead provider persistence

The lead provider was previously persisted during `:review_mentor_eligibility`.  
Since that step is now conditional, the logic has been moved to `:email_address`. This is the earliest reliable point where the information is available.  

This ensures the `TrainingPeriod` is created correctly later in the flow.

## AC's completed

<img width="799" height="112" alt="image" src="https://github.com/user-attachments/assets/50320076-f688-49c6-ad33-ee76bb9b9cdd" />

