### PR TITLE
Split `SchoolPartnerships::Query` to `SchoolPartnerships::Search`

### DIFF
--- a/app/models/concerns/training_period_sources.rb
+++ b/app/models/concerns/training_period_sources.rb
@@ -10,12 +10,7 @@ module TrainingPeriodSources
   end
 
   def earliest_matching_school_partnership
-    SchoolPartnerships::Search.new(
-      school:,
-      lead_provider:,
-      contract_period:,
-      sort: "created_at"
-    ).school_partnerships.first
+    SchoolPartnerships::Search.new(school:, lead_provider:, contract_period:).school_partnerships.first
   end
 
   def expression_of_interest

--- a/app/models/school_partnership.rb
+++ b/app/models/school_partnership.rb
@@ -23,4 +23,5 @@ class SchoolPartnership < ApplicationRecord
 
   # Scopes
   scope :for_contract_period, ->(year) { joins(:contract_period).where(contract_periods: { year: }) }
+  scope :earliest_first, -> { order(created_at: 'asc') }
 end

--- a/app/services/school_partnerships/search.rb
+++ b/app/services/school_partnerships/search.rb
@@ -1,45 +1,26 @@
 module SchoolPartnerships
   class Search
-    include Queries::ConditionFormats
-    include Queries::Orderable
-    include Queries::FilterIgnorable
-
     attr_reader :scope
 
-    def initialize(school: :ignore, contract_period: :ignore, lead_provider: :ignore, delivery_partner: :ignore, delivery_partner_api_ids: :ignore, updated_since: :ignore, sort: nil)
+    def initialize(school: :ignore, contract_period: :ignore, lead_provider: :ignore, delivery_partner: :ignore)
       @scope = default_scope
 
       where_lead_provider_is(lead_provider)
       where_contract_period_year_in(contract_period)
       where_school_is(school)
       where_delivery_partner_is(delivery_partner)
-      where_delivery_partner_api_ids_are(delivery_partner_api_ids)
-      where_updated_since(updated_since)
-      set_sort_by(sort)
     end
 
     delegate(:exists?, to: :scope)
 
     def school_partnerships
-      scope
-    end
-
-    def school_partnership_by_api_id(api_id)
-      return scope.find_by!(api_id:) if api_id.present?
-
-      fail(ArgumentError, "api_id needed")
-    end
-
-    def school_partnership_by_id(id)
-      return scope.find(id) if id.present?
-
-      fail(ArgumentError, "id needed")
+      scope.earliest_first
     end
 
   private
 
     def where_lead_provider_is(lead_provider)
-      return if ignore?(filter: lead_provider)
+      return if lead_provider == :ignore
 
       scope.merge!(
         scope.where(
@@ -49,45 +30,29 @@ module SchoolPartnerships
     end
 
     def where_contract_period_year_in(contract_period)
-      return if ignore?(filter: contract_period)
+      return if contract_period == :ignore
 
       scope.merge!(
         scope.where(
-          lead_provider_delivery_partnership: { active_lead_providers: { contract_period_year: extract_conditions(contract_period) } }
+          lead_provider_delivery_partnership: { active_lead_providers: { contract_period_year: contract_period } }
         )
       )
     end
 
     def where_school_is(school)
-      return if ignore?(filter: school)
+      return if school == :ignore
 
       scope.merge!(scope.where(school:))
     end
 
     def where_delivery_partner_is(delivery_partner)
-      return if ignore?(filter: delivery_partner)
+      return if delivery_partner == :ignore
 
       scope.merge!(
         scope.where(
           lead_provider_delivery_partnership: { delivery_partner: }
         )
       )
-    end
-
-    def where_delivery_partner_api_ids_are(delivery_partner_api_ids)
-      return if ignore?(filter: delivery_partner_api_ids)
-
-      scope.merge!(
-        scope.where(
-          lead_provider_delivery_partnership: { delivery_partners: { api_id: extract_conditions(delivery_partner_api_ids) } }
-        )
-      )
-    end
-
-    def where_updated_since(updated_since)
-      return if ignore?(filter: updated_since)
-
-      scope.merge!(SchoolPartnership.where(updated_at: updated_since..))
     end
 
     def default_scope
@@ -97,10 +62,6 @@ module SchoolPartnerships
           school: :gias_school,
           active_lead_provider: :lead_provider
         )
-    end
-
-    def set_sort_by(sort)
-      @scope = scope.order(sort_order(sort:, model: SchoolPartnership, default: { created_at: :asc }))
     end
   end
 end

--- a/app/services/schools/latest_registration_choices.rb
+++ b/app/services/schools/latest_registration_choices.rb
@@ -32,12 +32,9 @@ module Schools
   private
 
     def matching_partnerships
-      @matching_partnerships ||= SchoolPartnerships::Search.new(
-        school:,
-        contract_period:,
-        lead_provider: last_chosen_lead_provider,
-        sort: "created_at"
-      ).school_partnerships
+      @matching_partnerships ||= SchoolPartnerships::Search
+        .new(school:, contract_period:, lead_provider: last_chosen_lead_provider)
+        .school_partnerships
     end
 
     def first_used_partnership

--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -150,11 +150,7 @@ module Schools
         return false unless previous_lead_provider && contract_start_date && school
 
         SchoolPartnerships::Search
-          .new(
-            school:,
-            lead_provider: previous_lead_provider,
-            contract_period: contract_start_date
-          )
+          .new(school:, lead_provider: previous_lead_provider, contract_period: contract_start_date)
           .exists?
       end
 

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -46,5 +46,19 @@ describe SchoolPartnership do
         expect(described_class.for_contract_period(contract_period_2.id)).to contain_exactly(school_partnership_2)
       end
     end
+
+    describe '.earliest_first' do
+      let!(:school_partnership_first) { FactoryBot.create(:school_partnership, created_at: 3.weeks.ago) }
+      let!(:school_partnership_second) { FactoryBot.create(:school_partnership, created_at: 2.weeks.ago) }
+      let!(:school_partnership_third) { FactoryBot.create(:school_partnership, created_at: 1.week.ago) }
+
+      it 'orders with earliest created records first' do
+        expect(SchoolPartnership.earliest_first).to eq([
+          school_partnership_first,
+          school_partnership_second,
+          school_partnership_third,
+        ])
+      end
+    end
   end
 end

--- a/spec/services/school_partnerships/search_spec.rb
+++ b/spec/services/school_partnerships/search_spec.rb
@@ -49,12 +49,6 @@ describe SchoolPartnerships::Search do
 
           expect(query.school_partnerships).to be_empty
         end
-
-        it "does not filter by `lead_provider` if an empty string is supplied" do
-          query = described_class.new(lead_provider: " ")
-
-          expect(query.school_partnerships).to contain_exactly(school_partnership1, school_partnership2, school_partnership3)
-        end
       end
 
       describe "by `contract_period_years`" do
@@ -114,97 +108,6 @@ describe SchoolPartnerships::Search do
 
           expect(query.school_partnerships).to contain_exactly(school_partnership1)
         end
-
-        it "does not filter by `contract_period_years` if blank" do
-          query = described_class.new(contract_period: " ")
-
-          expect(query.school_partnerships).to contain_exactly(school_partnership1, school_partnership2, school_partnership3)
-        end
-      end
-
-      describe "by `updated_since`" do
-        it "filters by `updated_since`" do
-          FactoryBot.create(:school_partnership, updated_at: 2.days.ago)
-          school_partnership2 = FactoryBot.create(:school_partnership, updated_at: Time.zone.now)
-
-          query = described_class.new(updated_since: 1.day.ago)
-
-          expect(query.school_partnerships).to eq([school_partnership2])
-        end
-
-        context "when `updated_since` param is omitted" do
-          it "returns all statements" do
-            school_partnership1 = FactoryBot.create(:school_partnership, updated_at: 1.week.ago)
-            school_partnership2 = FactoryBot.create(:school_partnership, updated_at: 2.weeks.ago)
-
-            expect(described_class.new.school_partnerships).to contain_exactly(school_partnership1, school_partnership2)
-          end
-        end
-
-        it "does not filter by `updated_since` if blank" do
-          school_partnership1 = FactoryBot.create(:school_partnership, updated_at: 1.week.ago)
-          school_partnership2 = FactoryBot.create(:school_partnership, updated_at: 2.weeks.ago)
-
-          query = described_class.new(updated_since: " ")
-
-          expect(query.school_partnerships).to contain_exactly(school_partnership1, school_partnership2)
-        end
-      end
-
-      describe "by `delivery_partner_api_ids`" do
-        let!(:school_partnership1) { FactoryBot.create(:school_partnership) }
-        let!(:school_partnership2) { FactoryBot.create(:school_partnership) }
-        let!(:school_partnership3) { FactoryBot.create(:school_partnership) }
-
-        context "when `delivery_partner_api_ids` param is omitted" do
-          it "returns all school partnerships" do
-            expect(described_class.new.school_partnerships).to contain_exactly(school_partnership1, school_partnership2, school_partnership3)
-          end
-        end
-
-        it "filters by `delivery_partner`" do
-          query = described_class.new(delivery_partner: school_partnership2.delivery_partner)
-
-          expect(query.school_partnerships).to eq([school_partnership2])
-        end
-
-        it "filters by multiple `delivery_partners`" do
-          query = described_class.new(delivery_partner: [school_partnership1.delivery_partner, school_partnership2.delivery_partner])
-
-          expect(query.school_partnerships).to eq([school_partnership1, school_partnership2])
-        end
-
-        it "filters by `delivery_partner_api_ids`" do
-          query = described_class.new(delivery_partner_api_ids: school_partnership2.delivery_partner.api_id)
-
-          expect(query.school_partnerships).to eq([school_partnership2])
-        end
-
-        it "filters by multiple `delivery_partner_api_ids`" do
-          query1 = described_class.new(delivery_partner_api_ids: "#{school_partnership1.delivery_partner.api_id},#{school_partnership2.delivery_partner.api_id}")
-          expect(query1.school_partnerships).to contain_exactly(school_partnership1, school_partnership2)
-
-          query2 = described_class.new(delivery_partner_api_ids: [school_partnership2.delivery_partner.api_id, school_partnership3.delivery_partner.api_id])
-          expect(query2.school_partnerships).to contain_exactly(school_partnership2, school_partnership3)
-        end
-
-        it "returns no school partnerships if no `delivery_partner_api_ids` are found" do
-          query = described_class.new(delivery_partner_api_ids: "0000")
-
-          expect(query.school_partnerships).to be_empty
-        end
-
-        it "ignores invalid `delivery_partner_api_ids`" do
-          query = described_class.new(delivery_partner_api_ids: "#{school_partnership1.delivery_partner.api_id},invalid_api_id")
-
-          expect(query.school_partnerships).to contain_exactly(school_partnership1)
-        end
-
-        it "does not filter by `delivery_partner_api_ids` if blank" do
-          query = described_class.new(delivery_partner_api_ids: " ")
-
-          expect(query.school_partnerships).to contain_exactly(school_partnership1, school_partnership2, school_partnership3)
-        end
       end
     end
 
@@ -218,85 +121,6 @@ describe SchoolPartnerships::Search do
           expect(query.school_partnerships).to eq([school_partnership2, school_partnership1])
         end
       end
-
-      describe "order by created_at, in descending order" do
-        it "returns school partnerships in correct order" do
-          query = described_class.new(sort: "-created_at")
-          expect(query.school_partnerships).to eq([school_partnership1, school_partnership2])
-        end
-      end
-
-      describe "order by updated_at, in ascending order" do
-        it "returns school partnerships in correct order" do
-          query = described_class.new(sort: "+updated_at")
-          expect(query.school_partnerships).to eq([school_partnership2, school_partnership1])
-        end
-      end
-
-      describe "order by updated_at, in descending order" do
-        it "returns school partnerships in correct order" do
-          query = described_class.new(sort: "-updated_at")
-          expect(query.school_partnerships).to eq([school_partnership1, school_partnership2])
-        end
-      end
-    end
-  end
-
-  describe "#school_partnership_by_api_id" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
-
-    it "returns the school partnership for a given id" do
-      school_partnership = FactoryBot.create(:school_partnership)
-      query = described_class.new
-
-      expect(query.school_partnership_by_api_id(school_partnership.api_id)).to eq(school_partnership)
-    end
-
-    it "raises an error if the school partnership does not exist" do
-      query = described_class.new
-
-      expect { query.school_partnership_by_api_id("XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "raises an error if the school partnership is not in the filtered query" do
-      school_partnership1 = FactoryBot.create(:school_partnership)
-      school_partnership2 = FactoryBot.create(:school_partnership)
-
-      query = described_class.new(lead_provider: school_partnership1.lead_provider)
-
-      expect { query.school_partnership_by_api_id(school_partnership2.api_id) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "raises an error if an api_id is not supplied" do
-      expect { described_class.new.school_partnership_by_api_id(nil) }.to raise_error(ArgumentError, "api_id needed")
-    end
-  end
-
-  describe "#school_partnership_by_id" do
-    it "returns the school partnership for a given id" do
-      school_partnership = FactoryBot.create(:school_partnership)
-      query = described_class.new
-
-      expect(query.school_partnership_by_id(school_partnership.id)).to eq(school_partnership)
-    end
-
-    it "raises an error if the school partnership does not exist" do
-      query = described_class.new
-
-      expect { query.school_partnership_by_id("XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "raises an error if the school partnership is not in the filtered query" do
-      school_partnership1 = FactoryBot.create(:school_partnership)
-      school_partnership2 = FactoryBot.create(:school_partnership)
-
-      query = described_class.new(lead_provider: school_partnership1.lead_provider)
-
-      expect { query.school_partnership_by_id(school_partnership2.id) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "raises an error if an id is not supplied" do
-      expect { described_class.new.school_partnership_by_id(nil) }.to raise_error(ArgumentError, "id needed")
     end
   end
 
@@ -306,17 +130,16 @@ describe SchoolPartnerships::Search do
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
     let(:contract_period) { FactoryBot.create(:contract_period, year: 2027) }
     let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-    let!(:delivery_partner_api_ids) { delivery_partner.api_id }
     let(:school) { FactoryBot.create(:school) }
 
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
     let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
     let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:) }
 
-    let(:query_params) { { lead_provider:, school:, delivery_partner_api_ids:, contract_period: } }
+    let(:query_params) { { lead_provider:, school:, contract_period: } }
 
     it 'returns true when a school partnership matches lead provider, delivery partner API ID and school for the given registration period' do
-      expect(SchoolPartnerships::Search.new(lead_provider:, school:, contract_period:, delivery_partner_api_ids:)).to exist
+      expect(SchoolPartnerships::Search.new(lead_provider:, school:, contract_period:)).to exist
     end
 
     describe 'registration periods' do
@@ -362,22 +185,6 @@ describe SchoolPartnerships::Search do
 
       context 'when school omitted' do
         subject { SchoolPartnerships::Search.new(**query_params.except(:school)) }
-
-        it { is_expected.to(exist) }
-      end
-    end
-
-    describe 'delivery partners' do
-      context 'when delivery partner differs' do
-        subject { SchoolPartnerships::Search.new(**query_params.merge(delivery_partner_api_ids: other_delivery_partner.api_id)) }
-
-        let(:other_delivery_partner) { FactoryBot.create(:delivery_partner) }
-
-        it { is_expected.not_to(exist) }
-      end
-
-      context 'when delivery_partner omitted' do
-        subject { SchoolPartnerships::Search.new(**query_params.except(:delivery_partner_api_ids)) }
 
         it { is_expected.to(exist) }
       end


### PR DESCRIPTION
We originally wanted to keep searching/querying generic and have a single set of services for everything, but the API queries differ so much from the rest of the app it makes sense to separate them.

We unintentionally created a divide in naming with the app mainly using `Search` and the API using `Query` - the one place where there were both was `SchoolPartnerships` - hence this clash.

This change copies `SchoolPartnerships::Query` and to `SchoolPartnerships::Search` and simpifies the `Search` variant by removing the API-specific stuff (and reinstating the `.earliest_first` that was dropped in bc5da359d1e4aaa29ed51d41447607e0f9a72adc).

The `Query` objects will move under the API namespace which should hopefully avoid confusion.