### PR TITLE
[2303] Move `GIAS::School` `api_id` field to `School`

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -50,8 +50,6 @@ class School < ApplicationRecord
   validate :last_chosen_appropriate_body_for_state_funded_school,
            if: -> { state_funded? }
 
-  validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another school" }
-
   validates :urn,
             presence: true,
             uniqueness: true
@@ -67,6 +65,8 @@ class School < ApplicationRecord
   validates :induction_tutor_email,
             notify_email: true,
             allow_nil: true
+
+  validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another school" }
 
   # Scopes
   scope :search, ->(q) { includes(:gias_school).merge(GIAS::School.search(q)) }

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -150,7 +150,6 @@
   - address_line1
   - address_line2
   - address_line3
-  - api_id
   - postcode
   - primary_contact_email
   - secondary_contact_email

--- a/db/migrate/20250901173600_remove_api_id_from_gias_schools.rb
+++ b/db/migrate/20250901173600_remove_api_id_from_gias_schools.rb
@@ -1,0 +1,14 @@
+class RemoveAPIIdFromGIASSchools < ActiveRecord::Migration[8.0]
+  def up
+    remove_column :gias_schools, :api_id
+  end
+
+  def down
+    add_column :gias_schools, :api_id, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    add_index :gias_schools, :api_id, unique: true
+
+    GIAS::School.eager_load(:school).find_each do |gias_school|
+      gias_school.update!(api_id: gias_school.school.api_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_01_172046) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_01_173600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -286,8 +286,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_01_172046) do
     t.boolean "induction_eligibility", null: false
     t.boolean "in_england", null: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, ((((COALESCE((name)::text, ''::text) || ' '::text) || COALESCE((postcode)::text, ''::text)) || ' '::text) || COALESCE((urn)::text, ''::text)))", stored: true
-    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.index ["api_id"], name: "index_gias_schools_on_api_id", unique: true
     t.index ["name"], name: "index_gias_schools_on_name"
     t.index ["search"], name: "index_gias_schools_on_search", using: :gin
     t.index ["ukprn"], name: "index_gias_schools_on_ukprn", unique: true

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -48,14 +48,7 @@ describe School do
 
     it { is_expected.to validate_presence_of(:urn) }
     it { is_expected.to validate_uniqueness_of(:urn) }
-
-    context "api_id" do
-      it "validates uniqueness" do
-        another_school = FactoryBot.build(:school, api_id: subject.api_id)
-
-        expect(another_school).to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another school")
-      end
-    end
+    it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another school") }
 
     context "last_chosen_lead_provider_id" do
       subject { FactoryBot.build(:school) }


### PR DESCRIPTION
### Context

Ticket: [2303](https://github.com/DFE-Digital/register-ects-project-board/issues/2303)

The `api_id` is on `GIAS::School`. This poses a risk as GIAS data can be cleared and repopulated as it is deemed refreshable data. The `api_id` needs to remain intact regardless.

### Changes proposed in this pull request

- [First commit](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1259/commits/be7a5e13333025edf449c3c743f35565798d2360) - Add new column called `api_id` to `School` which follows the `api_id`;
- [Second commit](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1259/commits/9d82b274b190fb813e0e50b1b92b091f5e1bf0e0) - Update writes to new column from `GIAS::School` to `School`;
- [Third commit](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1259/commits/a649deba467a0fe0db4d42a0285fe577a879ecd9) - Update reads to new column from `GIAS::School` to `School`;
- [Fourth commit](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1259/commits/1b917440a3d3629c9fb942ba415bb05b95e114ee) - Delete old column from `GIAS::School`;

### Guidance to review

Reviewing this PR as a whole for now then I can split each commit into smaller PRs with separate migrations;
