### PR TITLE
Exclude `Signet::AuthorizationError` from Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,5 +6,6 @@ if Rails.application.config.enable_sentry
     config.traces_sample_rate = 0.1
     config.profiles_sample_rate = 0.1
     config.rails.active_job_report_on_retry_error = true
+    config.excluded_exceptions += ["Signet::AuthorizationError"]
   end
 end


### PR DESCRIPTION
Since we started tracking errors in jobs (#1000), we've seen lots (~35k `Signet::AuthorizationError` events in the `DfE::Analytics::SendEvents`job.

The error description suggests this is due to an invalid grant type, but the jobs almost always succeed when they are automatically retry.

We suspect there might be something amiss with how our service account is configured, or how we are refreshing tokens, but we haven't had a chance to investigate further yet.

In the meantime, we want to ignore these errors in Sentry because they are mostly noise but eat up a bunch of our quota.