### PR TITLE
[1249] Fix back links on CYA page for previously registered mentor journey (#MentorRegistrationFlow)

### DIFF
--- a/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/check_answers_step.rb
@@ -6,18 +6,38 @@ module Schools
       end
 
       def previous_step
-        if wizard.store.back_to == 'eligibility_lead_provider'
-          wizard.store.back_to = nil
-          :eligibility_lead_provider
-        else
+        return :eligibility_lead_provider if pop_back_to!(:eligibility_lead_provider)
 
-          return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
+        return previous_for_previously_registered if mentor.previously_registered_as_mentor?
 
-          :email_address
-        end
+        return :review_mentor_eligibility if ect.provider_led_training_programme? && mentor.funding_available?
+
+        :email_address
       end
 
     private
+
+      def pop_back_to!(key)
+        return false unless store.back_to.to_s == key.to_s
+
+        store.back_to = nil
+        true
+      end
+
+      def previous_for_previously_registered
+        return :mentoring_at_new_school_only if user_chose_no_to_mentoring_at_new_school_only?
+        return :programme_choices if user_chose_yes_to_use_same_programme_choices?
+
+        :lead_provider
+      end
+
+      def user_chose_no_to_mentoring_at_new_school_only?
+        store.mentoring_at_new_school_only == 'no'
+      end
+
+      def user_chose_yes_to_use_same_programme_choices?
+        store.use_same_programme_choices == 'yes'
+      end
 
       def persist
         ActiveRecord::Base.transaction do

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -32,6 +32,36 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
 
           it { expect(subject.previous_step).to eq(:email_address) }
         end
+
+        context 'when re-registering a mentor' do
+          before do
+            allow(wizard.mentor).to receive(:previously_registered_as_mentor?).and_return(true)
+          end
+
+          context 'when the user has previously chosen no to mentoring_at_new_school_only' do
+            before do
+              allow(store).to receive(:mentoring_at_new_school_only).and_return('no')
+            end
+
+            it { expect(subject.previous_step).to eq(:mentoring_at_new_school_only) }
+          end
+
+          context 'when the user has previously chosen yes to mentoring_at_new_school_only and is using the same programme choices' do
+            before do
+              allow(store).to receive_messages(mentoring_at_new_school_only: 'yes', use_same_programme_choices: 'yes')
+            end
+
+            it { expect(subject.previous_step).to eq(:programme_choices) }
+          end
+
+          context 'when the user has previously chosen yes to mentoring_at_new_school_only and is not using the same programme choices' do
+            before do
+              allow(store).to receive_messages(mentoring_at_new_school_only: 'yes', use_same_programme_choices: 'no')
+            end
+
+            it { expect(subject.previous_step).to eq(:lead_provider) }
+          end
+        end
       end
 
       context 'when the mentor is not available for funding' do


### PR DESCRIPTION
### Changes proposed

Fix the back link logic on the Check Answers page for the "previously registered mentor" journey.

Specifically:

- Return to `:mentoring_at_new_school_only` if the user selected 'no' to "Mentoring only at your school"
- Return to `:programme_choices` if the user selected 'yes' to both "Mentoring only at your school" and "Use same programme choices"
- Return to `:lead_provider` if not using previous programme choices
