### PR TITLE
Schools can change a mentor's email address

### DIFF
--- a/app/components/schools/mentors/details_component.rb
+++ b/app/components/schools/mentors/details_component.rb
@@ -35,7 +35,12 @@ module Schools
       def email_row
         {
           key: { text: 'Email address' },
-          value: { text: @mentor.email }
+          value: { text: @mentor.email },
+          actions: [{
+            text: "Change",
+            visually_hidden_text: "email address",
+            href: schools_mentors_change_email_address_wizard_edit_path(@mentor)
+          }]
         }
       end
 

--- a/app/controllers/schools/mentors/change_email_address_wizard_controller.rb
+++ b/app/controllers/schools/mentors/change_email_address_wizard_controller.rb
@@ -1,0 +1,54 @@
+module Schools
+  module Mentors
+    class ChangeEmailAddressWizardController < SchoolsController
+      before_action :set_mentor, :set_wizard
+      before_action :reset_wizard, only: :new
+
+      FORM_KEY = :schools_mentor_change_email_address_wizard
+      WIZARD_CLASS = ChangeEmailAddressWizard::Wizard
+
+      def new
+        render current_step
+      end
+
+      def create
+        if @wizard.save!
+          redirect_to @wizard.next_step_path
+        else
+          render current_step, status: :unprocessable_content
+        end
+      end
+
+    private
+
+      def set_mentor
+        @mentor = @school.mentor_at_school_periods.find(params[:mentor_id])
+      end
+
+      def set_wizard
+        @wizard = WIZARD_CLASS.new(
+          current_step:,
+          author: current_user,
+          step_params: params,
+          store:,
+          school: @school,
+          mentor: @mentor
+        )
+      end
+
+      def current_step
+        @current_step ||= request.path.split("/").last.underscore.to_sym.tap do |step_from_path|
+          redirect_to "/404" unless WIZARD_CLASS.step?(step_from_path)
+        end
+      end
+
+      def reset_wizard
+        @wizard.reset! if current_step == :edit
+      end
+
+      def store
+        @store ||= SessionRepository.new(session:, form_key: FORM_KEY)
+      end
+    end
+  end
+end

--- a/app/views/schools/mentors/change_email_address_wizard/check_answer.html.erb
+++ b/app/views/schools/mentors/change_email_address_wizard/check_answer.html.erb
@@ -1,0 +1,31 @@
+<% page_data(
+    title: "Check and confirm change",
+    backlink_href: @wizard.previous_step_path
+) %>
+
+<%= govuk_summary_list do |list| %>
+  <% list.with_row do |row| %>
+    <%= row.with_key { "Early career teacher" } %>
+    <%= row.with_value { @wizard.teacher_full_name } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <%= row.with_key { "Current email address" } %>
+    <%= row.with_value { @wizard.current_step.current_email } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <%= row.with_key { "New email address" } %>
+    <%= row.with_value { @wizard.current_step.new_email } %>
+    <%= row.with_action(
+          text: "Change",
+          visually_hidden_text: "email address",
+          href: @wizard.previous_step_path
+        ) %>
+  <% end %>
+<% end %>
+
+<%= govuk_button_to(
+      "Confirm change",
+      @wizard.current_step_path(mentor_id: @wizard.mentor.id)
+    ) %>

--- a/app/views/schools/mentors/change_email_address_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_email_address_wizard/confirmation.html.erb
@@ -1,0 +1,27 @@
+<% page_data(
+    title: "Email address updated for #{@wizard.teacher_full_name}",
+    header: false
+) %>
+
+<%= govuk_panel(
+      title_text: <<~TXT
+        You have changed #{@wizard.teacher_full_name}'s email address to
+        #{@wizard.current_step.new_email}
+      TXT
+    ) %>
+
+<h2 class="govuk-heading-m">
+ What happens next?
+</h2>
+
+<p class="govuk-body">
+  We'll tell the lead provider about this change.
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+        "Back to #{@wizard.teacher_full_name}'s details",
+        schools_mentor_path(@wizard.mentor),
+        no_visited_state: true
+      ) %>
+</p>

--- a/app/views/schools/mentors/change_email_address_wizard/edit.html.erb
+++ b/app/views/schools/mentors/change_email_address_wizard/edit.html.erb
@@ -1,0 +1,36 @@
+<% page_data(
+    title: "Change email address for #{@wizard.teacher_full_name}",
+    backlink_href: schools_mentor_path(@wizard.mentor)
+) %>
+
+<p class="govuk-body">
+  Make sure you use an email the ECT can access.
+</p>
+
+<p class="govuk-body">
+  Try to use their school email and do not use a generic email like
+  headteacher@school.com
+</p>
+
+<%= form_with(
+      model: @wizard.current_step,
+      url: @wizard.current_step_path(mentor_id: @wizard.mentor.id)
+    ) do |form| %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+  <%= form.govuk_email_field(
+        :email,
+        label: {text: "What's the correct email address for #{@wizard.teacher_full_name}"},
+        value: @wizard.current_step.email
+      ) %>
+
+  <%= form.govuk_submit "Continue" %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(
+          "Cancel and go back to #{@wizard.teacher_full_name}'s details",
+          schools_mentor_path(@wizard.mentor),
+          no_visited_state: true
+        ) %>
+  </p>
+<% end %>

--- a/app/wizards/schools/mentors/change_email_address_wizard/check_answer_step.rb
+++ b/app/wizards/schools/mentors/change_email_address_wizard/check_answer_step.rb
@@ -1,0 +1,25 @@
+module Schools
+  module Mentors
+    module ChangeEmailAddressWizard
+      class CheckAnswerStep < ApplicationWizardStep
+        def self.permitted_params = []
+
+        def previous_step = :edit
+        def next_step = :confirmation
+
+        def save!
+          mentor.update!(email: new_email)
+        end
+
+        def current_email = mentor.email
+        def new_email = store.email
+
+      private
+
+        delegate :mentor, to: :wizard
+
+        def pre_populate_attributes = nil
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/change_email_address_wizard/confirmation_step.rb
+++ b/app/wizards/schools/mentors/change_email_address_wizard/confirmation_step.rb
@@ -1,0 +1,19 @@
+module Schools
+  module Mentors
+    module ChangeEmailAddressWizard
+      class ConfirmationStep < ApplicationWizardStep
+        def self.permitted_params = []
+
+        def previous_step = :check_answer
+
+        def new_email = mentor.email
+
+      private
+
+        delegate :mentor, to: :wizard
+
+        def pre_populate_attributes = nil
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/change_email_address_wizard/edit_step.rb
+++ b/app/wizards/schools/mentors/change_email_address_wizard/edit_step.rb
@@ -1,0 +1,49 @@
+module Schools
+  module Mentors
+    module ChangeEmailAddressWizard
+      class EditStep < ApplicationWizardStep
+        attribute :email, :string
+
+        validates :email,
+                  presence: { message: "Enter an email address" }
+
+        validates :email, notify_email: true, allow_blank: true
+
+        validates :email,
+                  length: {
+                    maximum: 254,
+                    message: "Enter an email address that is less than 254 characters long"
+                  },
+                  allow_blank: true
+
+        validates :email,
+                  comparison: {
+                    other_than: ->(it) { it.mentor.email },
+                    case_sensitive: false,
+                    message: "The email must be different from the current email"
+                  },
+                  allow_blank: true
+
+        def self.permitted_params = [:email]
+
+        def next_step = :check_answer
+
+        def save!
+          persist if valid_step?
+        end
+
+      private
+
+        delegate :mentor, :valid_step?, to: :wizard
+
+        def persist
+          store.email = email
+        end
+
+        def pre_populate_attributes
+          self.email = store.email.presence || mentor.email
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/change_email_address_wizard/wizard.rb
+++ b/app/wizards/schools/mentors/change_email_address_wizard/wizard.rb
@@ -1,0 +1,28 @@
+module Schools
+  module Mentors
+    module ChangeEmailAddressWizard
+      class Wizard < ApplicationWizard
+        attr_accessor :store, :mentor
+
+        steps do
+          [{
+            edit: EditStep,
+            check_answer: CheckAnswerStep,
+            confirmation: ConfirmationStep
+          }]
+        end
+
+        def self.step?(step_name) = steps.first.key?(step_name)
+
+        delegate :save!, to: :current_step
+        delegate :reset!, to: :store
+
+        def default_path_arguments = { mentor_id: mentor.id }
+
+        def teacher_full_name
+          Teachers::Name.new(mentor.teacher).full_name
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,16 @@ Rails.application.routes.draw do
 
       get 'confirmation', action: :new
     end
+
+    scope module: :mentors, path: "/mentors/:mentor_id", as: :mentors do
+      namespace :change_email_address_wizard, path: "change-email-address" do
+        get :edit, action: :new
+        post :edit, action: :create
+        get "check-answer", action: :new
+        post "check-answer", action: :create
+        get :confirmation, action: :new
+      end
+    end
   end
 
   constraints -> { Rails.application.config.enable_api } do

--- a/spec/features/schools/mentors/change_email_address_spec.rb
+++ b/spec/features/schools/mentors/change_email_address_spec.rb
@@ -1,0 +1,152 @@
+describe "School user can change Mentor's email address" do
+  it "changes the email address" do
+    given_there_is_a_school
+    and_there_is_an_ect_with_a_mentor
+    and_i_am_logged_in_as_a_school_user
+
+    when_i_visit_the_mentor_page
+    then_i_can_change_the_email_address
+    and_i_see_the_change_email_form
+
+    when_i_do_not_enter_an_email_address
+    and_i_continue
+    error_message = "Enter an email address"
+    then_i_see_an_error(message: error_message)
+
+    when_i_do_not_enter_a_different_email_address
+    and_i_continue
+    error_message = "The email must be different from the current email"
+    then_i_see_an_error(message: error_message)
+
+    when_i_enter_an_invalid_email_address
+    and_i_continue
+    error_message = <<~TXT
+      Enter an email address in the correct format, like name@example.com
+    TXT
+    then_i_see_an_error(message: error_message)
+
+    when_i_enter_an_email_address_that_is_too_long
+    and_i_continue
+    error_message = <<~TXT
+      Enter an email address that is less than 254 characters long
+    TXT
+    then_i_see_an_error(message: error_message)
+
+    when_i_enter_a_valid_email_address
+    and_i_continue
+    then_i_am_asked_to_check_and_confirm_the_change
+
+    when_i_confirm_the_change
+    then_i_see_the_confirmation_message
+  end
+
+private
+
+  def given_there_is_a_school
+    @school = FactoryBot.create(:school)
+  end
+
+  def and_there_is_an_ect_with_a_mentor
+    start_date = 3.months.ago.to_date
+    @ect_teacher = FactoryBot.create(:teacher)
+    @ect_period = FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      :with_training_period,
+      teacher: @ect_teacher,
+      school: @school,
+      started_on: start_date
+    )
+    @mentor_teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "John",
+      trs_last_name: "Doe"
+    )
+    @mentor_period = FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      teacher: @mentor_teacher,
+      school: @school,
+      started_on: start_date,
+      email: "mentor@example.com"
+    )
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :provider_led,
+      :for_ect,
+      ect_at_school_period: @ect_period
+    )
+    FactoryBot.create(
+      :mentorship_period,
+      :ongoing,
+      mentor: @mentor_period,
+      mentee: @ect_period,
+      started_on: start_date
+    )
+  end
+
+  def and_i_am_logged_in_as_a_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def when_i_visit_the_mentor_page
+    page.goto(schools_mentor_path(@mentor_period))
+  end
+
+  def then_i_can_change_the_email_address
+    row = page.locator(".govuk-summary-list__row", hasText: "Email address")
+    row.get_by_role("link", name: "Change").click
+  end
+
+  def and_i_see_the_change_email_form
+    heading = page.locator("h1", hasText: "Change email address for John Doe")
+    expect(heading).to be_visible
+  end
+
+  def when_i_do_not_enter_an_email_address
+    page.get_by_label("Email address").fill("")
+  end
+
+  def when_i_do_not_enter_a_different_email_address
+    page.get_by_label("Email address").fill(@mentor_period.email)
+  end
+
+  def when_i_enter_an_invalid_email_address
+    page.get_by_label("Email address").fill("invalid_email")
+  end
+
+  def when_i_enter_an_email_address_that_is_too_long
+    page.get_by_label("Email address").fill("a" * 250 + "@example.com")
+  end
+
+  def when_i_enter_a_valid_email_address
+    page.get_by_label("Email address").fill("new@example.com")
+  end
+
+  def and_i_continue
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_see_an_error(message:)
+    error_summary = page.locator(".govuk-error-summary")
+    expect(error_summary).to have_text("There is a problem")
+    expect(error_summary).to have_text(message)
+  end
+
+  def then_i_am_asked_to_check_and_confirm_the_change
+    heading = page.locator("h1", hasText: "Check and confirm change")
+    expect(heading).to be_visible
+  end
+
+  def when_i_confirm_the_change
+    page.get_by_role("button", name: "Confirm change").click
+  end
+
+  def then_i_see_the_confirmation_message
+    success_panel = page.locator(".govuk-panel")
+    expect(success_panel).to have_text(
+      "You have changed John Doe's email address to new@example.com"
+    )
+  end
+end


### PR DESCRIPTION
A la #1264, this introduces a wizard for updating a Mentor's email address.