### PR TITLE
[1249] Fix back link on `:programme_choices_step` (#MentorRegistrationFlow)

### DIFF
--- a/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/programme_choices_step.rb
@@ -18,7 +18,7 @@ module Schools
       end
 
       def previous_step
-        :started_on
+        :previous_training_period_details
       end
 
     private

--- a/spec/wizards/schools/register_mentor_wizard/programme_choices_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/programme_choices_step_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Schools::RegisterMentorWizard::ProgrammeChoicesStep do
   let(:use_same_programme_choices) { 'yes' }
 
   describe '#previous_step' do
-    it { expect(step.previous_step).to eq(:started_on) }
+    it { expect(step.previous_step).to eq(:previous_training_period_details) }
   end
 
   describe '#valid?' do


### PR DESCRIPTION
### Context

Back from the `:programme_choices_step` should go back to `:previous_training_details`

