### PR TITLE
Refresh metadata after a data migration

### DIFF
--- a/app/migration/legacy_data_importer.rb
+++ b/app/migration/legacy_data_importer.rb
@@ -14,6 +14,8 @@ class LegacyDataImporter
     # we want to do this?
     DataMigration.all.find_each(&:destroy!)
 
+    Metadata::Manager.destroy_all_metadata!
+
     Migrators::Base.migrators_in_dependency_order.reverse.each(&:reset!)
   end
 end

--- a/app/migration/legacy_data_importer.rb
+++ b/app/migration/legacy_data_importer.rb
@@ -7,6 +7,8 @@ class LegacyDataImporter
     Migrators::Base.migrators_in_dependency_order.each do |migrator|
       migrator.queue if migrator.runnable?
     end
+
+    Metadata::Manager.refresh_all_metadata!(async: true) if DataMigration.incomplete.none?
   end
 
   def reset!

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -10,6 +10,16 @@ module Metadata::Handlers
           RefreshMetadataJob.send(job_method, object_type:, object_ids: objects.pluck(:id))
         end
       end
+
+      def destroy_all_metadata!
+        NotImplementedError
+      end
+
+    protected
+
+      def truncate_models!(*models)
+        models.each { it.connection.execute("TRUNCATE #{it.table_name} RESTART IDENTITY") }
+      end
     end
 
   protected

--- a/app/services/metadata/handlers/delivery_partner.rb
+++ b/app/services/metadata/handlers/delivery_partner.rb
@@ -10,6 +10,12 @@ module Metadata::Handlers
       upsert_lead_provider_metadata!
     end
 
+    class << self
+      def destroy_all_metadata!
+        truncate_models!(Metadata::DeliveryPartnerLeadProvider)
+      end
+    end
+
   private
 
     def upsert_lead_provider_metadata!

--- a/app/services/metadata/handlers/school.rb
+++ b/app/services/metadata/handlers/school.rb
@@ -11,6 +11,12 @@ module Metadata::Handlers
       upsert_lead_provider_contract_period_metadata!
     end
 
+    class << self
+      def destroy_all_metadata!
+        truncate_models!(Metadata::SchoolContractPeriod, Metadata::SchoolLeadProviderContractPeriod)
+      end
+    end
+
   private
 
     def upsert_contract_period_metadata!

--- a/app/services/metadata/manager.rb
+++ b/app/services/metadata/manager.rb
@@ -8,6 +8,10 @@ module Metadata
       def refresh_all_metadata!(async: false)
         Resolver.all_handlers.each { it.refresh_all_metadata!(async:) }
       end
+
+      def destroy_all_metadata!
+        Resolver.all_handlers.each(&:destroy_all_metadata!)
+      end
     end
 
   private

--- a/app/services/metadata/manager.rb
+++ b/app/services/metadata/manager.rb
@@ -1,16 +1,30 @@
 module Metadata
   class Manager
     def refresh_metadata!(objects)
+      return if Thread.current[:skip_metadata_updates]
+
       Array.wrap(objects).each { resolve_handler(it).refresh_metadata! }
     end
 
     class << self
       def refresh_all_metadata!(async: false)
+        return if Thread.current[:skip_metadata_updates]
+
         Resolver.all_handlers.each { it.refresh_all_metadata!(async:) }
       end
 
       def destroy_all_metadata!
+        return if Thread.current[:skip_metadata_updates]
+
         Resolver.all_handlers.each(&:destroy_all_metadata!)
+      end
+
+      def skip_metadata_updates
+        previous = Thread.current[:skip_metadata_updates]
+        Thread.current[:skip_metadata_updates] = true
+        yield
+      ensure
+        Thread.current[:skip_metadata_updates] = previous
       end
     end
 

--- a/spec/migration/legacy_data_importer_spec.rb
+++ b/spec/migration/legacy_data_importer_spec.rb
@@ -50,5 +50,11 @@ RSpec.describe LegacyDataImporter do
       expect([migrator1, migrator2]).to all(receive(:reset!))
       importer.reset!
     end
+
+    it "calls .destroy_all_metadata! on the manager" do
+      [migrator1, migrator2].each { allow(it).to receive(:reset!) }
+      expect(Metadata::Manager).to receive(:destroy_all_metadata!)
+      importer.reset!
+    end
   end
 end

--- a/spec/services/metadata/handlers/delivery_partner_spec.rb
+++ b/spec/services/metadata/handlers/delivery_partner_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe Metadata::Handlers::DeliveryPartner do
     let(:object) { delivery_partner }
   end
 
+  describe ".destroy_all_metadata!" do
+    subject(:destroy_all_metadata) { described_class.destroy_all_metadata! }
+
+    it "destroys all metadata for the delivery partner" do
+      expect { destroy_all_metadata }.to change(Metadata::DeliveryPartnerLeadProvider, :count).from(1).to(0)
+    end
+  end
+
   describe "#refresh_metadata!" do
     subject(:refresh_metadata) { instance.refresh_metadata! }
 

--- a/spec/services/metadata/handlers/school_spec.rb
+++ b/spec/services/metadata/handlers/school_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Metadata::Handlers::School do
     let(:object) { school }
   end
 
+  describe ".destroy_all_metadata!" do
+    subject(:destroy_all_metadata) { described_class.destroy_all_metadata! }
+
+    it "destroys all contract period metadata for the school" do
+      expect { destroy_all_metadata }.to change(Metadata::SchoolContractPeriod, :count).from(1).to(0)
+    end
+
+    it "destroys all lead provider contract period metadata for the school" do
+      expect { destroy_all_metadata }.to change(Metadata::SchoolLeadProviderContractPeriod, :count).from(1).to(0)
+    end
+  end
+
   describe "#refresh_metadata!" do
     subject(:refresh_metadata) { instance.refresh_metadata! }
 

--- a/spec/services/metadata/manager_spec.rb
+++ b/spec/services/metadata/manager_spec.rb
@@ -34,9 +34,19 @@ RSpec.describe Metadata::Manager do
       context "when given #{empty_value}" do
         let(:objects) { empty_value }
 
-        it "does not call resolve any handlers" do
+        it "does not resolve any handlers" do
           expect(Metadata::Resolver).not_to receive(:resolve_handler)
         end
+      end
+    end
+
+    context "when skipping metadata updates" do
+      around do |example|
+        described_class.skip_metadata_updates { example.run }
+      end
+
+      it "does not resolve any handlers" do
+        expect(Metadata::Resolver).not_to receive(:resolve_handler)
       end
     end
   end
@@ -61,6 +71,16 @@ RSpec.describe Metadata::Manager do
         refresh_all_metadata
       end
     end
+
+    context "when skipping metadata updates" do
+      around do |example|
+        described_class.skip_metadata_updates { example.run }
+      end
+
+      it "does not call any handlers" do
+        expect(Metadata::Resolver).not_to receive(:all_handlers)
+      end
+    end
   end
 
   describe ".destroy_all_metadata!" do
@@ -70,6 +90,16 @@ RSpec.describe Metadata::Manager do
       expect(Metadata::Resolver.all_handlers).to all(receive(:destroy_all_metadata!))
 
       destroy_all_metadata
+    end
+
+    context "when skipping metadata updates" do
+      around do |example|
+        described_class.skip_metadata_updates { example.run }
+      end
+
+      it "does not call any handlers" do
+        expect(Metadata::Resolver).not_to receive(:all_handlers)
+      end
     end
   end
 end

--- a/spec/services/metadata/manager_spec.rb
+++ b/spec/services/metadata/manager_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Metadata::Manager do
     let(:async) { true }
 
     it "calls refresh_metadata! for each handler with async: true" do
-      expect(Metadata::Handlers::School).to receive(:refresh_all_metadata!).with(async:)
+      expect(Metadata::Resolver.all_handlers).to all(receive(:refresh_all_metadata!).with(async:))
 
       refresh_all_metadata
     end
@@ -56,10 +56,20 @@ RSpec.describe Metadata::Manager do
       let(:async) { false }
 
       it "calls refresh_metadata! for each handler with async: false" do
-        expect(Metadata::Handlers::School).to receive(:refresh_all_metadata!).with(async:)
+        expect(Metadata::Resolver.all_handlers).to all(receive(:refresh_all_metadata!).with(async:))
 
         refresh_all_metadata
       end
+    end
+  end
+
+  describe ".destroy_all_metadata!" do
+    subject(:destroy_all_metadata) { described_class.destroy_all_metadata! }
+
+    it "calls destroy_all_metadata! for each handler" do
+      expect(Metadata::Resolver.all_handlers).to all(receive(:destroy_all_metadata!))
+
+      destroy_all_metadata
     end
   end
 end


### PR DESCRIPTION
### Context

We want to prevent any metadata from being created during a data migration, as it will lead to a slower migration time and multiple changes to the same object over the duration of a run. It's going to be more performant to instead trigger a 'refresh all metadata' once the data migration has completed.

### Changes proposed in this pull request

-  Clear metadata on `LegacyDataImporter.reset!`

To be consistent with the other migration data, we want to clear out the metadata when the migration is reset.

- Kck off metadata refresh after migration finishes

We want to populate the metadata once a migration has finished, but we don't want to block/slow the migration process down.

Kick off an async metadata refresh after migrating all data.

- Prevent metadata from being created during data migration

We want to stop metadata from being created during a migration as we refresh all the metadata at the end (which is more efficient/happens in a background job).

Add a method to `Metadata::Manager` that accepts a block; for code executed in the block no metadata will be created.

Wrap the contents of the `migrate` method in the `Migrators::Base` to ensure no metadata is created.

### Guidance to review

Tested by running on migration and checking metadata tables are empty after the delivery partner and school migrators have ran. Checked at the end to ensure the refresh all metadata is kicked off.