### PR TITLE
Fix ECT ordering bug

### DIFF
--- a/app/controllers/schools/ects_controller.rb
+++ b/app/controllers/schools/ects_controller.rb
@@ -11,7 +11,7 @@ module Schools
 
     def show
       @ect_at_school_period = @school.ect_at_school_periods.find(params[:id])
-      @training_period = @ect_at_school_period.current_training_period
+      @training_period = @ect_at_school_period.current_or_next_training_period
       @teacher = @ect_at_school_period.teacher
     end
   end

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -22,7 +22,7 @@ module Interval
     # Date relative scopes
     scope :ongoing_today, -> { ongoing_on(Time.zone.today) }
     scope :starting_tomorrow_or_after, -> { started_on_or_after(Time.zone.tomorrow) }
-    scope :ongoing_today_or_starting_tomorrow_or_after, -> { ongoing_today.or(starting_tomorrow_or_after).earliest_first }
+    scope :current_or_future, -> { ongoing_today.or(starting_tomorrow_or_after).earliest_first }
   end
 
   # Validations

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -22,7 +22,7 @@ module Interval
     # Date relative scopes
     scope :ongoing_today, -> { ongoing_on(Time.zone.today) }
     scope :starting_tomorrow_or_after, -> { started_on_or_after(Time.zone.tomorrow) }
-    scope :current_or_future, -> { ongoing_today.or(starting_tomorrow_or_after).earliest_first }
+    scope :current_or_future, -> { ongoing_today.or(starting_tomorrow_or_after) }
   end
 
   # Validations

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -12,8 +12,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :ect_at_school_period
   has_many :mentor_at_school_periods, through: :teacher
   has_many :events
-  has_one :current_training_period, -> { current_or_future.earliest_first }, class_name: 'TrainingPeriod'
-  has_one :current_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
+  has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: 'TrainingPeriod'
+  has_one :current_or_next_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 
@@ -70,8 +70,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   end
 
   delegate :trn, to: :teacher
-  delegate :provider_led_training_programme?, to: :current_training_period, allow_nil: true
-  delegate :school_led_training_programme?, to: :current_training_period, allow_nil: true
+  delegate :provider_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
+  delegate :school_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
 
 private
 

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -12,8 +12,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :ect_at_school_period
   has_many :mentor_at_school_periods, through: :teacher
   has_many :events
-  has_one :current_training_period, -> { current_or_future }, class_name: 'TrainingPeriod'
-  has_one :current_mentorship_period, -> { current_or_future }, class_name: 'MentorshipPeriod'
+  has_one :current_training_period, -> { current_or_future.earliest_first }, class_name: 'TrainingPeriod'
+  has_one :current_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -12,8 +12,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :ect_at_school_period
   has_many :mentor_at_school_periods, through: :teacher
   has_many :events
-  has_one :current_training_period, -> { ongoing_today_or_starting_tomorrow_or_after }, class_name: 'TrainingPeriod'
-  has_one :current_mentorship_period, -> { ongoing_today_or_starting_tomorrow_or_after }, class_name: 'MentorshipPeriod'
+  has_one :current_training_period, -> { current_or_future }, class_name: 'TrainingPeriod'
+  has_one :current_mentorship_period, -> { current_or_future }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -21,7 +21,7 @@ class Teacher < ApplicationRecord
 
   has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body
-  has_one :current_ect_at_school_period, -> { current_or_future.earliest_first }, class_name: 'ECTAtSchoolPeriod'
+  has_one :current_or_next_ect_at_school_period, -> { current_or_future.earliest_first }, class_name: 'ECTAtSchoolPeriod'
 
   has_many :events
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -21,7 +21,7 @@ class Teacher < ApplicationRecord
 
   has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body
-  has_one :current_ect_at_school_period, -> { ongoing_today_or_starting_tomorrow_or_after }, class_name: 'ECTAtSchoolPeriod'
+  has_one :current_ect_at_school_period, -> { current_or_future }, class_name: 'ECTAtSchoolPeriod'
 
   has_many :events
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -21,7 +21,7 @@ class Teacher < ApplicationRecord
 
   has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body
-  has_one :current_ect_at_school_period, -> { current_or_future }, class_name: 'ECTAtSchoolPeriod'
+  has_one :current_ect_at_school_period, -> { current_or_future.earliest_first }, class_name: 'ECTAtSchoolPeriod'
 
   has_many :events
 

--- a/app/services/ect_at_school_periods/current_training.rb
+++ b/app/services/ect_at_school_periods/current_training.rb
@@ -1,10 +1,10 @@
 module ECTAtSchoolPeriods
   class CurrentTraining
-    attr_reader :ect_at_school_period, :current_training_period
+    attr_reader :ect_at_school_period, :current_or_next_training_period
 
     def initialize(ect_at_school_period)
       @ect_at_school_period = ect_at_school_period
-      @current_training_period = ect_at_school_period.current_training_period
+      @current_or_next_training_period = ect_at_school_period.current_or_next_training_period
     end
 
     def expression_of_interest?
@@ -16,7 +16,7 @@ module ECTAtSchoolPeriods
     end
 
     # school_partnership
-    delegate :school_partnership, to: :current_training_period, allow_nil: true
+    delegate :school_partnership, to: :current_or_next_training_period, allow_nil: true
 
     # lead_provider_delivery_partnership
     delegate :lead_provider_delivery_partnership, to: :school_partnership, allow_nil: true, private: true
@@ -25,7 +25,7 @@ module ECTAtSchoolPeriods
     delegate :active_lead_provider, to: :lead_provider_delivery_partnership, allow_nil: true, private: true
 
     # expression_of_interest
-    delegate :expression_of_interest, to: :current_training_period, allow_nil: true, private: true
+    delegate :expression_of_interest, to: :current_or_next_training_period, allow_nil: true, private: true
 
     # expression_of_interest_lead_provider
     delegate :lead_provider, to: :expression_of_interest, allow_nil: true, prefix: :expression_of_interest, private: true
@@ -46,10 +46,10 @@ module ECTAtSchoolPeriods
     delegate :name, to: :expression_of_interest_lead_provider, allow_nil: true, prefix: :expression_of_interest_lead_provider
 
     # training_programme
-    delegate :training_programme, to: :current_training_period, allow_nil: true
+    delegate :training_programme, to: :current_or_next_training_period, allow_nil: true
 
     def provider_led?
-      current_training_period&.provider_led_training_programme?
+      current_or_next_training_period&.provider_led_training_programme?
     end
   end
 end

--- a/app/services/ect_at_school_periods/finish.rb
+++ b/app/services/ect_at_school_periods/finish.rb
@@ -52,14 +52,14 @@ module ECTAtSchoolPeriods
     end
 
     def training_period
-      @training_period ||= ect_at_school_period.current_training_period
+      @training_period ||= ect_at_school_period.current_or_next_training_period
     end
 
     def event_params
       {
         teacher: ect_at_school_period.teacher,
         school: ect_at_school_period.school,
-        training_period: ect_at_school_period.current_training_period
+        training_period: ect_at_school_period.current_or_next_training_period
       }
     end
   end

--- a/app/services/ect_at_school_periods/mentorship.rb
+++ b/app/services/ect_at_school_periods/mentorship.rb
@@ -6,8 +6,8 @@ module ECTAtSchoolPeriods
       @ect_at_school_period = ect_at_school_period
     end
 
-    def current_mentorship_period
-      @current_mentorship_period ||= ect_at_school_period.current_mentorship_period
+    def current_or_next_mentorship_period
+      @current_or_next_mentorship_period ||= ect_at_school_period.current_or_next_mentorship_period
     end
 
     def latest_mentorship_period
@@ -17,7 +17,7 @@ module ECTAtSchoolPeriods
     end
 
     # current_mentor
-    delegate :mentor, to: :current_mentorship_period, allow_nil: true, prefix: :current
+    delegate :mentor, to: :current_or_next_mentorship_period, allow_nil: true, prefix: :current
 
     def current_mentor_name
       @current_mentor_name ||= Teachers::Name.new(current_mentor.teacher).full_name if current_mentor

--- a/app/services/schools/assign_mentor.rb
+++ b/app/services/schools/assign_mentor.rb
@@ -27,7 +27,7 @@ module Schools
     end
 
     def finish_current_mentorship!
-      ECTAtSchoolPeriods::Mentorship.new(ect).current_mentorship_period&.finish!(earliest_possible_start)
+      ECTAtSchoolPeriods::Mentorship.new(ect).current_or_next_mentorship_period&.finish!(earliest_possible_start)
     end
 
     def record_events!

--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -68,7 +68,7 @@ module Teachers
       @scope.merge!(
         @scope.eager_load(ect_at_school_periods: [:school, { mentorship_periods: { mentor: :teacher } }])
               .where(ect_at_school_periods: { school: })
-              .merge(ECTAtSchoolPeriod.ongoing_today_or_starting_tomorrow_or_after)
+              .merge(ECTAtSchoolPeriod.current_or_future)
       )
 
       @sort_order = :mentorless_first_then_by_registration_date

--- a/app/views/schools/ects/index.html.erb
+++ b/app/views/schools/ects/index.html.erb
@@ -25,8 +25,8 @@
         <% @filtered_teachers.each do |teacher| %>
           <%= render Schools::ECTs::ListingCardComponent.new(
             teacher:,
-            ect_at_school_period: teacher.current_ect_at_school_period,
-            training_period: teacher.current_ect_at_school_period&.current_training_period)
+            ect_at_school_period: teacher.current_or_next_ect_at_school_period,
+            training_period: teacher.current_or_next_ect_at_school_period&.current_or_next_training_period)
           %>
         <% end %>
       <% end %>

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -110,12 +110,12 @@ describe Interval do
       end
     end
 
-    describe '.ongoing_today_or_starting_tomorrow_or_after' do
+    describe '.current_or_future' do
       it 'chains together .ongoing_today and .starting_tomorrow_or_after' do
         allow(DummyMentor).to receive(:ongoing_today).and_call_original
         allow(DummyMentor).to receive(:starting_tomorrow_or_after).and_call_original
 
-        DummyMentor.ongoing_today_or_starting_tomorrow_or_after
+        DummyMentor.current_or_future
 
         expect(DummyMentor).to have_received(:ongoing_today).once
         expect(DummyMentor).to have_received(:starting_tomorrow_or_after).once

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -15,16 +15,16 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to have_many(:mentors).through(:mentorship_periods).source(:mentor) }
     it { is_expected.to have_many(:events) }
 
-    describe '.current_training_period' do
+    describe '.current_or_next_training_period' do
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
 
-      it { is_expected.to have_one(:current_training_period).class_name('TrainingPeriod') }
+      it { is_expected.to have_one(:current_or_next_training_period).class_name('TrainingPeriod') }
 
       context 'when there is a current period' do
         let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
         it 'returns the current training_period' do
-          expect(ect_at_school_period.current_training_period).to eql(training_period)
+          expect(ect_at_school_period.current_or_next_training_period).to eql(training_period)
         end
       end
 
@@ -33,7 +33,7 @@ describe ECTAtSchoolPeriod do
         let!(:future_training_period) { FactoryBot.create(:training_period, started_on: 2.weeks.from_now, finished_on: nil, ect_at_school_period:) }
 
         it 'returns the current ect_at_school_period' do
-          expect(ect_at_school_period.current_training_period).to eql(training_period)
+          expect(ect_at_school_period.current_or_next_training_period).to eql(training_period)
         end
       end
 
@@ -41,12 +41,12 @@ describe ECTAtSchoolPeriod do
         let!(:training_period) { FactoryBot.create(:training_period, :finished, ect_at_school_period:) }
 
         it 'returns nil' do
-          expect(ect_at_school_period.current_training_period).to be_nil
+          expect(ect_at_school_period.current_or_next_training_period).to be_nil
         end
       end
     end
 
-    describe '.current_mentorship_period' do
+    describe '.current_or_next_mentorship_period' do
       let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
       let(:mentorship_started_on) { 3.weeks.ago }
@@ -62,11 +62,11 @@ describe ECTAtSchoolPeriod do
         )
       end
 
-      it { is_expected.to have_one(:current_mentorship_period).class_name('MentorshipPeriod') }
+      it { is_expected.to have_one(:current_or_next_mentorship_period).class_name('MentorshipPeriod') }
 
       context 'when there is a current period' do
         it 'returns the current mentorship_period' do
-          expect(ect_at_school_period.current_mentorship_period).to eql(mentorship_period)
+          expect(ect_at_school_period.current_or_next_mentorship_period).to eql(mentorship_period)
         end
       end
 
@@ -85,7 +85,7 @@ describe ECTAtSchoolPeriod do
         end
 
         it 'returns the current mentorship_period' do
-          expect(ect_at_school_period.current_mentorship_period).to eql(mentorship_period)
+          expect(ect_at_school_period.current_or_next_mentorship_period).to eql(mentorship_period)
         end
       end
 
@@ -93,7 +93,7 @@ describe ECTAtSchoolPeriod do
         let(:mentorship_finished_on) { 1.week.ago }
 
         it 'returns nil' do
-          expect(ect_at_school_period.current_training_period).to be_nil
+          expect(ect_at_school_period.current_or_next_training_period).to be_nil
         end
       end
     end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -16,7 +16,7 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to have_many(:events) }
 
     describe '.current_or_next_training_period' do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
 
       it { is_expected.to have_one(:current_or_next_training_period).class_name('TrainingPeriod') }
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -28,6 +28,15 @@ describe ECTAtSchoolPeriod do
         end
       end
 
+      context 'when there is a current period and a future period' do
+        let!(:training_period) { FactoryBot.create(:training_period, started_on: 1.year.ago, finished_on: 2.weeks.from_now, ect_at_school_period:) }
+        let!(:future_training_period) { FactoryBot.create(:training_period, started_on: 2.weeks.from_now, finished_on: nil, ect_at_school_period:) }
+
+        it 'returns the current ect_at_school_period' do
+          expect(ect_at_school_period.current_training_period).to eql(training_period)
+        end
+      end
+
       context 'when there is no current period' do
         let!(:training_period) { FactoryBot.create(:training_period, :finished, ect_at_school_period:) }
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -7,17 +7,17 @@ describe Teacher do
     it { is_expected.to have_many(:induction_extensions) }
     it { is_expected.to have_many(:events) }
 
-    describe '.current_ect_at_school_period' do
+    describe '.current_or_next_ect_at_school_period' do
       let(:teacher) { FactoryBot.create(:teacher) }
 
-      it { is_expected.to have_one(:current_ect_at_school_period).class_name('ECTAtSchoolPeriod') }
+      it { is_expected.to have_one(:current_or_next_ect_at_school_period).class_name('ECTAtSchoolPeriod') }
 
       context 'when there is a current period' do
         let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
         let!(:finished_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 10.years.ago, finished_on: 8.years.ago, teacher:) }
 
         it 'returns the current ect_at_school_period' do
-          expect(teacher.current_ect_at_school_period).to eql(ect_at_school_period)
+          expect(teacher.current_or_next_ect_at_school_period).to eql(ect_at_school_period)
         end
       end
 
@@ -26,7 +26,7 @@ describe Teacher do
         let!(:future_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.weeks.from_now, finished_on: nil, teacher:) }
 
         it 'returns the current ect_at_school_period' do
-          expect(teacher.current_ect_at_school_period).to eql(ect_at_school_period)
+          expect(teacher.current_or_next_ect_at_school_period).to eql(ect_at_school_period)
         end
       end
 
@@ -34,7 +34,7 @@ describe Teacher do
         let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :finished, teacher:) }
 
         it 'returns nil' do
-          expect(teacher.current_ect_at_school_period).to be_nil
+          expect(teacher.current_or_next_ect_at_school_period).to be_nil
         end
       end
     end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -21,6 +21,15 @@ describe Teacher do
         end
       end
 
+      context 'when there is a current period and a future period' do
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 2.weeks.from_now, teacher:) }
+        let!(:future_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.weeks.from_now, finished_on: nil, teacher:) }
+
+        it 'returns the current ect_at_school_period' do
+          expect(teacher.current_ect_at_school_period).to eql(ect_at_school_period)
+        end
+      end
+
       context 'when there is no current period' do
         let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :finished, teacher:) }
 

--- a/spec/services/ect_at_school_periods/current_training_spec.rb
+++ b/spec/services/ect_at_school_periods/current_training_spec.rb
@@ -1,6 +1,6 @@
 describe ECTAtSchoolPeriods::CurrentTraining do
-  describe "#current_training_period" do
-    subject { described_class.new(ect_at_school_period).current_training_period }
+  describe "#current_or_next_training_period" do
+    subject { described_class.new(ect_at_school_period).current_or_next_training_period }
 
     let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
 

--- a/spec/services/ect_at_school_periods/mentorship_spec.rb
+++ b/spec/services/ect_at_school_periods/mentorship_spec.rb
@@ -1,6 +1,6 @@
 describe ECTAtSchoolPeriods::Mentorship do
-  describe "#current_mentorship_period" do
-    subject { described_class.new(mentee).current_mentorship_period }
+  describe "#current_or_next_mentorship_period" do
+    subject { described_class.new(mentee).current_or_next_mentorship_period }
 
     let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 3.years.ago) }
     let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 3.years.ago) }

--- a/spec/services/schools/assign_mentor_form_spec.rb
+++ b/spec/services/schools/assign_mentor_form_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
         ect.reload
 
         expect(ECTAtSchoolPeriods::Mentorship.new(ect).current_mentor).to eq(mentor)
-        expect(ECTAtSchoolPeriods::Mentorship.new(ect).current_mentorship_period.started_on).to eq(Date.current)
+        expect(ECTAtSchoolPeriods::Mentorship.new(ect).current_or_next_mentorship_period.started_on).to eq(Date.current)
       end
     end
   end

--- a/spec/services/schools/assign_mentor_spec.rb
+++ b/spec/services/schools/assign_mentor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Schools::AssignMentor do
         expect(ECTAtSchoolPeriods::Mentorship.new(mentee).current_mentor).to eq(current_mentor)
         expect { service.assign! }.to change(MentorshipPeriod, :count).from(1).to(2)
         expect(ECTAtSchoolPeriods::Mentorship.new(mentee.reload).current_mentor).to eq(new_mentor)
-        expect(ECTAtSchoolPeriods::Mentorship.new(mentee).current_mentorship_period.started_on).to eq(Date.current)
+        expect(ECTAtSchoolPeriods::Mentorship.new(mentee).current_or_next_mentorship_period.started_on).to eq(Date.current)
       end
     end
 


### PR DESCRIPTION
### Context

The ordering of ECTs should be ECTs without mentors first, then start date (latest first).

This was broken by ordering being added to another scope which was also used by the query, which preceeded the custom sorting.

To fix this I moved `.earliest_first` from the scope to the `current_*` relationships and renamed those relationship to `current_or_next`.

### Changes proposed in this pull request

- **Rename scope to current_or_future**
- **Move earliest_first call from scope to relationships**
- **Rename current relationships to current_or_next**
