### PR TITLE
Adopt custom matcher in specs

### DIFF
--- a/spec/features/admin/finance/adjustments/list_adjustments_spec.rb
+++ b/spec/features/admin/finance/adjustments/list_adjustments_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "List adjustments for statement" do
   end
 
   def then_i_am_redirected_back_to_finance_statement_page
-    expect(page.url).to end_with(admin_finance_statement_path(@statement))
+    expect(page).to have_path(admin_finance_statement_path(@statement))
   end
 
   def summary_list_values

--- a/spec/features/admin/finance/statements/selector_spec.rb
+++ b/spec/features/admin/finance/statements/selector_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Admin finance statement selector" do
   end
 
   def then_i_am_redirected_different_statement
-    expect(page.url).to end_with(admin_finance_statement_path(@statement2))
+    expect(page).to have_path(admin_finance_statement_path(@statement2))
   end
 
   def then_i_am_redirected_to_statement_not_found_page

--- a/spec/features/admin/import_ect_spec.rb
+++ b/spec/features/admin/import_ect_spec.rb
@@ -92,13 +92,13 @@ private
   def given_i_am_on_the_admin_teachers_index_page
     path = '/admin/teachers'
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def given_i_am_on_the_find_ect_page
     path = '/admin/import-ect/find-ect/new'
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def then_i_should_see_the_import_ect_button
@@ -110,7 +110,7 @@ private
   end
 
   def then_i_should_be_on_the_find_ect_page
-    expect(page.url).to end_with('/admin/import-ect/find-ect/new')
+    expect(page).to have_path('/admin/import-ect/find-ect/new')
     expect(page.get_by_text('Find an early career teacher')).to be_visible
   end
 
@@ -142,7 +142,7 @@ private
   def then_i_should_be_on_the_check_ect_page
     @pending_induction_submission = PendingInductionSubmission.last
     path = "/admin/import-ect/check-ect/#{@pending_induction_submission.id}/edit"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_i_should_see_the_ect_details
@@ -157,7 +157,7 @@ private
 
   def then_i_should_be_on_the_register_ect_page
     path = "/admin/import-ect/register-ect/#{@pending_induction_submission.id}"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_i_should_see_the_success_message
@@ -181,7 +181,7 @@ private
 
   def then_i_should_be_redirected_to_the_existing_teacher_page
     teacher = Teacher.find_by(trn: '1234567')
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}")
   end
 
   def and_i_should_see_the_teacher_already_exists_message
@@ -192,7 +192,7 @@ private
   def then_i_should_be_on_the_no_qts_error_page
     @pending_induction_submission = PendingInductionSubmission.last
     path = "/admin/import-ect/errors/no-qts/#{@pending_induction_submission.id}"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_i_should_see_the_qts_error_message
@@ -203,7 +203,7 @@ private
   def then_i_should_be_on_the_prohibited_error_page
     @pending_induction_submission = PendingInductionSubmission.last
     path = "/admin/import-ect/errors/prohibited-from-teaching/#{@pending_induction_submission.id}"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_i_should_see_the_prohibited_error_message

--- a/spec/features/admin/schools/impersonating_a_school_spec.rb
+++ b/spec/features/admin/schools/impersonating_a_school_spec.rb
@@ -38,7 +38,7 @@ private
     path = "/admin/schools/#{@school.urn}/overview"
     page.goto(path)
 
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_sign_in_as_school
@@ -46,7 +46,7 @@ private
   end
 
   def then_i_should_be_on_the_schools_home_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_i_should_be_impersonating_the_school
@@ -62,14 +62,14 @@ private
   def then_i_should_be_on_the_admin_school_show_page
     path = "/admin/schools/#{@school.urn}/overview"
 
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_navigate_back_to_the_admin_interface
     path = "/admin/teachers"
     page.goto(path)
 
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def then_i_should_see_an_access_denied_error

--- a/spec/features/admin/teachers/delete_induction_period_spec.rb
+++ b/spec/features/admin/teachers/delete_induction_period_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Admin deletes an induction period" do
   def given_i_am_on_the_ect_page(teacher)
     path = "/admin/teachers/#{teacher.id}"
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def then_i_should_see_the_delete_link

--- a/spec/features/admin/teachers/edit_induction_period_spec.rb
+++ b/spec/features/admin/teachers/edit_induction_period_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Admin amending number of terms of an induction period" do
 private
 
   def given_i_am_on_the_teacher_page
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}")
   end
 
   def then_i_should_see_the_edit_link
@@ -102,7 +102,7 @@ private
   end
 
   def then_i_should_be_on_the_edit_induction_period_page
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}/induction-periods/#{induction_period.id}/edit")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}/induction-periods/#{induction_period.id}/edit")
   end
 
   def when_i_set_end_date(end_date)
@@ -121,7 +121,7 @@ private
   end
 
   def then_i_should_be_on_the_success_page
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}")
     expect(page.get_by_text('Induction period updated successfully')).to be_visible
   end
 

--- a/spec/features/admin/teachers/record_failed_outcome_spec.rb
+++ b/spec/features/admin/teachers/record_failed_outcome_spec.rb
@@ -26,7 +26,7 @@ private
   def given_i_am_on_the_ect_page(teacher)
     path = "/admin/teachers/#{teacher.id}"
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_link(text)
@@ -34,7 +34,7 @@ private
   end
 
   def then_i_should_be_on_the_record_outcome_page(teacher)
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}/record-failed-outcome/new")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}/record-failed-outcome/new")
   end
 
   def when_i_enter_the_finish_date
@@ -55,7 +55,7 @@ private
   end
 
   def then_i_should_be_on_the_success_page
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}/record-failed-outcome")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}/record-failed-outcome")
     expect(page.locator('.govuk-panel')).to be_visible
   end
 

--- a/spec/features/admin/teachers/record_passed_outcome_spec.rb
+++ b/spec/features/admin/teachers/record_passed_outcome_spec.rb
@@ -26,7 +26,7 @@ private
   def given_i_am_on_the_ect_page(teacher)
     path = "/admin/teachers/#{teacher.id}"
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_link(text)
@@ -34,7 +34,7 @@ private
   end
 
   def then_i_should_be_on_the_record_outcome_page(teacher)
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}/record-passed-outcome/new")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}/record-passed-outcome/new")
   end
 
   def when_i_enter_the_finish_date
@@ -55,7 +55,7 @@ private
   end
 
   def then_i_should_be_on_the_success_page
-    expect(page.url).to end_with("/admin/teachers/#{teacher.id}/record-passed-outcome")
+    expect(page).to have_path("/admin/teachers/#{teacher.id}/record-passed-outcome")
     expect(page.locator('.govuk-panel')).to be_visible
   end
 

--- a/spec/features/api/guidance/pages_spec.rb
+++ b/spec/features/api/guidance/pages_spec.rb
@@ -37,17 +37,17 @@ private
   def given_i_am_on_the_api_guidance_page
     path = '/api/guidance'
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_guidance
     page.get_by_role('link', name: 'Guidance', exact: true).click
-    expect(page.url).to end_with('/api/guidance/guidance-for-lead-providers')
+    expect(page).to have_path('/api/guidance/guidance-for-lead-providers')
   end
 
   def when_i_click_view_all_release_notes
     page.get_by_role('link', name: 'View all release notes', exact: true).click
-    expect(page.url).to end_with('/api/guidance/release-notes')
+    expect(page).to have_path('/api/guidance/release-notes')
   end
 
   def when_i_click_on_the_latest_release_note
@@ -80,7 +80,7 @@ private
   def when_i_visit_non_existing_guidance_page
     path = api_guidance_page_path("does-not-exist")
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def then_i_should_see_not_found

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -88,7 +88,7 @@ private
   def given_i_am_on_the_claim_an_ect_find_page
     path = '/appropriate-body/claim-an-ect/find-ect/new'
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
@@ -110,12 +110,12 @@ private
   def now_i_should_be_on_the_claim_an_ect_check_page
     @pending_induction_submission = PendingInductionSubmission.last
     path = "/appropriate-body/claim-an-ect/check-ect/#{@pending_induction_submission.id}/edit"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def now_i_should_be_on_the_claim_an_ect_register_page
     path = "/appropriate-body/claim-an-ect/register-ect/#{@pending_induction_submission.id}/edit"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   # FIXME: flaky spec, result changes depending on day it is run
@@ -141,7 +141,7 @@ private
 
   def now_i_should_be_on_the_confirmation_page
     path = "/appropriate-body/claim-an-ect/register-ect/#{@pending_induction_submission.id}"
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_the_data_i_submitted_should_be_saved_on_the_pending_record

--- a/spec/features/appropriate_bodies/edit_induction_period_spec.rb
+++ b/spec/features/appropriate_bodies/edit_induction_period_spec.rb
@@ -85,13 +85,13 @@ RSpec.describe "Appropriate body editing an induction period" do
 private
 
   def given_i_am_on_the_teacher_page
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}")
   end
 
   alias_method :then_i_should_be_on_the_teacher_page, :given_i_am_on_the_teacher_page
 
   def then_i_should_be_on_the_edit_induction_period_page
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/induction-periods/#{induction_period.id}/edit")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/induction-periods/#{induction_period.id}/edit")
   end
 
   def then_i_should_see_the_edit_link

--- a/spec/features/appropriate_bodies/process_batch_action_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_action_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Process bulk actions' do
 private
 
   def given_i_am_on_the_upload_page
-    expect(page.url).to end_with('/appropriate-body/bulk/actions/new')
+    expect(page).to have_path('/appropriate-body/bulk/actions/new')
   end
 
   def when_i_upload_a_file(input_file = file_path)
@@ -136,7 +136,7 @@ private
   end
 
   def then_i_should_see_the_error(error)
-    expect(page.url).to end_with('/appropriate-body/bulk/actions')
+    expect(page).to have_path('/appropriate-body/bulk/actions')
     expect(page.title).to start_with('Error:')
     expect(page.get_by_text("Error: #{error}")).to be_visible
   end

--- a/spec/features/appropriate_bodies/process_batch_claim_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_claim_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Process bulk claims' do
 private
 
   def given_i_am_on_the_upload_page
-    expect(page.url).to end_with('/appropriate-body/bulk/claims/new')
+    expect(page).to have_path('/appropriate-body/bulk/claims/new')
   end
 
   def when_i_upload_a_file(input_file = file_path)
@@ -95,7 +95,7 @@ private
   end
 
   def then_i_should_see_the_error(error)
-    expect(page.url).to end_with('/appropriate-body/bulk/claims')
+    expect(page).to have_path('/appropriate-body/bulk/claims')
     expect(page.title).to start_with('Error:')
     expect(page.get_by_text("Error: #{error}")).to be_visible
   end

--- a/spec/features/appropriate_bodies/process_batch_combo_spec.rb
+++ b/spec/features/appropriate_bodies/process_batch_combo_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Process bulk claims then actions events' do
   scenario 'happy path' do
     # action
     page.goto(new_ab_batch_claim_path)
-    expect(page.url).to end_with('/appropriate-body/bulk/claims/new')
+    expect(page).to have_path('/appropriate-body/bulk/claims/new')
     when_i_upload_a_file('valid_complete_claim.csv')
 
     expect(PendingInductionSubmissionBatch.last).to be_processing
@@ -59,7 +59,7 @@ RSpec.describe 'Process bulk claims then actions events' do
 
     # claim
     page.goto(new_ab_batch_action_path)
-    expect(page.url).to end_with('/appropriate-body/bulk/actions/new')
+    expect(page).to have_path('/appropriate-body/bulk/actions/new')
     when_i_upload_a_file('valid_complete_action.csv')
 
     expect(PendingInductionSubmissionBatch.last).to be_processing

--- a/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_failed_outcome_spec.rb
@@ -27,7 +27,7 @@ private
     path = "/appropriate-body/teachers/#{teacher.id}"
     page.goto(path)
 
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_link(text)
@@ -35,7 +35,7 @@ private
   end
 
   def then_i_should_be_on_the_record_outcome_page(teacher)
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome/new")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome/new")
   end
 
   def when_i_enter_the_finish_date
@@ -56,7 +56,7 @@ private
   end
 
   def then_i_should_be_on_the_success_page
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
     expect(page.locator('.govuk-panel')).to be_visible
   end
 

--- a/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
+++ b/spec/features/appropriate_bodies/record_passed_outcome_spec.rb
@@ -26,7 +26,7 @@ private
   def given_i_am_on_the_ect_page(teacher)
     path = "/appropriate-body/teachers/#{teacher.id}"
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_link(text)
@@ -34,7 +34,7 @@ private
   end
 
   def then_i_should_be_on_the_record_outcome_page(teacher)
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome/new")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome/new")
   end
 
   def when_i_enter_the_finish_date
@@ -55,7 +55,7 @@ private
   end
 
   def then_i_should_be_on_the_success_page
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
     expect(page.locator('.govuk-panel')).to be_visible
   end
 

--- a/spec/features/appropriate_bodies/release_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/release_an_ect_spec.rb
@@ -30,7 +30,7 @@ private
   def given_i_am_on_the_ect_page(teacher)
     path = "/appropriate-body/teachers/#{teacher.id}"
     page.goto(path)
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_link(text)
@@ -38,7 +38,7 @@ private
   end
 
   def then_i_should_be_on_the_release_ect_page(teacher)
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/release/new")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/release/new")
   end
 
   def when_i_submit_the_form_without_filling_anything_in
@@ -70,7 +70,7 @@ private
   end
 
   def then_i_should_be_on_the_success_page
-    expect(page.url).to end_with("/appropriate-body/teachers/#{teacher.id}/release")
+    expect(page).to have_path("/appropriate-body/teachers/#{teacher.id}/release")
     expect(page.locator('.govuk-panel')).to be_visible
 
     teacher_name = ::Teachers::Name.new(teacher).full_name

--- a/spec/features/migration/view_completed_parity_checks_spec.rb
+++ b/spec/features/migration/view_completed_parity_checks_spec.rb
@@ -64,6 +64,6 @@ RSpec.describe "View completed parity checks" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Run a parity check").click
-    expect(page.url).to end_with(new_migration_parity_check_path)
+    expect(page).to have_path(new_migration_parity_check_path)
   end
 end

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "View parity check request" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Parity check run ##{request.run.id}").click
-    expect(page.url).to end_with(migration_parity_check_path(request.run))
+    expect(page).to have_path(migration_parity_check_path(request.run))
   end
 
   scenario "Navigating back to completed parity checks" do
@@ -88,7 +88,7 @@ RSpec.describe "View parity check request" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Completed parity checks").click
-    expect(page.url).to end_with(completed_migration_parity_checks_path)
+    expect(page).to have_path(completed_migration_parity_checks_path)
   end
 
   scenario "Navigating back to run a parity check" do
@@ -98,6 +98,6 @@ RSpec.describe "View parity check request" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Run a parity check").click
-    expect(page.url).to end_with(new_migration_parity_check_path)
+    expect(page).to have_path(new_migration_parity_check_path)
   end
 end

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "View parity check response" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: response.request.description).click
-    expect(page.url).to end_with(migration_parity_check_request_path(response.run, response.request))
+    expect(page).to have_path(migration_parity_check_request_path(response.run, response.request))
   end
 
   scenario "Navigating back to the parity check run" do
@@ -96,7 +96,7 @@ RSpec.describe "View parity check response" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Parity check run ##{response.run.id}").click
-    expect(page.url).to end_with(migration_parity_check_path(response.run))
+    expect(page).to have_path(migration_parity_check_path(response.run))
   end
 
   scenario "Navigating back to completed parity checks" do
@@ -106,7 +106,7 @@ RSpec.describe "View parity check response" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Completed parity checks").click
-    expect(page.url).to end_with(completed_migration_parity_checks_path)
+    expect(page).to have_path(completed_migration_parity_checks_path)
   end
 
   scenario "Navigating back to run a parity check" do
@@ -116,6 +116,6 @@ RSpec.describe "View parity check response" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Run a parity check").click
-    expect(page.url).to end_with(new_migration_parity_check_path)
+    expect(page).to have_path(new_migration_parity_check_path)
   end
 end

--- a/spec/features/migration/view_parity_check_spec.rb
+++ b/spec/features/migration/view_parity_check_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "View parity check" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Completed parity checks").click
-    expect(page.url).to end_with(completed_migration_parity_checks_path)
+    expect(page).to have_path(completed_migration_parity_checks_path)
   end
 
   scenario "Navigating back to run a parity check" do
@@ -52,7 +52,7 @@ RSpec.describe "View parity check" do
 
     breadcrumbs = page.locator(".govuk-breadcrumbs")
     breadcrumbs.get_by_role("link", name: "Run a parity check").click
-    expect(page.url).to end_with(new_migration_parity_check_path)
+    expect(page).to have_path(new_migration_parity_check_path)
   end
 
   scenario "Viewing a parity check with no requests" do

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_in_the_requirements_page
-    expect(page.url).to end_with('/schools/register-ect/what-you-will-need')
+    expect(page).to have_path('/schools/register-ect/what-you-will-need')
   end
 
   def and_i_click_continue
@@ -35,7 +35,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_ect_start_date_page
-    expect(page.url).to end_with('/schools/register-ect/start-date')
+    expect(page).to have_path('/schools/register-ect/start-date')
   end
 
   def when_i_enter_a_valid_start_date
@@ -61,7 +61,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/schools/register-ect/check-answers')
+    expect(page).to have_path('/schools/register-ect/check-answers')
   end
 
   def and_i_see_the_correct_appropriate_body_on_the_page

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_in_the_requirements_page
-    expect(page.url).to end_with('/schools/register-ect/what-you-will-need')
+    expect(page).to have_path('/schools/register-ect/what-you-will-need')
   end
 
   def and_i_click_continue
@@ -41,7 +41,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_ect_start_date_page
-    expect(page.url).to end_with('/schools/register-ect/start-date')
+    expect(page).to have_path('/schools/register-ect/start-date')
   end
 
   def when_i_enter_a_valid_start_date
@@ -61,7 +61,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_training_programme_page
-    expect(page.url).to end_with('/schools/register-ect/training-programme')
+    expect(page).to have_path('/schools/register-ect/training-programme')
   end
 
   def when_i_select_school_led
@@ -73,7 +73,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/schools/register-ect/check-answers')
+    expect(page).to have_path('/schools/register-ect/check-answers')
   end
 
   def and_i_see_the_correct_appropriate_body_on_the_page

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Registering an ECT', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_start_adding_an_ect
@@ -79,7 +79,7 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/schools/register-ect/email-address')
+    expect(page).to have_path('/schools/register-ect/email-address')
   end
 
   def and_i_enter_an_email_address_already_in_use_by_an_ongoing_teacher
@@ -92,7 +92,7 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def then_i_should_be_taken_to_the_cant_use_email_page
-    expect(page.url).to end_with('/schools/register-ect/cant-use-email')
+    expect(page).to have_path('/schools/register-ect/cant-use-email')
   end
 
   def when_i_click_try_another_email
@@ -100,6 +100,6 @@ RSpec.describe 'Registering an ECT', :js do
   end
 
   def then_i_should_be_taken_to_the_ect_start_date_page
-    expect(page.url).to end_with('/schools/register-ect/start-date')
+    expect(page).to have_path('/schools/register-ect/start-date')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Registering an ECT' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_start_adding_an_ect
@@ -37,7 +37,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_in_the_requirements_page
-    expect(page.url).to end_with('/schools/register-ect/what-you-will-need')
+    expect(page).to have_path('/schools/register-ect/what-you-will-need')
   end
 
   def when_i_click_continue
@@ -45,7 +45,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_on_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 
   def when_i_submit_a_trn_and_a_date_of_birth_that_does_not_match
@@ -57,7 +57,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_national_insurance_number_step
-    expect(page.url).to end_with('/schools/register-ect/national-insurance-number')
+    expect(page).to have_path('/schools/register-ect/national-insurance-number')
   end
 
   def when_i_enter_a_matching_national_insurance_number
@@ -66,6 +66,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_review_details_step
-    expect(page.url).to end_with('/schools/register-ect/review-ect-details')
+    expect(page).to have_path('/schools/register-ect/review-ect-details')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_teacher_has_completed_their_induction_error_page
-    expect(page.url).to end_with('/schools/register-ect/induction-completed')
+    expect(page).to have_path('/schools/register-ect/induction-completed')
   end
 
   def when_i_click_register_another_ect
@@ -42,6 +42,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_teacher_has_completed_their_induction_error_page
-    expect(page.url).to end_with('/schools/register-ect/induction-completed')
+    expect(page).to have_path('/schools/register-ect/induction-completed')
   end
 
   def and_i_enter_a_matching_national_insurance_number_but_the_teacher_has_completed_their_induction
@@ -48,6 +48,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_teacher_has_completed_their_induction_error_page
-    expect(page.url).to end_with('/schools/register-ect/induction-exempt')
+    expect(page).to have_path('/schools/register-ect/induction-exempt')
   end
 
   def when_i_click_register_another_ect
@@ -42,6 +42,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_teacher_has_completed_their_induction_error_page
-    expect(page.url).to end_with('/schools/register-ect/induction-exempt')
+    expect(page).to have_path('/schools/register-ect/induction-exempt')
   end
 
   def and_i_enter_a_matching_national_insurance_number_but_the_teacher_has_completed_their_induction
@@ -48,6 +48,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_teacher_has_failed_their_induction_error_page
-    expect(page.url).to end_with('/schools/register-ect/induction-failed')
+    expect(page).to have_path('/schools/register-ect/induction-failed')
   end
 
   def when_i_click_register_another_ect
@@ -41,6 +41,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_teacher_has_failed_their_induction_error_page
-    expect(page.url).to end_with('/schools/register-ect/induction-failed')
+    expect(page).to have_path('/schools/register-ect/induction-failed')
   end
 
   def and_i_enter_a_matching_national_insurance_number_but_the_teacher_has_failed_their_induction
@@ -47,6 +47,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_taken_to_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Registering an ECT' do
   def and_i_am_on_the_find_ect_step_page
     path = '/schools/register-ect/find-ect'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_details_of_the_ect_already_registered
@@ -49,7 +49,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_ect_already_registered_error_page
-    expect(page.url).to end_with('/schools/register-ect/already-active_at-school')
+    expect(page).to have_path('/schools/register-ect/already-active_at-school')
   end
 
   def when_i_click_try_again
@@ -58,6 +58,6 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_find_ect_step_page
     path = '/schools/register-ect/find-ect'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Registering an ECT' do
   def when_i_am_on_the_find_ect_step_page
     path = '/schools/register-ect/find-ect'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_i_submit_details_of_a_prohibited_teacher
@@ -36,7 +36,7 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_cannot_register_ect_page
     path = '/schools/register-ect/cannot-register-ect'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_back_to_ects
@@ -45,6 +45,6 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_school_ects_page
     path = '/schools/home/ects'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Registering an ECT' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_start_adding_an_ect
@@ -40,7 +40,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_in_the_requirements_page
-    expect(page.url).to end_with('/schools/register-ect/what-you-will-need')
+    expect(page).to have_path('/schools/register-ect/what-you-will-need')
   end
 
   def when_i_click_continue
@@ -48,7 +48,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_on_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 
   def when_i_submit_a_date_of_birth_that_does_not_match
@@ -60,7 +60,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_national_insurance_number_step
-    expect(page.url).to end_with('/schools/register-ect/national-insurance-number')
+    expect(page).to have_path('/schools/register-ect/national-insurance-number')
   end
 
   def when_i_enter_a_national_insurance_number_that_does_not_match
@@ -69,7 +69,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_teacher_not_found_error_page
-    expect(page.url).to end_with('/schools/register-ect/not-found')
+    expect(page).to have_path('/schools/register-ect/not-found')
   end
 
   def when_i_click_try_again
@@ -78,6 +78,6 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_find_ect_step_page
     path = '/schools/register-ect/find-ect'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Registering an ECT' do
   def when_i_am_on_the_find_ect_step_page
     path = '/schools/register-ect/find-ect'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def and_i_submit_a_date_of_birth_and_unknown_trn
@@ -36,7 +36,7 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_teacher_not_found_error_page
     path = '/schools/register-ect/trn-not-found'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_try_again
@@ -45,6 +45,6 @@ RSpec.describe 'Registering an ECT' do
 
   def then_i_should_be_taken_to_the_find_ect_step_page
     path = '/schools/register-ect/find-ect'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'Registering an ECT' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_start_adding_an_ect
@@ -150,7 +150,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_in_the_requirements_page
-    expect(page.url).to end_with('/schools/register-ect/what-you-will-need')
+    expect(page).to have_path('/schools/register-ect/what-you-will-need')
   end
 
   def when_i_click_continue
@@ -158,7 +158,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_on_the_find_ect_step_page
-    expect(page.url).to end_with('/schools/register-ect/find-ect')
+    expect(page).to have_path('/schools/register-ect/find-ect')
   end
 
   def when_i_submit_the_find_ect_form(trn:, dob_day:, dob_month:, dob_year:)
@@ -170,7 +170,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_review_ect_details_page
-    expect(page.url).to end_with('/schools/register-ect/review-ect-details')
+    expect(page).to have_path('/schools/register-ect/review-ect-details')
   end
 
   def and_i_should_see_the_ect_details_in_the_review_page
@@ -192,7 +192,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/schools/register-ect/email-address')
+    expect(page).to have_path('/schools/register-ect/email-address')
   end
 
   def when_i_enter_the_ect_email_address
@@ -200,7 +200,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_training_programme_page
-    expect(page.url).to end_with('/schools/register-ect/training-programme')
+    expect(page).to have_path('/schools/register-ect/training-programme')
   end
 
   def when_i_select_school_led
@@ -216,7 +216,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_ect_start_date_page
-    expect(page.url).to end_with('/schools/register-ect/start-date')
+    expect(page).to have_path('/schools/register-ect/start-date')
   end
 
   def when_i_enter_a_valid_start_date
@@ -226,7 +226,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_use_previous_ect_choices_page
-    expect(page.url).to end_with('/schools/register-ect/use-previous-ect-choices')
+    expect(page).to have_path('/schools/register-ect/use-previous-ect-choices')
   end
 
   def and_i_should_see_the_previous_programme_choices
@@ -241,7 +241,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_appropriate_body_page
-    expect(page.url).to end_with('/schools/register-ect/state-school-appropriate-body')
+    expect(page).to have_path('/schools/register-ect/state-school-appropriate-body')
   end
 
   def when_i_select_an_appropriate_body
@@ -251,11 +251,11 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_i_should_be_taken_to_the_working_pattern_page
-    expect(page.url).to end_with('/schools/register-ect/working-pattern')
+    expect(page).to have_path('/schools/register-ect/working-pattern')
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/schools/register-ect/check-answers')
+    expect(page).to have_path('/schools/register-ect/check-answers')
   end
 
   def and_i_should_see_all_the_ect_data_on_the_page
@@ -271,7 +271,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_change_name_page
-    expect(page.url).to end_with('/schools/register-ect/change-review-ect-details')
+    expect(page).to have_path('/schools/register-ect/change-review-ect-details')
   end
 
   def when_i_click_the_back_link
@@ -283,7 +283,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_change_email_address_page
-    expect(page.url).to end_with('/schools/register-ect/change-email-address')
+    expect(page).to have_path('/schools/register-ect/change-email-address')
   end
 
   def when_i_enter_a_new_ect_email_address
@@ -299,7 +299,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_change_user_previous_ect_choices_page
-    expect(page.url).to end_with('/schools/register-ect/change-use-previous-ect-choices')
+    expect(page).to have_path('/schools/register-ect/change-use-previous-ect-choices')
   end
 
   def when_i_select_that_i_want_to_use_the_previous_ect_choices
@@ -311,7 +311,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_change_the_appropriate_body_page
-    expect(page.url).to end_with('/schools/register-ect/change-state-school-appropriate-body')
+    expect(page).to have_path('/schools/register-ect/change-state-school-appropriate-body')
   end
 
   def when_i_select_a_different_appropriate_body
@@ -325,7 +325,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_change_training_programme_page
-    expect(page.url).to end_with('/schools/register-ect/change-training-programme')
+    expect(page).to have_path('/schools/register-ect/change-training-programme')
   end
 
   def when_i_select_provider_led
@@ -333,7 +333,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_training_programme_change_lead_provider_page
-    expect(page.url).to end_with('/schools/register-ect/training-programme-change-lead-provider')
+    expect(page).to have_path('/schools/register-ect/training-programme-change-lead-provider')
   end
 
   def when_i_select_a_lead_provider
@@ -361,7 +361,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/schools/register-ect/confirmation')
+    expect(page).to have_path('/schools/register-ect/confirmation')
   end
 
   def when_i_click_on_back_to_your_ects
@@ -369,6 +369,6 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 end

--- a/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
+++ b/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_on_the_registered_before_page
-    expect(page.url).to end_with('/schools/register-ect/registered-before')
+    expect(page).to have_path('/schools/register-ect/registered-before')
   end
 
   def given_i_am_logged_in_as_a_state_funded_school_user_who_has_previously_registered_an_ect
@@ -90,10 +90,10 @@ RSpec.describe 'Registering an ECT' do
   end
 
   def then_i_am_on_the_email_address_page
-    expect(page.url).to end_with('/schools/register-ect/email-address')
+    expect(page).to have_path('/schools/register-ect/email-address')
   end
 
   def then_i_am_on_the_review_ect_details_page
-    expect(page.url).to end_with('/schools/register-ect/review-ect-details')
+    expect(page).to have_path('/schools/register-ect/review-ect-details')
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Registering a mentor', :js do
   def then_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -67,7 +67,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_am_in_the_who_will_mentor_page
     expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/new")
   end
 
   def when_i_select_register_a_new_mentor
@@ -86,7 +86,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_a_trn_and_a_date_of_birth_that_does_not_match
@@ -98,7 +98,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_national_insurance_number_step
-    expect(page.url).to end_with('/school/register-mentor/national-insurance-number')
+    expect(page).to have_path('/school/register-mentor/national-insurance-number')
   end
 
   def when_i_enter_a_matching_national_insurance_number_for_the_existing_mentor
@@ -107,7 +107,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_already_active_at_school_page
-    expect(page.url).to end_with('/school/register-mentor/already-active-at-school')
+    expect(page).to have_path('/school/register-mentor/already-active-at-school')
   end
 
   def when_i_click_to_assign_the_existing_mentor_to_the_ect
@@ -115,7 +115,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def when_i_click_on_back_to_ects
@@ -123,7 +123,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_the_ect_is_shown_linked_to_the_existing_mentor

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Registering a mentor', :js do
   def then_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -64,7 +64,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_am_in_the_who_will_mentor_page
     expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/new")
   end
 
   def when_i_select_register_a_new_mentor
@@ -83,7 +83,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form_with_the_existing_mentor_data
@@ -95,7 +95,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_already_active_at_school_page
-    expect(page.url).to end_with('/school/register-mentor/already-active-at-school')
+    expect(page).to have_path('/school/register-mentor/already-active-at-school')
   end
 
   def when_i_click_to_assign_the_existing_mentor_to_the_ect
@@ -103,7 +103,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def when_i_click_on_back_to_ects
@@ -111,7 +111,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_the_ect_is_shown_linked_to_the_existing_mentor

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Registering a mentor' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -57,7 +57,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_details_of_the_ect
@@ -69,7 +69,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_cannot_mentor_themself_page
-    expect(page.url).to end_with('/school/register-mentor/cannot-mentor-themself')
+    expect(page).to have_path('/school/register-mentor/cannot-mentor-themself')
   end
 
   def when_i_click_on_assign_a_different_mentor

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -76,7 +76,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -92,7 +92,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -114,7 +114,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_an_email_address_already_in_use
@@ -126,7 +126,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_cant_use_email_page
-    expect(page.url).to end_with('/school/register-mentor/cant-use-email')
+    expect(page).to have_path('/school/register-mentor/cant-use-email')
   end
 
   def when_i_click_try_another_email

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Registering a mentor' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -57,7 +57,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_a_trn_and_a_date_of_birth_that_does_not_match
@@ -69,7 +69,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_national_insurance_number_step
-    expect(page.url).to end_with('/school/register-mentor/national-insurance-number')
+    expect(page).to have_path('/school/register-mentor/national-insurance-number')
   end
 
   def when_i_enter_a_matching_national_insurance_number
@@ -78,6 +78,6 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_review_details_step
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Registering a mentor' do
   def then_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -59,7 +59,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_am_in_the_who_will_mentor_page
     expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/new")
   end
 
   def when_i_select_register_a_new_mentor
@@ -78,7 +78,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_details_of_a_prohibited_teacher
@@ -91,7 +91,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_cannot_register_mentor_page
     path = '/school/register-mentor/cannot-register-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_back_to_ects
@@ -100,6 +100,6 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_school_ects_page
     path = '/schools/home/ects'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Registering a mentor' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -52,7 +52,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_they_do_not_have_a_trn
@@ -60,6 +60,6 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_no_trn_page
-    expect(page.url).to end_with('/school/register-mentor/no-trn')
+    expect(page).to have_path('/school/register-mentor/no-trn')
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Registering a mentor' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -59,7 +59,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_a_date_of_birth_that_does_not_match
@@ -71,7 +71,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_national_insurance_number_step
-    expect(page.url).to end_with('/school/register-mentor/national-insurance-number')
+    expect(page).to have_path('/school/register-mentor/national-insurance-number')
   end
 
   def when_i_enter_a_national_insurance_number_that_does_not_match
@@ -80,7 +80,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_not_found_error_page
-    expect(page.url).to end_with('/school/register-mentor/not-found')
+    expect(page).to have_path('/school/register-mentor/not-found')
   end
 
   def when_i_click_try_again
@@ -88,6 +88,6 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_find_mentor_step_page
-    expect(page.url).to end_with('/school/register-mentor/find-mentor')
+    expect(page).to have_path('/school/register-mentor/find-mentor')
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -95,7 +95,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -111,7 +111,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -133,7 +133,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -145,7 +145,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentoring_at_your_school_only_page
-    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+    expect(page).to have_path('/school/register-mentor/mentoring-at-new-school-only')
   end
 
   def when_i_select_no_they_will_also_be_mentoring_at_another_school
@@ -154,7 +154,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -173,7 +173,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def and_mentor_has_mentorship_with_new_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -106,7 +106,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -122,7 +122,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -144,7 +144,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -156,7 +156,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentoring_at_your_school_only_page
-    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+    expect(page).to have_path('/school/register-mentor/mentoring-at-new-school-only')
   end
 
   def when_i_select_yes_they_will_be_mentoring_at_our_school_only
@@ -165,7 +165,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentor_start_date_page
-    expect(page.url).to end_with('/school/register-mentor/started-on')
+    expect(page).to have_path('/school/register-mentor/started-on')
   end
 
   def when_i_enter_mentor_start_date
@@ -176,7 +176,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_previous_training_period_details_page
-    expect(page.url).to end_with('/school/register-mentor/previous-training-period-details')
+    expect(page).to have_path('/school/register-mentor/previous-training-period-details')
   end
 
   def and_i_should_see_previous_training_period_details
@@ -189,7 +189,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_programme_choices_page
-    expect(page.url).to end_with('/school/register-mentor/programme-choices')
+    expect(page).to have_path('/school/register-mentor/programme-choices')
   end
 
   def when_i_select_no_choose_lead_provider
@@ -198,7 +198,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_lead_provider_page
-    expect(page.url).to end_with('/school/register-mentor/lead-provider')
+    expect(page).to have_path('/school/register-mentor/lead-provider')
   end
 
   def when_i_select_a_different_lead_provider
@@ -207,7 +207,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -230,7 +230,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def and_mentor_has_mentorship_with_new_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -104,7 +104,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -120,7 +120,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -142,7 +142,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -154,7 +154,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentoring_at_your_school_only_page
-    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+    expect(page).to have_path('/school/register-mentor/mentoring-at-new-school-only')
   end
 
   def when_i_select_yes_they_will_be_mentoring_at_our_school_only
@@ -163,7 +163,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentor_start_date_page
-    expect(page.url).to end_with('/school/register-mentor/started-on')
+    expect(page).to have_path('/school/register-mentor/started-on')
   end
 
   def when_i_enter_mentor_start_date
@@ -174,7 +174,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_previous_training_period_details_page
-    expect(page.url).to end_with('/school/register-mentor/previous-training-period-details')
+    expect(page).to have_path('/school/register-mentor/previous-training-period-details')
   end
 
   def and_i_should_see_previous_training_period_details
@@ -187,7 +187,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_programme_choices_page
-    expect(page.url).to end_with('/school/register-mentor/programme-choices')
+    expect(page).to have_path('/school/register-mentor/programme-choices')
   end
 
   def when_i_select_yes_use_same_programme_choices
@@ -196,7 +196,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -219,7 +219,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def and_mentor_has_mentorship_with_new_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -88,7 +88,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -104,7 +104,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -126,7 +126,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -138,7 +138,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentoring_at_your_school_only_page
-    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+    expect(page).to have_path('/school/register-mentor/mentoring-at-new-school-only')
   end
 
   def when_i_select_yes_they_will_be_mentoring_at_our_school_only
@@ -147,7 +147,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentor_start_date_page
-    expect(page.url).to end_with('/school/register-mentor/started-on')
+    expect(page).to have_path('/school/register-mentor/started-on')
   end
 
   def when_i_enter_mentor_start_date
@@ -158,7 +158,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -179,7 +179,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def and_mentor_has_mentorship_with_new_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -88,7 +88,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -104,7 +104,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -126,7 +126,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -138,7 +138,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentoring_at_your_school_only_page
-    expect(page.url).to end_with('/school/register-mentor/mentoring-at-new-school-only')
+    expect(page).to have_path('/school/register-mentor/mentoring-at-new-school-only')
   end
 
   def when_i_select_yes_they_will_be_mentoring_at_our_school_only
@@ -147,7 +147,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_mentor_start_date_page
-    expect(page.url).to end_with('/school/register-mentor/started-on')
+    expect(page).to have_path('/school/register-mentor/started-on')
   end
 
   def when_i_enter_mentor_start_date
@@ -158,7 +158,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -179,7 +179,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def and_mentor_has_mentorship_with_new_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Registering a mentor' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -57,7 +57,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_a_date_of_birth_and_unknown_trn
@@ -69,7 +69,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_teacher_not_found_error_page
-    expect(page.url).to end_with('/school/register-mentor/trn-not-found')
+    expect(page).to have_path('/school/register-mentor/trn-not-found')
   end
 
   def when_i_click_try_again
@@ -78,6 +78,6 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_step_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Registering a mentor' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -57,7 +57,7 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_a_date_of_birth_and_unknown_trn
@@ -69,7 +69,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def then_i_should_be_taken_to_the_teacher_not_found_error_page
-    expect(page.url).to end_with('/school/register-mentor/trn-not-found')
+    expect(page).to have_path('/school/register-mentor/trn-not-found')
   end
 
   def when_i_click_try_again
@@ -78,6 +78,6 @@ RSpec.describe 'Registering a mentor' do
 
   def then_i_should_be_taken_to_the_find_mentor_step_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 end

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Registering a mentor', :js do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -127,7 +127,7 @@ RSpec.describe 'Registering a mentor', :js do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form
@@ -143,7 +143,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -165,7 +165,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -181,7 +181,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_change_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/change-mentor-details')
+    expect(page).to have_path('/school/register-mentor/change-mentor-details')
   end
 
   def and_i_should_see_the_corrected_name
@@ -193,7 +193,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_change_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/change-email-address')
+    expect(page).to have_path('/school/register-mentor/change-email-address')
   end
 
   def and_i_should_see_the_current_email
@@ -201,7 +201,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+    expect(page).to have_path('/school/register-mentor/review-mentor-eligibility')
   end
 
   def and_i_should_see_mentor_funding_on_the_page
@@ -210,7 +210,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -227,7 +227,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def when_i_click_on_back_to_ects
@@ -235,7 +235,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_the_ect_is_shown_linked_to_the_mentor_just_registered

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_click_confirm_and_continue
@@ -92,7 +92,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -100,7 +100,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+    expect(page).to have_path('/school/register-mentor/review-mentor-eligibility')
   end
 
   def when_i_click_choose_another_provider_link
@@ -108,7 +108,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def then_i_should_be_taken_to_eligibility_lead_provider_page
-    expect(page.url).to end_with('/school/register-mentor/eligibility-lead-provider')
+    expect(page).to have_path('/school/register-mentor/eligibility-lead-provider')
   end
 
   def when_i_select_a_different_lead_provider
@@ -117,7 +117,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -136,7 +136,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def trn

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -50,7 +50,7 @@ private
   end
 
   def then_i_am_back_on_the_mentor_details_page
-    expect(page.url).to end_with(schools_mentor_path(@mentor))
+    expect(page).to have_path(schools_mentor_path(@mentor))
   end
 
   def and_i_sign_in_as_a_school
@@ -66,10 +66,10 @@ private
   end
 
   def then_i_am_on_the_mentor_details_page
-    expect(page.url).to end_with("/schools/mentors/#{@mentor.id}")
+    expect(page).to have_path("/schools/mentors/#{@mentor.id}")
   end
 
   def then_i_am_on_the_mentors_index_page
-    expect(page.url).to end_with('/schools/home/mentors')
+    expect(page).to have_path('/schools/home/mentors')
   end
 end

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Add a mentor to a provider led ECT' do
 
   def then_i_am_on_the_who_will_mentor_page
     expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/new")
   end
 
   def and_i_am_back_on_the_who_will_mentor_page
@@ -130,12 +130,12 @@ RSpec.describe 'Add a mentor to a provider led ECT' do
   end
 
   def then_i_should_be_taken_to_the_eligibility_page
-    expect(page.url).to end_with("assign-existing-mentor/review-mentor-eligibility")
+    expect(page).to have_path("/school/assign-existing-mentor/review-mentor-eligibility")
     expect(page.get_by_text("#{@mentor_name} can receive mentor training")).to be_visible
   end
 
   def then_i_should_be_taken_to_the_mentorship_confirmation_page
-    expect(page.url).to end_with("/school/assign-existing-mentor/confirmation")
+    expect(page).to have_path("/school/assign-existing-mentor/confirmation")
     expect(page.get_by_text("You’ve assigned #{@mentor_name} as a mentor for #{@ect_name}")).to be_visible
   end
 
@@ -144,7 +144,7 @@ RSpec.describe 'Add a mentor to a provider led ECT' do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_the_ect_is_shown_linked_to_the_mentor_just_registered

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Add a mentor to a school led ECT' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -51,7 +51,7 @@ RSpec.describe 'Add a mentor to a school led ECT' do
 
   def then_i_am_in_the_who_will_mentor_page
     expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/new")
   end
 
   def when_i_select_the_mentor
@@ -60,7 +60,7 @@ RSpec.describe 'Add a mentor to a school led ECT' do
   end
 
   def then_i_should_be_taken_to_the_mentorship_confirmation_page
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/confirmation")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/confirmation")
     expect(page.get_by_text("You’ve assigned #{@mentor_name} as a mentor for #{@ect_name}")).to be_visible
   end
 
@@ -69,7 +69,7 @@ RSpec.describe 'Add a mentor to a school led ECT' do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_the_ect_is_shown_linked_to_the_mentor_just_registered

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   def and_i_am_on_the_schools_landing_page
     path = '/schools/home/ects'
     page.goto path
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
@@ -85,7 +85,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
 
   def then_i_am_in_the_who_will_mentor_page
     expect(page.get_by_text("Who will mentor #{@ect_name}?")).to be_visible
-    expect(page.url).to end_with("/school/ects/#{@ect.id}/mentorship/new")
+    expect(page).to have_path("/school/ects/#{@ect.id}/mentorship/new")
   end
 
   def when_i_select_register_a_new_mentor
@@ -104,7 +104,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
 
   def then_i_should_be_taken_to_the_find_mentor_page
     path = '/school/register-mentor/find-mentor'
-    expect(page.url).to end_with(path)
+    expect(page).to have_path(path)
   end
 
   def when_i_submit_the_find_mentor_form(trn:, dob_day:, dob_month:, dob_year:)
@@ -116,7 +116,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_eligibility_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-eligibility')
+    expect(page).to have_path('/school/register-mentor/review-mentor-eligibility')
   end
 
   def and_i_should_see_mentor_funding_on_the_page
@@ -125,7 +125,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def then_i_should_be_taken_to_the_review_mentor_details_page
-    expect(page.url).to end_with('/school/register-mentor/review-mentor-details')
+    expect(page).to have_path('/school/register-mentor/review-mentor-details')
   end
 
   def and_i_should_see_the_mentor_details_in_the_review_page
@@ -143,7 +143,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def then_i_should_be_taken_to_the_email_address_page
-    expect(page.url).to end_with('/school/register-mentor/email-address')
+    expect(page).to have_path('/school/register-mentor/email-address')
   end
 
   def when_i_enter_the_mentor_email_address
@@ -155,7 +155,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def then_i_should_be_taken_to_the_check_answers_page
-    expect(page.url).to end_with('/school/register-mentor/check-answers')
+    expect(page).to have_path('/school/register-mentor/check-answers')
   end
 
   def and_i_should_see_all_the_mentor_data_on_the_page
@@ -174,7 +174,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def then_i_should_be_taken_to_the_confirmation_page
-    expect(page.url).to end_with('/school/register-mentor/confirmation')
+    expect(page).to have_path('/school/register-mentor/confirmation')
   end
 
   def when_i_click_on_back_to_ects
@@ -182,7 +182,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def then_i_should_be_taken_to_the_ects_page
-    expect(page.url).to end_with('/schools/home/ects')
+    expect(page).to have_path('/schools/home/ects')
   end
 
   def and_the_ect_is_shown_linked_to_the_mentor_just_registered


### PR DESCRIPTION
### Context

We have a Capybara style `have_current_path` equivalent: `expect(page).to have_path(path)`

### Changes proposed in this pull request

Use in remaining specs where applicable

### Guidance to review

https://github.com/user-attachments/assets/a721f4a2-9db8-425e-b7a5-a64f92f3ad80

