### PR TITLE
Add response ID diffs to parity check

### DIFF
--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -68,6 +68,10 @@ module ParityCheckHelper
     "🐌 #{formatted_ratio}x slower"
   end
 
+  def id_count_in_words(ids)
+    %(#{number_with_delimiter(ids.count)} #{'ID'.pluralize(ids.count)})
+  end
+
   def comparison_in_words(matching)
     if matching
       "the same"
@@ -77,7 +81,7 @@ module ParityCheckHelper
   end
 
   def sanitize_diff(html)
-    sanitize html, tags: %w[div ul li strong del ins span], attributes: %w[class]
+    sanitize html, tags: %w[div ul li strong del ins span br], attributes: %w[class]
   end
 
   def render_filterable_key_hash(hash, key_path: [], &block)

--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -80,5 +80,33 @@ module ParityCheck
 
       rates.sum.fdiv(rates.size).round
     end
+
+    def pretty_json(ugly_json)
+      JSON.pretty_generate(ugly_json)
+    end
+
+    def response_body_ids_different?
+      responses.any?(&:body_ids_different?)
+    end
+
+    def response_body_ids_matching?
+      !response_body_ids_different?
+    end
+
+    def ecf_response_body_ids
+      responses.map(&:ecf_body_ids).flatten.sort
+    end
+
+    def rect_response_body_ids
+      responses.map(&:rect_body_ids).flatten.sort
+    end
+
+    def ecf_only_response_body_ids
+      ecf_response_body_ids - rect_response_body_ids
+    end
+
+    def rect_only_response_body_ids
+      rect_response_body_ids - ecf_response_body_ids
+    end
   end
 end

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -59,6 +59,14 @@ module ParityCheck
       !bodies_matching?
     end
 
+    def body_ids_matching?
+      ecf_body_ids == rect_body_ids
+    end
+
+    def body_ids_different?
+      !body_ids_matching?
+    end
+
     def body_diff
       @body_diff ||= Diffy::Diff.new(ecf_body, rect_body, context: 3)
     end
@@ -72,18 +80,45 @@ module ParityCheck
     end
 
     def ecf_body=(value)
-      super(pretty_json(value))
+      super(format_body(value))
     end
 
     def rect_body=(value)
-      super(pretty_json(value))
+      super(format_body(value))
+    end
+
+    def ecf_body_ids
+      return [] unless ecf_body_hash
+
+      Array.wrap(ecf_body_hash[:data]).map { it[:id] }.sort
+    end
+
+    def rect_body_ids
+      return [] unless rect_body_hash
+
+      Array.wrap(rect_body_hash[:data]).map { it[:id] }.sort
+    end
+
+    def ecf_only_body_ids
+      ecf_body_ids - rect_body_ids
+    end
+
+    def rect_only_body_ids
+      rect_body_ids - ecf_body_ids
     end
 
   private
 
-    def pretty_json(value)
-      parsed_json = parse_json_body(value)
-      parsed_json ? JSON.pretty_generate(parsed_json) : value
+    def format_body(body)
+      parsed_json = parse_json_body(body)
+
+      return body unless parsed_json
+
+      pretty_json(parsed_json)
+    end
+
+    def pretty_json(ugly_json)
+      JSON.pretty_generate(ugly_json)
     end
 
     def parse_json_body(body)

--- a/app/views/migration/parity_checks/requests/_response_body_ids_diff.html.erb
+++ b/app/views/migration/parity_checks/requests/_response_body_ids_diff.html.erb
@@ -1,0 +1,18 @@
+<% if request.response_body_ids_different? %>
+  <span class="body-ids-diff">
+    <%= govuk_list do %>
+      <% request.ecf_only_response_body_ids.each do |id| %>
+        <%= tag.li(tag.span(class: "diff red") { id }) %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_list do %>
+      <% request.ecf_only_response_body_ids.each do |id| %>
+        <%= tag.li(tag.span(class: "diff green") { id }) %>
+      <% end %>
+    <% end %>
+  </span>
+<% else %>
+  <p class="no-differences govuk-!-font-size-27">No differences found 🙌</p>
+<% end %>
+

--- a/app/views/migration/parity_checks/requests/show.html.erb
+++ b/app/views/migration/parity_checks/requests/show.html.erb
@@ -10,6 +10,11 @@
   <strong><%= performance_gain(@request.rect_performance_gain_ratio) %></strong> performance when compared to ECF.
 </p>
 
+<p>
+  The response IDs were <strong><%= comparison_in_words(@request.response_body_ids_matching?) %></strong>. In total  
+  RECT returned <strong><%= id_count_in_words(@request.rect_response_body_ids) %></strong> and ECF returned <strong><%= id_count_in_words(@request.ecf_response_body_ids) %></strong>.
+</p>
+
 <hr class="govuk-section-break govuk-section-break--l">
 
 <%= govuk_table(classes: %w[parity-check-responses-table]) do |table|
@@ -71,3 +76,31 @@
 end %>
 
 <%= govuk_pagination(pagy: @pagy) %>
+
+
+<% if @request.response_body_ids_different? %>
+  <% content_for(:head) do %>
+    <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
+  <% end %>
+  
+  <hr class="govuk-section-break govuk-section-break--l">
+
+  <h2 class="govuk-heading-l">Response IDs</h2>
+
+  <div class="govuk-grid-row diff-container">
+    <div class="govuk-grid-column-one-third">
+      <p>
+        There <%= "was".pluralize(@request.ecf_only_response_body_ids.count) %> <span class="diff red"><%= id_count_in_words(@request.ecf_only_response_body_ids) %></span>
+        returned by ECF that were not returned by RECT.
+      </p>
+
+      <p>
+        There <%= "was".pluralize(@request.rect_only_response_body_ids.count) %> <span class="diff green"><%= id_count_in_words(@request.rect_only_response_body_ids) %></span>
+        returned by RECT that were not returned by ECF.
+      </p>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render partial: "response_body_ids_diff", locals: { request: @request } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/migration/parity_checks/responses/_body_diff.html.erb
+++ b/app/views/migration/parity_checks/responses/_body_diff.html.erb
@@ -1,5 +1,5 @@
 <% if response.bodies_different? %>
-  <%= sanitize_diff(response.body_diff.to_s(:html)) %>
+  <span class="body-diff"><%= sanitize_diff(response.body_diff.to_s(:html)) %></span>
 <% else %>
   <p class="no-differences govuk-!-font-size-27">No differences found 🙌</p>
 <% end %>

--- a/app/views/migration/parity_checks/responses/_body_ids_diff.html.erb
+++ b/app/views/migration/parity_checks/responses/_body_ids_diff.html.erb
@@ -1,0 +1,18 @@
+<% if response.body_ids_different? %>
+  <span class="body-ids-diff">
+    <%= govuk_list do %>
+      <% response.ecf_only_body_ids.each do |id| %>
+        <%= tag.li(tag.span(class: "diff red") { id }) %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_list do %>
+      <% response.ecf_only_body_ids.each do |id| %>
+        <%= tag.li(tag.span(class: "diff green") { id }) %>
+      <% end %>
+    <% end %>
+  </span>
+<% else %>
+  <p class="no-differences govuk-!-font-size-27">No differences found 🙌</p>
+<% end %>
+

--- a/app/views/migration/parity_checks/responses/show.html.erb
+++ b/app/views/migration/parity_checks/responses/show.html.erb
@@ -15,7 +15,12 @@
   <strong><%= performance_gain(@response.rect_performance_gain_ratio) %></strong> performance when compared to ECF.
 </p>
 
-<% if @response.bodies_different? %>
+<p>
+  The response IDs were <strong><%= comparison_in_words(@response.body_ids_matching?) %></strong>. In total
+  RECT returned <strong><%= id_count_in_words(@response.rect_body_ids) %></strong> and ECF returned <strong><%= id_count_in_words(@response.ecf_body_ids) %></strong>.
+</p>
+
+<% if @response.bodies_different? || @response.body_ids_different? %>
   <% content_for(:head) do %>
     <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
   <% end %>
@@ -26,24 +31,51 @@
     </p>
     
     <p>
-      Sections <span class="diff green">in green</span> show content that exists 
-      in the RECT response but is missing from the ECF response.
-    </p>
-
-    <p>
       Sections <span class="diff red">in red</span> show content that exists 
       in the ECF response but is missing from the RECT response.
     </p>
-  <% end %>
 
+    <p>
+      Sections <span class="diff green">in green</span> show content that exists 
+      in the RECT response but is missing from the ECF response.
+    </p>
+  <% end %>
+<% end %>
+
+<% if @response.bodies_different? %>
   <hr class="govuk-section-break govuk-section-break--l">
+
+  <h2 class="govuk-heading-l">Response body</h2>
 
   <div class="govuk-grid-row diff-container">
     <div class="govuk-grid-column-one-third">
       <%= render partial: "filter", locals: { filter: @filter } if @filter.filterable? %>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <%= render partial: "diff", locals: { response: @filter.filtered_response } %>
+      <%= render partial: "body_diff", locals: { response: @filter.filtered_response } %>
+    </div>
+  </div>
+<% end %>
+
+<% if @response.body_ids_different? %>
+  <hr class="govuk-section-break govuk-section-break--l">
+
+  <h2 class="govuk-heading-l">Response IDs</h2>
+
+  <div class="govuk-grid-row diff-container">
+    <div class="govuk-grid-column-one-third">
+      <p>
+        There <%= "was".pluralize(@response.ecf_only_body_ids.count) %> <span class="diff red"><%= id_count_in_words(@response.ecf_only_body_ids) %></span>
+        returned by ECF that were not returned by RECT.
+      </p>
+
+      <p>
+        There <%= "was".pluralize(@response.rect_only_body_ids.count) %> <span class="diff green"><%= id_count_in_words(@response.rect_only_body_ids) %></span>
+        returned by RECT that were not returned by ECF.
+      </p>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render partial: "body_ids_diff", locals: { response: @response } %>
     </div>
   </div>
 <% end %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -24,4 +24,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "ITT" # Initial teacher training
   inflect.acronym "OmniAuth"
   inflect.acronym "OpenID"
+
+  inflect.irregular "was", "were"
 end

--- a/db/seeds/parity_checks.rb
+++ b/db/seeds/parity_checks.rb
@@ -24,10 +24,26 @@ def create_in_progress_request(run:, lead_provider:, endpoint:)
 end
 
 def create_response(request, response_type, page)
-  options = { key: "Name.first_name", value: "Name.last_name" }
-  ecf_body = Faker::Json.shallow_json(width: 3, options:)
-  different_json = { data: { attributes: { name: Faker::Name.name, address: Faker::Address.full_address }, another: "test" } }.to_json
-  rect_body = response_type == :matching ? ecf_body : different_json
+  generate_response_item = -> {
+    {
+      id: SecureRandom.uuid,
+      attributes: {
+        name: Faker::Name.name,
+        address: Faker::Address.full_address
+      },
+      another: "test"
+    }
+  }
+  num_items = rand(1..5)
+  generate_response = -> {
+    items = Array.new(num_items) { generate_response_item.call }
+    {
+      data: items.size == 1 ? items.first : items
+    }.to_json
+  }
+
+  ecf_body = generate_response.call
+  rect_body = response_type == :matching ? ecf_body : generate_response.call
 
   ParityCheck::Response.create!(
     request:,

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "View parity check request" do
     expect(page.get_by_text("Overall the request was 50% successful")).to be_visible
     expect(page.get_by_text(/(equal|faster|slower) performance when compared to ECF/)).to be_visible
 
+    expect(page.get_by_text("The response IDs were the same. In total RECT returned 0 IDs and ECF returned 0 IDs.")).to be_visible
+
     table = page.locator("table")
     expect(table.get_by_text("Responses")).to be_visible
 
@@ -45,6 +47,21 @@ RSpec.describe "View parity check request" do
     end
 
     expect(page.locator(".govuk-pagination")).not_to be_visible
+  end
+
+  scenario "Viewing a parity check request with different IDs in the responses" do
+    run = FactoryBot.create(:parity_check_run, :completed)
+    response = FactoryBot.create(:parity_check_response, ecf_body: { data: [{ id: 123 }] }.to_json, rect_body: { data: [{ id: 456 }] }.to_json)
+    request = FactoryBot.create(:parity_check_request, :completed, run:, responses: [response])
+
+    page.goto(migration_parity_check_request_path(run, request))
+
+    expect(page.get_by_text("The response IDs were different. In total RECT returned 1 ID and ECF returned 1 ID.")).to be_visible
+
+    expect(page.get_by_role("heading", name: "Response IDs")).to be_visible
+
+    expect(page.get_by_text("There was 1 ID returned by ECF that were not returned by RECT.")).to be_visible
+    expect(page.get_by_text("There was 1 ID returned by RECT that were not returned by ECF.")).to be_visible
   end
 
   scenario "Paginating the parity check responses when there are many" do

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "View parity check response" do
 
   scenario "Viewing a parity check response" do
     run = FactoryBot.create(:parity_check_run, :completed)
-    response = FactoryBot.create(:parity_check_response, :different)
+    response = FactoryBot.create(:parity_check_response, :different, page: 1)
     request = FactoryBot.create(:parity_check_request, :completed, run:, responses: [response])
 
     page.goto(migration_parity_check_request_path(run, request))
@@ -22,6 +22,8 @@ RSpec.describe "View parity check response" do
     expect(page.get_by_text("The response bodies were different")).to be_visible
     expect(page.get_by_text(/(equal|faster|slower) performance when compared to ECF/)).to be_visible
 
+    expect(page.get_by_text("The response IDs were the same. In total RECT returned 0 IDs and ECF returned 0 IDs.")).to be_visible
+
     expect(page.get_by_text(/The diff below highlights/)).not_to be_visible
     page.get_by_text("Understanding the differences").click
     expect(page.get_by_text(/The diff below highlights/)).to be_visible
@@ -33,12 +35,31 @@ RSpec.describe "View parity check response" do
     expect(page.locator(".diff-filter")).not_to be_visible
   end
 
+  scenario "Viewing a parity check response with different IDs" do
+    run = FactoryBot.create(:parity_check_run, :completed)
+    rect_body = { data: { id: 456 } }.to_json
+    ecf_body = { data: { id: 123 } }.to_json
+    response = FactoryBot.create(:parity_check_response, ecf_body:, rect_body:)
+    FactoryBot.create(:parity_check_request, :completed, run:, responses: [response])
+
+    page.goto(migration_parity_check_response_path(response.run, response))
+
+    expect(page.get_by_text("The response IDs were different. In total RECT returned 1 ID and ECF returned 1 ID.")).to be_visible
+
+    expect(page.get_by_role("heading", name: "Response IDs")).to be_visible
+
+    expect(page.get_by_text("There was 1 ID returned by ECF that were not returned by RECT.")).to be_visible
+    expect(page.get_by_text("There was 1 ID returned by RECT that were not returned by ECF.")).to be_visible
+  end
+
   scenario "Viewing a parity check response where the bodies are filterable", :js do
     ecf_body = { key: { nested: :value, additional_nested: :nested_data } }.to_json
     rect_body = { key: { nested: :different_value }, additional: :data }.to_json
     response = FactoryBot.create(:parity_check_response, ecf_body:, rect_body:)
 
     page.goto(migration_parity_check_response_path(response.run, response))
+
+    expect(page.get_by_role("heading", name: "Response IDs")).not_to be_visible
 
     diff = page.locator(".diff")
     expect(diff.locator(".del").get_by_text(%("nested": "value"))).to be_visible

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -57,6 +57,28 @@ RSpec.describe ParityCheckHelper, type: :helper do
     it { is_expected.to eq(%(<ul class=\"govuk-list\"><li>Participant declarations</li><li>Users</li></ul>)) }
   end
 
+  describe "#id_count_in_words" do
+    subject { helper.id_count_in_words(ids) }
+
+    context "when there are no ids" do
+      let(:ids) { [] }
+
+      it { is_expected.to eq("0 IDs") }
+    end
+
+    context "when there is one id" do
+      let(:ids) { [123] }
+
+      it { is_expected.to eq("1 ID") }
+    end
+
+    context "when there are multiple ids" do
+      let(:ids) { Array.new(1001) }
+
+      it { is_expected.to eq("1,001 IDs") }
+    end
+  end
+
   describe "#match_rate_tag" do
     {
       0 => "red",


### PR DESCRIPTION
### Context

When a parity check request fails its often hard to figure out if the underlying objects are the same (even if their contents are different).

### Changes proposed in this pull request

- Add response ID diffs to parity check

Add response ID diff section to both the request page (to show differences across all responses) and the individual response page.

### Guidance to review

| Request    | Response |
| -------- | ------- |
| <img width="3384" height="4036" alt="screencapture-0-0-0-0-3000-migration-parity-checks-2-requests-29-2025-09-05-14_16_30" src="https://github.com/user-attachments/assets/5919e99e-9afc-44df-9158-3e3f72719eae" />  | <img width="3384" height="4866" alt="screencapture-0-0-0-0-3000-migration-parity-checks-2-responses-56-2025-09-05-14_15_37" src="https://github.com/user-attachments/assets/b1160b5b-64c5-471a-864d-920e3db42118" />   |

