### PR TITLE
[2304] Use FactoryBot in DB seeds

### DIFF
--- a/db/seeds/api_tokens.rb
+++ b/db/seeds/api_tokens.rb
@@ -6,7 +6,11 @@ maximum_lead_provider_name_length = LeadProvider.maximum("LENGTH(name)")
 
 LeadProvider.find_each do |lead_provider|
   token = lead_provider.name.parameterize
-  API::TokenManager.create_lead_provider_api_token!(lead_provider:, token:)
+  FactoryBot.create(:api_token,
+                    lead_provider:,
+                    token:,
+                    description: "A lead provider token for #{lead_provider.name}",
+                    last_used_at: nil)
 
   lead_provider_name = lead_provider.name.ljust(maximum_lead_provider_name_length)
   describe_api_token(lead_provider_name, token)

--- a/db/seeds/appropriate_bodies.rb
+++ b/db/seeds/appropriate_bodies.rb
@@ -2,7 +2,7 @@ def describe_appropriate_body(appropriate_body)
   print_seed_info(appropriate_body.name, indent: 2)
 end
 
-AppropriateBody.create!([
+[
   {
     body_type: 'teaching_school_hub',
     name: 'Angel Oak Academy', # Used by developers for DfE Sign In
@@ -46,8 +46,10 @@ AppropriateBody.create!([
     body_type: 'teaching_school_hub',
     name: 'Vista College',
   }
-]).each do |describe_appropriate|
-  describe_appropriate_body(describe_appropriate)
+].each do |describe_appropriate|
+  FactoryBot.create(:appropriate_body, **describe_appropriate).tap do |appropriate_body|
+    describe_appropriate_body(appropriate_body)
+  end
 end
 
 # - local development environment uses the test UUID

--- a/db/seeds/contract_periods.rb
+++ b/db/seeds/contract_periods.rb
@@ -10,10 +10,7 @@ end
   2025 => true,
   2026 => false
 }.each do |year, enabled|
-  ContractPeriod.create!(
-    year:,
-    started_on: Date.new(year, 6, 1),
-    finished_on: Date.new(year + 1, 5, 31),
-    enabled:
-  ).tap { |rp| describe_contract_period(rp) }
+  FactoryBot.create(:contract_period,
+                    year:,
+                    enabled:).tap { |cp| describe_contract_period(cp) }
 end

--- a/db/seeds/delivery_partners.rb
+++ b/db/seeds/delivery_partners.rb
@@ -11,6 +11,6 @@ end
   'Proving Potential Teaching School Hub',
   'Harvest Academy'
 ].each do |name|
-  delivery_partner = DeliveryPartner.create!(name:)
+  delivery_partner = FactoryBot.create(:delivery_partner, name:)
   describe_delivery_partner(delivery_partner)
 end

--- a/db/seeds/lead_provider_delivery_partnerships.rb
+++ b/db/seeds/lead_provider_delivery_partnerships.rb
@@ -38,8 +38,7 @@ rising_minds = DeliveryPartner.find_by!(name: "Rising Minds Network")
   { active_lead_provider: best_practice_network_2023, delivery_partner: rising_minds },
   { active_lead_provider: best_practice_network_2024, delivery_partner: rising_minds }
 ].each do |data|
-  LeadProviderDeliveryPartnership.find_or_create_by!(
-    active_lead_provider: data[:active_lead_provider],
-    delivery_partner: data[:delivery_partner]
-  ).tap { |lpdp| describe_lead_provider_delivery_partnership(lpdp) }
+  FactoryBot.create(:lead_provider_delivery_partnership,
+                    active_lead_provider: data[:active_lead_provider],
+                    delivery_partner: data[:delivery_partner]).tap { |lpdp| describe_lead_provider_delivery_partnership(lpdp) }
 end

--- a/db/seeds/parity_checks.rb
+++ b/db/seeds/parity_checks.rb
@@ -14,13 +14,13 @@ def create_in_progress_run
   mode = %i[concurrent sequential].sample
   started_at = random_time(1.month.ago, 1.month)
 
-  ParityCheck::Run.create!(state: :in_progress, mode:, started_at:)
+  FactoryBot.create(:parity_check_run, state: :in_progress, mode:, started_at:)
 end
 
 def create_in_progress_request(run:, lead_provider:, endpoint:)
   started_at = random_time(run.started_at, 10.minutes)
 
-  ParityCheck::Request.create!(state: :in_progress, started_at:, run:, lead_provider:, endpoint:)
+  FactoryBot.create(:parity_check_request, state: :in_progress, started_at:, run:, lead_provider:, endpoint:)
 end
 
 def create_response(request, response_type, page)
@@ -29,16 +29,15 @@ def create_response(request, response_type, page)
   different_json = { data: { attributes: { name: Faker::Name.name, address: Faker::Address.full_address }, another: "test" } }.to_json
   rect_body = response_type == :matching ? ecf_body : different_json
 
-  ParityCheck::Response.create!(
-    request:,
-    ecf_status_code: 200,
-    ecf_time_ms: rand(100..2000),
-    ecf_body:,
-    rect_status_code: 200,
-    rect_body:,
-    rect_time_ms: rand(100..2000),
-    page:
-  )
+  FactoryBot.create(:parity_check_response,
+                    request:,
+                    ecf_status_code: 200,
+                    ecf_time_ms: rand(100..2000),
+                    ecf_body:,
+                    rect_status_code: 200,
+                    rect_body:,
+                    rect_time_ms: rand(100..2000),
+                    page:)
 end
 
 def random_endpoint(run:)

--- a/db/seeds/persona_users.rb
+++ b/db/seeds/persona_users.rb
@@ -6,7 +6,7 @@ YAML.load_file(Rails.root.join('config/personas.yml'))
     .select { |p| p['type'] == 'DfE staff' }
     .map { |p| { name: p['name'], email: p['email'] } }
     .each do |user_params|
-  User.create!(**user_params)
-      .tap { |user| user.dfe_roles.create! }
-      .then { |user| describe_user(user) }
+  FactoryBot.create(:user, **user_params)
+     .tap { |user| user.dfe_roles.create! }
+     .then { |user| describe_user(user) }
 end

--- a/db/seeds/school_partnerships.rb
+++ b/db/seeds/school_partnerships.rb
@@ -47,4 +47,4 @@ teach_first__grain__2025 = find_lead_provider_delivery_partnership(delivery_part
   { school: ackley_bridge, lead_provider_delivery_partnership: ambition_institute__artisan__2023 },
   { school: mallory_towers, lead_provider_delivery_partnership: teach_first__grain__2022 },
   { school: brookfield_school, lead_provider_delivery_partnership: teach_first__grain__2022 },
-].each { |kwargs| SchoolPartnership.create!(**kwargs).tap { |sp| describe_school_partnership(sp) } }
+].each { |kwargs| FactoryBot.create(:school_partnership, **kwargs).tap { |sp| describe_school_partnership(sp) } }

--- a/db/seeds/schools.rb
+++ b/db/seeds/schools.rb
@@ -2,82 +2,79 @@ def describe_school(school)
   print_seed_info("#{school.name} (URN #{school.urn})", indent: 2)
 end
 
-school_types = {
-  independent: GIAS::Types::INDEPENDENT_SCHOOLS_TYPES,
-  state: GIAS::Types::STATE_SCHOOL_TYPES
-}
-
 [
   {
     urn: 141_666,
     name: 'Angel Oak Academy', # Used by developers for DfE Sign In
-    school_type: :state,
+    type: :state_school_type
   },
   {
     urn: 3_375_958,
     name: "Ackley Bridge",
-    school_type: :state,
+    type: :state_school_type,
     induction_tutor_email: "Monique.Friesen@example.com",
     induction_tutor_name: "Monique Friesen"
   },
   {
     urn: 1_759_427,
     name: "Abbey Grove School",
-    school_type: :state
+    type: :state_school_type
   },
   {
     urn: 2_472_261,
     name: "Grange Hill",
-    school_type: :state
+    type: :state_school_type
   },
   {
     urn: 3_583_173,
     name: "Coal Hill School",
-    school_type: :state,
+    type: :state_school_type,
     induction_tutor_email: "Carmelina.Hegmann@example.com",
     induction_tutor_name: "Carmelina Hegmann"
   },
   {
     urn: 5_279_293,
     name: "Malory Towers",
-    school_type: :state
+    type: :state_school_type
   },
   {
     urn: 2_921_596,
     name: "St Clare's School",
-    school_type: :state
+    type: :state_school_type
   },
   {
     urn: 2_976_163,
     name: "Brookfield School",
-    school_type: :independent,
+    type: :independent_school_type,
     induction_tutor_email: "Percy.Konopelski@example.com",
     induction_tutor_name: "Percy Konopelski"
   },
   {
     urn: 4_594_193,
     name: "Crunchem Hall Primary School",
-    school_type: :state
+    type: :state_school_type
   },
   {
     urn: 6_384_201,
     name: "Greyfriars School",
-    school_type: :state
+    type: :state_school_type
   }
 ].map do |data|
-  # FIXME: this is a bit nasty but gets the seeds working again
-  GIAS::School.create!(data.merge(
-    funding_eligibility: :eligible_for_fip,
-    induction_eligibility: :eligible,
-    local_authority_code: rand(20),
-    establishment_number: data[:urn],
-    type_name: school_types.fetch(data.delete(:school_type)).sample,
-    in_england: true,
-    section_41_approved: false
-  ).except(
-    :induction_tutor_name,
-    :induction_tutor_email
-  ))
-
-  School.create!(data.except(:name)).tap { |school| describe_school(school) }
+  FactoryBot.create(
+    :gias_school,
+    :with_school,
+    :eligible_type,
+    :in_england,
+    data.delete(:type),
+    **data.merge(
+      establishment_number: data[:urn],
+      section_41_approved: false
+    ).except(
+      :induction_tutor_name,
+      :induction_tutor_email
+    )
+  ).school.tap do |s|
+    s.update!(**data.except(:name))
+    describe_school(s)
+  end
 end

--- a/db/seeds/statements.rb
+++ b/db/seeds/statements.rb
@@ -56,7 +56,8 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
                  :open
                end
 
-      Statement.create!(
+      FactoryBot.create(
+        :statement,
         active_lead_provider: alp,
         month:,
         year:,

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -46,7 +46,8 @@ def describe_induction_period(ip)
     author_type: 'appropriate_body_user',
   }
 
-  Event.create!(
+  FactoryBot.create(
+    :event,
     event_type: 'induction_period_opened',
     induction_period: ip,
     teacher: ip.teacher,
@@ -57,7 +58,8 @@ def describe_induction_period(ip)
   )
 
   if ip.finished_on
-    Event.create!(
+    FactoryBot.create(
+      :event,
       event_type: 'induction_period_opened',
       induction_period: ip,
       teacher: ip.teacher,
@@ -141,6 +143,11 @@ ambition_artisan_partnership_2022 = find_school_partnership(
   delivery_partner: artisan_education_group,
   contract_period: ContractPeriod.find_by!(year: 2022)
 )
+ambition_artisan_partnership_2023 = find_school_partnership(
+  lead_provider: ambition_institute,
+  delivery_partner: artisan_education_group,
+  contract_period: ContractPeriod.find_by!(year: 2023)
+)
 teach_first_grain_partnership_2022 = find_school_partnership(
   contract_period: ContractPeriod.find_by!(year: 2022),
   lead_provider: teach_first,
@@ -155,502 +162,503 @@ teach_first_grain_partnership_2025 = find_school_partnership(
 print_seed_info("Emma Thompson (mentor)", indent: 2, colour: MENTOR_COLOUR)
 
 emma_thompson = Teacher.find_by!(trs_first_name: 'Emma', trs_last_name: 'Thompson')
-emma_thompson_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
-  teacher: emma_thompson,
-  school: abbey_grove_school,
-  email: 'emma.thompson@matilda.com',
-  started_on: 3.years.ago
-).tap { |sp| describe_mentor_at_school_period(sp) }
+emma_thompson_mentoring_at_abbey_grove = FactoryBot.create(:mentor_at_school_period,
+                                                           teacher: emma_thompson,
+                                                           school: abbey_grove_school,
+                                                           email: 'emma.thompson@matilda.com',
+                                                           started_on: 3.years.ago,
+                                                           finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
-  started_on: 3.years.ago,
-  finished_on: 140.weeks.ago,
-  expression_of_interest: ambition_artisan_2022,
-  school_partnership: ambition_artisan_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
+                  started_on: 3.years.ago,
+                  finished_on: 140.weeks.ago,
+                  expression_of_interest: ambition_artisan_2022,
+                  school_partnership: ambition_artisan_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 # 10 week break
 
-TrainingPeriod.create!(
-  mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
-  started_on: 130.weeks.ago,
-  finished_on: nil,
-  school_partnership: ambition_artisan_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  mentor_at_school_period: emma_thompson_mentoring_at_abbey_grove,
+                  started_on: 130.weeks.ago,
+                  finished_on: nil,
+                  school_partnership: ambition_artisan_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Kate Winslet (ECT)", indent: 2, colour: ECT_COLOUR)
 
 kate_winslet = Teacher.find_by!(trs_first_name: 'Kate', trs_last_name: 'Winslet')
-kate_winslet_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
-  teacher: kate_winslet,
-  school: ackley_bridge,
-  email: 'kate.winslet@titanic.com',
-  started_on: 1.year.ago,
-  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
-  working_pattern: 'full_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+kate_winslet_ect_at_ackley_bridge = FactoryBot.create(:ect_at_school_period,
+                                                      teacher: kate_winslet,
+                                                      school: ackley_bridge,
+                                                      email: 'kate.winslet@titanic.com',
+                                                      started_on: 1.year.ago,
+                                                      finished_on: nil,
+                                                      school_reported_appropriate_body: golden_leaf_teaching_school_hub,
+                                                      working_pattern: 'full_time').tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: kate_winslet_ect_at_ackley_bridge,
-  started_on: 1.year.ago,
-  expression_of_interest: nil,
-  school_partnership: nil,
-  training_programme: 'school_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: kate_winslet_ect_at_ackley_bridge,
+                  started_on: 1.year.ago,
+                  finished_on: nil,
+                  expression_of_interest: nil,
+                  school_partnership: nil,
+                  training_programme: 'school_led').tap { |tp| describe_training_period(tp) }
 
-InductionPeriod.create!(
-  teacher: kate_winslet,
-  started_on: 3.years.ago,
-  finished_on: 2.years.ago,
-  number_of_terms: 3,
-  appropriate_body: golden_leaf_teaching_school_hub,
-  induction_programme: 'fip',
-  training_programme: 'school_led'
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  teacher: kate_winslet,
+                  started_on: 3.years.ago,
+                  finished_on: 2.years.ago,
+                  number_of_terms: 3,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  induction_programme: 'fip',
+                  training_programme: 'school_led').tap { |ip| describe_induction_period(ip) }
 
-InductionPeriod.create!(
-  teacher: kate_winslet,
-  started_on: 1.year.ago,
-  appropriate_body: umber_teaching_school_hub,
-  induction_programme: 'fip',
-  training_programme: 'school_led'
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  teacher: kate_winslet,
+                  started_on: 1.year.ago,
+                  finished_on: nil,
+                  appropriate_body: umber_teaching_school_hub,
+                  induction_programme: 'fip',
+                  training_programme: 'school_led',
+                  number_of_terms: nil).tap { |ip| describe_induction_period(ip) }
 
 print_seed_info("Hugh Laurie (mentor)", indent: 2, colour: MENTOR_COLOUR)
 
 hugh_laurie = Teacher.find_by!(trs_first_name: 'Hugh', trs_last_name: 'Laurie')
-hugh_laurie_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
-  teacher: hugh_laurie,
-  school: abbey_grove_school,
-  email: 'hugh.laurie@house.com',
-  started_on: 2.years.ago
-).tap { |sp| describe_mentor_at_school_period(sp) }
+hugh_laurie_mentoring_at_abbey_grove = FactoryBot.create(:mentor_at_school_period,
+                                                         teacher: hugh_laurie,
+                                                         school: abbey_grove_school,
+                                                         email: 'hugh.laurie@house.com',
+                                                         started_on: 2.years.ago,
+                                                         finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  mentor_at_school_period: hugh_laurie_mentoring_at_abbey_grove,
-  started_on: 2.years.ago,
-  expression_of_interest: teach_first_grain_2022,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  mentor_at_school_period: hugh_laurie_mentoring_at_abbey_grove,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  expression_of_interest: teach_first_grain_2022,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Alan Rickman (ECT)", indent: 2, colour: ECT_COLOUR)
 
 alan_rickman = Teacher.find_by!(trs_first_name: 'Alan', trs_last_name: 'Rickman')
-alan_rickman_ect_at_ackley_bridge = ECTAtSchoolPeriod.create!(
-  teacher: alan_rickman,
-  school: ackley_bridge,
-  email: 'alan.rickman@diehard.com',
-  started_on: 2.years.ago,
-  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
-  working_pattern: 'part_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+alan_rickman_ect_at_ackley_bridge = FactoryBot.create(:ect_at_school_period,
+                                                      teacher: alan_rickman,
+                                                      school: ackley_bridge,
+                                                      email: 'alan.rickman@diehard.com',
+                                                      started_on: 2.years.ago,
+                                                      finished_on: nil,
+                                                      school_reported_appropriate_body: golden_leaf_teaching_school_hub,
+                                                      working_pattern: 'part_time').tap { |sp| describe_ect_at_school_period(sp) }
 
 ackley_bridge.update!(last_chosen_lead_provider: best_practice_network,
                       last_chosen_appropriate_body: golden_leaf_teaching_school_hub,
                       last_chosen_training_programme: 'provider_led')
 
-TrainingPeriod.create!(
-  ect_at_school_period: alan_rickman_ect_at_ackley_bridge,
-  started_on: 2.years.ago + 1.month,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: alan_rickman_ect_at_ackley_bridge,
+                  started_on: 2.years.ago + 1.month,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
-InductionPeriod.create!(
-  teacher: alan_rickman,
-  appropriate_body: golden_leaf_teaching_school_hub,
-  started_on: 2.years.ago + 2.months,
-  induction_programme: 'fip',
-  training_programme: 'provider_led'
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  teacher: alan_rickman,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  started_on: 2.years.ago + 2.months,
+                  finished_on: nil,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: nil).tap { |ip| describe_induction_period(ip) }
 
-InductionExtension.create!(
-  teacher: alan_rickman,
-  number_of_terms: 1.5
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: alan_rickman,
+                  number_of_terms: 1.5).tap { |ext| describe_extension(ext) }
 
 active_appropriate_bodies.each do |appropriate_body|
-  PendingInductionSubmission.create!(
-    appropriate_body:,
-    trn: alan_rickman.trn,
-    date_of_birth: Date.new(1946, 2, 21),
-    started_on: 1.month.ago,
-    trs_first_name: alan_rickman.trs_first_name,
-    trs_last_name: alan_rickman.trs_last_name
-  ).tap { |is| describe_pending_induction_submission(is) }
+  FactoryBot.create(:pending_induction_submission,
+                    appropriate_body:,
+                    trn: alan_rickman.trn,
+                    date_of_birth: Date.new(1946, 2, 21),
+                    started_on: 1.month.ago,
+                    finished_on: nil,
+                    trs_first_name: alan_rickman.trs_first_name,
+                    trs_last_name: alan_rickman.trs_last_name).tap { |is| describe_pending_induction_submission(is) }
 end
 
 print_seed_info("Hugh Grant (ECT)", indent: 2, colour: ECT_COLOUR)
 
 hugh_grant = Teacher.find_by!(trs_first_name: 'Hugh', trs_last_name: 'Grant')
-hugh_grant_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
-  teacher: hugh_grant,
-  school: abbey_grove_school,
-  email: 'hugh.grant@wonka.com',
-  started_on: 2.years.ago,
-  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
-  working_pattern: 'part_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+hugh_grant_ect_at_abbey_grove = FactoryBot.create(:ect_at_school_period,
+                                                  teacher: hugh_grant,
+                                                  school: abbey_grove_school,
+                                                  email: 'hugh.grant@wonka.com',
+                                                  started_on: 2.years.ago,
+                                                  finished_on: nil,
+                                                  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
+                                                  working_pattern: 'part_time').tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: hugh_grant_ect_at_abbey_grove,
-  started_on: 2.years.ago,
-  expression_of_interest: nil,
-  school_partnership: nil,
-  training_programme: 'school_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: hugh_grant_ect_at_abbey_grove,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  expression_of_interest: nil,
+                  school_partnership: nil,
+                  training_programme: 'school_led').tap { |tp| describe_training_period(tp) }
 
-InductionPeriod.create!(
-  teacher: hugh_grant,
-  appropriate_body: golden_leaf_teaching_school_hub,
-  started_on: 2.years.ago + 3.days,
-  finished_on: 1.week.ago,
-  induction_programme: 'fip',
-  training_programme: 'provider_led',
-  number_of_terms: 3
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  teacher: hugh_grant,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  started_on: 2.years.ago + 3.days,
+                  finished_on: 1.week.ago,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: 3).tap { |ip| describe_induction_period(ip) }
 
-InductionExtension.create!(
-  teacher: hugh_grant,
-  number_of_terms: 1.5
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: hugh_grant,
+                  number_of_terms: 1.5).tap { |ext| describe_extension(ext) }
 
-InductionExtension.create!(
-  teacher: hugh_grant,
-  number_of_terms: 1
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: hugh_grant,
+                  number_of_terms: 1).tap { |ext| describe_extension(ext) }
 
 print_seed_info("Colin Firth (ECT)", indent: 2, colour: ECT_COLOUR)
 
 colin_firth = Teacher.find_by!(trs_first_name: 'Colin', trs_last_name: 'Firth')
-colin_firth_ect_at_abbey_grove = ECTAtSchoolPeriod.create!(
-  teacher: colin_firth,
-  school: abbey_grove_school,
-  email: 'colin.firth@aol.com',
-  started_on: 2.years.ago,
-  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
-  working_pattern: 'full_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+colin_firth_ect_at_abbey_grove = FactoryBot.create(:ect_at_school_period,
+                                                   teacher: colin_firth,
+                                                   school: abbey_grove_school,
+                                                   email: 'colin.firth@aol.com',
+                                                   started_on: 2.years.ago,
+                                                   finished_on: nil,
+                                                   school_reported_appropriate_body: golden_leaf_teaching_school_hub,
+                                                   working_pattern: 'full_time').tap { |sp| describe_ect_at_school_period(sp) }
 
 abbey_grove_school.update!(last_chosen_lead_provider: nil,
                            last_chosen_appropriate_body: golden_leaf_teaching_school_hub,
                            last_chosen_training_programme: 'school_led')
 
-TrainingPeriod.create!(
-  ect_at_school_period: colin_firth_ect_at_abbey_grove,
-  started_on: 2.years.ago,
-  school_partnership: ambition_artisan_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: colin_firth_ect_at_abbey_grove,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  school_partnership: ambition_artisan_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
-InductionPeriod.create!(
-  teacher: colin_firth,
-  appropriate_body: golden_leaf_teaching_school_hub,
-  started_on: 2.years.ago + 3.days,
-  finished_on: 1.week.ago,
-  induction_programme: 'fip',
-  training_programme: 'provider_led',
-  number_of_terms: 3
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  teacher: colin_firth,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  started_on: 2.years.ago + 3.days,
+                  finished_on: 1.week.ago,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: 3).tap { |ip| describe_induction_period(ip) }
 
-InductionExtension.create!(
-  teacher: colin_firth,
-  number_of_terms: 1.5
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: colin_firth,
+                  number_of_terms: 1.5).tap { |ext| describe_extension(ext) }
 
-InductionExtension.create!(
-  teacher: colin_firth,
-  number_of_terms: 1
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: colin_firth,
+                  number_of_terms: 1).tap { |ext| describe_extension(ext) }
 
 print_seed_info("Harriet Walter (mentor)", indent: 2, colour: MENTOR_COLOUR)
 
 harriet_walter = Teacher.find_by!(trs_first_name: 'Harriet', trs_last_name: 'Walter')
-InductionPeriod.create!(
-  appropriate_body: umber_teaching_school_hub,
-  teacher: harriet_walter,
-  started_on: 2.years.ago,
-  finished_on: 1.year.ago,
-  induction_programme: 'fip',
-  training_programme: 'provider_led',
-  number_of_terms: [1, 2, 3].sample
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  appropriate_body: umber_teaching_school_hub,
+                  teacher: harriet_walter,
+                  started_on: 2.years.ago,
+                  finished_on: 1.year.ago,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: [1, 2, 3].sample).tap { |ip| describe_induction_period(ip) }
 
-InductionPeriod.create!(
-  appropriate_body: golden_leaf_teaching_school_hub,
-  teacher: harriet_walter,
-  started_on: 1.year.ago,
-  induction_programme: 'fip',
-  training_programme: 'provider_led'
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  teacher: harriet_walter,
+                  started_on: 1.year.ago,
+                  finished_on: nil,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: nil).tap { |ip| describe_induction_period(ip) }
 
-InductionExtension.create!(
-  teacher: harriet_walter,
-  number_of_terms: 1.3
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: harriet_walter,
+                  number_of_terms: 1.3).tap { |ext| describe_extension(ext) }
 
-InductionExtension.create!(
-  teacher: harriet_walter,
-  number_of_terms: 5
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: harriet_walter,
+                  number_of_terms: 5).tap { |ext| describe_extension(ext) }
 
 print_seed_info("Imogen Stubbs (ECT)", indent: 2, colour: ECT_COLOUR)
 
 imogen_stubbs = Teacher.find_by!(trs_first_name: 'Imogen', trs_last_name: 'Stubbs')
-InductionPeriod.create!(
-  appropriate_body: golden_leaf_teaching_school_hub,
-  teacher: imogen_stubbs,
-  started_on: 18.months.ago,
-  finished_on: 14.months.ago,
-  induction_programme: 'fip',
-  training_programme: 'provider_led',
-  number_of_terms: 1
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  teacher: imogen_stubbs,
+                  started_on: 18.months.ago,
+                  finished_on: 14.months.ago,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: 1).tap { |ip| describe_induction_period(ip) }
 
-InductionPeriod.create!(
-  appropriate_body: golden_leaf_teaching_school_hub,
-  teacher: imogen_stubbs,
-  started_on: 14.months.ago,
-  finished_on: nil,
-  induction_programme: 'cip',
-  training_programme: 'school_led'
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  appropriate_body: golden_leaf_teaching_school_hub,
+                  teacher: imogen_stubbs,
+                  started_on: 14.months.ago,
+                  finished_on: nil,
+                  induction_programme: 'cip',
+                  training_programme: 'school_led',
+                  number_of_terms: nil).tap { |ip| describe_induction_period(ip) }
 
-imogen_stubbs_at_malory_towers = ECTAtSchoolPeriod.create!(
-  teacher: imogen_stubbs,
-  school: mallory_towers,
-  email: 'imogen.stubbs@eriktheviking.com',
-  started_on: 2.years.ago,
-  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
-  working_pattern: 'full_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+imogen_stubbs_at_malory_towers = FactoryBot.create(:ect_at_school_period,
+                                                   teacher: imogen_stubbs,
+                                                   school: mallory_towers,
+                                                   email: 'imogen.stubbs@eriktheviking.com',
+                                                   started_on: 2.years.ago,
+                                                   finished_on: nil,
+                                                   school_reported_appropriate_body: golden_leaf_teaching_school_hub,
+                                                   working_pattern: 'full_time').tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: imogen_stubbs_at_malory_towers,
-  started_on: 1.year.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: imogen_stubbs_at_malory_towers,
+                  started_on: 1.year.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
-InductionExtension.create!(
-  teacher: imogen_stubbs,
-  number_of_terms: 1
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: imogen_stubbs,
+                  number_of_terms: 1).tap { |ext| describe_extension(ext) }
 
 print_seed_info("Gemma Jones (ECT)", indent: 2, colour: ECT_COLOUR)
 
 gemma_jones = Teacher.find_by!(trs_first_name: 'Gemma', trs_last_name: 'Jones')
-InductionPeriod.create!(
-  appropriate_body: umber_teaching_school_hub,
-  teacher: gemma_jones,
-  started_on: 20.months.ago,
-  finished_on: nil,
-  induction_programme: 'fip',
-  training_programme: 'provider_led'
-).tap { |ip| describe_induction_period(ip) }
+FactoryBot.create(:induction_period,
+                  appropriate_body: umber_teaching_school_hub,
+                  teacher: gemma_jones,
+                  started_on: 20.months.ago,
+                  finished_on: nil,
+                  induction_programme: 'fip',
+                  training_programme: 'provider_led',
+                  number_of_terms: nil).tap { |ip| describe_induction_period(ip) }
 
-gemma_jones_at_malory_towers = ECTAtSchoolPeriod.create!(
-  teacher: gemma_jones,
-  school: mallory_towers,
-  email: 'gemma.jones@rocketman.com',
-  started_on: 21.months.ago,
-  school_reported_appropriate_body: golden_leaf_teaching_school_hub,
-  working_pattern: 'part_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+gemma_jones_at_malory_towers = FactoryBot.create(:ect_at_school_period,
+                                                 teacher: gemma_jones,
+                                                 school: mallory_towers,
+                                                 email: 'gemma.jones@rocketman.com',
+                                                 started_on: 21.months.ago,
+                                                 finished_on: nil,
+                                                 school_reported_appropriate_body: golden_leaf_teaching_school_hub,
+                                                 working_pattern: 'part_time').tap { |sp| describe_ect_at_school_period(sp) }
 
 mallory_towers.update!(last_chosen_lead_provider: best_practice_network,
                        last_chosen_appropriate_body: golden_leaf_teaching_school_hub,
                        last_chosen_training_programme: 'provider_led')
 
-TrainingPeriod.create!(
-  ect_at_school_period: gemma_jones_at_malory_towers,
-  started_on: 20.months.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: gemma_jones_at_malory_towers,
+                  started_on: 20.months.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
-InductionExtension.create!(
-  teacher: gemma_jones,
-  number_of_terms: 1.5
-).tap { |ext| describe_extension(ext) }
+FactoryBot.create(:induction_extension,
+                  teacher: gemma_jones,
+                  number_of_terms: 1.5).tap { |ext| describe_extension(ext) }
 
 print_seed_info("André Roussimoff (ECT)", indent: 2, colour: ECT_COLOUR)
 
 andre_roussimoff = Teacher.find_by!(trs_first_name: 'André', trs_last_name: 'Roussimoff')
-andre_roussimoff_mentoring_at_ackley_bridge = MentorAtSchoolPeriod.create!(
-  teacher: andre_roussimoff,
-  school: ackley_bridge,
-  email: 'andre.giant@wwf.com',
-  started_on: 1.year.ago
-).tap { |sp| describe_mentor_at_school_period(sp) }
+andre_roussimoff_mentoring_at_ackley_bridge = FactoryBot.create(:mentor_at_school_period,
+                                                                teacher: andre_roussimoff,
+                                                                school: ackley_bridge,
+                                                                email: 'andre.giant@wwf.com',
+                                                                started_on: 1.year.ago,
+                                                                finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  mentor_at_school_period: andre_roussimoff_mentoring_at_ackley_bridge,
-  started_on: 1.year.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  mentor_at_school_period: andre_roussimoff_mentoring_at_ackley_bridge,
+                  started_on: 1.year.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Anthony Hopkins (ECT)", indent: 2, colour: ECT_COLOUR)
 
 anthony_hopkins = Teacher.find_by!(trs_first_name: 'Anthony', trs_last_name: 'Hopkins')
-anthony_hopkins_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
-  teacher: anthony_hopkins,
-  school: brookfield_school,
-  email: 'anthony.hopkins@favabeans.com',
-  school_reported_appropriate_body: umber_teaching_school_hub,
-  started_on: 2.years.ago,
-  working_pattern: 'part_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+anthony_hopkins_ect_at_brookfield_school = FactoryBot.create(:ect_at_school_period,
+                                                             teacher: anthony_hopkins,
+                                                             school: brookfield_school,
+                                                             email: 'anthony.hopkins@favabeans.com',
+                                                             school_reported_appropriate_body: umber_teaching_school_hub,
+                                                             started_on: 2.years.ago,
+                                                             finished_on: nil,
+                                                             working_pattern: 'part_time').tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: anthony_hopkins_ect_at_brookfield_school,
-  started_on: 2.years.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: anthony_hopkins_ect_at_brookfield_school,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Stephen Fry (ECT)", indent: 2, colour: ECT_COLOUR)
 
 stephen_fry = Teacher.find_by!(trs_first_name: 'Stephen', trs_last_name: 'Fry')
-stephen_fry_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
-  teacher: stephen_fry,
-  school: brookfield_school,
-  email: 'stephen.fry@sausage.com',
-  started_on: 2.years.ago,
-  school_reported_appropriate_body: south_yorkshire_studio_hub,
-  working_pattern: 'part_time'
-).tap { |sp| describe_ect_at_school_period(sp) }
+stephen_fry_ect_at_brookfield_school = FactoryBot.create(:ect_at_school_period,
+                                                         teacher: stephen_fry,
+                                                         school: brookfield_school,
+                                                         email: 'stephen.fry@sausage.com',
+                                                         started_on: 2.years.ago,
+                                                         finished_on: nil,
+                                                         school_reported_appropriate_body: south_yorkshire_studio_hub,
+                                                         working_pattern: 'part_time').tap { |sp| describe_ect_at_school_period(sp) }
 
 brookfield_school.update!(last_chosen_lead_provider: teach_first,
                           last_chosen_appropriate_body: south_yorkshire_studio_hub,
                           last_chosen_training_programme: 'provider_led')
 
-TrainingPeriod.create!(
-  ect_at_school_period: stephen_fry_ect_at_brookfield_school,
-  started_on: 2.years.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: stephen_fry_ect_at_brookfield_school,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Harriet Walter (ECT) with multiple induction periods", indent: 2, colour: ECT_COLOUR)
 
-harriet_walter_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
-  teacher: harriet_walter,
-  school: brookfield_school,
-  email: 'harriet-walter@history.com',
-  started_on: 2.years.ago,
-  school_reported_appropriate_body: south_yorkshire_studio_hub
-).tap { |sp| describe_ect_at_school_period(sp) }
+harriet_walter_ect_at_brookfield_school = FactoryBot.create(:ect_at_school_period,
+                                                            teacher: harriet_walter,
+                                                            school: brookfield_school,
+                                                            email: 'harriet-walter@history.com',
+                                                            started_on: 2.years.ago,
+                                                            finished_on: nil,
+                                                            school_reported_appropriate_body: south_yorkshire_studio_hub).tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: harriet_walter_ect_at_brookfield_school,
-  started_on: 2.years.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: harriet_walter_ect_at_brookfield_school,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Helen Mirren (mentor)", indent: 2, colour: MENTOR_COLOUR)
 
 helen_mirren = Teacher.find_by!(trs_first_name: 'Helen', trs_last_name: 'Mirren')
-helen_mirren_mentoring_at_brookfield_school = MentorAtSchoolPeriod.create!(
-  teacher: helen_mirren,
-  school: brookfield_school,
-  email: 'helen.mirren@titania.com',
-  started_on: 2.years.ago
-).tap { |sp| describe_mentor_at_school_period(sp) }
+helen_mirren_mentoring_at_brookfield_school = FactoryBot.create(:mentor_at_school_period,
+                                                                teacher: helen_mirren,
+                                                                school: brookfield_school,
+                                                                email: 'helen.mirren@titania.com',
+                                                                started_on: 2.years.ago,
+                                                                finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  mentor_at_school_period: helen_mirren_mentoring_at_brookfield_school,
-  started_on: 2.years.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  mentor_at_school_period: helen_mirren_mentoring_at_brookfield_school,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("John Withers (mentor)", indent: 2, colour: MENTOR_COLOUR)
 
 john_withers = Teacher.find_by!(trs_first_name: 'John', trs_last_name: 'Withers')
-john_withers_mentoring_at_abbey_grove = MentorAtSchoolPeriod.create!(
-  teacher: john_withers,
-  school: abbey_grove_school,
-  email: 'john.withers@amusementpark.com',
-  started_on: 2.years.ago
-).tap { |sp| describe_mentor_at_school_period(sp) }
+john_withers_mentoring_at_abbey_grove = FactoryBot.create(:mentor_at_school_period,
+                                                          teacher: john_withers,
+                                                          school: abbey_grove_school,
+                                                          email: 'john.withers@amusementpark.com',
+                                                          started_on: 2.years.ago,
+                                                          finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  mentor_at_school_period: john_withers_mentoring_at_abbey_grove,
-  started_on: 2.years.ago,
-  school_partnership: teach_first_grain_partnership_2022,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  mentor_at_school_period: john_withers_mentoring_at_abbey_grove,
+                  started_on: 2.years.ago,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2022,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Dominic West (ECT)", indent: 2, colour: ECT_COLOUR)
 
 dominic_west = Teacher.find_by!(trs_first_name: 'Dominic', trs_last_name: 'West')
-dominic_west_ect_at_brookfield_school = ECTAtSchoolPeriod.create!(
-  teacher: dominic_west,
-  school: brookfield_school,
-  email: 'harriet-walter@history.com',
-  started_on: 18.months.ago,
-  school_reported_appropriate_body: south_yorkshire_studio_hub
-).tap { |sp| describe_ect_at_school_period(sp) }
+dominic_west_ect_at_brookfield_school = FactoryBot.create(:ect_at_school_period,
+                                                          teacher: dominic_west,
+                                                          school: brookfield_school,
+                                                          email: 'harriet-walter@history.com',
+                                                          started_on: 18.months.ago,
+                                                          finished_on: nil,
+                                                          school_reported_appropriate_body: south_yorkshire_studio_hub).tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: dominic_west_ect_at_brookfield_school,
-  started_on: 18.months.ago,
-  expression_of_interest: ambition_artisan_2023,
-  training_programme: 'provider_led'
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: dominic_west_ect_at_brookfield_school,
+                  started_on: 18.months.ago,
+                  finished_on: nil,
+                  school_partnership: ambition_artisan_partnership_2023,
+                  expression_of_interest: ambition_artisan_2023,
+                  training_programme: 'provider_led').tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Peter Davison (ECT)", indent: 2, colour: ECT_COLOUR)
 
 peter_davison = Teacher.find_by!(trs_first_name: 'Peter', trs_last_name: 'Davison')
-peter_davison_at_abbey_grove_school = ECTAtSchoolPeriod.create!(
-  teacher: peter_davison,
-  school: abbey_grove_school,
-  email: 'pd@tardis.bbc',
-  started_on: 2.weeks.from_now,
-  school_reported_appropriate_body: south_yorkshire_studio_hub
-).tap { |sp| describe_ect_at_school_period(sp) }
+peter_davison_at_abbey_grove_school = FactoryBot.create(:ect_at_school_period,
+                                                        teacher: peter_davison,
+                                                        school: abbey_grove_school,
+                                                        email: 'pd@tardis.bbc',
+                                                        started_on: 2.weeks.from_now,
+                                                        finished_on: nil,
+                                                        school_reported_appropriate_body: south_yorkshire_studio_hub).tap { |sp| describe_ect_at_school_period(sp) }
 
-TrainingPeriod.create!(
-  ect_at_school_period: peter_davison_at_abbey_grove_school,
-  started_on: 2.weeks.from_now,
-  school_partnership: teach_first_grain_partnership_2025,
-  training_programme: 'provider_led',
-  expression_of_interest: teach_first_grain_2025
-).tap { |tp| describe_training_period(tp) }
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  ect_at_school_period: peter_davison_at_abbey_grove_school,
+                  started_on: 2.weeks.from_now,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_partnership_2025,
+                  training_programme: 'provider_led',
+                  expression_of_interest: teach_first_grain_2025).tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Adding mentorships:")
 
-MentorshipPeriod.create!(
-  mentor: emma_thompson_mentoring_at_abbey_grove,
-  mentee: hugh_grant_ect_at_abbey_grove,
-  started_on: 2.years.ago,
-  finished_on: 1.year.ago
-).tap { |mp| describe_mentorship_period(mp) }
+FactoryBot.create(:mentorship_period,
+                  mentor: emma_thompson_mentoring_at_abbey_grove,
+                  mentee: hugh_grant_ect_at_abbey_grove,
+                  started_on: 2.years.ago,
+                  finished_on: 1.year.ago).tap { |mp| describe_mentorship_period(mp) }
 
-MentorshipPeriod.create!(
-  mentor: hugh_laurie_mentoring_at_abbey_grove,
-  mentee: hugh_grant_ect_at_abbey_grove,
-  started_on: 1.year.ago,
-  finished_on: nil
-).tap { |mp| describe_mentorship_period(mp) }
+FactoryBot.create(:mentorship_period,
+                  mentor: hugh_laurie_mentoring_at_abbey_grove,
+                  mentee: hugh_grant_ect_at_abbey_grove,
+                  started_on: 1.year.ago,
+                  finished_on: nil).tap { |mp| describe_mentorship_period(mp) }
 
-MentorshipPeriod.create!(
-  mentor: andre_roussimoff_mentoring_at_ackley_bridge,
-  mentee: kate_winslet_ect_at_ackley_bridge,
-  started_on: 1.year.ago,
-  finished_on: nil
-).tap { |mp| describe_mentorship_period(mp) }
+FactoryBot.create(:mentorship_period,
+                  mentor: andre_roussimoff_mentoring_at_ackley_bridge,
+                  mentee: kate_winslet_ect_at_ackley_bridge,
+                  started_on: 1.year.ago,
+                  finished_on: nil).tap { |mp| describe_mentorship_period(mp) }
 
-MentorshipPeriod.create!(
-  mentor: helen_mirren_mentoring_at_brookfield_school,
-  mentee: stephen_fry_ect_at_brookfield_school,
-  started_on: 1.year.ago,
-  finished_on: nil
-).tap { |mp| describe_mentorship_period(mp) }
+FactoryBot.create(:mentorship_period,
+                  mentor: helen_mirren_mentoring_at_brookfield_school,
+                  mentee: stephen_fry_ect_at_brookfield_school,
+                  started_on: 1.year.ago,
+                  finished_on: nil).tap { |mp| describe_mentorship_period(mp) }

--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -38,5 +38,5 @@ teachers = [
 ]
 
 teachers.each do |attrs|
-  Teacher.create!(attrs).tap { |teacher| describe_teacher(teacher) }
+  FactoryBot.create(:teacher, attrs).tap { |teacher| describe_teacher(teacher) }
 end


### PR DESCRIPTION
### Context

Ticket: [2304](https://github.com/DFE-Digital/register-ects-project-board/issues/2304)

Currently, DB seeds use normal method creation on models to create records. We have moved now to create sandbox seeds from Factory Bot and should do the same in normal seeds.

### Changes proposed in this pull request

- Use factory bot in DB seeds for creating records;
- Ensure consistency with the expected records in the seeds and tidy up if necessary;

### Guidance to review

Review app