### PR TITLE
Support session object breaking changes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -125,7 +125,7 @@ RSpec/MatchArray:
     - 'spec/models/ect_at_school_period_spec.rb'
     - 'spec/models/mentor_at_school_period_spec.rb'
 
-# Offense count: 973
+# Offense count: 976
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
 # SupportedStyles: always, named_only
 RSpec/NamedSubject:
@@ -179,11 +179,12 @@ RSpec/SubjectDeclaration:
   Exclude:
     - 'spec/mailers/example_mailer_spec.rb'
 
-# Offense count: 14
+# Offense count: 15
 RSpec/SubjectStub:
   Exclude:
     - 'spec/forms/sessions/otp_sign_in_form_spec.rb'
     - 'spec/services/sessions/one_time_password_spec.rb'
+    - 'spec/services/sessions/session_manager_spec.rb'
     - 'spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb'
     - 'spec/wizards/schools/register_ect_wizard/email_address_step_spec.rb'
     - 'spec/wizards/schools/register_ect_wizard/lead_provider_step_spec.rb'
@@ -237,7 +238,7 @@ Rails/SaveBang:
   Exclude:
     - 'spec/support/rspec_playwright.rb'
 
-# Offense count: 8633
+# Offense count: 8616
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
 # SupportedStyles: single_quotes, double_quotes

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -7,18 +7,19 @@ RSpec.describe Sessions::Manager do
   let(:name) { 'Christopher Lee' }
   let(:school_urn) { FactoryBot.create(:school).urn }
   let(:last_active_at) { 4.minutes.ago }
+  let(:roles) { %w[SchoolUser] }
   let(:user) do
     Sessions::Users::SchoolUser.new(email:,
                                     name:,
                                     school_urn:,
-                                    dfe_sign_in_organisation_id: '1',
+                                    dfe_sign_in_organisation_id: SecureRandom.uuid,
                                     dfe_sign_in_user_id: '1',
-                                    dfe_sign_in_roles: %w[SchoolUser],
+                                    dfe_sign_in_roles: roles,
                                     last_active_at:)
   end
 
   before do
-    allow(DfESignIn::APIClient).to receive(:new).and_return(DfESignIn::FakeAPIClient.new(role_codes: %w[SchoolUser]))
+    allow(DfESignIn::APIClient).to receive(:new).and_return(DfESignIn::FakeAPIClient.new(role_codes: roles))
   end
 
   describe '#begin_session!' do
@@ -35,7 +36,7 @@ RSpec.describe Sessions::Manager do
       expect(session['user_session']['name']).to eql(name)
       expect(session['user_session']['school_urn']).to eql(school_urn)
       expect(session['user_session']['last_active_at']).to be_within(1.second).of(last_active_at)
-      expect(session['user_session']['dfe_sign_in_organisation_id']).to eql('1')
+      expect(session['user_session']['dfe_sign_in_organisation_id']).to eql(user.dfe_sign_in_organisation_id)
       expect(session['user_session']['dfe_sign_in_user_id']).to eql('1')
     end
 
@@ -56,11 +57,11 @@ RSpec.describe Sessions::Manager do
   end
 
   describe '#current_user' do
-    context 'when the session began' do
-      before do
-        service.begin_session!(user)
-      end
+    before do
+      service.begin_session!(user)
+    end
 
+    context 'when the session began' do
       it 'is kind of a Sessions::User' do
         expect(service.current_user).to be_a(Sessions::User)
       end
@@ -78,11 +79,23 @@ RSpec.describe Sessions::Manager do
         expect(new_user.last_active_at).to be_within(1.second).of(Time.zone.now)
       end
     end
+
+    context 'when the session cannot be loaded' do
+      before do
+        session['user_session']['unknown_param'] = 'new feature value'
+        allow(service).to receive(:end_session!).and_return(nil)
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it 'does not raise an error, reports to Sentry and ends the session' do
+        expect { service.current_user }.not_to raise_error
+      end
+    end
   end
 
   describe '#end_session!' do
-    let(:session) { double('Session', destroy: nil) }
-    let(:cookies) { double('Cookies', delete: nil) }
+    let(:session) { double('ActionDispatch::Request::Session', destroy: nil) }
+    let(:cookies) { double('ActionDispatch::Cookies::CookieJar', delete: nil) }
 
     before { service.end_session! }
 
@@ -118,6 +131,22 @@ RSpec.describe Sessions::Manager do
     it 'removes the requested path from the session' do
       service.requested_path
       expect(session.keys.map(&:to_s)).not_to include 'requested_path'
+    end
+  end
+
+  describe '#switch_role!' do
+    let(:roles) { %w[SchoolUser AppropriateBodyUser] }
+
+    before do
+      school = FactoryBot.create(:school, :eligible)
+      FactoryBot.create(:appropriate_body, name: school.name, dfe_sign_in_organisation_id: user.dfe_sign_in_organisation_id)
+      service.begin_session!(user)
+    end
+
+    it 'is kind of a Sessions::User' do
+      expect(service.current_user).to be_a(Sessions::Users::SchoolUser)
+      service.switch_role!
+      expect(service.current_user).to be_a(Sessions::Users::AppropriateBodyUser)
     end
   end
 end


### PR DESCRIPTION
### Context

See https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1284

We struggled with a production release when user session objects changed the required class parameters or session variables. An upcoming change that will face the same issue is when RECT logins use DSI UUID instead of URN to find the School.

### Changes proposed in this pull request

- Make it easier to change session objects in the future
- Mitigate crashes when new arguments are added or old ones removed
- Rescue and report when session objects have evolved
- Add unit test for session manager role switching

### Guidance to review

Edit the stored session from an earlier login by either removing an essential value or adding a new one. The session should be successfully purged so a new login attempt can be made.

This means production users need not clear session data and be inconvenienced.