### PR TITLE
[1249] Hide lead provider row if ineligible for funding (#MentorRegistrationFlow)

### DIFF
--- a/app/views/schools/register_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/register_mentor_wizard/check_answers.html.erb
@@ -52,7 +52,7 @@
     end
   end
 
-  if @mentor.provider_led_ect? && @mentor.mentoring_at_new_school_only?
+  if @mentor.provider_led_ect? && @mentor.mentoring_at_new_school_only? && @mentor.funding_available?
     summary_list.with_row do |row|
       row.with_key(text: "Lead provider")
       row.with_value(text: @mentor.lead_provider&.name || @mentor.ect_lead_provider&.name)

--- a/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/check_answers.html.erb_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
     context 'when mentoring_at_new_school_only? is false' do
       before do
-        allow(mentor).to receive_messages(provider_led_ect?: true, mentoring_at_new_school_only?: false, lead_provider:)
+        allow(mentor).to receive_messages(provider_led_ect?: true, mentoring_at_new_school_only?: false, lead_provider:, funding_available?: true)
         render
       end
 
@@ -164,7 +164,7 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
 
     context 'when mentoring_at_new_school_only? is not present' do
       before do
-        allow(mentor).to receive_messages(provider_led_ect?: true, mentoring_at_new_school_only?: nil, lead_provider:)
+        allow(mentor).to receive_messages(provider_led_ect?: true, mentoring_at_new_school_only?: nil, lead_provider:, funding_available?: true)
         render
       end
 
@@ -172,6 +172,32 @@ RSpec.describe "schools/register_mentor_wizard/check_answers.html.erb" do
         expect(rendered).not_to have_element(:dt, text: 'Lead provider')
         expect(rendered).not_to have_element(:dd, text: 'FraggleRock')
         expect(rendered).not_to have_link('Change', href: schools_register_mentor_wizard_change_lead_provider_path)
+      end
+    end
+
+    context 'when funding_available? is false' do
+      before do
+        allow(mentor).to receive_messages(provider_led_ect?: true, mentoring_at_new_school_only?: true, lead_provider:, funding_available?: false)
+        render
+      end
+
+      it 'does not show the lead provider row' do
+        expect(rendered).not_to have_element(:dt, text: 'Lead provider')
+        expect(rendered).not_to have_element(:dd, text: 'FraggleRock')
+        expect(rendered).not_to have_link('Change', href: schools_register_mentor_wizard_change_lead_provider_path)
+      end
+    end
+
+    context 'when funding_available? is true' do
+      before do
+        allow(mentor).to receive_messages(provider_led_ect?: true, mentoring_at_new_school_only?: true, lead_provider:, funding_available?: true)
+        render
+      end
+
+      it 'shows the lead provider row' do
+        expect(rendered).to have_element(:dt, text: 'Lead provider')
+        expect(rendered).to have_element(:dd, text: 'FraggleRock')
+        expect(rendered).to have_link('Change', href: schools_register_mentor_wizard_change_lead_provider_path)
       end
     end
 


### PR DESCRIPTION
### Context

Hide the lead provider row on the check your answers page when ineligible for funding.  

This question is not asked in this pathway, so the row should not be displayed.

| Before | After |
|--------|-------|
|<img width="716" height="600" alt="image" src="https://github.com/user-attachments/assets/144964f6-20a4-477f-b6f1-491d5e021327" />|<img width="782" height="551" alt="image" src="https://github.com/user-attachments/assets/2780cf38-cf97-4c12-aaca-a5770d04d19c" />|


