### PR TITLE
Fix schools endpoint behaviour on cohort filtering

### DIFF
--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -17,19 +17,19 @@ module API
     private
 
       def schools_query(conditions: {})
-        API::Schools::Query.new(**(default_query_conditions.merge(conditions)).compact)
+        API::Schools::Query.new(**(default_query_conditions.merge(conditions.compact)))
       end
 
       def default_query_conditions
         @default_query_conditions ||= {
-          contract_period_year: contract_period.year,
+          contract_period_year: contract_period&.year,
           lead_provider_id: current_lead_provider.id
         }
       end
 
       def serializer_options
         @serializer_options ||= {
-          contract_period_year: contract_period.year,
+          contract_period_year: contract_period&.year,
           lead_provider_id: current_lead_provider.id
         }
       end

--- a/app/services/api/schools/query.rb
+++ b/app/services/api/schools/query.rb
@@ -4,13 +4,13 @@ module API::Schools
 
     attr_reader :scope, :sort, :lead_provider_id, :contract_period_year
 
-    def initialize(lead_provider_id: :ignore, urn: :ignore, updated_since: :ignore, contract_period_year: :ignore, sort: { created_at: :asc })
+    def initialize(contract_period_year:, lead_provider_id: :ignore, urn: :ignore, updated_since: :ignore, sort: { created_at: :asc })
       @lead_provider_id = lead_provider_id
       @contract_period_year = contract_period_year
-      @scope = default_scope(contract_period_year)
-        .or(schools_with_existing_partnerships(contract_period_year))
-        .distinct
+      @scope = School.eligible.not_cip_only
 
+      or_where_school_partnership_exists(contract_period_year)
+      where_contract_period_exists(contract_period_year)
       where_urn_is(urn)
       where_updated_since(updated_since)
       set_sort_by(sort)
@@ -54,11 +54,19 @@ module API::Schools
       preloaded_results
     end
 
-    def schools_with_existing_partnerships(contract_period_year)
-      School
-        .where(id: School.select("schools.id")
-        .joins(school_partnerships: { lead_provider_delivery_partnership: { active_lead_provider: :contract_period } })
-        .where(contract_periods: { year: contract_period_year }))
+    def where_contract_period_exists(contract_period_year)
+      @scope = School.none unless ContractPeriod.exists?(year: contract_period_year)
+    end
+
+    def or_where_school_partnership_exists(contract_period_year)
+      return if ignore?(filter: contract_period_year)
+
+      @scope = scope.or(
+        School
+          .where(id: School.select("schools.id")
+          .joins(school_partnerships: { lead_provider_delivery_partnership: { active_lead_provider: :contract_period } })
+          .where(contract_periods: { year: contract_period_year }))
+      ).distinct
     end
 
     def where_urn_is(urn)
@@ -71,14 +79,6 @@ module API::Schools
       return if ignore?(filter: updated_since)
 
       scope.merge!(School.where(updated_at: updated_since..))
-    end
-
-    def default_scope(contract_period_year)
-      return School.none if ignore?(filter: contract_period_year) || ContractPeriod.find_by(year: contract_period_year).blank?
-
-      School
-        .eligible
-        .not_cip_only
     end
 
     def set_sort_by(sort)

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "Statements API", type: :request do
     it_behaves_like "an index endpoint"
     it_behaves_like "a paginated endpoint"
     it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
-    it_behaves_like "a filter by a single cohort (contract_period year) endpoint"
     it_behaves_like "a filter by updated_since endpoint"
   end
 

--- a/spec/services/api/schools/query_spec.rb
+++ b/spec/services/api/schools/query_spec.rb
@@ -78,12 +78,6 @@ RSpec.describe API::Schools::Query do
       }
     end
 
-    context "when no params is sent" do
-      it "returns no schools" do
-        expect(described_class.new.schools).to be_empty
-      end
-    end
-
     it "returns all eligible schools" do
       contract_period = FactoryBot.create(:contract_period)
       school = FactoryBot.create(:school, :eligible)
@@ -131,17 +125,19 @@ RSpec.describe API::Schools::Query do
           }
         end
 
-        it "filters by `contract_period_year`" do
+        it "includes ineligible schools with partnerships in the `contract_period_year`" do
           expect(query.schools).to contain_exactly(school1, school3)
         end
 
-        context "when `contract_period_year` param is omitted" do
-          it "returns no schools" do
-            expect(described_class.new.schools).to be_empty
+        context "when `contract_period_year` param is :ignore" do
+          let(:contract_period_year) { :ignore }
+
+          it "returns no schools (you must provide a contract period year)" do
+            expect(query.schools).to be_empty
           end
         end
 
-        context "when no `contract_period_year` is found" do
+        context "when `contract_period_year` is not found" do
           let!(:contract_period_year) { "0000" }
 
           it "returns no schools" do
@@ -151,6 +147,14 @@ RSpec.describe API::Schools::Query do
 
         context "when `contract_period_year` param is blank" do
           let!(:contract_period_year) { " " }
+
+          it "returns no schools" do
+            expect(query.schools).to be_empty
+          end
+        end
+
+        context "when `contract_period_year` param is nil" do
+          let!(:contract_period_year) { nil }
 
           it "returns no schools" do
             expect(query.schools).to be_empty

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -33,7 +33,17 @@ RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpo
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render(apply_expected_order([resource]), root: "data", **options))
+    expect(response.body).to eq(serializer.render([resource], root: "data", **options))
+  end
+
+  it "returns all resources when cohort is blank" do
+    resource = create_resource(active_lead_provider:)
+
+    authenticated_api_get(path, params: { filter: { cohort: "" } })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([resource], root: "data", **options))
   end
 end
 
@@ -93,19 +103,34 @@ RSpec.shared_examples "a filter by a single cohort (contract_period year) endpoi
     expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
   end
 
-  it "ignores invalid cohorts" do
-    resource = create_resource(active_lead_provider:)
+  it "returns no resources if the specified cohort is invalid" do
+    create_resource(active_lead_provider:)
 
     # Resource for the next contract_period should not be included.
     next_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)
     next_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
     create_resource(active_lead_provider: next_active_lead_provider)
 
-    authenticated_api_get(path, params: { filter: { cohort: "#{active_lead_provider.contract_period.year},invalid,cohort,1099" } })
+    authenticated_api_get(path, params: { filter: { cohort: "invalid" } })
 
     expect(response).to have_http_status(:ok)
     expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq(serializer.render([resource], root: "data", **serializer_options))
+    expect(response.body).to eq(serializer.render([], root: "data", **serializer_options))
+  end
+
+  it "returns no resources if the specified cohort is not found" do
+    create_resource(active_lead_provider:)
+
+    # Resource for the next contract_period should not be included.
+    next_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)
+    next_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
+    create_resource(active_lead_provider: next_active_lead_provider)
+
+    authenticated_api_get(path, params: { filter: { cohort: "1999" } })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([], root: "data", **serializer_options))
   end
 end
 


### PR DESCRIPTION
### Context

The schools endpoint is not behaving consistently with ECF, and the query service is also not consistent with the other query services.

We want the schools endpoint to return no schools if the `cohort` cannot be matched to a `ContractPeriod`.

We want the `contract_period_year` to be mandatory when querying a `School` (which makes sense now that the query service is only used by the API).

### Changes proposed in this pull request

- Update `API::Schools::Query` to make `contract_period_year` mandatory.

Return no schools if `contract_period_year` is `nil`, blank or not found.

Update `a filter by a single cohort (contract_period year) endpoint` to use schools behaviour and remove from statements endpoint specs (as this is covered by the multiple cohorts filtering context, which has different behaviour for `nil`/blank/not found).
