### PR TITLE
Change a mentor's name

### DIFF
--- a/app/components/schools/mentors/details_component.rb
+++ b/app/components/schools/mentors/details_component.rb
@@ -28,7 +28,12 @@ module Schools
       def name_row
         {
           key: { text: 'Name' },
-          value: { text: teacher_full_name(@teacher) }
+          value: { text: teacher_full_name(@teacher) },
+          actions: [{
+            text: "Change",
+            visually_hidden_text: "name",
+            href: schools_mentors_change_name_wizard_edit_path(@mentor)
+          }]
         }
       end
 

--- a/app/controllers/schools/mentors/change_name_wizard_controller.rb
+++ b/app/controllers/schools/mentors/change_name_wizard_controller.rb
@@ -1,0 +1,21 @@
+module Schools
+  module Mentors
+    class ChangeNameWizardController < SchoolsController
+      include Wizardable
+
+      wizard_for :mentor
+
+      def new
+        render @current_step
+      end
+
+      def create
+        if @wizard.save!
+          redirect_to @wizard.next_step_path
+        else
+          render @current_step, status: :unprocessable_content
+        end
+      end
+    end
+  end
+end

--- a/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/check_answers.html.erb
@@ -1,0 +1,28 @@
+<%
+  page_data(
+    title: 'Check and confirm change',
+    backlink_href: @wizard.previous_step_path
+  )
+%>
+
+<%= govuk_summary_list do |list| %>
+  <% list.with_row do |row| %>
+    <% row.with_key { 'Mentor' } %>
+    <% row.with_value { @wizard.teacher_full_name } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <% row.with_key { 'New name' } %>
+    <% row.with_value { @wizard.store.name } %>
+  <% end %>
+<% end %>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%= f.govuk_submit 'Confirm change' %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to "Cancel and go back to #{@wizard.teacher_full_name}’s details", schools_mentor_path(@mentor_at_school_period) %>
+</p>

--- a/app/views/schools/mentors/change_name_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/confirmation.html.erb
@@ -1,0 +1,16 @@
+<%
+  page_data(
+    title: "You have changed the mentor’s name to #{@wizard.teacher_full_name}",
+    header: false
+  )
+%>
+
+<%= govuk_panel(title_text: "You have changed the mentor’s name to #{@wizard.teacher_full_name}") %>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p class="govuk-body">The mentor can update their name in their teacher record using the Access your teaching qualifications service.</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to "Back to #{@wizard.teacher_full_name}’s details", schools_mentor_path(@mentor_at_school_period) %>
+</p>

--- a/app/views/schools/mentors/change_name_wizard/edit.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/edit.html.erb
@@ -1,0 +1,28 @@
+<% page_data(
+    title: "Change name for #{@wizard.teacher_full_name}",
+    error: @mentor_at_school_period.errors.present?,
+    backlink_href: schools_mentor_path(@mentor_at_school_period),
+) %>
+
+<p class="govuk-body">The name will be used in this service and communications with the mentor.</p>
+
+<p class="govuk-body">The mentor can update their name in their teacher record using the Access your teaching qualifications service.</p>
+
+<%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+  <%=
+    f.govuk_text_field(
+      :name,
+      label: { text: "What’s the correct full name for #{@wizard.teacher_full_name}?",
+               tag: 'h2',
+               size: 'm' }
+    ) do %>
+  <% end %>
+
+  <%= f.govuk_submit 'Continue' %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to "Cancel and go back to #{@wizard.teacher_full_name}’s details", schools_mentor_path(@mentor_at_school_period) %>
+</p>

--- a/app/wizards/schools/mentors/change_name_wizard/check_answers_step.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/check_answers_step.rb
@@ -1,0 +1,30 @@
+module Schools
+  module Mentors
+    module ChangeNameWizard
+      class CheckAnswersStep < Step
+        def previous_step = :edit
+        def next_step = :confirmation
+
+        def save!
+          ApplicationRecord.transaction do
+            old_name = wizard.teacher_full_name
+            mentor_at_school_period.teacher.update!(corrected_name: store.name)
+            new_name = wizard.teacher_full_name
+            record_event(old_name, new_name)
+          end
+        end
+
+      private
+
+        def record_event(old_name, new_name)
+          ::Events::Record.teacher_name_changed_in_trs_event!(
+            old_name:,
+            new_name:,
+            author:,
+            teacher: mentor_at_school_period.teacher
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/change_name_wizard/confirmation_step.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/confirmation_step.rb
@@ -1,0 +1,8 @@
+module Schools
+  module Mentors
+    module ChangeNameWizard
+      class ConfirmationStep < Step
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/change_name_wizard/edit_step.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/edit_step.rb
@@ -1,7 +1,7 @@
 module Schools
-  module ECTs
+  module Mentors
     module ChangeNameWizard
-      class EditStep < ECTs::Step
+      class EditStep < Mentors::Step
         attribute :name, :string
 
         validates :name,

--- a/app/wizards/schools/mentors/change_name_wizard/wizard.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/wizard.rb
@@ -1,0 +1,17 @@
+module Schools
+  module Mentors
+    module ChangeNameWizard
+      class Wizard < Mentors::Wizard
+        steps do
+          [
+            {
+              edit: EditStep,
+              check_answers: CheckAnswersStep,
+              confirmation: ConfirmationStep,
+            }
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/mentors/wizard.rb
+++ b/app/wizards/schools/mentors/wizard.rb
@@ -9,7 +9,7 @@ module Schools
 
       # @return [String]
       def teacher_full_name
-        ::Teachers::Name.new(mentor_at_school_period.teacher).full_name
+        ::Teachers::Name.new(mentor_at_school_period.teacher.reload).full_name
       end
 
       # @return [Hash]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -385,6 +385,14 @@ Rails.application.routes.draw do
     end
 
     scope module: :mentors, path: "/mentors/:mentor_id", as: :mentors do
+      namespace :change_name_wizard, path: "change-name" do
+        get "edit", action: :new
+        post "edit", action: :create
+        get "check-answers", action: :new
+        post "check-answers", action: :create
+        get "confirmation", action: :new
+      end
+
       namespace :change_email_address_wizard, path: "change-email-address" do
         get :edit, action: :new
         post :edit, action: :create

--- a/spec/factories/change_mentor_name_wizard_factory.rb
+++ b/spec/factories/change_mentor_name_wizard_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory(:change_mentor_name_wizard, class: "Schools::Mentors::ChangeNameWizard::Wizard") do
+    skip_create
+    initialize_with { new(current_step:, step_params:, store:) }
+
+    current_step { :edit }
+    step_params { {} }
+    store { FactoryBot.build(:session_repository) }
+  end
+end

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -1,0 +1,143 @@
+RSpec.describe "Changing an mentor's name" do
+  let!(:mentor_at_school_period) do
+    FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
+  end
+
+  let(:teacher) do
+    FactoryBot.create(:teacher, trs_first_name: 'Miriam', trs_last_name: 'Margolyes')
+  end
+
+  let(:school) { FactoryBot.create(:school) }
+
+  before do
+    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
+
+    given_i_am_logged_in_as_a_school_user
+    and_i_visit_the_mentors_page
+    when_i_select_a_mentor
+    and_i_try_to_change_the_mentor_name
+    then_i_should_see_the_change_name_page
+  end
+
+  scenario 'valid name' do
+    when_i_change_the_name_to('Sister Mildred')
+    and_i_click_the_continue_button
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_should_see_the_name('Sister Mildred')
+    and_i_should_see_the_name('Miriam Margolyes')
+    and_i_click_the_confirmation_button
+    then_i_should_be_taken_to_the_confirmation_page
+    then_the_teacher_name_should_be_corrected
+  end
+
+  scenario 'edit before confirming' do
+    when_i_change_the_name_to('Professor Sprout')
+    and_i_click_the_continue_button
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_click_the_back_link
+    then_i_should_see_the_change_name_page
+    then_the_form_should_should_show('Professor Sprout')
+    when_i_change_the_name_to('Sister Mildred')
+    and_i_click_the_continue_button
+    and_i_click_the_confirmation_button
+    then_the_teacher_name_should_be_corrected
+  end
+
+  scenario 'cancel and reset' do
+    when_i_change_the_name_to('Professor Sprout')
+    and_i_click_the_continue_button
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_click_the_cancel_link
+    and_i_try_to_change_the_mentor_name
+    then_i_should_see_the_change_name_page
+    then_the_form_should_be_reset
+  end
+
+  scenario 'invalid long name' do
+    when_i_change_the_name_to(Faker::Lorem.characters(number: 71))
+    and_i_click_the_continue_button
+    expect(page.get_by_role('link', name: 'Corrected name must be 70 characters or less')).to be_visible
+    then_i_should_be_taken_to_the_edit_page
+  end
+
+  scenario 'invalid blank name' do
+    when_i_change_the_name_to('')
+    and_i_click_the_continue_button
+    expect(page.get_by_role('link', name: 'Enter the correct full name')).to be_visible
+    then_i_should_be_taken_to_the_edit_page
+  end
+
+  scenario 'invalid same name' do
+    when_i_change_the_name_to('Miriam Margolyes')
+    and_i_click_the_continue_button
+    expect(page.get_by_role('link', name: 'The name must be different from the current name')).to be_visible
+    then_i_should_be_taken_to_the_edit_page
+  end
+
+  def given_i_am_logged_in_as_a_school_user
+    sign_in_as_school_user(school:)
+  end
+
+  def and_i_visit_the_mentors_page
+    page.goto(schools_mentors_home_path)
+    expect(page.url).to end_with('/schools/home/mentors')
+  end
+
+  def when_i_select_a_mentor
+    page.get_by_role('link', name: 'Miriam Margolyes').click
+  end
+
+  def then_i_should_see_the_change_name_page
+    expect(page.get_by_text('Change name for Miriam Margolyes')).to be_visible
+  end
+
+  def when_i_change_the_name_to(name)
+    page.get_by_label('What’s the correct full name for Miriam Margolyes?').fill(name)
+  end
+
+  def and_i_try_to_change_the_mentor_name
+    page.get_by_role('link', name: 'Change').first.click
+  end
+
+  def and_i_click_the_continue_button
+    page.get_by_role('button', name: 'Continue').click
+  end
+
+  def and_i_click_the_confirmation_button
+    page.get_by_role('button', name: 'Confirm change').click
+  end
+
+  def and_i_click_the_back_link
+    page.get_by_role('link', name: 'Back', exact: true).click
+  end
+
+  def and_i_click_the_cancel_link
+    page.get_by_role('link', name: 'Cancel').click
+  end
+
+  def then_i_should_be_taken_to_the_edit_page
+    expect(page.url).to end_with("/school/mentors/#{mentor_at_school_period.id}/change-name/edit")
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page.url).to end_with("/school/mentors/#{mentor_at_school_period.id}/change-name/check-answers")
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page.url).to end_with("/school/mentors/#{mentor_at_school_period.id}/change-name/confirmation")
+  end
+
+  def and_i_should_see_the_name(name)
+    expect(page.get_by_text(name, exact: true)).to be_visible
+  end
+
+  def then_the_teacher_name_should_be_corrected
+    expect(teacher.reload.corrected_name).to eq('Sister Mildred')
+  end
+
+  def then_the_form_should_be_reset(name = 'Miriam Margolyes')
+    expect(page.locator('#edit-name-field').input_value).to eq(name)
+  end
+
+  alias_method :then_the_form_should_should_show, :then_the_form_should_be_reset
+end

--- a/spec/wizards/schools/mentors/change_name_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/check_answers_step_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Schools::Mentors::ChangeNameWizard::CheckAnswersStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
+  let(:school) { FactoryBot.create(:school, :independent) }
+  let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
+  let(:store) { FactoryBot.build(:session_repository, name: 'Terry Pratchett') }
+
+  let(:wizard) do
+    FactoryBot.build(:change_mentor_name_wizard,
+                     current_step: :check_answers,
+                     author:,
+                     store:,
+                     mentor_at_school_period:)
+  end
+
+  describe '#next_step' do
+    it { expect(current_step.next_step).to eq(:confirmation) }
+  end
+
+  describe '#previous_step' do
+    it { expect(current_step.previous_step).to eq(:edit) }
+  end
+
+  context '#save!' do
+    it 'persists the corrected name' do
+      expect { current_step.save! }.to change(wizard.mentor_at_school_period.teacher, :corrected_name).from(nil).to('Terry Pratchett')
+    end
+
+    it 'records an event' do
+      expect { current_step.save! }.to have_enqueued_job(RecordEventJob)
+    end
+  end
+end

--- a/spec/wizards/schools/mentors/change_name_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/confirmation_step_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Schools::Mentors::ChangeNameWizard::ConfirmationStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    FactoryBot.build(:change_mentor_name_wizard,
+                     current_step: :confirmation)
+  end
+
+  describe '#next_step' do
+    it { expect { current_step.next_step }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#previous_step' do
+    it { expect { current_step.previous_step }.to raise_error(NotImplementedError) }
+  end
+end

--- a/spec/wizards/schools/mentors/change_name_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/edit_step_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe Schools::Mentors::ChangeNameWizard::EditStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period) }
+  let(:wizard) do
+    FactoryBot.build(:change_mentor_name_wizard,
+                     current_step: :edit,
+                     mentor_at_school_period:,
+                     step_params: ActionController::Parameters.new("edit" => params))
+  end
+
+  let(:params) do
+    { "name" => 'Terry Pratchett' }
+  end
+
+  describe 'validations' do
+    context 'when name has not changed' do
+      before do
+        mentor_at_school_period.teacher.update(corrected_name: 'Terry Pratchett')
+      end
+
+      it 'is not valid' do
+        expect(current_step).not_to be_valid
+        expect(current_step.errors[:name]).to include('The name must be different from the current name')
+      end
+    end
+
+    context 'when name is blank' do
+      let(:params) do
+        { "name" => '' }
+      end
+
+      it 'is not valid' do
+        expect(current_step).not_to be_valid
+        expect(current_step.errors[:name]).to include('Enter the correct full name')
+      end
+    end
+  end
+
+  describe '#next_step' do
+    it { expect(current_step.next_step).to eq(:check_answers) }
+  end
+
+  describe '#previous_step' do
+    it { expect { current_step.previous_step }.to raise_error(NotImplementedError) }
+  end
+
+  context '#save!' do
+    context 'when the step is not valid' do
+      let(:params) do
+        { "name" => '' }
+      end
+
+      it 'does not cache the new name' do
+        expect { current_step.save! }.not_to change(wizard.store, :name)
+      end
+    end
+
+    context 'when the step is valid' do
+      it 'caches the new name' do
+        expect { current_step.save! }.to change(wizard.store, :name).from(nil).to('Terry Pratchett')
+      end
+    end
+  end
+end

--- a/spec/wizards/schools/mentors/change_name_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/wizard_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Schools::Mentors::ChangeNameWizard::Wizard do
+  subject(:wizard) do
+    FactoryBot.build(:change_mentor_name_wizard, mentor_at_school_period:)
+  end
+
+  let(:teacher) do
+    FactoryBot.create(:teacher, trs_first_name: 'Terry', trs_last_name: 'Pratchett')
+  end
+
+  let(:mentor_at_school_period) do
+    FactoryBot.create(:mentor_at_school_period, teacher:)
+  end
+
+  describe '#teacher_full_name' do
+    it 'finds the mentor' do
+      expect(wizard.teacher_full_name).to eq('Terry Pratchett')
+    end
+  end
+
+  describe '#current_step_path' do
+    it { expect(wizard.current_step_path).to eq "/school/mentors/#{mentor_at_school_period.id}/change-name/edit" }
+  end
+end


### PR DESCRIPTION
### Context

School users need to edit mentor details.

### Changes proposed in this pull request

Mentor version of #1253 

### Guidance to review

- `/school/mentors/N/change-name/edit`
- `/school/mentors/N/change-name/check-answers`
- `/school/mentors/N/change-name/confirmation`

<img width="2374" height="1804" alt="cpd-ec2-review-1322-web test teacherservices cloud_schools_mentors_6" src="https://github.com/user-attachments/assets/6dec41bf-d4a0-418b-b6b8-94dcd8f33c6d" />

<img width="2374" height="2008" alt="cpd-ec2-review-1322-web test teacherservices cloud_school_mentors_6_change-name_edit" src="https://github.com/user-attachments/assets/144f9d60-f09a-47d9-b6ba-f2d4f36f1f06" />

<img width="2374" height="1792" alt="cpd-ec2-review-1322-web test teacherservices cloud_school_mentors_6_change-name_check-answers" src="https://github.com/user-attachments/assets/775560f0-14c5-4d96-9fda-daf5127ae767" />

<img width="2374" height="1898" alt="cpd-ec2-review-1322-web test teacherservices cloud_school_mentors_6_change-name_confirmation" src="https://github.com/user-attachments/assets/f4a41fa7-405a-4799-a756-4e6d9014dc63" />



