### PR TITLE
[2177] SPIKE: data model for participant_id_changes

### DIFF
--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -1,0 +1,6 @@
+class ParticipantIdChange < ApplicationRecord
+  belongs_to :teacher
+
+  validates :teacher, :from_participant_id, :to_participant_id, presence: true
+  validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another participant id change" }
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -13,6 +13,7 @@ class Teacher < ApplicationRecord
   has_many :ect_at_school_periods, inverse_of: :teacher
   has_many :mentor_at_school_periods, inverse_of: :teacher
   has_many :induction_extensions, inverse_of: :teacher
+  has_many :participant_id_changes, inverse_of: :teacher
 
   has_many :induction_periods
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"

--- a/app/serializers/api/participant_id_change_serializer.rb
+++ b/app/serializers/api/participant_id_change_serializer.rb
@@ -1,0 +1,5 @@
+class API::ParticipantIdChangeSerializer < Blueprinter::Base
+  field(:from_participant_id)
+  field(:to_participant_id)
+  field(:created_at, name: :changed_at)
+end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,0 +1,26 @@
+class API::ParticipantSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field(:full_name) { |teacher, _options| Teachers::Name.new(teacher).full_name }
+    field(:trn, name: :teacher_reference_number)
+    field(:api_updated_at, name: :updated_at)
+
+    field(:ecf_enrolments) do |_teacher, _options|
+      []
+    end
+
+    field(:participant_id_changes) do |teacher, _options|
+      (teacher.participant_id_changes || []).map do |participant_id_change|
+        API::ParticipantIdChangeSerializer.render_as_hash(participant_id_change)
+      end
+    end
+  end
+
+  identifier :ecf_user_id, name: :id
+  field(:type) { "participant" }
+
+  association :attributes, blueprint: AttributesSerializer do |participant|
+    participant
+  end
+end

--- a/db/migrate/20250908193455_add_unique_ecf_user_id_constraint_to_teachers.rb
+++ b/db/migrate/20250908193455_add_unique_ecf_user_id_constraint_to_teachers.rb
@@ -1,0 +1,11 @@
+class AddUniqueECFUserIdConstraintToTeachers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    add_index :teachers, :ecf_user_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :teachers, :ecf_user_id
+  end
+end

--- a/db/migrate/20250908202312_create_participant_id_changes.rb
+++ b/db/migrate/20250908202312_create_participant_id_changes.rb
@@ -1,0 +1,12 @@
+class CreateParticipantIdChanges < ActiveRecord::Migration[8.0]
+  def change
+    create_table :participant_id_changes do |t|
+      t.references :teacher, null: false, foreign_key: true
+      t.references :from_participant, null: false, type: :uuid, foreign_key: { to_table: :teachers, primary_key: :ecf_user_id }
+      t.references :to_participant, null: false, type: :uuid, foreign_key: { to_table: :teachers, primary_key: :ecf_user_id }
+      t.uuid :api_id, null: false, default: -> { "gen_random_uuid()" }, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_01_173600) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_202312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -465,6 +465,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_01_173600) do
     t.index ["state"], name: "index_parity_check_runs_on_state", unique: true, where: "(state = 'in_progress'::parity_check_run_states)"
   end
 
+  create_table "participant_id_changes", force: :cascade do |t|
+    t.bigint "teacher_id", null: false
+    t.uuid "from_participant_id", null: false
+    t.uuid "to_participant_id", null: false
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_id"], name: "index_participant_id_changes_on_api_id", unique: true
+    t.index ["from_participant_id"], name: "index_participant_id_changes_on_from_participant_id"
+    t.index ["teacher_id"], name: "index_participant_id_changes_on_teacher_id"
+    t.index ["to_participant_id"], name: "index_participant_id_changes_on_to_participant_id"
+  end
+
   create_table "pending_induction_submission_batches", force: :cascade do |t|
     t.bigint "appropriate_body_id", null: false
     t.enum "batch_type", null: false, enum_type: "batch_type"
@@ -727,6 +740,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_01_173600) do
     t.boolean "trs_deactivated", default: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(trs_first_name, ''::character varying))::text || ' '::text) || (COALESCE(trs_last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
+    t.index ["ecf_user_id"], name: "index_teachers_on_ecf_user_id", unique: true
     t.index ["search"], name: "index_teachers_on_search", using: :gin
     t.index ["trn"], name: "index_teachers_on_trn", unique: true
     t.index ["trs_first_name", "trs_last_name", "corrected_name"], name: "idx_on_trs_first_name_trs_last_name_corrected_name_6d0edad502", opclass: :gin_trgm_ops, using: :gin
@@ -807,6 +821,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_01_173600) do
   add_foreign_key "parity_check_requests", "parity_check_endpoints", column: "endpoint_id"
   add_foreign_key "parity_check_requests", "parity_check_runs", column: "run_id"
   add_foreign_key "parity_check_responses", "parity_check_requests", column: "request_id"
+  add_foreign_key "participant_id_changes", "teachers"
+  add_foreign_key "participant_id_changes", "teachers", column: "from_participant_id", primary_key: "ecf_user_id"
+  add_foreign_key "participant_id_changes", "teachers", column: "to_participant_id", primary_key: "ecf_user_id"
   add_foreign_key "pending_induction_submission_batches", "appropriate_bodies"
   add_foreign_key "pending_induction_submissions", "appropriate_bodies"
   add_foreign_key "pending_induction_submissions", "pending_induction_submission_batches"


### PR DESCRIPTION
### Context

**_This is just a spike PR.. not to be merged at all._**

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2177

### Changes proposed in this pull request

- Creates a new table/model to store participant id changes;
- It's an existing table in ECF1, so we need to migrate ecf1 ids to `api_id` column;
- `from_participant` and `to_participant` fields are keys to `teachers`.`ecf_user_id` which is not a required field at the moment;
- In order to have the above link, we need to create a unique index in `teachers`.`ecf_user_id`;
- Created a [draft participant serializer](https://github.com/DFE-Digital/register-early-career-teachers-public/compare/2177-spike-participant-id-changes-model?expand=1#diff-9b6be1e63afc85dbb8ed4a743f9e4c6cf249de7de998883d954457176e2022a6), where it calls the [participant id change serializer](https://github.com/DFE-Digital/register-early-career-teachers-public/compare/2177-spike-participant-id-changes-model?expand=1#diff-638d34a27efc44259cfee56061819cb18aa7d958b624f9b2ec35dab7f56cd30f);
- If needed, same sort of validation which is done in [npq-reg app](https://github.com/DFE-Digital/npq-registration/commit/424f2acf1bebbb191cc8b36b9e6dac670fc5f12d) can be used in the participants endpoint so when a lead provider attempts to use/fetch a transferred `participant_id` (i.e. a teacher who has been archived & had their declarations moved to a different teacher), so instead of getting an error response that says the `participant_id` does not exist... a message informing providers that the `participant_id` has changed is displayed, so that they can understand how to rectify the situation.

### Guidance to review

Review all bullets above with the team.