### PR TITLE
Set `author_name` for lead provider events

### DIFF
--- a/app/services/events/lead_provider_api_author.rb
+++ b/app/services/events/lead_provider_api_author.rb
@@ -1,5 +1,14 @@
 class Events::LeadProviderAPIAuthor
+  attr_reader :lead_provider
+
+  def initialize(lead_provider:)
+    @lead_provider = lead_provider
+  end
+
   def lead_provider_api_author_params
-    { author_type: 'lead_provider_api' }
+    {
+      author_type: 'lead_provider_api',
+      author_name: lead_provider.name,
+    }
   end
 end

--- a/app/services/school_partnerships/create.rb
+++ b/app/services/school_partnerships/create.rb
@@ -13,7 +13,8 @@ module SchoolPartnerships
           school:,
           lead_provider_delivery_partnership:
         ).tap do |school_partnership|
-          Events::Record.record_school_partnership_created_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:)
+          lead_provider = school_partnership.lead_provider
+          Events::Record.record_school_partnership_created_event!(author: Events::LeadProviderAPIAuthor.new(lead_provider:), school_partnership:)
         end
       end
     end

--- a/app/services/school_partnerships/update.rb
+++ b/app/services/school_partnerships/update.rb
@@ -13,7 +13,8 @@ module SchoolPartnerships
           previous_delivery_partner = school_partnership.delivery_partner
           school_partnership.update!(lead_provider_delivery_partnership:)
           modifications = school_partnership.saved_changes
-          Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new, school_partnership:, previous_delivery_partner:, modifications:)
+          lead_provider = school_partnership.lead_provider
+          Events::Record.record_school_partnership_updated_event!(author: Events::LeadProviderAPIAuthor.new(lead_provider:), school_partnership:, previous_delivery_partner:, modifications:)
         end
       end
     end

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -35,7 +35,10 @@ RSpec.describe SchoolPartnerships::Create do
         hash_including(
           {
             school_partnership:,
-            author: kind_of(Events::LeadProviderAPIAuthor),
+            author: an_object_having_attributes(
+              class: Events::LeadProviderAPIAuthor,
+              lead_provider:
+            ),
           }
         )
       )

--- a/spec/services/school_partnerships/update_spec.rb
+++ b/spec/services/school_partnerships/update_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe SchoolPartnerships::Update do
         hash_including(
           {
             school_partnership:,
-            author: kind_of(Events::LeadProviderAPIAuthor),
+            author: an_object_having_attributes(
+              class: Events::LeadProviderAPIAuthor,
+              lead_provider: school_partnership.lead_provider
+            ),
             previous_delivery_partner:,
             modifications: school_partnership.saved_changes
           }


### PR DESCRIPTION
### Context

Currently, the `LeadProviderAPIAuthor` does not specify an `author_name`, so in a teacher's timeline the event will display the `author_type` of `lead_provider_api`. We want to display the lead provider name in the teacher's timeline instead.

### Changes proposed in this pull request

- Set `author_name` for lead provider events

Update `LeadProviderAPIAuthor` to accept a `lead_provider`, so that we can populate `author_name` in the event parameters.

### Guidance to review

I don't think we can test this yet, as a school partnership create/update event isn't tied to a specific teacher and so won't appear in the timeline. We probably need to wait until we add the participant actions for something to show up.

For now, I manually added a teacher to a school partnership event to get it to show up:

```
lead_provider = LeadProvider.all.sample
school_partnership = SchoolPartnership.last
Events::Record.record_school_partnership_created_event!(author: Events::LeadProviderAPIAuthor.new(lead_provider:), school_partnership:)
# run jobs, then:
event = Event.last
teacher = Teacher.find(<teacher id>)
event.update!(teacher:)
```

<img width="670" height="213" alt="Screenshot 2025-09-10 at 08 33 48" src="https://github.com/user-attachments/assets/820f7549-b529-4531-a908-e93bde29b94a" />
