### PR TITLE
Ensure change ECT email label is styled correctly!

### DIFF
--- a/app/views/schools/ects/change_email_address_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_email_address_wizard/edit.html.erb
@@ -17,7 +17,10 @@
 
   <%= form.govuk_email_field(
         :email,
-        label: {text: "What’s the correct email address for #{@wizard.teacher_full_name}"},
+        label: {
+          text: "What’s the correct email address for #{@wizard.teacher_full_name}?",
+          size: "m"
+        },
         value: @wizard.current_step.email
       ) %>
 


### PR DESCRIPTION
Before, this label was missing the `--m` class.

Now, it isn't!

(Also added the missing `?`)

From [this comment](https://github.com/DFE-Digital/register-ects-project-board/issues/2098#issuecomment-3274740646)