### PR TITLE
[1249] Ensure EOI text appears on the programme choices page (#MentorRegistrationFlow)

### DIFF
--- a/app/views/schools/register_mentor_wizard/programme_choices.html.erb
+++ b/app/views/schools/register_mentor_wizard/programme_choices.html.erb
@@ -15,16 +15,14 @@
   summary_list.with_row do |row|
     row.with_key(text: "Lead provider")
     row.with_value(
-      text: (@mentor.ect_lead_provider || @mentor.ect_eoi_lead_provider).name,
+      text: @mentor.ect_lead_provider.name,
     )
   end
 end %>
 
-<% unless @mentor.ect_lead_provider %>
+<% if @mentor.expression_of_interest? %>
   <p class="govuk-body">
-    <%= @mentor.ect_eoi_lead_provider.name %>
-    will confirm if they’ll be working with your school and which delivery
-    partner will deliver training events.
+    <%= @mentor.ect_lead_provider.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
   </p>
 <% end %>
 

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -142,6 +142,8 @@ module Schools
         ect_training_service.lead_provider_via_school_partnership_or_eoi
       end
 
+      delegate :expression_of_interest?, to: :ect_training_service
+
       def mentoring_at_new_school_only?
         store.fetch("mentoring_at_new_school_only", "yes") == "yes"
       end

--- a/spec/views/schools/register_mentor_wizard/programme_choices.html.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/programme_choices.html.erb_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe 'schools/register_mentor_wizard/programme_choices.html.erb' do
+  include SchoolPartnershipHelpers
+
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:school)  { FactoryBot.create(:school) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+  let(:school_partnership) do
+    make_partnership_for(school, contract_period, lead_provider_name: 'Naruto Ninja Academy')
+  end
+
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+
+  let!(:training_period) do
+    FactoryBot.create(:training_period,
+                      :provider_led,
+                      :ongoing,
+                      ect_at_school_period:,
+                      school_partnership:)
+  end
+
+  let(:store) do
+    FactoryBot.build(:session_repository,
+                     trn: '0000007',
+                     trs_first_name: 'Sasuke',
+                     trs_last_name: 'Uchiha',
+                     change_name: 'no',
+                     corrected_name: nil,
+                     ect_id: ect_at_school_period.id)
+  end
+
+  let(:wizard) do
+    FactoryBot.build(:register_mentor_wizard,
+                     current_step: :programme_choices,
+                     ect_id: ect_at_school_period.id,
+                     store:)
+  end
+
+  let(:mentor) { wizard.mentor }
+
+  before do
+    assign(:wizard, wizard)
+    assign(:mentor, mentor)
+    assign(:ect_name, 'Naruto Uzumaki')
+  end
+
+  it 'always shows the lead provider row' do
+    render
+    expect(rendered).to have_element(:dt, text: 'Lead provider')
+    expect(rendered).to have_element(:dd, text: 'Naruto Ninja Academy')
+  end
+
+  context 'when mentor has expression_of_interest?' do
+    before do
+      allow(mentor).to receive(:expression_of_interest?).and_return(true)
+      render
+    end
+
+    it 'shows the explanatory text' do
+      expect(rendered).to have_text(
+        'Naruto Ninja Academy will confirm if they’ll be working with your school and which delivery partner will deliver training events.'
+      )
+    end
+  end
+
+  context 'when mentor does not have expression_of_interest?' do
+    before do
+      allow(mentor).to receive(:expression_of_interest?).and_return(false)
+      render
+    end
+
+    it 'does not show explanatory text' do
+      expect(rendered).not_to have_text('will confirm if they’ll be working with your school')
+    end
+  end
+end


### PR DESCRIPTION
### Changes proposed in this pull request

Ensure EOI text appears on the programme choices page.  

The previous methods were removed from the wrapper, which caused the text to silently fail to render.
The view has been updated to use `expression_of_interest?` and a view spec has been added for coverage.

### Guidance to product review

1. Sign in as Serena and register a new mentor.  
2. Sign in as Bob and register a provider-led ECT.  
3. Register a new mentor for them using the same details as the mentor registered for Serena.  
4. Confirm that the programme choices page shows the explanatory EOI text when applicable.
