### PR TITLE
Conditional view links in admin console

### DIFF
--- a/app/components/admin/appropriate_bodies/details_component.html.erb
+++ b/app/components/admin/appropriate_bodies/details_component.html.erb
@@ -1,0 +1,28 @@
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: 'Current ECTs')
+      row.with_value(text: current_ect_count)
+      row.with_action(
+        text: 'View',
+        href: admin_appropriate_body_current_ects_path(appropriate_body),
+        visually_hidden_text: 'current ECTs'
+      ) if current_ects?
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Number of bulk uploads')
+      row.with_value(text: bulk_upload_count)
+      row.with_action(
+        text: 'View',
+        href: admin_appropriate_body_batches_path(appropriate_body),
+        visually_hidden_text: 'bulk uploads'
+      ) if bulk_uploads?
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'DfE Sign-in organisation ID')
+      row.with_value(text: tag.code(appropriate_body.dfe_sign_in_organisation_id))
+    end
+  end
+%>

--- a/app/components/admin/appropriate_bodies/details_component.rb
+++ b/app/components/admin/appropriate_bodies/details_component.rb
@@ -1,0 +1,32 @@
+module Admin
+  module AppropriateBodies
+    class DetailsComponent < ApplicationComponent
+      attr_reader :appropriate_body
+
+      # @param appropriate_body [AppropriateBody]
+      def initialize(appropriate_body:)
+        @appropriate_body = appropriate_body
+      end
+
+      # @return [Boolean]
+      def current_ects?
+        current_ect_count.positive?
+      end
+
+      # @return [Integer]
+      def current_ect_count
+        ::Teachers::Search.new(appropriate_bodies: appropriate_body).search.count
+      end
+
+      # @return [Boolean]
+      def bulk_uploads?
+        bulk_upload_count.positive?
+      end
+
+      # @return [Integer]
+      def bulk_upload_count
+        ::PendingInductionSubmissionBatch.for_appropriate_body(appropriate_body).count
+      end
+    end
+  end
+end

--- a/app/controllers/admin/appropriate_bodies_controller.rb
+++ b/app/controllers/admin/appropriate_bodies_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class AppropriateBodiesController < AdminController
     include Pagy::Backend
 
-    layout 'full', only: 'index'
+    layout 'full'
 
     def index
       @breadcrumbs = {
@@ -17,10 +17,6 @@ module Admin
 
     def show
       @appropriate_body = AppropriateBody.find(params[:id])
-      @current_ect_count = ::Teachers::Search.new(appropriate_bodies: @appropriate_body).search.count
-      @bulk_batches_count = PendingInductionSubmissionBatch
-        .for_appropriate_body(@appropriate_body)
-        .count
     end
   end
 end

--- a/app/views/admin/appropriate_bodies/show.html.erb
+++ b/app/views/admin/appropriate_bodies/show.html.erb
@@ -5,34 +5,7 @@
   )
 %>
 
-<%=
-  govuk_summary_list do |sl|
-    sl.with_row do |row|
-      row.with_key(text: "Current ECTs")
-      row.with_value(text: @current_ect_count)
-      row.with_action(
-        text: 'View',
-        href: admin_appropriate_body_current_ects_path(@appropriate_body),
-        visually_hidden_text: 'current ECTs'
-      )
-    end
-
-    sl.with_row do |row|
-      row.with_key(text: "Number of bulk uploads")
-      row.with_value(text: @bulk_batches_count)
-      row.with_action(
-        text: "View",
-        href: admin_appropriate_body_batches_path(@appropriate_body),
-        visually_hidden_text: "bulk uploads"
-      )
-    end
-
-    sl.with_row do |row|
-      row.with_key(text: "DfE Sign-in organisation ID")
-      row.with_value(text: tag.code(@appropriate_body.dfe_sign_in_organisation_id))
-    end
-  end
-%>
+<%= render Admin::AppropriateBodies::DetailsComponent.new(appropriate_body: @appropriate_body) %>
 
 <p class='govuk-body'>
   <%# govuk_link_to('Timeline of events', admin_appropriate_body_timeline_path(@appropriate_body)) %>

--- a/spec/components/admin/appropriate_bodies/details_component_spec.rb
+++ b/spec/components/admin/appropriate_bodies/details_component_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Admin::AppropriateBodies::DetailsComponent, type: :component do
+  subject(:component) { described_class.new(appropriate_body:) }
+
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+  before { render_inline(component) }
+
+  describe 'ECTs' do
+    context 'with current ECTs' do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, appropriate_body:)
+        render_inline(component)
+      end
+
+      it do
+        expect(rendered_content).to have_link('View current ECTs',
+                                              href: "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/current-ects")
+      end
+    end
+
+    context 'without current ECTs' do
+      it do
+        expect(rendered_content).not_to have_link('View current ECTs')
+      end
+    end
+  end
+
+  describe 'bulk uploads' do
+    context 'with activity' do
+      before do
+        FactoryBot.create(:pending_induction_submission_batch, :claim, :completed, appropriate_body:)
+        render_inline(component)
+      end
+
+      it do
+        expect(rendered_content).to have_link('View bulk uploads',
+                                              href: "/admin/organisations/appropriate-bodies/#{appropriate_body.id}/batches")
+      end
+    end
+
+    context 'without activity' do
+      it do
+        expect(rendered_content).not_to have_link('View bulk uploads')
+      end
+    end
+  end
+end

--- a/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
@@ -1,10 +1,8 @@
 RSpec.describe 'admin/appropriate_bodies/show.html.erb' do
-  let(:current_ect_count) { 5 }
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
 
   before do
     assign(:appropriate_body, appropriate_body)
-    assign(:current_ect_count, current_ect_count)
     render
   end
 
@@ -13,19 +11,15 @@ RSpec.describe 'admin/appropriate_bodies/show.html.erb' do
     expect(view.content_for(:page_header)).to have_css('h1', text: appropriate_body.name)
   end
 
-  it 'displays a count of current ECTs' do
-    expect(rendered).to have_css('.govuk-summary-list__value', text: current_ect_count)
+  it 'displays the DfE Sign In organisation ID' do
+    expect(rendered).to have_css('.govuk-summary-list__value', text: appropriate_body.dfe_sign_in_organisation_id)
+  end
+
+  it 'displays counts of current ECTs and bulk uploads' do
+    expect(rendered).to have_css('.govuk-summary-list__value', exact_text: '0', count: 2)
   end
 
   it 'links to appropriate body timeline', skip: 'disabled for manual testing' do
     expect(rendered).to have_link('Timeline of events', href: admin_appropriate_body_timeline_path(appropriate_body))
-  end
-
-  it "links to the appropriate body's ECTs" do
-    expect(rendered).to have_link('View current ECTs', href: admin_appropriate_body_current_ects_path(appropriate_body))
-  end
-
-  it "links to the appropriate body's bulk uploads" do
-    expect(rendered).to have_link('View bulk uploads', href: admin_appropriate_body_batches_path(appropriate_body))
   end
 end


### PR DESCRIPTION
### Context

`View` links are rendered even when there is nothing to view

### Changes proposed in this pull request

Create an AB details component and use it on the AB admin show page with logic to make links conditional.
Also widen page to accommodate UUID.

### Guidance to review

Visit some ABs as an admin `/admin/organisations/appropriate-bodies/N`
