### PR TITLE
Fix flaky ECT specs

### DIFF
--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -47,8 +47,20 @@ describe ECTAtSchoolPeriod do
     end
 
     describe '.current_or_next_mentorship_period' do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:mentor_at_school_period) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          :ongoing,
+          started_on: mentorship_started_on - 5.days
+        )
+      end
+      let(:ect_at_school_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          :ongoing,
+          started_on: mentorship_started_on - 3.days
+        )
+      end
       let(:mentorship_started_on) { 3.weeks.ago }
       let(:mentorship_finished_on) { nil }
 

--- a/spec/services/schools/assign_mentor_form_spec.rb
+++ b/spec/services/schools/assign_mentor_form_spec.rb
@@ -54,9 +54,22 @@ RSpec.describe Schools::AssignMentorForm, type: :model do
     context "when the mentor is eligible to mentor the ect at the same school" do
       subject { described_class.new(ect:, mentor_id: mentor.id) }
 
-      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:ect) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          :ongoing,
+          started_on: 3.days.ago
+        )
+      end
+      let(:mentor) do
+        FactoryBot.create(
+          :mentor_at_school_period,
+          :ongoing,
+          school: ect.school,
+          started_on: 4.weeks.ago
+        )
+      end
       let(:author) { FactoryBot.create(:school_user, school_urn: ect.school.urn) }
-      let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
 
       it 'adds a new mentorship for the ect and the mentor starting today' do
         expect(ECTAtSchoolPeriods::Mentorship.new(ect).current_mentor).to be_nil


### PR DESCRIPTION
Before, we always relied on the ongoing ECT and Mentor periods being generated in the past.

But since the `started_on` dates are generated with a sequence, eventually we start building periods that start in the future.

This meant we ran into test failures where date ranges were no longer overlapping, or the earliest possible start date was in the future.

This updates the offending specs to initialise periods with explicit start dates, so now they should **always** pass.