### PR TITLE
Hardcode scope dates instead of using the `:ongoing` trait

### DIFF
--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -47,8 +47,8 @@ describe ECTAtSchoolPeriod do
     end
 
     describe '.current_or_next_mentorship_period' do
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 1.year.ago, finished_on: nil) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: nil) }
       let(:mentorship_started_on) { 3.weeks.ago }
       let(:mentorship_finished_on) { nil }
 
@@ -76,7 +76,6 @@ describe ECTAtSchoolPeriod do
         let!(:future_mentorship_period) do
           FactoryBot.create(
             :mentorship_period,
-            :ongoing,
             mentee: ect_at_school_period,
             mentor: mentor_at_school_period,
             started_on: mentorship_finished_on,


### PR DESCRIPTION
The trait makes use of the `base_ect_date` and `base_mentor_date` factories which are dynamic, so occasionally we get a failure because the inner (mentorship) range isn't contained by the outer (ect, mentor) ranges.

Hardcoding them should make these specs more robust.
