### PR TITLE
Fix flakey spec in `spec/services/schools/register_ect_spec`

### DIFF
--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Schools::RegisterECT do
         end
 
         context "when a Teacher record with the same TRN exists and has ect records at the same school" do
-          before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:) }
+          before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, started_on: Date.new(2024, 1, 1)) }
 
           it "raises an exception" do
             expect { service.register! }.to raise_error(ActiveRecord::RecordInvalid)


### PR DESCRIPTION
### Context

`spec/services/schools/register_ect_spec.rb:64` spec is flakey. This was the [failed run](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/17656376793/job/50180017365).

### Changes proposed in this pull request

- Fixed flakey spec;
- The same reason it was failing was [explained here](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1339);
- Copied the same `started_on` date as the previous spec in the same file.. keeping consistent.

