### PR TITLE
Strip extra whitespace on names

### DIFF
--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -15,4 +15,6 @@ class AppropriateBody < ApplicationRecord
   validates :name,
             presence: true,
             uniqueness: true
+
+  normalizes :name, with: -> { it.squish }
 end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -28,4 +28,6 @@ class DeliveryPartner < ApplicationRecord
 
   touch -> { self }, when_changing: %i[name], timestamp_attribute: :api_updated_at
   touch -> { school_partnerships }, when_changing: %i[name], timestamp_attribute: :api_updated_at
+
+  normalizes :name, with: -> { it.squish }
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -10,4 +10,6 @@ class LeadProvider < ApplicationRecord
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   scope :alphabetical, -> { order(name: :asc) }
+
+  normalizes :name, with: -> { it.squish }
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -61,4 +61,6 @@ class Teacher < ApplicationRecord
 
   scope :deactivated_in_trs, -> { where(trs_deactivated: true) }
   scope :active_in_trs, -> { where(trs_deactivated: false) }
+
+  normalizes :corrected_name, with: -> { it.squish }
 end

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -22,4 +22,12 @@ describe AppropriateBody do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
   end
+
+  describe "normalizing" do
+    subject { FactoryBot.build(:appropriate_body, name: " Some appropriate body ") }
+
+    it "removes leading and trailing spaces from the name" do
+      expect(subject.name).to eql("Some appropriate body")
+    end
+  end
 end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -21,6 +21,14 @@ describe DeliveryPartner do
     it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another delivery partner") }
   end
 
+  describe "normalizing" do
+    subject { FactoryBot.build(:delivery_partner, name: " Some delivery partner ") }
+
+    it "removes leading and trailing spaces from the name" do
+      expect(subject.name).to eql("Some delivery partner")
+    end
+  end
+
   describe "declarative touch" do
     let(:instance) { FactoryBot.create(:delivery_partner) }
 

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -23,4 +23,12 @@ describe LeadProvider do
       end
     end
   end
+
+  describe "normalizing" do
+    subject { FactoryBot.build(:lead_provider, name: " Some lead provider ") }
+
+    it "removes leading and trailing spaces from the name" do
+      expect(subject.name).to eql("Some lead provider")
+    end
+  end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -233,4 +233,12 @@ describe Teacher do
       end
     end
   end
+
+  describe "normalizing" do
+    subject { FactoryBot.build(:teacher, corrected_name: " Tobias Menzies ") }
+
+    it "removes leading and trailing spaces from the corrected name" do
+      expect(subject.corrected_name).to eql("Tobias Menzies")
+    end
+  end
 end


### PR DESCRIPTION
Rails' [normalizes](https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Normalization/ClassMethods.html) method allows us to apply formatting, in this case the removal of leading/trailing whitespace via ActiveSupport's `String#squish`.

Squishing removes:

* leading whitespace `" Appropriate body"` becomes `"Appropriate body"`
* trailing whitespace `"Appropriate body "` becomes `"Appropriate body"`
* contiguous whitespace `"Appropriate  body"` becomes `"Appropriate body"`

These often creep in when people are editing and paste in a name from another source. We never want them and they're likely to make formatting look wonky if we ever end up with them.
