### PR TITLE
[2384] Fix parity check POST/PUT endpoints

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -11,7 +11,8 @@ module ParityCheck
     def fetch(identifier)
       raise UnrecognizedIdentifierError, "Identifier not recognized: #{identifier}" unless respond_to?(identifier, true)
 
-      send(identifier)
+      @fetch ||= {}
+      @fetch[identifier] ||= send(identifier)
     end
 
   private
@@ -131,7 +132,7 @@ module ParityCheck
         .pluck(:school_id)
         .uniq
 
-      School.where.not(id: existing_school_ids).eligible.not_cip_only.first
+      School.where.not(id: existing_school_ids).eligible.not_cip_only.order("RANDOM()").first
     end
   end
 end

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -162,5 +162,16 @@ RSpec.describe ParityCheck::DynamicRequestContent do
         it { expect(fetch).to be_nil }
       end
     end
+
+    context "when fetching the same identifier more than once" do
+      let(:identifier) { :statement_id }
+      let!(:statement) { FactoryBot.create(:statement, :output_fee, lead_provider:) }
+
+      it "memoises the returned value for the same identifier in subsequent calls" do
+        expect(API::Statements::Query).to receive(:new).once.and_call_original
+
+        2.times { instance.fetch(identifier) }
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/parity_check_support.rb
+++ b/spec/support/shared_examples/parity_check_support.rb
@@ -53,10 +53,12 @@ RSpec.shared_examples "client performs requests with body" do
     ecf_body = ecf_requests.first.body
     rect_body = rect_requests.first.body
 
-    expect(ecf_body).to be_present
-    expect(rect_body).to be_present
-
     expect { JSON.parse(ecf_body) }.not_to raise_error
     expect { JSON.parse(rect_body) }.not_to raise_error
+
+    expect(JSON.parse(ecf_body)["data"]).to be_present
+    expect(JSON.parse(rect_body)["data"]).to be_present
+
+    expect(ecf_body).to eq(rect_body)
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2384

Currently, the parity check is sending different PUT/POST requests to ECF and RECT. Instead we'd like them to be similar

### Changes proposed in this pull request

- Memoise calls to `dynamic_request_content` service class so same endpoints calls to both ecf & rect will use the same params in the body.

### Guidance to review
