### PR TITLE
Show request body in parity check

### DIFF
--- a/app/assets/stylesheets/migration/parity_check.scss
+++ b/app/assets/stylesheets/migration/parity_check.scss
@@ -127,3 +127,11 @@
   margin-top: 100px;
   text-align: center;
 }
+
+.response-details code {
+  padding: 2px 5px;
+  font-family: monospace;
+  background-color: $govuk-template-background-colour;
+  white-space: pre-wrap;
+  font-size: 0.8em;
+}

--- a/app/migration/parity_check/client.rb
+++ b/app/migration/parity_check/client.rb
@@ -53,6 +53,9 @@ module ParityCheck
         rect_body: rect_response.body,
         rect_status_code: rect_response.status,
         rect_time_ms: rect_response.env[:request_duration_ms],
+        ecf_request_uri: CGI.unescape(ecf_response.env[:url].request_uri),
+        rect_request_uri: CGI.unescape(rect_response.env[:url].request_uri),
+        request_body: rect_response.env[:request_body],
         page: request_builder.page
       )
     end

--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -20,7 +20,7 @@ module ParityCheck
     scope :with_all_responses_matching, -> { joins(:responses).where.not(id: ParityCheck::Response.different.pluck(:request_id)).distinct }
     scope :with_lead_provider, ->(lead_provider) { where(lead_provider:) }
 
-    delegate :description, to: :endpoint
+    delegate :description, :method, to: :endpoint
 
     state_machine :state, initial: :pending do
       state :queued

--- a/app/views/migration/parity_checks/requests/show.html.erb
+++ b/app/views/migration/parity_checks/requests/show.html.erb
@@ -82,7 +82,7 @@ end %>
     <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
   <% end %>
   
-  <hr class="govuk-section-break govuk-section-break--l">
+  <hr class="govuk-section-break govuk-section-break--m">
 
   <h2 class="govuk-heading-m">Response IDs</h2>
 

--- a/app/views/migration/parity_checks/requests/show.html.erb
+++ b/app/views/migration/parity_checks/requests/show.html.erb
@@ -77,7 +77,6 @@ end %>
 
 <%= govuk_pagination(pagy: @pagy) %>
 
-
 <% if @request.response_body_ids_different? %>
   <% content_for(:head) do %>
     <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
@@ -85,7 +84,7 @@ end %>
   
   <hr class="govuk-section-break govuk-section-break--l">
 
-  <h2 class="govuk-heading-l">Response IDs</h2>
+  <h2 class="govuk-heading-m">Response IDs</h2>
 
   <div class="govuk-grid-row diff-container">
     <div class="govuk-grid-column-one-third">

--- a/app/views/migration/parity_checks/responses/_filter.html.erb
+++ b/app/views/migration/parity_checks/responses/_filter.html.erb
@@ -1,6 +1,6 @@
 <div class="diff-filter" data-controller="parity-check-response-body-filter">
   <%= form_for(filter, url: migration_parity_check_response_path(filter.response.run, filter.response), method: :get, html: { data: { "parity-check-response-body-filter-target": "form" } }) do |f| %>
-    <%= f.govuk_check_boxes_fieldset :selected_key_paths, legend: { text: "What do you want to compare?"}, hint: { text: "Only selected attributes will appear in the diff." }, small: true do %>
+    <%= f.govuk_check_boxes_fieldset :selected_key_paths, legend: { text: "What do you want to compare?", size: "s" }, hint: { text: "Only selected attributes will appear in the diff." }, small: true do %>
       <%= render_filterable_key_hash(filter.filterable_key_hash) do |key_path| %>
         <% f.govuk_check_box :selected_key_paths, key_path, label: { text: key_path.last }, checked: filter.selected?(key_path), data: { "parity-check-response-body-filter-target": "checkbox", action: "click->parity-check-response-body-filter#clickedCheckbox" } %>
       <% end %>

--- a/app/views/migration/parity_checks/responses/show.html.erb
+++ b/app/views/migration/parity_checks/responses/show.html.erb
@@ -45,7 +45,7 @@
 <% if @response.bodies_different? %>
   <hr class="govuk-section-break govuk-section-break--l">
 
-  <h2 class="govuk-heading-l">Response body</h2>
+  <h2 class="govuk-heading-m">Response body</h2>
 
   <div class="govuk-grid-row diff-container">
     <div class="govuk-grid-column-one-third">
@@ -60,7 +60,7 @@
 <% if @response.body_ids_different? %>
   <hr class="govuk-section-break govuk-section-break--l">
 
-  <h2 class="govuk-heading-l">Response IDs</h2>
+  <h2 class="govuk-heading-m">Response IDs</h2>
 
   <div class="govuk-grid-row diff-container">
     <div class="govuk-grid-column-one-third">

--- a/app/views/migration/parity_checks/responses/show.html.erb
+++ b/app/views/migration/parity_checks/responses/show.html.erb
@@ -20,7 +20,33 @@
   RECT returned <strong><%= id_count_in_words(@response.rect_body_ids) %></strong> and ECF returned <strong><%= id_count_in_words(@response.ecf_body_ids) %></strong>.
 </p>
 
-<% if @response.bodies_different? || @response.body_ids_different? %>
+<hr class="govuk-section-break govuk-section-break--m">
+
+<h2 class="govuk-heading-m">Request details</h2>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="response-details">
+      The request to <strong>ECF</strong> was made to: <code><%= "#{@response.request.method.upcase} #{@response.ecf_request_uri}" %></code>
+    </p>
+
+    <p class="response-details">
+      The request to <strong>RECT</strong> was made to: <code><%= "#{@response.request.method.upcase} #{@response.rect_request_uri}" %></code>
+    </p>
+
+    <% if @response.request_body %>
+      <p>The request body sent to both services was:</p>
+
+      <pre><%= JSON.pretty_generate(@response.request_body) %></pre>
+    <% end %>
+  </div>  
+</div>
+
+<% if @response.bodies_different? %>
+  <hr class="govuk-section-break govuk-section-break--m">
+
+  <h2 class="govuk-heading-m">Response body</h2>
+
   <% content_for(:head) do %>
     <style type="text/css" nonce="<%= content_security_policy_nonce %>"><%= Diffy::CSS %></style>
   <% end %>
@@ -40,12 +66,6 @@
       in the RECT response but is missing from the ECF response.
     </p>
   <% end %>
-<% end %>
-
-<% if @response.bodies_different? %>
-  <hr class="govuk-section-break govuk-section-break--l">
-
-  <h2 class="govuk-heading-m">Response body</h2>
 
   <div class="govuk-grid-row diff-container">
     <div class="govuk-grid-column-one-third">
@@ -58,7 +78,7 @@
 <% end %>
 
 <% if @response.body_ids_different? %>
-  <hr class="govuk-section-break govuk-section-break--l">
+  <hr class="govuk-section-break govuk-section-break--m">
 
   <h2 class="govuk-heading-m">Response IDs</h2>
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -457,6 +457,9 @@
   - rect_body
   - ecf_time_ms
   - rect_time_ms
+  - ecf_request_uri
+  - rect_request_uri
+  - request_body
   - page
   - created_at
   - updated_at

--- a/db/migrate/20250915065439_add_request_details_to_parity_check_responses.rb
+++ b/db/migrate/20250915065439_add_request_details_to_parity_check_responses.rb
@@ -1,0 +1,9 @@
+class AddRequestDetailsToParityCheckResponses < ActiveRecord::Migration[8.0]
+  def change
+    change_table :parity_check_responses, bulk: true do |t|
+      t.string :ecf_request_uri
+      t.string :rect_request_uri
+      t.jsonb :request_body
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_11_141514) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_15_065439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -451,6 +451,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_11_141514) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "page"
+    t.string "ecf_request_uri"
+    t.string "rect_request_uri"
+    t.jsonb "request_body"
     t.index ["request_id", "page"], name: "index_parity_check_responses_on_request_id_and_page", unique: true
     t.index ["request_id"], name: "index_parity_check_responses_on_request_id"
   end

--- a/spec/factories/parity_check/response_factory.rb
+++ b/spec/factories/parity_check/response_factory.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     rect_body { "RECT response body" }
     rect_status_code { 201 }
     rect_time_ms { Faker::Number.between(from: 10, to: 2000) }
+    ecf_request_uri { "/path/to/ecf/endpoint" }
+    rect_request_uri { "/path/to/rect/endpoint" }
+    request_body { { example: { request: "body" } } }
 
     trait :matching do
       ecf_status_code { 200 }

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe "View parity check response" do
 
     expect(page.get_by_text("The response IDs were the same. In total RECT returned 0 IDs and ECF returned 0 IDs.")).to be_visible
 
+    expect(page.get_by_role("heading", name: "Request details")).to be_visible
+    expect(page.get_by_text("The request to ECF was made to: GET /path/to/ecf/endpoint")).to be_visible
+    expect(page.get_by_text("The request to RECT was made to: GET /path/to/rect/endpoint")).to be_visible
+    expect(page.get_by_text("The request body sent to both services was:")).to be_visible
+    expect(page.get_by_text(JSON.pretty_generate(response.request_body))).to be_visible
+
     expect(page.get_by_text(/The diff below highlights/)).not_to be_visible
     page.get_by_text("Understanding the differences").click
     expect(page.get_by_text(/The diff below highlights/)).to be_visible

--- a/spec/models/parity_check/request_spec.rb
+++ b/spec/models/parity_check/request_spec.rb
@@ -10,6 +10,7 @@ describe ParityCheck::Request do
 
   describe "delegate methods" do
     it { is_expected.to delegate_method(:description).to(:endpoint) }
+    it { is_expected.to delegate_method(:method).to(:endpoint) }
   end
 
   describe "validations" do

--- a/spec/support/shared_examples/parity_check_support.rb
+++ b/spec/support/shared_examples/parity_check_support.rb
@@ -40,7 +40,10 @@ RSpec.shared_examples "client performs requests" do
         ecf_time_ms: be >= 0,
         rect_body:,
         rect_status_code: 201,
-        rect_time_ms: be >= 0
+        rect_time_ms: be >= 0,
+        ecf_request_uri: CGI.unescape(ecf_requests.first.uri.request_uri),
+        rect_request_uri: CGI.unescape(rect_requests.first.uri.request_uri),
+        request_body: (rect_requests + ecf_requests).sample.body,
       })
     end
   end


### PR DESCRIPTION
### Context

We want to store and surface the request URIs and body from parity check requests in the UI to help us notice/debug potential issues with the check/requests.

### Changes proposed in this pull request

- Ensure ParityCheck::Client makes consistent requests

We ran into an issue with the parity check where the request bodies were being uniquely generated for a particular `ParityCheck::Request` (so one sent to ECF and another to RECT).

This is hard to debug in the user interface; we have since fixed the underlying issue, but this puts a safety net in place to ensure at the `Client` level it is verifying the requests are being consistently made by comparing `method`, `request_body`, `request_headers` and `query`.

- Retain request URIs and body in ParityCheck::Response

We want to surface the request body and URIs in the parity check interface so that we can easily double check the requests that were made.

Add request URIs to the `Response` model; we need to store both separately as on occasion the paths will differ.

Add request body to the `Response` model; we only need to persist this once for both ECF and RECT as we have tests that ensure the same request body is used for both requests.

- Fix heading sizes on parity check pages

The heading sizes were a bit mismatched between pages and even on the same page.

Retain one `l` heading and then use `m` for sub headings.

- Show request details in parity check UI

Surface the request URIs and the request body when viewing a parity check response. This will help us to debug any issues with requests going forward.

### Guidance to review

It's hard to generate decent seed data with paths and request bodies due to not all LPs having, for example, school partnerships. I've left the seed data generic for now, so it won't match the rest of the response details.

<img width="600" alt="screencapture-0-0-0-0-3000-migration-parity-checks-7-responses-404-2025-09-15-13_23_27" src="https://github.com/user-attachments/assets/468d78e0-50b4-4cdb-a89b-d15c5ddcf201" />

Example failure on migration (as this was without the incoming fix being applied):

<img width="600" alt="Screenshot 2025-09-16 at 08 48 54" src="https://github.com/user-attachments/assets/193f7c7c-33e9-44d3-a501-4204988ce1ff" />

