### PR TITLE
[2172] Link relevant training periods when creating a school partnership

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -42,6 +42,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   validate :teacher_distinct_period
 
   # Scopes
+  scope :for_school, ->(school_id) { where(school_id:) }
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
   scope :with_partnerships_for_contract_period, ->(year) {
     joins(training_periods: {

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,6 +41,7 @@ class Event < ApplicationRecord
     teacher_trs_induction_end_date_updated
     teacher_trs_induction_start_date_updated
     teacher_trs_induction_status_updated
+    training_period_assigned_to_school_partnership
   ].freeze
 
   belongs_to :author, class_name: 'User'

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -45,6 +45,10 @@ class TrainingPeriod < ApplicationRecord
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
   scope :for_mentor, ->(mentor_at_school_period_id) { where(mentor_at_school_period_id:) }
   scope :for_school_partnership, ->(school_partnership_id) { where(school_partnership_id:) }
+  scope :at_school, ->(school_id) {
+    left_joins(:ect_at_school_period, :mentor_at_school_period)
+      .where('ect_at_school_periods.school_id = :id OR mentor_at_school_periods.school_id = :id', id: school_id)
+  }
 
   # Delegations
   delegate :name, to: :delivery_partner, prefix: true, allow_nil: true

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -45,11 +45,10 @@ class TrainingPeriod < ApplicationRecord
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
   scope :for_mentor, ->(mentor_at_school_period_id) { where(mentor_at_school_period_id:) }
   scope :for_school_partnership, ->(school_partnership_id) { where(school_partnership_id:) }
-  scope :at_school, ->(school_id) {
-    left_joins(:ect_at_school_period, :mentor_at_school_period)
-      .where('ect_at_school_periods.school_id = :id OR mentor_at_school_periods.school_id = :id', id: school_id)
+  scope :at_school, ->(school) {
+    left_outer_joins(:ect_at_school_period, :mentor_at_school_period)
+      .merge(ECTAtSchoolPeriod.for_school(school).or(MentorAtSchoolPeriod.for_school(school)))
   }
-
   # Delegations
   delegate :name, to: :delivery_partner, prefix: true, allow_nil: true
   delegate :name, to: :lead_provider, prefix: true, allow_nil: true

--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -27,6 +27,7 @@ module API::SchoolPartnerships
       return false unless valid?
 
       SchoolPartnerships::Create.new(
+        author: Events::LeadProviderAPIAuthor.new(lead_provider:),
         school:,
         lead_provider_delivery_partnership:
       ).create

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -399,6 +399,47 @@ module Events
       new(event_type:, author:, heading:, mentor_at_school_period:, teacher:, school:, happened_at:).record_event!
     end
 
+    def self.record_training_period_assigned_to_school_partnership_event!(
+      author:,
+      training_period:,
+      ect_at_school_period:,
+      mentor_at_school_period:,
+      school_partnership:,
+      lead_provider:,
+      delivery_partner:,
+      school:,
+      teacher:,
+      happened_at: Time.zone.now
+    )
+      if ect_at_school_period.present? && mentor_at_school_period.present?
+        fail(ArgumentError, 'either ect_at_school_period or mentor_at_school_period permitted, not both')
+      end
+
+      if ect_at_school_period.nil? && mentor_at_school_period.nil?
+        fail(ArgumentError, 'either ect_at_school_period or mentor_at_school_period is required')
+      end
+
+      event_type = :training_period_assigned_to_school_partnership
+      teacher_name = Teachers::Name.new(teacher).full_name
+      training_type = ect_at_school_period.present? ? 'ECT' : 'mentor'
+      heading = "#{teacher_name}’s #{training_type} training period was assigned to a school partnership"
+
+      new(
+        event_type:,
+        author:,
+        heading:,
+        training_period:,
+        ect_at_school_period:,
+        mentor_at_school_period:,
+        school_partnership:,
+        lead_provider:,
+        delivery_partner:,
+        school:,
+        teacher:,
+        happened_at:
+      ).record_event!
+    end
+
     # Bulk Upload Events
 
     def self.record_bulk_upload_started_event!(author:, batch:)

--- a/app/services/school_partnerships/assign_training_periods.rb
+++ b/app/services/school_partnerships/assign_training_periods.rb
@@ -1,0 +1,22 @@
+module SchoolPartnerships
+  class AssignTrainingPeriods
+    def initialize(school_partnership:, school:, lead_provider:, contract_period:)
+      @school_partnership = school_partnership
+      @school = school
+      @lead_provider = lead_provider
+      @contract_period = contract_period
+    end
+
+    def call
+      TrainingPeriods::Search.new
+        .linkable_to_school_partnership(
+          school: @school,
+          lead_provider: @lead_provider,
+          contract_period: @contract_period
+        )
+        .find_each do |tp|
+          tp.update!(school_partnership: @school_partnership)
+        end
+    end
+  end
+end

--- a/app/services/school_partnerships/assign_training_periods.rb
+++ b/app/services/school_partnerships/assign_training_periods.rb
@@ -1,10 +1,11 @@
 module SchoolPartnerships
   class AssignTrainingPeriods
-    def initialize(school_partnership:, school:, lead_provider:, contract_period:)
+    def initialize(school_partnership:, school:, lead_provider:, contract_period:, author:)
       @school_partnership = school_partnership
       @school = school
       @lead_provider = lead_provider
       @contract_period = contract_period
+      @author = author
     end
 
     def call
@@ -18,7 +19,7 @@ module SchoolPartnerships
           tp.update!(school_partnership: @school_partnership)
 
           Events::Record.record_training_period_assigned_to_school_partnership_event!(
-            author: Events::LeadProviderAPIAuthor.new(lead_provider: @lead_provider),
+            author: @author,
             training_period: tp,
             ect_at_school_period: tp.ect_at_school_period,
             mentor_at_school_period: tp.mentor_at_school_period,

--- a/app/services/school_partnerships/assign_training_periods.rb
+++ b/app/services/school_partnerships/assign_training_periods.rb
@@ -16,6 +16,18 @@ module SchoolPartnerships
         )
         .find_each do |tp|
           tp.update!(school_partnership: @school_partnership)
+
+          Events::Record.record_training_period_assigned_to_school_partnership_event!(
+            author: Events::LeadProviderAPIAuthor.new(lead_provider: @lead_provider),
+            training_period: tp,
+            ect_at_school_period: tp.ect_at_school_period,
+            mentor_at_school_period: tp.mentor_at_school_period,
+            teacher: tp.ect_at_school_period&.teacher || tp.mentor_at_school_period&.teacher,
+            school_partnership: @school_partnership,
+            lead_provider: @lead_provider,
+            delivery_partner: @school_partnership.delivery_partner,
+            school: @school
+          )
         end
     end
   end

--- a/app/services/school_partnerships/create.rb
+++ b/app/services/school_partnerships/create.rb
@@ -14,7 +14,16 @@ module SchoolPartnerships
           lead_provider_delivery_partnership:
         ).tap do |school_partnership|
           lead_provider = school_partnership.lead_provider
+          contract_period = school_partnership.contract_period
+
           Events::Record.record_school_partnership_created_event!(author: Events::LeadProviderAPIAuthor.new(lead_provider:), school_partnership:)
+
+          SchoolPartnerships::AssignTrainingPeriods.new(
+            school_partnership:,
+            school:,
+            lead_provider:,
+            contract_period:
+          ).call
         end
       end
     end

--- a/app/services/school_partnerships/create.rb
+++ b/app/services/school_partnerships/create.rb
@@ -1,10 +1,11 @@
 module SchoolPartnerships
   class Create
-    attr_reader :school, :lead_provider_delivery_partnership
+    attr_reader :school, :lead_provider_delivery_partnership, :author
 
-    def initialize(school:, lead_provider_delivery_partnership:)
+    def initialize(author:, school:, lead_provider_delivery_partnership:)
       @school = school
       @lead_provider_delivery_partnership = lead_provider_delivery_partnership
+      @author = author
     end
 
     def create
@@ -16,9 +17,10 @@ module SchoolPartnerships
           lead_provider = school_partnership.lead_provider
           contract_period = school_partnership.contract_period
 
-          Events::Record.record_school_partnership_created_event!(author: Events::LeadProviderAPIAuthor.new(lead_provider:), school_partnership:)
+          Events::Record.record_school_partnership_created_event!(author:, school_partnership:)
 
           SchoolPartnerships::AssignTrainingPeriods.new(
+            author:,
             school_partnership:,
             school:,
             lead_provider:,

--- a/app/services/training_periods/search.rb
+++ b/app/services/training_periods/search.rb
@@ -15,12 +15,9 @@ module TrainingPeriods
     def linkable_to_school_partnership(school:, lead_provider:, contract_period:)
       @scope = scope
         .where(school_partnership_id: nil)
-        .at_school(school.id)
+        .at_school(school)
         .joins(:expression_of_interest)
-        .where(active_lead_providers: {
-          lead_provider_id: lead_provider.id,
-          contract_period_year: contract_period.year
-        }).distinct
+        .where(active_lead_providers: { lead_provider:, contract_period: })
     end
 
   private

--- a/app/services/training_periods/search.rb
+++ b/app/services/training_periods/search.rb
@@ -12,6 +12,17 @@ module TrainingPeriods
       scope
     end
 
+    def linkable_to_school_partnership(school:, lead_provider:, contract_period:)
+      @scope = scope
+        .where(school_partnership_id: nil)
+        .at_school(school.id)
+        .joins(:expression_of_interest)
+        .where(active_lead_providers: {
+          lead_provider_id: lead_provider.id,
+          contract_period_year: contract_period.year
+        }).distinct
+    end
+
   private
 
     def filter_by_ect_id(ect_id)

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -270,6 +270,12 @@ describe ECTAtSchoolPeriod do
     let!(:period_3) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: period_2.finished_on, finished_on: nil) }
     let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
 
+    describe '.for_school' do
+      it 'returns only ect periods for the specified school' do
+        expect(described_class.for_school(period_1.school_id)).to match_array([period_1, period_3, teacher_2_period])
+      end
+    end
+
     describe ".for_teacher" do
       it "returns ect periods only for the specified teacher" do
         expect(described_class.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -1,4 +1,5 @@
 describe TrainingPeriod do
+  include SchoolPartnershipHelpers
   describe "declarative updates" do
     let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 3.years.ago.to_date, finished_on: nil) }
     let(:school_partnership) { FactoryBot.create(:school_partnership) }
@@ -291,6 +292,56 @@ describe TrainingPeriod do
     describe ".for_mentor" do
       it "returns training periods only for the specified mentor at school period" do
         expect(TrainingPeriod.for_mentor(456).to_sql).to end_with(%(WHERE "training_periods"."mentor_at_school_period_id" = 456))
+      end
+    end
+
+    describe '.at_school' do
+      let(:school) { FactoryBot.create(:school) }
+      let(:contract_period) { FactoryBot.create(:contract_period) }
+      let(:partnership) { make_partnership_for(school, contract_period) }
+
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+      let(:ect_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period:,
+          school_partnership: partnership,
+          started_on: ect_at_school_period.started_on,
+          finished_on: ect_at_school_period.finished_on
+        )
+      end
+
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
+      let(:mentor_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_mentor,
+          mentor_at_school_period:,
+          school_partnership: partnership,
+          started_on: mentor_at_school_period.started_on,
+          finished_on: mentor_at_school_period.finished_on
+        )
+      end
+
+      let(:other_school) { FactoryBot.create(:school) }
+      let(:other_ect_period) { FactoryBot.create(:ect_at_school_period, school: other_school) }
+      let(:other_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period: other_ect_period,
+          started_on: other_ect_period.started_on,
+          finished_on: other_ect_period.finished_on
+        )
+      end
+
+      it 'returns training periods for ECTs and Mentors at the school' do
+        expect(TrainingPeriod.at_school(school.id)).to include(ect_training_period, mentor_training_period)
+      end
+
+      it 'does not return training periods for ECTs and Mentors at other schools' do
+        expect(TrainingPeriod.at_school(school.id)).not_to include(other_training_period)
       end
     end
   end

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -161,8 +161,10 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
 
     it "creates a school partnership via create service" do
       school_partnership_service = double("SchoolPartnerships::Create")
-      allow(SchoolPartnerships::Create).to receive(:new).with(school:, lead_provider_delivery_partnership:).and_return(school_partnership_service)
-      allow(school_partnership_service).to receive(:create).once
+      author = an_instance_of(Events::LeadProviderAPIAuthor)
+
+      allow(SchoolPartnerships::Create).to receive(:new).with(author:, school:, lead_provider_delivery_partnership:).and_return(school_partnership_service)
+      allow(school_partnership_service).to receive(:create)
 
       create_school_partnership
 

--- a/spec/services/school_partnerships/assign_training_periods_spec.rb
+++ b/spec/services/school_partnerships/assign_training_periods_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe SchoolPartnerships::AssignTrainingPeriods do
         school_partnership:,
         school:,
         lead_provider:,
-        contract_period:
+        contract_period:,
+        author:
       )
     end
 
+    let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
     let(:school) { FactoryBot.create(:school) }
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
     let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }

--- a/spec/services/school_partnerships/assign_training_periods_spec.rb
+++ b/spec/services/school_partnerships/assign_training_periods_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe SchoolPartnerships::AssignTrainingPeriods do
+  describe '#call' do
+    subject(:service) do
+      described_class.new(
+        school_partnership:,
+        school:,
+        lead_provider:,
+        contract_period:
+      )
+    end
+
+    let(:school) { FactoryBot.create(:school) }
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+
+    let(:school_partnership) do
+      FactoryBot.create(:school_partnership,
+                        school:,
+                        lead_provider_delivery_partnership: FactoryBot.create(
+                          :lead_provider_delivery_partnership,
+                          active_lead_provider: FactoryBot.create(
+                            :active_lead_provider,
+                            lead_provider:,
+                            contract_period:
+                          )
+                        ))
+    end
+
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period,
+                        school:,
+                        started_on: Date.new(2025, 1, 1),
+                        finished_on: Date.new(2025, 12, 31))
+    end
+
+    let(:matching_expression_of_interest) do
+      FactoryBot.create(:active_lead_provider,
+                        lead_provider:,
+                        contract_period_year: contract_period.year)
+    end
+
+    let!(:linkable_tp) do
+      FactoryBot.create(:training_period,
+                        :with_only_expression_of_interest,
+                        ect_at_school_period:,
+                        expression_of_interest: matching_expression_of_interest,
+                        started_on: Date.new(2025, 3, 1),
+                        finished_on: Date.new(2025, 3, 31))
+    end
+
+    let!(:already_linked_tp) do
+      FactoryBot.create(:training_period,
+                        :with_expression_of_interest,
+                        ect_at_school_period:,
+                        school_partnership: FactoryBot.create(:school_partnership),
+                        expression_of_interest: matching_expression_of_interest,
+                        started_on: Date.new(2025, 4, 1),
+                        finished_on: Date.new(2025, 4, 30))
+    end
+
+    let!(:wrong_provider_tp) do
+      FactoryBot.create(:training_period,
+                        :with_only_expression_of_interest,
+                        ect_at_school_period:,
+                        expression_of_interest: FactoryBot.create(:active_lead_provider,
+                                                                  lead_provider: FactoryBot.create(:lead_provider), # different provider
+                                                                  contract_period_year: contract_period.year),
+                        started_on: Date.new(2025, 5, 1),
+                        finished_on: Date.new(2025, 5, 31))
+    end
+
+    let!(:wrong_year_tp) do
+      wrong_contract_period = FactoryBot.create(:contract_period, year: 2030)
+
+      FactoryBot.create(:training_period,
+                        :with_only_expression_of_interest,
+                        ect_at_school_period:,
+                        expression_of_interest: FactoryBot.create(:active_lead_provider,
+                                                                  lead_provider:,
+                                                                  contract_period_year: wrong_contract_period.year),
+                        started_on: Date.new(2025, 6, 1),
+                        finished_on: Date.new(2025, 6, 30))
+    end
+
+    it 'links only eligible training periods to the given school partnership' do
+      expect {
+        service.call
+      }.to change { linkable_tp.reload.school_partnership }
+        .from(nil)
+        .to(school_partnership)
+    end
+
+    it 'does not link already linked training periods' do
+      expect { service.call }.not_to(change { already_linked_tp.reload.school_partnership })
+    end
+
+    it 'does not link tp with different lead providers' do
+      expect { service.call }.not_to(change { wrong_provider_tp.reload.school_partnership })
+    end
+
+    it 'does not link tp with different contract periods' do
+      expect { service.call }.not_to(change { wrong_year_tp.reload.school_partnership })
+    end
+  end
+end

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -69,6 +69,23 @@ RSpec.describe SchoolPartnerships::Create do
         .from(nil).to(created_school_partnership)
     end
 
+    it 'delegates training period assignment to AssignTrainingPeriods' do
+      assign_service = instance_double(SchoolPartnerships::AssignTrainingPeriods, call: true)
+
+      allow(SchoolPartnerships::AssignTrainingPeriods).to receive(:new)
+        .with(
+          school_partnership: an_instance_of(SchoolPartnership),
+          school:,
+          lead_provider:,
+          contract_period:
+        )
+        .and_return(assign_service)
+
+      service.create
+
+      expect(assign_service).to have_received(:call).once
+    end
+
     it 'raises an error if the school and delivery partnership are already linked' do
       FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
 

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -68,5 +68,13 @@ RSpec.describe SchoolPartnerships::Create do
       }.to change { training_period.school_partnership }
         .from(nil).to(created_school_partnership)
     end
+
+    it 'raises an error if the school and delivery partnership are already linked' do
+      FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
+
+      expect {
+        service.create
+      }.to raise_error(ActiveRecord::RecordInvalid, /must be unique/)
+    end
   end
 end

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe SchoolPartnerships::Create do
         )
         .and_return(assign_service)
 
-      service.create
+      create_school_partnership
 
       expect(assign_service).to have_received(:call).once
     end
@@ -93,7 +93,7 @@ RSpec.describe SchoolPartnerships::Create do
       FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:)
 
       expect {
-        service.create
+        create_school_partnership
       }.to raise_error(ActiveRecord::RecordInvalid, /must be unique/)
     end
   end

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -43,5 +43,30 @@ RSpec.describe SchoolPartnerships::Create do
         )
       )
     end
+
+    it 'links eligible training periods to the new school partnership' do
+      ect_at_school_period = FactoryBot.create(
+        :ect_at_school_period,
+        school:,
+        started_on: Date.new(2025, 1, 1),
+        finished_on: Date.new(2025, 12, 31)
+      )
+
+      training_period = FactoryBot.create(
+        :training_period,
+        :with_only_expression_of_interest,
+        ect_at_school_period:,
+        expression_of_interest: active_lead_provider,
+        started_on: Date.new(2025, 3, 1),
+        finished_on: Date.new(2025, 3, 31)
+      )
+
+      created_school_partnership = create_school_partnership
+
+      expect {
+        training_period.reload
+      }.to change { training_period.school_partnership }
+        .from(nil).to(created_school_partnership)
+    end
   end
 end

--- a/spec/services/school_partnerships/create_spec.rb
+++ b/spec/services/school_partnerships/create_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe SchoolPartnerships::Create do
   let(:school) { FactoryBot.create(:school, :eligible) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+  let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
 
   let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
   let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
 
   let(:service) do
     described_class.new(
+      author:,
       school:,
       lead_provider_delivery_partnership:
     )
@@ -74,6 +76,7 @@ RSpec.describe SchoolPartnerships::Create do
 
       allow(SchoolPartnerships::AssignTrainingPeriods).to receive(:new)
         .with(
+          author: an_instance_of(Events::LeadProviderAPIAuthor),
           school_partnership: an_instance_of(SchoolPartnership),
           school:,
           lead_provider:,


### PR DESCRIPTION
### Context

When a lead provider submits a partnership over the API, we need to ensure the partnership is linked to any relevant ECTs or mentors. This ensures the lead provider and delivery partner appear correctly on the teacher's record. 

### Changes proposed in this pull request

- Builds on the `SchoolPartnerships::Create` service
- Automatically links eligible training periods (ECTs or mentors in provider-led training) to the new school partnership.
- Records a `training_period_assigned_to_school_partnership` event for each linked training period

### Rails console

**Check:**

```ruby
Event.where(event_type: "training_period_assigned_to_school_partnership").pluck(:event_type, :heading, :school_partnership_id, :training_period_id)
```

**Result:**
```plaintext
=> [["training_period_assigned_to_school_partnership", "First name 1 Last name 1’s ECT training period was assigned to a school partnership", 9, 18]]
```