### PR TITLE
Add payments frozen attributes to `Teacher`

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -228,6 +228,8 @@
   - trs_last_name
   - mentor_became_ineligible_for_funding_on
   - mentor_became_ineligible_for_funding_reason
+  - ect_payments_frozen_year
+  - mentor_payments_frozen_year
   :pending_induction_submissions:
   - id
   - appropriate_body_id

--- a/db/migrate/20250916071240_add_payments_frozen_years_to_teacher.rb
+++ b/db/migrate/20250916071240_add_payments_frozen_years_to_teacher.rb
@@ -1,0 +1,11 @@
+class AddPaymentsFrozenYearsToTeacher < ActiveRecord::Migration[8.0]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.integer :ect_payments_frozen_year, null: true
+      t.integer :mentor_payments_frozen_year, null: true
+
+      t.foreign_key :contract_periods, column: :ect_payments_frozen_year, primary_key: :year
+      t.foreign_key :contract_periods, column: :mentor_payments_frozen_year, primary_key: :year
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_15_065439) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_16_071240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -753,6 +753,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_15_065439) do
     t.uuid "api_user_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "api_ect_profile_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "api_mentor_profile_id", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "ect_payments_frozen_year"
+    t.integer "mentor_payments_frozen_year"
     t.index ["api_ect_profile_id"], name: "index_teachers_on_api_ect_profile_id", unique: true
     t.index ["api_mentor_profile_id"], name: "index_teachers_on_api_mentor_profile_id", unique: true
     t.index ["api_user_id"], name: "index_teachers_on_api_user_id", unique: true
@@ -855,6 +857,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_15_065439) do
   add_foreign_key "statement_adjustments", "statements"
   add_foreign_key "statements", "active_lead_providers"
   add_foreign_key "teacher_migration_failures", "teachers"
+  add_foreign_key "teachers", "contract_periods", column: "ect_payments_frozen_year", primary_key: "year"
+  add_foreign_key "teachers", "contract_periods", column: "mentor_payments_frozen_year", primary_key: "year"
   add_foreign_key "training_periods", "active_lead_providers", column: "expression_of_interest_id"
   add_foreign_key "training_periods", "ect_at_school_periods"
   add_foreign_key "training_periods", "mentor_at_school_periods"

--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -7,7 +7,18 @@ def describe_teacher(teacher)
                  Colourize.text('no', :red)
                end
 
-  print_seed_info("#{teacher_name} (early roll out mentor: #{ero_status})", indent: 2)
+  payments_frozen =
+    if teacher.ect_payments_frozen_year.present? && teacher.mentor_payments_frozen_year.present?
+      Colourize.text('ECT/mentor', :green)
+    elsif teacher.ect_payments_frozen_year.present?
+      Colourize.text('ECT', :green)
+    elsif teacher.mentor_payments_frozen_year.present?
+      Colourize.text('mentor', :green)
+    else
+      Colourize.text('no', :red)
+    end
+
+  print_seed_info("#{teacher_name} (early roll out mentor: #{ero_status}, payments frozen: #{payments_frozen})", indent: 2)
 end
 
 early_roll_out_mentor_attrs = {
@@ -25,13 +36,13 @@ teachers = [
   { trs_first_name: 'Hugh', trs_last_name: 'Laurie', trn: '4786654', trs_induction_status: 'Passed', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Stephen', trs_last_name: 'Fry', trn: '4786655', trs_induction_status: 'RequiredToComplete' },
   { trs_first_name: 'André', trs_last_name: 'Roussimoff', trn: '8886654', trs_induction_status: 'FailedInWales' },
-  { trs_first_name: 'Imogen', trs_last_name: 'Stubbs', trn: '6352869', trs_induction_status: 'InProgress' },
+  { trs_first_name: 'Imogen', trs_last_name: 'Stubbs', trn: '6352869', trs_induction_status: 'InProgress', ect_payments_frozen_year: 2021 },
   { trs_first_name: 'Gemma', trs_last_name: 'Jones', trn: '9578426', trs_induction_status: 'InProgress' },
-  { trs_first_name: 'Anthony', trs_last_name: 'Hopkins', trn: '6228282', trs_induction_status: 'Exempt' },
+  { trs_first_name: 'Anthony', trs_last_name: 'Hopkins', trn: '6228282', trs_induction_status: 'Exempt', mentor_payments_frozen_year: 2021 },
   { trs_first_name: 'John', trs_last_name: 'Withers', corrected_name: 'Old Man Withers', trn: '8590123', trs_induction_status: 'Failed' },
   { trs_first_name: 'Helen', trs_last_name: 'Mirren', corrected_name: 'Dame Helen Mirren', trn: '0000007', trs_induction_status: 'Passed' },
   { trs_first_name: 'Dominic', trs_last_name: 'West', trn: '9292929', trs_induction_status: 'InProgress' },
-  { trs_first_name: 'Peter', trs_last_name: 'Davison', trn: '0011223', trs_induction_status: 'RequiredToComplete' },
+  { trs_first_name: 'Peter', trs_last_name: 'Davison', trn: '0011223', trs_induction_status: 'RequiredToComplete', ect_payments_frozen_year: 2022, mentor_payments_frozen_year: 2022 },
   { trs_first_name: 'Robson', trs_last_name: 'Scottie', trn: '3002582', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Muhammed', trs_last_name: 'Ali', trn: '3002580', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Roy', trs_last_name: 'Dotrice', trn: '7000007', **early_roll_out_mentor_attrs }

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -122,6 +122,8 @@ erDiagram
     uuid api_user_id
     uuid api_ect_profile_id
     uuid api_mentor_profile_id
+    integer ect_payments_frozen_year
+    integer mentor_payments_frozen_year
   }
   PendingInductionSubmission {
     integer id

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -48,6 +48,13 @@ FactoryBot.define do
       association :school_reported_appropriate_body, :teaching_school_hub, factory: :appropriate_body
     end
 
+    trait :with_teacher_payments_frozen_year do
+      after(:create) do |record|
+        ect_payments_frozen_year = FactoryBot.create(:contract_period, year: [2021, 2022].sample).year
+        record.teacher.update!(ect_payments_frozen_year:)
+      end
+    end
+
     trait :with_training_period do
       transient do
         lead_provider { nil }

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -13,5 +13,12 @@ FactoryBot.define do
       started_on { generate(:base_mentor_date) + 1.year }
       finished_on { nil }
     end
+
+    trait :with_teacher_payments_frozen_year do
+      after(:create) do |record|
+        mentor_payments_frozen_year = FactoryBot.create(:contract_period, year: [2021, 2022].sample).year
+        record.teacher.update!(mentor_payments_frozen_year:)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

We need to store if a participant has migrated from a payments frozen contract period so that we can surface this information in the API. In ECF we store a `boolean` flag to indicate this, but it makes determining the particular year they migrated from more complicated as we have to dive into their declarations. In RECT we are opting to store the contract period year on the `Teacher` model; we need this for both ECTs and mentors, so are adding attributes for each.

We will revisit this approach down the line when we are building the change schedule service and have a better idea of how all these ECT/mentor specific attributes could hang together.

### Changes proposed in this pull request

- Add ect/mentor_payments_frozen_year to Teacher

We want to track the payments frozen year for teachers, so we can expose this information in the API and lead providers can determine if a participant has migrated from a payments frozen cohort.

- Add payments frozen year to teacher seeds

Generate `Teacher` records with `ect/mentor_payments_frozen_year` values.

- Add with_payments_frozen_years trait to Teacher factory
