### PR TITLE
[2400] Fix validation error when switching from provider-led to school-led ECT registration

### DIFF
--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -105,13 +105,9 @@ module Schools
     end
 
     def update_school_last_choices!
-      choices = {
-        last_chosen_appropriate_body: school_reported_appropriate_body,
-        last_chosen_lead_provider: lead_provider,
-        last_chosen_training_programme: training_programme
-      }
-
-      school.update!(**choices.compact)
+      school.update!(last_chosen_appropriate_body: school_reported_appropriate_body,
+                     last_chosen_lead_provider: lead_provider,
+                     last_chosen_training_programme: training_programme)
     end
 
     def close_ongoing_ect_period!

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -218,6 +218,24 @@ RSpec.describe Schools::RegisterECT do
       end
     end
 
+    context 'when switching from provider-led to school-led' do
+      let(:training_programme) { 'school_led' }
+      let(:lead_provider) { nil }
+      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+
+      before do
+        school.update!(
+          last_chosen_training_programme: 'provider_led',
+          last_chosen_lead_provider: FactoryBot.create(:lead_provider)
+        )
+      end
+
+      it 'clears the last chosen lead provider' do
+        expect { service.register! }
+          .to change(school, :last_chosen_lead_provider_id).to(nil)
+      end
+    end
+
     context 'when ECT is transferring from another school' do
       let(:training_programme) { 'school_led' }
       let(:lead_provider) { nil }

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -221,18 +221,20 @@ RSpec.describe Schools::RegisterECT do
     context 'when switching from provider-led to school-led' do
       let(:training_programme) { 'school_led' }
       let(:lead_provider) { nil }
-      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
 
       before do
         school.update!(
+          last_chosen_lead_provider: FactoryBot.create(:lead_provider),
           last_chosen_training_programme: 'provider_led',
-          last_chosen_lead_provider: FactoryBot.create(:lead_provider)
+          last_chosen_appropriate_body: nil
         )
       end
 
-      it 'clears the last chosen lead provider' do
+      it 'updates the last chosen fields correctly' do
         expect { service.register! }
-          .to change(school, :last_chosen_lead_provider_id).to(nil)
+          .to change { school.reload.last_chosen_lead_provider_id }.to(nil)
+           .and change { school.reload.last_chosen_training_programme }.to('school_led')
+           .and change { school.reload.last_chosen_appropriate_body }.to(school_reported_appropriate_body)
       end
     end
 


### PR DESCRIPTION
### Context

When registering an ECT, we store the school's last chosen appropriate body, lead provider, and training programme.  
A previous refactor introduced `choices.compact` in `update_school_last_choices!`. This skipped updating attributes when the value was `nil`.

### What was the problem?

When switching from **provider-led** to **school-led** training, the `last_chosen_lead_provider` attribute was left populated (because the `nil` update was compacted away).  
This caused a validation failure:

`Validation failed: Last chosen lead provider must be nil`


### Changes proposed

- Restored the original behaviour so that all three attributes are always updated.
- This ensures irrelevant fields are explicitly cleared (`nil`) when moving between training types.

### Guidance to review

- Confirm that school-led journeys now succeed when registering an ECT after a provider-led registration.  
- Check that provider-led journeys continue to behave as expected.