### PR TITLE
Changes to use `api_updated_at` in `School` and `DeliveryPartner` migrators

### DIFF
--- a/app/migration/migrators/delivery_partner.rb
+++ b/app/migration/migrators/delivery_partner.rb
@@ -28,7 +28,7 @@ module Migrators
       dp = ::DeliveryPartner.find_or_initialize_by(api_id: delivery_partner.id)
       dp.name = delivery_partner.name
       dp.created_at = delivery_partner.created_at
-      dp.updated_at = delivery_partner.updated_at
+      dp.api_updated_at = delivery_partner.updated_at
       dp.save!
       dp
     end

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -93,7 +93,7 @@ module Migrators
       attrs = {
         api_id: ecf_school.id,
         created_at: ecf_school.created_at,
-        updated_at: ecf_school.updated_at
+        api_updated_at: ecf_school.updated_at
       }
       school.update_columns(attrs)
     end

--- a/spec/migration/migrators/delivery_partner_spec.rb
+++ b/spec/migration/migrators/delivery_partner_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Migrators::DeliveryPartner do
           source_record = Migration::DeliveryPartner.find(delivery_partner.api_id)
           expect(delivery_partner.name).to eq source_record.name
           expect(delivery_partner.created_at).to eq source_record.created_at
-          expect(delivery_partner.updated_at).to eq source_record.updated_at
+          expect(delivery_partner.api_updated_at).to eq source_record.updated_at
         end
       end
     end

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -154,7 +154,7 @@ describe Migrators::School do
         expect(data_migration.reload.failure_count).to eq(0)
         gias_school.reload
         expect(gias_school.school.created_at).to eq(ecf_school.created_at)
-        expect(gias_school.school.updated_at).to eq(ecf_school.updated_at)
+        expect(gias_school.school.api_updated_at).to eq(ecf_school.updated_at)
       end
     end
   end


### PR DESCRIPTION
### Context

Recent changes have introduced the `api_updated_at` field to certain records that the API is concerned with.  This allows an  independent timestamp to be saved for changes relevant to the API.
The `School` and `DeliveryPartner` migrators were synch'ing the ECF `updated_at` timestamp to the `RECT` `updated_at` timestamp but this is no longer necessary and the ECF value should be synch'ed to `api_updated_at` for those records.

### Changes proposed in this pull request
- `School` migrator migrates `School.updated_at` from ECF to `School.api_updated_at`
- `DeliveryPartner` migrator migrates `DeliveryPartner.updated_at` to `DeliveryPartner.api_updated_at`

### Guidance to review
