### PR TITLE
Add timestamps to `SchoolPartnership` migrator

### DIFF
--- a/app/migration/migrators/school_partnership.rb
+++ b/app/migration/migrators/school_partnership.rb
@@ -39,6 +39,8 @@ module Migrators
 
       school_partnership.lead_provider_delivery_partnership = lpdp
       school_partnership.school = find_school_by_urn!(partnership.school.urn)
+      school_partnership.created_at = partnership.created_at
+      school_partnership.api_updated_at = partnership.updated_at
       school_partnership.save!
       school_partnership
     end

--- a/spec/migration/migrators/school_partnership_spec.rb
+++ b/spec/migration/migrators/school_partnership_spec.rb
@@ -38,6 +38,8 @@ describe Migrators::SchoolPartnership do
           expect(delivery_partner.api_id).to eq partnership.delivery_partner_id
           expect(year).to eq partnership.cohort.start_year
           expect(school.urn.to_s).to eq partnership.school.urn
+          expect(school_partnership.created_at).to eq partnership.created_at
+          expect(school_partnership.api_updated_at).to eq partnership.updated_at
         end
       end
     end


### PR DESCRIPTION
### Context

The migrator for `SchoolPartnership` should migrate the timestamps from the ECF `Partnership` record

### Changes proposed in this pull request
- Migrates the ECF `Partnership.created_at` to `SchoolPartnership.created_at`
- Migrates the ECF `Partnership.updated_at` to `SchoolPartnership.api_updated_at`

### Guidance to review
