### PR TITLE
Add induction coordinator to `School` migrator

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -90,8 +90,12 @@ module Migrators
     end
 
     def update_school!(school:, ecf_school:)
+      induction_coordinator = ecf_school.induction_coordinators.first
+
       attrs = {
         api_id: ecf_school.id,
+        induction_tutor_name: induction_coordinator&.full_name,
+        induction_tutor_email: induction_coordinator&.email,
         created_at: ecf_school.created_at,
         updated_at: ecf_school.updated_at
       }

--- a/app/models/migration/induction_coordinator_profile.rb
+++ b/app/models/migration/induction_coordinator_profile.rb
@@ -1,0 +1,7 @@
+module Migration
+  class InductionCoordinatorProfile < Migration::Base
+    belongs_to :user
+    has_many :induction_coordinator_profiles_schools
+    has_many :schools, through: :induction_coordinator_profiles_schools
+  end
+end

--- a/app/models/migration/induction_coordinator_profiles_school.rb
+++ b/app/models/migration/induction_coordinator_profiles_school.rb
@@ -1,0 +1,6 @@
+module Migration
+  class InductionCoordinatorProfilesSchool < Migration::Base
+    belongs_to :induction_coordinator_profile
+    belongs_to :school
+  end
+end

--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -10,6 +10,9 @@ module Migration
     has_many :induction_programmes, through: :school_cohorts
     has_many :induction_records, through: :induction_programmes
     has_many :partnerships
+    has_many :induction_coordinator_profiles_schools, dependent: :destroy
+    has_many :induction_coordinator_profiles, through: :induction_coordinator_profiles_schools
+    has_many :induction_coordinators, through: :induction_coordinator_profiles, source: :user
 
     has_many :school_local_authorities
     has_many :local_authorities, through: :school_local_authorities

--- a/spec/factories/migration/induction_coordinator_profiles_factory.rb
+++ b/spec/factories/migration/induction_coordinator_profiles_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :migration_induction_coordinator_profile, class: "Migration::InductionCoordinatorProfile" do
+    user { FactoryBot.create(:migration_user) }
+    schools { [build(:ecf_migration_school)] }
+  end
+end

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -11,6 +11,7 @@ describe Migrators::School do
                       school_status_name: 'Open',
                       school_type_name: 'Academy converter').tap do |ecf_school|
       FactoryBot.create(:ecf_migration_school_local_authority, school: ecf_school)
+      FactoryBot.create(:migration_induction_coordinator_profile, schools: [ecf_school])
     end
   end
 
@@ -155,6 +156,12 @@ describe Migrators::School do
         gias_school.reload
         expect(gias_school.school.created_at).to eq(ecf_school.created_at)
         expect(gias_school.school.updated_at).to eq(ecf_school.updated_at)
+      end
+
+      it "syncs the induction coordinator details" do
+        gias_school.reload
+        expect(gias_school.school.induction_tutor_name).to eq(ecf_school.induction_coordinators.first.full_name)
+        expect(gias_school.school.induction_tutor_email).to eq(ecf_school.induction_coordinators.first.email)
       end
     end
   end


### PR DESCRIPTION
### Context

We need to migrate the current ECF induction coordinator details (name and email) to the `School` when we check/migrate school data with the `School` migrator.
We are taking the details from the `User` associated with the first `School.induction_coordinator_profiles` record, commonly accessed in ECF via `School.induction_coordinators.first`

### Changes proposed in this pull request

- Migrate ECF `School.induction_coordinators.first.full_name` to `School.induction_tutor_name`
- Migrate ECF `School.induction_coordinators.first.email` to `School.induction_tutor_email`
- Add migration models for the `InductionCoordinatorProfile` and `InductionCoordinatorProfilesSchool` ECF models
- Update `Migration::School` model with relationships for induction coordinators

### Guidance to review
