### PR TITLE
Finish periods on new start date instead of previous day

### DIFF
--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -82,7 +82,7 @@ module Schools
     end
 
     def finish_existing_at_school_periods!
-      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: started_on.prev_day, author:).finish_existing_at_school_periods!
+      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: started_on, author:).finish_existing_at_school_periods!
     end
 
     def start_at_school!

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Schools::RegisterMentor do
               expect(mentor_at_school_period.started_on).to eq(started_on)
 
               expect(existing_mentor_at_school_period.reload.teacher_id).to eq(teacher.id)
-              expect(existing_mentor_at_school_period.finished_on).to eq(mentor_at_school_period.started_on.prev_day)
+              expect(existing_mentor_at_school_period.finished_on).to eq(mentor_at_school_period.started_on)
             end
           end
         end


### PR DESCRIPTION
## Context

Previously we used `.prev_day`, which introduced an unnecessary gap and prevented re-registering a mentor the day after their previous period.

## Changes proposed in this pull request

Update `finish_existing_at_school_periods!` to pass `finished_on: started_on` instead of `started_on.prev_day`.

## Guidance to review

- Register a mentor at one school, then register the same mentor at another school using tomorrow's date - it should work.

- Try the same flow on `main` or `staging` - it should blow up.

