### PR TITLE
Fix AB manual ECT claims when TRS status is Exempt, Passed or Failed

### DIFF
--- a/app/components/appropriate_bodies/claim_ect_actions_component.html.erb
+++ b/app/components/appropriate_bodies/claim_ect_actions_component.html.erb
@@ -1,9 +1,13 @@
 <% if registration_blocked? %>
+
   <%= govuk_inset_text do %>
     <%= blocked_registration_message %>
   <% end %>
+
 <% elsif show_claim_form? %>
-  <%= form_with(model: @pending_induction_submission, url: ab_claim_an_ect_check_path(@pending_induction_submission, method: 'patch')) do |f| %>
+
+  <%= form_with(model: pending_induction_submission, url: ab_claim_an_ect_check_path(pending_induction_submission, method: 'patch')) do |f| %>
     <%= f.govuk_submit("Claim induction") %>
   <% end %>
+
 <% end %>

--- a/app/controllers/appropriate_bodies/claim_an_ect/errors_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/errors_controller.rb
@@ -9,9 +9,6 @@ module AppropriateBodies
       def no_qts = nil
       def prohibited_from_teaching = nil
 
-      def exempt = nil
-      def completed = nil
-
     private
 
       def find_pending_induction_submission

--- a/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
@@ -9,36 +9,32 @@ module AppropriateBodies
       end
 
       def create
-        find_ect = AppropriateBodies::ClaimAnECT::FindECT
-        .new(
-          appropriate_body: @appropriate_body,
-          pending_induction_submission: PendingInductionSubmission.new(
-            **pending_induction_submission_params,
-            **pending_induction_submission_attributes
-          )
-        )
         @pending_induction_submission = find_ect.pending_induction_submission
 
         if find_ect.import_from_trs!
-          redirect_to(edit_ab_claim_an_ect_check_path(find_ect.pending_induction_submission))
+          redirect_to edit_ab_claim_an_ect_check_path(@pending_induction_submission)
         else
           render(:new)
         end
-      rescue TRS::Errors::QTSNotAwarded
+
         # FIXME: I'm not especially fond of saving these throwaway pending induction
         #        submissions, can we not make the error pages generic and flash the
         #        details through instead?
+      rescue TRS::Errors::QTSNotAwarded
         @pending_induction_submission.save!
         redirect_to ab_claim_an_ect_errors_no_qts_path(@pending_induction_submission)
       rescue TRS::Errors::ProhibitedFromTeaching
         @pending_induction_submission.save!
         redirect_to ab_claim_an_ect_errors_prohibited_path(@pending_induction_submission)
+      rescue TRS::Errors::InductionAlreadyCompleted
+        @pending_induction_submission.save!
+        redirect_to edit_ab_claim_an_ect_check_path(@pending_induction_submission)
       rescue TRS::Errors::TeacherNotFound, TRS::Errors::TeacherDeactivated
         @pending_induction_submission.errors.add(:base, "No teacher with this TRN and date of birth was found")
 
         render(:new)
       rescue AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB => e
-        teacher_id = Teacher.find_by!(trn: find_ect.pending_induction_submission.trn).id
+        teacher_id = Teacher.find_by!(trn: @pending_induction_submission.trn).id
 
         redirect_to(ab_teacher_path(teacher_id), notice: e.message)
       end
@@ -51,6 +47,17 @@ module AppropriateBodies
 
       def pending_induction_submission_attributes
         { appropriate_body_id: @appropriate_body.id }
+      end
+
+      def find_ect
+        @find_ect ||=
+          AppropriateBodies::ClaimAnECT::FindECT.new(
+            appropriate_body: @appropriate_body,
+            pending_induction_submission: PendingInductionSubmission.new(
+              **pending_induction_submission_params,
+              **pending_induction_submission_attributes
+            )
+          )
       end
     end
   end

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -109,15 +109,10 @@ class PendingInductionSubmission < ApplicationRecord
 
   # Instance methods
 
-  # @return [Boolean]
-  def exempt?
-    trs_induction_status.eql?('Exempt')
-  end
-
-  # @return [Boolean]
-  def release?
-    outcome.nil?
-  end
+  def exempt? = trs_induction_status.eql?('Exempt')
+  def passed? = trs_induction_status.eql?('Passed')
+  def failed? = trs_induction_status.eql?('Failed')
+  def release? = outcome.nil?
 
   # @return [Boolean] capture multiple error messages and reset before saving
   def playback_errors

--- a/app/services/appropriate_bodies/claim_an_ect/find_ect.rb
+++ b/app/services/appropriate_bodies/claim_an_ect/find_ect.rb
@@ -1,13 +1,22 @@
 module AppropriateBodies
   module ClaimAnECT
     class FindECT
-      attr_reader :appropriate_body, :pending_induction_submission
+      attr_reader :api_client, :appropriate_body, :pending_induction_submission
 
       def initialize(appropriate_body:, pending_induction_submission:)
+        @api_client = TRS::APIClient.build
         @appropriate_body = appropriate_body
         @pending_induction_submission = pending_induction_submission
       end
 
+      # @raise [TRS::Errors::TeacherDeactivated]
+      # @raise [TRS::Errors::TeacherNotFound]
+      # @raise [TRS::Errors::ProhibitedFromTeaching]
+      # @raise [TRS::Errors::InductionAlreadyCompleted]
+      # @raise [TRS::Errors::QTSNotAwarded]
+      # @raise [AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB]
+      #
+      # @return [Boolean]
       def import_from_trs!
         # In this case, the AB attempting to claim the ECT must be able to easily reference details of the AB associated with the open induction period._
 
@@ -15,13 +24,12 @@ module AppropriateBodies
         #       our database as a fully registered teacher?
         #       we probably want a guard clause here or to make the if statement
         #       below a case and add different errors to the :base
-        return unless pending_induction_submission.valid?(:find_ect)
+        return false unless pending_induction_submission.valid?(:find_ect)
 
-        pending_induction_submission
-          .assign_attributes(
-            appropriate_body:,
-            **trs_teacher.present.except(:trs_national_insurance_number)
-          )
+        pending_induction_submission.assign_attributes(
+          appropriate_body:,
+          **trs_teacher.present.except(:trs_national_insurance_number)
+        )
 
         check_if_teacher_has_ongoing_induction_period_with_appropriate_body!
         trs_teacher.check_eligibility!
@@ -31,24 +39,22 @@ module AppropriateBodies
 
     private
 
+      # @return [TRS::Teacher]
       def trs_teacher
-        @trs_teacher ||= api_client.find_teacher(trn: pending_induction_submission.trn, date_of_birth: pending_induction_submission.date_of_birth)
+        @trs_teacher ||= api_client.find_teacher(
+          trn: pending_induction_submission.trn,
+          date_of_birth: pending_induction_submission.date_of_birth
+        )
       end
 
-      def api_client
-        @api_client ||= TRS::APIClient.build
-      end
-
+      # @raise [AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB]
+      # @return [nil]
       def check_if_teacher_has_ongoing_induction_period_with_appropriate_body!
         existing_teacher = Teacher.find_by(trn: pending_induction_submission.trn)
 
-        return unless existing_teacher
+        return unless existing_teacher&.ongoing_induction_period
 
-        ongoing_induction_period = ::Teachers::InductionPeriod.new(existing_teacher).ongoing_induction_period
-
-        return unless ongoing_induction_period
-
-        if ongoing_induction_period.appropriate_body == appropriate_body
+        if existing_teacher.ongoing_induction_period.appropriate_body == appropriate_body
           raise AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB, ::Teachers::Name.new(existing_teacher).full_name
         end
       end

--- a/lib/trs/fake_api_client.rb
+++ b/lib/trs/fake_api_client.rb
@@ -1,4 +1,15 @@
 module TRS
+  # 7000001 - 7000009 are special TRNs that mimic:
+  #
+  # 1. Missing QTS
+  # 2. Not found
+  # 3. Prohibited
+  # 4. Deactivated
+  # 5. Alerts
+  # 6. ERO mentor
+  # 7. Passed induction
+  # 8. Failed induction
+  # 9. Exempt
   class FakeAPIClient
     class FakeAPIClientUsedInProduction < StandardError; end
 
@@ -131,6 +142,9 @@ module TRS
       when 7_000_004 then raise(TRS::Errors::TeacherDeactivated)
       when 7_000_005 then @has_alerts_but_not_prohibited = true
       when 7_000_006 then nil # teacher with TRN 7000006 is seeded as an early roll out mentor
+      when 7_000_007 then @induction_status = 'Passed'
+      when 7_000_008 then @induction_status = 'Failed'
+      when 7_000_009 then @induction_status = 'Exempt'
       else
         @has_qts = true
         @has_itt = true

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -6,8 +6,12 @@ module TRS
                 :first_name,
                 :last_name,
                 :date_of_birth,
-                :induction_status,
+                :email_address,
                 :national_insurance_number,
+                :alerts,
+                :induction_start_date,
+                :induction_status,
+                :induction_status_description,
                 :qts_awarded_on,
                 :qts_status_description,
                 :initial_teacher_training_provider_name,
@@ -20,42 +24,39 @@ module TRS
       @date_of_birth = data['dateOfBirth']
       @email_address = data['emailAddress']
       @national_insurance_number = data['nationalInsuranceNumber']
-
-      @alerts = data['alerts']
+      @alerts = data.fetch('alerts', [])
       @induction_start_date = data.dig('induction', 'startDate')
       @induction_status = data.dig('induction', 'status')
-
+      @induction_status_description = data.dig('induction', 'statusDescription')
       @qts_awarded_on = data.dig('qts', 'awarded')
       @qts_status_description = data.dig('qts', 'statusDescription')
-
-      @induction_status_description = data.dig('induction', 'statusDescription')
-
       @initial_teacher_training_provider_name = data.dig('initialTeacherTraining', -1, 'provider', 'name')
       @initial_teacher_training_end_date = data.dig('initialTeacherTraining', -1, 'endDate')
     end
 
     def present
       {
-        trn: @trn,
-        date_of_birth: @date_of_birth,
-        trs_national_insurance_number: @national_insurance_number,
-        trs_first_name: @first_name,
-        trs_last_name: @last_name,
-        trs_email_address: @email_address,
-        trs_alerts: @alerts,
-        trs_induction_start_date: @induction_start_date,
-        trs_induction_status: @induction_status,
-        trs_induction_status_description: @induction_status_description,
-        trs_initial_teacher_training_provider_name: @initial_teacher_training_provider_name,
-        trs_initial_teacher_training_end_date: @initial_teacher_training_end_date,
-        trs_qts_awarded_on: @qts_awarded_on,
-        trs_qts_status_description: @qts_status_description,
+        trn:,
+        date_of_birth:,
+        trs_first_name: first_name,
+        trs_last_name: last_name,
+        trs_email_address: email_address,
+        trs_national_insurance_number: national_insurance_number,
+        trs_alerts: alerts,
+        trs_induction_start_date: induction_start_date,
+        trs_induction_status: induction_status,
+        trs_induction_status_description: induction_status_description,
+        trs_qts_awarded_on: qts_awarded_on,
+        trs_qts_status_description: qts_status_description,
+        trs_initial_teacher_training_provider_name: initial_teacher_training_provider_name,
+        trs_initial_teacher_training_end_date: initial_teacher_training_end_date,
       }
     end
 
     def check_eligibility!
-      raise TRS::Errors::QTSNotAwarded unless qts_awarded?
+      raise TRS::Errors::InductionAlreadyCompleted if already_completed?
       raise TRS::Errors::ProhibitedFromTeaching if prohibited_from_teaching?
+      raise TRS::Errors::QTSNotAwarded unless qts_awarded?
 
       true
     end
@@ -69,7 +70,11 @@ module TRS
     end
 
     def qts_awarded?
-      @qts_awarded_on.present?
+      qts_awarded_on.present?
+    end
+
+    def already_completed?
+      %w[Passed Failed Exempt].include?(induction_status)
     end
 
   private
@@ -79,9 +84,7 @@ module TRS
     end
 
     def alert_codes
-      return [] if @alerts.blank?
-
-      @alerts.map { |a| a.dig(*%w[alertType alertCategory alertCategoryId]) }
+      alerts.map { |a| a.dig(*%w[alertType alertCategory alertCategoryId]) }
     end
   end
 end

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -1,88 +1,97 @@
 RSpec.describe 'Claiming an ECT' do
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  let(:teacher) { FactoryBot.create(:teacher, trn: '1234567') }
   let(:other_body) { FactoryBot.create(:appropriate_body) }
+  let(:teacher) { FactoryBot.create(:teacher, trn: '1234567') }
+  let(:pending_induction_submission) { PendingInductionSubmission.last }
 
   before { sign_in_as_appropriate_body_user(appropriate_body:) }
 
-  describe "when the ECT has not passed the induction" do
+  describe 'when the teacher has not passed the induction' do
     let!(:induction_period) do
-      FactoryBot.create(:induction_period, teacher:, started_on: 14.months.ago, finished_on: 13.months.ago, appropriate_body: other_body)
+      FactoryBot.create(:induction_period, teacher:,
+                                           started_on: 14.months.ago,
+                                           finished_on: 13.months.ago,
+                                           appropriate_body: other_body)
     end
 
     include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
-    scenario 'Happy path when induction is not completed' do
+    scenario 'the teacher can be claimed' do
       given_i_am_on_the_claim_an_ect_find_page
       when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
       and_i_submit_the_form
-
       now_i_should_be_on_the_claim_an_ect_check_page
       when_i_begin_the_claim_process
-
       now_i_should_be_on_the_claim_an_ect_register_page
       when_i_enter_the_start_date
       and_choose_an_induction_programme
       and_i_submit_the_form
-
       now_i_should_be_on_the_confirmation_page
       and_the_data_i_submitted_should_be_saved_on_the_pending_record
     end
   end
 
-  describe "when the ECT is already claimed by another appropriate body" do
+  describe 'when the teacher is already claimed by another appropriate body' do
     include_context 'test trs api client that finds teacher with specific induction status', 'InProgress'
 
     before do
       FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body: other_body)
     end
 
-    scenario 'Button is hidden when induction is ongoing' do
+    scenario 'the teacher cannot be claimed' do
       given_i_am_on_the_claim_an_ect_find_page
       when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
       and_i_submit_the_form
-
       now_i_should_be_on_the_claim_an_ect_check_page
       then_i_should_not_see_the_claim_button
-
       then_i_should_be_told_the_ect_cannot_register
-      expect(page.get_by_text('Our records show that Kirk Van Houten is completing their induction with another appropriate body.')).to be_visible
+      and_i_should_see_the_message('Our records show that Kirk Van Houten is completing their induction with another appropriate body.')
     end
   end
 
-  describe "when the ECT has passed the induction" do
+  describe 'when the teacher has passed' do
     include_context 'test trs api client that finds teacher with specific induction status', 'Passed'
 
-    scenario 'Button is hidden when induction is completed' do
+    scenario 'the teacher cannot be claimed' do
       given_i_am_on_the_claim_an_ect_find_page
       when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
       and_i_submit_the_form
-
       now_i_should_be_on_the_claim_an_ect_check_page
       then_i_should_not_see_the_claim_button
+      and_i_should_see_the_message('Our records show that Kirk Van Houten has already passed their induction.')
     end
   end
 
-  describe "when the ECT is exempt from induction" do
-    include_context 'test trs api client that finds teacher with specific induction status', 'Exempt'
+  describe 'when the teacher has failed' do
+    include_context 'test trs api client that finds teacher with specific induction status', 'Failed'
 
-    scenario 'Button is hidden and exempt message is shown' do
+    scenario 'the teacher cannot be claimed' do
       given_i_am_on_the_claim_an_ect_find_page
       when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
       and_i_submit_the_form
-
       now_i_should_be_on_the_claim_an_ect_check_page
       then_i_should_not_see_the_claim_button
+      and_i_should_see_the_message('Our records show that Kirk Van Houten has already failed their induction.')
+    end
+  end
 
-      then_i_should_be_told_the_ect_cannot_register
-      expect(page.get_by_text('Our records show that Kirk Van Houten is exempt from completing their induction')).to be_visible
+  describe 'when the teacher is exempt' do
+    include_context 'test trs api client that finds teacher with specific induction status', 'Exempt'
+
+    scenario 'the teacher cannot be claimed' do
+      given_i_am_on_the_claim_an_ect_find_page
+      when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
+      and_i_submit_the_form
+      now_i_should_be_on_the_claim_an_ect_check_page
+      then_i_should_not_see_the_claim_button
+      and_i_should_see_the_message('Our records show that Kirk Van Houten is exempt from completing their induction.')
     end
   end
 
 private
 
   def then_i_should_not_see_the_claim_button
-    expect(page.get_by_role('button', name: "Claim induction")).not_to be_visible
+    expect(page.get_by_role('button', name: 'Claim induction')).not_to be_visible
   end
 
   def given_i_am_on_the_claim_an_ect_find_page
@@ -99,27 +108,28 @@ private
   end
 
   def when_i_begin_the_claim_process
-    page.get_by_role('button', name: "Claim induction").click
+    page.get_by_role('button', name: 'Claim induction').click
   end
 
   def when_i_submit_the_form
-    page.get_by_role('button', name: "Continue").click
+    page.get_by_role('button', name: 'Continue').click
   end
   alias_method :and_i_submit_the_form, :when_i_submit_the_form
 
   def now_i_should_be_on_the_claim_an_ect_check_page
-    @pending_induction_submission = PendingInductionSubmission.last
-    path = "/appropriate-body/claim-an-ect/check-ect/#{@pending_induction_submission.id}/edit"
-    expect(page).to have_path(path)
+    expect(page).to have_path("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}/edit")
   end
 
   def now_i_should_be_on_the_claim_an_ect_register_page
-    path = "/appropriate-body/claim-an-ect/register-ect/#{@pending_induction_submission.id}/edit"
-    expect(page).to have_path(path)
+    expect(page).to have_path("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
+  end
+
+  def now_i_should_be_on_the_confirmation_page
+    expect(page).to have_path("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
   end
 
   # FIXME: flaky spec, result changes depending on day it is run
-  # On 3rd May (2005-05-03) the "finished_on: 13.months.ago" causes the unexpected error
+  # On 3rd May (2005-05-03) the 'finished_on: 13.months.ago' causes the unexpected error
   # Enter a start date after the last induction period finished (3 April 2024)
   #
   def when_i_enter_the_start_date
@@ -131,16 +141,11 @@ private
   end
 
   def and_choose_an_induction_programme
-    page.get_by_label("School-led").check
-  end
-
-  def now_i_should_be_on_the_confirmation_page
-    path = "/appropriate-body/claim-an-ect/register-ect/#{@pending_induction_submission.id}"
-    expect(page).to have_path(path)
+    page.get_by_label('School-led').check
   end
 
   def and_the_data_i_submitted_should_be_saved_on_the_pending_record
-    @pending_induction_submission.reload.tap do |sub|
+    pending_induction_submission.reload.tap do |sub|
       expect(sub.date_of_birth).to eql(Date.new(2003, 2, 1))
       expect(sub.trs_first_name).to eql('Kirk')
       expect(sub.trs_last_name).to eql('Van Houten')
@@ -149,6 +154,10 @@ private
   end
 
   def then_i_should_be_told_the_ect_cannot_register
-    expect(page.get_by_text('You cannot register Kirk Van Houten')).to be_visible
+    expect(page.get_by_text('You cannot register Kirk Van Houten.')).to be_visible
+  end
+
+  def and_i_should_see_the_message(message)
+    expect(page.get_by_text(message)).to be_visible
   end
 end

--- a/spec/features/appropriate_bodies/edit_induction_period_spec.rb
+++ b/spec/features/appropriate_bodies/edit_induction_period_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe "Appropriate body editing an induction period" do
   include ActiveJob::TestHelper
 
   let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-  # let(:teacher) { FactoryBot.create(:teacher) }
   let(:teacher) { FactoryBot.create(:teacher, trs_qts_awarded_on: 1.year.ago) }
 
   let!(:induction_period) do

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TRS::APIClient do
         teacher = client.find_teacher(trn:, date_of_birth:)
 
         expect(teacher).to be_a(TRS::Teacher)
-        expect(teacher.present.compact).to eq({ trn: "1234567", trs_first_name: "John" })
+        expect(teacher.present.compact).to eq({ trn: "1234567", trs_alerts: [], trs_first_name: "John" })
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe TRS::APIClient do
         teacher = client.find_teacher(trn:, national_insurance_number:)
 
         expect(teacher).to be_a(TRS::Teacher)
-        expect(teacher.present.compact).to eq({ trn: "1234567", trs_first_name: "John" })
+        expect(teacher.present.compact).to eq({ trn: "1234567", trs_alerts: [], trs_first_name: "John" })
       end
     end
 

--- a/spec/lib/trs/fake_api_client_spec.rb
+++ b/spec/lib/trs/fake_api_client_spec.rb
@@ -1,24 +1,30 @@
 describe TRS::FakeAPIClient do
+  subject(:client) { TRS::FakeAPIClient.new }
+
   describe 'initializing' do
     it 'fails when used in production' do
       allow(Rails.env).to receive(:production?).and_return(true)
 
-      expect { TRS::FakeAPIClient.new }.to raise_error(TRS::FakeAPIClient::FakeAPIClientUsedInProduction)
+      expect { client }.to raise_error(TRS::FakeAPIClient::FakeAPIClientUsedInProduction)
     end
   end
 
   describe '#find_teacher' do
-    subject { TRS::FakeAPIClient.new }
+    let(:trs_teacher) { client.find_teacher(trn:) }
 
     context 'without a special TRN' do
       let(:trn) { 1_234_567 }
 
+      it 'returns a teacher' do
+        expect(trs_teacher).to be_a(TRS::Teacher)
+      end
+
       it 'returns a teacher with a qts_awarded_on date' do
-        expect(subject.find_teacher(trn:).qts_awarded_on).not_to be_nil
+        expect(trs_teacher.qts_awarded_on).not_to be_nil
       end
 
       it 'returns a teacher who is not prohibited from teaching' do
-        expect(subject.find_teacher(trn:)).not_to be_prohibited_from_teaching
+        expect(trs_teacher).not_to be_prohibited_from_teaching
       end
     end
 
@@ -26,35 +32,35 @@ describe TRS::FakeAPIClient do
       let(:trn) { 7_000_001 }
 
       it 'returns a teacher who is not QTS awarded' do
-        expect(subject.find_teacher(trn:)).not_to be_qts_awarded
+        expect(trs_teacher).not_to be_qts_awarded
       end
 
       it 'returns a teacher without a qts_awarded_on date' do
-        expect(subject.find_teacher(trn:).qts_awarded_on).to be_nil
+        expect(trs_teacher.qts_awarded_on).to be_nil
       end
     end
 
     context 'when TRN is 7_000_002' do
       let(:trn) { 7_000_002 }
 
-      it 'raises a TRS::Errors::TeacherNotFound error' do
-        expect { subject.find_teacher(trn:) }.to raise_error(TRS::Errors::TeacherNotFound)
+      it do
+        expect { trs_teacher }.to raise_error(TRS::Errors::TeacherNotFound)
       end
     end
 
     context 'when TRN is 7_000_003' do
       let(:trn) { 7_000_003 }
 
-      it 'returns a teacher with a prhohibited from teaching alert' do
-        expect(subject.find_teacher(trn:)).to be_prohibited_from_teaching
+      it 'returns a teacher with a prohibited from teaching alert' do
+        expect(trs_teacher).to be_prohibited_from_teaching
       end
     end
 
     context 'when TRN is 7_000_004' do
       let(:trn) { 7_000_004 }
 
-      it 'raises a TRS::Errors::TeacherNotFound error' do
-        expect { subject.find_teacher(trn:) }.to raise_error(TRS::Errors::TeacherDeactivated)
+      it do
+        expect { trs_teacher }.to raise_error(TRS::Errors::TeacherDeactivated)
       end
     end
 
@@ -62,11 +68,11 @@ describe TRS::FakeAPIClient do
       let(:trn) { 7_000_005 }
 
       it 'returns a teacher who has alerts' do
-        expect(subject.find_teacher(trn:)).to have_alerts
+        expect(trs_teacher).to have_alerts
       end
 
-      it 'returns a teacher is not prohibited from teaching' do
-        expect(subject.find_teacher(trn:)).not_to be_prohibited_from_teaching
+      it 'returns a teacher who is not prohibited from teaching' do
+        expect(trs_teacher).not_to be_prohibited_from_teaching
       end
     end
 
@@ -74,18 +80,42 @@ describe TRS::FakeAPIClient do
       let(:trn) { 7_000_006 }
 
       it 'returns a teacher (this teacher should be seeded with early_roll_out_mentor_attrs, see db/seeds/teachers.rb)' do
-        expect(subject.find_teacher(trn:)).to be_present
+        expect(trs_teacher).to be_present
+      end
+    end
+
+    context "when TRN is 7_000_007" do
+      let(:trn) { 7_000_007 }
+
+      it 'returns a teacher who has passed' do
+        expect(trs_teacher.induction_status).to eql('Passed')
+      end
+    end
+
+    context "when TRN is 7_000_008" do
+      let(:trn) { 7_000_008 }
+
+      it 'returns a teacher who has failed' do
+        expect(trs_teacher.induction_status).to eql('Failed')
+      end
+    end
+
+    context "when TRN is 7_000_009" do
+      let(:trn) { 7_000_009 }
+
+      it 'returns a teacher who is exempt' do
+        expect(trs_teacher.induction_status).to eql('Exempt')
       end
     end
 
     context 'when the teacher already exists in the database' do
       let(:trn) { 1_112_222 }
 
-      before { FactoryBot.create(:teacher, trn:, trs_first_name: 'Christopher', trs_last_name: 'Eccleston') }
+      before do
+        FactoryBot.create(:teacher, trn:, trs_first_name: 'Christopher', trs_last_name: 'Eccleston')
+      end
 
       it 'returns the TRS teacher with name of the existing teacher' do
-        trs_teacher = subject.find_teacher(trn:)
-
         expect(trs_teacher.first_name).to eql('Christopher')
         expect(trs_teacher.last_name).to eql('Eccleston')
       end
@@ -93,18 +123,17 @@ describe TRS::FakeAPIClient do
   end
 
   describe 'Redis data storing functionality', :redis do
-    subject { TRS::FakeAPIClient.new }
-
     let(:teacher) { FactoryBot.build(:teacher) }
     let(:trn) { teacher.trn }
     let(:key) { trn + ':induction' }
     let(:start_date) { 3.months.ago.to_date }
     let(:redis_client) { Redis.new }
+    let(:trs_teacher) { client.find_teacher(trn:) }
 
     before { redis_client.del(key) }
 
     describe '#begin_induction!' do
-      before { subject.begin_induction!(trn: teacher.trn, start_date:) }
+      before { client.begin_induction!(trn: teacher.trn, start_date:) }
 
       it 'writes the in progress status to Redis' do
         expect(redis_client.hgetall(key)).to match(
@@ -116,8 +145,6 @@ describe TRS::FakeAPIClient do
       end
 
       it 'retrieves the teacher record with the updated info' do
-        trs_teacher = subject.find_teacher(trn:)
-
         expect(trs_teacher.induction_status).to eql('InProgress')
       end
     end
@@ -138,8 +165,6 @@ describe TRS::FakeAPIClient do
       end
 
       it 'retrieves the teacher record with the updated info' do
-        trs_teacher = subject.find_teacher(trn:)
-
         expect(trs_teacher.induction_status).to eql('Passed')
       end
     end
@@ -160,8 +185,6 @@ describe TRS::FakeAPIClient do
       end
 
       it 'retrieves the teacher record with the updated info' do
-        trs_teacher = subject.find_teacher(trn:)
-
         expect(trs_teacher.induction_status).to eql('Failed')
       end
     end
@@ -182,8 +205,6 @@ describe TRS::FakeAPIClient do
       end
 
       it 'retrieves the teacher record with the updated info' do
-        trs_teacher = subject.find_teacher(trn:)
-
         expect(trs_teacher.induction_status).to eql('RequiredToComplete')
       end
     end
@@ -204,8 +225,6 @@ describe TRS::FakeAPIClient do
       end
 
       it 'retrieves the teacher record with the updated info' do
-        trs_teacher = subject.find_teacher(trn:)
-
         expect(trs_teacher.induction_status).to eql('InProgress')
       end
     end

--- a/spec/lib/trs/teacher_spec.rb
+++ b/spec/lib/trs/teacher_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe TRS::Teacher do
-  subject { described_class.new(data) }
+  subject(:service) { described_class.new(data) }
 
   let(:data) do
     {
@@ -99,16 +99,38 @@ RSpec.describe TRS::Teacher do
         trs_national_insurance_number: "AB123456C",
       }
 
-      expect(subject.present).to eq(expected_hash)
+      expect(service.present).to eq(expected_hash)
     end
   end
 
   describe "#check_eligibility!" do
+    context "when the teacher is exempt" do
+      it do
+        expect { service.check_eligibility! }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
+      end
+    end
+
+    context "when the teacher has passed their induction" do
+      let(:data) { { 'induction' => { 'status' => 'Passed' } } }
+
+      it do
+        expect { service.check_eligibility! }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
+      end
+    end
+
+    context "when the teacher has failed their induction" do
+      let(:data) { { 'induction' => { 'status' => 'Failed' } } }
+
+      it do
+        expect { service.check_eligibility! }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
+      end
+    end
+
     context "when the teacher has not been awarded QTS" do
       let(:data) { { 'qts' => { 'awarded' => nil } } }
 
-      it "raises TRS::Errors::QTSNotAwarded" do
-        expect { subject.check_eligibility! }.to raise_error(TRS::Errors::QTSNotAwarded)
+      it do
+        expect { service.check_eligibility! }.to raise_error(TRS::Errors::QTSNotAwarded)
       end
     end
 
@@ -124,8 +146,8 @@ RSpec.describe TRS::Teacher do
         }
       end
 
-      it "raises TRS::Errors::ProhibitedFromTeaching" do
-        expect { subject.check_eligibility! }.to raise_error(TRS::Errors::ProhibitedFromTeaching)
+      it do
+        expect { service.check_eligibility! }.to raise_error(TRS::Errors::ProhibitedFromTeaching)
       end
     end
   end

--- a/spec/services/admin/import_ect/find_ect_spec.rb
+++ b/spec/services/admin/import_ect/find_ect_spec.rb
@@ -1,135 +1,106 @@
 RSpec.describe Admin::ImportECT::FindECT do
-  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, appropriate_body: nil) }
+  subject(:find_ect) { Admin::ImportECT::FindECT.new(pending_induction_submission:) }
 
-  describe "#initialize" do
-    it "assigns the provided pending induction submission params" do
-      find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
+  let(:pending_induction_submission) do
+    FactoryBot.create(:pending_induction_submission,
+                      appropriate_body: nil)
+  end
 
+  describe '#initialize' do
+    it 'assigns the provided pending induction submission params' do
       expect(find_ect.pending_induction_submission).to eql(pending_induction_submission)
     end
   end
 
-  describe "#import_from_trs!" do
-    context "when the pending_induction_submission is invalid" do
-      let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, date_of_birth: nil, appropriate_body: nil) }
+  describe '#import_from_trs!' do
+    context 'when the pending_induction_submission is invalid' do
+      let(:pending_induction_submission) do
+        FactoryBot.create(:pending_induction_submission,
+                          date_of_birth: nil,
+                          appropriate_body: nil)
+      end
 
-      it "returns nil" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
-        expect(find_ect.import_from_trs!).to be_nil
+      it do
+        expect(find_ect.import_from_trs!).to be(false)
       end
     end
 
-    context "when there is a match" do
+    context 'when the teacher is required to complete' do
       include_context 'test trs api client that finds teacher with specific induction status', 'RequiredToComplete'
 
-      let(:find_ect) { Admin::ImportECT::FindECT.new(pending_induction_submission:) }
-
-      it "makes a call to the TRS API client with the expected parameters" do
-        allow(TRS::APIClient).to receive(:build).and_call_original
-
-        find_ect.import_from_trs!
-
-        expect(TRS::APIClient).to have_received(:build)
-      end
-
-      it "assigns the incoming attributes to the pending_induction_submission and returns it" do
-        result = find_ect.import_from_trs!
-
-        expect(result).to be(true)
+      it 'saves attributes from TRS to the pending_induction_submission' do
+        expect(find_ect.import_from_trs!).to be(true)
         pending_induction_submission.reload
         expect(pending_induction_submission.trs_first_name).to eq('Kirk')
         expect(pending_induction_submission.trs_last_name).to eq('Van Houten')
         expect(pending_induction_submission.trs_induction_status).to eq('RequiredToComplete')
       end
-
-      it "saves the pending_induction_submission with find_ect context" do
-        expect(pending_induction_submission).to receive(:save).with(context: :find_ect)
-
-        find_ect.import_from_trs!
-      end
     end
 
-    context "when teacher already exists in system" do
+    context 'when teacher already exists in system' do
       include_context 'test trs api client'
 
-      let!(:existing_teacher) { FactoryBot.create(:teacher, trn: pending_induction_submission.trn) }
-      let(:find_ect) { Admin::ImportECT::FindECT.new(pending_induction_submission:) }
+      before do
+        FactoryBot.create(:teacher, trn: pending_induction_submission.trn)
+      end
 
-      it "raises TeacherAlreadyExists error" do
-        expect { find_ect.import_from_trs! }.to raise_error do |error|
-          expect(error).to be_a(Admin::Errors::TeacherAlreadyExists)
-          expect(error.message).to match(/\A#<Teacher:/)
-        end
+      it do
+        expect { find_ect.import_from_trs! }.to raise_error(Admin::Errors::TeacherAlreadyExists)
       end
     end
 
-    context "when there is no match" do
+    context 'when no teacher is found' do
       include_context 'test trs api client that finds nothing'
 
-      it "raises teacher not found error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::TeacherNotFound)
       end
     end
 
-    context "when teacher is prohibited from teaching" do
+    context 'when the teacher is prohibited from teaching' do
       include_context 'test trs api client that finds teacher prohibited from teaching'
 
-      it "raises prohibited from teaching error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::ProhibitedFromTeaching)
       end
     end
 
-    context "when teacher does not have QTS" do
+    context 'when the teacher does not have QTS' do
       include_context 'test trs api client that finds teacher without QTS'
 
-      it "raises QTS not awarded error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::QTSNotAwarded)
       end
     end
 
-    context "when teacher has completed induction" do
+    context 'when the teacher has passed' do
       include_context 'test trs api client that finds teacher with specific induction status', 'Passed'
 
-      it "raises induction already completed error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
       end
     end
 
-    context "when teacher has failed induction" do
+    context 'when the ECT has failed' do
       include_context 'test trs api client that finds teacher with specific induction status', 'Failed'
 
-      it "raises induction already completed error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
       end
     end
 
-    context "when teacher is exempt from induction" do
+    context 'when the teacher is exempt' do
       include_context 'test trs api client that finds teacher with specific induction status', 'Exempt'
 
-      it "raises induction already completed error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
       end
     end
 
-    context "when teacher is deactivated" do
+    context 'when teacher is deactivated' do
       include_context 'test trs api client deactivated teacher'
 
-      it "raises teacher deactivated error" do
-        find_ect = Admin::ImportECT::FindECT.new(pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::TeacherDeactivated)
       end
     end

--- a/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/services/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,73 +1,107 @@
 RSpec.describe AppropriateBodies::ClaimAnECT::FindECT do
-  let(:appropriate_body) { FactoryBot.build(:appropriate_body) }
+  subject(:find_ect) do
+    AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
+  end
 
-  describe "#initialize" do
-    let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
 
-    it "assigns the provided appropriate body and pending induction submission params" do
-      find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
-
+  describe '#initialize' do
+    it 'assigns the provided appropriate body and pending induction submission params' do
       expect(find_ect.appropriate_body).to eql(appropriate_body)
       expect(find_ect.pending_induction_submission).to eql(pending_induction_submission)
     end
   end
 
-  describe "#import_from_trs!" do
-    context "when the pending_induction_submission is invalid" do
+  describe '#import_from_trs!' do
+    context 'when the pending_induction_submission is invalid' do
       let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, date_of_birth: nil) }
 
-      it "returns nil" do
-        find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
-
-        expect(find_ect.import_from_trs!).to be_nil
+      it do
+        expect(find_ect.import_from_trs!).to be(false)
       end
     end
 
-    context "when there is a match" do
-      it "makes a call to the TRS API client with the expected parameters"
-      it "assigns the incoming attributes to the pending_induction_submission and returns it"
-    end
+    context 'when no teacher is found' do
+      include_context 'test trs api client that finds nothing'
 
-    context "when there is a match and the teacher has an ongoing induction period" do
-      let(:teacher) { FactoryBot.create(:teacher) }
-      let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
-      let!(:induction_period) do
-        FactoryBot.create(:induction_period, :ongoing, appropriate_body:, teacher:, started_on: Date.parse("2 October 2022"))
-      end
-
-      context "when the induction period is with another AB" do
-        include_context "test trs api client"
-        let(:appropriate_body) { FactoryBot.create(:appropriate_body) }
-
-        it "returns true" do
-          find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(
-            appropriate_body: FactoryBot.create(:appropriate_body), pending_induction_submission:
-          )
-
-          expect(find_ect.import_from_trs!).to be(true)
-        end
-      end
-
-      context "when there's an open induction_period with the same AB" do
-        include_context "test trs api client"
-        let(:appropriate_body) { pending_induction_submission.appropriate_body }
-
-        it "raises TeacherHasActiveInductionPeriodWithCurrentAB" do
-          find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
-
-          expect { find_ect.import_from_trs! }.to raise_error(AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB)
-        end
-      end
-    end
-
-    context "when there is no match" do
-      include_context "test trs api client that finds nothing"
-
-      it "raises teacher not found error" do
-        pending_induction_submission = FactoryBot.create(:pending_induction_submission)
-        find_ect = AppropriateBodies::ClaimAnECT::FindECT.new(appropriate_body:, pending_induction_submission:)
-
+      it do
         expect { find_ect.import_from_trs! }.to raise_error(TRS::Errors::TeacherNotFound)
+      end
+    end
+
+    context 'when the teacher is required to complete' do
+      include_context 'test trs api client that finds teacher with specific induction status', 'RequiredToComplete'
+
+      it 'saves attributes from TRS to the pending_induction_submission' do
+        expect(find_ect.import_from_trs!).to be(true)
+        pending_induction_submission.reload
+        expect(pending_induction_submission.trs_first_name).to eq('Kirk')
+        expect(pending_induction_submission.trs_last_name).to eq('Van Houten')
+        expect(pending_induction_submission.trs_induction_status).to eq('RequiredToComplete')
+      end
+
+      context 'with an ongoing induction period' do
+        let(:teacher) { FactoryBot.create(:teacher) }
+        let(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission, trn: teacher.trn) }
+
+        context 'with another AB' do
+          before do
+            FactoryBot.create(:induction_period, :ongoing,
+                              teacher:,
+                              appropriate_body: FactoryBot.create(:appropriate_body),
+                              started_on: Date.parse('2 October 2022'))
+          end
+
+          it do
+            expect(find_ect.import_from_trs!).to be(true)
+          end
+        end
+
+        context 'with the same AB' do
+          before do
+            FactoryBot.create(:induction_period, :ongoing,
+                              teacher:,
+                              appropriate_body:,
+                              started_on: Date.parse('2 October 2022'))
+          end
+
+          it do
+            expect {
+              find_ect.import_from_trs!
+            }.to raise_error(AppropriateBodies::Errors::TeacherHasActiveInductionPeriodWithCurrentAB)
+          end
+        end
+      end
+    end
+
+    context 'when the teacher has passed' do
+      include_context 'test trs api client that finds teacher with specific induction status', 'Passed'
+
+      it do
+        expect {
+          find_ect.import_from_trs!
+        }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
+      end
+    end
+
+    context 'when the teacher has failed' do
+      include_context 'test trs api client that finds teacher with specific induction status', 'Failed'
+
+      it do
+        expect {
+          find_ect.import_from_trs!
+        }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
+      end
+    end
+
+    context 'when the teacher is exempt' do
+      include_context 'test trs api client that finds teacher with specific induction status', 'Exempt'
+
+      it do
+        expect {
+          find_ect.import_from_trs!
+        }.to raise_error(TRS::Errors::InductionAlreadyCompleted)
       end
     end
   end


### PR DESCRIPTION
### Context

At some point TRS checks for ECTs that were either exempt, or had already passed or failed were mistakenly removed from the AB claims manual journey. Recently they were partially (exempt only) restored using a different approach for the admin console. 

This PR prevents ECTs who should not be claimed from being claimed manually. This is also missing from the bulk equivalent which will be tackled in another PR #1368.

A following piece is planned to refactor the logic for simplicity and consistency replacing static error pages.

<img width="657" height="343" alt="Screenshot 2025-09-17 at 09 43 07" src="https://github.com/user-attachments/assets/818150d8-ce5d-484d-a7b0-e2e128eff948" />

### Changes proposed in this pull request

- Update manual journey to prevent ABs from claiming already passed and failed ECTs using the same approach as exempt ECTs.
- Add missing TRNs to the fake TRS API to mimic these scenarios.

### Guidance to review


<img width="2446" height="2704" alt="localhost_3000_appropriate-body_claim-an-ect_check-ect_250_edit" src="https://github.com/user-attachments/assets/d1002611-04e9-4c6c-9c33-254aeb8922f4" />
<img width="2446" height="2704" alt="localhost_3000_appropriate-body_claim-an-ect_check-ect_249_edit" src="https://github.com/user-attachments/assets/4e69e334-ad3e-4fe3-a7a0-01b6e3cb8083" />
<img width="2446" height="2704" alt="localhost_3000_appropriate-body_claim-an-ect_check-ect_247_edit" src="https://github.com/user-attachments/assets/0288a702-e725-49d2-afbe-45bb735875a9" />

