### PR TITLE
[2178] spike latest training period - Option 2

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,12 +1,34 @@
 module API
   module V3
     class ParticipantsController < BaseController
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
+      def show
+        render json: to_json(participants_query.participant(id: participant_params[:id]))
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
+
+    private
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider }
+
+        Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(:id)
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -15,6 +15,11 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: 'TrainingPeriod'
   has_one :current_or_next_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
 
+  has_one :latest_training_period,
+          -> { latest_first },
+          class_name: "TrainingPeriod",
+          inverse_of: :ect_at_school_period
+
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 
   # Validations

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -13,6 +13,11 @@ class MentorAtSchoolPeriod < ApplicationRecord
            through: :mentorship_periods,
            source: :mentee
 
+  has_one :latest_training_period,
+          -> { latest_first },
+          class_name: "TrainingPeriod",
+          inverse_of: :mentor_at_school_period
+
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 
   # Validations

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -6,31 +6,26 @@ class API::ParticipantSerializer < Blueprinter::Base
       lead_provider = options[:lead_provider]
 
       (teacher.ect_at_school_periods + teacher.mentor_at_school_periods).map { |trainee|
-        training_period = latest_training_period(trainee, lead_provider)
-        next unless training_period
+        training_period = trainee.latest_training_period
+        next unless training_period&.lead_provider == lead_provider
 
         ecf_enrolment(training_period)
       }.compact
     end
 
     class << self
-      def latest_training_period(trainee, lead_provider)
-        # `training_periods` already preloaded, sort in memory
-        trainee.training_periods.sort_by(&:started_on).reverse.find do |training_period|
-          training_period.lead_provider == lead_provider
-        end
-      end
-
       def ecf_enrolment(training_period)
         trainee = training_period.trainee
         teacher = trainee.teacher
         training_record_id = training_period.for_ect? ? teacher.api_ect_profile_id : teacher.api_mentor_profile_id
         {
+          school_period_id: trainee.id,
           training_record_id:,
           email: trainee.email,
           participant_type: training_period.for_ect? ? "ect" : "mentor",
-          started_on: training_period.started_on,
-          finished_on: training_period.finished_on,
+          started_on: training_period.started_on&.iso8601,
+          finished_on: training_period.finished_on&.iso8601,
+          lead_provider: training_period.lead_provider.name,
         }
       end
     end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,0 +1,45 @@
+class API::ParticipantSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field(:ecf_enrolments) do |teacher, options|
+      lead_provider = options[:lead_provider]
+
+      (teacher.ect_at_school_periods + teacher.mentor_at_school_periods).map { |trainee|
+        training_period = latest_training_period(trainee, lead_provider)
+        next unless training_period
+
+        ecf_enrolment(training_period)
+      }.compact
+    end
+
+    class << self
+      def latest_training_period(trainee, lead_provider)
+        # `training_periods` already preloaded, sort in memory
+        trainee.training_periods.sort_by(&:started_on).reverse.find do |training_period|
+          training_period.lead_provider == lead_provider
+        end
+      end
+
+      def ecf_enrolment(training_period)
+        trainee = training_period.trainee
+        teacher = trainee.teacher
+        training_record_id = training_period.for_ect? ? teacher.api_ect_profile_id : teacher.api_mentor_profile_id
+        {
+          training_record_id:,
+          email: trainee.email,
+          participant_type: training_period.for_ect? ? "ect" : "mentor",
+          started_on: training_period.started_on,
+          finished_on: training_period.finished_on,
+        }
+      end
+    end
+  end
+
+  # identifier :ecf_id, name: :id
+  field(:type) { "participant" }
+
+  association :attributes, blueprint: AttributesSerializer do |participant|
+    participant
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -1,0 +1,45 @@
+module Participants
+  class Query
+    attr_reader :scope, :lead_provider
+
+    def initialize(lead_provider:)
+      @lead_provider = lead_provider
+      @scope = all_participants
+    end
+
+    def participants
+      scope.order(created_at: :asc)
+    end
+
+    def participant(id:)
+      scope.where(id:)
+    end
+
+  private
+
+    def all_participants
+      # Union both queries and preload associations for serialization
+      Teacher
+        .select("teachers.*")
+        .from("(#{ect_teachers.to_sql} UNION #{mentor_teachers.to_sql}) as teachers")
+        .includes(
+          ect_at_school_periods: { training_periods: :lead_provider },
+          mentor_at_school_periods: { training_periods: :lead_provider }
+        )
+    end
+
+    def ect_teachers
+      Teacher
+        .select("teachers.*")
+        .joins(ect_at_school_periods: { training_periods: :lead_provider })
+        .where(lead_providers: { id: lead_provider.id })
+    end
+
+    def mentor_teachers
+      Teacher
+        .select("teachers.*")
+        .joins(mentor_at_school_periods: { training_periods: :lead_provider })
+        .where(lead_providers: { id: lead_provider.id })
+    end
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -23,23 +23,23 @@ module Participants
         .select("teachers.*")
         .from("(#{ect_teachers.to_sql} UNION #{mentor_teachers.to_sql}) as teachers")
         .includes(
-          ect_at_school_periods: { training_periods: :lead_provider },
-          mentor_at_school_periods: { training_periods: :lead_provider }
+          ect_at_school_periods: { latest_training_period: :lead_provider },
+          mentor_at_school_periods: { latest_training_period: :lead_provider }
         )
     end
 
     def ect_teachers
       Teacher
         .select("teachers.*")
-        .joins(ect_at_school_periods: { training_periods: :lead_provider })
-        .where(lead_providers: { id: lead_provider.id })
+        .joins(ect_at_school_periods: { latest_training_period: :lead_provider })
+        .where(lead_provider: { id: lead_provider.id })
     end
 
     def mentor_teachers
       Teacher
         .select("teachers.*")
-        .joins(mentor_at_school_periods: { training_periods: :lead_provider })
-        .where(lead_providers: { id: lead_provider.id })
+        .joins(mentor_at_school_periods: { latest_training_period: :lead_provider })
+        .where(lead_provider: { id: lead_provider.id })
     end
   end
 end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     independent_school
 
     started_on { generate(:base_ect_date) }
-    finished_on { started_on + 1.day }
+    finished_on { started_on + 1.year }
     email { Faker::Internet.email }
     working_pattern { WORKING_PATTERNS.keys.sample }
 

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     association :teacher
 
     started_on { generate(:base_mentor_date) }
-    finished_on { started_on + 1.day }
+    finished_on { started_on + 1.year }
     email { Faker::Internet.email }
 
     trait :ongoing do

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,67 +1,92 @@
 RSpec.describe "Participants API", type: :request do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let!(:ect_teacher) { FactoryBot.create(:teacher) }
+  let!(:mentor_teacher) { FactoryBot.create(:teacher) }
+  let!(:both_teacher) { FactoryBot.create(:teacher) }
+
+  let!(:school_partnership) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+  end
+  let!(:lead_provider_delivery_partnership) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+  end
+  let!(:active_lead_provider) do
+    FactoryBot.create(:active_lead_provider, lead_provider:)
+  end
+
+  let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: ect_teacher) }
+  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher) }
+  let!(:both_ect_period) { FactoryBot.create(:ect_at_school_period, teacher: both_teacher) }
+  let!(:both_mentor_period) { FactoryBot.create(:mentor_at_school_period, teacher: both_teacher) }
+
+  before do
+    # ECT only
+    finished_on = ect_at_school_period.started_on + 30.days
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: ect_at_school_period.started_on,
+                      finished_on:)
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: ect_at_school_period.finished_on)
+
+    # Mentor only
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period:,
+                      school_partnership:,
+                      started_on: mentor_at_school_period.started_on,
+                      finished_on: mentor_at_school_period.finished_on)
+
+    # Both ECT and mentor
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period: both_ect_period,
+                      school_partnership:,
+                      started_on: both_ect_period.started_on,
+                      finished_on: both_ect_period.finished_on)
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: both_mentor_period,
+                      school_partnership:,
+                      started_on: both_mentor_period.started_on,
+                      finished_on: both_mentor_period.finished_on)
+  end
+
   describe "#index" do
-    let(:path) { api_v3_participants_path }
+    let(:parsed_response) { JSON.parse(response.body)["data"] }
 
-    it_behaves_like "a token authenticated endpoint", :get
+    it "returns the correct body" do
+      authenticated_api_get(api_v3_participants_path)
 
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#show" do
-    let(:path) { api_v3_participant_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#change_schedule" do
-    let(:path) { api_v3_participant_change_schedule_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#defer" do
-    let(:path) { api_v3_participant_defer_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#resume" do
-    let(:path) { api_v3_participant_resume_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#withdraw" do
-    let(:path) { api_v3_participant_withdraw_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response).to include(
+        include(
+          "type" => "participant",
+          "attributes" => include(
+            "ecf_enrolments" => contain_exactly(
+              include("email" => ect_at_school_period.email, "training_record_id" => ect_teacher.api_ect_profile_id)
+            )
+          )
+        ),
+        include(
+          "type" => "participant",
+          "attributes" => include(
+            "ecf_enrolments" => contain_exactly(
+              include("email" => mentor_at_school_period.email, "training_record_id" => mentor_teacher.api_mentor_profile_id)
+            )
+          )
+        ),
+        include(
+          "type" => "participant",
+          "attributes" => include(
+            "ecf_enrolments" => contain_exactly(
+              include("email" => both_ect_period.email, "training_record_id" => both_teacher.api_ect_profile_id),
+              include("email" => both_mentor_period.email, "training_record_id" => both_teacher.api_mentor_profile_id)
+            )
+          )
+        )
+      )
     end
   end
 end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -14,24 +14,38 @@ RSpec.describe "Participants API", type: :request do
     FactoryBot.create(:active_lead_provider, lead_provider:)
   end
 
+  let!(:school_partnership2) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership2)
+  end
+  let!(:lead_provider_delivery_partnership2) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2)
+  end
+  let!(:active_lead_provider2) do
+    FactoryBot.create(:active_lead_provider, lead_provider: lead_provider2)
+  end
+  let!(:lead_provider2) { FactoryBot.create(:lead_provider) }
+
   let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: ect_teacher) }
   let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher) }
+  let!(:mentor_at_school_period2) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, started_on: mentor_at_school_period.finished_on.next_day) }
   let!(:both_ect_period) { FactoryBot.create(:ect_at_school_period, teacher: both_teacher) }
   let!(:both_mentor_period) { FactoryBot.create(:mentor_at_school_period, teacher: both_teacher) }
 
   before do
     # ECT only
     finished_on = ect_at_school_period.started_on + 30.days
-    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
-                      ect_at_school_period:,
-                      school_partnership:,
-                      started_on: ect_at_school_period.started_on,
-                      finished_on:)
+    # latest
     FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
                       ect_at_school_period:,
                       school_partnership:,
                       started_on: finished_on.next_day,
                       finished_on: ect_at_school_period.finished_on)
+    # old
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: ect_at_school_period.started_on,
+                      finished_on:)
 
     # Mentor only
     FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
@@ -39,17 +53,39 @@ RSpec.describe "Participants API", type: :request do
                       school_partnership:,
                       started_on: mentor_at_school_period.started_on,
                       finished_on: mentor_at_school_period.finished_on)
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: mentor_at_school_period2,
+                      school_partnership: school_partnership2,
+                      started_on: mentor_at_school_period2.started_on,
+                      finished_on: mentor_at_school_period2.finished_on)
 
     # Both ECT and mentor
+    finished_on = both_ect_period.started_on + 15.days
+    # old
     FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
                       ect_at_school_period: both_ect_period,
                       school_partnership:,
                       started_on: both_ect_period.started_on,
+                      finished_on:)
+    # latest
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period: both_ect_period,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
                       finished_on: both_ect_period.finished_on)
+
+    finished_on = both_mentor_period.started_on + 10.days
+    # old
     FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
                       mentor_at_school_period: both_mentor_period,
                       school_partnership:,
                       started_on: both_mentor_period.started_on,
+                      finished_on:)
+    # latest
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: both_mentor_period,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
                       finished_on: both_mentor_period.finished_on)
   end
 
@@ -60,30 +96,54 @@ RSpec.describe "Participants API", type: :request do
       authenticated_api_get(api_v3_participants_path)
 
       expect(response).to have_http_status(:ok)
-      expect(parsed_response).to include(
-        include(
-          "type" => "participant",
-          "attributes" => include(
-            "ecf_enrolments" => contain_exactly(
-              include("email" => ect_at_school_period.email, "training_record_id" => ect_teacher.api_ect_profile_id)
-            )
+      # debugger
+
+      attrs1 = parsed_response.dig(0, "attributes")
+      expect(attrs1).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "school_period_id" => ect_at_school_period.id,
+            "email" => ect_at_school_period.email,
+            "training_record_id" => ect_teacher.api_ect_profile_id,
+            "started_on" => (ect_at_school_period.started_on + 31.days).iso8601,
+            "finished_on" => ect_at_school_period.finished_on.iso8601,
+            "lead_provider" => lead_provider.name
           )
-        ),
-        include(
-          "type" => "participant",
-          "attributes" => include(
-            "ecf_enrolments" => contain_exactly(
-              include("email" => mentor_at_school_period.email, "training_record_id" => mentor_teacher.api_mentor_profile_id)
-            )
+        )
+      )
+
+      attrs2 = parsed_response.dig(1, "attributes")
+      expect(attrs2).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "school_period_id" => mentor_at_school_period.id,
+            "email" => mentor_at_school_period.email,
+            "training_record_id" => mentor_teacher.api_mentor_profile_id,
+            "started_on" => mentor_at_school_period.started_on.iso8601,
+            "finished_on" => mentor_at_school_period.finished_on.iso8601,
+            "lead_provider" => lead_provider.name
           )
-        ),
-        include(
-          "type" => "participant",
-          "attributes" => include(
-            "ecf_enrolments" => contain_exactly(
-              include("email" => both_ect_period.email, "training_record_id" => both_teacher.api_ect_profile_id),
-              include("email" => both_mentor_period.email, "training_record_id" => both_teacher.api_mentor_profile_id)
-            )
+        )
+      )
+
+      attrs3 = parsed_response.dig(2, "attributes")
+      expect(attrs3).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "school_period_id" => both_ect_period.id,
+            "email" => both_ect_period.email,
+            "training_record_id" => both_teacher.api_ect_profile_id,
+            "started_on" => (both_ect_period.started_on + 16.days).iso8601,
+            "finished_on" => both_ect_period.finished_on.iso8601,
+            "lead_provider" => lead_provider.name
+          ),
+          include(
+            "school_period_id" => both_mentor_period.id,
+            "email" => both_mentor_period.email,
+            "training_record_id" => both_teacher.api_mentor_profile_id,
+            "started_on" => (both_mentor_period.started_on + 11.days).iso8601,
+            "finished_on" => both_mentor_period.finished_on.iso8601,
+            "lead_provider" => lead_provider.name
           )
         )
       )

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe Participants::Query do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+
+  describe "#participants" do
+    subject(:participants) { described_class.new(lead_provider:).participants }
+
+    context "when there are both ECT and mentor training periods for the lead provider" do
+      let!(:ect_teacher) { FactoryBot.create(:teacher) }
+      let!(:mentor_teacher) { FactoryBot.create(:teacher) }
+      let!(:both_teacher) { FactoryBot.create(:teacher) }
+
+      let!(:school_partnership) do
+        FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+      end
+      let!(:lead_provider_delivery_partnership) do
+        FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+      end
+      let!(:active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, lead_provider:)
+      end
+
+      before do
+        # ECT only
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher: ect_teacher)
+        FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                          ect_at_school_period:,
+                          school_partnership:,
+                          started_on: ect_at_school_period.started_on,
+                          finished_on: ect_at_school_period.finished_on)
+
+        # Mentor only
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher)
+        FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                          mentor_at_school_period:,
+                          school_partnership:,
+                          started_on: mentor_at_school_period.started_on,
+                          finished_on: mentor_at_school_period.finished_on)
+
+        # Both ECT and mentor
+        both_ect_period = FactoryBot.create(:ect_at_school_period, teacher: both_teacher)
+        both_mentor_period = FactoryBot.create(:mentor_at_school_period, teacher: both_teacher)
+        FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                          ect_at_school_period: both_ect_period,
+                          school_partnership:,
+                          started_on: both_ect_period.started_on,
+                          finished_on: both_ect_period.finished_on)
+        FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                          mentor_at_school_period: both_mentor_period,
+                          school_partnership:,
+                          started_on: both_mentor_period.started_on,
+                          finished_on: both_mentor_period.finished_on)
+      end
+
+      it "returns all teachers without duplicates" do
+        expect(participants).to contain_exactly(ect_teacher, mentor_teacher, both_teacher)
+      end
+
+      it "includes teacher who is both ECT and mentor only once" do
+        expect(participants.where(id: both_teacher.id).count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2178

### Changes proposed in this pull request

* Participants query service `Participants::Query`
* Serialize `API::ParticipantSerializer`
* Latest training period by `started_on DESC`
* Query is union of ECT teachers and Mentor teachers
* Serializer chooses the latest training period by choosing the newest `started_on` training period
* No N+1 queries
* Using `has_one` association on ECT/Mentor At School Periods to filter training periods and only return that one needed

### Guidance to review
