### PR TITLE
Change `context` to `describe` when testing methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,11 +45,6 @@ RSpec/ClassCheck:
     - 'spec/models/induction_period_spec.rb'
     - 'spec/models/pending_induction_submission_spec.rb'
 
-# Offense count: 41
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/ContextMethod:
-  Enabled: false
-
 # Offense count: 181
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without

--- a/spec/components/admin/statements/adjustments_component_spec.rb
+++ b/spec/components/admin/statements/adjustments_component_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::Statements::AdjustmentsComponent, type: :component do
     end
   end
 
-  context ".adjustment_editable?" do
+  describe ".adjustment_editable?" do
     let!(:adjustment1) { FactoryBot.create :statement_adjustment, statement:, payment_type: "Big amount", amount: 999.99 }
 
     context "non-paid statement" do

--- a/spec/components/admin/statements/filter_component_spec.rb
+++ b/spec/components/admin/statements/filter_component_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
   let(:filter_params) { {} }
   let(:component) { described_class.new filter_params: }
 
-  context ".lead_providers" do
+  describe ".lead_providers" do
     let!(:lead_provider1) { FactoryBot.create(:lead_provider, name: "C") }
     let!(:lead_provider2) { FactoryBot.create(:lead_provider, name: "A") }
     let!(:lead_provider3) { FactoryBot.create(:lead_provider, name: "B") }
@@ -12,7 +12,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".lead_provider_id" do
+  describe ".lead_provider_id" do
     let(:filter_params) { { lead_provider_id: 123 } }
 
     it "returns filter param lead_provider_id" do
@@ -20,7 +20,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".contract_periods" do
+  describe ".contract_periods" do
     let!(:contract_period1) { FactoryBot.create(:contract_period, year: 2025) }
     let!(:contract_period2) { FactoryBot.create(:contract_period, year: 2021) }
     let!(:contract_period3) { FactoryBot.create(:contract_period, year: 2022) }
@@ -30,7 +30,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".contract_period_year" do
+  describe ".contract_period_year" do
     let(:filter_params) { { contract_period_year: 2025 } }
 
     it "returns filter param contract_period_year" do
@@ -38,7 +38,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".statement_dates" do
+  describe ".statement_dates" do
     let!(:statement1) { FactoryBot.create(:statement, year: 2025, month: 5) }
     let!(:statement2) { FactoryBot.create(:statement, year: 2024, month: 5) }
     let!(:statement3) { FactoryBot.create(:statement, year: 2023, month: 5) }
@@ -56,7 +56,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".statement_date" do
+  describe ".statement_date" do
     let(:filter_params) { { statement_date: "2025-01" } }
 
     it "returns filter param statement_date" do
@@ -64,7 +64,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".statement_types" do
+  describe ".statement_types" do
     it "returns statement types" do
       dates = component.statement_types
       expect(dates[0].id).to eq("all")
@@ -78,7 +78,7 @@ RSpec.describe Admin::Statements::FilterComponent, type: :component do
     end
   end
 
-  context ".statement_type" do
+  describe ".statement_type" do
     let(:filter_params) { { statement_type: "all" } }
 
     it "returns filter param statement_type" do

--- a/spec/components/admin/statements/selector_component_spec.rb
+++ b/spec/components/admin/statements/selector_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
   let(:statement_lead_provider) { statement.active_lead_provider.lead_provider }
   let(:statement_contract_period) { FactoryBot.create(:contract_period, year: 2034) }
 
-  context ".lead_providers" do
+  describe ".lead_providers" do
     let!(:lead_provider1) { FactoryBot.create(:lead_provider, name: "AAAC") }
     let!(:lead_provider2) { FactoryBot.create(:lead_provider, name: "AAAA") }
     let!(:lead_provider3) { FactoryBot.create(:lead_provider, name: "AAAB") }
@@ -15,13 +15,13 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
     end
   end
 
-  context ".lead_provider_id" do
+  describe ".lead_provider_id" do
     it "returns lead_provider_id from statement" do
       expect(component.lead_provider_id).to eq(statement.active_lead_provider.lead_provider_id)
     end
   end
 
-  context ".contract_periods" do
+  describe ".contract_periods" do
     let!(:contract_period1) { FactoryBot.create(:contract_period, year: 2035) }
     let!(:contract_period2) { FactoryBot.create(:contract_period, year: 2031) }
     let!(:contract_period3) { FactoryBot.create(:contract_period, year: 2032) }
@@ -36,13 +36,13 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
     end
   end
 
-  context ".contract_period_year" do
+  describe ".contract_period_year" do
     it "returns contract_period_year from statement" do
       expect(component.contract_period_year).to eq(statement.active_lead_provider.contract_period_year)
     end
   end
 
-  context ".statement_dates" do
+  describe ".statement_dates" do
     let!(:statement1) { FactoryBot.create(:statement, year: 2021, month: 3) }
     let!(:statement2) { FactoryBot.create(:statement, year: 2021, month: 2) }
     let!(:statement3) { FactoryBot.create(:statement, year: 2021, month: 1) }
@@ -60,7 +60,7 @@ RSpec.describe Admin::Statements::SelectorComponent, type: :component do
     end
   end
 
-  context ".statement_date" do
+  describe ".statement_date" do
     it "returns statement_date from statement" do
       expect(component.statement_date).to eq([statement.year, statement.month].join("-"))
     end

--- a/spec/misc/terraform_versions_spec.rb
+++ b/spec/misc/terraform_versions_spec.rb
@@ -20,7 +20,7 @@ describe 'Terraform versions' do
     end
   end
 
-  context '.tool-versions' do
+  describe '.tool-versions' do
     version_in_tool_versions = File.open(Rails.root.join('.tool-versions')).then { |v| extract_terraform_version(v, /terraform/) }
 
     it "is at version #{version_in_tool_versions}" do

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -220,7 +220,7 @@ describe ECTAtSchoolPeriod do
       let(:finished_on_message) { 'End date cannot overlap another Teacher ECT period' }
       let(:teacher) { FactoryBot.create(:teacher) }
 
-      context '#teacher_distinct_period' do
+      describe '#teacher_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             before do

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe InductionPeriod do
       let(:finished_on_message) { 'End date cannot overlap another induction period' }
       let(:teacher) { FactoryBot.create(:teacher) }
 
-      context '#teacher_distinct_period' do
+      describe '#teacher_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             before do

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -34,7 +34,7 @@ describe MentorAtSchoolPeriod do
       let(:teacher) { FactoryBot.create(:teacher) }
       let(:school) { FactoryBot.create(:school) }
 
-      context '#teacher_distinct_period' do
+      describe '#teacher_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             before do

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -29,7 +29,7 @@ describe MentorshipPeriod do
       let(:started_on_message) { 'Start date cannot overlap another Mentee period' }
       let(:finished_on_message) { 'End date cannot overlap another Mentee period' }
 
-      context '#mentee_distinct_period' do
+      describe '#mentee_distinct_period' do
         PeriodHelpers::PeriodExamples.period_examples.each_with_index do |test, index|
           context test.description do
             let(:mentor) do
@@ -114,7 +114,7 @@ describe MentorshipPeriod do
       end
     end
 
-    context '#not_self_mentoring' do
+    describe '#not_self_mentoring' do
       context 'when mentor and mentee are the same teacher' do
         subject { FactoryBot.build(:mentorship_period, mentee: ect_at_school_period, mentor: mentor_at_school_period) }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -207,7 +207,7 @@ describe School do
     end
   end
 
-  context "#expression_of_interest_for?" do
+  describe "#expression_of_interest_for?" do
     subject(:school) { FactoryBot.create(:school) }
 
     let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership) }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -128,7 +128,7 @@ describe Statement do
     end
   end
 
-  context ".adjustment_editable?" do
+  describe ".adjustment_editable?" do
     context "paid statement" do
       subject { FactoryBot.build(:statement, :paid) }
 
@@ -160,7 +160,7 @@ describe Statement do
     end
   end
 
-  context ".can_authorise_payment?" do
+  describe ".can_authorise_payment?" do
     context "open statement" do
       subject { FactoryBot.build(:statement, :open) }
 

--- a/spec/services/teachers/induction_period_spec.rb
+++ b/spec/services/teachers/induction_period_spec.rb
@@ -3,7 +3,7 @@ describe Teachers::InductionPeriod do
 
   let(:teacher) { FactoryBot.create(:teacher) }
 
-  context '#induction_start_date' do
+  describe '#induction_start_date' do
     context 'when teacher does not have induction periods' do
       it { expect(service.induction_start_date).to be_nil }
     end
@@ -25,7 +25,7 @@ describe Teachers::InductionPeriod do
     end
   end
 
-  context '#ongoing_induction_period' do
+  describe '#ongoing_induction_period' do
     context 'without ongoing induction period' do
       before do
         FactoryBot.create(:induction_period, teacher:, started_on: '2023-10-3', finished_on: '2023-12-3')

--- a/spec/wizards/schools/ects/change_name_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_name_wizard/check_answers_step_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Schools::ECTs::ChangeNameWizard::CheckAnswersStep, type: :model d
     it { expect(current_step.previous_step).to eq(:edit) }
   end
 
-  context '#save!' do
+  describe '#save!' do
     it 'persists the corrected name' do
       expect { current_step.save! }.to change(wizard.ect_at_school_period.teacher, :corrected_name).from(nil).to('Terry Pratchett')
     end

--- a/spec/wizards/schools/ects/change_name_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_name_wizard/edit_step_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Schools::ECTs::ChangeNameWizard::EditStep, type: :model do
     it { expect { current_step.previous_step }.to raise_error(NotImplementedError) }
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       let(:params) do
         { "name" => '' }

--- a/spec/wizards/schools/mentors/change_name_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/check_answers_step_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Schools::Mentors::ChangeNameWizard::CheckAnswersStep, type: :mode
     it { expect(current_step.previous_step).to eq(:edit) }
   end
 
-  context '#save!' do
+  describe '#save!' do
     it 'persists the corrected name' do
       expect { current_step.save! }.to change(wizard.mentor_at_school_period.teacher, :corrected_name).from(nil).to('Terry Pratchett')
     end

--- a/spec/wizards/schools/mentors/change_name_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/edit_step_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Schools::Mentors::ChangeNameWizard::EditStep, type: :model do
     it { expect { current_step.previous_step }.to raise_error(NotImplementedError) }
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       let(:params) do
         { "name" => '' }

--- a/spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb
@@ -41,7 +41,7 @@ describe Schools::RegisterECTWizard::CheckAnswersStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       before do
         allow(subject).to receive(:valid?).and_return(false)

--- a/spec/wizards/schools/register_ect_wizard/email_address_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/email_address_step_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Schools::RegisterECTWizard::EmailAddressStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     subject { wizard.current_step }
 
     let(:step_params) do

--- a/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/find_ect_step_spec.rb
@@ -225,7 +225,7 @@ describe Schools::RegisterECTWizard::FindECTStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 

--- a/spec/wizards/schools/register_ect_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/national_insurance_number_step_spec.rb
@@ -130,7 +130,7 @@ describe Schools::RegisterECTWizard::NationalInsuranceNumberStep, type: :model d
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 

--- a/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
@@ -82,7 +82,7 @@ describe Schools::RegisterECTWizard::ReviewECTDetailsStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     subject { wizard.current_step }
 
     let(:step_params) do

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     let(:step_params) do
       ActionController::Parameters.new(
         "start_date" => { "start_date(1i)" => "2024", "start_date(2i)" => "07", "start_date(3i)" => "01" }

--- a/spec/wizards/schools/register_ect_wizard/training_programme_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/training_programme_step_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Schools::RegisterECTWizard::TrainingProgrammeStep, type: :model d
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     subject { wizard.current_step }
 
     let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :training_programme, step_params:) }

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
     it { expect(subject.previous_step).to eq(:working_pattern) }
   end
 
-  context '#save!' do
+  describe '#save!' do
     let(:step_params) do
       ActionController::Parameters.new(
         "use_previous_ect_choices" => {

--- a/spec/wizards/schools/register_ect_wizard/working_pattern_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/working_pattern_step_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Schools::RegisterECTWizard::WorkingPatternStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     subject { wizard.current_step }
 
     let(:step_params) do

--- a/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/check_answers_step_spec.rb
@@ -74,7 +74,7 @@ describe Schools::RegisterMentorWizard::CheckAnswersStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     let(:ect) { FactoryBot.create(:ect_at_school_period) }
     let(:ect_id) { ect.id }
 

--- a/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/find_mentor_step_spec.rb
@@ -183,7 +183,7 @@ describe Schools::RegisterMentorWizard::FindMentorStep, type: :model do
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 

--- a/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/national_insurance_number_step_spec.rb
@@ -165,7 +165,7 @@ describe Schools::RegisterMentorWizard::NationalInsuranceNumberStep, type: :mode
     end
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/review_mentor_details_step.rb
@@ -76,7 +76,7 @@ RSpec.shared_examples "a review mentor details step" do |current_step:, next_ste
     it { expect(subject.next_step).to eq(next_step) }
   end
 
-  context '#save!' do
+  describe '#save!' do
     context 'when the step is not valid' do
       subject { wizard.current_step }
 


### PR DESCRIPTION
### Context

We should be using `describe` to test methods and `context` to test different scenarios.

The cop is now re-enabled.

<img width="763" height="188" alt="image" src="https://github.com/user-attachments/assets/14c4146e-fbe8-42b9-acc2-a42dbf212318" />


Refs #1318 