### PR TITLE
Remove unused methods from `Teachers::InductionStatus`

### DIFF
--- a/app/services/teachers/induction_status.rb
+++ b/app/services/teachers/induction_status.rb
@@ -1,22 +1,36 @@
 class Teachers::InductionStatus
   attr_reader :teacher, :induction_periods, :trs_induction_status
 
+  Status = Data.define(:name, :colour) do
+    def to_h = { text: name, colour: }
+  end
+
   def initialize(teacher:, induction_periods:, trs_induction_status:)
     @teacher = teacher
     @induction_periods = induction_periods
     @trs_induction_status = trs_induction_status
   end
 
-  def status_tag_kwargs
+  def status_tag_kwargs = determine_status.to_h
+  def induction_status = determine_status.name
+  def induction_status_colour = determine_status.colour
+
+  def completed?
+    trs_induction_status.in?(%w[Exempt Passed Failed FailedInWales])
+  end
+
+private
+
+  def determine_status
     case induction_info
     in { trs_induction_status: 'RequiredToComplete' }
       required_to_complete
     in { trs_induction_status: 'Exempt' }
       exempt
-    in { has_an_open_induction_period: false, trs_induction_status: 'InProgress' }
-      paused
-    in { has_an_open_induction_period: true, trs_induction_status: 'InProgress' }
+    in { trs_induction_status: 'InProgress', has_an_open_induction_period: true }
       in_progress
+    in { trs_induction_status: 'InProgress' }
+      paused
     in { trs_induction_status: 'Failed' }
       failed
     in { trs_induction_status: 'Passed' }
@@ -30,51 +44,21 @@ class Teachers::InductionStatus
     end
   end
 
-  def induction_status = status_tag_kwargs.fetch(:text)
-  def induction_status_colour = status_tag_kwargs.fetch(:colour)
-
-  def completed?
-    %w[
-      Exempt
-      Passed
-      Failed
-      FailedInWales
-    ].include?(trs_induction_status)
-  end
-
-private
-
   def induction_info
-    {
-      has_an_open_induction_period: has_any_open_induction_periods?,
-      has_an_induction_outcome: has_an_induction_outcome?,
-      teacher_with_induction_periods_present: teacher.present? && induction_periods.present?,
-      induction_outcome:,
-      trs_induction_status:,
-    }
+    { trs_induction_status:, has_an_open_induction_period: }
   end
 
-  def has_any_open_induction_periods?
-    induction_periods&.any?(&:ongoing?) || false
+  def has_an_open_induction_period
+    induction_periods&.any?(&:ongoing?)
   end
 
-  def has_an_induction_outcome?
-    induction_periods&.any? { |ip| ip.outcome.present? }
-  end
-
-  def induction_outcome
-    return unless (period_with_outcome = induction_periods&.find { |ip| ip.outcome.present? })
-
-    period_with_outcome.outcome
-  end
-
-  def exempt = { text: 'Exempt', colour: 'green' }
-  def failed = { text: 'Failed', colour: 'red' }
-  def failed_in_wales = { text: 'Failed in Wales', colour: 'red' }
-  def in_progress = { text: 'In progress', colour: 'blue' }
-  def none = { text: 'None', colour: 'grey' }
-  def passed = { text: 'Passed', colour: 'green' }
-  def paused = { text: 'Induction paused', colour: 'pink' }
-  def required_to_complete = { text: 'Required to complete', colour: 'yellow' }
-  def unknown = { text: 'Unknown', colour: 'grey' }
+  def exempt = Status.new(name: 'Exempt', colour: 'green')
+  def failed = Status.new(name: 'Failed', colour: 'red')
+  def failed_in_wales = Status.new(name: 'Failed in Wales', colour: 'red')
+  def in_progress = Status.new(name: 'In progress', colour: 'blue')
+  def none = Status.new(name: 'None', colour: 'grey')
+  def passed = Status.new(name: 'Passed', colour: 'green')
+  def paused = Status.new(name: 'Induction paused', colour: 'pink')
+  def required_to_complete = Status.new(name: 'Required to complete', colour: 'yellow')
+  def unknown = Status.new(name: 'Unknown', colour: 'grey')
 end


### PR DESCRIPTION
Also refactor the class a little. Originally this class's only purpose was to splat arguments into the status tag, however it's now also used to provide the status name elsewhere.

Now its use has shifted, moving the raw statuses away from a hash allows us to make the public methods a little clearer by calling the attribute on the Status struct.

I also switched the in_progress/paused clauses around which:

* allowed me to remove the `false` check, so only `true` returns `in_progress` and anything else (including `nil`) returns `paused` - meaning we can get rid of the `|| false`
* line up the `trs_induction_status` values nicely
