### PR TITLE
Relax order sensitive assertions in school partnerships spec

### DIFF
--- a/spec/services/sandbox_seed_data/school_partnerships_spec.rb
+++ b/spec/services/sandbox_seed_data/school_partnerships_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe SandboxSeedData::SchoolPartnerships do
     it "creates school partnerships for all lead providers" do
       instance.plant
 
-      expect(SchoolPartnership.all.map(&:lead_provider).uniq).to eq(LeadProvider.all)
+      expect(SchoolPartnership.all.map(&:lead_provider).uniq).to match_array(LeadProvider.all)
     end
 
     it "creates school partnerships for all contract periods" do
       instance.plant
 
-      expect(SchoolPartnership.all.map(&:contract_period).uniq).to eq(ContractPeriod.all)
+      expect(SchoolPartnership.all.map(&:contract_period).uniq).to match_array(ContractPeriod.all)
     end
 
     it "creates school partnership with same school but different delivery partner" do


### PR DESCRIPTION
### Context

The school partnerships spec compared arrays of ActiveRecord objects with `==`,  which is order sensitive. This caused flakiness when the same records were returned in a different order:

```plaintext
expected: [LeadProvider(2191), LeadProvider(2192)]
got: [LeadProvider(2192), LeadProvider(2191)]
```

[See failure in CI here](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/17826787050/job/50681751295)


### Changes proposed

Replace `==` with `match_array`. This asserts that all lead providers and contract periods are covered without requiring a specific order.


### Guidance to review

Run the spec multiple times, It should never fail.
