### PR TITLE
[2408] Rename profile IDs on Teacher

### DIFF
--- a/app/components/migration/induction_record_component.rb
+++ b/app/components/migration/induction_record_component.rb
@@ -9,11 +9,11 @@ module Migration
     def migrated_mentor
       return unless mentor_present?
 
-      Teacher.find_by(api_mentor_profile_id: induction_record.mentor_profile_id)
+      Teacher.find_by(api_mentor_training_record_id: induction_record.mentor_training_record_id)
     end
 
     def mentor_present?
-      induction_record.mentor_profile_id.present?
+      induction_record.mentor_training_record_id.present?
     end
 
     def attributes_for(_attr)

--- a/app/components/migration/teacher_migration_failure_component.rb
+++ b/app/components/migration/teacher_migration_failure_component.rb
@@ -27,10 +27,10 @@ module Migration
     def load_participant_profile
       pid = if teacher_migration_failure.migration_item_type == "Migration::ParticipantProfile"
               teacher_migration_failure.migration_item_id
-            elsif teacher.api_ect_profile_id.present?
-              teacher.api_ect_profile_id
-            elsif teacher.api_mentor_profile_id.present?
-              teacher.api_mentor_profile_id
+            elsif teacher.api_ect_training_record_id.present?
+              teacher.api_ect_training_record_id
+            elsif teacher.api_mentor_training_record_id.present?
+              teacher.api_mentor_training_record_id
             end
       Migration::ParticipantProfilePresenter.new(Migration::ParticipantProfile.find(pid)) if pid.present?
     end

--- a/app/controllers/migration/teachers_controller.rb
+++ b/app/controllers/migration/teachers_controller.rb
@@ -42,17 +42,17 @@ private
   end
 
   def ect_profile
-    @ect_profile = if teacher.api_ect_profile_id.present?
+    @ect_profile = if teacher.api_ect_training_record_id.present?
                      Migration::ParticipantProfilePresenter.new(
-                       Migration::ParticipantProfile.find(teacher.api_ect_profile_id)
+                       Migration::ParticipantProfile.find(teacher.api_ect_training_record_id)
                      )
                    end
   end
 
   def mentor_profile
-    @mentor_profile = if teacher.api_mentor_profile_id.present?
+    @mentor_profile = if teacher.api_mentor_training_record_id.present?
                         Migration::ParticipantProfilePresenter.new(
-                          Migration::ParticipantProfile.find(teacher.api_mentor_profile_id)
+                          Migration::ParticipantProfile.find(teacher.api_mentor_training_record_id)
                         )
                       end
   end

--- a/app/migration/mentorship_period_extractor.rb
+++ b/app/migration/mentorship_period_extractor.rb
@@ -31,7 +31,7 @@ private
       elsif current_mentor_id != mentor_id
         current_mentor_id = mentor_id
 
-        mentor_teacher = ::Teacher.find_by(api_mentor_profile_id: mentor_id)
+        mentor_teacher = ::Teacher.find_by(api_mentor_training_record_id: mentor_id)
 
         current_period = Migration::MentorshipPeriodData.new(mentor_teacher:,
                                                              start_date: induction_record.start_date,

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -49,7 +49,7 @@ module Migrators
 
             school_periods.flatten!
 
-            teacher.update!(api_ect_profile_id: participant_profile.id)
+            teacher.update!(api_ect_training_record_id: participant_profile.id)
             result = Builders::ECT::SchoolPeriods.new(teacher:, school_periods:).build
           else
             ::TeacherMigrationFailure.create!(teacher:,

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -48,7 +48,7 @@ module Migrators
               school_periods << SchoolPeriodExtractor.new(induction_records: induction_records_group).school_periods
             end
 
-            teacher.update!(api_mentor_profile_id: participant_profile.id)
+            teacher.update!(api_mentor_training_record_id: participant_profile.id)
             result = Builders::Mentor::SchoolPeriods.new(teacher:, school_periods: school_periods.flatten).build
           else
             ::TeacherMigrationFailure.create!(teacher:,

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -45,8 +45,8 @@ class Teacher < ApplicationRecord
             presence: { message: 'Choose the reason why the mentor became ineligible for funding' },
             if: -> { mentor_became_ineligible_for_funding_on.present? }
   validates :api_user_id, uniqueness: { case_sensitive: false, message: "API user id already exists for another teacher" }
-  validates :api_ect_profile_id, uniqueness: { case_sensitive: false, message: "API ect profile id already exists for another teacher" }
-  validates :api_mentor_profile_id, uniqueness: { case_sensitive: false, message: "API mentor profile id already exists for another teacher" }
+  validates :api_ect_training_record_id, uniqueness: { case_sensitive: false, message: "API ect training record id already exists for another teacher" }
+  validates :api_mentor_training_record_id, uniqueness: { case_sensitive: false, message: "API mentor training record id already exists for another teacher" }
 
   # Scopes
   scope :search, ->(query_string) {

--- a/app/presenters/migration/migration_failure_presenter.rb
+++ b/app/presenters/migration/migration_failure_presenter.rb
@@ -41,8 +41,8 @@ module Migration
     end
 
     def profile_id_from_parent
-      return parent.api_ect_profile_id if parent.api_ect_profile_id.present?
-      return parent.api_mentor_profile_id if parent.api_mentor_profile_id.present?
+      return parent.api_ect_training_record_id if parent.api_ect_training_record_id.present?
+      return parent.api_mentor_training_record_id if parent.api_mentor_training_record_id.present?
 
       if parent.api_user_id.present?
         # NOTE: if they have both ECT and Mentor profiles we don't know which had the issue

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -221,8 +221,8 @@
   - api_updated_at
   :teachers:
   - api_user_id
-  - api_ect_profile_id
-  - api_mentor_profile_id
+  - api_ect_training_record_id
+  - api_mentor_training_record_id
   - corrected_name
   - trs_first_name
   - trs_last_name

--- a/db/migrate/20250918153321_rename_profile_ids_to_training_record_ids.rb
+++ b/db/migrate/20250918153321_rename_profile_ids_to_training_record_ids.rb
@@ -1,0 +1,6 @@
+class RenameProfileIdsToTrainingRecordIds < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :teachers, :api_ect_profile_id, :api_ect_training_record_id
+    rename_column :teachers, :api_mentor_profile_id, :api_mentor_training_record_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_17_185258) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -764,12 +764,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_185258) do
     t.boolean "trs_deactivated", default: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(trs_first_name, ''::character varying))::text || ' '::text) || (COALESCE(trs_last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
     t.uuid "api_user_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_ect_profile_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_mentor_profile_id", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }, null: false
     t.integer "ect_payments_frozen_year"
     t.integer "mentor_payments_frozen_year"
-    t.index ["api_ect_profile_id"], name: "index_teachers_on_api_ect_profile_id", unique: true
-    t.index ["api_mentor_profile_id"], name: "index_teachers_on_api_mentor_profile_id", unique: true
+    t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
+    t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
     t.index ["api_user_id"], name: "index_teachers_on_api_user_id", unique: true
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["search"], name: "index_teachers_on_search", using: :gin

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -138,8 +138,8 @@ erDiagram
     enum mentor_became_ineligible_for_funding_reason
     boolean trs_deactivated
     uuid api_user_id
-    uuid api_ect_profile_id
-    uuid api_mentor_profile_id
+    uuid api_ect_training_record_id
+    uuid api_mentor_training_record_id
     integer ect_payments_frozen_year
     integer mentor_payments_frozen_year
   }

--- a/spec/migration/migrators/mentorship_period_spec.rb
+++ b/spec/migration/migrators/mentorship_period_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Migrators::MentorshipPeriod do
     end
 
     def create_resource(migration_resource)
-      ect = FactoryBot.create(:teacher, trn: migration_resource.teacher_profile.trn, api_ect_profile_id: migration_resource.id)
+      ect = FactoryBot.create(:teacher, trn: migration_resource.teacher_profile.trn, api_ect_training_record_id: migration_resource.id)
       school = FactoryBot.create(:school, urn: migration_resource.school_cohort.school.urn)
       FactoryBot.create(:ect_at_school_period, teacher: ect, school:, started_on: migration_resource.induction_records.first.start_date, finished_on: nil)
 
       migration_mentor = migration_resource.induction_records.first.mentor_profile
-      mentor = FactoryBot.create(:teacher, trn: migration_mentor.teacher_profile.trn, api_mentor_profile_id: migration_mentor.id)
+      mentor = FactoryBot.create(:teacher, trn: migration_mentor.teacher_profile.trn, api_mentor_training_record_id: migration_mentor.id)
       FactoryBot.create(:mentor_at_school_period, teacher: mentor, school:, started_on: migration_mentor.induction_records.first.start_date, finished_on: nil)
     end
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -92,8 +92,8 @@ describe Teacher do
     it { is_expected.to validate_length_of(:trs_induction_status).with_message('TRS induction status must be shorter than 18 characters') }
 
     it { is_expected.to validate_uniqueness_of(:api_user_id).case_insensitive.with_message("API user id already exists for another teacher") }
-    it { is_expected.to validate_uniqueness_of(:api_ect_profile_id).case_insensitive.with_message("API ect profile id already exists for another teacher") }
-    it { is_expected.to validate_uniqueness_of(:api_mentor_profile_id).case_insensitive.with_message("API mentor profile id already exists for another teacher") }
+    it { is_expected.to validate_uniqueness_of(:api_ect_training_record_id).case_insensitive.with_message("API ect training record id already exists for another teacher") }
+    it { is_expected.to validate_uniqueness_of(:api_mentor_training_record_id).case_insensitive.with_message("API mentor training record id already exists for another teacher") }
 
     describe "trn" do
       it { is_expected.to validate_uniqueness_of(:trn).with_message('TRN already exists').case_insensitive }


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2408

### Changes proposed in this pull request

* Migration on `Teacher` to rename:
  * `api_ect_profile_id` to `api_ect_training_record_id`
  * `api_mentor_profile_id` to `api_mentor_training_record_id`
* Updated all uses of the old column name to new column name, inc validation

### Guidance to review
