### PR TITLE
Fix `ErrorsController` for unauthenticated users

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,6 @@
 class AdminController < ApplicationController
+  before_action :authenticate
+
   include Authorisation
 
   def index

--- a/app/controllers/api/documentation_controller.rb
+++ b/app/controllers/api/documentation_controller.rb
@@ -2,8 +2,6 @@
 
 module API
   class DocumentationController < ApplicationController
-    skip_before_action :authenticate
-
     layout "api_docs"
 
     def index

--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -2,8 +2,6 @@ module API
   class GuidanceController < ApplicationController
     include ReleaseNotes
 
-    skip_before_action :authenticate
-
     layout 'api_guidance'
 
     def show

--- a/app/controllers/api/release_notes_controller.rb
+++ b/app/controllers/api/release_notes_controller.rb
@@ -2,8 +2,6 @@ module API
   class ReleaseNotesController < ApplicationController
     include ReleaseNotes
 
-    skip_before_action :authenticate
-
     layout 'api_guidance'
 
     def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
 
   class UnredirectableError < StandardError; end
 
-  before_action :authenticate
   before_action :set_sentry_user
 
   include Pagy::Backend

--- a/app/controllers/appropriate_bodies_controller.rb
+++ b/app/controllers/appropriate_bodies_controller.rb
@@ -1,4 +1,6 @@
 class AppropriateBodiesController < ApplicationController
+  before_action :authenticate
+
   include Authorisation
 
   before_action :set_appropriate_body

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,5 @@
 class ErrorsController < ApplicationController
-  skip_before_action :verify_authenticity_token, :authenticate
+  skip_before_action :verify_authenticity_token
 
   def not_found
     render 'not_found', status: :not_found

--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,6 +1,4 @@
 class HealthCheckController < ApplicationController
-  skip_before_action :authenticate
-
   def show = render(json:)
 
 private

--- a/app/controllers/otp_sessions_controller.rb
+++ b/app/controllers/otp_sessions_controller.rb
@@ -1,5 +1,4 @@
 class OTPSessionsController < ApplicationController
-  skip_before_action :authenticate
   before_action :build_otp_form, except: %i[new request_code]
 
   def new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,4 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate
-
   def home
     redirect_to(post_login_redirect_path) and return if authenticated?
 

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,5 +1,4 @@
 class PersonasController < ApplicationController
-  skip_before_action :authenticate
   layout 'full'
 
   def index

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,4 +1,6 @@
 class SchoolsController < ApplicationController
+  before_action :authenticate
+
   include Authorisation
 
   before_action :set_school

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,8 +3,6 @@
 # 2. Sessions::Manager#current_user -> Sessions::User.from_session
 #
 class SessionsController < ApplicationController
-  skip_before_action :authenticate
-
   def new
     render :new
   end


### PR DESCRIPTION
### Context

At the moment, if we hit a 404 error it ends up being swallowed by the `authenticate` `before_action` and instead results in a redirect to the `pre_login_redirect_path`.

We want to surface errors correctly for unauthenticated users.

### Changes proposed in this pull request

- Skip authenticate in ErrorsController

By skipping `authenticate` in `ErrorsController` we will correctly pick up and respond with the correct status code/view.

- Add test coverage to ErrorsController

Add tests that will ensure our `ErrorsController` is correctly handling errors.

### Guidance to review

Initially we wanted to restrict the changes to the API, thinking this was API-specific, however it turned out to be a general issue with error handling in the app.

The API errors already have test coverage in the various shared contexts for testing endpoints.