### PR TITLE
Rework previous choices page

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -23,6 +23,7 @@ private
 
   def set_school
     @school = school_from_session
+    @decorated_school = Schools::DecoratedSchool.new(school_from_session)
   end
 
   def school_from_session

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -22,16 +22,10 @@ private
   end
 
   def set_school
-    # This is temporary. 'School' will be set once DfE signin hooked up
-    # School in the session or first school with ects but no mentors or first school
-    @school = (school_from_session || first_school)
+    @school = school_from_session
   end
 
   def school_from_session
     School.joins(:gias_school).find_by_urn(current_user.school_urn)
-  end
-
-  def first_school
-    School.joins(:gias_school).first
   end
 end

--- a/app/services/schools/latest_registration_choices.rb
+++ b/app/services/schools/latest_registration_choices.rb
@@ -11,6 +11,10 @@ module Schools
 
     delegate :last_chosen_appropriate_body, to: :school
     delegate :last_chosen_lead_provider, to: :school
+    delegate :last_chosen_training_programme, to: :school
+
+    delegate :lead_provider, to: :lead_provider_and_delivery_partner
+    delegate :delivery_partner, to: :lead_provider_and_delivery_partner
 
     def appropriate_body = last_chosen_appropriate_body
 

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -32,7 +32,7 @@
   end
 end %>
 
-<% if @decorated_school.provider_led_training_programme_chosen? && !@decorated_school.has_partnership_with?(lead_provider: @decorated_school.latest_registration_choices.lead_provider.name, contract_period: @ect.contract_start_date) %>
+<% if @decorated_school.provider_led_training_programme_chosen? && !@decorated_school.has_partnership_with?(lead_provider: @decorated_school.latest_registration_choices.lead_provider, contract_period: @ect.contract_start_date) %>
   <p class="govuk-body">
     <%= @decorated_school.latest_registration_choices.lead_provider.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
   </p>

--- a/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
+++ b/app/views/schools/register_ect_wizard/_use_previous_ect_choices.html.erb
@@ -5,39 +5,36 @@
 <p class="govuk-body">You used these programme choices the last time you registered an ECT.</p>
 
 <%= govuk_summary_list do |summary_list|
-  summary_list.with_row do |row|
-    row.with_key(text: 'Appropriate body')
-    row.with_value(text: @school.last_chosen_appropriate_body_name)
+  if @decorated_school.latest_registration_choices.appropriate_body.present?
+    summary_list.with_row do |row|
+      row.with_key(text: 'Appropriate body')
+      row.with_value(text: @decorated_school.latest_registration_choices.appropriate_body.name)
+    end
   end
 
   summary_list.with_row do |row|
     row.with_key(text: 'Training programme')
-    row.with_value(text: training_programme_name(@school.last_chosen_training_programme))
+    row.with_value(text: training_programme_name(@decorated_school.last_chosen_training_programme))
   end
 
-  if @school.provider_led_training_programme_chosen?
-    if @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school)
-      summary_list.with_row do |row|
-        row.with_key(text: 'Lead provider')
-        row.with_value(text: @ect.previous_lead_provider_name)
-      end
+  if @decorated_school.provider_led_training_programme_chosen? && @decorated_school.latest_registration_choices.lead_provider.present?
+    summary_list.with_row do |row|
+      row.with_key(text: 'Lead provider')
+      row.with_value(text: @decorated_school.latest_registration_choices.lead_provider.name)
+    end
 
+    if @decorated_school.latest_registration_choices.delivery_partner.present?
       summary_list.with_row do |row|
         row.with_key(text: 'Delivery partner')
-        row.with_value(text: @ect.previous_delivery_partner_name)
-      end
-    else
-      summary_list.with_row do |row|
-        row.with_key(text: 'Lead provider')
-        row.with_value(text: @ect.previous_eoi_lead_provider_name || @school.last_chosen_lead_provider&.name)
+        row.with_value(text: @decorated_school.latest_registration_choices.delivery_partner.name)
       end
     end
   end
 end %>
 
-<% if @school.provider_led_training_programme_chosen? && !@ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school) %>
+<% if @decorated_school.provider_led_training_programme_chosen? && !@decorated_school.has_partnership_with?(lead_provider: @decorated_school.latest_registration_choices.lead_provider.name, contract_period: @ect.contract_start_date) %>
   <p class="govuk-body">
-    <%= @ect.previous_eoi_lead_provider_name || @school.last_chosen_lead_provider.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
+    <%= @decorated_school.latest_registration_choices.lead_provider.name %> will confirm if they’ll be working with your school and which delivery partner will deliver training events.
   </p>
 <% end %>
 

--- a/app/wizards/schools/decorated_school.rb
+++ b/app/wizards/schools/decorated_school.rb
@@ -1,0 +1,11 @@
+module Schools
+  class DecoratedSchool < SimpleDelegator
+    def latest_registration_choices(contract_period: ContractPeriod.containing_date(Time.zone.today))
+      @latest_registration_choices ||= Schools::LatestRegistrationChoices.new(school: self, contract_period:)
+    end
+
+    def has_partnership_with?(lead_provider:, contract_period:)
+      SchoolPartnerships::Search.new(lead_provider:, contract_period:).exists?
+    end
+  end
+end

--- a/spec/services/schools/latest_registration_choices_spec.rb
+++ b/spec/services/schools/latest_registration_choices_spec.rb
@@ -1,15 +1,26 @@
 describe Schools::LatestRegistrationChoices do
   let(:service) { Schools::LatestRegistrationChoices.new(school:, contract_period:) }
 
-  let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let(:school) { FactoryBot.build(:school) }
+  let(:contract_period) { FactoryBot.build(:contract_period) }
   let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+
+  describe 'delegation' do
+    subject { service }
+
+    it { is_expected.to delegate_method(:last_chosen_appropriate_body).to(:school) }
+    it { is_expected.to delegate_method(:last_chosen_lead_provider).to(:school) }
+    it { is_expected.to delegate_method(:last_chosen_training_programme).to(:school) }
+    it { is_expected.to delegate_method(:lead_provider).to(:lead_provider_and_delivery_partner) }
+    it { is_expected.to delegate_method(:delivery_partner).to(:lead_provider_and_delivery_partner) }
+  end
 
   describe '#lead_provider_and_delivery_partner' do
     subject { service.lead_provider_and_delivery_partner }
 
     context 'when there is no last_chosen_lead_provider present on the school' do
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
-      let(:school) { FactoryBot.create(:school, last_chosen_lead_provider: nil) }
+      let(:lead_provider) { FactoryBot.build(:lead_provider) }
+      let(:school) { FactoryBot.build(:school, last_chosen_lead_provider: nil) }
 
       it { is_expected.to be_nil }
     end

--- a/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
@@ -137,7 +137,10 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
         appropriate_body: last_chosen_appropriate_body,
         delivery_partner: nil
       )
-      allow(decorated_school).to receive(:latest_registration_choices).and_return(choices)
+      allow(decorated_school).to receive_messages(
+        latest_registration_choices: choices,
+        has_partnership_with?: false
+      )
 
       assign(:school, school)
       assign(:decorated_school, decorated_school)
@@ -155,6 +158,13 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
 
     it 'renders the explanatory paragraph' do
       expect(rendered).to include("#{last_chosen_lead_provider.name} will confirm if they’ll be working with your school and which delivery partner will deliver training events.")
+    end
+
+    it 'calls #has_partnership_with? using the lead provider and contract period' do
+      expect(decorated_school).to have_received(:has_partnership_with?).with(
+        lead_provider: decorated_school.latest_registration_choices.lead_provider,
+        contract_period: wizard.ect.contract_start_date
+      )
     end
   end
 end

--- a/spec/wizards/schools/decorated_school_spec.rb
+++ b/spec/wizards/schools/decorated_school_spec.rb
@@ -1,0 +1,42 @@
+describe Schools::DecoratedSchool do
+  let(:school) { FactoryBot.create(:school) }
+  let(:decorated_school) { Schools::DecoratedSchool.new(school) }
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+
+  it 'decorates a School' do
+    expect(decorated_school.__getobj__).to be_a(School)
+  end
+
+  describe '#latest_registration_choices' do
+    let(:fake_latest_registration_choices) { double('Schools::LatestRegistrationChoices') }
+
+    before do
+      allow(Schools::LatestRegistrationChoices).to receive(:new)
+                                                     .with(school: decorated_school, contract_period:)
+                                                     .and_return(fake_latest_registration_choices)
+    end
+
+    it 'returns a Schools::LatestRegistrationChoices object' do
+      expect(decorated_school.latest_registration_choices(contract_period:)).to eql(fake_latest_registration_choices)
+    end
+  end
+
+  describe '#has_partnership_with?' do
+    subject { decorated_school.has_partnership_with?(lead_provider:, contract_period:) }
+
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:fake_partnership_check) { double('SchoolPartnerships::Search', exists?: true) }
+
+    before do
+      allow(SchoolPartnerships::Search).to receive(:new)
+                                             .with(lead_provider:, contract_period:)
+                                             .and_return(fake_partnership_check)
+    end
+
+    it 'creates a SchoolPartnerships::Search and calls #exists?' do
+      expect(subject).to be(true)
+      expect(fake_partnership_check).to have_received(:exists?).once
+      expect(SchoolPartnerships::Search).to have_received(:new).with(lead_provider:, contract_period:)
+    end
+  end
+end


### PR DESCRIPTION
### Context

This branch attempts to make the ECT previous choices page simpler and ensures the previous choice information is accurate.

It does this by using the `Schools::LatestRegistrationChoices` service (DFE-Digital/register-early-career-teachers-public#856). Because this is very much a school level thing, rather than pulling it via the wizard's `ECT` class I added a new `DecoratedSchool` instance variable which has a couple of school-specific methods.

I think this is a sensible first move when it comes to simplifying the `ECT` class.

### Final tasks

* [x] ensure the choices made are stored correctly in the wizard store

### Links

Fixes #1393, DFE-Digital/register-ects-project-board#2309
