### PR TITLE
[2260] - add new school link type

### DIFF
--- a/app/models/gias/school_link.rb
+++ b/app/models/gias/school_link.rb
@@ -2,6 +2,7 @@ class GIAS::SchoolLink < ApplicationRecord
   self.table_name = "gias_school_links"
 
   LINK_TYPES = [
+    "Children's Centre Link",
     "Closure",
     "Expansion",
     "Merged - change in age range",


### PR DESCRIPTION
### Context
GIAS import is providing a school link type missing on RECT: `"Children's Centre Link"`

### Changes proposed in this pull request
Add `"Children's Centre Link"` to the list of valid school link types that RECT could receive from GIAS

### Guidance to review
