### PR TITLE
[2479] Fix POST partnership endpoint swagger docs bug

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -151,7 +151,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/PartnershipRequest"
+              "$ref": "#/components/schemas/PartnershipCreateRequest"
   "/api/v3/partnerships/{id}":
     get:
       summary: Retrieve a single partnership

--- a/spec/requests/api/docs/v3/partnerships_spec.rb
+++ b/spec/requests/api/docs/v3/partnerships_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                     url: "/api/v3/partnerships",
                     tag: "Partnerships",
                     resource_description: "partnership",
-                    request_schema_ref: "#/components/schemas/PartnershipRequest",
+                    request_schema_ref: "#/components/schemas/PartnershipCreateRequest",
                     response_schema_ref: "#/components/schemas/PartnershipResponse",
                   } do
                     let(:params) do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2479

An error is displayed when `POST /api/v3/partnerships` endpoint is section is opened.

```
Resolver error at paths./api/v3/partnerships.post.requestBody.content.application/json.schema.$ref
Could not resolve reference: Could not resolve pointer: /components/schemas/PartnershipRequest does not exist in document
```

### Changes proposed in this pull request

- Fix POST partnership endpoint swagger docs bug.

### Guidance to review

[Review app](https://cpd-ec2-review-1409-web.test.teacherservices.cloud/api/docs/v3#/Partnerships/post_api_v3_partnerships)
