### PR TITLE
[2449] Investigate created_at participant profile timestamps - Option 2

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,12 +1,34 @@
 module API
   module V3
     class ParticipantsController < BaseController
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
+      def show
+        render json: to_json(participants_query.participant(id: participant_params[:id]))
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
+
+    private
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider }
+
+        Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(:id)
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -15,6 +15,16 @@ class Teacher < ApplicationRecord
   has_many :induction_extensions, inverse_of: :teacher
   has_many :teacher_id_changes, inverse_of: :teacher
 
+  has_one :earliest_ect_at_school_period,
+          -> { earliest_first },
+          class_name: "ECTAtSchoolPeriod",
+          inverse_of: :teacher
+
+  has_one :earliest_mentor_at_school_period,
+          -> { earliest_first },
+          class_name: "MentorAtSchoolPeriod",
+          inverse_of: :teacher
+
   has_many :induction_periods
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"
   has_one :last_induction_period, -> { order(started_on: :desc) }, class_name: "InductionPeriod"

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,0 +1,46 @@
+class API::ParticipantSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field(:ecf_enrolments) do |teacher, options|
+      lead_provider = options[:lead_provider]
+
+      (teacher.ect_at_school_periods + teacher.mentor_at_school_periods).map { |trainee|
+        training_period = latest_training_period(trainee, lead_provider)
+        next unless training_period
+
+        ecf_enrolment(training_period)
+      }.compact
+    end
+
+    class << self
+      def latest_training_period(trainee, lead_provider)
+        # `training_periods` already preloaded, sort in memory
+        trainee.training_periods.sort_by(&:started_on).reverse.find do |training_period|
+          training_period.lead_provider == lead_provider
+        end
+      end
+
+      def ecf_enrolment(training_period)
+        trainee = training_period.trainee
+        teacher = trainee.teacher
+        training_record_id = training_period.for_ect? ? teacher.api_ect_training_record_id : teacher.api_mentor_training_record_id
+        earliest_trainee = training_period.for_ect? ? teacher.earliest_ect_at_school_period : teacher.earliest_mentor_at_school_period
+        {
+          training_record_id:,
+          email: trainee.email,
+          participant_type: training_period.for_ect? ? "ect" : "mentor",
+          lead_provider: training_period.lead_provider.name,
+          created_at: earliest_trainee&.created_at&.rfc3339,
+        }
+      end
+    end
+  end
+
+  # identifier :ecf_id, name: :id
+  field(:type) { "participant" }
+
+  association :attributes, blueprint: AttributesSerializer do |participant|
+    participant
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -1,0 +1,47 @@
+module Participants
+  class Query
+    attr_reader :scope, :lead_provider
+
+    def initialize(lead_provider:)
+      @lead_provider = lead_provider
+      @scope = all_participants
+    end
+
+    def participants
+      scope.order(created_at: :asc)
+    end
+
+    def participant(id:)
+      scope.where(id:)
+    end
+
+  private
+
+    def all_participants
+      # Union both queries and preload associations for serialization
+      Teacher
+        .select("teachers.*")
+        .from("(#{ect_teachers.to_sql} UNION #{mentor_teachers.to_sql}) as teachers")
+        .includes(
+          :earliest_mentor_at_school_period,
+          :earliest_ect_at_school_period,
+          ect_at_school_periods: { training_periods: :lead_provider },
+          mentor_at_school_periods: { training_periods: :lead_provider }
+        )
+    end
+
+    def ect_teachers
+      Teacher
+        .select("teachers.*")
+        .joins(ect_at_school_periods: { training_periods: :lead_provider })
+        .where(lead_providers: { id: lead_provider.id })
+    end
+
+    def mentor_teachers
+      Teacher
+        .select("teachers.*")
+        .joins(mentor_at_school_periods: { training_periods: :lead_provider })
+        .where(lead_providers: { id: lead_provider.id })
+    end
+  end
+end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     independent_school
 
     started_on { generate(:base_ect_date) }
-    finished_on { started_on + 1.day }
+    finished_on { started_on + 1.year }
     email { Faker::Internet.email }
     working_pattern { WORKING_PATTERNS.keys.sample }
 

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     association :teacher
 
     started_on { generate(:base_mentor_date) }
-    finished_on { started_on + 1.day }
+    finished_on { started_on + 1.year }
     email { Faker::Internet.email }
 
     trait :ongoing do

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,67 +1,144 @@
 RSpec.describe "Participants API", type: :request do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let!(:ect_teacher) { FactoryBot.create(:teacher) }
+  let!(:mentor_teacher) { FactoryBot.create(:teacher) }
+  let!(:both_teacher) { FactoryBot.create(:teacher) }
+
+  let!(:school_partnership) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+  end
+  let!(:lead_provider_delivery_partnership) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+  end
+  let!(:active_lead_provider) do
+    FactoryBot.create(:active_lead_provider, lead_provider:)
+  end
+
+  let!(:school_partnership2) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership2)
+  end
+  let!(:lead_provider_delivery_partnership2) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2)
+  end
+  let!(:active_lead_provider2) do
+    FactoryBot.create(:active_lead_provider, lead_provider: lead_provider2)
+  end
+  let!(:lead_provider2) { FactoryBot.create(:lead_provider) }
+
+  let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: ect_teacher) }
+  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher) }
+  let!(:mentor_at_school_period2) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, started_on: mentor_at_school_period.finished_on.next_day) }
+  let!(:both_ect_period) { FactoryBot.create(:ect_at_school_period, teacher: both_teacher) }
+  let!(:both_mentor_period) { FactoryBot.create(:mentor_at_school_period, teacher: both_teacher) }
+
+  before do
+    # ECT only
+    finished_on = ect_at_school_period.started_on + 30.days
+    # latest
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: ect_at_school_period.finished_on)
+    # old
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: ect_at_school_period.started_on,
+                      finished_on:)
+
+    # Mentor only
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period:,
+                      school_partnership:,
+                      started_on: mentor_at_school_period.started_on,
+                      finished_on: mentor_at_school_period.finished_on)
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: mentor_at_school_period2,
+                      school_partnership: school_partnership2,
+                      started_on: mentor_at_school_period2.started_on,
+                      finished_on: mentor_at_school_period2.finished_on)
+
+    # Both ECT and mentor
+    finished_on = both_ect_period.started_on + 15.days
+    # old
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period: both_ect_period,
+                      school_partnership:,
+                      started_on: both_ect_period.started_on,
+                      finished_on:)
+    # latest
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period: both_ect_period,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: both_ect_period.finished_on)
+
+    finished_on = both_mentor_period.started_on + 10.days
+    # old
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: both_mentor_period,
+                      school_partnership:,
+                      started_on: both_mentor_period.started_on,
+                      finished_on:)
+    # latest
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: both_mentor_period,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: both_mentor_period.finished_on)
+  end
+
   describe "#index" do
-    let(:path) { api_v3_participants_path }
+    let(:parsed_response) { JSON.parse(response.body)["data"] }
 
-    it_behaves_like "a token authenticated endpoint", :get
+    it "returns the correct body" do
+      authenticated_api_get(api_v3_participants_path)
 
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
+      expect(response).to have_http_status(:ok)
+      # debugger
 
-  describe "#show" do
-    let(:path) { api_v3_participant_path(123) }
+      attrs1 = parsed_response.dig(0, "attributes")
+      expect(attrs1).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "training_record_id" => ect_teacher.api_ect_training_record_id,
+            "email" => ect_at_school_period.email,
+            "lead_provider" => lead_provider.name,
+            "created_at" => ect_at_school_period.created_at&.rfc3339
+          )
+        )
+      )
 
-    it_behaves_like "a token authenticated endpoint", :get
+      attrs2 = parsed_response.dig(1, "attributes")
+      expect(attrs2).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "training_record_id" => mentor_teacher.api_mentor_training_record_id,
+            "email" => mentor_at_school_period.email,
+            "lead_provider" => lead_provider.name,
+            "created_at" => mentor_at_school_period.created_at&.rfc3339
+          )
+        )
+      )
 
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#change_schedule" do
-    let(:path) { api_v3_participant_change_schedule_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#defer" do
-    let(:path) { api_v3_participant_defer_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#resume" do
-    let(:path) { api_v3_participant_resume_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#withdraw" do
-    let(:path) { api_v3_participant_withdraw_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
+      attrs3 = parsed_response.dig(2, "attributes")
+      expect(attrs3).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "training_record_id" => both_teacher.api_ect_training_record_id,
+            "email" => both_ect_period.email,
+            "lead_provider" => lead_provider.name,
+            "created_at" => both_ect_period.created_at&.rfc3339
+          ),
+          include(
+            "training_record_id" => both_teacher.api_mentor_training_record_id,
+            "email" => both_mentor_period.email,
+            "lead_provider" => lead_provider.name,
+            "created_at" => both_mentor_period.created_at&.rfc3339
+          )
+        )
+      )
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2449

### Changes proposed in this pull request

* Use `has_one` association to find the earliest ECT/Mentor at school periods

### Guidance to review
