### PR TITLE
Point to ecf migration when running parity check even in parity env

### DIFF
--- a/config/terraform/application/config/paritycheck.yml
+++ b/config/terraform/application/config/paritycheck.yml
@@ -21,5 +21,5 @@ ENCRYPTION_PRIMARY_KEY: parity_check_primary_key
 ENCRYPTION_DETERMINISTIC_KEY: paritycheck_deterministic_key
 ENCRYPTION_DERIVATION_SALT: paritycheck_derivation_salt
 RAILS_ENV: paritycheck
-PARITY_CHECK_ECF_URL: https://cpd-ecf-paritycheck-web.teacherservices.cloud
+PARITY_CHECK_ECF_URL: https://cpd-ecf-migration-web.teacherservices.cloud
 PARITY_CHECK_RECT_URL: https://cpd-ec2-paritycheck-web.teacherservices.cloud


### PR DESCRIPTION
### Context
We don't have a parity check env in ecf, so can't point parity check to it

### Changes proposed in this pull request
Change parity check url for ECF1 to migration

### Guidance to review
deployed and tested in parity check
