### PR TITLE
Add more delivery partnerships for review seed data

### DIFF
--- a/db/seeds/lead_provider_delivery_partnerships.rb
+++ b/db/seeds/lead_provider_delivery_partnerships.rb
@@ -3,6 +3,8 @@ def describe_lead_provider_delivery_partnership(lpdp)
   print_seed_info("#{lpdp.delivery_partner.name} are working with #{alp.lead_provider.name} in #{alp.contract_period.year}")
 end
 
+# These delivery partnerships are used by other seeds, so are created explicitly.
+
 ambition_institute = LeadProvider.find_by!(name: 'Ambition Institute')
 teach_first = LeadProvider.find_by!(name: 'Teach First')
 best_practice_network = LeadProvider.find_by!(name: 'Best Practice Network')
@@ -45,4 +47,18 @@ rising_minds = DeliveryPartner.find_by!(name: "Rising Minds Network")
   FactoryBot.create(:lead_provider_delivery_partnership,
                     active_lead_provider: data[:active_lead_provider],
                     delivery_partner: data[:delivery_partner]).tap { |lpdp| describe_lead_provider_delivery_partnership(lpdp) }
+end
+
+# These are additional delivery partnerships useful for testing.
+
+all_delivery_partners = DeliveryPartner.all
+
+ActiveLeadProvider.find_each do |active_lead_provider|
+  all_delivery_partners.sample(rand(1..3)).each do |delivery_partner|
+    next if LeadProviderDeliveryPartnership.exists?(active_lead_provider:, delivery_partner:)
+
+    FactoryBot
+      .create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
+      .tap { describe_lead_provider_delivery_partnership(it) }
+  end
 end


### PR DESCRIPTION
### Context

We are finding that only a couple of lead providers have delivery partners, and of those there is only one per lead provider. It makes testing easier when there are multiple delivery partners and at least one per lead provider/contract period pairing.

### Changes proposed in this pull request

- Add more delivery partnerships for review seed data

Add more delivery partnerships for each lead provider; between 1 and 3 per contract period.

### Guidance to review

Example seed output:

```
🪴 planting db/seeds/lead_provider_delivery_partnerships.rb
🌱 Artisan Education Group are working with Ambition Institute in 2021
🌱 Artisan Education Group are working with Ambition Institute in 2022
🌱 Artisan Education Group are working with Ambition Institute in 2023
🌱 Artisan Education Group are working with Ambition Institute in 2024
🌱 Artisan Education Group are working with Ambition Institute in 2026
🌱 Grain Teaching School Hub are working with Teach First in 2021
🌱 Grain Teaching School Hub are working with Teach First in 2022
🌱 Grain Teaching School Hub are working with Teach First in 2023
🌱 Grain Teaching School Hub are working with Teach First in 2024
🌱 Grain Teaching School Hub are working with Teach First in 2025
🌱 Rising Minds Network are working with Best Practice Network in 2023
🌱 Rising Minds Network are working with Best Practice Network in 2024
🌱 Proving Potential Teaching School Hub are working with Ambition Institute in 2021
🌱 Grain Teaching School Hub are working with Ambition Institute in 2021
🌱 Grain Teaching School Hub are working with Ambition Institute in 2022
🌱 Miller Teaching School Hub are working with Ambition Institute in 2022
🌱 Proving Potential Teaching School Hub are working with Ambition Institute in 2023
🌱 Harvest Academy are working with Ambition Institute in 2024
🌱 Rising Minds Network are working with Ambition Institute in 2025
🌱 Artisan Education Group are working with Ambition Institute in 2025
🌱 Proving Potential Teaching School Hub are working with Ambition Institute in 2025
🌱 Harvest Academy are working with Ambition Institute in 2026
🌱 Miller Teaching School Hub are working with Best Practice Network in 2022
🌱 Proving Potential Teaching School Hub are working with Best Practice Network in 2022
🌱 Rise Teaching School Hub are working with Best Practice Network in 2023
🌱 Harvest Academy are working with Best Practice Network in 2023
🌱 Miller Teaching School Hub are working with Best Practice Network in 2024
🌱 Artisan Education Group are working with Best Practice Network in 2024
🌱 Rise Teaching School Hub are working with Best Practice Network in 2024
🌱 Rising Minds Network are working with Best Practice Network in 2025
🌱 Artisan Education Group are working with Best Practice Network in 2025
🌱 Rise Teaching School Hub are working with Best Practice Network in 2025
🌱 Grain Teaching School Hub are working with Capita in 2021
🌱 Harvest Academy are working with Capita in 2021
🌱 Grain Teaching School Hub are working with Capita in 2022
🌱 Miller Teaching School Hub are working with Capita in 2022
🌱 Harvest Academy are working with Capita in 2022
🌱 Rising Minds Network are working with Capita in 2023
🌱 Harvest Academy are working with Capita in 2023
🌱 Miller Teaching School Hub are working with Education Development Trust in 2021
🌱 Artisan Education Group are working with Education Development Trust in 2021
🌱 Miller Teaching School Hub are working with Education Development Trust in 2022
🌱 Proving Potential Teaching School Hub are working with Education Development Trust in 2023
🌱 Harvest Academy are working with Education Development Trust in 2023
🌱 Miller Teaching School Hub are working with Education Development Trust in 2023
🌱 Harvest Academy are working with Education Development Trust in 2024
🌱 Rise Teaching School Hub are working with Education Development Trust in 2024
🌱 Miller Teaching School Hub are working with Education Development Trust in 2025
🌱 Artisan Education Group are working with Education Development Trust in 2025
🌱 Rising Minds Network are working with National Institute of Teaching in 2021
🌱 Rise Teaching School Hub are working with Teach First in 2021
🌱 Rising Minds Network are working with Teach First in 2021
🌱 Proving Potential Teaching School Hub are working with Teach First in 2021
🌱 Miller Teaching School Hub are working with Teach First in 2022
🌱 Artisan Education Group are working with Teach First in 2023
🌱 Harvest Academy are working with Teach First in 2023
🌱 Harvest Academy are working with Teach First in 2024
🌱 Rising Minds Network are working with Teach First in 2024
🌱 Artisan Education Group are working with Teach First in 2024
🌱 Rising Minds Network are working with Teach First in 2025
🌱 Rising Minds Network are working with UCL Institute of Education in 2021
🌱 Rise Teaching School Hub are working with UCL Institute of Education in 2021
🌱 Proving Potential Teaching School Hub are working with UCL Institute of Education in 2021
🌱 Rise Teaching School Hub are working with UCL Institute of Education in 2022
🌱 Miller Teaching School Hub are working with UCL Institute of Education in 2022
🌱 Rise Teaching School Hub are working with UCL Institute of Education in 2023
🌱 Harvest Academy are working with UCL Institute of Education in 2023
🌱 Rising Minds Network are working with UCL Institute of Education in 2023
🌱 Rising Minds Network are working with UCL Institute of Education in 2024
🌱 Rise Teaching School Hub are working with UCL Institute of Education in 2024
🌱 Proving Potential Teaching School Hub are working with UCL Institute of Education in 2024
🌱 Miller Teaching School Hub are working with UCL Institute of Education in 2025
🌱 Grain Teaching School Hub are working with UCL Institute of Education in 2025
🌱 Rise Teaching School Hub are working with UCL Institute of Education in 2025
```