### PR TITLE
Update show.html.erb_spec.rb

### DIFF
--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -26,7 +26,7 @@ module ECTHelper
 
   # @param ect [ECTAtSchoolPeriod]
   def link_to_assign_mentor(ect)
-    govuk_warning_text(text: "You must #{assign_or_create_mentor_link(ect)} for this ECT.".html_safe)
+    govuk_warning_text(text: assign_or_create_mentor_link(ect))
   end
 
   # @param ect [ECTAtSchoolPeriod]
@@ -72,7 +72,7 @@ module ECTHelper
 private
 
   def assign_or_create_mentor_link(ect)
-    govuk_link_to("assign a mentor or register a new one", assign_or_create_mentor_path(ect), no_visited_state: true)
+    govuk_link_to("Assign a mentor for this ECT", assign_or_create_mentor_path(ect), no_visited_state: true)
   end
 
   def assign_or_create_mentor_path(ect)

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_who_will_mentor_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_who_will_mentor_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_who_will_mentor_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Registering a mentor' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Registering a mentor', :js do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_requirements_page

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Selecting a different lead provider' do
   end
 
   def and_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def and_i_click_continue(link_or_button)

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Add a mentor to a provider led ECT' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role(:link, name: 'assign a mentor or register a new one').click
+    page.get_by_role(:link, name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_on_the_who_will_mentor_page

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Add a mentor to a school led ECT' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role(:link, name: 'assign a mentor or register a new one').click
+    page.get_by_role(:link, name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_who_will_mentor_page

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Redirect to register a new mentor for an ECT' do
   end
 
   def when_i_click_to_assign_a_mentor_to_the_ect
-    page.get_by_role('link', name: 'assign a mentor or register a new one').click
+    page.get_by_role('link', name: 'Assign a mentor for this ECT').click
   end
 
   def then_i_am_in_the_who_will_mentor_page

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
       context 'when unassigned' do
         it 'has instruction to assign' do
           expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Mentor')
-          expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Assign a mentor to this ECT.')
+          expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Assign a mentor for this ECT')
         end
       end
     end

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'schools/ects/show.html.erb' do
       context 'when unassigned' do
         it 'has instruction to assign' do
           expect(rendered).to have_css('dt.govuk-summary-list__key', text: 'Mentor')
-          expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'You must assign a mentor or register a new one for this ECT.')
+          expect(rendered).to have_css('dd.govuk-summary-list__value', text: 'Assign a mentor to this ECT.')
         end
       end
     end


### PR DESCRIPTION
2300. Update assign mentor text (summary and details page)

### Context
Update the CTA link for assigning a mentor on ECT summary and detail pages.

### Changes proposed in this pull request
Single line change, reflected on ECT summary and detail page. Shorten text, remove 'must' but keep warning pattern.

### Guidance to review
