### PR TITLE
Fix parity check ids to show both rect and ecf diffs

### DIFF
--- a/app/views/migration/parity_checks/requests/_response_body_ids_diff.html.erb
+++ b/app/views/migration/parity_checks/requests/_response_body_ids_diff.html.erb
@@ -2,13 +2,13 @@
   <span class="body-ids-diff">
     <%= govuk_list do %>
       <% request.ecf_only_response_body_ids.each do |id| %>
-        <%= tag.li(tag.span(class: "diff red") { id }) %>
+        <%= tag.li(tag.span(id, class: "diff red")) %>
       <% end %>
     <% end %>
 
     <%= govuk_list do %>
-      <% request.ecf_only_response_body_ids.each do |id| %>
-        <%= tag.li(tag.span(class: "diff green") { id }) %>
+      <% request.rect_only_response_body_ids.each do |id| %>
+        <%= tag.li(tag.span(id, class: "diff green")) %>
       <% end %>
     <% end %>
   </span>

--- a/app/views/migration/parity_checks/responses/_body_ids_diff.html.erb
+++ b/app/views/migration/parity_checks/responses/_body_ids_diff.html.erb
@@ -2,13 +2,13 @@
   <span class="body-ids-diff">
     <%= govuk_list do %>
       <% response.ecf_only_body_ids.each do |id| %>
-        <%= tag.li(tag.span(class: "diff red") { id }) %>
+        <%= tag.li(tag.span(id, class: "diff red")) %>
       <% end %>
     <% end %>
 
     <%= govuk_list do %>
-      <% response.ecf_only_body_ids.each do |id| %>
-        <%= tag.li(tag.span(class: "diff green") { id }) %>
+      <% response.rect_only_body_ids.each do |id| %>
+        <%= tag.li(tag.span(id, class: "diff green")) %>
       <% end %>
     <% end %>
   </span>

--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -61,7 +61,10 @@ RSpec.describe "View parity check request" do
     expect(page.get_by_role("heading", name: "Response IDs")).to be_visible
 
     expect(page.get_by_text("There was 1 ID returned by ECF that were not returned by RECT.")).to be_visible
+    expect(page.get_by_text("123")).to be_visible
+
     expect(page.get_by_text("There was 1 ID returned by RECT that were not returned by ECF.")).to be_visible
+    expect(page.get_by_text("456")).to be_visible
   end
 
   scenario "Paginating the parity check responses when there are many" do

--- a/spec/features/migration/view_parity_check_response_spec.rb
+++ b/spec/features/migration/view_parity_check_response_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe "View parity check response" do
     expect(page.get_by_role("heading", name: "Response IDs")).to be_visible
 
     expect(page.get_by_text("There was 1 ID returned by ECF that were not returned by RECT.")).to be_visible
+    expect(page.locator("li span.diff.red").text_content).to eq("123")
+
     expect(page.get_by_text("There was 1 ID returned by RECT that were not returned by ECF.")).to be_visible
+    expect(page.locator("li span.diff.green").text_content).to eq("456")
   end
 
   scenario "Viewing a parity check response where the bodies are filterable", :js do


### PR DESCRIPTION
### Context
Currently we are showing only ecf diff ids, we need to show the RECT ids in green. Also playwrite specs weren't rendering correctly for list/span components

### Changes proposed in this pull request
- In both response/request views show the RECT id diff
- Fix rendering the ids in the diff span as those weren't rendering correctly in playwrite
<img width="728" height="248" alt="Screenshot 2025-09-24 at 14 49 35" src="https://github.com/user-attachments/assets/dec69309-310c-44ec-ac02-e869f0165359" />


