### PR TITLE
[2242] - school migrator fails after migration data reset

### DIFF
--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -88,7 +88,7 @@ module Migrators
 
   protected
 
-    def migrate(collection)
+    def migrate(collection, &block)
       DeclarativeUpdates.skip do
         items = collection.order(:id).offset(offset).limit(limit)
 
@@ -99,7 +99,7 @@ module Migrators
         end
 
         # As we're using offset/limit, we can't use find_each!
-        items.each { |item| process_item(item) }
+        items.each { |item| process_item(item, &block) }
 
         finalise_migration!
       end

--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -99,13 +99,7 @@ module Migrators
         end
 
         # As we're using offset/limit, we can't use find_each!
-        items.each do |item|
-          success = yield(item)
-          DataMigration.update_counters(data_migration.id, processed_count: 1, failure_count: success ? 0 : 1)
-        rescue StandardError => e
-          DataMigration.update_counters(data_migration.id, failure_count: 1, processed_count: 1)
-          failure_manager.record_failure(item, e.message)
-        end
+        items.each { |item| process_item(item) }
 
         finalise_migration!
       end
@@ -192,6 +186,14 @@ module Migrators
     end
 
   private
+
+    def process_item(item)
+      success = yield(item)
+      DataMigration.update_counters(data_migration.id, processed_count: 1, failure_count: success ? 0 : 1)
+    rescue StandardError => e
+      DataMigration.update_counters(data_migration.id, failure_count: 1, processed_count: 1)
+      failure_manager.record_failure(item, e.message)
+    end
 
     def offset
       worker * self.class.records_per_worker

--- a/app/migration/migrators/gias_import.rb
+++ b/app/migration/migrators/gias_import.rb
@@ -17,7 +17,7 @@ module Migrators
     end
 
     def migrate!
-      Metadata::Manager.skip_metadata_updates do
+      DeclarativeUpdates.skip do
         start_migration!(self.class.record_count)
         preload_caches if respond_to?(:preload_caches, true)
 

--- a/app/migration/migrators/gias_import.rb
+++ b/app/migration/migrators/gias_import.rb
@@ -1,0 +1,36 @@
+module Migrators
+  class GIASImport < Migrators::Base
+    class_attribute :gias_importer, instance_writer: false, default: GIAS::Importer.new
+
+    def self.model = :gias_import
+
+    def self.record_count = gias_importer.number_of_schools_to_import + gias_importer.number_of_school_links_to_import
+
+    def self.records_per_worker = record_count
+
+    def self.reset!
+      self.gias_importer = GIAS::Importer.new
+
+      if Rails.application.config.enable_migration_testing
+        ::GIAS::School.connection.execute("TRUNCATE #{::GIAS::School.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      Metadata::Manager.skip_metadata_updates do
+        start_migration!(self.class.record_count)
+        preload_caches if respond_to?(:preload_caches, true)
+
+        gias_importer.foreach_school_row do |school_row|
+          process_item(school_row) { gias_importer.parse_school_row(it) }
+        end
+
+        gias_importer.foreach_school_link_row do |school_link_row|
+          process_item(school_link_row) { gias_importer.parse_school_link_row(it) }
+        end
+
+        finalise_migration!
+      end
+    end
+  end
+end

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -22,7 +22,11 @@ module Migrators
 
     def self.record_count = schools.count
 
-    def self.reset! = nil
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::GIAS::School.connection.execute("TRUNCATE #{::GIAS::School.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
 
     def self.schools
       ::Migration::School.with(eligible_or_cip_or_with_irs:

--- a/app/services/gias/importer.rb
+++ b/app/services/gias/importer.rb
@@ -3,14 +3,57 @@ require "csv"
 
 module GIAS
   class Importer
-    SCHOOLS_FILENAME = "ecf_tech.csv"
-    SCHOOL_LINKS_FILENAME = "links.csv"
+    ENCODING = "ISO-8859-1:UTF-8".freeze
+    SCHOOLS_FILENAME = "ecf_tech.csv".freeze
+    SCHOOL_LINKS_FILENAME = "links.csv".freeze
 
     def fetch
       DeclarativeUpdates.skip(:metadata) do
         import_only? ? fetch_and_import_only : fetch_and_update
       end
       Metadata::Handlers::School.refresh_all_metadata!(async: true)
+    end
+
+    def foreach_school_row(&block)
+      CSV.foreach(schools_file_path, headers: true, encoding: ENCODING, &block)
+    end
+
+    def foreach_school_link_row(&block)
+      CSV.foreach(school_links_file_path, headers: true, encoding: ENCODING, &block)
+    end
+
+    def number_of_schools_to_import
+      @number_of_schools_to_import ||= File.foreach(schools_file_path, encoding: ENCODING).count
+    end
+
+    def number_of_school_links_to_import
+      @number_of_school_links_to_import ||= File.foreach(school_links_file_path, encoding: ENCODING).count
+    end
+
+    def parse_school_row(row)
+      @school_row = GIAS::SchoolRow.new(row)
+      if eligible_for_registration?
+        import_only? ? import_school! : update_school!
+      end
+
+      true
+    end
+
+    def parse_school_link_row(row)
+      link_date = row.fetch("LinkEstablishedDate")
+      link_type = row.fetch("LinkType")
+      link_urn = row.fetch("LinkURN")
+      urn = row.fetch("URN")
+      gias_school = GIAS::School.find_by(urn:)
+
+      if gias_school
+        link = gias_school.gias_school_links
+                          .create_with(link_date:, link_type:, link_urn:)
+                          .find_or_create_by!(link_urn:)
+        link.update!(link_type:) if link.link_type != link_type
+      end
+
+      true
     end
 
   private
@@ -47,31 +90,17 @@ module GIAS
       end
     end
 
-    def import_schools(path: gias_files[SCHOOLS_FILENAME].path)
-      CSV.foreach(path, headers: true, encoding: "ISO-8859-1:UTF-8") do |data|
-        @school_row = GIAS::SchoolRow.new(data)
-        if eligible_for_registration?
-          import_only? ? import_school! : update_school!
-        end
-      end
+    def import_schools
+      foreach_school_row { |row| parse_school_row(row) }
     end
 
-    def import_school_links(path: gias_files[SCHOOL_LINKS_FILENAME].path)
-      CSV.foreach(path, headers: true, encoding: "ISO-8859-1:UTF-8") do |row|
-        link_date = row.fetch("LinkEstablishedDate")
-        link_type = row.fetch("LinkType")
-        link_urn = row.fetch("LinkURN")
-        urn = row.fetch("URN")
-        gias_school = GIAS::School.find_by(urn:)
-
-        if gias_school
-          link = gias_school.gias_school_links
-                            .create_with(link_date:, link_type:, link_urn:)
-                            .find_or_create_by!(link_urn:)
-          link.update!(link_type:) if link.link_type != link_type
-        end
-      end
+    def import_school_links
+      foreach_school_link_row { |row| parse_school_link_row(row) }
     end
+
+    def schools_file_path = gias_files[SCHOOLS_FILENAME].path
+
+    def school_links_file_path = gias_files[SCHOOL_LINKS_FILENAME].path
 
     def sync_changes!
       gias_school.assign_attributes(attributes)

--- a/app/services/gias/importer.rb
+++ b/app/services/gias/importer.rb
@@ -3,9 +3,9 @@ require "csv"
 
 module GIAS
   class Importer
-    ENCODING = "ISO-8859-1:UTF-8".freeze
-    SCHOOLS_FILENAME = "ecf_tech.csv".freeze
-    SCHOOL_LINKS_FILENAME = "links.csv".freeze
+    ENCODING = "ISO-8859-1:UTF-8"
+    SCHOOLS_FILENAME = "ecf_tech.csv"
+    SCHOOL_LINKS_FILENAME = "links.csv"
 
     def fetch
       DeclarativeUpdates.skip(:metadata) do

--- a/spec/factories/migration/csv_school_row_factory.rb
+++ b/spec/factories/migration/csv_school_row_factory.rb
@@ -1,0 +1,75 @@
+FactoryBot.define do
+  factory :csv_school_row, class: "CSV::Row" do
+    sequence(:name) { |n| "School #{n}" }
+
+    transient do
+      header { ["URN", "LA (code)", "LA (name)", "EstablishmentNumber", "EstablishmentName", "TypeOfEstablishment (code)", "TypeOfEstablishment (name)", "EstablishmentStatus (code)", "EstablishmentStatus (name)", "OpenDate", "CloseDate", "PhaseOfEducation (code)", "PhaseOfEducation (name)", "UKPRN", "LastChangedDate", "Street", "Locality", "Address3", "Town", "Postcode", "SchoolWebsite", "MainEmail", "AlternativeEmail", "Section41Approved (name)", "DistrictAdministrative (code)", "DistrictAdministrative (name)", "Easting", "Northing", "PreviousLA (code)", "PreviousLA (name)"] }
+
+      urn { Faker::Number.unique.number(digits: 6).to_s }
+      local_authority_code { Faker::Number.unique.number(digits: 3).to_s }
+      local_authority_name { "" }
+      establishment_number { urn }
+      type_code { "47" }
+      type_name { "Children's centre" }
+      status_code { "1" }
+      status { "open" }
+      opened_on { "18-12-2009" }
+      closed_on { "" }
+      phase_code { "0" }
+      phase_name { "Not Applicable" }
+      ukprn { Faker::Number.unique.number(digits: 5).to_s }
+      last_changed_date { "25-06-2025" }
+      street { Faker::Address.street_address }
+      locality { "" }
+      address3 { "Gladeside" }
+      town { "Bar Hill" }
+      postcode { Faker::Address.postcode }
+      website { "https://#{name}.com" }
+      main_email { Faker::Internet.unique.email }
+      alternative_email { Faker::Internet.unique.email }
+      section_41_approved_name { "Approved" }
+      administrative_district_code { "E07000012" }
+      administrative_district_name { "South Cambridgeshire" }
+      easting { "538104" }
+      northing { "263602" }
+      previous_local_authority_code { "999" }
+      previous_local_authority_name { "" }
+    end
+
+    skip_create
+
+    initialize_with do
+      new(header,
+          [urn,
+           local_authority_code,
+           local_authority_name,
+           establishment_number,
+           name,
+           type_code,
+           type_name,
+           status_code,
+           status,
+           opened_on,
+           closed_on,
+           phase_code,
+           phase_name,
+           ukprn,
+           last_changed_date,
+           street,
+           locality,
+           address3,
+           town,
+           postcode,
+           website,
+           main_email,
+           alternative_email,
+           section_41_approved_name,
+           administrative_district_code,
+           administrative_district_name,
+           easting,
+           northing,
+           previous_local_authority_code,
+           previous_local_authority_name])
+    end
+  end
+end

--- a/spec/migration/legacy_data_importer_spec.rb
+++ b/spec/migration/legacy_data_importer_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe LegacyDataImporter do
       let!(:data_migration) { FactoryBot.create(:data_migration, :completed) }
 
       it "initiates an async refresh of the metadata" do
+        allow(Migrators::Base).to receive(:migrators_in_dependency_order).and_return([])
+
         expect(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true)
         importer.migrate!
       end

--- a/spec/migration/migrators/gias_import_spec.rb
+++ b/spec/migration/migrators/gias_import_spec.rb
@@ -1,0 +1,64 @@
+describe Migrators::GIASImport do
+  def create_csv_row(status: "open")
+    FactoryBot.build(:csv_school_row, status:)
+  end
+
+  def create_school_row(csv_row)
+    GIAS::SchoolRow.new(csv_row)
+  end
+
+  def create_gias_school(csv_row)
+    school_row = create_school_row(csv_row)
+    FactoryBot.create(:gias_school, :with_school,
+                      urn: school_row.urn,
+                      administrative_district_name: school_row.administrative_district_name,
+                      funding_eligibility: school_row.funding_eligibility,
+                      induction_eligibility: school_row.induction_eligibility,
+                      in_england: school_row.in_england,
+                      name: school_row.name,
+                      phase_name: school_row.phase_name,
+                      section_41_approved: school_row.section_41_approved,
+                      status: school_row.status,
+                      type_name: school_row.type_name,
+                      ukprn: school_row.ukprn)
+  end
+
+  # rubocop:disable RSpec/AnyInstance
+  def stub_gias_importer
+    allow_any_instance_of(GIAS::Importer).to receive(:schools_file_path).and_return("schools.csv")
+    allow_any_instance_of(GIAS::Importer).to receive(:school_links_file_path).and_return("school_links.csv")
+    allow(File).to receive(:foreach).with("schools.csv", any_args).and_invoke(->(*_) { csv_rows })
+    allow(File).to receive(:foreach).with("school_links.csv", any_args).and_invoke(->(*_) { [] })
+    allow(CSV).to receive(:foreach).with("schools.csv", any_args).and_invoke(school_row_lambda)
+    allow(CSV).to receive(:foreach).with("school_links.csv", any_args).and_invoke(school_link_row_lambda)
+  end
+  # rubocop:enable RSpec/AnyInstance
+
+  let(:csv_rows) { [create_csv_row, create_csv_row] }
+  let(:school_row_lambda) { ->(*_, &block) { csv_rows.each(&block) } }
+  let(:school_link_row_lambda) { ->(*_, &block) { [].each(&block) } }
+
+  before do
+    stub_gias_importer
+  end
+
+  it_behaves_like "a migrator", :gias_import, [], multiple_workers: false do
+    def create_migration_resource = create_csv_row
+
+    def create_resource(migration_resource) = create_gias_school(migration_resource)
+
+    def setup_failure_state
+      csv_rows << FactoryBot.build(:csv_school_row, ukprn: csv_rows.first["UKPRN"])
+      stub_gias_importer
+    end
+  end
+
+  describe "#migrate!" do
+    let!(:data_migration) { FactoryBot.create(:data_migration, model: :gias_import, worker: 0) }
+    let(:migrator) { described_class.new(worker: 0) }
+
+    it "calls GIAS::Importer on each row to parse it and create a new school" do
+      expect { migrator.migrate! }.to change(GIAS::School, :count).by(csv_rows.size)
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/2242)

The Reset all migration data action on the migration page causes migration failures and inconsistent migration behavior across runs.

### Problem
Migration failures:
Migrations expect School records to already exist, but resetting migration data removes these School records, causing subsequent runs to fail. The root cause is that the LeadProvider migrator uses TRUNCATE CASCADE to clear the lead_providers table. Because the schools table has a [foreign key](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/5eaef55ead63b93c6c95ea8e9b6db80f9eae353e/db/schema.rb#L802) to lead_providers, PostgreSQL automatically truncates the schools table as well.

Inconsistent migrator behavior:
The first migration run updates GIAS::School records. When migration data is reset, GIAS::School records remain untouched. As a result, subsequent runs skip these updates, leading to different outcomes compared to the first run.

Resetting migration data should truncate both GIAS::School and School records, then re-import them before running migrations.

This ensures that every migration run starts from a clean, consistent state.


### Changes proposed in this pull request

This PR:
  - truncates GIAS::SchoolLink, GIAS::School and School tables on every migration reset
  - adds a new `gias_import` migrator so that schools are imported from GIAS as a first dependency before the rest of models are migrated.
 
### Guidance to review
