### PR TITLE
Use the combined redirection and destination matcher

### DIFF
--- a/spec/requests/admin/batches_spec.rb
+++ b/spec/requests/admin/batches_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Admin::BatchesController", type: :request do
     context "when not signed in" do
       it "redirects to sign in" do
         get admin_batches_path
-        expect(response).to be_redirection
+        expect(response).to redirect_to("/sign-in")
       end
     end
   end

--- a/spec/requests/admin/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_outcome_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe 'Admin recording a failed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the sign in page' do
         get("/admin/teachers/#{teacher.id}/record-failed-outcome/new")
-
-        expect(response).to be_redirection
         expect(response).to redirect_to(sign_in_path)
       end
     end
@@ -102,8 +100,7 @@ RSpec.describe 'Admin recording a failed outcome for a teacher' do
             author: an_instance_of(Sessions::Users::DfEPersona)
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to end_with("/admin/teachers/#{teacher.id}/record-failed-outcome")
+          expect(response).to redirect_to("/admin/teachers/#{teacher.id}/record-failed-outcome")
         end
       end
 

--- a/spec/requests/admin/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_outcome_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe 'Admin recording a passed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the sign in page' do
         get("/admin/teachers/#{teacher.id}/record-passed-outcome/new")
-
-        expect(response).to be_redirection
         expect(response).to redirect_to(sign_in_path)
       end
     end
@@ -102,8 +100,7 @@ RSpec.describe 'Admin recording a passed outcome for a teacher' do
             author: an_instance_of(Sessions::Users::DfEPersona)
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to end_with("/admin/teachers/#{teacher.id}/record-passed-outcome")
+          expect(response).to redirect_to("/admin/teachers/#{teacher.id}/record-passed-outcome")
         end
       end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -53,9 +51,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     context 'when not signed in' do
       it 'redirects to the root page' do
         patch("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -78,8 +74,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
             pending_induction_submission:
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to match(%r{/claim-an-ect/register-ect/\d+/edit\z})
+          expect(response).to redirect_to(%r{/claim-an-ect/register-ect/\d+/edit\z})
         end
       end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       it 'redirects to the root page' do
         get('/appropriate-body/claim-an-ect/find-ect/new')
 
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -33,9 +32,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         post('/appropriate-body/claim-an-ect/find-ect')
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -67,8 +64,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
             pending_induction_submission: PendingInductionSubmission.last
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to match(%r{/claim-an-ect/check-ect/\d+/edit\z})
+          expect(response).to redirect_to(%r{/claim-an-ect/check-ect/\d+/edit\z})
         end
       end
 
@@ -81,7 +77,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
             params: { pending_induction_submission: search_params }
           )
 
-          expect(response.redirect_url).to match(%r{/appropriate-body/claim-an-ect/errors/no-qts/\d+\z})
+          expect(response).to redirect_to(%r{/appropriate-body/claim-an-ect/errors/no-qts/\d+\z})
         end
       end
 
@@ -94,7 +90,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
             params: { pending_induction_submission: search_params }
           )
 
-          expect(response.redirect_url).to match(%r{/appropriate-body/claim-an-ect/errors/prohibited-from-teaching/\d+\z})
+          expect(response).to redirect_to(%r{/appropriate-body/claim-an-ect/errors/prohibited-from-teaching/\d+\z})
         end
       end
 
@@ -118,7 +114,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
 
           last_pending_induction_submission_id = PendingInductionSubmission.last.id
 
-          expect(response.redirect_url).to end_with("/appropriate-body/claim-an-ect/check-ect/#{last_pending_induction_submission_id}/edit")
+          expect(response).to redirect_to("/appropriate-body/claim-an-ect/check-ect/#{last_pending_induction_submission_id}/edit")
         end
       end
 
@@ -141,8 +137,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
             params: { pending_induction_submission: search_params }
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to match(%r{/teachers/\d+\z})
+          expect(response).to redirect_to(%r{/teachers/\d+\z})
           expect(flash[:notice]).to eq("Teacher #{teacher.trs_first_name} #{teacher.trs_last_name} already has an active induction period with this appropriate body")
         end
       end

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
       it 'redirects to the root page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
 
-        expect(response).to be_redirection
-        expect(response.redirect_url).to end_with(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -37,8 +36,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
       it 'redirects to the root page' do
         patch("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
 
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -92,8 +90,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
             end
           end
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to match(%r{/claim-an-ect/register-ect/\d+\z})
+          expect(response).to redirect_to(%r{/claim-an-ect/register-ect/\d+\z})
         end
 
         it 'calls AppropriateBodies::ClaimAnECT::RegisterECT#register' do
@@ -138,8 +135,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
               end
             end
 
-            expect(response).to be_redirection
-            expect(response.redirect_url).to match(%r{/claim-an-ect/register-ect/\d+\z})
+            expect(response).to redirect_to(%r{/claim-an-ect/register-ect/\d+\z})
           end
         end
       end
@@ -167,8 +163,7 @@ RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
       it 'redirects to the root page' do
         get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
 
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/process_batch/actions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/index_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe "Appropriate Body bulk actions index page", type: :request do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/bulk/actions")
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/process_batch/actions/show_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/actions/show_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Appropriate Body bulk actions show page", type: :request do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/bulk/actions/#{batch.id}")
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/process_batch/claims/index_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/claims/index_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Appropriate Body bulk claims index page", type: :request do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/bulk/claims")
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/process_batch/claims/show_spec.rb
+++ b/spec/requests/appropriate_bodies/process_batch/claims/show_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe "Appropriate Body bulk claims show page", type: :request do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/bulk/claims/#{batch.id}")
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/extensions/index_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "Appropriate Body teacher extensions index", type: :request do
     it 'redirects to the root page' do
       get("/appropriate-body/teachers/#{teacher.id}/extensions")
 
-      expect(response).to be_redirection
-      expect(response.redirect_url).to eql(root_url)
+      expect(response).to redirect_to(root_url)
     end
   end
 

--- a/spec/requests/appropriate_bodies/teachers/index_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/index_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe "Appropriate Body teacher index page", type: :request do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_outcome_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome/new")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -55,9 +53,7 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         post("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -103,8 +99,7 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
             author: an_instance_of(Sessions::Users::AppropriateBodyPersona)
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to end_with("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
+          expect(response).to redirect_to("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
         end
       end
 
@@ -166,9 +161,7 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -177,7 +170,6 @@ RSpec.describe 'Appropriate body recording a failed outcome for a teacher' do
 
       it 'renders the show page for a valid teacher' do
         get("/appropriate-body/teachers/#{teacher.id}/record-failed-outcome")
-
         expect(response).to be_successful
       end
     end

--- a/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_outcome_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome/new")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -55,9 +53,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         post("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -103,8 +99,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
             author: an_instance_of(Sessions::Users::AppropriateBodyPersona)
           )
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to end_with("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
+          expect(response).to redirect_to("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
         end
       end
 
@@ -166,9 +161,7 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -177,7 +170,6 @@ RSpec.describe 'Appropriate body recording a passed outcome for a teacher' do
 
       it 'renders the show page for a valid teacher' do
         get("/appropriate-body/teachers/#{teacher.id}/record-passed-outcome")
-
         expect(response).to be_successful
       end
     end

--- a/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/release_ect_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}/release/new")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -36,9 +34,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         post("/appropriate-body/teachers/#{teacher.id}/release")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -86,8 +82,7 @@ RSpec.describe 'Appropriate body releasing an ECT' do
           expect(induction_period.finished_on).to eq(Date.parse("2023-07-31"))
           expect(induction_period.number_of_terms).to eq(6)
 
-          expect(response).to be_redirection
-          expect(response.redirect_url).to end_with("/appropriate-body/teachers/#{teacher.id}/release")
+          expect(response).to redirect_to("/appropriate-body/teachers/#{teacher.id}/release")
         end
 
         context 'with missing params' do

--- a/spec/requests/appropriate_bodies/teachers/show_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/show_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe "Appropriate Body teacher show page", type: :request do
       it 'redirects to the root page' do
         get("/appropriate-body/teachers/#{teacher.id}")
 
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/school/ects/#{ect_at_school_period.id}/mentorship/new")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -39,9 +37,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         post("/school/ects/#{ect_at_school_period.id}/mentorship")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -55,9 +51,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
 
         it 'redirects to the start of the wizard to add a new mentor to the school' do
           post("/school/ects/#{ect_at_school_period.id}/mentorship", params:)
-
-          expect(response).to be_redirection
-          expect(response.redirect_url).to eq(schools_register_mentor_wizard_start_url(ect_id: ect_at_school_period.id))
+          expect(response).to redirect_to(schools_register_mentor_wizard_start_url(ect_id: ect_at_school_period.id))
         end
       end
 
@@ -90,8 +84,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
 
           expect(Schools::AssignMentorForm).to have_received(:new).with(ect: ect_at_school_period, mentor_id: mentor.id.to_s).once
           expect(ECTAtSchoolPeriods::Mentorship.new(ect_at_school_period).current_mentor).to eq(mentor)
-          expect(response).to be_redirection
-          expect(response.redirect_url).to eq(confirmation_schools_ect_mentorship_url(ect_id: ect_at_school_period.id))
+          expect(response).to redirect_to(confirmation_schools_ect_mentorship_url(ect_id: ect_at_school_period.id))
         end
       end
 
@@ -154,9 +147,7 @@ RSpec.describe 'Create mentorship of an ECT to a mentor' do
     context 'when not signed in' do
       it 'redirects to the root page' do
         get("/school/ects/#{ect_at_school_period.id}/mentorship/confirmation")
-
-        expect(response).to be_redirection
-        expect(response.redirect_url).to eql(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
 


### PR DESCRIPTION
### Context

A little housekeeping. 

### Changes proposed in this pull request

Use the `expect(response).to redirect_to(path)` matcher consistently in specs and remove any redundant `expect(response).to be_redirection` matchers

### Guidance to review
