### PR TITLE
Fix AppropriateBodies::RecordOutcome for old induction period programme types

### DIFF
--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -23,6 +23,8 @@ module AppropriateBodies
       raise Errors::ECTHasNoOngoingInductionPeriods if ongoing_induction_period.blank?
 
       ActiveRecord::Base.transaction do
+        map_legacy_programme_type!
+
         close_induction_period(outcome)
         case outcome
         when :pass
@@ -54,6 +56,15 @@ module AppropriateBodies
         teacher:,
         appropriate_body:,
         induction_period: ongoing_induction_period
+      )
+    end
+
+    # Legacy induction periods have "induction programme" not "training programme" set.
+    def map_legacy_programme_type!
+      return if ongoing_induction_period.training_programme.present?
+
+      ongoing_induction_period.update!(
+        training_programme: ::PROGRAMME_MAPPER[ongoing_induction_period.induction_programme]
       )
     end
 

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -24,5 +24,14 @@ FactoryBot.define do
 
     trait(:cip) { induction_programme { "cip" } }
     trait(:diy) { induction_programme { "diy" } }
+
+    # bypass setter to set legacy programme type and unset new one
+    trait :legacy_programme_type do
+      after(:build) do |ip|
+        ip.write_attribute(:training_programme, nil)
+        ip.write_attribute(:induction_programme, 'fip')
+        ip.save!(validate: false)
+      end
+    end
   end
 end

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -157,6 +157,24 @@ RSpec.describe AppropriateBodies::RecordOutcome do
         expect { subject.pass! }.to raise_error(AppropriateBodies::Errors::ECTHasNoOngoingInductionPeriods)
       end
     end
+
+    context "when ongoing induction period only has the legacy programme type" do
+      let!(:induction_period) do
+        FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
+                          appropriate_body:,
+                          teacher:,
+                          started_on: '2024-1-1')
+      end
+
+      it "populates the new programme type and outcome" do
+        service.pass!
+
+        expect(induction_period.reload).to have_attributes(
+          training_programme: 'provider_led',
+          outcome: 'pass'
+        )
+      end
+    end
   end
 
   describe "#fail!" do
@@ -249,6 +267,24 @@ RSpec.describe AppropriateBodies::RecordOutcome do
     context "when an ECT has no ongoing induction periods" do
       it do
         expect { subject.fail! }.to raise_error(AppropriateBodies::Errors::ECTHasNoOngoingInductionPeriods)
+      end
+    end
+
+    context "when ongoing induction period only has the legacy programme type" do
+      let!(:induction_period) do
+        FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
+                          appropriate_body:,
+                          teacher:,
+                          started_on: '2024-1-1')
+      end
+
+      it "populates the new programme type and outcome" do
+        service.fail!
+
+        expect(induction_period.reload).to have_attributes(
+          training_programme: 'provider_led',
+          outcome: 'fail'
+        )
       end
     end
   end


### PR DESCRIPTION
### Context

@cpjmcquillan spotted this validation failure which is caused by old records having no `training_programme` when they come to be closed by the AB.

https://dfe-teacher-services.sentry.io/issues/6900212741/?environment=production&project=4508369974788096&query=is%3Aunresolved&referrer=issue-stream

### Changes proposed in this pull request

Insert new programme type when recording an outcome.

### Guidance to review
