### PR TITLE
Update error message for past start dates

### DIFF
--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -26,7 +26,7 @@ module Schools
         return unless earliest_permitted_date
         return unless value_as_date < earliest_permitted_date
 
-        "Start date cannot be earlier than the last 2 registration periods. Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}."
+        "Start date cannot be this far in the past. Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}."
       end
 
       def earliest_permitted_date

--- a/spec/lib/schools/validation/ect_start_date_spec.rb
+++ b/spec/lib/schools/validation/ect_start_date_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Schools::Validation::ECTStartDate do
 
       it 'is not valid and returns the correct error message' do
         expect(subject).not_to be_valid
-        expect(subject.error_message).to eq('Start date cannot be earlier than the last 2 registration periods. Enter a date later than 1 June 2024.')
+        expect(subject.error_message).to eq('Start date cannot be this far in the past. Enter a date later than 1 June 2024.')
       end
     end
 


### PR DESCRIPTION
2494. Update error message to remove reference to 'registration periods'.

### Context
The message currently uses the term '2 registration periods'. We think this is language that won't be fully understood by our users.

### Changes proposed in this pull request
Update error message for past start dates to remove reference to 'registration periods'.


### Guidance to review
