### PR TITLE
Fix flakey test by comparing the collection

### DIFF
--- a/spec/jobs/refresh_metadata_job_spec.rb
+++ b/spec/jobs/refresh_metadata_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RefreshMetadataJob, type: :job do
 
         manager = instance_double(Metadata::Manager)
         allow(Metadata::Manager).to receive(:new) { manager }
-        expect(manager).to receive(:refresh_metadata!).with(schools, track_changes: true)
+        expect(manager).to receive(:refresh_metadata!).with(a_collection_containing_exactly(*schools), track_changes: true)
 
         described_class.new.perform(object_type: School, object_ids: schools.map(&:id), track_changes: true)
       end


### PR DESCRIPTION
### Context
We get a flakey test that compares the array to an active record relation, adding the `a_collection_containing_exactly` ensures we always compare both collections instead.


### Changes proposed in this pull request
Compare schools using `a_collection_containing_exactly` to avoid comparing an array to a relation

### Guidance to review
failure reported by @leandroalemao here https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/18033991795/job/51316626282