### PR TITLE
[2448] Spike - investigate participant endpoint query for latest training periods

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,12 +1,34 @@
 module API
   module V3
     class ParticipantsController < APIController
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
+      def show
+        render json: to_json(participants_query.participant(id: participant_params[:id]))
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
+
+    private
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider }
+
+        Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(:id)
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -19,6 +19,7 @@ module Interval
     scope :overlapping_with, ->(period) { where(*overlapping_with_range(period.started_on, period.finished_on)) }
     scope :containing_period, ->(period) { where(*containing_range(period.started_on, period.finished_on)) }
     scope :ongoing_on, ->(date) { where(*date_in_range(date)) }
+    scope :started, -> { where(started_on: ..Time.zone.today) }
 
     # Date relative scopes
     scope :ongoing_today, -> { ongoing_on(Time.zone.today) }

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -16,6 +16,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_one :current_or_next_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
+  refresh_metadata -> { teacher }, on_event: %i[create destroy update]
 
   # Validations
   validate :appropriate_body_for_independent_school,

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -14,6 +14,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
            source: :mentee
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
+  refresh_metadata -> { teacher }, on_event: %i[create destroy update]
 
   # Validations
   validates :email,

--- a/app/models/metadata/teacher_lead_provider.rb
+++ b/app/models/metadata/teacher_lead_provider.rb
@@ -1,0 +1,14 @@
+module Metadata
+  class TeacherLeadProvider < Metadata::Base
+    self.table_name = :metadata_teacher_lead_providers
+
+    belongs_to :teacher
+    belongs_to :lead_provider
+
+    belongs_to :latest_ect_training_period, optional: true, class_name: "TrainingPeriod"
+    belongs_to :latest_mentor_training_period, optional: true, class_name: "TrainingPeriod"
+
+    validates :teacher, presence: true
+    validates :lead_provider, presence: true
+  end
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -14,6 +14,7 @@ class Teacher < ApplicationRecord
   has_many :mentor_at_school_periods, inverse_of: :teacher
   has_many :induction_extensions, inverse_of: :teacher
   has_many :teacher_id_changes, inverse_of: :teacher
+  has_many :lead_provider_metadata, class_name: "Metadata::TeacherLeadProvider"
 
   has_many :induction_periods
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,0 +1,55 @@
+class API::ParticipantSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field(:ecf_enrolments) do |teacher, options|
+      lead_provider = options[:lead_provider]
+
+      latest_ect_training_period = TrainingPeriod
+        .includes(:ect_at_school_period)
+        .where(ect_at_school_period: { teacher: } )
+        .latest_first
+        .started
+        .find do |training_period|
+          training_period.lead_provider == lead_provider
+        end
+
+      latest_mentor_training_period = TrainingPeriod
+        .includes(:mentor_at_school_period)
+        .where(mentor_at_school_period: { teacher: } )
+        .latest_first
+        .started
+        .find do |training_period|
+          training_period.lead_provider == lead_provider
+        end
+
+      [latest_ect_training_period, latest_mentor_training_period].compact.map do |training_period|
+        ecf_enrolment(training_period)
+      end
+    end
+
+    class << self
+      def ecf_enrolment(training_period)
+        trainee = training_period.trainee
+        teacher = trainee.teacher
+        training_record_id = training_period.for_ect? ? teacher.api_ect_training_record_id : teacher.api_mentor_training_record_id
+        {
+          school_period_id: trainee.id,
+          training_record_id:,
+          email: trainee.email,
+          participant_type: training_period.for_ect? ? "ect" : "mentor",
+          started_on: training_period.started_on&.iso8601,
+          finished_on: training_period.finished_on&.iso8601,
+          lead_provider: training_period.lead_provider.name,
+        }
+      end
+    end
+  end
+
+  # identifier :ecf_id, name: :id
+  field(:type) { "participant" }
+
+  association :attributes, blueprint: AttributesSerializer do |participant|
+    participant
+  end
+end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -5,25 +5,9 @@ class API::ParticipantSerializer < Blueprinter::Base
     field(:ecf_enrolments) do |teacher, options|
       lead_provider = options[:lead_provider]
 
-      latest_ect_training_period = TrainingPeriod
-        .includes(:ect_at_school_period)
-        .where(ect_at_school_period: { teacher: } )
-        .latest_first
-        .started
-        .find do |training_period|
-          training_period.lead_provider == lead_provider
-        end
+      metadata = teacher.lead_provider_metadata.select { it.lead_provider_id == lead_provider.id }.sole
 
-      latest_mentor_training_period = TrainingPeriod
-        .includes(:mentor_at_school_period)
-        .where(mentor_at_school_period: { teacher: } )
-        .latest_first
-        .started
-        .find do |training_period|
-          training_period.lead_provider == lead_provider
-        end
-
-      [latest_ect_training_period, latest_mentor_training_period].compact.map do |training_period|
+      [metadata.latest_ect_training_period, metadata.latest_mentor_training_period].compact.map do |training_period|
         ecf_enrolment(training_period)
       end
     end

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -1,0 +1,57 @@
+module Metadata::Handlers
+  class Teacher < Base
+    attr_reader :teacher
+
+    def initialize(teacher)
+      @teacher = teacher
+    end
+
+    def refresh_metadata!
+      upsert_lead_provider_metadata!
+    end
+
+    class << self
+      def destroy_all_metadata!
+        truncate_models!(Metadata::TeacherLeadProvider)
+      end
+    end
+
+  private
+
+    def upsert_lead_provider_metadata!
+      lead_provider_ids.each do |lead_provider_id|
+        metadata = Metadata::TeacherLeadProvider.find_or_initialize_by(
+          teacher:,
+          lead_provider_id:
+        )
+
+        latest_ect_training_period = TrainingPeriod
+          .includes(:ect_at_school_period)
+          .where(ect_at_school_period: { teacher: } )
+          .latest_first
+          .started
+          .find do |training_period|
+            training_period.lead_provider.id == lead_provider_id
+          end
+
+        latest_mentor_training_period = TrainingPeriod
+          .includes(:mentor_at_school_period)
+          .where(mentor_at_school_period: { teacher: } )
+          .latest_first
+          .started
+          .find do |training_period|
+            training_period.lead_provider.id == lead_provider_id
+          end
+
+        upsert(metadata, latest_ect_training_period:, latest_mentor_training_period:)
+      end
+    end
+
+    def lead_provider_ids
+      (
+        teacher.ect_at_school_periods.includes(training_periods: :lead_provider).pluck(:lead_provider_id) +
+        teacher.mentor_at_school_periods.includes(training_periods: :lead_provider).pluck(:lead_provider_id)
+      ).compact.uniq
+    end
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -22,6 +22,18 @@ module Participants
       Teacher
         .select("teachers.*")
         .from("(#{ect_teachers.to_sql} UNION #{mentor_teachers.to_sql}) as teachers")
+        .includes(
+          lead_provider_metadata: {
+            latest_ect_training_period: [
+              :lead_provider,
+              { ect_at_school_period: :teacher },
+            ],
+            latest_mentor_training_period: [
+              :lead_provider,
+              { mentor_at_school_period: :teacher },
+            ]
+          }
+        )
     end
 
     def ect_teachers

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -1,0 +1,41 @@
+module Participants
+  class Query
+    attr_reader :scope, :lead_provider
+
+    def initialize(lead_provider:)
+      @lead_provider = lead_provider
+      @scope = all_participants
+    end
+
+    def participants
+      scope.order(created_at: :asc)
+    end
+
+    def participant(id:)
+      scope.where(id:)
+    end
+
+  private
+
+    def all_participants
+      # Union both queries and preload associations for serialization
+      Teacher
+        .select("teachers.*")
+        .from("(#{ect_teachers.to_sql} UNION #{mentor_teachers.to_sql}) as teachers")
+    end
+
+    def ect_teachers
+      Teacher
+        .select("teachers.*")
+        .joins(ect_at_school_periods: { training_periods: :lead_provider })
+        .where(lead_providers: { id: lead_provider.id })
+    end
+
+    def mentor_teachers
+      Teacher
+        .select("teachers.*")
+        .joins(mentor_at_school_periods: { training_periods: :lead_provider })
+        .where(lead_providers: { id: lead_provider.id })
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -232,6 +232,14 @@
   - mentor_payments_frozen_year
   - ect_pupil_premium_uplift
   - ect_sparsity_uplift
+  :metadata_teacher_lead_providers:
+  - id
+  - teacher_id
+  - lead_provider_id
+  - latest_ect_training_period_id
+  - latest_mentor_training_period_id
+  - created_at
+  - updated_at
   :pending_induction_submissions:
   - id
   - appropriate_body_id

--- a/db/migrate/20250926151056_create_metadata_teacher_lead_providers.rb
+++ b/db/migrate/20250926151056_create_metadata_teacher_lead_providers.rb
@@ -1,0 +1,13 @@
+class CreateMetadataTeacherLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :metadata_teacher_lead_providers do |t|
+      t.references :teacher, foreign_key: true
+      t.references :lead_provider, foreign_key: true
+
+      t.references :latest_ect_training_period, foreign_key: { to_table: :training_periods }, null: true
+      t.references :latest_mentor_training_period, foreign_key: { to_table: :training_periods }, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_151056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -407,6 +407,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
     t.index ["lead_provider_id"], name: "idx_on_lead_provider_id_bb46a39503"
     t.index ["school_id", "lead_provider_id", "contract_period_year"], name: "idx_on_school_id_lead_provider_id_contract_period_y_54fbb99e92", unique: true
     t.index ["school_id"], name: "idx_on_school_id_b772864906"
+  end
+
+  create_table "metadata_teacher_lead_providers", force: :cascade do |t|
+    t.bigint "teacher_id"
+    t.bigint "lead_provider_id"
+    t.bigint "latest_ect_training_period_id"
+    t.bigint "latest_mentor_training_period_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_ab4ac7c7e1"
+    t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_9e56b0e54c"
+    t.index ["lead_provider_id"], name: "index_metadata_teacher_lead_providers_on_lead_provider_id"
+    t.index ["teacher_id"], name: "index_metadata_teacher_lead_providers_on_teacher_id"
   end
 
   create_table "migration_failures", force: :cascade do |t|
@@ -850,6 +863,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "lead_providers"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "schools"
+  add_foreign_key "metadata_teacher_lead_providers", "lead_providers"
+  add_foreign_key "metadata_teacher_lead_providers", "teachers"
+  add_foreign_key "metadata_teacher_lead_providers", "training_periods", column: "latest_ect_training_period_id"
+  add_foreign_key "metadata_teacher_lead_providers", "training_periods", column: "latest_mentor_training_period_id"
   add_foreign_key "milestones", "schedules"
   add_foreign_key "parity_check_requests", "lead_providers"
   add_foreign_key "parity_check_requests", "parity_check_endpoints", column: "endpoint_id"

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     independent_school
 
     started_on { generate(:base_ect_date) }
-    finished_on { started_on + 1.day }
+    finished_on { started_on + 1.year }
     email { Faker::Internet.email }
     working_pattern { WORKING_PATTERNS.keys.sample }
 
@@ -46,13 +46,6 @@ FactoryBot.define do
 
     trait :teaching_school_hub_ab do
       association :school_reported_appropriate_body, :teaching_school_hub, factory: :appropriate_body
-    end
-
-    trait :with_teacher_payments_frozen_year do
-      after(:create) do |record|
-        ect_payments_frozen_year = FactoryBot.create(:contract_period, year: [2021, 2022].sample).year
-        record.teacher.update!(ect_payments_frozen_year:)
-      end
     end
 
     trait :with_training_period do

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -6,19 +6,12 @@ FactoryBot.define do
     association :teacher
 
     started_on { generate(:base_mentor_date) }
-    finished_on { started_on + 1.day }
+    finished_on { started_on + 1.year }
     email { Faker::Internet.email }
 
     trait :ongoing do
       started_on { generate(:base_mentor_date) + 1.year }
       finished_on { nil }
-    end
-
-    trait :with_teacher_payments_frozen_year do
-      after(:create) do |record|
-        mentor_payments_frozen_year = FactoryBot.create(:contract_period, year: [2021, 2022].sample).year
-        record.teacher.update!(mentor_payments_frozen_year:)
-      end
     end
   end
 end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,67 +1,157 @@
 RSpec.describe "Participants API", type: :request do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let!(:ect_teacher) { FactoryBot.create(:teacher) }
+  let!(:mentor_teacher) { FactoryBot.create(:teacher) }
+  let!(:both_teacher) { FactoryBot.create(:teacher) }
+
+  let!(:school_partnership) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+  end
+  let!(:lead_provider_delivery_partnership) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+  end
+  let!(:active_lead_provider) do
+    FactoryBot.create(:active_lead_provider, lead_provider:)
+  end
+
+  let!(:school_partnership2) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership: lead_provider_delivery_partnership2)
+  end
+  let!(:lead_provider_delivery_partnership2) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2)
+  end
+  let!(:active_lead_provider2) do
+    FactoryBot.create(:active_lead_provider, lead_provider: lead_provider2)
+  end
+  let!(:lead_provider2) { FactoryBot.create(:lead_provider) }
+
+  # Second training period should start in the future
+  let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: ect_teacher, started_on: 10.days.ago) }
+  let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher) }
+  let!(:mentor_at_school_period2) { FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, started_on: mentor_at_school_period.finished_on.next_day) }
+  # Ended in the past
+  let!(:both_ect_period) { FactoryBot.create(:ect_at_school_period, teacher: both_teacher, started_on: 19.months.ago, finished_on: 1.month.ago) }
+  # Started in the past and ongoing
+  let!(:both_mentor_period) { FactoryBot.create(:mentor_at_school_period, teacher: both_teacher, started_on: 2.months.ago, finished_on: nil) }
+
+  before do
+    # ECT only
+    finished_on = ect_at_school_period.started_on + 30.days
+    # latest
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: ect_at_school_period.finished_on)
+    # old
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period:,
+                      school_partnership:,
+                      started_on: ect_at_school_period.started_on,
+                      finished_on:)
+
+    # Mentor only
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period:,
+                      school_partnership:,
+                      started_on: mentor_at_school_period.started_on,
+                      finished_on: mentor_at_school_period.finished_on)
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: mentor_at_school_period2,
+                      school_partnership: school_partnership2,
+                      started_on: mentor_at_school_period2.started_on,
+                      finished_on: mentor_at_school_period2.finished_on)
+
+    # Both ECT and mentor
+    finished_on = both_ect_period.started_on + 15.days
+    # old
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period: both_ect_period,
+                      school_partnership:,
+                      started_on: both_ect_period.started_on,
+                      finished_on:)
+    # latest
+    FactoryBot.create(:training_period, :for_ect, :with_school_partnership,
+                      ect_at_school_period: both_ect_period,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: both_ect_period.finished_on)
+
+    finished_on = both_mentor_period.started_on + 10.days
+    # old
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: both_mentor_period,
+                      school_partnership:,
+                      started_on: both_mentor_period.started_on,
+                      finished_on:)
+    # latest
+    FactoryBot.create(:training_period, :for_mentor, :with_school_partnership,
+                      mentor_at_school_period: both_mentor_period,
+                      school_partnership:,
+                      started_on: finished_on.next_day,
+                      finished_on: both_mentor_period.finished_on)
+  end
+
   describe "#index" do
-    let(:path) { api_v3_participants_path }
+    let(:parsed_response) { JSON.parse(response.body)["data"] }
 
-    it_behaves_like "a token authenticated endpoint", :get
+    it "returns the correct body" do
+      authenticated_api_get(api_v3_participants_path)
 
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
+      expect(response).to have_http_status(:ok)
+      # debugger
 
-  describe "#show" do
-    let(:path) { api_v3_participant_path(123) }
+      attrs1 = parsed_response.dig(0, "attributes")
+      expect(attrs1).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "school_period_id" => ect_at_school_period.id,
+            "email" => ect_at_school_period.email,
+            "training_record_id" => ect_teacher.api_ect_training_record_id,
+            # "started_on" => 21.days.from_now.to_date.iso8601,
+            # "finished_on" => ect_at_school_period.finished_on.iso8601,
+            "started_on" => ect_at_school_period.started_on.iso8601,
+            "finished_on" => 20.days.from_now.to_date.iso8601,
+            "lead_provider" => lead_provider.name
+          )
+        )
+      )
 
-    it_behaves_like "a token authenticated endpoint", :get
+      attrs2 = parsed_response.dig(1, "attributes")
+      expect(attrs2).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "school_period_id" => mentor_at_school_period.id,
+            "email" => mentor_at_school_period.email,
+            "training_record_id" => mentor_teacher.api_mentor_training_record_id,
+            "started_on" => mentor_at_school_period.started_on.iso8601,
+            "finished_on" => mentor_at_school_period.finished_on.iso8601,
+            "lead_provider" => lead_provider.name
+          )
+        )
+      )
 
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#change_schedule" do
-    let(:path) { api_v3_participant_change_schedule_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#defer" do
-    let(:path) { api_v3_participant_defer_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#resume" do
-    let(:path) { api_v3_participant_resume_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
-  end
-
-  describe "#withdraw" do
-    let(:path) { api_v3_participant_withdraw_path(123) }
-
-    it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
+      attrs3 = parsed_response.dig(2, "attributes")
+      expect(attrs3).to include(
+        "ecf_enrolments" => contain_exactly(
+          include(
+            "school_period_id" => both_ect_period.id,
+            "email" => both_ect_period.email,
+            "training_record_id" => both_teacher.api_ect_training_record_id,
+            "started_on" => (both_ect_period.started_on + 16.days).iso8601,
+            "finished_on" => both_ect_period.finished_on.iso8601,
+            "lead_provider" => lead_provider.name
+          ),
+          include(
+            "school_period_id" => both_mentor_period.id,
+            "email" => both_mentor_period.email,
+            "training_record_id" => both_teacher.api_mentor_training_record_id,
+            "started_on" => (both_mentor_period.started_on + 11.days).iso8601,
+            "finished_on" => both_mentor_period.finished_on&.iso8601,
+            "lead_provider" => lead_provider.name
+          )
+        )
+      )
     end
   end
 end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -90,6 +90,8 @@ RSpec.describe "Participants API", type: :request do
                       school_partnership:,
                       started_on: finished_on.next_day,
                       finished_on: both_mentor_period.finished_on)
+
+    Metadata::Manager.refresh_all_metadata!(async: false, track_changes: false)
   end
 
   describe "#index" do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2448

### Changes proposed in this pull request

- New `started` scope on `Interval` to only show periods that have started (ignoring future starting periods)
- Using metadata, set the latest training period for ECT and Mentor on Teacher

### Guidance to review
