### PR TITLE
Spike into eligible for ECT/mentor training dates

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -16,6 +16,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_one :current_or_next_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
+  refresh_metadata -> { teacher }, on_event: %i[create destroy]
+  refresh_metadata -> { teacher }, when_changing: %i[started_on finished_on], on_event: %i[update]
 
   # Validations
   validate :appropriate_body_for_independent_school,

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -4,6 +4,10 @@ class InductionPeriod < ApplicationRecord
   include Interval
   include SharedInductionPeriodValidation
   include SharedNumberOfTermsValidation
+  include DeclarativeUpdates
+
+  refresh_metadata -> { teacher }, on_event: %i[create destroy]
+  refresh_metadata -> { teacher }, when_changing: %i[started_on finished_on outcome], on_event: %i[update]
 
   # Associations
   belongs_to :appropriate_body

--- a/app/models/metadata/teacher.rb
+++ b/app/models/metadata/teacher.rb
@@ -1,0 +1,12 @@
+module Metadata
+  class Teacher < Metadata::Base
+    self.table_name = :metadata_teachers
+
+    belongs_to :teacher
+
+    validates :teacher, presence: true
+    validates :teacher_id, uniqueness: true
+    validates :first_became_eligible_for_ect_training_at, immutable_once_set: true
+    validates :first_became_eligible_for_mentor_training_at, immutable_once_set: true
+  end
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -68,4 +68,12 @@ class Teacher < ApplicationRecord
   scope :active_in_trs, -> { where(trs_deactivated: false) }
 
   normalizes :corrected_name, with: -> { it.squish }
+
+  def eligible_for_ect_training?
+    induction_periods.ongoing_today.any? && ect_at_school_periods.ongoing_today.any?
+  end
+
+  def eligible_for_mentor_training?
+    mentor_became_ineligible_for_funding_on.blank? && mentor_became_ineligible_for_funding_reason.blank?
+  end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -49,6 +49,8 @@ class Teacher < ApplicationRecord
   validates :api_user_id, uniqueness: { case_sensitive: false, message: "API user id already exists for another teacher" }
   validates :api_ect_training_record_id, uniqueness: { case_sensitive: false, message: "API ect training record id already exists for another teacher" }
   validates :api_mentor_training_record_id, uniqueness: { case_sensitive: false, message: "API mentor training record id already exists for another teacher" }
+  validates :first_became_eligible_for_ect_training_at, immutable_once_set: true
+  validates :first_became_eligible_for_mentor_training_at, immutable_once_set: true
 
   # Scopes
   scope :search, ->(query_string) {

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,4 +1,6 @@
 class Teacher < ApplicationRecord
+  include DeclarativeUpdates
+
   TRN_FORMAT = %r{\A\d{7}\z}
 
   self.ignored_columns = %i[search]
@@ -8,6 +10,9 @@ class Teacher < ApplicationRecord
     completed_during_early_roll_out: 'completed_during_early_roll_out',
     started_not_completed: 'started_not_completed',
   }
+
+  refresh_metadata -> { self }, on_event: %i[create]
+  refresh_metadata -> { self }, when_changing: %i[mentor_became_ineligible_for_funding_on mentor_became_ineligible_for_funding_reason], on_event: %i[update]
 
   # Associations
   has_many :ect_at_school_periods, inverse_of: :teacher
@@ -21,6 +26,7 @@ class Teacher < ApplicationRecord
   has_one :ongoing_induction_period, -> { ongoing }, class_name: "InductionPeriod"
   has_one :started_induction_period, -> { earliest_first }, class_name: "InductionPeriod"
   has_one :finished_induction_period, -> { finished.with_outcome.latest_first }, class_name: "InductionPeriod"
+  has_one :metadata, class_name: "Metadata::Teacher"
 
   has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body

--- a/app/services/induction_periods/create_induction_period.rb
+++ b/app/services/induction_periods/create_induction_period.rb
@@ -24,6 +24,8 @@ module InductionPeriods
         record_event or raise ActiveRecord::Rollback
       end
 
+      set_eligibility!
+
       if teacher.induction_periods.started_before(induction_period.started_on)
           .or(teacher.induction_periods.with_outcome)
           .none?
@@ -48,6 +50,18 @@ module InductionPeriods
       )
 
       true
+    end
+
+    def set_eligibility!
+      if teacher.eligible_for_mentor_training?
+        teacher.first_became_eligible_for_mentor_training_at ||= Time.zone.now
+      end
+
+      if teacher.eligible_for_ect_training?
+        teacher.first_became_eligible_for_ect_training_at ||= Time.zone.now
+      end
+
+      teacher.save!
     end
 
     def notify_trs_of_new_induction_start

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -1,0 +1,40 @@
+module Metadata::Handlers
+  class Teacher < Base
+    attr_reader :teacher
+
+    def initialize(teacher)
+      @teacher = teacher
+    end
+
+    def refresh_metadata!
+      upsert_metadata!
+    end
+
+    class << self
+      def destroy_all_metadata!
+        truncate_models!(Metadata::Teacher)
+      end
+    end
+
+  private
+
+    def upsert_metadata!
+      metadata = Metadata::Teacher.find_or_initialize_by(teacher:)
+
+      changes = {}
+
+      changes[:first_became_eligible_for_ect_training_at] = Time.zone.now if became_eligible_for_ect_training?(teacher:)
+      changes[:first_became_eligible_for_mentor_training_at] = Time.zone.now if became_eligible_for_mentor_training?(teacher:)
+
+      upsert(metadata, **changes) if changes.any?
+    end
+
+    def became_eligible_for_ect_training?(teacher:)
+      teacher.eligible_for_ect_training? && teacher.first_became_eligible_for_ect_training_at.nil?
+    end
+
+    def became_eligible_for_mentor_training?(teacher:)
+      teacher.eligible_for_mentor_training? && teacher.first_became_eligible_for_mentor_training_at.nil?
+    end
+  end
+end

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -51,6 +51,7 @@ module Schools
         close_ongoing_ect_period!
         @ect_at_school_period = start_at_school!
         create_training_period!
+        set_eligibility!
         record_event!
       end
 
@@ -71,6 +72,13 @@ module Schools
 
     def create_teacher!
       @teacher = ::Teacher.create_with(trs_first_name:, trs_last_name:, corrected_name:).find_or_create_by!(trn:)
+    end
+
+    def set_eligibility!
+      return unless teacher.eligible_for_ect_training?
+
+      teacher.first_became_eligible_for_ect_training_at ||= Time.zone.now
+      teacher.save!
     end
 
     def create_training_period!

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -44,6 +44,7 @@ module Schools
         finish_existing_at_school_periods! if finish_existing_at_school_periods
         start_at_school!
         create_training_period!
+        set_eligibility!
         record_event!
       end
 
@@ -75,6 +76,13 @@ module Schools
         trs_last_name:,
         corrected_name:
       ).find_or_create_by!(trn:)
+    end
+
+    def set_eligibility!
+      return unless teacher.eligible_for_mentor_training?
+
+      teacher.first_became_eligible_for_mentor_training_at ||= Time.zone.now
+      teacher.save!
     end
 
     def school

--- a/app/validators/immutable_once_set_validator.rb
+++ b/app/validators/immutable_once_set_validator.rb
@@ -1,0 +1,8 @@
+class ImmutableOnceSetValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    old_value = record.public_send("#{attribute}_was")
+    return if old_value.nil? || old_value == value
+
+    record.errors.add(attribute, "cannot be changed once set")
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -234,6 +234,13 @@
   - ect_sparsity_uplift
   - first_became_eligible_for_ect_training_at
   - first_became_eligible_for_mentor_training_at
+  :metadata_teachers:
+  - id
+  - teacher_id
+  - created_at
+  - updated_at
+  - first_became_eligible_for_ect_training_at
+  - first_became_eligible_for_mentor_training_at
   :pending_induction_submissions:
   - id
   - appropriate_body_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -232,6 +232,8 @@
   - mentor_payments_frozen_year
   - ect_pupil_premium_uplift
   - ect_sparsity_uplift
+  - first_became_eligible_for_ect_training_at
+  - first_became_eligible_for_mentor_training_at
   :pending_induction_submissions:
   - id
   - appropriate_body_id

--- a/db/migrate/20250926104754_add_eligible_for_training_flags_to_teachers.rb
+++ b/db/migrate/20250926104754_add_eligible_for_training_flags_to_teachers.rb
@@ -1,0 +1,8 @@
+class AddEligibleForTrainingFlagsToTeachers < ActiveRecord::Migration[8.0]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.datetime :first_became_eligible_for_ect_training_at, null: true
+      t.datetime :first_became_eligible_for_mentor_training_at, null: true
+    end
+  end
+end

--- a/db/migrate/20250929081437_create_metadata_teachers.rb
+++ b/db/migrate/20250929081437_create_metadata_teachers.rb
@@ -1,0 +1,10 @@
+class CreateMetadataTeachers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :metadata_teachers do |t|
+      t.references :teacher, null: false, foreign_key: true, index: { unique: true }
+      t.date :first_became_eligible_for_ect_training_at, null: true
+      t.date :first_became_eligible_for_mentor_training_at, null: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_104754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -770,6 +770,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
     t.integer "mentor_payments_frozen_year"
     t.boolean "ect_pupil_premium_uplift", default: false, null: false
     t.boolean "ect_sparsity_uplift", default: false, null: false
+    t.datetime "first_became_eligible_for_ect_training_at"
+    t.datetime "first_became_eligible_for_mentor_training_at"
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
     t.index ["api_user_id"], name: "index_teachers_on_api_user_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_104754) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_29_081437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -407,6 +407,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_104754) do
     t.index ["lead_provider_id"], name: "idx_on_lead_provider_id_bb46a39503"
     t.index ["school_id", "lead_provider_id", "contract_period_year"], name: "idx_on_school_id_lead_provider_id_contract_period_y_54fbb99e92", unique: true
     t.index ["school_id"], name: "idx_on_school_id_b772864906"
+  end
+
+  create_table "metadata_teachers", force: :cascade do |t|
+    t.bigint "teacher_id", null: false
+    t.date "first_became_eligible_for_ect_training_at"
+    t.date "first_became_eligible_for_mentor_training_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["teacher_id"], name: "index_metadata_teachers_on_teacher_id", unique: true
   end
 
   create_table "migration_failures", force: :cascade do |t|
@@ -852,6 +861,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_104754) do
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "lead_providers"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "schools"
+  add_foreign_key "metadata_teachers", "teachers"
   add_foreign_key "milestones", "schedules"
   add_foreign_key "parity_check_requests", "lead_providers"
   add_foreign_key "parity_check_requests", "parity_check_endpoints", column: "endpoint_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -328,6 +328,15 @@ erDiagram
   }
   ActiveLeadProvider }o--|| ContractPeriod : belongs_to
   ActiveLeadProvider }o--|| LeadProvider : belongs_to
+  Metadata_Teacher {
+    integer id
+    integer teacher_id
+    date first_became_eligible_for_ect_training_at
+    date first_became_eligible_for_mentor_training_at
+    datetime created_at
+    datetime updated_at
+  }
+  Metadata_Teacher }o--|| Teacher : belongs_to
   Metadata_SchoolLeadProviderContractPeriod {
     integer id
     integer school_id

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -144,6 +144,8 @@ erDiagram
     integer mentor_payments_frozen_year
     boolean ect_pupil_premium_uplift
     boolean ect_sparsity_uplift
+    datetime first_became_eligible_for_ect_training_at
+    datetime first_became_eligible_for_mentor_training_at
   }
   PendingInductionSubmission {
     integer id

--- a/spec/factories/metadata/teacher_factory.rb
+++ b/spec/factories/metadata/teacher_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory(:teacher_metadata, class: "Metadata::Teacher") do
+    after(:build) do |metadata|
+      metadata.teacher ||= DeclarativeUpdates.skip(:metadata) { FactoryBot.create(:teacher) }
+    end
+
+    first_became_eligible_for_ect_training_at { nil }
+    first_became_eligible_for_mentor_training_at { nil }
+  end
+end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -1,9 +1,26 @@
 describe ECTAtSchoolPeriod do
   describe "declarative updates" do
-    let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, school: target) }
-    let!(:target) { FactoryBot.create(:school) }
+    describe "school" do
+      let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, school: target) }
+      let!(:target) { FactoryBot.create(:school) }
 
-    it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+      it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+    end
+
+    describe "teacher" do
+      let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: target) }
+      let(:target) { FactoryBot.create(:teacher) }
+
+      def generate_new_value(attribute_to_change:)
+        return 2.years.ago if attribute_to_change == :started_on
+        return 1.day.ago if attribute_to_change == :finished_on
+
+        super(attribute_to_change:)
+      end
+
+      it_behaves_like "a declarative metadata model", on_event: %i[create destroy]
+      it_behaves_like "a declarative metadata model", when_changing: %i[started_on finished_on], on_event: %i[update], target_optional: false
+    end
   end
 
   describe "associations" do

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -4,6 +4,22 @@ RSpec.describe InductionPeriod do
 
   it_behaves_like 'an induction period'
 
+  describe "declarative updates" do
+    let(:instance) { FactoryBot.create(:induction_period, teacher: target) }
+    let(:target) { FactoryBot.create(:teacher) }
+
+    def generate_new_value(attribute_to_change:)
+      return 2.years.ago if attribute_to_change == :started_on
+      return 1.day.ago if attribute_to_change == :finished_on
+      return :fail if attribute_to_change == :outcome
+
+      super(attribute_to_change:)
+    end
+
+    it_behaves_like "a declarative metadata model", on_event: %i[create destroy]
+    it_behaves_like "a declarative metadata model", when_changing: %i[started_on finished_on outcome], on_event: %i[update]
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:appropriate_body) }
     it { is_expected.to belong_to(:teacher) }

--- a/spec/models/metadata/teacher_spec.rb
+++ b/spec/models/metadata/teacher_spec.rb
@@ -1,0 +1,34 @@
+describe Metadata::Teacher do
+  include_context "restricts updates to the Metadata namespace", :teacher_metadata
+
+  describe "associations" do
+    it { is_expected.to belong_to(:teacher) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:teacher_metadata) }
+
+    it { is_expected.to validate_presence_of(:teacher) }
+
+    describe ".first_became_eligible_for_ect_training_at, .first_became_eligible_for_mentor_training_at" do
+      context "when not yet set" do
+        subject { FactoryBot.create(:teacher_metadata, first_became_eligible_for_ect_training_at: nil, first_became_eligible_for_mentor_training_at: nil) }
+
+        it { is_expected.to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_ect_training_at) }
+        it { is_expected.to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_mentor_training_at) }
+      end
+
+      context "when already set" do
+        subject { FactoryBot.create(:teacher_metadata, first_became_eligible_for_ect_training_at: time, first_became_eligible_for_mentor_training_at: time) }
+
+        let(:time) { Time.zone.now }
+
+        it { is_expected.not_to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_ect_training_at) }
+        it { is_expected.to allow_value(time).for(:first_became_eligible_for_ect_training_at) }
+
+        it { is_expected.not_to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_mentor_training_at) }
+        it { is_expected.to allow_value(time).for(:first_became_eligible_for_mentor_training_at) }
+      end
+    end
+  end
+end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -152,6 +152,27 @@ describe Teacher do
     it { is_expected.to validate_uniqueness_of(:api_ect_training_record_id).case_insensitive.with_message("API ect training record id already exists for another teacher") }
     it { is_expected.to validate_uniqueness_of(:api_mentor_training_record_id).case_insensitive.with_message("API mentor training record id already exists for another teacher") }
 
+    describe ".first_became_eligible_for_ect_training_at, .first_became_eligible_for_mentor_training_at" do
+      context "when not yet set" do
+        subject { FactoryBot.create(:teacher, first_became_eligible_for_ect_training_at: nil, first_became_eligible_for_mentor_training_at: nil) }
+
+        it { is_expected.to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_ect_training_at) }
+        it { is_expected.to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_mentor_training_at) }
+      end
+
+      context "when already set" do
+        subject { FactoryBot.create(:teacher, first_became_eligible_for_ect_training_at: time, first_became_eligible_for_mentor_training_at: time) }
+
+        let(:time) { Time.zone.now }
+
+        it { is_expected.not_to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_ect_training_at) }
+        it { is_expected.to allow_value(time).for(:first_became_eligible_for_ect_training_at) }
+
+        it { is_expected.not_to allow_values("", " ", nil, "test", Date.new).for(:first_became_eligible_for_mentor_training_at) }
+        it { is_expected.to allow_value(time).for(:first_became_eligible_for_mentor_training_at) }
+      end
+    end
+
     describe "trn" do
       it { is_expected.to validate_uniqueness_of(:trn).with_message('TRN already exists').case_insensitive }
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -320,4 +320,52 @@ describe Teacher do
       expect(subject.corrected_name).to eql("Tobias Menzies")
     end
   end
+
+  describe "#eligible_for_ect_training?" do
+    subject(:teacher) { FactoryBot.create(:teacher) }
+
+    it { is_expected.not_to be_eligible_for_ect_training }
+
+    context "when there is an ongoing induction period and ect at school period" do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+      end
+
+      it { is_expected.to be_eligible_for_ect_training }
+    end
+
+    context "when there is an ongoing induction period and an ect at school period that has finished" do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:ect_at_school_period, :finished, teacher:)
+      end
+
+      it { is_expected.not_to be_eligible_for_ect_training }
+    end
+
+    context "when there is an ongoing induction period but no ect at school period" do
+      before { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+
+      it { is_expected.not_to be_eligible_for_ect_training }
+    end
+
+    context "when there is an ongoing ect at school. period but no induction period" do
+      before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+
+      it { is_expected.not_to be_eligible_for_ect_training }
+    end
+  end
+
+  describe "#eligible_for_mentor_training?" do
+    subject(:teacher) { FactoryBot.create(:teacher) }
+
+    it { is_expected.to be_eligible_for_mentor_training }
+
+    context "when the mentor became ineligible for funding" do
+      subject(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
+
+      it { is_expected.not_to be_eligible_for_ect_training }
+    end
+  end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -1,4 +1,24 @@
 describe Teacher do
+  describe "declarative updates" do
+    let(:instance) { FactoryBot.create(:teacher) }
+    let(:target) { instance }
+
+    def generate_new_value(attribute_to_change:)
+      return 1.day.ago if attribute_to_change == :mentor_became_ineligible_for_funding_on
+      return "started_not_completed" if attribute_to_change == :mentor_became_ineligible_for_funding_reason
+
+      super(attribute_to_change:)
+    end
+
+    def will_change_attribute(attribute_to_change:, new_value:) # rubocop:disable Lint/UnusedMethodArgument
+      instance.mentor_became_ineligible_for_funding_on = 1.day.ago if attribute_to_change == :mentor_became_ineligible_for_funding_reason
+      instance.mentor_became_ineligible_for_funding_reason = "started_not_completed" if attribute_to_change == :mentor_became_ineligible_for_funding_on
+    end
+
+    it_behaves_like "a declarative metadata model", on_event: %i[create]
+    it_behaves_like "a declarative metadata model", when_changing: %i[mentor_became_ineligible_for_funding_on mentor_became_ineligible_for_funding_reason], on_event: %i[update]
+  end
+
   describe "associations" do
     it { is_expected.to have_many(:ect_at_school_periods) }
     it { is_expected.to have_many(:mentor_at_school_periods) }
@@ -9,6 +29,7 @@ describe Teacher do
     it { is_expected.to have_many(:teacher_id_changes) }
     it { is_expected.to have_one(:started_induction_period).class_name("InductionPeriod") }
     it { is_expected.to have_one(:finished_induction_period).class_name("InductionPeriod") }
+    it { is_expected.to have_one(:metadata).class_name("Metadata::Teacher") }
 
     describe ".started_induction_period" do
       subject { teacher.started_induction_period }

--- a/spec/services/induction_periods/create_induction_period_spec.rb
+++ b/spec/services/induction_periods/create_induction_period_spec.rb
@@ -73,6 +73,52 @@ describe InductionPeriods::CreateInductionPeriod do
           .to have_enqueued_job(BeginECTInductionJob)
           .with(trn: teacher.trn, start_date: started_on)
       end
+
+      context "when the teacher is eligible for ECT training" do
+        before do
+          FactoryBot.create(:ect_at_school_period, :ongoing, teacher:)
+        end
+
+        it "sets `first_became_eligible_for_ect_training_at`" do
+          expect { subject.create_induction_period! }.to change { teacher.reload.first_became_eligible_for_ect_training_at }.to be_within(5.seconds).of(Time.zone.now)
+        end
+
+        context "when `first_became_eligible_for_ect_training_at` is already set" do
+          before { teacher.update!(first_became_eligible_for_ect_training_at: 1.month.ago) }
+
+          it "does not change `first_became_eligible_for_ect_training_at`" do
+            expect { subject.create_induction_period! }.not_to(change { teacher.reload.first_became_eligible_for_ect_training_at })
+          end
+        end
+      end
+
+      context "when the teacher is not eligible for ECT training" do
+        it "does not set `first_became_eligible_for_ect_training_at`" do
+          expect { subject.create_induction_period! }.not_to(change { teacher.reload.first_became_eligible_for_ect_training_at })
+        end
+      end
+
+      context "when the teacher is eligible for mentor training" do
+        it "sets `first_became_eligible_for_mentor_training_at`" do
+          expect { subject.create_induction_period! }.to change { teacher.reload.first_became_eligible_for_mentor_training_at }.to be_within(5.seconds).of(Time.zone.now)
+        end
+
+        context "when `first_became_eligible_for_mentor_training_at` is already set" do
+          before { teacher.update!(first_became_eligible_for_mentor_training_at: 1.month.ago) }
+
+          it "does not change `first_became_eligible_for_mentor_training_at`" do
+            expect { subject.create_induction_period! }.not_to(change { teacher.reload.first_became_eligible_for_mentor_training_at })
+          end
+        end
+      end
+
+      context "when the teacher is not eligible for mentor training" do
+        let(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
+
+        it "does not set `first_became_eligible_for_mentor_training_at`" do
+          expect { subject.create_induction_period! }.not_to(change { teacher.reload.first_became_eligible_for_mentor_training_at })
+        end
+      end
     end
 
     context "when the induction period is earlier than existing periods" do

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe Metadata::Handlers::Teacher do
+  let(:instance) { described_class.new(teacher) }
+  let!(:teacher) { FactoryBot.create(:teacher) }
+
+  include_context "supports refreshing all metadata", :teacher, Teacher do
+    let(:object) { teacher }
+  end
+
+  describe ".destroy_all_metadata!" do
+    subject(:destroy_all_metadata) { described_class.destroy_all_metadata! }
+
+    it "destroys all metadata for the teacher" do
+      expect { destroy_all_metadata }.to change(Metadata::Teacher, :count).from(1).to(0)
+    end
+  end
+
+  describe "#refresh_metadata!" do
+    subject(:refresh_metadata) { instance.refresh_metadata! }
+
+    describe "Teacher" do
+      before { Metadata::Teacher.destroy_all }
+
+      include_context "supports tracking metadata upsert changes", Metadata::Teacher do
+        let(:handler) { instance }
+
+        def perform_refresh_metadata
+          refresh_metadata
+        end
+      end
+
+      it "creates metadata" do
+        expect { refresh_metadata }.to change(Metadata::Teacher, :count).by(1)
+      end
+
+      context "when metadata already exists" do
+        before { instance.refresh_metadata! }
+
+        it "does not create metadata" do
+          expect { refresh_metadata }.not_to change(Metadata::Teacher, :count)
+        end
+
+        # it "updates the metadata when the induction period changes" do
+        #   induction_period = FactoryBot.create(:induction_period, :pass, teacher:, started_on: 1.month.ago, finished_on: 1.day.ago)
+
+        #   Metadata::Teacher.bypass_update_restrictions { teacher.metadata.update!(induction_started_on: nil, induction_finished_on: nil) }
+
+        #   expect { refresh_metadata }.to change { teacher.reload.metadata.induction_started_on }.from(nil).to(induction_period.started_on)
+        #     .and change { teacher.reload.metadata.induction_finished_on }.from(nil).to(induction_period.finished_on)
+        # end
+
+        it "does not update the metadata if no changes are made" do
+          expect { refresh_metadata }.not_to(change { teacher.reload.metadata.attributes })
+        end
+      end
+    end
+  end
+end

--- a/spec/services/metadata/resolver_spec.rb
+++ b/spec/services/metadata/resolver_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe Metadata::Resolver do
   describe ".all_handlers" do
     subject { described_class.all_handlers }
 
-    it { is_expected.to contain_exactly(Metadata::Handlers::School, Metadata::Handlers::DeliveryPartner) }
+    it { is_expected.to contain_exactly(Metadata::Handlers::School, Metadata::Handlers::DeliveryPartner, Metadata::Handlers::Teacher) }
   end
 end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe Schools::RegisterECT do
           end
         end
 
+        context "when a Teacher record with the same TRN exists and is eligible for ECT training" do
+          before { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+
+          it "sets `first_became_eligible_for_ect_training_at`" do
+            expect { service.register! }.to change { teacher.reload.first_became_eligible_for_ect_training_at }.to be_within(5.seconds).of(Time.zone.now)
+          end
+
+          context "when `first_became_eligible_for_ect_training_at` is already set" do
+            before { teacher.update!(first_became_eligible_for_ect_training_at: 1.month.ago) }
+
+            it "does not change `first_became_eligible_for_ect_training_at`" do
+              expect { service.register! }.not_to(change { teacher.reload.first_became_eligible_for_ect_training_at })
+            end
+          end
+        end
+
+        context "when a Teacher record with the same TRN exists and is not eligible for ECT training" do
+          it "does not set `first_became_eligible_for_ect_training_at`" do
+            expect { service.register! }.not_to(change { teacher.reload.first_became_eligible_for_ect_training_at })
+          end
+        end
+
         context "when a Teacher record with the same TRN exists and has ect records at the same school" do
           before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, started_on: Date.new(2024, 1, 1)) }
 

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -94,6 +94,30 @@ RSpec.describe Schools::RegisterMentor do
         end
       end
 
+      context "when a Teacher record with the same TRN exists and is eligible for mentor training" do
+        let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+
+        it "sets `first_became_eligible_for_mentor_training_at`" do
+          expect { service.register! }.to change { teacher.reload.first_became_eligible_for_mentor_training_at }.to be_within(5.seconds).of(Time.zone.now)
+        end
+
+        context "when `first_became_eligible_for_mentor_training_at` is already set" do
+          before { teacher.update!(first_became_eligible_for_mentor_training_at: 1.month.ago) }
+
+          it "does not change `first_became_eligible_for_mentor_training_at`" do
+            expect { service.register! }.not_to(change { teacher.reload.first_became_eligible_for_mentor_training_at })
+          end
+        end
+      end
+
+      context "when a Teacher record with the same TRN exists and is not eligible for mentor training" do
+        let!(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding, trn:) }
+
+        it "does not set `first_became_eligible_for_mentor_training_at`" do
+          expect { service.register! }.not_to(change { teacher.reload.first_became_eligible_for_mentor_training_at })
+        end
+      end
+
       context 'when no SchoolPartnerships exist' do
         it 'creates a TrainingPeriod linked to the MentorAtSchoolPeriod and with an expression of interest for the ActiveLeadProvider' do
           expect { service.register! }.to change(TrainingPeriod, :count).by(1)

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -274,7 +274,7 @@ RSpec.shared_examples "a declarative metadata model" do |when_changing: [], on_e
 
         instance
 
-        expect(manager).to have_received(:refresh_metadata!).with(target)
+        expect(manager).to have_received(:refresh_metadata!).with(target).at_least(:once)
       end
     end
 

--- a/spec/validators/immutable_once_set_validator_spec.rb
+++ b/spec/validators/immutable_once_set_validator_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe ImmutableOnceSetValidator, type: :model do
+  subject { instance.tap(&:valid?).errors[:attribute] }
+
+  let(:instance) { test_class.new(attribute: new_value, attribute_was: current_value) }
+  let(:test_class) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :attribute, :attribute_was
+
+      validates :attribute, immutable_once_set: true
+    end
+  end
+
+  context "when attribute is `nil` and changing to `true`" do
+    let(:current_value) { nil }
+    let(:new_value) { true }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "when attribute is `nil` and changing to `nil`" do
+    let(:current_value) { nil }
+    let(:new_value) { nil }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "when attribute is `\"set\"` and changing to `\"set\"`" do
+    let(:current_value) { "set" }
+    let(:new_value) { "set" }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "when attribute is `false` and changing to `\"test\"`" do
+    let(:current_value) { false }
+    let(:new_value) { "test" }
+
+    it { is_expected.to include("cannot be changed once set") }
+  end
+
+  context "when the attribute is `\"\"` and is changing to `true`" do
+    let(:current_value) { "" }
+    let(:new_value) { true }
+
+    it { is_expected.to include("cannot be changed once set") }
+  end
+
+  context "when the attribute is `true` and is changing to `false`" do
+    let(:current_value) { true }
+    let(:new_value) { false }
+
+    it { is_expected.to include("cannot be changed once set") }
+  end
+
+  context "when the attribute is `true` and is changing to `nil`" do
+    let(:current_value) { true }
+    let(:new_value) { nil }
+
+    it { is_expected.to include("cannot be changed once set") }
+  end
+end


### PR DESCRIPTION
### Context

Evaluates two approaches to storing the dates that a teacher became eligible for ECT or mentor training:

- Stamping attributes on `Teacher`
- Using metadata to track the dates

### Changes proposed in this pull request

- Add ECT/mentor became eligible attributes to Teacher

We want to track when an ECT or mentor first became eligible for training, as we require this for the API. Once they have become eligible as far as the API is concerned they won't revert.

Add attributes to `Teacher` to track first eligible dates.

Add validator to make dates immutable once set.

- Set first_became_eligible_for_ect/mentor_training_at

Update the `RegisterECT`, `RegisterMentor` and `CreateInductionPeriod` services to populate the new eligibility attributes on `Teacher`.

- Add Metadata::Teacher for teacher eligibility dates

Spike into adding a `Metadata::Teacher` model that we use to keep track of the dates a teacher became eliugible for ECT/mentor training.

### Guidance to review

Stamping the attributes on `Teacher` is the way to go IMO; we don't need metadata to accomplish this and it just overcomplicates it.