### PR TITLE
Spike participant actions

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -32,7 +32,8 @@ class TrainingPeriod < ApplicationRecord
   # Validations
   validates :started_on,
             presence: true
-
+  validates :api_withdrawal_reason, presence: true, if: -> { api_withdrawn_at.present? }
+  validates :api_deferral_reason, presence: true, if: -> { api_deferred_at.present? }
   validate :one_id_of_trainee_present
   validate :at_least_expression_of_interest_or_school_partnership_present, if: :provider_led_training_programme?
   validate :expression_of_interest_absent_for_school_led, if: :school_led_training_programme?

--- a/app/services/teachers/defer.rb
+++ b/app/services/teachers/defer.rb
@@ -1,0 +1,70 @@
+module Teachers
+  class Defer
+    attr_reader :teacher, :lead_provider, :course_identifier, :deferral_reason
+
+    def initialize(teacher:, lead_provider:, course_identifier:, deferral_reason:)
+      @teacher = teacher
+      @lead_provider = lead_provider
+      @course_identifier = course_identifier
+      @deferral_reason = deferral_reason
+    end
+
+    def defer!
+      finish_training_period! if training_period.ongoing?
+      mark_training_period_as_deferred!
+    end
+
+  private
+
+    def finish_training_period!
+      options = {
+        training_period:,
+        finished_on:,
+        teacher:,
+        author: Events::LeadProviderAPIAuthor.new(lead_provider:),
+      }
+
+      service = if mentor_course_identifier?
+                  TrainingPeriods::Finish.mentor_training(**options.merge(ect_at_school_period:))
+                else
+                  TrainingPeriods::Finish.ect_training(**options.merge(mentor_at_school_period:))
+                end
+
+      service.finish!
+    end
+
+    def mark_training_period_as_deferred!
+      training_period.update!(api_deferred_at: finished_on, deferral_reason:)
+    end
+
+    def finished_on
+      @finished_on ||= Time.zone.now.to_date
+    end
+
+    def ect_at_school_period
+      @ect_at_school_period ||= training_period.ect_at_school_period
+    end
+
+    def mentor_at_school_period
+      @mentor_at_school_period ||= training_period.mentor_at_school_period
+    end
+
+    def training_period
+      @training_period ||= if mentor_course_identifier?
+                             metadata.latest_mentor_training_period
+                           else
+                             metadata.latest_ect_training_period
+                           end
+    end
+
+    def mentor_course_identifier?
+      course_identifier == "ecf-mentor"
+    end
+
+    def metadata
+      @metadata ||= teacher
+        .lead_provider_metadata
+        .find_by(lead_provider:)
+    end
+  end
+end

--- a/app/services/teachers/resume.rb
+++ b/app/services/teachers/resume.rb
@@ -1,0 +1,57 @@
+module Teachers
+  class Resume
+    attr_reader :teacher, :lead_provider, :course_identifier
+
+    def initialize(teacher:, lead_provider:, course_identifier:)
+      @teacher = teacher
+      @lead_provider = lead_provider
+      @course_identifier = course_identifier
+    end
+
+    def resume!
+      create_training_period!
+    end
+
+  private
+
+    def create_training_period!
+      ::TrainingPeriods::Create.provider_led(
+        period:,
+        started_on: Time.zone.now.to_date,
+        school_partnership: training_period.school_partnership
+      ).call
+    end
+
+    def started_on
+      @started_on ||= Time.zone.now.to_date
+    end
+
+    def ect_at_school_period
+      @ect_at_school_period ||= training_period.ect_at_school_period
+    end
+
+    def mentor_at_school_period
+      @mentor_at_school_period ||= training_period.mentor_at_school_period
+    end
+
+    def training_period
+      @training_period ||= if mentor_course_identifier?
+                             metadata.latest_mentor_training_period
+                           else
+                             metadata.latest_ect_training_period
+                           end
+    end
+
+    def period
+      @period ||= if mentor_course_identifier?
+                    mentor_at_school_period
+                  else
+                    ect_at_school_period
+                  end
+    end
+
+    def mentor_course_identifier?
+      course_identifier == "ecf-mentor"
+    end
+  end
+end

--- a/app/services/teachers/withdraw.rb
+++ b/app/services/teachers/withdraw.rb
@@ -1,0 +1,70 @@
+module Teachers
+  class Withdraw
+    attr_reader :teacher, :lead_provider, :course_identifier, :withdrawal_reason
+
+    def initialize(teacher:, lead_provider:, course_identifier:, withdrawal_reason:)
+      @teacher = teacher
+      @lead_provider = lead_provider
+      @course_identifier = course_identifier
+      @withdrawal_reason = withdrawal_reason
+    end
+
+    def withdraw!
+      finish_training_period! if training_period.ongoing?
+      mark_training_period_as_withdrawn!
+    end
+
+  private
+
+    def finish_training_period!
+      options = {
+        training_period:,
+        finished_on:,
+        teacher:,
+        author: Events::LeadProviderAPIAuthor.new(lead_provider:),
+      }
+
+      service = if mentor_course_identifier?
+                  TrainingPeriods::Finish.mentor_training(**options.merge(ect_at_school_period:))
+                else
+                  TrainingPeriods::Finish.ect_training(**options.merge(mentor_at_school_period:))
+                end
+
+      service.finish!
+    end
+
+    def mark_training_period_as_withdrawn!
+      training_period.update!(api_withdrawn_at: finished_on, withdrawal_reason:)
+    end
+
+    def finished_on
+      @finished_on ||= Time.zone.now.to_date
+    end
+
+    def ect_at_school_period
+      @ect_at_school_period ||= training_period.ect_at_school_period
+    end
+
+    def mentor_at_school_period
+      @mentor_at_school_period ||= training_period.mentor_at_school_period
+    end
+
+    def training_period
+      @training_period ||= if mentor_course_identifier?
+                             metadata.latest_mentor_training_period
+                           else
+                             metadata.latest_ect_training_period
+                           end
+    end
+
+    def mentor_course_identifier?
+      course_identifier == "ecf-mentor"
+    end
+
+    def metadata
+      @metadata ||= teacher
+        .lead_provider_metadata
+        .find_by(lead_provider:)
+    end
+  end
+end

--- a/app/services/training_periods/finish.rb
+++ b/app/services/training_periods/finish.rb
@@ -38,7 +38,7 @@ module TrainingPeriods
 
     def finish!
       ActiveRecord::Base.transaction do
-        training_period.update!(finished_on:)
+        training_period.update!(finished_on: earliest_finished_on)
 
         Events::Record.record_teacher_finishes_training_period_event!(
           author:,
@@ -50,6 +50,12 @@ module TrainingPeriods
           teacher:
         )
       end
+    end
+
+  private
+
+    def earliest_finished_on
+      [finished_on, training_period.api_withdrawn_at, training_period.api_deferred_at].compact.min
     end
   end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -190,6 +190,10 @@
   - ecf_end_induction_record_id
   - expression_of_interest_id
   - training_programme
+  - api_deferral_reason
+  - api_deferred_at
+  - api_withdrawal_reason
+  - api_withdrawn_at
   :teacher_migration_failures:
   - id
   - teacher_id

--- a/db/migrate/20250930070440_add_withdrawn_deferred_to_training_periods.rb
+++ b/db/migrate/20250930070440_add_withdrawn_deferred_to_training_periods.rb
@@ -1,0 +1,26 @@
+class AddWithdrawnDeferredToTrainingPeriods < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :api_withdrawal_reasons, %w[
+      left-teaching-profession
+      moved-school
+      mentor-no-longer-being-mentor
+      switched-to-school-led
+      other
+    ]
+
+    create_enum :api_deferral_reasons, %w[
+      bereavement
+      long-term-sickness
+      parental-leave
+      career-break
+      other
+    ]
+
+    change_table :training_periods, bulk: true do |t|
+      t.date :api_deferred_at
+      t.enum :api_deferral_reason, enum_type: :api_deferral_reasons
+      t.date :api_withdrawn_at
+      t.enum :api_withdrawal_reason, enum_type: :api_withdrawal_reasons
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_30_070440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -19,6 +19,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "api_deferral_reasons", ["bereavement", "long-term-sickness", "parental-leave", "career-break", "other"]
+  create_enum "api_withdrawal_reasons", ["left-teaching-profession", "moved-school", "mentor-no-longer-being-mentor", "switched-to-school-led", "other"]
   create_enum "appropriate_body_type", ["local_authority", "national", "teaching_school_hub"]
   create_enum "batch_status", ["pending", "processing", "processed", "completing", "completed", "failed"]
   create_enum "batch_type", ["action", "claim"]
@@ -792,6 +794,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_153321) do
     t.uuid "ecf_end_induction_record_id"
     t.bigint "expression_of_interest_id"
     t.enum "training_programme", null: false, enum_type: "training_programme"
+    t.date "api_deferred_at"
+    t.enum "api_deferral_reason", enum_type: "api_deferral_reasons"
+    t.date "api_withdrawn_at"
+    t.enum "api_withdrawal_reason", enum_type: "api_withdrawal_reasons"
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -23,6 +23,10 @@ erDiagram
     uuid ecf_end_induction_record_id
     integer expression_of_interest_id
     enum training_programme
+    date api_deferred_at
+    enum api_deferral_reason
+    date api_withdrawn_at
+    enum api_withdrawal_reason
   }
   TrainingPeriod }o--|| ECTAtSchoolPeriod : belongs_to
   TrainingPeriod }o--|| MentorAtSchoolPeriod : belongs_to


### PR DESCRIPTION
A look into participant actions following the logic defined around withdrawals, deferrals and resuming a participant.

[Discussion on processes](https://github.com/DFE-Digital/register-ects-project-board/discussions/2425)

# Key Concepts
- **Participant status** → determined by **training status** (school view).  
- **Training status** → determined by **training periods** (lead provider view).  

---

# Scenarios

## 1. New school registers an ECT already training elsewhere

- **School A**
  - School period has `finished_on` set.  
    - If `finished_on` is **in the future** → `LEAVING`  
    - If `finished_on` is **in the past** → `LEFT`  
  - Training status is `ACTIVE` until LP withdraws/defers
- **School B**
  - School period has `started_on` set.  
    - If `started_on` is **in the future** → `JOINING`  
    - If `started_on` is **in the past** → `ACTIVE`  
  - Training status is:
    - `JOINING` if `started_on` is in the future
    - `ACTIVE` if `started_on` is in the past

---

## 2. Lead provider submits withdrawal/deferral

- Training period `finished_on` is set.  
- Until `finished_on` is reached:  
  - Training status = `ACTIVE`  
  - Participant status = `ACTIVE`  
- After `finished_on` is reached:  
  - Training status = `WITHDRAWN` (or `DEFERRED`)  
  - Participant status = `LEFT`

---

## 3. Lead provider submits resume

- New training period created:  
  - `started_on` = today  
  - `finished_on` = nil  
- Status updates:  
  - Training status = `ACTIVE`  
  - Participant status = `ACTIVE`  
- Note: there may be a **gap** between training periods

---

# Status Definitions

## Participant status
- **JOINING** → latest training period exists with `started_on` in the future.  
- **LEAVING** → latest training period exists with `finished_on` in the future.  
- **LEFT** →  latest training period has `finished_on` in the past.
- **ACTIVE** → latest school period exists with no `finished_on`.  

---

## Training status
- **N/A** → latest training period exists with `started_on` in the future.  
- **ACTIVE** → latest training period exists with `started_on` in the past and `withdrawn_at`/`deferred_at` are both `nil` or future dated.
- **WITHDRAWN/DEFERRED** → latest training period exists and `withdrawn_at`/`deferred_at` set and in the past.