### PR TITLE
[2393] Prevent `TrainingPeriod` creation for ineligible mentors

### DIFF
--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -69,7 +69,7 @@ module Schools
     end
 
     def ensure_mentor_is_eligible!
-      unless Teachers::MentorFundingEligibility.new(trn: teacher.trn).eligible?
+      if Teachers::MentorFundingEligibility.new(trn: teacher.trn).ineligible?
         raise MentorIneligibleForTraining,
               "Mentor #{teacher.id} is not eligible for funded training"
       end

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe Schools::RegisterMentor do
           expect(mentor_at_school_period.started_on).to eq(Date.current)
         end
       end
+
+      context 'when the mentor is ineligible for funding' do
+        let!(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding, trn:) }
+
+        it 'raises a MentorIneligibleForTraining error' do
+          expect { service.register! }
+            .to raise_error(Schools::RegisterMentor::MentorIneligibleForTraining,
+                            /Mentor #{teacher.id} is not eligible for funded training/)
+        end
+      end
     end
 
     context 'when school-led' do


### PR DESCRIPTION
### Context

It should not be possible to reach the point of creating a `TrainingPeriod` for an ineligible mentor. However, we have added an explicit safeguard to ensure this cannot happen.

### Changes proposed in this pull request

- Prevent creation of a `TrainingPeriod` for ineligible mentors.
- Raise a `MentorIneligibleForTraining` error instead of returning silently,  so that if the flow ever does reach this point it is caught explicitly.
- Added service spec coverage using the `:ineligible_for_mentor_funding` factory trait.

### Guidance to review

🚢 
