### PR TITLE
Fix failing `RegisterECT` spec on main

### DIFF
--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Schools::RegisterECT do
         context "when a Teacher record with the same TRN has a future period at different school" do
           let(:other_school) { FactoryBot.create(:school) }
           let(:started_on) { Date.current + 3.months } # Future start date after the other school's period
+          let!(:contract_period) { FactoryBot.create(:contract_period, year: Date.current.year) }
           let!(:future_contract_period) { FactoryBot.create(:contract_period, year: started_on.year) }
           let!(:future_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: future_contract_period) }
 


### PR DESCRIPTION
### Context

This spec was failing on main because no `ContractPeriod` existed for the current year. This caused `TrainingPeriodSources` to raise `ActiveRecord::RecordNotFound`.

```
Failures:

  1) Schools::RegisterECT#register! when provider led when provider-led when a Teacher record with the same TRN has a future period at different school allows registration with non-overlapping future date
     Failure/Error: @active_lead_provider ||= ActiveLeadProvider.find_by!(lead_provider:, contract_period:)
     
     ActiveRecord::RecordNotFound:
       Couldn't find ActiveLeadProvider with [WHERE "active_lead_providers"."lead_provider_id" = $1 AND "active_lead_providers"."contract_period_year" IS NULL]
     # ./app/models/concerns/training_period_sources.rb:9:in 'TrainingPeriodSources#active_lead_provider'
     # ./app/models/concerns/training_period_sources.rb:17:in 'TrainingPeriodSources#expression_of_interest'
     # ./app/services/schools/register_ect.rb:88:in 'Schools::RegisterECT#create_training_period!'
     # ./app/services/schools/register_ect.rb:53:in 'block in Schools::RegisterECT#register!'
     # ./app/services/schools/register_ect.rb:47:in 'Schools::RegisterECT#register!'
     # ./spec/services/schools/register_ect_spec.rb:125:in 'block (7 levels) in <main>'
     # ./spec/services/schools/register_ect_spec.rb:125:in 'block (6 levels) in <main>'
     # ./spec/support/rack_attack.rb:15:in 'block (2 levels) in <main>'

Finished in 2.03 seconds (files took 5.31 seconds to load)
20 examples, 1 failure

Failed examples:

rspec ./spec/services/schools/register_ect_spec.rb:124 # Schools::RegisterECT#register! when provider led when provider-led when a Teacher record with the same TRN has a future period at different school allows registration with non-overlapping future date
```

### Changes proposed in this pull request

- Explicitly create a current year `ContractPeriod` in the spec.
- Explicitly create a `ContractPeriod` for the `started_on` date.

### Guidance to review

🚢 
