### PR TITLE
Change Induction Period validation for training programme to be conditional

### DIFF
--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -22,11 +22,13 @@ class InductionPeriod < ApplicationRecord
               message: "Choose an induction programme"
             }
 
-  # TODO: add null: false to the database column after populating old records
   validates :training_programme,
             inclusion: {
               in: ::TRAINING_PROGRAMME.keys.map(&:to_s),
               message: "Choose an induction programme"
+            },
+            unless: ->(ip) {
+              ip.induction_programme.in?(%w[unknown pre_september_2021])
             }
 
   validates :outcome,

--- a/app/services/appropriate_bodies/record_outcome.rb
+++ b/app/services/appropriate_bodies/record_outcome.rb
@@ -23,8 +23,6 @@ module AppropriateBodies
       raise Errors::ECTHasNoOngoingInductionPeriods if ongoing_induction_period.blank?
 
       ActiveRecord::Base.transaction do
-        map_legacy_programme_type!
-
         close_induction_period(outcome)
         case outcome
         when :pass
@@ -56,15 +54,6 @@ module AppropriateBodies
         teacher:,
         appropriate_body:,
         induction_period: ongoing_induction_period
-      )
-    end
-
-    # Legacy induction periods have "induction programme" not "training programme" set.
-    def map_legacy_programme_type!
-      return if ongoing_induction_period.training_programme.present?
-
-      ongoing_induction_period.update!(
-        training_programme: ::PROGRAMME_MAPPER[ongoing_induction_period.induction_programme]
       )
     end
 

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -24,13 +24,13 @@ FactoryBot.define do
 
     trait(:cip) { induction_programme { "cip" } }
     trait(:diy) { induction_programme { "diy" } }
+    trait(:pre_2021) { induction_programme { "pre_september_2021" } }
 
-    # bypass setter to set legacy programme type and unset new one
     trait :legacy_programme_type do
-      after(:build) do |ip|
+      after(:build) do |ip, evaluator|
         ip.write_attribute(:training_programme, nil)
-        ip.write_attribute(:induction_programme, 'fip')
-        ip.save!(validate: false)
+        ip.write_attribute(:induction_programme, evaluator.induction_programme)
+        ip.save!
       end
     end
   end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -64,9 +64,21 @@ RSpec.describe InductionPeriod do
       end
     end
 
-    it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy unknown pre_september_2021]).with_message("Choose an induction programme") }
+    describe '#induction_programme' do
+      it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy unknown pre_september_2021]).with_message("Choose an induction programme") }
+    end
 
-    describe "outcome validation" do
+    describe '#training_programme' do
+      it { is_expected.to validate_inclusion_of(:training_programme).in_array(%w[provider_led school_led]).with_message("Choose an induction programme") }
+
+      context 'when the induction pre-dates School-led and Provider-Led programme types and training_programme is blank' do
+        subject { FactoryBot.create(:induction_period, :ongoing, :pre_2021, :legacy_programme_type) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe "#outcome" do
       subject { FactoryBot.build(:induction_period) }
 
       it { is_expected.to allow_value('pass').for(:outcome) }
@@ -84,7 +96,7 @@ RSpec.describe InductionPeriod do
       end
     end
 
-    describe "started_on_not_in_future" do
+    describe "#started_on_not_in_future" do
       subject { FactoryBot.build(:induction_period, :ongoing, appropriate_body:, started_on:) }
 
       context "when started_on is today" do
@@ -109,7 +121,7 @@ RSpec.describe InductionPeriod do
       end
     end
 
-    describe "finished_on_not_in_future" do
+    describe "#finished_on_not_in_future" do
       subject { FactoryBot.build(:induction_period, appropriate_body:, finished_on:) }
 
       context "when finished_on is today" do
@@ -134,7 +146,7 @@ RSpec.describe InductionPeriod do
       end
     end
 
-    describe "number_of_terms" do
+    describe "#number_of_terms" do
       context "when finished_on is empty" do
         subject { FactoryBot.build(:induction_period, :ongoing, appropriate_body:) }
 
@@ -185,7 +197,7 @@ RSpec.describe InductionPeriod do
     end
   end
 
-  describe "training_programme=" do
+  describe "#training_programme=" do
     subject { FactoryBot.build(:induction_period, appropriate_body_id: 1) }
 
     it "assigns the induction_programme for provider_led and is valid" do
@@ -242,28 +254,23 @@ RSpec.describe InductionPeriod do
     context "with completed siblings and nil finished_on and inserting after them" do
       let(:teacher) { FactoryBot.create(:teacher) }
       let!(:previous_period) do
-        FactoryBot.create(:induction_period,
+        FactoryBot.create(:induction_period, :pre_2021,
                           teacher:,
                           started_on: "2017-09-11",
-                          finished_on: "2018-03-23",
-                          induction_programme: "pre_september_2021")
+                          finished_on: "2018-03-23")
       end
 
       let!(:next_period) do
-        FactoryBot.create(:induction_period,
+        FactoryBot.create(:induction_period, :pre_2021,
                           teacher:,
                           started_on: "2019-01-07",
-                          finished_on: "2019-07-16",
-                          induction_programme: "pre_september_2021")
+                          finished_on: "2019-07-16")
       end
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period,
+        FactoryBot.create(:induction_period, :ongoing,
                           teacher:,
-                          started_on: "2025-01-01",
-                          finished_on: nil,
-                          number_of_terms: nil,
-                          induction_programme: "fip")
+                          started_on: "2025-01-01")
       end
 
       let(:params) { { started_on: "2025-02-24" } }
@@ -277,28 +284,23 @@ RSpec.describe InductionPeriod do
     context "with completed siblings and nil finished_on and inserting between them" do
       let(:teacher) { FactoryBot.create(:teacher) }
       let!(:previous_period) do
-        FactoryBot.create(:induction_period,
+        FactoryBot.create(:induction_period, :pre_2021,
                           teacher:,
                           started_on: "2017-09-01",
-                          finished_on: "2018-03-01",
-                          induction_programme: "pre_september_2021")
+                          finished_on: "2018-03-01")
       end
 
       let!(:next_period) do
-        FactoryBot.create(:induction_period,
+        FactoryBot.create(:induction_period, :pre_2021,
                           teacher:,
                           started_on: "2019-01-01",
-                          finished_on: "2019-07-01",
-                          induction_programme: "pre_september_2021")
+                          finished_on: "2019-07-01")
       end
 
       let!(:induction_period) do
-        FactoryBot.create(:induction_period,
+        FactoryBot.create(:induction_period, :ongoing,
                           teacher:,
-                          started_on: "2025-01-01",
-                          finished_on: nil,
-                          number_of_terms: nil,
-                          induction_programme: "fip")
+                          started_on: "2025-01-01")
       end
 
       let(:params) { { started_on: "2019-04-24" } }

--- a/spec/services/appropriate_bodies/record_outcome_spec.rb
+++ b/spec/services/appropriate_bodies/record_outcome_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe AppropriateBodies::RecordOutcome do
       end
     end
 
-    context "when ongoing induction period only has the legacy programme type" do
+    context "when ongoing induction period only has a mappable legacy programme type" do
       let!(:induction_period) do
         FactoryBot.create(:induction_period, :ongoing, :legacy_programme_type,
                           appropriate_body:,
@@ -278,11 +278,31 @@ RSpec.describe AppropriateBodies::RecordOutcome do
                           started_on: '2024-1-1')
       end
 
-      it "populates the new programme type and outcome" do
+      it "maps the new programme type" do
         service.fail!
 
         expect(induction_period.reload).to have_attributes(
+          induction_programme: 'fip',
           training_programme: 'provider_led',
+          outcome: 'fail'
+        )
+      end
+    end
+
+    context "when ongoing induction period only has an unmappable legacy programme type" do
+      let!(:induction_period) do
+        FactoryBot.create(:induction_period, :ongoing, :pre_2021, :legacy_programme_type,
+                          appropriate_body:,
+                          teacher:,
+                          started_on: '2024-1-1')
+      end
+
+      it "leaves the new programme type blank" do
+        service.fail!
+
+        expect(induction_period.reload).to have_attributes(
+          induction_programme: 'pre_september_2021',
+          training_programme: nil,
           outcome: 'fail'
         )
       end


### PR DESCRIPTION
### Context

Legacy `induction_programme` types of `unknown` and `pre_september_2021` cannot automatically be mapped to the new `training_programme` types.

We have decided that rather than have the AB edit the period and choose `school_led` or `provider_led` we will allow `nil` values.

Closes https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/2531

Related to https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1458

### Changes proposed in this pull request

- Make validation conditional
- Update factory traits and specs

### Guidance to review
