### PR TITLE
Fix bulk claims validations so prohibited comes before passed

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -50,8 +50,8 @@ class TestGuidanceComponent < ApplicationComponent
         ["John Smith",          "1247646", "19/06/1986", "6J8B903G8", "Failed induction in Wales"],
         ["Jim Laney",           "3002065", "01/01/1990", "OA046772B", "Failed induction in Wales"],
         ["Dona Msa",            "3003943", "02/02/1964", "AB722128C", "No QTS"],
-        ["George Orwell",       "2632412", "16/02/1984", "",          "Prohibited from teaching"],
-        ["Neils Clarke-Dolan",  "2908239", "12/08/1978", "",          "Prohibited from teaching"],
+        ["George Orwell",       "2632412", "16/02/1984", "",          "Prohibited from teaching (In progress)"],
+        ["Neils Clarke-Dolan",  "2908239", "12/08/1978", "",          "Prohibited from teaching (Passed)"],
       ]
     end
 

--- a/app/services/appropriate_bodies/process_batch/claim.rb
+++ b/app/services/appropriate_bodies/process_batch/claim.rb
@@ -67,6 +67,9 @@ module AppropriateBodies
           else
             false # can be claimed
           end
+        elsif pending_induction_submission.prohibited_from_teaching?
+          capture_error("#{name} is prohibited from teaching")
+          true
         elsif pending_induction_submission.passed?
           capture_error("#{name} has already passed their induction")
           true
@@ -75,9 +78,6 @@ module AppropriateBodies
           true
         elsif pending_induction_submission.exempt?
           capture_error("#{name} is exempt from completing their induction")
-          true
-        elsif pending_induction_submission.prohibited_from_teaching?
-          capture_error("#{name} is prohibited from teaching")
           true
         elsif pending_induction_submission.no_qts?
           capture_error("#{name} does not have their qualified teacher status (QTS)")

--- a/spec/fixtures/seeds_claim.csv
+++ b/spec/fixtures/seeds_claim.csv
@@ -18,5 +18,5 @@
 "1247646","1986-06-19","provider-led","2025-01-01","Failed induction in Wales"
 "3002065","1990-01-01","school-led","2025-01-01","Failed induction in Wales"
 "3003943","1964-02-02","provider-led","2025-01-01","No QTS"
-"2632412","1984-02-16","provider-led","2025-01-01","Prohibited from teaching"
-"2908239","1978-08-12","school-led","2025-01-01","Prohibited from teaching"
+"2632412","1984-02-16","provider-led","2025-01-01","Prohibited from teaching (In progress)"
+"2908239","1978-08-12","school-led","2025-01-01","Prohibited from teaching (Passed)"


### PR DESCRIPTION
### Context

Bulk errors didn't match the manual journey, if an ECT was passed and also prohibited, the `already passed` error was shown.

### Changes proposed in this pull request

Reorder the validations and annotate the prohibited test teachers.

### Guidance to review

Bulk claim using seed fixtures