### PR TITLE
Disable test guidance in the test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   config.dfe_sign_in_enabled = true
   config.enable_api = true
   config.enable_migration_testing = false
+  config.enable_test_guidance = false
 
   config.active_job.queue_adapter = :test
 


### PR DESCRIPTION
We use the test guidance functionality to help with manual testing by providing users with clues on how to fill in certain fields.

We never want this when running the automated tests as it can trigger false positives - especially now as it controls the session debug info in the footer. i.e. some tests were failing locally because '2025' was expected on the page and also appeared in the session info.
