### PR TITLE
Fix a failing spec by hardcoding the period dates

### DIFF
--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -2,10 +2,12 @@ describe TrainingPeriod do
   include SchoolPartnershipHelpers
 
   describe "declarative updates" do
+    let(:period_boundaries) { { started_on: 3.years.ago.to_date, finished_on: nil } }
+
     context "when target is school" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 3.years.ago.to_date, finished_on: nil) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, **period_boundaries) }
       let(:school_partnership) { FactoryBot.create(:school_partnership) }
-      let(:instance) { FactoryBot.create(:training_period, ect_at_school_period:, school_partnership:) }
+      let(:instance) { FactoryBot.create(:training_period, ect_at_school_period:, school_partnership:, **period_boundaries) }
       let!(:target) { school_partnership.school }
 
       it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
@@ -16,14 +18,14 @@ describe TrainingPeriod do
       let!(:target) { teacher }
 
       context "ECT training period" do
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:) }
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, **period_boundaries) }
         let(:instance) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: ect_at_school_period.started_on, finished_on: ect_at_school_period.finished_on) }
 
         it_behaves_like "a declarative metadata model", on_event: %i[create destroy update], when_changing: %i[started_on finished_on]
       end
 
       context "Mentor training period" do
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:) }
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, **period_boundaries) }
         let(:instance) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: mentor_at_school_period.started_on, finished_on: mentor_at_school_period.finished_on) }
 
         it_behaves_like "a declarative metadata model", on_event: %i[create destroy update], when_changing: %i[started_on finished_on]


### PR DESCRIPTION
We have a few instances of these specs failing because the sequence in the training period factory appears to push the start date beyond the finish date.

```
ActiveRecord::StatementInvalid:
  PG::DataException: ERROR:··range lower bound must be less than or equal to range upper bound
```

In the longer term I think we ought to stop using the base dates (or restrict them to traits) and hardcode them where possible, as in the long run it'll be more robust (at the expense of being a bit more verbose).
