### PR TITLE
Add deferral/withdrawal attribute to `TrainingPeriod`

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -41,6 +41,11 @@ class TrainingPeriod < ApplicationRecord
   validate :trainee_distinct_period
   validate :enveloped_by_trainee_at_school_period
   validate :only_provider_led_mentor_training
+  validate :withdrawn_deferred_are_mutually_exclusive
+  validates :withdrawn_at, presence: true, if: -> { withdrawal_reason.present? }
+  validates :withdrawal_reason, presence: true, if: -> { withdrawn_at.present? }
+  validates :deferred_at, presence: true, if: -> { deferral_reason.present? }
+  validates :deferral_reason, presence: true, if: -> { deferred_at.present? }
 
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
@@ -137,5 +142,11 @@ private
     return if school_partnership.blank?
 
     errors.add(:school_partnership, 'School partnership must be absent for school-led training programmes')
+  end
+
+  def withdrawn_deferred_are_mutually_exclusive
+    return unless withdrawn_at.present? && deferred_at.present?
+
+    errors.add(:base, "A training period cannot be both withdrawn and deferred")
   end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -191,6 +191,10 @@
   - ecf_end_induction_record_id
   - expression_of_interest_id
   - training_programme
+  - deferred_at
+  - deferral_reason
+  - withdrawn_at
+  - withdrawal_reason
   :teacher_migration_failures:
   - id
   - teacher_id

--- a/db/migrate/20251006110349_add_withdrawn_deferred_to_training_periods.rb
+++ b/db/migrate/20251006110349_add_withdrawn_deferred_to_training_periods.rb
@@ -1,0 +1,26 @@
+class AddWithdrawnDeferredToTrainingPeriods < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :withdrawal_reasons, %w[
+      left-teaching-profession
+      moved-school
+      mentor-no-longer-being-mentor
+      switched-to-school-led
+      other
+    ]
+
+    create_enum :deferral_reasons, %w[
+      bereavement
+      long-term-sickness
+      parental-leave
+      career-break
+      other
+    ]
+
+    change_table :training_periods, bulk: true do |t|
+      t.datetime :deferred_at
+      t.enum :deferral_reason, enum_type: :deferral_reasons
+      t.datetime :withdrawn_at
+      t.enum :withdrawal_reason, enum_type: :withdrawal_reasons
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_06_073517) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_073517) do
   create_enum "batch_status", ["pending", "processing", "processed", "completing", "completed", "failed"]
   create_enum "batch_type", ["action", "claim"]
   create_enum "declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed", "extended-1", "extended-2", "extended-3"]
+  create_enum "deferral_reasons", ["bereavement", "long-term-sickness", "parental-leave", "career-break", "other"]
   create_enum "dfe_role_type", ["admin", "super_admin", "finance"]
   create_enum "event_author_types", ["appropriate_body_user", "school_user", "dfe_staff_user", "system", "lead_provider_api"]
   create_enum "fee_types", ["output", "service"]
@@ -39,6 +40,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_073517) do
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
+  create_enum "withdrawal_reasons", ["left-teaching-profession", "moved-school", "mentor-no-longer-being-mentor", "switched-to-school-led", "other"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
   create_table "active_lead_providers", force: :cascade do |t|
@@ -798,6 +800,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_073517) do
     t.uuid "ecf_end_induction_record_id"
     t.bigint "expression_of_interest_id"
     t.enum "training_programme", null: false, enum_type: "training_programme"
+    t.datetime "deferred_at"
+    t.enum "deferral_reason", enum_type: "deferral_reasons"
+    t.datetime "withdrawn_at"
+    t.enum "withdrawal_reason", enum_type: "withdrawal_reasons"
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -24,6 +24,10 @@ erDiagram
     uuid ecf_end_induction_record_id
     integer expression_of_interest_id
     enum training_programme
+    datetime deferred_at
+    enum deferral_reason
+    datetime withdrawn_at
+    enum withdrawal_reason
   }
   TrainingPeriod }o--|| ECTAtSchoolPeriod : belongs_to
   TrainingPeriod }o--|| MentorAtSchoolPeriod : belongs_to

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -63,5 +63,15 @@ FactoryBot.define do
       association :mentor_at_school_period
       ect_at_school_period { nil }
     end
+
+    trait :withdrawn do
+      withdrawn_at { Time.zone.today }
+      withdrawal_reason { "left-teaching-profession" }
+    end
+
+    trait :deferred do
+      deferred_at { Time.zone.today }
+      deferral_reason { "long-term-sickness" }
+    end
   end
 end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -61,7 +61,44 @@ describe TrainingPeriod do
   end
 
   describe "validations" do
+    it { is_expected.not_to validate_presence_of(:withdrawn_at) }
+    it { is_expected.not_to validate_presence_of(:withdrawal_reason) }
+    it { is_expected.not_to validate_presence_of(:deferred_at) }
+    it { is_expected.not_to validate_presence_of(:deferral_reason) }
     it { is_expected.to validate_presence_of(:started_on) }
+
+    context "when deferred_at and withdrawn_at are both present" do
+      subject { FactoryBot.build(:training_period, deferred_at: Time.zone.now, withdrawn_at: Time.zone.now) }
+
+      it "is expected to have an error on base" do
+        subject.valid?
+        expect(subject.errors.messages[:base]).to include("A training period cannot be both withdrawn and deferred")
+      end
+    end
+
+    context "when withdrawn_at is present" do
+      subject { FactoryBot.build(:training_period, withdrawn_at: Time.zone.now) }
+
+      it { is_expected.to validate_presence_of(:withdrawal_reason) }
+    end
+
+    context "when withdrawal_reason is present" do
+      subject { FactoryBot.build(:training_period, withdrawal_reason: "moved-school") }
+
+      it { is_expected.to validate_presence_of(:withdrawn_at) }
+    end
+
+    context "when deferred_at is present" do
+      subject { FactoryBot.build(:training_period, deferred_at: Time.zone.now) }
+
+      it { is_expected.to validate_presence_of(:deferral_reason) }
+    end
+
+    context "when deferral_reason is present" do
+      subject { FactoryBot.build(:training_period, deferral_reason: "parental-leave") }
+
+      it { is_expected.to validate_presence_of(:deferred_at) }
+    end
 
     context "exactly one id of trainee present" do
       context "when ect_at_school_period_id and mentor_at_school_period_id are all nil" do


### PR DESCRIPTION
### Context

In order to support deferrals and withdrawals we need to stamp the date and a reason for the action on the teacher's `TrainingPeriod`.

### Changes proposed in this pull request

Add `withdrawn_at`, `withdrawal_reason`, `deferred_at` and `deferral_reason` to `TrainingPeriod`.
