### PR TITLE
Create training periods with consistent schools in specs

### DIFF
--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -30,7 +30,11 @@ FactoryBot.define do
     end
 
     trait :with_school_partnership do
-      association :school_partnership
+      transient do
+        teacher_period { ect_at_school_period.presence || mentor_at_school_period }
+      end
+
+      school_partnership { association :school_partnership, school: teacher_period.school }
     end
 
     trait :with_no_school_partnership do


### PR DESCRIPTION
Before, it was possible for us to create `TrainingPeriod` records for ECTs or Mentors where the `School` associated to the ECT or Mentor period was **different** to the school associated to the training period via the school partnership.

This doesn't reflect what happens in reality. If an ECT or Mentor is undergoing provider-led training, this will be happening via a school partnership between the lead provider and their school.

This tweaks the factory so we can pass through the school prevent this mismatch.