### PR TITLE
Fix flaky test

### DIFF
--- a/spec/features/migration/view_parity_check_request_spec.rb
+++ b/spec/features/migration/view_parity_check_request_spec.rb
@@ -61,10 +61,12 @@ RSpec.describe "View parity check request" do
     expect(page.get_by_role("heading", name: "Response IDs")).to be_visible
 
     expect(page.get_by_text("There was 1 ID returned by ECF that were not returned by RECT.")).to be_visible
-    expect(page.get_by_text("123")).to be_visible
+    ids = page.locator(".body-ids-diff span.red")
+    expect(ids).to have_text("123")
 
     expect(page.get_by_text("There was 1 ID returned by RECT that were not returned by ECF.")).to be_visible
-    expect(page.get_by_text("456")).to be_visible
+    ids = page.locator(".body-ids-diff span.green")
+    expect(ids).to have_text("456")
   end
 
   scenario "Paginating the parity check responses when there are many" do


### PR DESCRIPTION
Before, this test could fail due to some ambigious matching!!!

If the "Lead Provider" ID clashed with the request IDs created in the test (i.e `123` or `456` were a subset of the lead provider ID (e.g `1237`).

Here is an example [failure].

This refines the expectation so we're looking specifically at the relevant part of the parity check diff.

Now, the test always passes!

[failure]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/18224131789/job/51890828513