### PR TITLE
Don't reset "Change" wizards from a wizard step

### DIFF
--- a/app/controllers/concerns/schools/wizardable.rb
+++ b/app/controllers/concerns/schools/wizardable.rb
@@ -25,7 +25,7 @@ module Schools
 
       before_action -> { @wizard.reset },
                     if: -> { @current_step == :edit },
-                    unless: -> { @previous_step == :check_answers },
+                    unless: -> { wizard_class.step?(@previous_step) },
                     only: :new
 
     private


### PR DESCRIPTION
Before, we reset "Change" wizards if the current step was the `:edit` step unless navigating back from the `:check_answers` step.

This worked fine when our wizards were simple (i.e `:edit` -> `:check_answers` -> `:confirmation`). But this doesn't work well for more complicated wizards.

In the "change mentor" journey, we don't want to reset the wizard if the user navigates back to the `:edit` step from one of the later steps.

But we do want to reset the wizard if the user starts again.