### PR TITLE
Schools can change an ECT's mentor to another registered mentor

### DIFF
--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -26,6 +26,14 @@
   <% list.with_row do |row| %>
     <% row.with_key { "Mentor" } %>
     <% row.with_value { ect_mentor_details(@ect) } %>
+    <% if current_mentor.present? %>
+      <% row.with_action(
+          text: "Change",
+          visually_hidden_text: "mentor",
+          href: schools_ects_change_mentor_wizard_edit_path(@ect),
+          classes: "govuk-link--no-visited-state"
+        ) %>
+    <% end %>
   <% end %>
 
   <% list.with_row do |row| %>

--- a/app/components/schools/teacher_profile_summary_list_component.rb
+++ b/app/components/schools/teacher_profile_summary_list_component.rb
@@ -20,7 +20,7 @@ module Schools
       when "Exempt"
         govuk_tag(text: "Exempt", colour: "grey")
       else
-        if current_mentor_name(@ect)
+        if current_mentor_name
           govuk_tag(text: "Registered", colour: "green")
         else
           govuk_tag(text: "Mentor required", colour: "red")
@@ -28,8 +28,9 @@ module Schools
       end
     end
 
-    def current_mentor_name(ect)
-      ECTAtSchoolPeriods::Mentorship.new(ect).current_mentor_name
-    end
+    def current_mentor = mentorship.current_mentor
+    def current_mentor_name = mentorship.current_mentor_name
+
+    def mentorship = @mentorship ||= ECTAtSchoolPeriods::Mentorship.new(@ect)
   end
 end

--- a/app/controllers/schools/ects/change_mentor_wizard_controller.rb
+++ b/app/controllers/schools/ects/change_mentor_wizard_controller.rb
@@ -1,0 +1,21 @@
+module Schools
+  module ECTs
+    class ChangeMentorWizardController < SchoolsController
+      include Wizardable
+
+      wizard_for :ect
+
+      def new
+        render @current_step
+      end
+
+      def create
+        if @wizard.save!
+          redirect_to @wizard.next_step_path
+        else
+          render @current_step, status: :unprocessable_content
+        end
+      end
+    end
+  end
+end

--- a/app/services/ect_at_school_periods/switch_mentor.rb
+++ b/app/services/ect_at_school_periods/switch_mentor.rb
@@ -1,0 +1,75 @@
+module ECTAtSchoolPeriods
+  class SwitchMentor
+    include TrainingPeriodSources
+
+    def self.switch(...) = new(...).switch
+
+    def initialize(ect_at_school_period, to:, author:, lead_provider:)
+      @ect_at_school_period = ect_at_school_period
+      @mentor_at_school_period = to
+      @author = author
+      @lead_provider = lead_provider
+    end
+
+    def switch
+      ActiveRecord::Base.transaction do
+        assign_mentor!
+
+        if mentor_eligible_for_training?
+          training_period = create_training_period!
+          record_training_period_event!(training_period)
+        end
+      end
+    end
+
+  private
+
+    attr_reader :mentor_at_school_period,
+                :ect_at_school_period,
+                :lead_provider,
+                :author
+
+    def assign_mentor!
+      Schools::AssignMentor.new(
+        author:,
+        ect: ect_at_school_period,
+        mentor: mentor_at_school_period
+      ).assign!
+    end
+
+    def create_training_period!
+      TrainingPeriods::Create.provider_led(
+        period: mentor_at_school_period,
+        started_on: earliest_possible_start_date,
+        school_partnership: earliest_matching_school_partnership,
+        expression_of_interest:
+      ).call
+    end
+
+    def record_training_period_event!(training_period)
+      Events::Record.record_teacher_starts_training_period_event!(
+        author:,
+        teacher: mentor_at_school_period.teacher,
+        school: mentor_at_school_period.school,
+        training_period:,
+        mentor_at_school_period:,
+        ect_at_school_period: nil,
+        happened_at: earliest_possible_start_date
+      )
+    end
+
+    def school = mentor_at_school_period.school
+    def started_on = mentor_at_school_period.started_on
+
+    def earliest_possible_start_date
+      [Date.current, mentor_at_school_period.started_on].max
+    end
+
+    def mentor_eligible_for_training?
+      ::MentorAtSchoolPeriods::Eligibility.for_first_provider_led_training?(
+        ect_at_school_period:,
+        mentor_at_school_period:
+      )
+    end
+  end
+end

--- a/app/views/schools/ects/change_mentor_wizard/check_answers.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/check_answers.html.erb
@@ -1,0 +1,31 @@
+<% page_data(
+    title: "Check and confirm change",
+    backlink_href: @wizard.previous_step_path
+) %>
+
+<%= govuk_summary_list do |list| %>
+  <% list.with_row do |row| %>
+    <%= row.with_key { "Early career teacher" } %>
+    <%= row.with_value { @wizard.teacher_full_name } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <%= row.with_key { "Current mentor" } %>
+    <%= row.with_value { @wizard.current_step.current_mentor_name } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <%= row.with_key { "New mentor" } %>
+    <%= row.with_value { @wizard.current_step.new_mentor_name } %>
+  <% end %>
+<% end %>
+
+<%= govuk_button_to "Confirm change", @wizard.current_step_path %>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+        "Cancel and go back to #{@wizard.teacher_full_name}’s details",
+        schools_ect_path(@wizard.ect_at_school_period),
+        no_visited_state: true
+      ) %>
+</p>

--- a/app/views/schools/ects/change_mentor_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/confirmation.html.erb
@@ -1,0 +1,28 @@
+<% page_data(
+    title: "Mentor updated for #{@wizard.teacher_full_name}",
+    header: false
+) %>
+
+<%= govuk_panel(
+      title_text: <<~TXT
+        You have changed #{@wizard.teacher_full_name}’s mentor to
+        #{@wizard.current_step.current_mentor_name}
+      TXT
+    ) %>
+
+<h2 class="govuk-heading-m">
+ What happens next?
+</h2>
+
+<p class="govuk-body">
+  <%= @wizard.current_step.current_mentor_name %> is now responsible for mentoring
+  <%= @wizard.teacher_full_name %>.
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+        "Back to #{@wizard.teacher_full_name}’s details",
+        schools_ect_path(@wizard.ect_at_school_period),
+        no_visited_state: true
+      ) %>
+</p>

--- a/app/views/schools/ects/change_mentor_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/edit.html.erb
@@ -1,0 +1,26 @@
+<% page_data(
+    title: "Who will mentor #{@wizard.teacher_full_name}?",
+    backlink_href: schools_ect_path(@wizard.ect_at_school_period)
+) %>
+
+<%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |form| %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+  <%= form.govuk_collection_radio_buttons(
+        :mentor_at_school_period_id,
+        @wizard.current_step.mentors_for_select,
+        :id,
+        -> { @wizard.name_for(it.teacher) },
+        legend: {text: "Select the mentor", hidden: true}
+      ) %>
+
+  <%= form.govuk_submit "Continue" %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(
+          "Cancel and go back to #{@wizard.teacher_full_name}’s details",
+          schools_ect_path(@wizard.ect_at_school_period),
+          no_visited_state: true
+        ) %>
+  </p>
+<% end %>

--- a/app/views/schools/ects/change_mentor_wizard/lead_provider.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/lead_provider.html.erb
@@ -1,0 +1,39 @@
+<% page_data(
+    title: "Which lead provider would you like to contact your school about training #{@wizard.current_step.new_mentor_name}?",
+    backlink_href: @wizard.previous_step_path
+  ) %>
+
+<p class="govuk-body">
+  We’ll let the lead provider know that your school is interested in working
+  with them. They’ll contact your school to discuss this further before you
+  decide if you want to go ahead with the mentor training.
+</p>
+
+<%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |form| %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+  <%= form.govuk_collection_radio_buttons(
+        :lead_provider_id,
+        @wizard.current_step.lead_providers_for_select,
+        :id,
+        :name,
+        legend: {text: "Select lead provider", hidden: true},
+      ) %>
+
+  <%= govuk_details(summary_text: "What are the roles of an appropriate body, lead provider and delivery partner?") do %>
+    <p class="govuk-body">
+      An appropriate body is responsible for assuring the quality of the
+      statutory induction of ECTs. A lead provider provides the online learning
+      platform used for training ECTs and mentors, while the delivery partner
+      delivers training events.
+    </p>
+
+    <p class="govuk-body">
+      These roles are sometimes undertaken by the same organisation, for
+      example an appropriate body might be the same organisation as the
+      delivery partner.
+    </p>
+  <% end %>
+
+  <%= form.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/schools/ects/change_mentor_wizard/training.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/training.html.erb
@@ -1,0 +1,33 @@
+<% page_data(
+    title: "#{@wizard.current_step.new_mentor_name} can receive mentor training",
+    backlink_href: @wizard.previous_step_path
+) %>
+
+<p class="govuk-body">
+  Our records show that <%= @wizard.current_step.new_mentor_name %> can get up
+  to 20 hours of ECTE mentor training as your school is working with a
+  DfE-funded training provider.
+</p>
+
+<p class="govuk-body">
+  We’ll pass on their details to
+  <%= @wizard.current_step.current_lead_provider_name %> who will contact them
+  to arrange the training.
+</p>
+
+<%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |form| %>
+  <%= form.hidden_field :accepting_current_lead_provider, value: true %>
+  <%= form.govuk_submit "Continue" %>
+
+  <p class="govuk-body">
+    <% change_provider_link_text = <<~TXT.squish
+        #{@wizard.current_step.current_lead_provider_name} will not be providing
+        mentor training to #{@wizard.current_step.new_mentor_name}
+      TXT
+    %>
+    <%= govuk_link_to(
+          change_provider_link_text,
+          schools_ects_change_mentor_wizard_lead_provider_path(@wizard.current_step.ect_at_school_period)
+        ) %>
+  </p>
+<% end %>

--- a/app/wizards/schools/ects/change_mentor_wizard/check_answers_step.rb
+++ b/app/wizards/schools/ects/change_mentor_wizard/check_answers_step.rb
@@ -1,0 +1,64 @@
+module Schools
+  module ECTs
+    module ChangeMentorWizard
+      class CheckAnswersStep < Step
+        def previous_step
+          return :edit unless mentor_eligible_for_training?
+          return :training if store.accepting_current_lead_provider
+
+          :lead_provider
+        end
+
+        def next_step = :confirmation
+
+        def current_mentor_name = name_for(current_mentor_at_school_period.teacher)
+        def new_mentor_name = name_for(selected_mentor_at_school_period.teacher)
+
+        def save!
+          ECTAtSchoolPeriods::SwitchMentor.switch(
+            ect_at_school_period,
+            to: selected_mentor_at_school_period,
+            author:,
+            lead_provider: selected_lead_provider
+          )
+
+          true
+        end
+
+      private
+
+        def mentor_eligible_for_training?
+          ::MentorAtSchoolPeriods::Eligibility.for_first_provider_led_training?(
+            ect_at_school_period:,
+            mentor_at_school_period: selected_mentor_at_school_period
+          )
+        end
+
+        def current_mentor_at_school_period
+          ect_at_school_period.current_or_next_mentorship_period.mentor
+        end
+
+        def selected_mentor_at_school_period
+          ect_at_school_period
+            .school
+            .mentor_at_school_periods
+            .find(store.mentor_at_school_period_id)
+        end
+
+        def selected_lead_provider
+          @selected_lead_provider ||= if store.accepting_current_lead_provider
+                                        lead_provider_for_ect_at_school_period
+                                      else
+                                        LeadProvider.find_by(id: store.lead_provider_id)
+                                      end
+        end
+
+        def lead_provider_for_ect_at_school_period
+          @lead_provider_for_ect_at_school_period ||= ECTAtSchoolPeriods::CurrentTraining
+            .new(ect_at_school_period)
+            .lead_provider_via_school_partnership_or_eoi
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_mentor_wizard/confirmation_step.rb
+++ b/app/wizards/schools/ects/change_mentor_wizard/confirmation_step.rb
@@ -1,0 +1,17 @@
+module Schools
+  module ECTs
+    module ChangeMentorWizard
+      class ConfirmationStep < Step
+        def previous_step = :check_answers
+
+        def current_mentor_name = name_for(current_mentor_at_school_period.teacher)
+
+      private
+
+        def current_mentor_at_school_period
+          ect_at_school_period.current_or_next_mentorship_period.mentor
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_mentor_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/change_mentor_wizard/edit_step.rb
@@ -1,0 +1,67 @@
+module Schools
+  module ECTs
+    module ChangeMentorWizard
+      class EditStep < Step
+        attribute :mentor_at_school_period_id, :string
+
+        validates :mentor_at_school_period_id,
+                  inclusion: {
+                    in: ->(step) do
+                      step.mentors_for_select.map { it.id.to_s }
+                    end,
+                    message: "Select a mentor from the list provided"
+                  },
+                  allow_blank: false
+
+        def self.permitted_params = [:mentor_at_school_period_id]
+
+        def next_step
+          if mentor_eligible_for_training?
+            :training
+          else
+            :check_answers
+          end
+        end
+
+        def save!
+          store.mentor_at_school_period_id = mentor_at_school_period_id if valid_step?
+        end
+
+        def mentors_for_select
+          eligible_mentors.without(current_mentor_at_school_period)
+        end
+
+      private
+
+        def pre_populate_attributes
+          self.mentor_at_school_period_id = store.mentor_at_school_period_id
+        end
+
+        def mentor_eligible_for_training?
+          ::MentorAtSchoolPeriods::Eligibility.for_first_provider_led_training?(
+            ect_at_school_period:,
+            mentor_at_school_period: selected_mentor_at_school_period
+          )
+        end
+
+        def current_mentor_at_school_period
+          ect_at_school_period.current_or_next_mentorship_period.mentor
+        end
+
+        def selected_mentor_at_school_period
+          ect_at_school_period
+            .school
+            .mentor_at_school_periods
+            .find(store.mentor_at_school_period_id)
+        end
+
+        def eligible_mentors
+          @eligible_mentors ||= Schools::EligibleMentors
+            .new(ect_at_school_period.school)
+            .for_ect(ect_at_school_period)
+            .includes(:teacher)
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_mentor_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/ects/change_mentor_wizard/lead_provider_step.rb
@@ -1,0 +1,61 @@
+module Schools
+  module ECTs
+    module ChangeMentorWizard
+      class LeadProviderStep < Step
+        attribute :lead_provider_id, :string
+
+        validates :lead_provider_id,
+                  presence: { message: "Select which lead provider will be training the ECT" },
+                  lead_provider: { message: "Enter the name of a known lead provider" }
+
+        def self.permitted_params = [:lead_provider_id]
+
+        def previous_step = :training
+        def next_step = :check_answers
+
+        def new_mentor_name = name_for(selected_mentor_at_school_period.teacher)
+
+        def save!
+          store.lead_provider_id = lead_provider_id if valid_step?
+        end
+
+        def lead_providers_for_select
+          active_lead_providers_in_contract_period
+            .without(lead_provider_for_ect_at_school_period)
+        end
+
+      private
+
+        def pre_populate_attributes
+          self.lead_provider_id = store.lead_provider_id
+        end
+
+        def selected_mentor_at_school_period
+          ect_at_school_period
+            .school
+            .mentor_at_school_periods
+            .find(store.mentor_at_school_period_id)
+        end
+
+        def active_lead_providers_in_contract_period
+          return [] unless contract_period
+
+          @active_lead_providers_in_contract_period ||= ::LeadProviders::Active
+            .in_contract_period(contract_period)
+            .select(:id, :name)
+        end
+
+        def contract_period
+          @contract_period ||= ContractPeriod
+            .containing_date(selected_mentor_at_school_period.started_on)
+        end
+
+        def lead_provider_for_ect_at_school_period
+          @lead_provider_for_ect_at_school_period ||= ECTAtSchoolPeriods::CurrentTraining
+            .new(ect_at_school_period)
+            .lead_provider_via_school_partnership_or_eoi
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_mentor_wizard/training_step.rb
+++ b/app/wizards/schools/ects/change_mentor_wizard/training_step.rb
@@ -1,0 +1,36 @@
+module Schools
+  module ECTs
+    module ChangeMentorWizard
+      class TrainingStep < Step
+        attribute :accepting_current_lead_provider, :boolean
+
+        def self.permitted_params = [:accepting_current_lead_provider]
+
+        def previous_step = :edit
+        def next_step = :check_answers
+
+        def current_lead_provider_name = lead_provider_for_ect_at_school_period&.name
+        def new_mentor_name = name_for(selected_mentor_at_school_period.teacher)
+
+        def save!
+          store.accepting_current_lead_provider = accepting_current_lead_provider
+        end
+
+      private
+
+        def selected_mentor_at_school_period
+          ect_at_school_period
+            .school
+            .mentor_at_school_periods
+            .find(store.mentor_at_school_period_id)
+        end
+
+        def lead_provider_for_ect_at_school_period
+          @lead_provider_for_ect_at_school_period ||= ECTAtSchoolPeriods::CurrentTraining
+            .new(ect_at_school_period)
+            .lead_provider_via_school_partnership_or_eoi
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/ects/change_mentor_wizard/wizard.rb
@@ -1,0 +1,17 @@
+module Schools
+  module ECTs
+    module ChangeMentorWizard
+      class Wizard < ECTs::Wizard
+        steps do
+          [{
+            edit: EditStep,
+            training: TrainingStep,
+            lead_provider: LeadProviderStep,
+            check_answers: CheckAnswersStep,
+            confirmation: ConfirmationStep
+          }]
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/step.rb
+++ b/app/wizards/schools/ects/step.rb
@@ -5,7 +5,7 @@ module Schools
 
     private
 
-      delegate :ect_at_school_period, :author, :valid_step?, to: :wizard
+      delegate :ect_at_school_period, :author, :valid_step?, :name_for, to: :wizard
 
       def pre_populate_attributes = nil
     end

--- a/app/wizards/schools/ects/wizard.rb
+++ b/app/wizards/schools/ects/wizard.rb
@@ -8,8 +8,11 @@ module Schools
       end
 
       # @return [String]
+      def name_for(...) = ::Teachers::Name.new(...).full_name
+
+      # @return [String]
       def teacher_full_name
-        ::Teachers::Name.new(ect_at_school_period.teacher.reload).full_name
+        name_for(ect_at_school_period.teacher.reload)
       end
 
       # @return [Hash]

--- a/config/routes/school.rb
+++ b/config/routes/school.rb
@@ -26,6 +26,10 @@ constraints -> { Rails.application.config.enable_schools_interface } do
       namespace :change_training_programme_wizard, path: "change-training-programme" do
         concerns :wizardable, wizard: Schools::ECTs::ChangeTrainingProgrammeWizard
       end
+
+      namespace :change_mentor_wizard, path: "change-mentor" do
+        concerns :wizardable, wizard: Schools::ECTs::ChangeMentorWizard
+      end
     end
 
     scope module: :mentors, path: "/mentors/:mentor_id", as: :mentors do

--- a/spec/features/schools/ects/change/mentor_spec.rb
+++ b/spec/features/schools/ects/change/mentor_spec.rb
@@ -1,0 +1,295 @@
+describe "School user can change ECTs email address", :enable_schools_interface do
+  context "when the mentor does not need mentor training" do
+    it "changes the mentor to an existing mentor" do
+      given_there_is_a_school
+      and_there_is_an_ect
+      with_school_led_training
+      and_the_ect_has_an_assigned_mentor
+      and_there_is_another_registered_mentor
+      and_i_am_logged_in_as_a_school_user
+
+      when_i_visit_the_ect_page
+      then_i_can_change_the_assigned_mentor
+      and_i_see_the_change_mentor_form
+      and_the_current_mentor_is_not_an_option
+
+      when_i_change_the_mentor_to_another_registered_mentor
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_navigate_back_to_the_form
+      and_i_see_the_change_mentor_form
+      then_the_mentor_is_selected
+
+      when_i_continue
+      and_i_confirm_the_change
+      then_i_see_the_confirmation_message
+    end
+  end
+
+  context "when the mentor can receive mentor training" do
+    it "changes the mentor to an existing mentor with the same lead provider" do
+      given_there_is_a_school
+      and_there_is_an_ect
+      and_there_is_a_contract_period
+      with_provider_led_training
+      and_the_ect_has_an_assigned_mentor
+      and_there_is_another_registered_mentor
+      and_the_other_registered_mentor_can_receive_mentor_training
+      and_i_am_logged_in_as_a_school_user
+
+      when_i_visit_the_ect_page
+      then_i_can_change_the_assigned_mentor
+      and_i_see_the_change_mentor_form
+      and_the_current_mentor_is_not_an_option
+
+      when_i_change_the_mentor_to_another_registered_mentor
+      and_i_continue
+      then_the_mentor_can_receive_mentor_training
+
+      when_i_navigate_back_to_the_form
+      and_i_see_the_change_mentor_form
+      then_the_mentor_is_selected
+
+      when_i_continue
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_navigate_back_to_the_form
+      then_the_mentor_can_receive_mentor_training
+
+      when_i_continue
+      and_i_confirm_the_change
+      then_i_see_the_confirmation_message
+    end
+
+    it "changes the mentor to an existing mentor with a different lead provider" do
+      given_there_is_a_school
+      and_there_is_an_ect
+      and_there_is_a_contract_period
+      and_there_is_an_active_lead_provider
+      with_provider_led_training
+      and_the_ect_has_an_assigned_mentor
+      and_there_is_another_registered_mentor
+      and_the_other_registered_mentor_can_receive_mentor_training
+      and_i_am_logged_in_as_a_school_user
+
+      when_i_visit_the_ect_page
+      then_i_can_change_the_assigned_mentor
+      and_i_see_the_change_mentor_form
+      and_the_current_mentor_is_not_an_option
+
+      when_i_change_the_mentor_to_another_registered_mentor
+      and_i_continue
+      then_the_mentor_can_receive_mentor_training
+
+      when_i_navigate_back_to_the_form
+      and_i_see_the_change_mentor_form
+      then_the_mentor_is_selected
+
+      when_i_continue
+      then_i_change_lead_provider
+      and_i_see_the_change_lead_provider_form
+
+      when_i_choose_a_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_navigate_back_to_the_form
+      and_i_see_the_change_lead_provider_form
+      then_the_lead_provider_is_selected
+
+      when_i_continue
+      and_i_confirm_the_change
+      then_i_see_the_confirmation_message
+    end
+  end
+
+private
+
+  def given_there_is_a_school
+    @school = FactoryBot.create(:school)
+  end
+
+  def and_there_is_an_ect
+    @teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "John",
+      trs_last_name: "Doe"
+    )
+    @ect = FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      teacher: @teacher,
+      school: @school,
+      email: "ect@example.com",
+      started_on: 1.week.ago
+    )
+  end
+
+  def and_there_is_a_contract_period
+    @contract_period = FactoryBot.create(:contract_period, :current)
+  end
+
+  def and_there_is_an_active_lead_provider
+    lead_provider = FactoryBot.create(:lead_provider, name: "Testing Provider")
+    @active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      contract_period: @contract_period,
+      lead_provider:
+    )
+  end
+
+  def with_school_led_training
+    FactoryBot.create(
+      :training_period,
+      :school_led,
+      :for_ect,
+      :ongoing,
+      ect_at_school_period: @ect,
+      started_on: @ect.started_on
+    )
+  end
+
+  def with_provider_led_training
+    @provider_led_training_period = FactoryBot.create(
+      :training_period,
+      :provider_led,
+      :for_ect,
+      :ongoing,
+      ect_at_school_period: @ect,
+      started_on: @ect.started_on
+    )
+    @provider_led_training_period
+      .active_lead_provider
+      .update!(contract_period: @contract_period)
+  end
+
+  def and_the_ect_has_an_assigned_mentor
+    teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "John",
+      trs_last_name: "Mentor"
+    )
+    mentor_at_school_period = FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      teacher:,
+      school: @school,
+      started_on: @ect.started_on - 2.months
+    )
+    FactoryBot.create(
+      :mentorship_period,
+      :ongoing,
+      mentee: @ect,
+      mentor: mentor_at_school_period,
+      started_on: @ect.started_on
+    )
+  end
+
+  def and_there_is_another_registered_mentor
+    @mentor_teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "Jane",
+      trs_last_name: "Smith"
+    )
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      teacher: @mentor_teacher,
+      school: @school,
+      started_on: @ect.started_on - 1.month
+    )
+  end
+
+  def and_the_other_registered_mentor_can_receive_mentor_training
+    @mentor_teacher.update!(
+      mentor_became_ineligible_for_funding_on: nil,
+      mentor_became_ineligible_for_funding_reason: nil
+    )
+  end
+
+  def and_i_am_logged_in_as_a_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def when_i_visit_the_ect_page
+    page.goto(schools_ect_path(@ect))
+  end
+
+  def then_i_can_change_the_assigned_mentor
+    row = page.locator(".govuk-summary-list__row", hasText: "Mentor")
+    row.get_by_role("link", name: "Change").click
+  end
+
+  def and_i_see_the_change_mentor_form
+    heading = page.locator("h1")
+    expect(heading).to have_text("Who will mentor John Doe?")
+  end
+
+  def and_the_current_mentor_is_not_an_option
+    expect(page.get_by_label("John Mentor")).not_to be_visible
+  end
+
+  def when_i_change_the_mentor_to_another_registered_mentor
+    page.get_by_label("Jane Smith").check
+  end
+
+  def and_i_continue
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_the_mentor_can_receive_mentor_training
+    heading = page.locator("h1")
+    expect(heading).to have_text("Jane Smith can receive mentor training")
+  end
+
+  def then_i_am_asked_to_check_and_confirm_the_change
+    heading = page.locator("h1")
+    expect(heading).to have_text("Check and confirm change")
+  end
+
+  def when_i_navigate_back_to_the_form
+    page.get_by_role("link", name: "Back", exact: true).click
+  end
+
+  def then_the_mentor_is_selected
+    mentor_radio = page.get_by_label("Jane Smith")
+    expect(mentor_radio).to be_checked
+  end
+
+  alias_method :when_i_continue, :and_i_continue
+
+  def and_i_confirm_the_change
+    page.get_by_role("button", name: "Confirm change").click
+  end
+
+  def then_i_change_lead_provider
+    change_provider_link_text = <<~TXT.squish
+      #{@provider_led_training_period.lead_provider.name} will not be providing
+      mentor training to Jane Smith
+    TXT
+    page.get_by_role("link", name: change_provider_link_text).click
+  end
+
+  def and_i_see_the_change_lead_provider_form
+    heading = page.locator("h1")
+    expect(heading).to have_text("Which lead provider would you like to contact")
+  end
+
+  def when_i_choose_a_lead_provider
+    page.get_by_label("Testing Provider").check
+  end
+
+  def then_the_lead_provider_is_selected
+    lead_provider_radio = page.get_by_label("Testing Provider")
+    expect(lead_provider_radio).to be_checked
+  end
+
+  def then_i_see_the_confirmation_message
+    success_panel = page.locator(".govuk-panel")
+    expect(success_panel).to have_text(
+      "You have changed John Doe’s mentor to Jane Smith"
+    )
+  end
+end

--- a/spec/requests/schools/ects/change_mentor_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_mentor_wizard_spec.rb
@@ -1,0 +1,388 @@
+describe "Schools::ECTs::ChangeMentorWizardController", :enable_schools_interface do
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      teacher:,
+      school:,
+      started_on: contract_period.started_on + 2.months
+    )
+  end
+  let(:mentor_teacher) { FactoryBot.create(:teacher) }
+  let(:mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      teacher: mentor_teacher,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let!(:mentorship_period) do
+    FactoryBot.create(
+      :mentorship_period,
+      :ongoing,
+      mentee: ect_at_school_period,
+      mentor: mentor_at_school_period,
+      started_on: ect_at_school_period.started_on
+    )
+  end
+
+  describe "GET #new" do
+    context "when not signed in" do
+      it "redirects to the root page" do
+        get path_for_step("edit")
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed in as a non-School user" do
+      include_context "sign in as DfE user"
+
+      it "returns unauthorized" do
+        get path_for_step("edit")
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when signed in as a School user" do
+      before { sign_in_as(:school_user, school:) }
+
+      context "when the current_step is invalid" do
+        it "returns not found" do
+          get path_for_step("nope")
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the current_step is valid" do
+        it "returns ok" do
+          get path_for_step("edit")
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe "POST #create" do
+    let(:other_mentor_teacher) { FactoryBot.create(:teacher) }
+    let(:other_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :ongoing,
+        teacher: other_mentor_teacher,
+        school:,
+        started_on: ect_at_school_period.started_on - 1.week
+      )
+    end
+    let(:mentor_at_school_period_id) { other_mentor_at_school_period.id }
+    let(:params) { { edit: { mentor_at_school_period_id: } } }
+
+    context "when not signed in" do
+      it "redirects to the root path" do
+        post(path_for_step("edit"), params:)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed in as a non-School user" do
+      include_context "sign in as DfE user"
+
+      it "returns unauthorized" do
+        post(path_for_step("edit"), params:)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when signed in as a School user" do
+      let(:school_user) { FactoryBot.create(:school_user, school:) }
+
+      before { sign_in_as(:school_user, school:) }
+
+      context "when the current_step is invalid" do
+        it "returns not found" do
+          post(path_for_step("nope"), params:)
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the ECT is undergoing school-led training" do
+        let!(:ect_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :school_led,
+            :for_ect,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+
+        it "assigns a mentor without training" do
+          post(path_for_step("edit"), params:)
+
+          expect(response).to redirect_to(path_for_step("check-answers"))
+
+          follow_redirect!
+
+          expect { post(path_for_step("check-answers")) }
+            .not_to change(TrainingPeriod, :count)
+
+          ect_at_school_period.reload
+          expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+            .to eq(other_mentor_at_school_period)
+          expect(other_mentor_at_school_period.training_periods)
+            .to be_empty
+          expect(response).to redirect_to(path_for_step("confirmation"))
+        end
+
+        it "records the relevant events only after confirmation" do
+          allow(Events::Record).to receive(:record_teacher_starts_training_period_event!)
+          allow(Events::Record).to receive(:record_teacher_starts_being_mentored_event!)
+          allow(Events::Record).to receive(:record_teacher_starts_mentoring_event!)
+
+          post(path_for_step("edit"), params:)
+          follow_redirect!
+          post(path_for_step("check-answers"))
+
+          expect(Events::Record).not_to have_received(:record_teacher_starts_training_period_event!)
+          expect(Events::Record).to have_received(:record_teacher_starts_being_mentored_event!)
+          expect(Events::Record).to have_received(:record_teacher_starts_mentoring_event!)
+
+          expect(response).to redirect_to(path_for_step("confirmation"))
+        end
+      end
+
+      context "when the ECT is undergoing provider-led training" do
+        let!(:ect_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :provider_led,
+            :for_ect,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+
+        before do
+          ect_training_period.active_lead_provider.update!(contract_period:)
+        end
+
+        context "when the mentor has a provider-led training period" do
+          let!(:other_mentor_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :ongoing,
+              :provider_led,
+              :for_mentor,
+              mentor_at_school_period: other_mentor_at_school_period,
+              started_on: other_mentor_at_school_period.started_on
+            )
+          end
+
+          it "assigns a mentor without training" do
+            post(path_for_step("edit"), params:)
+
+            expect(response).to redirect_to(path_for_step("check-answers"))
+
+            follow_redirect!
+
+            expect { post(path_for_step("check-answers")) }
+              .not_to change(TrainingPeriod, :count)
+
+            ect_at_school_period.reload
+            expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+              .to eq(other_mentor_at_school_period)
+            expect(other_mentor_at_school_period.training_periods)
+              .to contain_exactly(other_mentor_training_period)
+            expect(response).to redirect_to(path_for_step("confirmation"))
+          end
+
+          it "records the relevant events only after confirmation" do
+            allow(Events::Record).to receive(:record_teacher_starts_training_period_event!)
+            allow(Events::Record).to receive(:record_teacher_starts_being_mentored_event!)
+            allow(Events::Record).to receive(:record_teacher_starts_mentoring_event!)
+
+            post(path_for_step("edit"), params:)
+            follow_redirect!
+            post(path_for_step("check-answers"))
+
+            expect(Events::Record).not_to have_received(:record_teacher_starts_training_period_event!)
+            expect(Events::Record).to have_received(:record_teacher_starts_being_mentored_event!)
+            expect(Events::Record).to have_received(:record_teacher_starts_mentoring_event!)
+
+            expect(response).to redirect_to(path_for_step("confirmation"))
+          end
+        end
+
+        context "when the mentor is ineligible for funding" do
+          let(:other_mentor_teacher) do
+            FactoryBot.create(:teacher, :ineligible_for_mentor_funding)
+          end
+
+          it "assigns a mentor without training" do
+            post(path_for_step("edit"), params:)
+
+            expect(response).to redirect_to(path_for_step("check-answers"))
+
+            follow_redirect!
+
+            expect { post(path_for_step("check-answers")) }
+              .not_to change(TrainingPeriod, :count)
+
+            ect_at_school_period.reload
+            expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+              .to eq(other_mentor_at_school_period)
+            expect(other_mentor_at_school_period.training_periods)
+              .to be_empty
+            expect(response).to redirect_to(path_for_step("confirmation"))
+          end
+
+          it "records the relevant events only after confirmation" do
+            allow(Events::Record).to receive(:record_teacher_starts_training_period_event!)
+            allow(Events::Record).to receive(:record_teacher_starts_being_mentored_event!)
+            allow(Events::Record).to receive(:record_teacher_starts_mentoring_event!)
+
+            post(path_for_step("edit"), params:)
+            follow_redirect!
+            post(path_for_step("check-answers"))
+
+            expect(Events::Record).not_to have_received(:record_teacher_starts_training_period_event!)
+            expect(Events::Record).to have_received(:record_teacher_starts_being_mentored_event!)
+            expect(Events::Record).to have_received(:record_teacher_starts_mentoring_event!)
+
+            expect(response).to redirect_to(path_for_step("confirmation"))
+          end
+        end
+
+        context "when the mentor is eligible for funding" do
+          context "when the mentor has the same lead provider" do
+            it "assigns a mentor with training" do
+              post(path_for_step("edit"), params:)
+
+              expect(response).to redirect_to(path_for_step("training"))
+
+              follow_redirect!
+
+              training_params = { training: { accepting_current_lead_provider: true } }
+              post(path_for_step("training"), params: training_params)
+
+              expect(response).to redirect_to(path_for_step("check-answers"))
+
+              follow_redirect!
+
+              expect { post(path_for_step("check-answers")) }
+                .to change(TrainingPeriod, :count).by(1)
+
+              ect_at_school_period.reload
+              new_training_period = TrainingPeriod.last
+              expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+                .to eq(other_mentor_at_school_period)
+              expect(other_mentor_at_school_period.training_periods)
+                .to contain_exactly(new_training_period)
+              expect(new_training_period.lead_provider)
+                .to eq(ect_training_period.lead_provider)
+              expect(response).to redirect_to(path_for_step("confirmation"))
+            end
+
+            it "records the relevant events only after confirmation" do
+              allow(Events::Record).to receive(:record_teacher_starts_training_period_event!)
+              allow(Events::Record).to receive(:record_teacher_starts_being_mentored_event!)
+              allow(Events::Record).to receive(:record_teacher_starts_mentoring_event!)
+
+              post(path_for_step("edit"), params:)
+              follow_redirect!
+              training_params = { training: { accepting_current_lead_provider: true } }
+              post(path_for_step("training"), params: training_params)
+              follow_redirect!
+              post(path_for_step("check-answers"))
+
+              expect(Events::Record).to have_received(:record_teacher_starts_training_period_event!)
+              expect(Events::Record).to have_received(:record_teacher_starts_being_mentored_event!)
+              expect(Events::Record).to have_received(:record_teacher_starts_mentoring_event!)
+
+              expect(response).to redirect_to(path_for_step("confirmation"))
+            end
+          end
+
+          context "when the mentor has a different lead provider" do
+            let(:other_lead_provider) do
+              FactoryBot.create(:active_lead_provider, contract_period:)
+                .lead_provider
+            end
+
+            it "assigns a mentor with training" do
+              post(path_for_step("edit"), params:)
+
+              expect(response).to redirect_to(path_for_step("training"))
+
+              follow_redirect!
+
+              get(path_for_step("lead-provider"))
+
+              lead_provider_params = {
+                lead_provider: { lead_provider_id: other_lead_provider.id }
+              }
+              post(path_for_step("lead-provider"), params: lead_provider_params)
+
+              expect(response).to redirect_to(path_for_step("check-answers"))
+
+              follow_redirect!
+
+              expect { post(path_for_step("check-answers")) }
+                .to change(TrainingPeriod, :count).by(1)
+
+              ect_at_school_period.reload
+              new_training_period = TrainingPeriod.last
+              expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+                .to eq(other_mentor_at_school_period)
+              expect(other_mentor_at_school_period.training_periods)
+                .to contain_exactly(new_training_period)
+              expect(new_training_period.expression_of_interest_lead_provider)
+                .to eq(other_lead_provider)
+              expect(response).to redirect_to(path_for_step("confirmation"))
+            end
+
+            it "records the relevant events only after confirmation" do
+              allow(Events::Record).to receive(:record_teacher_starts_training_period_event!)
+              allow(Events::Record).to receive(:record_teacher_starts_being_mentored_event!)
+              allow(Events::Record).to receive(:record_teacher_starts_mentoring_event!)
+
+              post(path_for_step("edit"), params:)
+              follow_redirect!
+              lead_provider_params = {
+                lead_provider: { lead_provider_id: other_lead_provider.id }
+              }
+              post(path_for_step("lead-provider"), params: lead_provider_params)
+              follow_redirect!
+              post(path_for_step("check-answers"))
+
+              expect(Events::Record).to have_received(:record_teacher_starts_training_period_event!)
+              expect(Events::Record).to have_received(:record_teacher_starts_being_mentored_event!)
+              expect(Events::Record).to have_received(:record_teacher_starts_mentoring_event!)
+
+              expect(response).to redirect_to(path_for_step("confirmation"))
+            end
+          end
+        end
+      end
+    end
+  end
+
+private
+
+  def path_for_step(step)
+    "/school/ects/#{ect_at_school_period.id}/change-mentor/#{step}"
+  end
+end

--- a/spec/services/ect_at_school_periods/switch_mentor_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_mentor_spec.rb
@@ -1,0 +1,181 @@
+module ECTAtSchoolPeriods
+  describe SwitchMentor do
+    subject(:switch_mentor) do
+      SwitchMentor.switch(
+        ect_at_school_period,
+        to: selected_mentor_at_school_period,
+        author:,
+        lead_provider:
+      )
+    end
+
+    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+    let(:author) do
+      FactoryBot.create(:school_user, school_urn: ect_at_school_period.school.urn)
+    end
+
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.ago)
+    end
+
+    let(:selected_mentor_teacher) { FactoryBot.create(:teacher) }
+    let(:selected_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :ongoing,
+        school: ect_at_school_period.school,
+        teacher: selected_mentor_teacher,
+        started_on: ect_at_school_period.started_on - 1.month
+      )
+    end
+
+    describe ".switch" do
+      context "when the ECT is undergoing school-led training" do
+        let!(:ect_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :school_led,
+            :for_ect,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+        let(:lead_provider) { nil }
+
+        it "assigns a mentor" do
+          expect { switch_mentor }.to change(MentorshipPeriod, :count).by(1)
+
+          ect_at_school_period.reload
+          expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+            .to eq(selected_mentor_at_school_period)
+        end
+
+        it "does not create a training period" do
+          expect { switch_mentor }.not_to change(TrainingPeriod, :count)
+        end
+
+        it "does not record a `teacher_starts_training_period` event" do
+          allow(Events::Record)
+            .to receive(:record_teacher_starts_training_period_event!)
+
+          switch_mentor
+
+          expect(Events::Record)
+            .not_to have_received(:record_teacher_starts_training_period_event!)
+        end
+      end
+
+      context "when the ECT is undergoing provider-led training" do
+        let!(:ect_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :provider_led,
+            :for_ect,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on
+          )
+        end
+        let(:lead_provider) { ect_training_period.lead_provider }
+
+        before do
+          ect_training_period.active_lead_provider.update!(contract_period:)
+        end
+
+        context "when the mentor has a provider-led training period" do
+          let!(:selected_mentor_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :ongoing,
+              :provider_led,
+              :for_mentor,
+              mentor_at_school_period: selected_mentor_at_school_period,
+              started_on: selected_mentor_at_school_period.started_on
+            )
+          end
+
+          it "assigns a mentor" do
+            expect { switch_mentor }.to change(MentorshipPeriod, :count).by(1)
+
+            ect_at_school_period.reload
+            expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+              .to eq(selected_mentor_at_school_period)
+          end
+
+          it "does not create a training period" do
+            expect { switch_mentor }.not_to change(TrainingPeriod, :count)
+          end
+
+          it "does not record a `teacher_starts_training_period` event" do
+            allow(Events::Record)
+              .to receive(:record_teacher_starts_training_period_event!)
+
+            switch_mentor
+
+            expect(Events::Record)
+              .not_to have_received(:record_teacher_starts_training_period_event!)
+          end
+        end
+
+        context "when the mentor is ineligible for funding" do
+          let(:selected_mentor_teacher) do
+            FactoryBot.create(:teacher, :ineligible_for_mentor_funding)
+          end
+
+          it "assigns a mentor" do
+            expect { switch_mentor }.to change(MentorshipPeriod, :count).by(1)
+
+            ect_at_school_period.reload
+            expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+              .to eq(selected_mentor_at_school_period)
+          end
+
+          it "does not create a training period" do
+            expect { switch_mentor }.not_to change(TrainingPeriod, :count)
+          end
+
+          it "does not record a `teacher_starts_training_period` event" do
+            allow(Events::Record)
+              .to receive(:record_teacher_starts_training_period_event!)
+
+            switch_mentor
+
+            expect(Events::Record)
+              .not_to have_received(:record_teacher_starts_training_period_event!)
+          end
+        end
+
+        context "when the mentor is eligible for funding" do
+          it "assigns a mentor" do
+            expect { switch_mentor }.to change(MentorshipPeriod, :count).by(1)
+
+            ect_at_school_period.reload
+            expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
+              .to eq(selected_mentor_at_school_period)
+          end
+
+          it "creates a training period" do
+            expect { switch_mentor }.to change(TrainingPeriod, :count).by(1)
+
+            new_training_period = TrainingPeriod.last
+            expect(selected_mentor_at_school_period.training_periods)
+              .to contain_exactly(new_training_period)
+            expect(new_training_period.lead_provider)
+              .to eq(ect_training_period.lead_provider)
+          end
+
+          it "records a `teacher_starts_training_period` event" do
+            allow(Events::Record)
+              .to receive(:record_teacher_starts_training_period_event!)
+
+            switch_mentor
+
+            expect(Events::Record)
+              .to have_received(:record_teacher_starts_training_period_event!)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_mentor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/check_answers_step_spec.rb
@@ -1,0 +1,144 @@
+describe Schools::ECTs::ChangeMentorWizard::CheckAnswersStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeMentorWizard::Wizard.new(
+      current_step: :check_answers,
+      step_params: ActionController::Parameters.new(check_answers: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) do
+    FactoryBot.build(
+      :session_repository,
+      mentor_at_school_period_id: mentor_at_school_period.id,
+      accepting_current_lead_provider:
+    )
+  end
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      school:,
+      started_on: 1.week.ago
+    )
+  end
+  let(:mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let(:accepting_current_lead_provider) { nil }
+  let(:params) { {} }
+
+  describe "#previous_step" do
+    context "when the mentor is not eligible for training" do
+      before do
+        allow(::MentorAtSchoolPeriods::Eligibility)
+          .to receive(:for_first_provider_led_training?)
+          .and_return(false)
+      end
+
+      it "returns the edit step" do
+        expect(current_step.previous_step).to eq(:edit)
+      end
+    end
+
+    context "when the mentor is eligible for training" do
+      before do
+        allow(::MentorAtSchoolPeriods::Eligibility)
+          .to receive(:for_first_provider_led_training?)
+          .and_return(true)
+      end
+
+      context "when the current lead provider has been accepted" do
+        let(:accepting_current_lead_provider) { true }
+
+        it "returns the training step" do
+          expect(current_step.previous_step).to eq(:training)
+        end
+      end
+
+      context "when the current lead provider has not been accepted" do
+        it "returns the lead provider step" do
+          expect(current_step.previous_step).to eq(:lead_provider)
+        end
+      end
+    end
+  end
+
+  describe "#next_step" do
+    it "returns the check answers step" do
+      expect(current_step.next_step).to eq(:confirmation)
+    end
+  end
+
+  describe "#current_mentor_name" do
+    let(:current_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :ongoing,
+        school:,
+        started_on: ect_at_school_period.started_on - 2.months
+      )
+    end
+    let!(:mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        :ongoing,
+        mentee: ect_at_school_period,
+        mentor: current_mentor_at_school_period,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+
+    it "returns the teacher's name from the current mentor_at_school_period" do
+      expect(current_step.current_mentor_name)
+        .to eq(Teachers::Name.new(current_mentor_at_school_period.teacher).full_name)
+    end
+  end
+
+  describe "#new_mentor_name" do
+    it "returns the teacher's name from the selected mentor_at_school_period" do
+      expect(current_step.new_mentor_name)
+        .to eq(Teachers::Name.new(mentor_at_school_period.teacher).full_name)
+    end
+  end
+
+  describe "#save!" do
+    let(:current_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :ongoing,
+        school:,
+        started_on: ect_at_school_period.started_on - 2.months
+      )
+    end
+    let!(:mentorship_period) do
+      FactoryBot.create(
+        :mentorship_period,
+        :ongoing,
+        mentee: ect_at_school_period,
+        mentor: current_mentor_at_school_period,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+
+    it "assigns the mentor" do
+      expect { current_step.save! }.to change(MentorshipPeriod, :count).by(1)
+      expect(ect_at_school_period.reload.current_or_next_mentorship_period.mentor)
+        .to eq(mentor_at_school_period)
+    end
+
+    it "is truthy" do
+      expect(current_step.save!).to be_truthy
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_mentor_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/confirmation_step_spec.rb
@@ -1,0 +1,56 @@
+describe Schools::ECTs::ChangeMentorWizard::ConfirmationStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeMentorWizard::Wizard.new(
+      current_step: :confirmation,
+      step_params: ActionController::Parameters.new(confirmation: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+  end
+  let(:mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let!(:mentorship_period) do
+    FactoryBot.create(
+      :mentorship_period,
+      :ongoing,
+      mentee: ect_at_school_period,
+      mentor: mentor_at_school_period,
+      started_on: ect_at_school_period.started_on
+    )
+  end
+  let(:params) { {} }
+
+  describe "#previous_step" do
+    it "returns the previous step" do
+      expect(current_step.previous_step).to eq(:check_answers)
+    end
+  end
+
+  describe "#next_step" do
+    it "raises an error" do
+      expect { current_step.next_step }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#current_mentor_name" do
+    it "returns the current mentor's teacher's name" do
+      expect(current_step.current_mentor_name)
+        .to eq(Teachers::Name.new(mentor_at_school_period.teacher).full_name)
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_mentor_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/edit_step_spec.rb
@@ -1,0 +1,145 @@
+describe Schools::ECTs::ChangeMentorWizard::EditStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeMentorWizard::Wizard.new(
+      current_step: :edit,
+      step_params: ActionController::Parameters.new(edit: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+  end
+  let(:current_mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let!(:current_mentorship_period) do
+    FactoryBot.create(
+      :mentorship_period,
+      :ongoing,
+      mentee: ect_at_school_period,
+      mentor: current_mentor_at_school_period,
+      started_on: ect_at_school_period.started_on + 1.week
+    )
+  end
+  let(:mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let(:params) { { mentor_at_school_period_id: "" } }
+
+  describe ".permitted_params" do
+    it "returns the permitted parameters" do
+      expect(described_class.permitted_params).to contain_exactly(:mentor_at_school_period_id)
+    end
+  end
+
+  describe "#previous_step" do
+    it "raises an error" do
+      expect { current_step.previous_step }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#next_step" do
+    before { store.mentor_at_school_period_id = mentor_at_school_period.id }
+
+    context "when the mentor is eligible for training" do
+      before do
+        allow(::MentorAtSchoolPeriods::Eligibility)
+          .to receive(:for_first_provider_led_training?)
+          .and_return(true)
+      end
+
+      it "returns the training step" do
+        expect(current_step.next_step).to eq(:training)
+      end
+    end
+
+    context "when the mentor is not eligible for training" do
+      before do
+        allow(::MentorAtSchoolPeriods::Eligibility)
+          .to receive(:for_first_provider_led_training?)
+          .and_return(false)
+      end
+
+      it "returns the check answers step" do
+        expect(current_step.next_step).to eq(:check_answers)
+      end
+    end
+  end
+
+  describe "validations" do
+    context "when the mentor_at_school_period_id is blank" do
+      let(:params) { { mentor_at_school_period_id: "" } }
+
+      it "is invalid" do
+        expect(current_step).not_to be_valid
+        expect(current_step.errors.messages_for(:mentor_at_school_period_id))
+          .to contain_exactly("Select a mentor from the list provided")
+      end
+    end
+
+    context "when the mentor_at_school_period_id is not in the list" do
+      let(:params) { { mentor_at_school_period_id: "invalid_id" } }
+
+      it "is invalid" do
+        expect(current_step).not_to be_valid
+        expect(current_step.errors.messages_for(:mentor_at_school_period_id))
+          .to contain_exactly("Select a mentor from the list provided")
+      end
+    end
+
+    context "when the mentor_at_school_period_id is valid" do
+      let(:params) { { mentor_at_school_period_id: mentor_at_school_period.id } }
+
+      it "is valid" do
+        expect(current_step).to be_valid
+        expect(current_step.errors).to be_empty
+      end
+    end
+  end
+
+  describe "#save!" do
+    context "when the mentor_at_school_period_id is valid" do
+      let(:params) { { mentor_at_school_period_id: mentor_at_school_period.id } }
+
+      it "stores the mentor_at_school_period_id" do
+        expect { current_step.save! }
+          .to change(store, :mentor_at_school_period_id)
+          .from(nil).to(mentor_at_school_period.id.to_s)
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+    end
+
+    context "when the mentor_at_school_period_id is invalid" do
+      let(:params) { { mentor_at_school_period_id: "" } }
+
+      it "does not store the mentor_at_school_period_id" do
+        expect { current_step.save! }
+          .not_to change(store, :mentor_at_school_period_id)
+      end
+
+      it "is falsy" do
+        expect(current_step.save!).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/lead_provider_step_spec.rb
@@ -1,0 +1,119 @@
+describe Schools::ECTs::ChangeMentorWizard::LeadProviderStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeMentorWizard::Wizard.new(
+      current_step: :lead_provider,
+      step_params: ActionController::Parameters.new(lead_provider: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) do
+    FactoryBot.build(
+      :session_repository,
+      mentor_at_school_period_id: mentor_at_school_period.id,
+      accepting_current_lead_provider: nil
+    )
+  end
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+  let(:mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let(:params) { { lead_provider_id: "" } }
+
+  describe ".permitted_params" do
+    it "returns the permitted parameters" do
+      expect(described_class.permitted_params)
+        .to contain_exactly(:lead_provider_id)
+    end
+  end
+
+  describe "#previous_step" do
+    it "returns the edit step" do
+      expect(current_step.previous_step).to eq(:training)
+    end
+  end
+
+  describe "#next_step" do
+    it "returns the check answers step" do
+      expect(current_step.next_step).to eq(:check_answers)
+    end
+  end
+
+  describe "#new_mentor_name" do
+    it "returns the teacher's name from the selected mentor_at_school_period" do
+      expect(current_step.new_mentor_name)
+        .to eq(Teachers::Name.new(mentor_at_school_period.teacher).full_name)
+    end
+  end
+
+  describe "validations" do
+    context "when the lead_provider_id is blank" do
+      let(:params) { { lead_provider_id: "" } }
+
+      it "is invalid" do
+        expect(current_step).to be_invalid
+        expect(current_step.errors.messages_for(:lead_provider_id))
+          .to contain_exactly("Select which lead provider will be training the ECT")
+      end
+    end
+
+    context "when the lead_provider_id is invalid" do
+      let(:params) { { lead_provider_id: "invalid" } }
+
+      it "is invalid" do
+        expect(current_step).to be_invalid
+        expect(current_step.errors.messages_for(:lead_provider_id))
+          .to contain_exactly("Enter the name of a known lead provider")
+      end
+    end
+
+    context "when the lead_provider_id is valid" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:params) { { lead_provider_id: lead_provider.id } }
+
+      it "is valid" do
+        expect(current_step).to be_valid
+        expect(current_step.errors).to be_empty
+      end
+    end
+  end
+
+  describe "#save!" do
+    context "when the step is invalid" do
+      let(:params) { { lead_provider_id: "" } }
+
+      it "does not store the lead provider" do
+        expect { current_step.save! }.not_to(change(store, :lead_provider_id))
+      end
+
+      it "is falsey" do
+        expect(current_step.save!).to be_falsey
+      end
+    end
+
+    context "when the lead_provider_id is valid" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:params) { { lead_provider_id: lead_provider.id } }
+
+      it "stores the lead provider" do
+        expect { current_step.save! }
+          .to(change(store, :lead_provider_id)
+          .from(nil).to(lead_provider.id.to_s))
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_mentor_wizard/training_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/training_step_spec.rb
@@ -1,0 +1,88 @@
+describe Schools::ECTs::ChangeMentorWizard::TrainingStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeMentorWizard::Wizard.new(
+      current_step: :training,
+      step_params: ActionController::Parameters.new(training: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) do
+    FactoryBot.build(
+      :session_repository,
+      mentor_at_school_period_id: mentor_at_school_period.id
+    )
+  end
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+  end
+  let(:mentor_at_school_period) do
+    FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      school:,
+      started_on: ect_at_school_period.started_on - 1.month
+    )
+  end
+  let(:params) { { accepting_current_lead_provider: "true" } }
+
+  describe ".permitted_params" do
+    it "returns the permitted parameters" do
+      expect(described_class.permitted_params)
+        .to contain_exactly(:accepting_current_lead_provider)
+    end
+  end
+
+  describe "#previous_step" do
+    it "returns the edit step" do
+      expect(current_step.previous_step).to eq(:edit)
+    end
+  end
+
+  describe "#next_step" do
+    it "returns the check answers step" do
+      expect(current_step.next_step).to eq(:check_answers)
+    end
+  end
+
+  describe "#current_lead_provider_name" do
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :ongoing,
+        :with_school_partnership,
+        ect_at_school_period:,
+        started_on: ect_at_school_period.started_on
+      )
+    end
+
+    it "returns the lead provider's name from the ECT's current lead provider" do
+      expect(current_step.current_lead_provider_name)
+        .to eq(training_period.lead_provider.name)
+    end
+  end
+
+  describe "#new_mentor_name" do
+    it "returns the teacher's name from the selected mentor_at_school_period" do
+      expect(current_step.new_mentor_name)
+        .to eq(Teachers::Name.new(mentor_at_school_period.teacher).full_name)
+    end
+  end
+
+  describe "#save!" do
+    it "stores the accepting_current_lead_provider" do
+      expect { current_step.save! }
+        .to change(store, :accepting_current_lead_provider)
+        .from(nil).to(true)
+    end
+
+    it "is truthy" do
+      expect(current_step.save!).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2102

### Changes proposed in this pull request

This builds on some similar journeys and introduces a "Change mentor" journey
for schools.

Even though this might seem straightforward, there is a bunch of logic and a few
different branches to cover.

This change covers:

- Changing to a registered mentor who is not eligible for training
- Changing to a registered mentor who is eligible for training and using the
  existing provider
- Changing to a registered mentor who is eligible for training and choosing a
  different provider
- Changing to a registered mentor when the ECT is undergoing school-led training

Lots of this is tests and boilerplate.

Some steps share quite a few methods. Previous iterations of this change
experimented with a few different abstractions, but none quite felt right.

This keeps things explicit and verbose (if a little repetitive) for now. We can
always circle back later and make improvements if things become clearer.

### Guidance to review
