### PR TITLE
Rename `metadata_teacher_lead_providers` for consistency

### DIFF
--- a/app/models/metadata/teacher_lead_provider.rb
+++ b/app/models/metadata/teacher_lead_provider.rb
@@ -1,6 +1,6 @@
 module Metadata
   class TeacherLeadProvider < Metadata::Base
-    self.table_name = :metadata_teacher_lead_providers
+    self.table_name = :metadata_teachers_lead_providers
 
     belongs_to :teacher
     belongs_to :lead_provider

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -233,7 +233,7 @@
   - mentor_payments_frozen_year
   - ect_pupil_premium_uplift
   - ect_sparsity_uplift
-  :metadata_teacher_lead_providers:
+  :metadata_teachers_lead_providers:
   - id
   - teacher_id
   - lead_provider_id

--- a/db/migrate/20251006073517_rename_metadata_teacher_lead_providers_to_metadata_teachers_lead_providers.rb
+++ b/db/migrate/20251006073517_rename_metadata_teacher_lead_providers_to_metadata_teachers_lead_providers.rb
@@ -1,0 +1,5 @@
+class RenameMetadataTeacherLeadProvidersToMetadataTeachersLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    rename_table :metadata_teacher_lead_providers, :metadata_teachers_lead_providers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_29_155810) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_06_073517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -401,17 +401,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_29_155810) do
     t.index ["school_id"], name: "idx_on_school_id_b772864906"
   end
 
-  create_table "metadata_teacher_lead_providers", force: :cascade do |t|
+  create_table "metadata_teachers_lead_providers", force: :cascade do |t|
     t.bigint "teacher_id"
     t.bigint "lead_provider_id"
     t.bigint "latest_ect_training_period_id"
     t.bigint "latest_mentor_training_period_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_ab4ac7c7e1"
-    t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_9e56b0e54c"
-    t.index ["lead_provider_id"], name: "index_metadata_teacher_lead_providers_on_lead_provider_id"
-    t.index ["teacher_id"], name: "index_metadata_teacher_lead_providers_on_teacher_id"
+    t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
+    t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
+    t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"
+    t.index ["teacher_id"], name: "index_metadata_teachers_lead_providers_on_teacher_id"
   end
 
   create_table "migration_failures", force: :cascade do |t|
@@ -856,10 +856,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_29_155810) do
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "lead_providers"
   add_foreign_key "metadata_schools_lead_providers_contract_periods", "schools"
-  add_foreign_key "metadata_teacher_lead_providers", "lead_providers"
-  add_foreign_key "metadata_teacher_lead_providers", "teachers"
-  add_foreign_key "metadata_teacher_lead_providers", "training_periods", column: "latest_ect_training_period_id", on_delete: :nullify
-  add_foreign_key "metadata_teacher_lead_providers", "training_periods", column: "latest_mentor_training_period_id", on_delete: :nullify
+  add_foreign_key "metadata_teachers_lead_providers", "lead_providers"
+  add_foreign_key "metadata_teachers_lead_providers", "teachers"
+  add_foreign_key "metadata_teachers_lead_providers", "training_periods", column: "latest_ect_training_period_id", on_delete: :nullify
+  add_foreign_key "metadata_teachers_lead_providers", "training_periods", column: "latest_mentor_training_period_id", on_delete: :nullify
   add_foreign_key "milestones", "schedules"
   add_foreign_key "parity_check_requests", "lead_providers"
   add_foreign_key "parity_check_requests", "parity_check_endpoints", column: "endpoint_id"


### PR DESCRIPTION
This should be `metadata_teachers_lead_providers` to match other metadata table naming and to be consistent with how Rails names join tables.
