### PR TITLE
Enable schools interface in tests with a flag

### DIFF
--- a/spec/features/admin/schools/impersonating_a_school_spec.rb
+++ b/spec/features/admin/schools/impersonating_a_school_spec.rb
@@ -1,8 +1,4 @@
-RSpec.describe 'Impersonating a school user' do
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
-
+RSpec.describe 'Impersonating a school user', :enable_schools_interface do
   scenario 'successfully impersonating a school user' do
     given_i_am_signed_in_as_an_admin_user
     and_i_am_on_the_admin_show_page_for_a_school

--- a/spec/features/schools/ects/change/email_address_spec.rb
+++ b/spec/features/schools/ects/change/email_address_spec.rb
@@ -1,6 +1,4 @@
-describe "School user can change ECTs email address" do
-  before { enable_schools_interface }
-
+describe "School user can change ECTs email address", :enable_schools_interface do
   it "changes the email address" do
     given_there_is_a_school
     and_there_is_an_ect
@@ -24,12 +22,6 @@ describe "School user can change ECTs email address" do
   end
 
 private
-
-  def enable_schools_interface
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
-  end
 
   def given_there_is_a_school
     @school = FactoryBot.create(:school)

--- a/spec/features/schools/ects/change/name_spec.rb
+++ b/spec/features/schools/ects/change/name_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Changing an ECT's name" do
+RSpec.describe "Changing an ECT's name", :enable_schools_interface do
   let!(:ect_at_school_period) do
     FactoryBot.create(:ect_at_school_period, :not_started_yet, school:, teacher:)
   end
@@ -10,8 +10,6 @@ RSpec.describe "Changing an ECT's name" do
   let(:school) { FactoryBot.create(:school) }
 
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-
     given_i_am_logged_in_as_a_school_user
     then_i_should_be_taken_to_the_ects_page
     when_i_select_an_ect

--- a/spec/features/schools/ects/change/training_programme_spec.rb
+++ b/spec/features/schools/ects/change/training_programme_spec.rb
@@ -1,6 +1,4 @@
-describe "School user can change ECTs training programme" do
-  before { enable_schools_interface }
-
+describe "School user can change ECTs training programme", :enable_schools_interface do
   it "changes the training programme from provider-led to school-led" do
     given_there_is_a_school
     and_there_is_an_ect
@@ -48,12 +46,6 @@ describe "School user can change ECTs training programme" do
   end
 
 private
-
-  def enable_schools_interface
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
-  end
 
   def given_there_is_a_school
     @school = FactoryBot.create(:school)

--- a/spec/features/schools/ects/change_working_pattern_spec.rb
+++ b/spec/features/schools/ects/change_working_pattern_spec.rb
@@ -1,10 +1,4 @@
-describe "School user can change ECTs working pattern" do
-  before do
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
-  end
-
+describe "School user can change ECTs working pattern", :enable_schools_interface do
   it "changes the working pattern" do
     given_there_is_a_school
     and_there_is_an_ect

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
@@ -1,8 +1,4 @@
-RSpec.describe 'Registering an ECT' do
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
-
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   scenario 'Independent school selects ISTIP as appropriate body' do
     given_i_am_logged_in_as_an_independent_school_user
     and_i_am_on_the_start_date_step_of_the_register_ect_journey

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
@@ -1,6 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
     FactoryBot.create(:appropriate_body, name: 'Golden Leaf Teaching Hub')
   end
 

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT', :js do
+RSpec.describe 'Registering an ECT', :enable_schools_interface, :js do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Finding a teacher using national insurance number' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client that finds teacher that has passed their induction'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'User enters date of birth (find ECT step) but teacher has completed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api returns a teacher and then a teacher that has completed their induction'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'User enters national insurance number but teacher has completed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client that finds teacher that is exempt from induction'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'User enters date of birth (find ECT step) but teacher has completed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api returns a teacher and then a teacher that is exempt from induction'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'User enters national insurance number but teacher is exempt from induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client that finds teacher that has failed their induction'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'User enters date of birth (find ECT step) but teacher has failed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api returns a teacher and then a teacher that has failed their induction'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'User enters national insurance number but teacher has failed their induction' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Teacher with trn has already registered as an ECT at a school' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client that finds teacher prohibited from teaching'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'The ECT is prohibited from teaching' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client returns 200 then 400'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Teacher with national insurance number is not found' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client that finds nothing'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Teacher with TRN is not found' do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -1,8 +1,7 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client'
 
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
     create_contract_period_for_start_date
     create_lead_provider_and_active_lead_provider
     create_school_with_previous_choices

--- a/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
+++ b/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering an ECT' do
+RSpec.describe 'Registering an ECT', :enable_schools_interface do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'previously registered' do
     given_i_am_logged_in_as_a_state_funded_school_user_who_has_previously_registered_an_ect

--- a/spec/features/schools/ects/search_spec.rb
+++ b/spec/features/schools/ects/search_spec.rb
@@ -1,8 +1,7 @@
-RSpec.describe 'Searching for an ECT', type: :feature do
+RSpec.describe 'Searching for an ECT', :enable_schools_interface do
   include_context 'test trs api client'
 
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
     given_there_is_a_school_with_teachers
     and_i_am_logged_in_as_a_school_user
     and_i_am_on_the_ects_list_page

--- a/spec/features/schools/mentors/change/email_address_spec.rb
+++ b/spec/features/schools/mentors/change/email_address_spec.rb
@@ -1,6 +1,4 @@
-describe "School user can change mentor's email address" do
-  before { enable_schools_interface }
-
+describe "School user can change mentor's email address", :enable_schools_interface do
   it "changes the email address" do
     given_there_is_a_school
     and_there_is_a_mentor
@@ -24,12 +22,6 @@ describe "School user can change mentor's email address" do
   end
 
 private
-
-  def enable_schools_interface
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
-  end
 
   def given_there_is_a_school
     @school = FactoryBot.create(:school)

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Changing an mentor's name" do
+RSpec.describe "Changing an mentor's name", :enable_schools_interface do
   let!(:mentor_at_school_period) do
     FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
   end
@@ -10,8 +10,6 @@ RSpec.describe "Changing an mentor's name" do
   let(:school) { FactoryBot.create(:school) }
 
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-
     given_i_am_logged_in_as_a_school_user
     and_i_visit_the_mentors_page
     when_i_select_a_mentor

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'mentor already active at the school from trn and nino' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'mentor already active at the school from trn and dob' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor' do
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'An ECT becoming mentor cannot mentor themself' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor' do
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Finding a teacher using national insurance number' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor' do
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   include_context 'test trs api client that finds teacher prohibited from teaching'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'School attempts to register a prohibited teacher as a mentor' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -1,8 +1,4 @@
-RSpec.describe 'Registering a mentor' do
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
-
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   scenario 'Teacher without a TRN cannot be registered' do
     given_there_is_a_school_in_the_service
     and_there_is_an_ect_with_no_mentor_registered_at_the_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor' do
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   include_context 'test trs api client returns 200 then 400'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Teacher with TRN is not found' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -1,12 +1,8 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
   include SchoolPartnershipHelpers
 
   let(:trn) { '3002586' }
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   scenario 'mentor has existing mentorship and is not mentoring at new school only' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -1,10 +1,6 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
   include SchoolPartnershipHelpers
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -1,10 +1,6 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
   include SchoolPartnershipHelpers
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -1,8 +1,8 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
 
   before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
+    allow(Rails.application.config).to receive_messages(enable_test_guidance: false)
   end
 
   let(:trn) { '3002586' }

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor' do
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   include_context 'test trs api client that finds nothing'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Teacher with TRN is not found' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe 'Registering a mentor' do
+RSpec.describe 'Registering a mentor', :enable_schools_interface do
   include_context 'test trs api client that finds nothing'
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   scenario 'Teacher with TRN is not found' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -1,10 +1,6 @@
-RSpec.describe 'Registering a mentor', :js do
+RSpec.describe 'Registering a mentor', :enable_schools_interface, :js do
   include_context 'test trs api client'
   include SchoolPartnershipHelpers
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   let(:trn) { '3002586' }
 

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -1,10 +1,6 @@
-RSpec.describe 'Selecting a different lead provider' do
+RSpec.describe 'Selecting a different lead provider', :enable_schools_interface do
   include_context 'test trs api client'
   include SchoolPartnershipHelpers
-
-  before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
-  end
 
   scenario 'Registering a new mentor' do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/search_spec.rb
+++ b/spec/features/schools/mentors/search_spec.rb
@@ -1,8 +1,7 @@
-RSpec.describe 'Searching for a mentor', type: :feature do
+RSpec.describe 'Searching for a mentor', :enable_schools_interface do
   include_context 'test trs api client'
 
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
     given_there_is_a_school_with_teachers
     and_i_am_logged_in_as_a_school_user
     and_i_am_on_the_mentor_list_page

--- a/spec/features/schools/mentors/viewing_a_mentor_spec.rb
+++ b/spec/features/schools/mentors/viewing_a_mentor_spec.rb
@@ -1,8 +1,4 @@
-RSpec.describe "Viewing a mentor" do
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
-
+RSpec.describe "Viewing a mentor", :enable_schools_interface do
   scenario "Happy path" do
     given_that_i_have_an_active_mentor_with_an_ect
     and_i_sign_in_as_a_school

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_provider_led_ect_spec.rb
@@ -1,6 +1,5 @@
-RSpec.describe 'Add a mentor to a provider led ECT' do
+RSpec.describe 'Add a mentor to a provider led ECT', :enable_schools_interface do
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
     given_there_is_a_school_in_the_service
     and_the_school_has_a_provider_led_ect_with_no_mentor
     and_the_school_has_a_mentor_eligible_to_mentor_the_ect

--- a/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
+++ b/spec/features/schools/mentorship/add_a_mentor_to_a_school_led_ect_spec.rb
@@ -1,8 +1,4 @@
-RSpec.describe 'Add a mentor to a school led ECT' do
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
-
+RSpec.describe 'Add a mentor to a school led ECT', :enable_schools_interface do
   scenario 'happy path' do
     given_there_is_a_school_in_the_service
     and_there_is_a_school_led_ect_with_no_mentor_registered_at_the_school

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe 'Redirect to register a new mentor for an ECT' do
+RSpec.describe 'Redirect to register a new mentor for an ECT', :enable_schools_interface do
   include_context 'test trs api client'
   include SchoolPartnershipHelpers
 
   before do
-    allow(Rails.application.config).to receive_messages(enable_schools_interface: true, enable_test_guidance: false)
+    allow(Rails.application.config).to receive_messages(enable_test_guidance: false)
   end
 
   let(:trn) { '9876543' }

--- a/spec/features/user_roles_spec.rb
+++ b/spec/features/user_roles_spec.rb
@@ -1,10 +1,6 @@
-RSpec.describe 'User roles' do
+RSpec.describe 'User roles', :enable_schools_interface do
   let(:school) { FactoryBot.create(:school, :state_funded) }
   let(:appropriate_body) { FactoryBot.create(:appropriate_body, name: school.name) }
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   context 'when the user has multiple roles (School and AB)' do
     before do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,4 +28,10 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+
+  config.before(:each, :enable_schools_interface) do
+    allow(Rails.application.config)
+      .to receive(:enable_schools_interface)
+      .and_return(true)
+  end
 end

--- a/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
+++ b/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
@@ -1,11 +1,10 @@
-RSpec.describe 'Assign existing mentor wizard', type: :request do
+RSpec.describe 'Assign existing mentor wizard', :enable_schools_interface do
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { Date.new(2023, 9, 1) }
   let(:ect)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
 
   before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
     contract_period = FactoryBot.create(:contract_period, year: 2023)
     school_partnership = FactoryBot.create(:school_partnership)
     school_partnership.lead_provider_delivery_partnership.active_lead_provider.update!(contract_period:)

--- a/spec/requests/schools/ects/change_email_address_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_email_address_wizard_spec.rb
@@ -1,4 +1,4 @@
-describe "Schools::ECTs::ChangeEmailAddressWizardController" do
+describe "Schools::ECTs::ChangeEmailAddressWizardController", :enable_schools_interface do
   let(:school) { FactoryBot.create(:school) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:ect_at_school_period) do
@@ -9,12 +9,6 @@ describe "Schools::ECTs::ChangeEmailAddressWizardController" do
       school:,
       email: "ect@example.com"
     )
-  end
-
-  before do
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
   end
 
   describe "GET #new" do

--- a/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
@@ -1,4 +1,4 @@
-describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
+describe "Schools::ECTs::ChangeTrainingProgrammeWizardController", :enable_schools_interface do
   let(:school) { FactoryBot.create(:school) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:ect_at_school_period) do
@@ -17,12 +17,6 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
       ect_at_school_period:,
       started_on: ect_at_school_period.started_on
     )
-  end
-
-  before do
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
   end
 
   describe "GET #new" do

--- a/spec/requests/schools/ects/change_working_pattern_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_working_pattern_wizard_spec.rb
@@ -1,4 +1,4 @@
-describe "Schools::ECTs::ChangeWorkingPatternWizardController" do
+describe "Schools::ECTs::ChangeWorkingPatternWizardController", :enable_schools_interface do
   let(:school) { FactoryBot.create(:school) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:ect_at_school_period) do
@@ -9,12 +9,6 @@ describe "Schools::ECTs::ChangeWorkingPatternWizardController" do
       school:,
       working_pattern: "full_time"
     )
-  end
-
-  before do
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
   end
 
   describe "GET #new" do

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -1,10 +1,6 @@
-RSpec.describe 'ECT summary' do
+RSpec.describe 'ECT summary', :enable_schools_interface do
   let(:ect) { FactoryBot.create(:ect_at_school_period, school:) }
   let(:school) { FactoryBot.create(:school) }
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   describe "GET #index" do
     context "when not signed in" do

--- a/spec/requests/schools/mentors/change_email_address_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_email_address_wizard_spec.rb
@@ -1,4 +1,4 @@
-describe "Schools::Mentors::ChangeEmailAddressWizardController" do
+describe "Schools::Mentors::ChangeEmailAddressWizardController", :enable_schools_interface do
   let(:school) { FactoryBot.create(:school) }
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:mentor_at_school_period) do
@@ -9,12 +9,6 @@ describe "Schools::Mentors::ChangeEmailAddressWizardController" do
       school:,
       email: "mentor@example.com"
     )
-  end
-
-  before do
-    allow(Rails.application.config)
-      .to receive(:enable_schools_interface)
-      .and_return(true)
   end
 
   describe "GET #new" do

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -1,13 +1,9 @@
-RSpec.describe 'Create mentorship of an ECT to a mentor' do
+RSpec.describe 'Create mentorship of an ECT to a mentor', :enable_schools_interface do
   include ActionView::Helpers::SanitizeHelper
 
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
   let(:school) { FactoryBot.create(:school, :independent) }
-
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
 
   describe 'GET /school/ects/:id/mentorship/new' do
     context 'when not signed in' do

--- a/spec/routing/wizardable_spec.rb
+++ b/spec/routing/wizardable_spec.rb
@@ -1,8 +1,4 @@
-RSpec.describe 'Wizardable routes' do
-  before do
-    allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-  end
-
+RSpec.describe 'Wizardable routes', :enable_schools_interface do
   it 'creates GET and POST routes for each step' do
     expect(get: '/school/register-mentor/find-mentor')
       .to route_to(controller: 'schools/register_mentor_wizard', action: 'new')


### PR DESCRIPTION
Before, we needed to stub the `enable_schools_interface` configuration explicitly in every test.

As we get closer to launching the schools interface, and build out more of the functionality, we need to do this more and more.

This stubs the `enable_schools_interface` configuration based on the presence of an `:enable_schools_interface` flag in the example metadata.