### PR TITLE
[2515] Make statement seed more realistic and similar to ecf1

### DIFF
--- a/db/seeds/statements.rb
+++ b/db/seeds/statements.rb
@@ -4,6 +4,8 @@ STATEMENT_STATE_COLOURS = {
   paid: :green,
 }.freeze
 
+OUTPUT_FEE_MONTHS = [1, 4, 8, 10].freeze
+
 def describe_group_of_statements(lead_provider, statements, month_col_width: 15, year_col_width: 18)
   return if statements.empty?
 
@@ -45,13 +47,11 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
     years = [registration_year, registration_year + 1]
 
     years.product(months).map do |year, month|
-      deadline_date = Time.zone.local(year, month).end_of_month
-      payment_date = Time.zone.at(rand(deadline_date.to_i..(deadline_date + 2.months).to_i))
-      fee_type = %w[service output].sample
-      status = if payment_date < Date.current && fee_type == 'output'
-                 :paid
-               elsif Date.current.between?(deadline_date, payment_date)
-                 :payable
+      deadline_date = Date.new(year, month, 1).prev_day
+      payment_date = Date.new(year, month, 25)
+      fee_type = month.in?(OUTPUT_FEE_MONTHS) ? "output" : "service"
+      status = if payment_date.past?
+                 fee_type == 'output' ? :paid : :payable
                else
                  :open
                end

--- a/db/seeds/statements.rb
+++ b/db/seeds/statements.rb
@@ -50,8 +50,10 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
       deadline_date = Date.new(year, month, 1).prev_day
       payment_date = Date.new(year, month, 25)
       fee_type = month.in?(OUTPUT_FEE_MONTHS) ? "output" : "service"
-      status = if payment_date.past?
-                 fee_type == 'output' ? :paid : :payable
+      status = if payment_date.past? && fee_type == "output"
+                 :paid
+               elsif deadline_date.past?
+                 :payable
                else
                  :open
                end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2515

### Changes proposed in this pull request

* Set deadline date to be the last day of the previous month
* Set payment date to be the 25th of the month
* Set output fee statements for January, April, August and October.
* Set status to `paid` only if output fee, otherwise `payable`.

### Guidance to review
