### PR TITLE
Add `Teachers::Query` service

### DIFF
--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -1,0 +1,161 @@
+module API::Teachers
+  class Query
+    include Queries::FilterIgnorable
+
+    attr_reader :scope, :lead_provider_id
+
+    def initialize(
+      lead_provider_id: :ignore,
+      contract_period_years: :ignore,
+      training_status: :ignore,
+      api_from_teacher_id: :ignore,
+      updated_since: :ignore,
+      sort: { created_at: :asc }
+    )
+      @lead_provider_id = lead_provider_id
+      @scope = Teacher.distinct
+
+      where_lead_provider_is(lead_provider_id)
+      where_contract_period_year_in(contract_period_years)
+      where_training_status_is(training_status)
+      where_api_from_teacher_id_is(api_from_teacher_id)
+      where_updated_since(updated_since)
+      set_sort_by(sort)
+    end
+
+    def teachers
+      preload_associations(block_given? ? yield(scope) : scope)
+    end
+
+    def teacher_by_api_id(api_id)
+      return preload_associations(scope).find_by!(api_id:) if api_id.present?
+
+      fail(ArgumentError, "api_id needed")
+    end
+
+    def teacher_by_id(id)
+      return preload_associations(scope).find(id) if id.present?
+
+      fail(ArgumentError, "id needed")
+    end
+
+  private
+
+    def preload_associations(results)
+      preloaded_results = results
+        .strict_loading
+        .eager_load(
+          :earliest_ect_at_school_period,
+          :earliest_mentor_at_school_period,
+          :teacher_id_changes,
+          lead_provider_metadata: {
+            latest_ect_training_period: {
+              school_partnership: %i[
+                school
+                contract_period
+                delivery_partner
+              ],
+              ect_at_school_period: {
+                teacher: %i[
+                  started_induction_period
+                  finished_induction_period
+                ]
+              }
+            },
+            latest_mentor_training_period: {
+              school_partnership: %i[
+                school
+                contract_period
+                delivery_partner
+              ],
+              mentor_at_school_period: {
+                teacher: %i[
+                  started_induction_period
+                  finished_induction_period
+                ]
+              }
+            }
+          }
+        )
+
+      unless ignore?(filter: lead_provider_id)
+        preloaded_results = preloaded_results
+          .references(:lead_provider_metadata)
+          .where(lead_provider_metadata: { lead_provider_id: })
+      end
+
+      preloaded_results
+    end
+
+    def where_lead_provider_is(lead_provider_id)
+      return if ignore?(filter: lead_provider_id)
+
+      @scope = scope
+        .joins(:lead_provider_metadata)
+        .where(lead_provider_metadata: { lead_provider_id: })
+        # Metadata exists for all lead provider/teacher combinations, but when
+        # filtering by lead provider we only want teachers who have a training period
+        # with that lead provider.
+        .where.not(
+          lead_provider_metadata: {
+            latest_ect_training_period: nil,
+            latest_mentor_training_period: nil
+          }
+        )
+    end
+
+    def where_contract_period_year_in(contract_period_years)
+      return if ignore?(filter: contract_period_years)
+
+      @scope = scope
+          .left_joins(
+            lead_provider_metadata: {
+              latest_ect_training_period: {
+                school_partnership: {
+                  lead_provider_delivery_partnership: :active_lead_provider
+                }
+              },
+              latest_mentor_training_period: {
+                school_partnership: {
+                  lead_provider_delivery_partnership: :active_lead_provider
+                }
+              }
+            }
+          )
+          .where(
+            # The first where conditional is for ECTs and the second for mentors
+            # (using the alias names Rails creates for the join tables).
+            <<~SQL.squish,
+              active_lead_providers.contract_period_year IN (:years)
+              OR active_lead_providers_lead_provider_delivery_partnerships.contract_period_year IN (:years)
+            SQL
+            years: contract_period_years
+          )
+    end
+
+    def where_training_status_is(training_status)
+      nil if ignore?(filter: training_status)
+
+      # TODO: implement when we have the training status field
+    end
+
+    def where_api_from_teacher_id_is(api_from_teacher_id)
+      return if ignore?(filter: api_from_teacher_id)
+
+      @scope = scope
+        .joins(:teacher_id_changes)
+        .where(teacher_id_changes: { api_from_teacher_id: })
+    end
+
+    def where_updated_since(updated_since)
+      return if ignore?(filter: updated_since)
+
+      # TODO: update when we have an accurate updated_at field
+      @scope = scope.where(updated_at: updated_since..)
+    end
+
+    def set_sort_by(sort)
+      @scope = scope.order(sort)
+    end
+  end
+end

--- a/spec/factories/teacher_id_change_factory.rb
+++ b/spec/factories/teacher_id_change_factory.rb
@@ -5,9 +5,7 @@ FactoryBot.define do
     api_to_teacher_id { teacher.api_id }
 
     after(:build) do |teacher_id_change|
-      from_teacher = create(:teacher)
-
-      teacher_id_change.api_from_teacher_id = from_teacher.api_id
+      teacher_id_change.api_from_teacher_id ||= create(:teacher).api_id
     end
   end
 end

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -1,0 +1,343 @@
+RSpec.describe API::Teachers::Query do
+  it_behaves_like "a query that avoids includes" do
+    before { FactoryBot.create(:teacher) }
+  end
+
+  describe "preloading relationships" do
+    shared_examples "preloaded associations" do
+      it { expect(result.association(:earliest_ect_at_school_period)).to be_loaded }
+      it { expect(result.association(:earliest_mentor_at_school_period)).to be_loaded }
+      it { expect(result.association(:teacher_id_changes)).to be_loaded }
+      it { expect(result.association(:lead_provider_metadata)).to be_loaded }
+
+      it { expect(result.lead_provider_metadata.map { |metadata| metadata.association(:latest_ect_training_period) }).to all(be_loaded) }
+      it { expect(result.lead_provider_metadata.map { |metadata| metadata.association(:latest_mentor_training_period) }).to all(be_loaded) }
+
+      it "preloads latest_ect_training_period and latest_mentor_training_period associations" do
+        latest_training_periods = result.lead_provider_metadata
+          .map { |it| [it.latest_ect_training_period, it.latest_mentor_training_period] }
+          .flatten
+          .compact
+
+        expect(latest_training_periods).not_to be_empty
+
+        latest_training_periods.each do |training_period|
+          expect(training_period.association(:school_partnership)).to be_loaded
+          expect(training_period.school_partnership.association(:school)).to be_loaded
+          expect(training_period.school_partnership.association(:contract_period)).to be_loaded
+          expect(training_period.school_partnership.association(:delivery_partner)).to be_loaded
+
+          if training_period.for_ect?
+            expect(training_period.association(:ect_at_school_period)).to be_loaded
+            expect(training_period.ect_at_school_period.association(:teacher)).to be_loaded
+            expect(training_period.ect_at_school_period.teacher.association(:started_induction_period)).to be_loaded
+            expect(training_period.ect_at_school_period.teacher.association(:finished_induction_period)).to be_loaded
+          elsif training_period.for_mentor?
+            expect(training_period.association(:mentor_at_school_period)).to be_loaded
+            expect(training_period.mentor_at_school_period.association(:teacher)).to be_loaded
+            expect(training_period.mentor_at_school_period.teacher.association(:started_induction_period)).to be_loaded
+            expect(training_period.mentor_at_school_period.teacher.association(:finished_induction_period)).to be_loaded
+          end
+        end
+      end
+
+      context "when a lead_provider_id is specified" do
+        let(:lead_provider_id) { lead_provider.id }
+
+        before { FactoryBot.create(:teacher_lead_provider_metadata, lead_provider:, teacher:) }
+
+        it "only contains relevant metadata" do
+          expect(result.lead_provider_metadata).to contain_exactly(lead_provider_metadata)
+        end
+      end
+    end
+
+    let(:lead_provider_id) { :ignore }
+    let(:instance) { described_class.new(lead_provider_id:) }
+
+    let!(:teacher) { FactoryBot.create(:teacher) }
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let!(:lead_provider_metadata) { FactoryBot.create(:teacher_lead_provider_metadata, :with_latest_ect_training_period, :with_latest_mentor_training_period, teacher:, lead_provider:) }
+
+    before do
+      # Ensure other metadata exists.
+      other_lead_provider = FactoryBot.create(:lead_provider)
+      FactoryBot.create(:teacher_lead_provider_metadata, teacher:, lead_provider: other_lead_provider)
+    end
+
+    describe "#teachers" do
+      subject(:result) { instance.teachers.first }
+
+      include_context "preloaded associations"
+    end
+
+    describe "#teacher_by_api_id" do
+      subject(:result) { instance.teacher_by_api_id(teacher.api_id) }
+
+      include_context "preloaded associations"
+    end
+
+    describe "#teacher_by_id" do
+      subject(:result) { instance.teacher_by_id(teacher.id) }
+
+      include_context "preloaded associations"
+    end
+  end
+
+  describe "#teachers" do
+    it "returns all teachers" do
+      teachers = FactoryBot.create_list(:teacher, 3)
+      query = described_class.new
+
+      expect(query.teachers).to match_array(teachers)
+    end
+
+    it "orders teachers by created_at in ascending order" do
+      teacher1 = travel_to(2.days.ago) { FactoryBot.create(:teacher) }
+      teacher2 = travel_to(1.day.ago) { FactoryBot.create(:teacher) }
+      teacher3 = FactoryBot.create(:teacher)
+
+      query = described_class.new
+
+      expect(query.teachers).to eq([teacher1, teacher2, teacher3])
+    end
+
+    describe "filtering" do
+      describe "by `lead_provider`" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
+        let!(:teacher1) { training_period.trainee.teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+
+        context "when `lead_provider` param is omitted" do
+          it "returns all teachers" do
+            expect(described_class.new.teachers).to contain_exactly(teacher1, teacher2, teacher3)
+          end
+        end
+
+        it "filters by `lead_provider`" do
+          lead_provider_id = training_period.lead_provider.id
+          query = described_class.new(lead_provider_id:)
+
+          expect(query.teachers).to contain_exactly(teacher1)
+        end
+
+        it "returns empty if no teachers are found for the given `lead_provider`" do
+          query = described_class.new(lead_provider_id: FactoryBot.create(:lead_provider).id)
+
+          expect(query.teachers).to be_empty
+        end
+
+        it "does not filter by `lead_provider` if an empty string is supplied" do
+          query = described_class.new(lead_provider_id: " ")
+
+          expect(query.teachers).to contain_exactly(teacher1, teacher2, teacher3)
+        end
+      end
+
+      describe "by `contract_period_years`" do
+        let(:contract_period1) { FactoryBot.create(:contract_period) }
+        let(:contract_period2) { FactoryBot.create(:contract_period) }
+        let(:contract_period3) { FactoryBot.create(:contract_period) }
+        let(:school_partnership1) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period1)) }
+        let(:school_partnership2) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period2)) }
+        let(:school_partnership3) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period3)) }
+        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership1).trainee.teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, school_partnership: school_partnership2).trainee.teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership3).trainee.teacher }
+
+        context "when `contract_period_years` param is omitted" do
+          it "returns all teachers" do
+            expect(described_class.new.teachers).to contain_exactly(teacher1, teacher2, teacher3)
+          end
+        end
+
+        it "filters by `contract_period_years`" do
+          query = described_class.new(contract_period_years: contract_period2.year.to_s)
+
+          expect(query.teachers).to contain_exactly(teacher2)
+        end
+
+        it "filters by multiple `contract_period_years`" do
+          query1 = described_class.new(contract_period_years: [contract_period1.year, contract_period2.year])
+          expect(query1.teachers).to contain_exactly(teacher1, teacher2)
+
+          query2 = described_class.new(contract_period_years: [contract_period2.year.to_s, contract_period3.year.to_s])
+          expect(query2.teachers).to contain_exactly(teacher2, teacher3)
+        end
+
+        it "returns no delivery partners if no `contract_period_years` are found" do
+          query = described_class.new(contract_period_years: "0000")
+
+          expect(query.teachers).to be_empty
+        end
+
+        it "ignores invalid `contract_period_years`" do
+          query = described_class.new(contract_period_years: [contract_period1.year, 1099])
+
+          expect(query.teachers).to contain_exactly(teacher1)
+        end
+
+        it "does not filter by `contract_period_years` if blank" do
+          query = described_class.new(contract_period_years: " ")
+
+          expect(query.teachers).to contain_exactly(teacher1, teacher2, teacher3)
+        end
+      end
+
+      describe "by `api_from_teacher_id`" do
+        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher }
+        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+        let!(:teacher_id_change1) { FactoryBot.create(:teacher_id_change, teacher: teacher1, api_from_teacher_id: teacher2.api_id) }
+        let!(:teacher_id_change2) { FactoryBot.create(:teacher_id_change, teacher: teacher2, api_from_teacher_id: teacher3.api_id) }
+        let!(:teacher_id_change3) { FactoryBot.create(:teacher_id_change, teacher: teacher3, api_from_teacher_id: teacher1.api_id) }
+
+        context "when `api_from_teacher_id` param is omitted" do
+          it "returns all teachers" do
+            expect(described_class.new.teachers).to contain_exactly(teacher1, teacher2, teacher3)
+          end
+        end
+
+        it "filters by `api_from_teacher_id`" do
+          api_from_teacher_id = teacher_id_change2.api_from_teacher_id
+          query = described_class.new(api_from_teacher_id:)
+
+          expect(query.teachers).to contain_exactly(teacher2)
+        end
+
+        it "returns empty if no teachers are found for the given `api_from_teacher_id`" do
+          query = described_class.new(api_from_teacher_id: SecureRandom.uuid)
+
+          expect(query.teachers).to be_empty
+        end
+
+        it "does not filter by `api_from_teacher_id` if an empty string is supplied" do
+          query = described_class.new(api_from_teacher_id: " ")
+
+          expect(query.teachers).to contain_exactly(teacher1, teacher2, teacher3)
+        end
+      end
+
+      describe "by `updated_since`" do
+        it "filters by `updated_since`" do
+          FactoryBot.create(:teacher).tap { it.update(updated_at: 2.days.ago) }
+          teacher2 = FactoryBot.create(:teacher)
+
+          query = described_class.new(updated_since: 1.day.ago)
+
+          expect(query.teachers).to contain_exactly(teacher2)
+        end
+
+        it "does not filter by `updated_since`` if omitted" do
+          teacher1 = FactoryBot.create(:teacher).tap { it.update(updated_at: 1.week.ago) }
+          teacher2 = FactoryBot.create(:teacher).tap { it.update(updated_at: 2.weeks.ago) }
+
+          expect(described_class.new.teachers).to contain_exactly(teacher1, teacher2)
+        end
+
+        it "does not filter by `updated_since` if blank" do
+          teacher1 = FactoryBot.create(:teacher).tap { it.update(updated_at: 1.week.ago) }
+          teacher2 = FactoryBot.create(:teacher).tap { it.update(updated_at: 2.weeks.ago) }
+
+          query = described_class.new(updated_since: " ")
+
+          expect(query.teachers).to contain_exactly(teacher1, teacher2)
+        end
+      end
+    end
+
+    describe "ordering" do
+      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher } }
+
+      describe "default order" do
+        it "returns teachers ordered by created_at, in ascending order" do
+          query = described_class.new
+          expect(query.teachers).to eq([teacher2, teacher1])
+        end
+      end
+
+      describe "order by created_at, in descending order" do
+        it "returns teachers in correct order" do
+          query = described_class.new(sort: { created_at: :desc })
+          expect(query.teachers).to eq([teacher1, teacher2])
+        end
+      end
+
+      describe "order by updated_at, in ascending order" do
+        before { teacher2.update!(updated_at: 1.day.from_now) }
+
+        it "returns teachers in correct order" do
+          query = described_class.new(sort: { updated_at: :asc })
+          expect(query.teachers).to eq([teacher1, teacher2])
+        end
+      end
+
+      describe "order by updated_at, in descending order" do
+        it "returns teachers in correct order" do
+          query = described_class.new(sort: { updated_at: :desc })
+          expect(query.teachers).to eq([teacher1, teacher2])
+        end
+      end
+    end
+  end
+
+  describe "#teacher_by_api_id" do
+    it "returns the teachers for a given id" do
+      teacher = FactoryBot.create(:teacher)
+      query = described_class.new
+
+      expect(query.teacher_by_api_id(teacher.api_id)).to eq(teacher)
+    end
+
+    it "raises an error if the teacher does not exist" do
+      query = described_class.new
+
+      expect { query.teacher_by_api_id("XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if the teacher is not in the filtered query" do
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher
+      lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
+
+      query = described_class.new(lead_provider_id:)
+
+      expect { query.teacher_by_api_id(teacher2.api_id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if an api_id is not supplied" do
+      expect { described_class.new.teacher_by_api_id(nil) }.to raise_error(ArgumentError, "api_id needed")
+    end
+  end
+
+  describe "#teacher_by_id" do
+    it "returns the teacher for a given id" do
+      teacher = FactoryBot.create(:teacher)
+      query = described_class.new
+
+      expect(query.teacher_by_id(teacher.id)).to eq(teacher)
+    end
+
+    it "raises an error if the teacher does not exist" do
+      query = described_class.new
+
+      expect { query.teacher_by_id("XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if the teacher is not in the filtered query" do
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher
+      lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
+
+      query = described_class.new(lead_provider_id:)
+
+      expect { query.teacher_by_id(teacher2.api_id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if an id is not supplied" do
+      expect { described_class.new.teacher_by_id(nil) }.to raise_error(ArgumentError, "id needed")
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are adding the `Teachers::Query` service to allow us to query teachers according to the API specification.

### Changes proposed in this pull request

- Make api_from_teacher_id optionally set

If we want to specify our own `api_from_teacher_id` to avoid extra creations (which throws off our tests of the `Teachers::Query`, for example) its useful to be able to pass in the `api_from_teacher_id`.

- Add Teachers::Query

### Guidance to review

Note that we have to `eager_load` instead of `includes` when preloading the associations in order to be able to filter out the metadata not associated with the given lead provider. As `eager_load` can be a little less efficient that `includes` (it creates a single, bloated query and the results are paired back in memory) we may want to drop the metadata filtering and `includes` instead if we find performance is an issue.

Filtering on `contract_period_year` is also non-trivial in this query due to needing to filter across two relationships
(`latest_ect_training_period` OR `latest_mentor_training_period`). The alias names for joined tables Rails generates are not very clear. We will look into adding the contract periods to `Metadata::TeacherLeadProvider` to clean this up and make it more efficient in a follow up ticket.

#### Benchmarking

Running the query on the parity check env yields the following results:

##### 1,000 items per page

```
{
    "no filters": {
        "label": "",
        "real": 2.656694935634732,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.6337030000000001,
        "utime": 0.9968810000000001,
        "total": 1.630584
    },
    "lead provider filtering": {
        "label": "",
        "real": 0.9812330780550838,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.24396299999999993,
        "utime": 0.2689579999999996,
        "total": 0.5129209999999995
    },
    "contract period filtering": {
        "label": "",
        "real": 4.378857615403831,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.5035270000000001,
        "utime": 1.1909360000000007,
        "total": 1.6944630000000007
    },
    "updated since filtering": {
        "label": "",
        "real": 2.023762419819832,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.1946370000000002,
        "utime": 0.821847,
        "total": 1.016484
    }
}
```

###### 100 items per page

```
{
    "no filters": {
        "label": "",
        "real": 1.234193793963641,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.42882599999999993,
        "utime": 0.2486369999999996,
        "total": 0.6774629999999995
    },
    "lead provider filtering": {
        "label": "",
        "real": 0.6680415971204638,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.14522000000000013,
        "utime": 0.07106499999999993,
        "total": 0.21628500000000006
    },
    "contract period filtering": {
        "label": "",
        "real": 2.08220246527344,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.4018510000000002,
        "utime": 0.1903639999999998,
        "total": 0.5922149999999999
    },
    "updated since filtering": {
        "label": "",
        "real": 0.6533589838072658,
        "cstime": 0.0,
        "cutime": 0.0,
        "stime": 0.04337200000000019,
        "utime": 0.05860899999999969,
        "total": 0.10198099999999988
    }
}
````