### PR TITLE
Prevent implicit teachers from being seeded

### DIFF
--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -45,33 +45,33 @@ uplift_attrs = {
 }
 
 teachers = [
+  { trs_first_name: 'Stephen', trs_last_name: 'Griddle', trn: '7347584', trs_induction_status: 'InProgress' },
+  { trs_first_name: 'Hugh', trs_last_name: 'Stipend', trn: '2342798', trs_induction_status: 'Failed' },
+  { trs_first_name: 'Dominic', trs_last_name: 'East', trn: '9855743', trs_induction_status: 'InProgress' },
   { trs_first_name: 'Emma', trs_last_name: 'Thompson', trn: '1023456', trs_induction_status: 'InProgress', **uplift_attrs },
   { trs_first_name: 'Kate', trs_last_name: 'Winslet', trn: '1023457', trs_induction_status: 'Passed', **uplift_attrs },
   { trs_first_name: 'Alan', trs_last_name: 'Rickman', trn: '2084589', trs_induction_status: 'RequiredToComplete' },
-  { trs_first_name: 'Hugh', trs_last_name: 'Grant', trn: '3657894', trs_induction_status: 'Failed' },
+  { trs_first_name: 'Hugh', trs_last_name: 'Grant', trn: '3657894', trs_induction_status: 'Failed', id_changed_from_trn: '2342798', traits: %i[with_teacher_id_change] },
   { trs_first_name: 'Colin', trs_last_name: 'Firth', trn: '1237894', trs_induction_status: 'Exempt' },
   { trs_first_name: 'Harriet', trs_last_name: 'Walter', trn: '2017654', trs_induction_status: 'InProgress', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Hugh', trs_last_name: 'Laurie', trn: '4786654', trs_induction_status: 'Passed', **early_roll_out_mentor_attrs },
-  { trs_first_name: 'Stephen', trs_last_name: 'Fry', trn: '4786655', trs_induction_status: 'RequiredToComplete' },
+  { trs_first_name: 'Stephen', trs_last_name: 'Fry', trn: '4786655', trs_induction_status: 'RequiredToComplete', id_changed_from_trn: '7347584', traits: %i[with_teacher_id_change] },
   { trs_first_name: 'André', trs_last_name: 'Roussimoff', trn: '8886654', trs_induction_status: 'FailedInWales' },
   { trs_first_name: 'Imogen', trs_last_name: 'Stubbs', trn: '6352869', trs_induction_status: 'InProgress', ect_payments_frozen_year: 2021 },
   { trs_first_name: 'Gemma', trs_last_name: 'Jones', trn: '9578426', trs_induction_status: 'InProgress' },
   { trs_first_name: 'Anthony', trs_last_name: 'Hopkins', trn: '6228282', trs_induction_status: 'Exempt', mentor_payments_frozen_year: 2021 },
   { trs_first_name: 'John', trs_last_name: 'Withers', corrected_name: 'Old Man Withers', trn: '8590123', trs_induction_status: 'Failed' },
   { trs_first_name: 'Helen', trs_last_name: 'Mirren', corrected_name: 'Dame Helen Mirren', trn: '0000007', trs_induction_status: 'Passed' },
-  { trs_first_name: 'Dominic', trs_last_name: 'West', trn: '9292929', trs_induction_status: 'InProgress' },
+  { trs_first_name: 'Dominic', trs_last_name: 'West', trn: '9292929', trs_induction_status: 'InProgress', id_changed_from_trn: '9855743', traits: %i[with_teacher_id_change] },
   { trs_first_name: 'Peter', trs_last_name: 'Davison', trn: '0011223', trs_induction_status: 'RequiredToComplete', ect_payments_frozen_year: 2022, mentor_payments_frozen_year: 2022 },
   { trs_first_name: 'Robson', trs_last_name: 'Scottie', trn: '3002582', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Muhammed', trs_last_name: 'Ali', trn: '3002580', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Roy', trs_last_name: 'Dotrice', trn: '7000007', **early_roll_out_mentor_attrs },
   { trs_first_name: 'Ichigo', trs_last_name: 'Kurosaki', trn: '7777654', trs_induction_status: 'InProgress' },
-  { trs_first_name: 'Naruto', trs_last_name: 'Uzumaki', trn: '9300999', trs_induction_status: 'InProgress' },
 ]
 
 teachers.each do |attrs|
-  FactoryBot.create(:teacher, attrs).tap do |teacher|
-    FactoryBot.create(:teacher_id_change, teacher:) if Faker::Boolean.boolean(true_ratio: 0.2)
-
+  FactoryBot.create(:teacher, *attrs[:traits], attrs.excluding(:traits)).tap do |teacher|
     describe_teacher(teacher)
   end
 end

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -40,5 +40,19 @@ FactoryBot.define do
         ].sample
       end
     end
+
+    trait :with_teacher_id_change do
+      transient do
+        id_changed_from_trn { FactoryBot.create(:teacher, trs_first_name:).trn }
+      end
+
+      after(:create) do |teacher, evaluator|
+        FactoryBot.create(
+          :teacher_id_change,
+          teacher:,
+          api_from_teacher_id: Teacher.find_by_trn(evaluator.id_changed_from_trn).api_id
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Currently, after running the seeds we have a small number of teachers that are created implicitly by the factories and are not defined in the `teachers.rb` seed. We only want to end up with teachers that we explicitly define.

### Changes proposed in this pull request

- Prevent implicit teachers from being seeded

This happens because the `teacher_id_change` factory will always create a new teacher to assign the `api_from_teacher_id` to. Instead, we can make this create a new teacher only if one is not specified and explicitly pass in the `api_from_teacher_id` in the teacher seeds.

### Guidance to review

After running the updated seeds:

```
Teacher.pluck(:trs_first_name, :trs_last_name).sort

=> 
=> 
[["Alan", "Rickman"],
 ["André", "Roussimoff"],
 ["Anthony", "Hopkins"],
 ["Colin", "Firth"],
 ["Dominic", "East"],
 ["Dominic", "West"],
 ["Emma", "Thompson"],
 ["Gemma", "Jones"],
 ["Harriet", "Walter"],
 ["Helen", "Mirren"],
 ["Hugh", "Grant"],
 ["Hugh", "Laurie"],
 ["Hugh", "Stipend"],
 ["Ichigo", "Kurosaki"],
 ["Imogen", "Stubbs"],
 ["John", "Withers"],
 ["Kate", "Winslet"],
 ["Muhammed", "Ali"],
 ["Naruto", "Uzumaki"],
 ["Peter", "Davison"],
 ["Robson", "Scottie"],
 ["Roy", "Dotrice"],
 ["Stephen", "Fry"],
 ["Stephen", "Griddle"]]
 ```
