### PR TITLE
[2239] Spike on nuclear withdrawals - part 1

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -59,6 +59,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
     with_expressions_of_interest_for_contract_period(year)
     .where(expression_of_interest: { lead_provider_id: })
   }
+  scope :active, -> { where(withdrawn_by_error: false) }
 
   def school_reported_appropriate_body_name = school_reported_appropriate_body&.name
 
@@ -67,7 +68,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   def siblings
     return ECTAtSchoolPeriod.none unless teacher
 
-    teacher.ect_at_school_periods.excluding(self)
+    teacher.ect_at_school_periods.active.excluding(self)
   end
 
   delegate :trn, to: :teacher

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -42,6 +42,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
   validate :teacher_distinct_period
 
   # Scopes
+  default_scope { where(withdrawn_by_error: false) }
+
   scope :for_school, ->(school_id) { where(school_id:) }
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
   scope :with_partnerships_for_contract_period, ->(year) {
@@ -59,7 +61,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
     with_expressions_of_interest_for_contract_period(year)
     .where(expression_of_interest: { lead_provider_id: })
   }
-  scope :active, -> { where(withdrawn_by_error: false) }
 
   def school_reported_appropriate_body_name = school_reported_appropriate_body&.name
 
@@ -68,7 +69,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   def siblings
     return ECTAtSchoolPeriod.none unless teacher
 
-    teacher.ect_at_school_periods.active.excluding(self)
+    teacher.ect_at_school_periods.excluding(self)
   end
 
   delegate :trn, to: :teacher

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -32,6 +32,8 @@ class MentorAtSchoolPeriod < ApplicationRecord
   validate :teacher_school_distinct_period
 
   # Scopes
+  default_scope { where(withdrawn_by_error: false) }
+
   scope :for_school, ->(school_id) { where(school_id:) }
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
   scope :with_partnerships_for_contract_period, ->(year) {
@@ -54,7 +56,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   def siblings
     return MentorAtSchoolPeriod.none unless teacher
 
-    teacher.mentor_at_school_periods.active.for_school(school_id).excluding(self)
+    teacher.mentor_at_school_periods.for_school(school_id).excluding(self)
   end
 
 private

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -54,7 +54,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   def siblings
     return MentorAtSchoolPeriod.none unless teacher
 
-    teacher.mentor_at_school_periods.for_school(school_id).excluding(self)
+    teacher.mentor_at_school_periods.active.for_school(school_id).excluding(self)
   end
 
 private

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -24,8 +24,8 @@ class Teacher < ApplicationRecord
   has_one :ongoing_induction_period, -> { ongoing }, class_name: "InductionPeriod"
   has_one :started_induction_period, -> { earliest_first }, class_name: "InductionPeriod"
   has_one :finished_induction_period, -> { finished.with_outcome.latest_first }, class_name: "InductionPeriod"
-  has_one :earliest_ect_at_school_period, -> { earliest_first }, class_name: "ECTAtSchoolPeriod"
-  has_one :earliest_mentor_at_school_period, -> { earliest_first }, class_name: "MentorAtSchoolPeriod"
+  has_one :earliest_ect_at_school_period, -> { unscope(where: :withdrawn_by_error).earliest_first }, class_name: "ECTAtSchoolPeriod"
+  has_one :earliest_mentor_at_school_period, -> { unscope(where: :withdrawn_by_error).earliest_first }, class_name: "MentorAtSchoolPeriod"
 
   has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -10,8 +10,10 @@ class TrainingPeriod < ApplicationRecord
        suffix: :training_programme
 
   # Associations
-  belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :training_periods
+  belongs_to :ect_at_school_period, inverse_of: :training_periods
   belongs_to :mentor_at_school_period, inverse_of: :training_periods
+  belongs_to :unscoped_ect_at_school_period, -> { unscope(where: :withdrawn_by_error) }, class_name: "ECTAtSchoolPeriod", foreign_key: :ect_at_school_period_id
+  belongs_to :unscoped_mentor_at_school_period, -> { unscope(where: :withdrawn_by_error) }, class_name: "MentorAtSchoolPeriod", foreign_key: :mentor_at_school_period_id
   belongs_to :school_partnership
 
   has_one :lead_provider_delivery_partnership, through: :school_partnership
@@ -57,13 +59,13 @@ class TrainingPeriod < ApplicationRecord
   }
 
   scope :ect_training_periods_latest_first, ->(teacher:, lead_provider:) {
-    includes(:ect_at_school_period, :lead_provider)
-    .where(ect_at_school_period: { teacher: }, lead_provider: { id: lead_provider })
+    includes(:unscoped_ect_at_school_period, :lead_provider)
+    .where(unscoped_ect_at_school_period: { teacher: }, lead_provider: { id: lead_provider })
     .latest_first
   }
   scope :mentor_training_periods_latest_first, ->(teacher:, lead_provider:) {
-    includes(:mentor_at_school_period, :lead_provider)
-    .where(mentor_at_school_period: { teacher: }, lead_provider: { id: lead_provider })
+    includes(:unscoped_mentor_at_school_period, :lead_provider)
+    .where(unscoped_mentor_at_school_period: { teacher: }, lead_provider: { id: lead_provider })
     .latest_first
   }
 

--- a/app/models/unscoped_ect_at_school_period.rb
+++ b/app/models/unscoped_ect_at_school_period.rb
@@ -1,0 +1,3 @@
+class UnscopedECTAtSchoolPeriod < ECTAtSchoolPeriod
+  self.default_scopes = []
+end

--- a/app/models/unscoped_mentor_at_school_period.rb
+++ b/app/models/unscoped_mentor_at_school_period.rb
@@ -1,0 +1,3 @@
+class UnscopedMentorAtSchoolPeriod < MentorAtSchoolPeriod
+  self.default_scopes = []
+end

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -10,6 +10,7 @@ module API::Teachers
       training_status: :ignore,
       api_from_teacher_id: :ignore,
       updated_since: :ignore,
+      include_withdrawn_by_error: true,
       sort: { created_at: :asc }
     )
       @lead_provider_id = lead_provider_id
@@ -20,6 +21,7 @@ module API::Teachers
       where_training_status_is(training_status)
       where_api_from_teacher_id_is(api_from_teacher_id)
       where_updated_since(updated_since)
+      where_including_withdrawn_by_error(include_withdrawn_by_error)
       set_sort_by(sort)
     end
 
@@ -152,6 +154,12 @@ module API::Teachers
 
       # TODO: update when we have an accurate updated_at field
       @scope = scope.where(updated_at: updated_since..)
+    end
+
+    def where_including_withdrawn_by_error(include_withdrawn_by_error)
+      return if ignore?(filter: include_withdrawn_by_error)
+
+      @scope = scope.merge(ECTAtSchoolPeriod.unscope(:left_outer_joins, where: :withdrawn_by_error)).merge(MentorAtSchoolPeriod.unscope(:left_outer_joins, where: :withdrawn_by_error))
     end
 
     def set_sort_by(sort)

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -21,7 +21,6 @@ module API::Teachers
       where_training_status_is(training_status)
       where_api_from_teacher_id_is(api_from_teacher_id)
       where_updated_since(updated_since)
-      where_including_withdrawn_by_error(include_withdrawn_by_error)
       set_sort_by(sort)
     end
 
@@ -57,7 +56,7 @@ module API::Teachers
                 contract_period
                 delivery_partner
               ],
-              ect_at_school_period: {
+              unscoped_ect_at_school_period: {
                 teacher: %i[
                   started_induction_period
                   finished_induction_period
@@ -70,7 +69,7 @@ module API::Teachers
                 contract_period
                 delivery_partner
               ],
-              mentor_at_school_period: {
+              unscoped_mentor_at_school_period: {
                 teacher: %i[
                   started_induction_period
                   finished_induction_period
@@ -154,12 +153,6 @@ module API::Teachers
 
       # TODO: update when we have an accurate updated_at field
       @scope = scope.where(updated_at: updated_since..)
-    end
-
-    def where_including_withdrawn_by_error(include_withdrawn_by_error)
-      return if ignore?(filter: include_withdrawn_by_error)
-
-      @scope = scope.merge(ECTAtSchoolPeriod.unscope(:left_outer_joins, where: :withdrawn_by_error)).merge(MentorAtSchoolPeriod.unscope(:left_outer_joins, where: :withdrawn_by_error))
     end
 
     def set_sort_by(sort)

--- a/db/migrate/20251007154530_add_withdrawn_by_error_flag_to_ect_and_mentor_at_school_periods.rb
+++ b/db/migrate/20251007154530_add_withdrawn_by_error_flag_to_ect_and_mentor_at_school_periods.rb
@@ -1,0 +1,8 @@
+class AddWithdrawnByErrorFlagToECTAndMentorAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ect_at_school_periods, :withdrawn_by_error, :boolean, default: false, null: false
+    add_column :mentor_at_school_periods, :withdrawn_by_error, :boolean, default: false, null: false
+    add_index :ect_at_school_periods, :withdrawn_by_error
+    add_index :mentor_at_school_periods, :withdrawn_by_error
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -185,12 +185,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_144737) do
     t.enum "working_pattern", enum_type: "working_pattern"
     t.citext "email"
     t.bigint "school_reported_appropriate_body_id"
+    t.boolean "withdrawn_by_error", default: false, null: false
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
     t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
+    t.index ["withdrawn_by_error"], name: "index_ect_at_school_periods_on_withdrawn_by_error"
   end
 
   create_table "events", force: :cascade do |t|
@@ -344,10 +346,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_144737) do
     t.uuid "ecf_start_induction_record_id"
     t.uuid "ecf_end_induction_record_id"
     t.citext "email"
+    t.boolean "withdrawn_by_error", default: false, null: false
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
     t.index ["teacher_id"], name: "index_mentor_at_school_periods_on_teacher_id"
+    t.index ["withdrawn_by_error"], name: "index_mentor_at_school_periods_on_withdrawn_by_error"
   end
 
   create_table "mentorship_periods", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -782,6 +782,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_144737) do
     t.integer "mentor_payments_frozen_year"
     t.boolean "ect_pupil_premium_uplift", default: false, null: false
     t.boolean "ect_sparsity_uplift", default: false, null: false
+    t.datetime "ect_first_became_eligible_for_training_at"
+    t.datetime "mentor_first_became_eligible_for_training_at"
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true


### PR DESCRIPTION
### Context

Spike ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2239

### Changes proposed in this pull request

- add a `withdrawn_by_error` flag: Introduce a boolean column, withdrawn_by_error, to the ect/mentor_at_school_period model. This flag will explicitly mark records corresponding to accidental registrations

- modify Interval concern: Update the overlapping validation logic to ignore ect/mentor_at_school_period records where `withdrawn_by_error` is true when checking for overlaps. This will prevent validation issues when a participant is legitimately claimed or transferred by/to another school after a mistaken registration.

- use `EctAtSchoolPeriod.active` where needed in API related queries / metadata refresh methods

- decided not to go for `default_scope` to ect/mentor at school periods, as it can hide data unexpectedly data in other places and adding `unscoped` to these places is often forgotten

- I'm suggesting the name of the field to be `withdrawn_by_error` but this could be only a boolean field called `withdrawn` also with `closed_at` field with to stamp when the teacher was withdrawn and a `withdrawn_reason= 'legacy_ecf1_withdrawn'` to mark the reason for that.

### Guidance to review
