### PR TITLE
[2198] - set first school_period created_at time to that of its participant profile migrated from ECF1

### DIFF
--- a/app/migration/builders/ect/school_periods.rb
+++ b/app/migration/builders/ect/school_periods.rb
@@ -1,11 +1,12 @@
 module Builders
   module ECT
     class SchoolPeriods
-      attr_reader :teacher, :school_periods
+      attr_reader :teacher, :school_periods, :created_at
 
-      def initialize(teacher:, school_periods:)
+      def initialize(teacher:, school_periods:, created_at:)
         @teacher = teacher
         @school_periods = school_periods
+        @created_at = created_at
       end
 
       def build
@@ -16,6 +17,8 @@ module Builders
           school_period = ::ECTAtSchoolPeriod.find_or_initialize_by(teacher:, school:, started_on: period.start_date)
           school_period.ecf_start_induction_record_id = period.start_source_id
           next_period = school_periods[idx + 1]
+
+          school_period.created_at = created_at if idx.zero?
 
           if next_period.present? && period.end_date.present? && (period.end_date > next_period.start_date || period.end_date < period.start_date)
             school_period.finished_on = next_period.start_date

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -50,7 +50,9 @@ module Migrators
             school_periods.flatten!
 
             teacher.update!(api_ect_training_record_id: participant_profile.id)
-            result = Builders::ECT::SchoolPeriods.new(teacher:, school_periods:).build
+            result = Builders::ECT::SchoolPeriods
+                       .new(teacher:, school_periods:, created_at: participant_profile.created_at)
+                       .build
           else
             ::TeacherMigrationFailure.create!(teacher:,
                                               model: :ect_at_school_period,

--- a/spec/migration/builders/ect/school_periods_spec.rb
+++ b/spec/migration/builders/ect/school_periods_spec.rb
@@ -1,5 +1,5 @@
 describe Builders::ECT::SchoolPeriods do
-  subject(:service) { described_class.new(teacher:, school_periods:) }
+  subject(:service) { described_class.new(teacher:, school_periods:, created_at:) }
 
   let(:school_1) { FactoryBot.create(:school, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, urn: "987654") }
@@ -7,6 +7,7 @@ describe Builders::ECT::SchoolPeriods do
   let(:period_1) { FactoryBot.build(:school_period, urn: school_1.urn, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
   let(:period_2) { FactoryBot.build(:school_period, urn: school_2.urn, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:school_periods) { [period_1, period_2] }
+  let(:created_at) { period_1.start_date.to_time }
 
   before do
     CacheManager.instance.clear_all_caches!
@@ -23,6 +24,7 @@ describe Builders::ECT::SchoolPeriods do
       service.build
       periods = teacher.ect_at_school_periods.order(:started_on)
 
+      expect(periods.first.created_at).to eq created_at
       expect(periods.first.school).to eq school_1
       expect(periods.first.started_on).to eq period_1.start_date
       expect(periods.first.finished_on).to eq period_1.end_date
@@ -43,6 +45,7 @@ describe Builders::ECT::SchoolPeriods do
         service.build
         periods = teacher.ect_at_school_periods.order(:started_on)
 
+        expect(periods.first.created_at).to eq created_at
         expect(periods.first.school).to eq school_1
         expect(periods.first.started_on).to eq period_1.start_date
         expect(periods.first.finished_on).to eq period_2.start_date


### PR DESCRIPTION
### Context

[Ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/2198)

When we migrate a ParticipantProfile::ECT record we store the ECF ID on the Teacher record in the attribute ecf_ect_profile_id. We also need to store the ParticipantProfile.created_at attribute in RECT alongside this.

We should store the ParticipantProfile::ECT.created_at timestamp in the earliest/first ECTAtSchoolPeriod.created_at

### Changes proposed in this pull request
Updates the Migrators::ECTAtSchoolPeriod to store the ParticipantProfile::ECT.created_at in the first ECTAtSchoolPeriod.created_at.

### Guidance to review
