### PR TITLE
Prevent school periods that end before they start

### DIFF
--- a/app/migration/school_period_extractor.rb
+++ b/app/migration/school_period_extractor.rb
@@ -43,7 +43,7 @@ private
                                                      end_source_id: induction_record.id,
                                                      training_programme:)
         periods << current_period
-      elsif induction_record.end_date && induction_record.end_date > current_period.end_date
+      elsif induction_record.end_date.nil? || induction_record.end_date > current_period.end_date
         current_period.end_date = induction_record.end_date
         current_period.end_source_id = induction_record.id
       end

--- a/app/migration/school_period_extractor.rb
+++ b/app/migration/school_period_extractor.rb
@@ -43,7 +43,7 @@ private
                                                      end_source_id: induction_record.id,
                                                      training_programme:)
         periods << current_period
-      else
+      elsif induction_record.end_date && induction_record.end_date > current_period.end_date
         current_period.end_date = induction_record.end_date
         current_period.end_source_id = induction_record.id
       end


### PR DESCRIPTION
### Context
Some induction records report that a participant left the school before their start date. These incorrect records cause issues when extracting school periods.

To address this, such induction records should be ignored. Instead, the extractor should use the most recent induction record where the school period has a valid date range (end date after the start date).

### Changes proposed in this pull request
- Update the SchoolPeriodExtractor to ignore induction records where the end date is before the period's start date.

### Guidance to review
