### PR TITLE
[2199] - set first mentor_at_school_period created_at time to that of its participant profile imported from ECF

### DIFF
--- a/app/migration/builders/mentor/school_periods.rb
+++ b/app/migration/builders/mentor/school_periods.rb
@@ -1,21 +1,23 @@
 module Builders
   module Mentor
     class SchoolPeriods
-      attr_reader :teacher, :school_periods
+      attr_reader :teacher, :school_periods, :created_at
 
-      def initialize(teacher:, school_periods:)
+      def initialize(teacher:, school_periods:, created_at:)
         @teacher = teacher
         @school_periods = school_periods
+        @created_at = created_at
       end
 
       def build
         success = true
-        school_periods.each do |period|
+        school_periods.each_with_index do |period, idx|
           school = find_school_by_urn!(period.urn)
           school_period = ::MentorAtSchoolPeriod.find_or_initialize_by(teacher:, school:, started_on: period.start_date)
           school_period.finished_on = period.end_date
           school_period.ecf_start_induction_record_id = period.start_source_id
           school_period.ecf_end_induction_record_id = period.end_source_id
+          school_period.created_at = created_at if idx.zero?
           school_period.save!
         rescue ActiveRecord::ActiveRecordError => e
           ::TeacherMigrationFailure.create!(teacher:, model: :mentor_at_school_period, message: e.message, migration_item_id: period.start_source_id, migration_item_type: "Migration::InductionRecord")

--- a/app/migration/migrators/mentor_at_school_period.rb
+++ b/app/migration/migrators/mentor_at_school_period.rb
@@ -49,7 +49,9 @@ module Migrators
             end
 
             teacher.update!(api_mentor_training_record_id: participant_profile.id)
-            result = Builders::Mentor::SchoolPeriods.new(teacher:, school_periods: school_periods.flatten).build
+            result = Builders::Mentor::SchoolPeriods
+                       .new(teacher:, school_periods: school_periods.flatten, created_at: participant_profile.created_at)
+                       .build
           else
             ::TeacherMigrationFailure.create!(teacher:,
                                               model: :mentor_at_school_period,

--- a/spec/migration/builders/mentor/school_periods_spec.rb
+++ b/spec/migration/builders/mentor/school_periods_spec.rb
@@ -1,5 +1,5 @@
 describe Builders::Mentor::SchoolPeriods do
-  subject(:service) { described_class.new(teacher:, school_periods:) }
+  subject(:service) { described_class.new(teacher:, school_periods:, created_at:) }
 
   let(:school_1) { FactoryBot.create(:school, urn: "123456") }
   let(:school_2) { FactoryBot.create(:school, urn: "987654") }
@@ -7,6 +7,7 @@ describe Builders::Mentor::SchoolPeriods do
   let(:period_1) { FactoryBot.build(:school_period, urn: school_1.urn, start_date: 1.year.ago.to_date, end_date: 1.month.ago.to_date) }
   let(:period_2) { FactoryBot.build(:school_period, urn: school_2.urn, start_date: 1.month.ago.to_date, end_date: nil) }
   let(:school_periods) { [period_1, period_2] }
+  let(:created_at) { period_1.start_date.to_time }
 
   before do
     CacheManager.instance.clear_all_caches!
@@ -23,6 +24,7 @@ describe Builders::Mentor::SchoolPeriods do
       service.build
       periods = teacher.mentor_at_school_periods.order(:started_on)
 
+      expect(periods.first.created_at).to eq created_at
       expect(periods.first.school).to eq school_1
       expect(periods.first.started_on).to eq period_1.start_date
       expect(periods.first.finished_on).to eq period_1.end_date


### PR DESCRIPTION
[Ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/2199)

### Context
When we migrate a ParticipantProfile::Mentor record we store the ECF ID on the Teacher record in the attribute ecf_mentor_profile_id. We also need to store the ParticipantProfile.created_at attribute in RECT alongside this.

We should store the ParticipantProfile::Mentor.created_at timestamp in the earliest/first MentorAtSchoolPeriod.created_at

### Changes proposed in this pull request
Updates the Migrators::MentorAtSchoolPeriod to store the original ECF ParticipantProfile::Mentor.created_at in the first MentorAtSchoolPeriod record's created_at attribute.

### Guidance to review
