### PR TITLE
Add `mentor_api_id` to `Metadata::TeacherLeadProvider`

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -17,6 +17,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_one :latest_mentorship_period, -> { latest_first }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
+  refresh_metadata -> { teacher }, on_event: %i[create destroy]
 
   # Validations
   validate :appropriate_body_for_independent_school,

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -14,6 +14,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :events
   has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: 'TrainingPeriod'
   has_one :current_or_next_mentorship_period, -> { current_or_future.earliest_first }, class_name: 'MentorshipPeriod'
+  has_one :latest_mentorship_period, -> { latest_first }, class_name: 'MentorshipPeriod'
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -1,5 +1,6 @@
 class MentorshipPeriod < ApplicationRecord
   include Interval
+  include DeclarativeUpdates
 
   # Associations
   belongs_to :mentee,
@@ -32,6 +33,8 @@ class MentorshipPeriod < ApplicationRecord
   # Scopes
   scope :for_mentee, ->(id) { where(ect_at_school_period_id: id) }
   scope :for_mentor, ->(id) { where(mentor_at_school_period_id: id) }
+
+  refresh_metadata -> { mentee.teacher }, on_event: %i[create destroy]
 
   # Instance methods
   def siblings

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -27,8 +27,9 @@ module Metadata::Handlers
 
         latest_ect_training_period = TrainingPeriod.ect_training_periods_latest_first(teacher:, lead_provider: lead_provider_id).first
         latest_mentor_training_period = TrainingPeriod.mentor_training_periods_latest_first(teacher:, lead_provider: lead_provider_id).first
+        mentor_api_id = latest_ect_training_period&.trainee&.latest_mentorship_period&.mentor&.teacher&.api_id
 
-        upsert(metadata, latest_ect_training_period:, latest_mentor_training_period:)
+        upsert(metadata, latest_ect_training_period:, latest_mentor_training_period:, mentor_api_id:)
       end
     end
 

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -27,9 +27,9 @@ module Metadata::Handlers
 
         latest_ect_training_period = TrainingPeriod.ect_training_periods_latest_first(teacher:, lead_provider: lead_provider_id).first
         latest_mentor_training_period = TrainingPeriod.mentor_training_periods_latest_first(teacher:, lead_provider: lead_provider_id).first
-        mentor_api_id = latest_ect_training_period&.trainee&.latest_mentorship_period&.mentor&.teacher&.api_id
+        api_mentor_id = latest_ect_training_period&.trainee&.latest_mentorship_period&.mentor&.teacher&.api_id
 
-        upsert(metadata, latest_ect_training_period:, latest_mentor_training_period:, mentor_api_id:)
+        upsert(metadata, latest_ect_training_period:, latest_mentor_training_period:, api_mentor_id:)
       end
     end
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -243,6 +243,7 @@
   - lead_provider_id
   - latest_ect_training_period_id
   - latest_mentor_training_period_id
+  - api_mentor_id
   - created_at
   - updated_at
   :pending_induction_submissions:

--- a/db/migrate/20251010075339_add_api_mentor_id_to_metadata_teachers_lead_providers.rb
+++ b/db/migrate/20251010075339_add_api_mentor_id_to_metadata_teachers_lead_providers.rb
@@ -1,0 +1,5 @@
+class AddAPIMentorIdToMetadataTeachersLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :metadata_teachers_lead_providers, :api_mentor_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_08_144737) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_10_075339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -410,6 +410,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_144737) do
     t.bigint "latest_mentor_training_period_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "api_mentor_id"
     t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
     t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
     t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -332,6 +332,7 @@ erDiagram
     integer latest_mentor_training_period_id
     datetime created_at
     datetime updated_at
+    uuid api_mentor_id
   }
   Metadata_TeacherLeadProvider }o--|| Teacher : belongs_to
   Metadata_TeacherLeadProvider }o--|| LeadProvider : belongs_to

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -97,6 +97,37 @@ describe ECTAtSchoolPeriod do
         end
       end
     end
+
+    describe '.latest_mentorship_period' do
+      subject { ect_at_school_period.latest_mentorship_period }
+
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+      let(:mentorship_started_on) { 3.weeks.ago }
+      let(:mentorship_finished_on) { nil }
+      let!(:latest_mentorship_period) do
+        FactoryBot.create(
+          :mentorship_period,
+          mentee: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          started_on: mentorship_started_on,
+          finished_on: mentorship_finished_on
+        )
+      end
+
+      before do
+        # Previous mentorship period.
+        FactoryBot.create(
+          :mentorship_period,
+          mentee: ect_at_school_period,
+          mentor: mentor_at_school_period,
+          started_on: latest_mentorship_period.started_on - 6.months,
+          finished_on: latest_mentorship_period.started_on
+        )
+      end
+
+      it { is_expected.to eq(latest_mentorship_period) }
+    end
   end
 
   describe "validations" do

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -1,9 +1,18 @@
 describe ECTAtSchoolPeriod do
   describe "declarative updates" do
-    let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, school: target) }
-    let!(:target) { FactoryBot.create(:school) }
+    describe "school target" do
+      let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, school: target) }
+      let!(:target) { FactoryBot.create(:school) }
 
-    it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+      it_behaves_like "a declarative metadata model", on_event: %i[create destroy update]
+    end
+
+    describe "teacher target" do
+      let(:instance) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: target) }
+      let!(:target) { FactoryBot.create(:teacher) }
+
+      it_behaves_like "a declarative metadata model", on_event: %i[create destroy]
+    end
   end
 
   describe "associations" do

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -1,4 +1,13 @@
 describe MentorshipPeriod do
+  describe "declarative updates" do
+    let(:instance) { FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor:, started_on: 1.year.ago, finished_on: nil) }
+    let(:mentee) { FactoryBot.create(:ect_at_school_period, started_on: 5.years.ago, finished_on: nil, teacher: target) }
+    let(:mentor) { FactoryBot.create(:mentor_at_school_period, started_on: 5.years.ago, finished_on: nil) }
+    let!(:target) { FactoryBot.create(:teacher) }
+
+    it_behaves_like "a declarative metadata model", on_event: %i[create destroy]
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:mentee).class_name("ECTAtSchoolPeriod").with_foreign_key(:ect_at_school_period_id).inverse_of(:mentorship_periods) }
     it { is_expected.to belong_to(:mentor).class_name("MentorAtSchoolPeriod").with_foreign_key(:mentor_at_school_period_id).inverse_of(:mentorship_periods) }

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -74,11 +74,24 @@ describe API::TeacherSerializer, type: :serializer do
       context "when there are ECT/mentor training periods for the lead provider" do
         let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider:) }
 
-        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
-        let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:, lead_provider_delivery_partnership:) }
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: 2.months.ago, finished_on: nil) }
+        let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, started_on: 1.month.ago, ect_at_school_period:, lead_provider_delivery_partnership:) }
 
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:) }
-        let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, lead_provider_delivery_partnership:) }
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 2.months.ago, finished_on: nil) }
+        let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.month.ago, mentor_at_school_period:, lead_provider_delivery_partnership:) }
+
+        let(:other_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 2.months.ago, finished_on: nil) }
+        let!(:other_mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.month.ago, mentor_at_school_period: other_mentor_at_school_period, lead_provider_delivery_partnership:) }
+
+        let!(:latest_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            mentee: ect_at_school_period,
+            mentor: other_mentor_at_school_period,
+            started_on: ect_training_period.started_on + 1.week,
+            finished_on: nil
+          )
+        end
 
         it { expect(ecf_enrolments.count).to eq(2) }
 
@@ -94,7 +107,15 @@ describe API::TeacherSerializer, type: :serializer do
           end
 
           it "serializes `mentor_id`" do
-            expect(ect_enrolment["mentor_id"]).to eq("mentor_api_id")
+            expect(ect_enrolment["mentor_id"]).to eq(latest_mentorship_period.mentor.teacher.api_id)
+          end
+
+          context "when there is no latest mentor training period" do
+            let(:latest_mentorship_period) { nil }
+
+            it "serializes `mentor_id` as nil" do
+              expect(ect_enrolment["mentor_id"]).to be_nil
+            end
           end
 
           it "serializes `school_urn`" do

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe Metadata::Handlers::Teacher do
             teacher: teacher1,
             lead_provider: lead_provider1,
             latest_ect_training_period: ect_training_period1,
-            latest_mentor_training_period: mentor_training_period1
+            latest_mentor_training_period: mentor_training_period1,
+            mentor_api_id: nil
           )
 
           metadata2 = Metadata::TeacherLeadProvider.where(lead_provider: lead_provider2).sole
@@ -119,7 +120,8 @@ RSpec.describe Metadata::Handlers::Teacher do
             teacher: teacher1,
             lead_provider: lead_provider2,
             latest_ect_training_period: ect_training_period2,
-            latest_mentor_training_period: mentor_training_period2
+            latest_mentor_training_period: mentor_training_period2,
+            mentor_api_id: nil
           )
         end
       end
@@ -193,7 +195,8 @@ RSpec.describe Metadata::Handlers::Teacher do
             teacher: teacher1,
             lead_provider: lead_provider1,
             latest_ect_training_period: ect_training_period2,
-            latest_mentor_training_period: mentor_training_period2
+            latest_mentor_training_period: mentor_training_period2,
+            mentor_api_id: nil
           )
         end
       end
@@ -225,13 +228,14 @@ RSpec.describe Metadata::Handlers::Teacher do
             teacher: teacher1,
             lead_provider: lead_provider1,
             latest_ect_training_period: ect_training_period1,
-            latest_mentor_training_period: nil
+            latest_mentor_training_period: nil,
+            mentor_api_id: nil
           )
         end
       end
 
       context "teacher without any training periods" do
-        it "creates metadata with nil latest training periods" do
+        it "creates metadata with nil latest training periods and mentor_api_id" do
           refresh_metadata
 
           metadata = Metadata::TeacherLeadProvider.where(lead_provider: lead_provider1).sole
@@ -239,7 +243,79 @@ RSpec.describe Metadata::Handlers::Teacher do
             teacher: teacher1,
             lead_provider: lead_provider1,
             latest_ect_training_period: nil,
-            latest_mentor_training_period: nil
+            latest_mentor_training_period: nil,
+            mentor_api_id: nil
+          )
+        end
+      end
+
+      context "when the latest ECT training period has mentorship periods" do
+        let!(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            school: school1,
+            teacher: teacher1,
+            started_on: 1.year.ago,
+            finished_on: nil
+          )
+        end
+        let!(:mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            school: school1,
+            started_on: 1.year.ago,
+            finished_on: nil
+          )
+        end
+        let!(:ect_training_period1) do
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            started_on: ect_at_school_period.started_on + 1.month,
+            finished_on: nil,
+            ect_at_school_period:,
+            school_partnership: school_partnership1
+          )
+        end
+        let!(:latest_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            mentee: ect_at_school_period,
+            mentor: mentor_at_school_period,
+            started_on: ect_training_period1.started_on + 1.month,
+            finished_on: nil
+          )
+        end
+
+        before do
+          # Previous mentorship period.
+          FactoryBot.create(
+            :mentorship_period,
+            mentee: ect_at_school_period,
+            mentor: mentor_at_school_period,
+            started_on: latest_mentorship_period.started_on - 1.month,
+            finished_on: latest_mentorship_period.started_on
+          )
+
+          # Previous ECT training period.
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            started_on: ect_at_school_period.started_on,
+            finished_on: ect_training_period1.started_on,
+            ect_at_school_period:,
+            school_partnership: school_partnership1
+          )
+        end
+
+        it "creates metadata with the correct/latest mentor_api_id" do
+          refresh_metadata
+
+          metadata = Metadata::TeacherLeadProvider.where(teacher: teacher1, lead_provider: lead_provider1).sole
+          expect(metadata).to have_attributes(
+            teacher: teacher1,
+            lead_provider: lead_provider1,
+            mentor_api_id: latest_mentorship_period.mentor.teacher.api_id
           )
         end
       end

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             lead_provider: lead_provider1,
             latest_ect_training_period: ect_training_period1,
             latest_mentor_training_period: mentor_training_period1,
-            mentor_api_id: nil
+            api_mentor_id: nil
           )
 
           metadata2 = Metadata::TeacherLeadProvider.where(lead_provider: lead_provider2).sole
@@ -121,7 +121,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             lead_provider: lead_provider2,
             latest_ect_training_period: ect_training_period2,
             latest_mentor_training_period: mentor_training_period2,
-            mentor_api_id: nil
+            api_mentor_id: nil
           )
         end
       end
@@ -196,7 +196,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             lead_provider: lead_provider1,
             latest_ect_training_period: ect_training_period2,
             latest_mentor_training_period: mentor_training_period2,
-            mentor_api_id: nil
+            api_mentor_id: nil
           )
         end
       end
@@ -229,13 +229,13 @@ RSpec.describe Metadata::Handlers::Teacher do
             lead_provider: lead_provider1,
             latest_ect_training_period: ect_training_period1,
             latest_mentor_training_period: nil,
-            mentor_api_id: nil
+            api_mentor_id: nil
           )
         end
       end
 
       context "teacher without any training periods" do
-        it "creates metadata with nil latest training periods and mentor_api_id" do
+        it "creates metadata with nil latest training periods and api_mentor_id" do
           refresh_metadata
 
           metadata = Metadata::TeacherLeadProvider.where(lead_provider: lead_provider1).sole
@@ -244,7 +244,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             lead_provider: lead_provider1,
             latest_ect_training_period: nil,
             latest_mentor_training_period: nil,
-            mentor_api_id: nil
+            api_mentor_id: nil
           )
         end
       end
@@ -308,14 +308,14 @@ RSpec.describe Metadata::Handlers::Teacher do
           )
         end
 
-        it "creates metadata with the correct/latest mentor_api_id" do
+        it "creates metadata with the correct/latest api_mentor_id" do
           refresh_metadata
 
           metadata = Metadata::TeacherLeadProvider.where(teacher: teacher1, lead_provider: lead_provider1).sole
           expect(metadata).to have_attributes(
             teacher: teacher1,
             lead_provider: lead_provider1,
-            mentor_api_id: latest_mentorship_period.mentor.teacher.api_id
+            api_mentor_id: latest_mentorship_period.mentor.teacher.api_id
           )
         end
       end

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -278,7 +278,7 @@ RSpec.shared_examples "a declarative metadata model" do |when_changing: [], on_e
 
         instance
 
-        expect(manager).to have_received(:refresh_metadata!).with(target)
+        expect(manager).to have_received(:refresh_metadata!).with(target).at_least(:once)
       end
     end
 


### PR DESCRIPTION
### Context

We want to stamp the `api_mentor_id` on the `Metadata::TeacherLeadProvider` so that we can easily include it in the `TeacherSerializer`. This will always be the mentor of the latest `MentorshipPeriod` relative to the `LeadProvider`.

### Changes proposed in this pull request

- Add `api_mentor_id` to `Metadata::TeacherLeadProvider`

This will be used to store the mentor for a given teacher relative to each lead provider based on their latest ECT training/mentorship period.

- Populate `api_mentor_id` on `Metadata::TeacherLeadProvider`

Populate the `api_mentor_id` on `Metadata::TeacherLeadProvider` from the `latest_ect_training_period` and `latest_mentorship_period`.

Add `latest_mentorship_period` scope to find the latest mentor for a teacher.

- Refresh `Metadata::TeacherLeadProvider` for `api_mentor_id`

We need to refresh the `Metadata::TeacherLeadProvider` to update `api_mentor_id` when any of the following occur:

`ECTAtSchoolPeriod` created/destroyed
`MentorshipPeriod` created/destroyed

This assumes the `mentor` will not change on a `MentorshipPeriod`.

The `teacher` metadata is already refreshed when a `TrainingPeriod` is created/destroyed/updated.

Minor update to the declarative updates shared context as we now have scenarios where the `instance` and `target` refresh the metadata on `create`, so we have multiple calls to `refresh_metadata!`.

- Add `api_mentor_id` to `TeacherSerializer`

We can now populate the `mentor_api_id` from the value we stamp on the `Metadata::TeacherLeadProvider`.

Inline the metadata lookup as we can't call the class method from the nested classes/serializers.

### Guidance to review
