### PR TITLE
Remove autogeneration from training records

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -54,8 +54,8 @@ class Teacher < ApplicationRecord
             presence: { message: 'Choose the reason why the mentor became ineligible for funding' },
             if: -> { mentor_became_ineligible_for_funding_on.present? }
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another teacher" }
-  validates :api_ect_training_record_id, uniqueness: { case_sensitive: false, message: "API ect training record id already exists for another teacher" }
-  validates :api_mentor_training_record_id, uniqueness: { case_sensitive: false, message: "API mentor training record id already exists for another teacher" }
+  validates :api_ect_training_record_id, uniqueness: { case_sensitive: false, message: "API ect training record id already exists for another teacher" }, allow_nil: true
+  validates :api_mentor_training_record_id, uniqueness: { case_sensitive: false, message: "API mentor training record id already exists for another teacher" }, allow_nil: true
 
   # Scopes
   scope :search, ->(query_string) {

--- a/db/migrate/20251008144737_remove_autogeneration_from_api_training_record_ids.rb
+++ b/db/migrate/20251008144737_remove_autogeneration_from_api_training_record_ids.rb
@@ -1,0 +1,11 @@
+class RemoveAutogenerationFromAPITrainingRecordIds < ActiveRecord::Migration[8.0]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.change_default :api_ect_training_record_id, from: -> { "gen_random_uuid()" }, to: nil
+      t.change_default :api_mentor_training_record_id, from: -> { "gen_random_uuid()" }, to: nil
+
+      t.change_null :api_ect_training_record_id, true
+      t.change_null :api_mentor_training_record_id, true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_08_144737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -772,8 +772,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
     t.boolean "trs_deactivated", default: false
     t.virtual "search", type: :tsvector, as: "to_tsvector('unaccented'::regconfig, (((((COALESCE(trs_first_name, ''::character varying))::text || ' '::text) || (COALESCE(trs_last_name, ''::character varying))::text) || ' '::text) || (COALESCE(corrected_name, ''::character varying))::text))", stored: true
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "api_ect_training_record_id"
+    t.uuid "api_mentor_training_record_id"
     t.integer "ect_payments_frozen_year"
     t.integer "mentor_payments_frozen_year"
     t.boolean "ect_pupil_premium_uplift", default: false, null: false

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   sequence(:base_ect_date) { |n| 3.years.ago.to_date + (2 * n).days }
 
   factory(:ect_at_school_period) do
-    association :teacher
+    teacher { association :teacher, api_ect_training_record_id: SecureRandom.uuid }
 
     independent_school
 

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory(:mentor_at_school_period) do
     association :school
-    association :teacher
+    teacher { association :teacher, api_mentor_training_record_id: SecureRandom.uuid }
 
     started_on { generate(:base_mentor_date) }
     finished_on { started_on + 1.day }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -201,8 +201,8 @@ describe Teacher do
     it { is_expected.to validate_length_of(:trs_induction_status).with_message('TRS induction status must be shorter than 18 characters') }
 
     it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another teacher") }
-    it { is_expected.to validate_uniqueness_of(:api_ect_training_record_id).case_insensitive.with_message("API ect training record id already exists for another teacher") }
-    it { is_expected.to validate_uniqueness_of(:api_mentor_training_record_id).case_insensitive.with_message("API mentor training record id already exists for another teacher") }
+    it { is_expected.to validate_uniqueness_of(:api_ect_training_record_id).case_insensitive.with_message("API ect training record id already exists for another teacher").allow_nil }
+    it { is_expected.to validate_uniqueness_of(:api_mentor_training_record_id).case_insensitive.with_message("API mentor training record id already exists for another teacher").allow_nil }
 
     describe "trn" do
       it { is_expected.to validate_uniqueness_of(:trn).with_message('TRN already exists').case_insensitive }


### PR DESCRIPTION
### Context
This is causing issues in participant profile migration, we should not set automatically and only set when a teacher is registered as an ect or mentor

### Changes proposed in this pull request
- Remove autogeneration on those fields for teacher
- Set in factories for ect or mentor

### Guidance to review
Setting those values explicitly in the services will happen in a followup pr this is just to unblock migration