### PR TITLE
Fix flaky test

### DIFF
--- a/spec/services/teachers/role_spec.rb
+++ b/spec/services/teachers/role_spec.rb
@@ -33,7 +33,13 @@ RSpec.describe Teachers::Role do
 
       context 'when teacher has inactive ECT period at any school' do
         before do
-          FactoryBot.create(:ect_at_school_period, teacher:, school:, finished_on: 1.month.ago)
+          FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school:,
+            started_on: 2.months.ago,
+            finished_on: 1.month.ago
+          )
         end
 
         it 'returns ECT (Inactive) role' do


### PR DESCRIPTION
Another date-related flaky test. This time it fails any time the ECT started on date is later than the finished on date.

This sets both explicitly to ensure we don't run into any `PG::DataException` errors when creating the record.