### PR TITLE
Skip declarative updates by default in tests

### DIFF
--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ParityCheck::DynamicRequestContent do
       it { is_expected.to eq(statement.api_id) }
     end
 
-    context "when fetching school_id" do
+    context "when fetching school_id", :with_metadata do
       let(:identifier) { :school_id }
       let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, school:, active_lead_provider:) }
@@ -38,14 +38,12 @@ RSpec.describe ParityCheck::DynamicRequestContent do
           .tap { it.gias_school.update!(funding_eligibility: :ineligible) }
         # CIP only school
         FactoryBot.create(:school, :eligible, :cip_only)
-
-        Metadata::Manager.refresh_all_metadata!
       end
 
       it { is_expected.to eq(school.api_id) }
     end
 
-    context "when fetching delivery_partner_id" do
+    context "when fetching delivery_partner_id", :with_metadata do
       let(:identifier) { :delivery_partner_id }
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:delivery_partner) { lead_provider_delivery_partnership.delivery_partner }
@@ -53,8 +51,6 @@ RSpec.describe ParityCheck::DynamicRequestContent do
       before do
         # Delivery partner for different lead provider should not be used.
         FactoryBot.create(:delivery_partner)
-
-        Metadata::Manager.refresh_all_metadata!
       end
 
       it { is_expected.to eq(delivery_partner.api_id) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,4 +34,17 @@ RSpec.configure do |config|
       .to receive(:enable_schools_interface)
       .and_return(true)
   end
+
+  config.around do |example|
+    declarative_updates_to_skip = %i[metadata touch]
+
+    declarative_updates_to_skip.delete(:metadata) if example.metadata[:with_metadata]
+    declarative_updates_to_skip.delete(:touch) if example.metadata[:with_touches]
+
+    if declarative_updates_to_skip.empty?
+      example.run
+    else
+      DeclarativeUpdates.skip(*declarative_updates_to_skip) { example.run }
+    end
+  end
 end

--- a/spec/requests/api/docs/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/docs/v3/delivery_partners_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "Delivery partners endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "Delivery partners endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "Schools endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "Schools endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:resource) { FactoryBot.create(:school, :eligible) }

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Delivery partners API", type: :request do
+RSpec.describe "Delivery partners API", :with_metadata, type: :request do
   let(:serializer) { API::DeliveryPartnerSerializer }
   let(:serializer_options) { { lead_provider_id: lead_provider.id } }
   let(:query) { API::DeliveryPartners::Query }

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Schools API", type: :request do
+RSpec.describe "Schools API", :with_metadata, type: :request do
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let(:lead_provider) { active_lead_provider.lead_provider }
   let(:contract_period) { active_lead_provider.contract_period }

--- a/spec/serializers/api/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/delivery_partner_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe API::DeliveryPartnerSerializer, type: :serializer do
+describe API::DeliveryPartnerSerializer, :with_metadata, type: :serializer do
   subject(:response) do
     options = { lead_provider_id: lead_provider.id }
     JSON.parse(described_class.render(delivery_partner, **options))
@@ -12,7 +12,6 @@ describe API::DeliveryPartnerSerializer, type: :serializer do
   before do
     # Ensure other metadata exists for another lead provider.
     FactoryBot.create(:lead_provider)
-    Metadata::Manager.refresh_all_metadata!
   end
 
   describe "core attributes" do

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe API::TeacherSerializer, type: :serializer do
+describe API::TeacherSerializer, :with_metadata, type: :serializer do
   subject(:response) do
     options = { lead_provider_id: lead_provider.id }
     JSON.parse(described_class.render(teacher, **options))
@@ -10,7 +10,6 @@ describe API::TeacherSerializer, type: :serializer do
   before do
     # Ensure other metadata exists for another lead provider.
     FactoryBot.create(:lead_provider)
-    Metadata::Manager.refresh_all_metadata!
   end
 
   describe "core attributes" do

--- a/spec/services/api/delivery_partners/query_spec.rb
+++ b/spec/services/api/delivery_partners/query_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe API::DeliveryPartners::Query do
       expect(query.delivery_partners).to eq([delivery_partner1, delivery_partner2, delivery_partner3])
     end
 
-    describe "filtering" do
+    describe "filtering", :with_metadata do
       describe "by `lead_provider`" do
         let(:lead_provider_delivery_partnership1) { FactoryBot.create(:lead_provider_delivery_partnership) }
         let!(:delivery_partner1) { lead_provider_delivery_partnership1.delivery_partner }

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
   let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
   let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
 
-  before { Metadata::Manager.refresh_all_metadata! }
-
   describe "validations" do
     subject { service }
 
@@ -140,7 +138,7 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
       end
     end
 
-    context "when the induction programme choice is school_led" do
+    context "when the induction programme choice is school_led", :with_metadata do
       before { Metadata::SchoolContractPeriod.bypass_update_restrictions { school.contract_period_metadata.update!(induction_programme_choice: :school_led) } }
 
       it "is invalid" do
@@ -149,7 +147,7 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
       end
     end
 
-    context "when the induction programme choice is not_yet_known" do
+    context "when the induction programme choice is not_yet_known", :with_metadata do
       before { Metadata::SchoolContractPeriod.bypass_update_restrictions { school.contract_period_metadata.update!(induction_programme_choice: :not_yet_known) } }
 
       it { is_expected.to be_valid }

--- a/spec/services/api/schools/query_spec.rb
+++ b/spec/services/api/schools/query_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe API::Schools::Query do
+RSpec.describe API::Schools::Query, :with_metadata do
   before { FactoryBot.create(:lead_provider) } # Needed for metadata.
 
   it_behaves_like "a query that avoids includes" do
@@ -181,9 +181,6 @@ RSpec.describe API::Schools::Query do
         end
 
         before do
-          Metadata::Manager.new.refresh_metadata!([school1, school2, school3])
-
-          # Needs to happen after metadata refreshes.
           school1.update!(api_updated_at: 2.days.ago)
           school2.update!(api_updated_at: 10.minutes.ago)
         end

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe API::Teachers::Query do
+RSpec.describe API::Teachers::Query, :with_metadata do
   it_behaves_like "a query that avoids includes" do
     before { FactoryBot.create(:teacher) }
   end

--- a/spec/services/metadata/handlers/delivery_partner_spec.rb
+++ b/spec/services/metadata/handlers/delivery_partner_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metadata::Handlers::DeliveryPartner do
+RSpec.describe Metadata::Handlers::DeliveryPartner, :with_metadata do
   let(:instance) { described_class.new(delivery_partner) }
   let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
   let!(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, delivery_partner:, active_lead_provider:) }

--- a/spec/services/metadata/handlers/school_spec.rb
+++ b/spec/services/metadata/handlers/school_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metadata::Handlers::School do
+RSpec.describe Metadata::Handlers::School, :with_metadata do
   let(:instance) { described_class.new(school) }
   let(:school) { FactoryBot.create(:school) }
   let(:school_partnership) { FactoryBot.create(:school_partnership, school:) }

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metadata::Handlers::Teacher do
+RSpec.describe Metadata::Handlers::Teacher, :with_metadata do
   let(:instance) { described_class.new(teacher1) }
 
   let!(:teacher1) { FactoryBot.create(:teacher) }

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -15,7 +15,7 @@ def generate_new_value(attribute_to_change:)
   end
 end
 
-RSpec.shared_examples "a declarative touch model" do |when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, target_optional: true|
+RSpec.shared_examples "a declarative touch model", :with_touches do |when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, target_optional: true|
   if :update.in?(on_event)
     context "when updating" do
       before { instance } # Ensure it's created first.
@@ -177,7 +177,7 @@ RSpec.shared_examples "a declarative touch model" do |when_changing: [], on_even
   end
 end
 
-RSpec.shared_examples "a declarative metadata model" do |when_changing: [], on_event: %i[update], target_optional: true|
+RSpec.shared_examples "a declarative metadata model", :with_metadata do |when_changing: [], on_event: %i[update], target_optional: true|
   let(:manager) { instance_double(Metadata::Manager, refresh_metadata!: nil) }
 
   if :update.in?(on_event)


### PR DESCRIPTION
We are finding that the metadata and touch callbacks are slowing down the test suite (by making it take longer to create fixtures).

Disable metadata/touch updates by default as most tests don't need them.

Add `with_metadata` and `with_touches` context for tests that require them.

Looking at the recent spec runs on `main` this knocks about a minute off the runtime.
