### PR TITLE
[2540] spike - nuclear withdrawals part 2 - Option 1

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -77,8 +77,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
   def remove!
     transaction do
       training_periods.each do |tp|
-        tp.withdrawn_at = Time.zone.now
-        tp.withdrawal_reason = "other"
         tp.finished_on = started_on
         tp.save!
       end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -74,6 +74,22 @@ class ECTAtSchoolPeriod < ApplicationRecord
   delegate :provider_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
   delegate :school_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
 
+  def remove!
+    transaction do
+      training_periods.each do |tp|
+        tp.withdrawn_at = Time.zone.now
+        tp.withdrawal_reason = "other"
+        tp.finished_on = started_on
+        tp.save!
+      end
+
+      self.removed_at = Time.zone.now
+      self.removed_reason = "registered_by_error"
+      self.finished_on = started_on
+      save!
+    end
+  end
+
 private
 
   def appropriate_body_for_independent_school

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -366,6 +366,8 @@
   - email
   - school_reported_appropriate_body_id
   - training_programme
+  - removed_at
+  - removed_reason
   :delivery_partners:
   - id
   - name

--- a/db/migrate/20251008133529_add_removed_at_to_ect_at_school_periods.rb
+++ b/db/migrate/20251008133529_add_removed_at_to_ect_at_school_periods.rb
@@ -1,0 +1,6 @@
+class AddRemovedAtToECTAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ect_at_school_periods, :removed_at, :datetime
+    add_column :ect_at_school_periods, :removed_reason, :string
+  end
+end

--- a/db/migrate/20251008135737_remove_teacher_id_started_on_index_on_ect_at_school_periods.rb
+++ b/db/migrate/20251008135737_remove_teacher_id_started_on_index_on_ect_at_school_periods.rb
@@ -1,0 +1,5 @@
+class RemoveTeacherIdStartedOnIndexOnECTAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :ect_at_school_periods, column: %i[teacher_id started_on]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_08_135737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -185,11 +185,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
     t.enum "working_pattern", enum_type: "working_pattern"
     t.citext "email"
     t.bigint "school_reported_appropriate_body_id"
+    t.datetime "removed_at"
+    t.string "removed_reason"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
-    t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
   end
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -365,8 +365,6 @@ describe ECTAtSchoolPeriod do
       expect(ect_at_school_period.finished_on).to eq(ect_at_school_period.started_on)
 
       training_period1.reload
-      expect(training_period1.withdrawn_at.iso8601).to eq(Time.zone.now.iso8601)
-      expect(training_period1.withdrawal_reason).to eq("other")
       expect(training_period1.finished_on).to eq(training_period1.started_on)
 
       # Register new school


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2540

### Changes proposed in this pull request

* "Removed" a at school period using the existing period method without creating new status columns
* `ECT/MentorAtSchoolPeriod`
  * add new columns `removed_at` and `removed_reason`
  * When removing, set `finished_on` to `started_on`, therefore we now have "zero days"
  * For related `TrainingPeriod` set `finished_on` to `started_on`
  * Remove index on `[teacher_id started_on]`, this allows a new school to register the teacher for the same period

### Guidance to review
