### PR TITLE
[2540] spike - nuclear withdrawals part 2 - Option 2

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -83,8 +83,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
   def mark_withdrawn!
     transaction do
       training_periods.each do |tp|
-        tp.withdrawn_at = Time.zone.now
-        tp.withdrawal_reason = "other"
         tp.finished_on = Time.zone.now
         tp.save!
       end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -366,6 +366,8 @@
   - email
   - school_reported_appropriate_body_id
   - training_programme
+  - status
+  - withdrawn_at
   :delivery_partners:
   - id
   - name

--- a/db/migrate/20251009133638_add_status_to_ect_at_school_periods.rb
+++ b/db/migrate/20251009133638_add_status_to_ect_at_school_periods.rb
@@ -1,0 +1,6 @@
+class AddStatusToECTAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ect_at_school_periods, :status, :string, default: "active"
+    add_column :ect_at_school_periods, :withdrawn_at, :datetime
+  end
+end

--- a/db/migrate/20251009140022_remove_teacher_id_started_on_index_on_ect_at_school_periods.rb
+++ b/db/migrate/20251009140022_remove_teacher_id_started_on_index_on_ect_at_school_periods.rb
@@ -1,0 +1,6 @@
+class RemoveTeacherIdStartedOnIndexOnECTAtSchoolPeriods < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :ect_at_school_periods, column: %i[teacher_id started_on]
+    add_index :ect_at_school_periods, %i[teacher_id started_on], unique: true, where: "status = 'active'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_09_140022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -185,11 +185,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_110349) do
     t.enum "working_pattern", enum_type: "working_pattern"
     t.citext "email"
     t.bigint "school_reported_appropriate_body_id"
+    t.string "status", default: "active"
+    t.datetime "withdrawn_at"
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
-    t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
+    t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_and_started_on", unique: true, where: "((status)::text = 'active'::text)"
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
   end
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -338,4 +338,41 @@ describe ECTAtSchoolPeriod do
       expect(ect_at_school_period.siblings).to match_array([period_1, period_2, period_3])
     end
   end
+
+  describe "nuclear withdrawal" do
+    let!(:started_on) { 10.days.ago.to_date }
+    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:school1) { FactoryBot.create(:school) }
+    let!(:school2) { FactoryBot.create(:school) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school: school1, started_on:, finished_on: 20.days.from_now) }
+    let!(:training_period1) do
+      FactoryBot.create(
+        :training_period,
+        :for_ect,
+        ect_at_school_period:,
+        started_on: ect_at_school_period.started_on,
+        finished_on: ect_at_school_period.finished_on
+      )
+    end
+
+    it "allows us to withdraw a ect at school period and register teacher with new school for the same period" do
+      freeze_time
+
+      # Withdraw ect at school period
+      ect_at_school_period.mark_withdrawn!
+      expect(ect_at_school_period.status).to eq("withdrawn")
+      expect(ect_at_school_period.withdrawn_at.iso8601).to eq(Time.zone.now.iso8601)
+      expect(ect_at_school_period.finished_on).to eq(Time.zone.now.to_date)
+
+      training_period1.reload
+      expect(training_period1.withdrawn_at.iso8601).to eq(Time.zone.now.iso8601)
+      expect(training_period1.withdrawn_at.iso8601).to eq(Time.zone.now.iso8601)
+      expect(training_period1.withdrawal_reason).to eq("other")
+      expect(training_period1.finished_on).to eq(Time.zone.now.to_date)
+
+      # Register new school
+      ect_at_school_period2 = FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school: school2, started_on:, finished_on: nil)
+      expect(ect_at_school_period2.started_on.iso8601).to eq(started_on.iso8601)
+    end
+  end
 end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -365,9 +365,6 @@ describe ECTAtSchoolPeriod do
       expect(ect_at_school_period.finished_on).to eq(Time.zone.now.to_date)
 
       training_period1.reload
-      expect(training_period1.withdrawn_at.iso8601).to eq(Time.zone.now.iso8601)
-      expect(training_period1.withdrawn_at.iso8601).to eq(Time.zone.now.iso8601)
-      expect(training_period1.withdrawal_reason).to eq("other")
       expect(training_period1.finished_on).to eq(Time.zone.now.to_date)
 
       # Register new school


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2540

### Changes proposed in this pull request

* Add new `active`/`withdrawn` status
* `ECT/MentorAtSchoolPeriod`
  * add new columns `status` and `withdrawn_at`
  * Set `finished_on` to `Time.now`
  * For related `TrainingPeriod` set `finished_on` to `Time.now`
  * New `status` enum with `active`/`withdrawn`, defaulting to `active`
  * Change index on `[teacher_id started_on]` to only check unique on `status = "active"`
  * Update period validation to only check for `active` scope.

### Guidance to review
