### PR TITLE
Schools can change an ECT's lead provider

### DIFF
--- a/app/components/schools/ect_training_details_component.rb
+++ b/app/components/schools/ect_training_details_component.rb
@@ -51,7 +51,13 @@ module Schools
     def lead_provider_row
       {
         key: { text: 'Lead provider' },
-        value: { text: lead_provider_display_text }
+        value: { text: lead_provider_display_text },
+        actions: [{
+          text: "Change",
+          visually_hidden_text: "lead provider",
+          href: schools_ects_change_lead_provider_wizard_edit_path(@ect_at_school_period),
+          classes: "govuk-link--no-visited-state"
+        }]
       }
     end
 

--- a/app/controllers/schools/ects/change_lead_provider_wizard_controller.rb
+++ b/app/controllers/schools/ects/change_lead_provider_wizard_controller.rb
@@ -1,0 +1,21 @@
+module Schools
+  module ECTs
+    class ChangeLeadProviderWizardController < SchoolsController
+      include Wizardable
+
+      wizard_for :ect
+
+      def new
+        render @current_step
+      end
+
+      def create
+        if @wizard.save!
+          redirect_to @wizard.next_step_path
+        else
+          render @current_step, status: :unprocessable_content
+        end
+      end
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,6 +22,7 @@ class Event < ApplicationRecord
     teacher_email_address_updated
     teacher_working_pattern_updated
     teacher_training_programme_updated
+    teacher_training_lead_provider_updated
     teacher_fails_induction
     teacher_funding_eligibility_set
     teacher_imported_from_trs

--- a/app/services/ect_at_school_periods/switch_lead_provider.rb
+++ b/app/services/ect_at_school_periods/switch_lead_provider.rb
@@ -1,0 +1,70 @@
+module ECTAtSchoolPeriods
+  class SwitchLeadProvider
+    include TrainingPeriodSources
+
+    def self.switch(...) = new(...).switch
+
+    def initialize(ect_at_school_period, to:, from:, author:)
+      @ect_at_school_period = ect_at_school_period
+      @selected_lead_provider = to
+      @current_lead_provider = from
+      @author = author
+    end
+
+    def switch
+      ActiveRecord::Base.transaction do
+        if date_of_transition.future? || training_period.school_partnership.blank?
+          training_period.destroy!
+        else
+          finish_training_period!
+        end
+
+        create_training_period!
+        record_lead_provider_updated_event!
+      end
+    end
+
+  private
+
+    attr_reader :ect_at_school_period,
+                :current_lead_provider,
+                :selected_lead_provider,
+                :author
+
+    def finish_training_period!
+      TrainingPeriods::Finish.ect_training(
+        training_period:,
+        ect_at_school_period:,
+        finished_on: Date.current,
+        author:
+      ).finish!
+    end
+
+    def create_training_period!
+      TrainingPeriods::Create.provider_led(
+        period: ect_at_school_period,
+        started_on: date_of_transition,
+        school_partnership: earliest_matching_school_partnership,
+        expression_of_interest:
+      ).call
+    end
+
+    def record_lead_provider_updated_event!
+      Events::Record.record_teacher_training_lead_provider_updated_event!(
+        old_lead_provider_name: current_lead_provider.name,
+        new_lead_provider_name: selected_lead_provider.name,
+        author:,
+        ect_at_school_period:,
+        school: ect_at_school_period.school,
+        teacher: ect_at_school_period.teacher,
+        happened_at: Time.current
+      )
+    end
+
+    def date_of_transition = [ect_at_school_period.started_on, Date.current].max
+    def training_period = ect_at_school_period.current_or_next_training_period
+    def school = ect_at_school_period.school
+    def lead_provider = selected_lead_provider
+    def started_on = date_of_transition
+  end
+end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -401,6 +401,17 @@ module Events
       new(event_type:, author:, heading:, ect_at_school_period:, school:, teacher:, happened_at:).record_event!
     end
 
+    def self.record_teacher_training_lead_provider_updated_event!(old_lead_provider_name:, new_lead_provider_name:, author:, ect_at_school_period:, school:, teacher:, happened_at:)
+      event_type = :teacher_training_lead_provider_updated
+      heading = TransitionDescription.for(
+        "lead provider",
+        from: old_lead_provider_name,
+        to: new_lead_provider_name
+      )
+
+      new(event_type:, author:, heading:, ect_at_school_period:, school:, teacher:, happened_at:).record_event!
+    end
+
     def self.record_teacher_left_school_as_mentor!(author:, mentor_at_school_period:, teacher:, school:, happened_at:)
       event_type = :teacher_left_school_as_mentor
       teacher_name = Teachers::Name.new(teacher).full_name

--- a/app/views/schools/ects/change_lead_provider_wizard/check_answers.html.erb
+++ b/app/views/schools/ects/change_lead_provider_wizard/check_answers.html.erb
@@ -1,0 +1,34 @@
+<% page_data(
+    title: "Check and confirm change",
+    backlink_href: @wizard.previous_step_path
+) %>
+
+<%= govuk_summary_list do |list| %>
+  <% list.with_row do |row| %>
+    <%= row.with_key { "Early career teacher" } %>
+    <%= row.with_value { @wizard.teacher_full_name } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <%= row.with_key { "Current lead provider" } %>
+    <%= row.with_value { @wizard.current_step.current_lead_provider_name } %>
+  <% end %>
+
+  <% list.with_row do |row| %>
+    <%= row.with_key { "New lead provider" } %>
+    <%= row.with_value { @wizard.current_step.new_lead_provider_name } %>
+  <% end %>
+<% end %>
+
+<%= govuk_button_to(
+      "Confirm change",
+      @wizard.current_step_path
+    ) %>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+        "Cancel and go back to #{@wizard.teacher_full_name}’s details",
+        schools_ect_path(@wizard.ect_at_school_period),
+        no_visited_state: true
+      ) %>
+</p>

--- a/app/views/schools/ects/change_lead_provider_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_lead_provider_wizard/confirmation.html.erb
@@ -1,0 +1,34 @@
+<% page_data(
+    title: "Training programme updated for #{@wizard.teacher_full_name}",
+    header: false
+) %>
+
+<%= govuk_panel(
+      title_text: <<~TXT.squish
+        You have chosen #{@wizard.current_step.current_lead_provider_name} as
+        the new lead provider for #{@wizard.teacher_full_name}
+      TXT
+    ) %>
+
+<h2 class="govuk-heading-m">
+ What happens next?
+</h2>
+
+<p class="govuk-body">
+  We’ll let <%= @wizard.current_step.current_lead_provider_name %> know your
+  school wants to work with them. They’ll contact us to confirm the change and
+  tell us the delivery partner they’ll be working with.
+</p>
+
+<p class="govuk-body">
+  We’ll also let the old lead provider know that they’ll no longer be training
+  <%= @wizard.teacher_full_name %>.
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+        "Back to #{@wizard.teacher_full_name}’s details",
+        schools_ect_path(@wizard.ect_at_school_period),
+        no_visited_state: true
+      ) %>
+</p>

--- a/app/views/schools/ects/change_lead_provider_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_lead_provider_wizard/edit.html.erb
@@ -1,0 +1,56 @@
+<% page_data(
+  title: "Change lead provider for #{@wizard.teacher_full_name}",
+  backlink_href: schools_ect_path(@wizard.ect_at_school_period)
+) %>
+
+<p class="govuk-body">
+  If your school wants to change lead provider, you should, for continuity, make
+  changes at the end of the school year.
+</p>
+
+<p class="govuk-body">
+  If you change <%= @wizard.teacher_full_name %>’s lead provider it means that
+  their training will stop immediately. They’ll need to wait until the new lead
+  provider confirms the partnership before they can continue.
+</p>
+
+<p class="govuk-body">
+  Changing the lead provider might mean that <%= @wizard.teacher_full_name %>
+  will have a different delivery partner. Their training might be delivered
+  differently.
+</p>
+
+<p class="govuk-body">
+  If you do change lead provider, we’ll let the:
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>new provider know that you want to work with them</li>
+    <li>old provider know they’re no longer working with the ECT</li>
+  </ul>
+</p>
+
+<p class="govuk-body">
+  The new provider will confirm the delivery partner they’re working with.
+</p>
+
+<%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |form| %>
+  <%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+  <%= form.govuk_collection_radio_buttons(
+        :lead_provider_id,
+        @wizard.current_step.lead_providers_for_select,
+        :id,
+        :name,
+        legend: { text: "Select the new lead provider for #{@wizard.teacher_full_name}" }
+      ) %>
+
+  <%= form.govuk_submit "Continue" %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(
+          "Cancel and go back to #{@wizard.teacher_full_name}’s details",
+          schools_ect_path(@wizard.ect_at_school_period),
+          no_visited_state: true
+        ) %>
+  </p>
+<% end %>

--- a/app/wizards/schools/ects/change_lead_provider_wizard/check_answers_step.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/check_answers_step.rb
@@ -1,0 +1,34 @@
+module Schools
+  module ECTs
+    module ChangeLeadProviderWizard
+      class CheckAnswersStep < Step
+        def previous_step = :edit
+        def next_step = :confirmation
+
+        def current_lead_provider_name = current_lead_provider&.name
+        def new_lead_provider_name = selected_lead_provider.name
+
+        def save!
+          ECTAtSchoolPeriods::SwitchLeadProvider.switch(
+            ect_at_school_period,
+            to: selected_lead_provider,
+            from: current_lead_provider,
+            author:
+          )
+
+          true
+        end
+
+      private
+
+        def current_lead_provider
+          @current_lead_provider ||= ECTAtSchoolPeriods::CurrentTraining
+            .new(ect_at_school_period)
+            .lead_provider_via_school_partnership_or_eoi
+        end
+
+        def selected_lead_provider = LeadProvider.find(store.lead_provider_id)
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_lead_provider_wizard/confirmation_step.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/confirmation_step.rb
@@ -1,0 +1,19 @@
+module Schools
+  module ECTs
+    module ChangeLeadProviderWizard
+      class ConfirmationStep < Step
+        def previous_step = :check_answers
+
+        def current_lead_provider_name = current_lead_provider&.name
+
+      private
+
+        def current_lead_provider
+          @current_lead_provider ||= ECTAtSchoolPeriods::CurrentTraining
+            .new(ect_at_school_period)
+            .lead_provider_via_school_partnership_or_eoi
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
@@ -1,0 +1,52 @@
+module Schools
+  module ECTs
+    module ChangeLeadProviderWizard
+      class EditStep < Step
+        attribute :lead_provider_id, :string
+
+        validates :lead_provider_id,
+                  presence: { message: "Select which lead provider will be training the ECT" },
+                  lead_provider: { message: "Enter the name of a known lead provider" }
+
+        def self.permitted_params = [:lead_provider_id]
+
+        def next_step = :check_answers
+
+        def current_lead_provider_name = current_lead_provider&.name
+
+        def save!
+          store.lead_provider_id = lead_provider_id if valid_step?
+        end
+
+        def lead_providers_for_select
+          active_lead_providers_in_contract_period.without(current_lead_provider)
+        end
+
+      private
+
+        def pre_populate_attributes
+          self.lead_provider_id = store.lead_provider_id
+        end
+
+        def active_lead_providers_in_contract_period
+          return [] unless contract_period
+
+          @active_lead_providers_in_contract_period ||= ::LeadProviders::Active
+            .in_contract_period(contract_period)
+            .select(:id, :name)
+        end
+
+        def contract_period
+          @contract_period ||= ContractPeriod
+            .containing_date(ect_at_school_period.started_on)
+        end
+
+        def current_lead_provider
+          @current_lead_provider ||= ECTAtSchoolPeriods::CurrentTraining
+            .new(ect_at_school_period)
+            .lead_provider_via_school_partnership_or_eoi
+        end
+      end
+    end
+  end
+end

--- a/app/wizards/schools/ects/change_lead_provider_wizard/wizard.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/wizard.rb
@@ -1,0 +1,15 @@
+module Schools
+  module ECTs
+    module ChangeLeadProviderWizard
+      class Wizard < ECTs::Wizard
+        steps do
+          [{
+            edit: EditStep,
+            check_answers: CheckAnswersStep,
+            confirmation: ConfirmationStep
+          }]
+        end
+      end
+    end
+  end
+end

--- a/config/routes/school.rb
+++ b/config/routes/school.rb
@@ -30,6 +30,10 @@ constraints -> { Rails.application.config.enable_schools_interface } do
       namespace :change_mentor_wizard, path: "change-mentor" do
         concerns :wizardable, wizard: Schools::ECTs::ChangeMentorWizard
       end
+
+      namespace :change_lead_provider_wizard, path: "change-lead-provider" do
+        concerns :wizardable, wizard: Schools::ECTs::ChangeLeadProviderWizard
+      end
     end
 
     scope module: :mentors, path: "/mentors/:mentor_id", as: :mentors do

--- a/spec/features/schools/ects/change/lead_provider_spec.rb
+++ b/spec/features/schools/ects/change/lead_provider_spec.rb
@@ -1,0 +1,142 @@
+describe "School user can change ECT's lead provider", :enable_schools_interface do
+  it "changes the lead provider" do
+    given_there_is_a_school
+    and_there_is_an_ect
+    and_there_is_a_contract_period
+    and_there_is_an_active_lead_provider
+    with_provider_led_training
+    and_there_is_another_active_lead_provider
+    and_i_am_logged_in_as_a_school_user
+
+    when_i_visit_the_ect_page
+    then_i_can_change_the_assigned_lead_provider
+    and_i_see_the_change_lead_provider_form
+    and_the_current_lead_provider_is_not_an_option
+
+    when_i_choose_a_lead_provider
+    and_i_continue
+    then_i_am_asked_to_check_and_confirm_the_change
+
+    when_i_navigate_back_to_the_form
+    and_i_see_the_change_lead_provider_form
+    then_the_lead_provider_is_selected
+
+    when_i_continue
+    and_i_confirm_the_change
+    then_i_see_the_confirmation_message
+  end
+
+private
+
+  def given_there_is_a_school
+    @school = FactoryBot.create(:school)
+  end
+
+  def and_there_is_an_ect
+    @teacher = FactoryBot.create(
+      :teacher,
+      trs_first_name: "John",
+      trs_last_name: "Doe"
+    )
+    @ect = FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      teacher: @teacher,
+      school: @school,
+      email: "ect@example.com",
+      started_on: 1.week.ago
+    )
+  end
+
+  def and_there_is_a_contract_period
+    @contract_period = FactoryBot.create(:contract_period, :current)
+  end
+
+  def and_there_is_an_active_lead_provider
+    lead_provider = FactoryBot.create(:lead_provider, name: "Testing Provider")
+    @active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      contract_period: @contract_period,
+      lead_provider:
+    )
+  end
+
+  def with_provider_led_training
+    @provider_led_training_period = FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :for_ect,
+      :provider_led,
+      :with_only_expression_of_interest,
+      ect_at_school_period: @ect,
+      started_on: @ect.started_on,
+      expression_of_interest: @active_lead_provider
+    )
+  end
+
+  def and_there_is_another_active_lead_provider
+    lead_provider = FactoryBot.create(:lead_provider, name: "Other Lead Provider")
+    @other_active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      contract_period: @contract_period,
+      lead_provider:
+    )
+  end
+
+  def and_i_am_logged_in_as_a_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def when_i_visit_the_ect_page
+    page.goto(schools_ect_path(@ect))
+  end
+
+  def then_i_can_change_the_assigned_lead_provider
+    row = page.locator(".govuk-summary-list__row", hasText: "Lead provider")
+    row.get_by_role("link", name: "Change").click
+  end
+
+  def and_i_see_the_change_lead_provider_form
+    heading = page.locator("h1")
+    expect(heading).to have_text("Change lead provider for John Doe")
+  end
+
+  def and_the_current_lead_provider_is_not_an_option
+    expect(page.get_by_label("Testing Provider")).not_to be_visible
+  end
+
+  def when_i_choose_a_lead_provider
+    page.get_by_label("Other Lead Provider").check
+  end
+
+  def and_i_continue
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  alias_method :when_i_continue, :and_i_continue
+
+  def then_i_am_asked_to_check_and_confirm_the_change
+    heading = page.locator("h1")
+    expect(heading).to have_text("Check and confirm change")
+  end
+
+  def when_i_navigate_back_to_the_form
+    page.get_by_role("link", name: "Back", exact: true).click
+  end
+
+  def then_the_lead_provider_is_selected
+    lead_provider_radio = page.get_by_label("Other Lead Provider")
+    expect(lead_provider_radio).to be_checked
+  end
+
+  def and_i_confirm_the_change
+    page.get_by_role("button", name: "Confirm change").click
+  end
+
+  def then_i_see_the_confirmation_message
+    success_panel = page.locator(".govuk-panel")
+    expect(success_panel).to have_text(
+      "You have chosen Other Lead Provider as the new lead provider for John Doe"
+    )
+  end
+end

--- a/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
@@ -1,0 +1,186 @@
+describe "Schools::ECTs::ChangeLeadProviderWizardController", :enable_schools_interface do
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      teacher:,
+      school:,
+      started_on: contract_period.started_on + 2.months
+    )
+  end
+  let(:lead_provider) do
+    FactoryBot.create(:lead_provider, name: "Testing Provider")
+  end
+  let(:active_lead_provider) do
+    FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:)
+  end
+  let!(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :for_ect,
+      :provider_led,
+      :with_only_expression_of_interest,
+      ect_at_school_period:,
+      started_on: ect_at_school_period.started_on,
+      expression_of_interest: active_lead_provider
+    )
+  end
+  let(:other_lead_provider) do
+    FactoryBot.create(:lead_provider, name: "Other Lead Provider")
+  end
+  let!(:other_active_lead_provider) do
+    FactoryBot.create(
+      :active_lead_provider,
+      contract_period:,
+      lead_provider: other_lead_provider
+    )
+  end
+
+  describe "GET #new" do
+    context "when not signed in" do
+      it "redirects to the root page" do
+        get path_for_step("edit")
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed in as a non-School user" do
+      include_context "sign in as DfE user"
+
+      it "returns unauthorized" do
+        get path_for_step("edit")
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when signed in as a School user" do
+      before { sign_in_as(:school_user, school:) }
+
+      context "when the current_step is invalid" do
+        it "returns not found" do
+          get path_for_step("nope")
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the current_step is valid" do
+        it "returns ok" do
+          get path_for_step("edit")
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe "POST #create" do
+    let(:lead_provider_id) { other_lead_provider.id }
+    let(:params) { { edit: { lead_provider_id: } } }
+
+    context "when not signed in" do
+      it "redirects to the root path" do
+        post(path_for_step("edit"), params:)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed in as a non-School user" do
+      include_context "sign in as DfE user"
+
+      it "returns unauthorized" do
+        post(path_for_step("edit"), params:)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when signed in as a School user" do
+      let(:school_user) { FactoryBot.create(:school_user, school:) }
+
+      before { sign_in_as(:school_user, school:) }
+
+      context "when the current_step is invalid" do
+        it "returns not found" do
+          post(path_for_step("nope"), params:)
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the lead provider id is missing" do
+        let(:lead_provider_id) { "" }
+
+        it "returns unprocessable_content" do
+          post(path_for_step("edit"), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
+      context "when the lead provider id is invalid" do
+        let(:lead_provider_id) { "invalid" }
+
+        it "returns unprocessable_content" do
+          post(path_for_step("edit"), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
+      context "when the lead provider id is valid" do
+        let(:lead_provider_id) { other_lead_provider.id }
+
+        it "updates the lead provider only after confirmation" do
+          post(path_for_step("edit"), params:)
+
+          follow_redirect!
+
+          training = current_training_for(ect_at_school_period.reload)
+          expect(training.lead_provider_via_school_partnership_or_eoi)
+            .to eq(lead_provider)
+
+          post(path_for_step("check-answers"))
+
+          training = current_training_for(ect_at_school_period.reload)
+          expect(training.lead_provider_via_school_partnership_or_eoi)
+            .to eq(other_lead_provider)
+          expect(response).to redirect_to(path_for_step("confirmation"))
+        end
+
+        it "creates an event only after confirmation" do
+          allow(Events::Record).to receive(:record_teacher_training_lead_provider_updated_event!)
+
+          post(path_for_step("edit"), params:)
+
+          expect(Events::Record).not_to have_received(:record_teacher_training_lead_provider_updated_event!)
+          expect(response).to redirect_to(path_for_step("check-answers"))
+
+          follow_redirect!
+
+          post path_for_step("check-answers")
+
+          expect(Events::Record).to have_received(:record_teacher_training_lead_provider_updated_event!)
+          expect(response).to redirect_to(path_for_step("confirmation"))
+        end
+      end
+    end
+  end
+
+private
+
+  def path_for_step(step)
+    "/school/ects/#{ect_at_school_period.id}/change-lead-provider/#{step}"
+  end
+
+  def current_training_for(ect_at_school_period)
+    ECTAtSchoolPeriods::CurrentTraining.new(ect_at_school_period)
+  end
+end

--- a/spec/services/ect_at_school_periods/switch_lead_provider_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_lead_provider_spec.rb
@@ -1,0 +1,252 @@
+module ECTAtSchoolPeriods
+  describe SwitchLeadProvider do
+    subject(:switch_lead_provider) do
+      SwitchLeadProvider.switch(
+        ect_at_school_period,
+        to: lead_provider,
+        from: current_lead_provider,
+        author:
+      )
+    end
+
+    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+    let(:author) do
+      FactoryBot.create(:school_user, school_urn: ect_at_school_period.school.urn)
+    end
+
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.ago)
+    end
+
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let!(:active_lead_provider) do
+      FactoryBot.create(
+        :active_lead_provider,
+        lead_provider:,
+        contract_period:
+      )
+    end
+
+    let(:current_lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:current_active_lead_provider) do
+      FactoryBot.create(
+        :active_lead_provider,
+        lead_provider: current_lead_provider,
+        contract_period:
+      )
+    end
+
+    context "when there is an existing school partnership" do
+      let(:lead_provider_delivery_partnership) do
+        FactoryBot.create(
+          :lead_provider_delivery_partnership,
+          active_lead_provider: current_active_lead_provider
+        )
+      end
+      let(:school_partnership) do
+        FactoryBot.create(
+          :school_partnership,
+          lead_provider_delivery_partnership:,
+          school: ect_at_school_period.school
+        )
+      end
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          :provider_led,
+          :with_school_partnership,
+          ect_at_school_period:,
+          started_on: ect_at_school_period.started_on,
+          school_partnership:
+        )
+      end
+
+      context "when the date of transition is today" do
+        it "finishes the existing training period" do
+          freeze_time
+
+          switch_lead_provider
+
+          expect { training_period.reload }.not_to raise_error
+          expect(training_period.finished_on).to eq(Date.current)
+        end
+
+        it "creates a new training period with the new lead provider" do
+          switch_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(Date.current)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          switch_lead_provider
+        end
+      end
+
+      context "when the date of transition is in the future" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            started_on: 1.month.from_now
+          )
+        end
+
+        it "destroys the existing training period" do
+          freeze_time
+
+          switch_lead_provider
+
+          expect { training_period.reload }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "creates a new training period" do
+          switch_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(ect_at_school_period.started_on)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          switch_lead_provider
+        end
+      end
+    end
+
+    context "when there is no existing school partnership" do
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :ongoing,
+          :provider_led,
+          :with_only_expression_of_interest,
+          ect_at_school_period:,
+          started_on: ect_at_school_period.started_on,
+          expression_of_interest: current_active_lead_provider
+        )
+      end
+
+      context "when the date of transition is today" do
+        it "destroys the existing training period" do
+          freeze_time
+
+          switch_lead_provider
+
+          expect { training_period.reload }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "creates a new training period" do
+          switch_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(Date.current)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.expression_of_interest.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          switch_lead_provider
+        end
+      end
+
+      context "when the date of transition is in the future" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            started_on: 1.month.from_now
+          )
+        end
+
+        it "destroys the existing training period" do
+          freeze_time
+
+          switch_lead_provider
+
+          expect { training_period.reload }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "creates a new training period" do
+          switch_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(ect_at_school_period.started_on)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.expression_of_interest.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          switch_lead_provider
+        end
+      end
+    end
+  end
+end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1035,6 +1035,35 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_teacher_training_lead_provider_updated_event!" do
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+
+    it "enqueues a RecordEventJob with the correct values" do
+      freeze_time
+
+      Events::Record.record_teacher_training_lead_provider_updated_event!(
+        old_lead_provider_name: "Old Lead Provider",
+        new_lead_provider_name: "New Lead Provider",
+        author:,
+        ect_at_school_period:,
+        school: ect_at_school_period.school,
+        teacher:,
+        happened_at: 5.minutes.ago
+      )
+
+      expect(RecordEventJob).to have_received(:perform_later).with(
+        teacher:,
+        school: ect_at_school_period.school,
+        ect_at_school_period:,
+        heading: "Lead provider changed from 'Old Lead Provider' to 'New Lead Provider'",
+        event_type: :teacher_training_lead_provider_updated,
+        happened_at: 5.minutes.ago,
+        **author_params
+      )
+    end
+  end
+
   describe '.record_teacher_left_school_as_mentor!' do
     let(:finished_on) { 1.month.ago.to_date }
     let(:school) { FactoryBot.create(:school) }

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
@@ -1,0 +1,104 @@
+describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeLeadProviderWizard::Wizard.new(
+      current_step: :check_answers,
+      step_params: ActionController::Parameters.new(check_answers: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) do
+    FactoryBot.build(:session_repository, lead_provider_id: lead_provider.id)
+  end
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, :current)
+  end
+  let(:ect_at_school_period) do
+    FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      school:,
+      started_on: contract_period.started_on + 1.week
+    )
+  end
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let!(:active_lead_provider) do
+    FactoryBot.create(
+      :active_lead_provider,
+      lead_provider:,
+      contract_period:
+    )
+  end
+  let(:current_lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:current_active_lead_provider) do
+    FactoryBot.create(
+      :active_lead_provider,
+      lead_provider: current_lead_provider,
+      contract_period:
+    )
+  end
+  let!(:training_period) do
+    FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :provider_led,
+      :with_only_expression_of_interest,
+      ect_at_school_period:,
+      started_on: ect_at_school_period.started_on,
+      expression_of_interest: current_active_lead_provider
+    )
+  end
+  let(:params) { {} }
+
+  describe "#previous_step" do
+    it "returns the edit step" do
+      expect(current_step.previous_step).to eq(:edit)
+    end
+  end
+
+  describe "#next_step" do
+    it "returns the confirmation step" do
+      expect(current_step.next_step).to eq(:confirmation)
+    end
+  end
+
+  describe "#current_lead_provider_name" do
+    it "returns the current lead provider's name" do
+      expect(current_step.current_lead_provider_name)
+        .to eq(current_lead_provider.name)
+    end
+  end
+
+  describe "#new_lead_provider_name" do
+    it "returns the selected lead provider's name" do
+      expect(current_step.new_lead_provider_name).to eq(lead_provider.name)
+    end
+  end
+
+  describe "#save!" do
+    it "changes the lead provider" do
+      expect { current_step.save! }
+        .to change { lead_provider_for(ect_at_school_period) }
+        .from(current_lead_provider)
+        .to(lead_provider)
+    end
+
+    it "is truthy" do
+      expect(current_step.save!).to be_truthy
+    end
+  end
+
+private
+
+  def lead_provider_for(ect_at_school_period)
+    ect_at_school_period.reload
+      .current_or_next_training_period
+      .expression_of_interest
+      .lead_provider
+  end
+end

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/confirmation_step_spec.rb
@@ -1,0 +1,32 @@
+describe Schools::ECTs::ChangeLeadProviderWizard::ConfirmationStep, type: :model do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeLeadProviderWizard::Wizard.new(
+      current_step: :confirmation,
+      step_params: ActionController::Parameters.new(confirmation: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) do
+    FactoryBot.create(:ect_at_school_period, :ongoing, school:)
+  end
+  let(:params) { {} }
+
+  describe "#previous_step" do
+    it "returns the previous step" do
+      expect(current_step.previous_step).to eq(:check_answers)
+    end
+  end
+
+  describe "#next_step" do
+    it "raises an error" do
+      expect { current_step.next_step }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
@@ -1,0 +1,97 @@
+describe Schools::ECTs::ChangeLeadProviderWizard::EditStep do
+  subject(:current_step) { wizard.current_step }
+
+  let(:wizard) do
+    Schools::ECTs::ChangeLeadProviderWizard::Wizard.new(
+      current_step: :edit,
+      step_params: ActionController::Parameters.new(edit: params),
+      author:,
+      store:,
+      ect_at_school_period:
+    )
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
+  let(:school) { FactoryBot.create(:school) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+  let(:params) { { lead_provider_id: "" } }
+
+  describe ".permitted_params" do
+    it "returns the permitted parameters" do
+      expect(described_class.permitted_params).to contain_exactly(:lead_provider_id)
+    end
+  end
+
+  describe "#previous_step" do
+    it "raises an error" do
+      expect { current_step.previous_step }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#next_step" do
+    it "returns the check answers step" do
+      expect(current_step.next_step).to eq(:check_answers)
+    end
+  end
+
+  describe "validations" do
+    context "when the lead_provider_id is blank" do
+      let(:params) { { lead_provider_id: "" } }
+
+      it "is invalid" do
+        expect(current_step).to be_invalid
+        expect(current_step.errors.messages_for(:lead_provider_id))
+          .to contain_exactly("Select which lead provider will be training the ECT")
+      end
+    end
+
+    context "when the lead_provider_id is invalid" do
+      let(:params) { { lead_provider_id: "invalid" } }
+
+      it "is invalid" do
+        expect(current_step).to be_invalid
+        expect(current_step.errors.messages_for(:lead_provider_id))
+          .to contain_exactly("Enter the name of a known lead provider")
+      end
+    end
+
+    context "when the lead_provider_id is valid" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:params) { { lead_provider_id: lead_provider.id } }
+
+      it "is valid" do
+        expect(current_step).to be_valid
+        expect(current_step.errors).to be_empty
+      end
+    end
+  end
+
+  describe "#save!" do
+    context "when the step is invalid" do
+      let(:params) { { lead_provider_id: "" } }
+
+      it "does not store the lead provider" do
+        expect { current_step.save! }.not_to(change(store, :lead_provider_id))
+      end
+
+      it "is falsey" do
+        expect(current_step.save!).to be_falsey
+      end
+    end
+
+    context "when the lead_provider_id is valid" do
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:params) { { lead_provider_id: lead_provider.id } }
+
+      it "stores the lead provider" do
+        expect { current_step.save! }
+          .to(change(store, :lead_provider_id)
+          .from(nil).to(lead_provider.id.to_s))
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2101

### Changes proposed in this pull request

This introduces a new "Change" journey, which allows Schools to change an ECT's
lead provider.

This is a straightforward journey, but there is still considerable business
logic to consider when switching from one lead provider to another.

For now, this is abstracted away in the `ECTAtSchoolPeriods::SwitchLeadProvider`
service object. But it's possible we might unearth something more useful as we
continue to build out these "Change" journeys.

### Guidance to review
