### PR TITLE
Update partnerships link on the guidance sidebar

### DIFF
--- a/app/components/api/guidance/sidebar_component.rb
+++ b/app/components/api/guidance/sidebar_component.rb
@@ -5,7 +5,7 @@ module API
       GUIDANCE_PAGES = [
         { title: "API IDs explained", path: "api-ids-explained" },
         { title: "API data states", path: "api-data-states" },
-        { title: "Partnerships", path: "partnerships" },
+        { title: "Create, view and update partnerships", path: "create-view-and-update-partnerships" },
         { title: "Syncing data best practice", path: "data-syncing" },
       ].freeze
 


### PR DESCRIPTION
### Context

We also need to update the link to the renamed partnerships guidance page on the sidebar of the guidance page.

https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/create-view-and-update-partnerships

### Changes proposed in this pull request

- Update the link to the correct one.

### Guidance to review

[Review app](https://cpd-ec2-review-1526-web.test.teacherservices.cloud/api/guidance/guidance-for-lead-providers/create-view-and-update-partnerships)