### PR TITLE
[2442] - migrate sparsity_uplift and pupil_premium_uplift

### DIFF
--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -51,6 +51,8 @@ module Migrators
 
             ect_payments_frozen_year = participant_profile.previous_payments_frozen_cohort_start_year
             teacher.ect_payments_frozen_year = ect_payments_frozen_year if ect_payments_frozen_year
+            teacher.ect_pupil_premium_uplift = true if participant_profile.pupil_premium_uplift
+            teacher.ect_sparsity_uplift = true if participant_profile.sparsity_uplift
             teacher.api_ect_training_record_id = participant_profile.id
             teacher.save!
 

--- a/spec/migration/migrators/ect_at_school_period_spec.rb
+++ b/spec/migration/migrators/ect_at_school_period_spec.rb
@@ -1,7 +1,10 @@
 RSpec.describe Migrators::ECTAtSchoolPeriod do
   it_behaves_like "a migrator", :ect_at_school_period, %i[teacher school] do
     def create_migration_resource
-      ect = FactoryBot.create(:migration_participant_profile, :ect)
+      ect = FactoryBot.create(:migration_participant_profile,
+                              :ect,
+                              sparsity_uplift: [true, false].sample,
+                              pupil_premium_uplift: [true, false].sample)
       FactoryBot.create(:migration_induction_record, participant_profile: ect)
       ect.teacher_profile
     end
@@ -24,6 +27,8 @@ RSpec.describe Migrators::ECTAtSchoolPeriod do
           teacher = ::Teacher.find_by!(trn: teacher_profile.trn)
 
           teacher_profile.participant_profiles.first.induction_records.each do |induction_record|
+            expect(teacher.ect_pupil_premium_uplift).to eq(teacher_profile.participant_profiles.first.pupil_premium_uplift)
+            expect(teacher.ect_sparsity_uplift).to eq(teacher_profile.participant_profiles.first.sparsity_uplift)
             expect(teacher.ect_at_school_periods.first.started_on.to_date).to eq induction_record.start_date.to_date
             expect(teacher.ect_at_school_periods.first.school.urn).to eq induction_record.induction_programme.school_cohort.school.urn.to_i
           end


### PR DESCRIPTION
### Context
[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/2442)

We need to migrate the pupil premium and sparsity uplift flags for ECTs to RECT. These are stored on the `ParticipantProfile` in ECF and we should migrate them to new fields on `Teacher`.  It makes sense to do this in the `ECTAtSchoolPeriod` migrator when we also store the profile ID.

### Changes proposed in this pull request

- `ParticipantProfile::ECT.pupil_premium_uplift` migrated to `Teacher.ect_pupil_premium_uplift`
- `ParticipantProfile::ECT.sparsity_uplift` migrated to `Teacher.ect_sparsity_uplift`

### Guidance to review
