### PR TITLE
Remove a Teacher record and associated dependents

### DIFF
--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -7,9 +7,9 @@ class ECTAtSchoolPeriod < ApplicationRecord
   belongs_to :teacher, inverse_of: :ect_at_school_periods
   belongs_to :school_reported_appropriate_body, class_name: "AppropriateBody"
 
-  has_many :mentorship_periods, inverse_of: :mentee
+  has_many :mentorship_periods, inverse_of: :mentee, dependent: :destroy
   has_many :mentors, through: :mentorship_periods, source: :mentor
-  has_many :training_periods, inverse_of: :ect_at_school_period
+  has_many :training_periods, inverse_of: :ect_at_school_period, dependent: :destroy
   has_many :mentor_at_school_periods, through: :teacher
   has_many :events
   has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: "TrainingPeriod"

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -5,8 +5,8 @@ class MentorAtSchoolPeriod < ApplicationRecord
   # Associations
   belongs_to :school, inverse_of: :mentor_at_school_periods
   belongs_to :teacher, inverse_of: :mentor_at_school_periods
-  has_many :mentorship_periods, inverse_of: :mentor
-  has_many :training_periods, inverse_of: :mentor_at_school_period
+  has_many :mentorship_periods, inverse_of: :mentor, dependent: :destroy
+  has_many :training_periods, inverse_of: :mentor_at_school_period, dependent: :destroy
   has_many :declarations, through: :training_periods
   has_many :events
   has_many :currently_assigned_ects,

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -16,11 +16,13 @@ class Teacher < ApplicationRecord
   has_many :mentor_at_school_periods, inverse_of: :teacher
   has_many :ect_training_periods, through: :ect_at_school_periods, source: :training_periods
   has_many :mentor_training_periods, through: :mentor_at_school_periods, source: :training_periods
-
   has_many :induction_extensions, inverse_of: :teacher
-  has_many :teacher_id_changes, inverse_of: :teacher
-  has_many :lead_provider_metadata, class_name: "Metadata::TeacherLeadProvider"
+  has_many :teacher_id_changes, inverse_of: :teacher, dependent: :destroy
+  has_many :lead_provider_metadata, class_name: "Metadata::TeacherLeadProvider", dependent: :destroy
   has_many :induction_periods
+  has_many :appropriate_bodies, through: :induction_periods
+  has_many :events
+
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"
   has_one :last_induction_period, -> { order(started_on: :desc) }, class_name: "InductionPeriod"
   has_one :ongoing_induction_period, -> { ongoing }, class_name: "InductionPeriod"
@@ -28,11 +30,9 @@ class Teacher < ApplicationRecord
   has_one :finished_induction_period, -> { finished.with_outcome.latest_first }, class_name: "InductionPeriod"
   has_one :earliest_ect_at_school_period, -> { earliest_first }, class_name: "ECTAtSchoolPeriod"
   has_one :earliest_mentor_at_school_period, -> { earliest_first }, class_name: "MentorAtSchoolPeriod"
-  has_many :appropriate_bodies, through: :induction_periods
   has_one :current_appropriate_body, through: :ongoing_induction_period, source: :appropriate_body
   has_one :current_or_next_ect_at_school_period, -> { current_or_future.earliest_first }, class_name: "ECTAtSchoolPeriod"
   has_one :latest_mentor_at_school_period, -> { latest_first }, class_name: "MentorAtSchoolPeriod"
-  has_many :events
 
   # TODO: remove after migration complete
   has_many :teacher_migration_failures

--- a/lib/remove_teacher.rb
+++ b/lib/remove_teacher.rb
@@ -1,0 +1,43 @@
+# Remove teacher training records
+#
+class RemoveTeacher
+  attr_reader :teacher
+
+  # @param teacher_id [Integer]
+  def initialize(teacher_id)
+    @teacher = Teacher.find(teacher_id)
+  end
+
+  # @return [Teacher, false]
+  def call
+    Teacher.transaction do
+      destroy_has_many!
+      teacher.destroy! or raise(ActiveRecord::Rollback)
+    end
+
+    teacher
+  rescue ActiveRecord::Rollback,
+         ActiveRecord::InvalidForeignKey,
+         ActiveRecord::StatementInvalid => e
+    Rails.logger.debug e.message
+    false
+  end
+
+  # @return [Array<Symbol>]
+  def has_many_associations
+    Teacher.reflect_on_all_associations(:has_many).map(&:name).sort
+  end
+
+private
+
+  def destroy_has_many!
+    has_many_associations.each do |assoc|
+      records = teacher.send(assoc)
+
+      if records.any?
+        Rails.logger.debug "Destroying #{records.count} #{assoc}"
+        teacher.send(assoc).destroy_all
+      end
+    end
+  end
+end

--- a/spec/lib/remove_teacher_spec.rb
+++ b/spec/lib/remove_teacher_spec.rb
@@ -1,0 +1,115 @@
+RSpec.describe RemoveTeacher, :aggregate_failures do
+  subject(:remove_teacher) { described_class.new(teacher.id) }
+
+  let!(:teacher) { FactoryBot.create(:teacher) }
+
+  it "#has_many_associations" do
+    expect(remove_teacher.has_many_associations).to eq(%i[
+      appropriate_bodies
+      ect_at_school_periods
+      ect_training_periods
+      events
+      induction_extensions
+      induction_periods
+      lead_provider_metadata
+      mentor_at_school_periods
+      mentor_training_periods
+      teacher_id_changes
+      teacher_migration_failures
+    ])
+  end
+
+  describe "#call" do
+    let!(:first_appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+    let!(:second_appropriate_body) { FactoryBot.create(:appropriate_body) }
+
+    let!(:induction_period) do
+      FactoryBot.create(:induction_period,
+                        teacher:,
+                        appropriate_body: first_appropriate_body)
+    end
+
+    let!(:ongoing_induction_period) do
+      FactoryBot.create(:induction_period, :ongoing,
+                        teacher:,
+                        appropriate_body: second_appropriate_body,
+                        started_on: 1.week.ago)
+    end
+
+    let!(:other_teacher) { FactoryBot.create(:teacher) }
+
+    let!(:passed_induction_period) do
+      FactoryBot.create(:induction_period, :pass,
+                        teacher: other_teacher,
+                        appropriate_body: second_appropriate_body)
+    end
+
+    before do
+      FactoryBot.create(:event,
+                        teacher:,
+                        appropriate_body: first_appropriate_body)
+
+      FactoryBot.create(:event,
+                        teacher:,
+                        appropriate_body: second_appropriate_body)
+
+      FactoryBot.create(:event,
+                        teacher: other_teacher,
+                        appropriate_body: second_appropriate_body)
+    end
+
+    describe "unrelated records" do
+      before do
+        FactoryBot.create(:api_token)
+        FactoryBot.create(:contract_period)
+        FactoryBot.create(:delivery_partner)
+        FactoryBot.create(:gias_school)
+        FactoryBot.create(:lead_provider)
+        FactoryBot.create(:school)
+        FactoryBot.create(:statement)
+        FactoryBot.create(:user)
+      end
+
+      it do
+        expect {
+          remove_teacher.call
+        }.to not_change(AppropriateBody, :count)
+          .and not_change(API::Token, :count)
+          .and not_change(ContractPeriod, :count)
+          .and not_change(DeliveryPartner, :count)
+          .and not_change(GIAS::School, :count)
+          .and not_change(LeadProvider, :count)
+          .and not_change(School, :count)
+          .and not_change(Statement, :count)
+          .and not_change(User, :count)
+      end
+    end
+
+    it "removes teacher and training data" do
+      # Original
+      expect(Teacher.count).to eq(2)
+      expect(InductionPeriod.count).to eq(3)
+      expect(AppropriateBody.count).to eq(2)
+      expect(Event.count).to eq(3)
+
+      # Remove
+      remove_teacher.call
+
+      # Targeted
+      expect { Teacher.find(teacher.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { InductionPeriod.find(induction_period.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { InductionPeriod.find(ongoing_induction_period.id) }.to raise_error(ActiveRecord::RecordNotFound)
+
+      # Ignored
+      expect(Teacher.find(other_teacher.id)).to be_a(Teacher)
+      expect(InductionPeriod.find(passed_induction_period.id)).to be_an(InductionPeriod)
+
+      # Result
+      expect(Teacher.count).to eq(1)
+      expect(InductionPeriod.count).to eq(1)
+      expect(AppropriateBody.count).to eq(2)
+      expect(Event.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Two tickets require the removal of `Teacher` records and associated induction data.

The first is a support ticket for a single ECT claimed in error, because exemption validations were broken.
That teacher's TRS status has since been corrected and we need to remove them and the induction.

The second is a collection of exempt ECTs, in various induction states, that were imported.

- [#2520](https://github.com/DFE-Digital/register-ects-project-board/issues/2520)
- [#2461](https://github.com/DFE-Digital/register-ects-project-board/issues/2461)


### Changes proposed in this pull request

Add a function outside the main app for use in one-off scripts that can keep working if new associations are added later.

- destroy dependent mentorship and training periods
- destroy dependent teacher_id_changes and lead_provider_metadata

### Guidance to review

- [script to delete off-shore teachers](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1555)
- test run on sandbox


