### PR TITLE
Add `trnless` flag and update TRN index

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -40,8 +40,14 @@ class Teacher < ApplicationRecord
 
   # Validations
   validates :trn,
-            uniqueness: { message: 'TRN already exists', case_sensitive: false },
-            teacher_reference_number: true
+            uniqueness: { message: 'TRN already exists', case_sensitive: false, allow_nil: true },
+            teacher_reference_number: true,
+            presence: { message: 'Enter the teacher reference number (TRN)' },
+            unless: :trnless?
+
+  validates :trn,
+            absence: { message: 'TRN not allowed when trnless is true' },
+            if: :trnless?
 
   validates :trs_induction_status,
             allow_nil: true,

--- a/app/wizards/schools/register_ect_wizard/find_ect_step.rb
+++ b/app/wizards/schools/register_ect_wizard/find_ect_step.rb
@@ -3,7 +3,9 @@ module Schools
     class FindECTStep < Step
       attr_accessor :trn, :date_of_birth
 
-      validates :trn, teacher_reference_number: true
+      validates :trn,
+                teacher_reference_number: true,
+                presence: { message: 'Enter the teacher reference number (TRN)' }
       validates :date_of_birth, date_of_birth: true
 
       def self.permitted_params

--- a/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
@@ -3,7 +3,9 @@ module Schools
     class FindMentorStep < Step
       attr_accessor :trn, :date_of_birth
 
-      validates :trn, teacher_reference_number: true
+      validates :trn,
+                teacher_reference_number: true,
+                presence: { message: 'Enter the teacher reference number (TRN)' }
       validates :date_of_birth, date_of_birth: true
 
       def self.permitted_params

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -31,6 +31,7 @@ shared:
     - created_at
     - updated_at
     - trn
+    - trnless
     - trs_qts_awarded_on
     - trs_qts_status_description
     - trs_induction_status

--- a/db/migrate/20251014131805_add_trnless_flag_to_teachers.rb
+++ b/db/migrate/20251014131805_add_trnless_flag_to_teachers.rb
@@ -1,0 +1,13 @@
+class AddTrnlessFlagToTeachers < ActiveRecord::Migration[8.0]
+  def up
+    # rubocop:disable Rails/BulkChangeTable
+    add_column :teachers, :trnless, :boolean, null: false, default: false
+    change_column :teachers, :trn, :varchar, null: true
+    add_check_constraint :teachers, "trnless or (trn is not null)", name: :check_trn_presence
+    # rubocop:enable Rails/BulkChangeTable
+  end
+
+  def down
+    remove_column :trnless, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_10_075339) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_14_131805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -759,7 +759,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_075339) do
     t.string "corrected_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "trn", null: false
+    t.string "trn"
     t.string "trs_first_name"
     t.string "trs_last_name"
     t.date "trs_qts_awarded_on"
@@ -781,6 +781,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_075339) do
     t.boolean "ect_sparsity_uplift", default: false, null: false
     t.datetime "ect_first_became_eligible_for_training_at"
     t.datetime "mentor_first_became_eligible_for_training_at"
+    t.boolean "trnless", default: false, null: false
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
@@ -788,6 +789,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_075339) do
     t.index ["search"], name: "index_teachers_on_search", using: :gin
     t.index ["trn"], name: "index_teachers_on_trn", unique: true
     t.index ["trs_first_name", "trs_last_name", "corrected_name"], name: "idx_on_trs_first_name_trs_last_name_corrected_name_6d0edad502", opclass: :gin_trgm_ops, using: :gin
+    t.check_constraint "trnless OR trn IS NOT NULL", name: "check_trn_presence"
   end
 
   create_table "training_periods", force: :cascade do |t|

--- a/lib/schools/validation/teacher_reference_number.rb
+++ b/lib/schools/validation/teacher_reference_number.rb
@@ -4,26 +4,21 @@ module Schools
       MIN_UNPADDED_TRN_LENGTH = 5
       PADDED_TRN_LENGTH = 7
 
-      attr_reader :trn, :error_message
+      attr_reader :trn, :error_message, :formatted_trn
 
       def initialize(trn)
         @trn = trn
         @error_message = nil
-      end
-
-      def formatted_trn
-        @formatted_trn ||= extract_trn_value
+        @formatted_trn ||= format_trn
       end
 
       def valid?
-        formatted_trn.present?
+        @error_message.nil?
       end
 
     private
 
-      def extract_trn_value
-        @error_message = "Enter the teacher reference number (TRN)" and return if trn.blank?
-
+      def format_trn
         # remove any characters that are not digits
         only_digits = trn.to_s.gsub(/[^\d]/, "")
 

--- a/spec/validators/teacher_reference_number_validator_spec.rb
+++ b/spec/validators/teacher_reference_number_validator_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe TeacherReferenceNumberValidator, type: :model do
   context "when the trn is invalid" do
     invalid_trns = [{ trn: "1234", error_message: "Teacher reference number must include at least 5 digits" },
                     { trn: "RP99/123457", error_message: "Teacher reference number cannot include more than 7 digits" },
-                    { trn: "No-numbers", error_message: "Teacher reference number must include at least 5 digits" },
-                    { trn: "", error_message: "Enter the teacher reference number (TRN)" }]
+                    { trn: "No-numbers", error_message: "Teacher reference number must include at least 5 digits" }]
 
     invalid_trns.each do |item|
       it "adds an error for trn - #{item[:trn]} " do


### PR DESCRIPTION
We have some historic cases where some ECF1 records have no TRN, but we have to import them.

For all new records we want TRNs to be present, and ideally we want to keep the database level checks to ensure we don't accidentally add bad data.

This change does the following:

1. it adds a `trnless` boolean field to teachers
2. when `trnless: true`
    - the validation in the model skips the TRN/uniqueness check
    - the database level validation for TRN presence isn't applied
3. when `trnless: false` (default)
    - the validation in the model is applied
    - the database level validation is applied

## Other changes

Now we're allowing records without TRNs I had to adjust the `TeacherReferenceNumber` validator so that it no longer checks for presence.

I've moved the individual presence checks to the places they're used, `FindECTStep` and `FindMentorStep` in the school registration wizards.