### PR TITLE
Fix issue with attribute name in component

### DIFF
--- a/app/components/migration/induction_record_component.rb
+++ b/app/components/migration/induction_record_component.rb
@@ -9,11 +9,11 @@ module Migration
     def migrated_mentor
       return unless mentor_present?
 
-      Teacher.find_by(api_mentor_training_record_id: induction_record.mentor_training_record_id)
+      Teacher.find_by(api_mentor_training_record_id: induction_record.mentor_profile_id)
     end
 
     def mentor_present?
-      induction_record.mentor_training_record_id.present?
+      induction_record.mentor_profile_id.present?
     end
 
     def attributes_for(_attr)


### PR DESCRIPTION
### Context

A recent change had incorrectly renamed a reference to an ECF1 attribute. This then caused the migration view of teacher details to error. This restores the correct attribute name.

### Changes proposed in this pull request

Restore the attribute name back to `induction_record.mentor_profile_id` in the view component.

### Guidance to review
