### PR TITLE
[2367] Add participants to sandbox seed data task

### DIFF
--- a/app/services/sandbox_seed_data/api_teachers_with_histories.rb
+++ b/app/services/sandbox_seed_data/api_teachers_with_histories.rb
@@ -1,0 +1,383 @@
+module SandboxSeedData
+  class APITeachersWithHistories < Base
+    NUMBER_OF_RECORDS = 500
+
+    TRAINING_STATUS_COLOURS = {
+      active: :green,
+      withdrawn: :red,
+      deferred: :yellow,
+    }.freeze
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("api teachers with histories")
+
+      groups_of_active_lead_providers.each_value do |grouped_active_lead_providers|
+        grouped_active_lead_providers.each do |active_lead_provider|
+          (NUMBER_OF_RECORDS / grouped_active_lead_providers.size).times do
+            create_api_teachers_records_for(active_lead_provider)
+          end
+        end
+      end
+    end
+
+  private
+
+    def create_teacher
+      teacher = FactoryBot.create(
+        :teacher,
+        :with_realistic_name,
+        trn: Helpers::TRNGenerator.next
+      ).tap do |t|
+        random_date = rand(1..100).days.ago
+        t.update!(created_at: random_date, updated_at: random_date)
+      end
+
+      log_seed_info(::Teachers::Name.new(teacher).full_name, indent: 2)
+      teacher
+    end
+
+    def groups_of_active_lead_providers
+      ActiveLeadProvider.all.group_by(&:lead_provider_id)
+    end
+
+    def create_api_teachers_records_for(active_lead_provider)
+      school_partnership = find_school_partnership(active_lead_provider)
+      return if school_partnership.blank?
+
+      school = school_partnership.school
+      finished_on = Faker::Boolean.boolean(true_ratio: 0.3) ? nil : 6.months.from_now.to_date
+
+      teacher = create_teacher
+      school_period = random_period_within(started_on: teacher.created_at.to_date, finished_on:)
+      training_period_data = random_period_within(**school_period)
+      training_period_traits = generate_training_period_traits
+      ect_mentor_traits = generate_ect_mentor_school_period_traits
+      ect_specific_traits = generate_ect_specific_traits
+      schedule = find_schedule(school_partnership.contract_period)
+
+      if Faker::Boolean.boolean(true_ratio: 0.5)
+        create_ect_and_optional_mentor_training(
+          teacher,
+          school,
+          school_period,
+          schedule,
+          school_partnership,
+          training_period_data,
+          training_period_traits,
+          ect_mentor_traits,
+          ect_specific_traits
+        )
+      else
+        create_mentor_and_optional_ect_training(
+          teacher,
+          school,
+          school_period,
+          schedule,
+          school_partnership,
+          training_period_data,
+          training_period_traits,
+          ect_mentor_traits,
+          ect_specific_traits
+        )
+      end
+    end
+
+    def find_school_partnership(active_lead_provider)
+      SchoolPartnership
+        .joins(:lead_provider_delivery_partnership)
+        .where(lead_provider_delivery_partnership: { active_lead_provider: })
+        .order(Arel.sql("RANDOM()"))
+        .first
+    end
+
+    def find_schedule(contract_period)
+      if Faker::Boolean.boolean(true_ratio: 0.8)
+        return Schedule.find_by(
+          contract_period:,
+          identifier: "ecf-standard-september"
+        )
+      end
+
+      Schedule
+        .where(contract_period:)
+        .order(Arel.sql("RANDOM()"))
+        .first
+    end
+
+    def generate_training_period_traits
+      [].tap do |traits|
+        if Faker::Boolean.boolean(true_ratio: 0.2)
+          traits << :withdrawn
+        elsif Faker::Boolean.boolean(true_ratio: 0.15)
+          traits << :deferred
+        end
+      end
+    end
+
+    def generate_ect_mentor_school_period_traits
+      [].tap do |traits|
+        traits << :with_teacher_payments_frozen_year if Faker::Boolean.boolean(true_ratio: 0.10)
+      end
+    end
+
+    def generate_ect_specific_traits
+      [].tap do |traits|
+        traits << :with_teacher_payments_frozen_year if Faker::Boolean.boolean(true_ratio: 0.1)
+      end
+    end
+
+    def create_ect_and_optional_mentor_training(
+      teacher,
+      school,
+      school_period,
+      schedule,
+      school_partnership,
+      training_period_data,
+      training_period_traits,
+      ect_mentor_traits,
+      ect_specific_traits
+    )
+      ect_at_school_period_record = ect_at_school_period(
+        teacher:,
+        school:,
+        school_period:,
+        traits: ect_mentor_traits + ect_specific_traits
+      )
+
+      FactoryBot.create(
+        :training_period,
+        *training_period_traits.compact,
+        :with_schedule,
+        :for_ect,
+        schedule:,
+        ect_at_school_period: ect_at_school_period_record,
+        school_partnership:,
+        **training_period_data
+      ).tap { |tp| log_training_period(training_period: tp) }
+
+      set_ect_attributes(teacher:)
+      create_teacher_id_change_for(teacher:)
+
+      if Faker::Boolean.boolean(true_ratio: 0.1)
+        mentor_at_school_period_record = mentor_at_school_period(
+          teacher:,
+          school:,
+          school_period:,
+          traits: ect_mentor_traits
+        )
+
+        FactoryBot.create(
+          :training_period,
+          *training_period_traits.compact,
+          :with_schedule,
+          :for_mentor,
+          schedule:,
+          mentor_at_school_period: mentor_at_school_period_record,
+          school_partnership:,
+          **training_period_data
+        ).tap { |tp| log_training_period(training_period: tp) }
+      end
+    end
+
+    def create_mentor_and_optional_ect_training(
+      teacher,
+      school,
+      school_period,
+      schedule,
+      school_partnership,
+      training_period_data,
+      training_period_traits,
+      ect_mentor_traits,
+      ect_specific_traits
+    )
+      mentor_at_school_period_record = mentor_at_school_period(
+        teacher:,
+        school:,
+        school_period:,
+        traits: ect_mentor_traits
+      )
+
+      FactoryBot.create(
+        :training_period,
+        *training_period_traits.compact,
+        :with_schedule,
+        :for_mentor,
+        schedule:,
+        mentor_at_school_period: mentor_at_school_period_record,
+        school_partnership:,
+        **training_period_data
+      ).tap { |tp| log_training_period(training_period: tp) }
+
+      set_mentor_attributes(teacher:)
+      create_teacher_id_change_for(teacher:)
+
+      if Faker::Boolean.boolean(true_ratio: 0.1)
+        ect_at_school_period_record = ect_at_school_period(
+          teacher:,
+          school:,
+          school_period:,
+          traits: ect_mentor_traits + ect_specific_traits
+        )
+
+        FactoryBot.create(
+          :training_period,
+          *training_period_traits.compact,
+          :with_schedule,
+          :for_ect,
+          schedule:,
+          ect_at_school_period: ect_at_school_period_record,
+          school_partnership:,
+          **training_period_data
+        ).tap { |tp| log_training_period(training_period: tp) }
+      end
+
+      assign_ect_to_mentor(teacher:, school:, mentor_at_school_period_record:)
+    end
+
+    def ect_at_school_period(teacher:, school:, school_period:, traits:)
+      email = Faker::Internet.email(name: ::Teachers::Name.new(teacher).full_name)
+      school_reported_appropriate_body = random_appropriate_body
+
+      FactoryBot.create(
+        :ect_at_school_period,
+        *traits.compact,
+        teacher:,
+        school:,
+        email:,
+        school_reported_appropriate_body:,
+        created_at: teacher.created_at,
+        **school_period
+      ).tap { |easp| log_ect_at_school_period(ect_at_school_period: easp) }
+    end
+
+    def mentor_at_school_period(teacher:, school:, school_period:, traits:)
+      email = Faker::Internet.email(name: ::Teachers::Name.new(teacher).full_name)
+
+      FactoryBot.create(
+        :mentor_at_school_period,
+        *traits.compact,
+        teacher:,
+        school:,
+        email:,
+        created_at: teacher.created_at,
+        **school_period
+      ).tap { |masp| log_mentor_at_school_period(mentor_at_school_period: masp) }
+    end
+
+    def set_ect_attributes(teacher:)
+      teacher.update!(
+        api_ect_training_record_id: SecureRandom.uuid
+      )
+
+      return unless Faker::Boolean.boolean(true_ratio: 0.65)
+
+      teacher.update!(
+        ect_first_became_eligible_for_training_at: teacher.created_at + 3.months,
+        ect_pupil_premium_uplift: Faker::Boolean.boolean(true_ratio: 0.15),
+        ect_sparsity_uplift: Faker::Boolean.boolean(true_ratio: 0.20)
+      )
+    end
+
+    def set_mentor_attributes(teacher:)
+      teacher.update!(
+        api_mentor_training_record_id: SecureRandom.uuid
+      )
+
+      return unless Faker::Boolean.boolean(true_ratio: 0.65)
+
+      teacher.update!(mentor_first_became_eligible_for_training_at: teacher.created_at + 2.months)
+    end
+
+    def create_teacher_id_change_for(teacher:)
+      return unless Faker::Boolean.boolean(true_ratio: 0.15)
+
+      api_from_teacher_id = FactoryBot.create(:teacher, trs_first_name: teacher.trs_first_name, trn: Helpers::TRNGenerator.next).api_id
+
+      FactoryBot.create(
+        :teacher_id_change,
+        teacher:,
+        api_from_teacher_id:
+      )
+    end
+
+    def assign_ect_to_mentor(teacher:, school:, mentor_at_school_period_record:)
+      return unless Faker::Boolean.boolean(true_ratio: 0.20)
+
+      # Assign an ECT to the mentor for the same period excluding ECTs who are already mentees
+      ect_at_school_period = school.ect_at_school_periods.where.not(teacher_id: teacher.id).where.not(id: MentorshipPeriod.distinct.pluck(:ect_at_school_period_id)).started_on_or_after(mentor_at_school_period_record.started_on).finished_before(mentor_at_school_period_record.finished_on).last
+
+      return if ect_at_school_period.blank?
+
+      FactoryBot.create(:mentorship_period,
+                        mentor: mentor_at_school_period_record,
+                        mentee: ect_at_school_period,
+                        started_on: ect_at_school_period.started_on,
+                        finished_on: ect_at_school_period.finished_on)
+    end
+
+    def random_period_within(started_on:, finished_on:)
+      started_on = rand(started_on..(finished_on || Time.zone.today))
+      finished_on = finished_on.present? ? rand(started_on..finished_on) : nil
+
+      { started_on:, finished_on: }
+    end
+
+    def random_appropriate_body
+      AppropriateBody.order(Arel.sql("RANDOM()")).first
+    end
+
+    def log_ect_at_school_period(ect_at_school_period:)
+      suffix = "(ECT at school period)"
+      log_seed_info(
+        "* has been an ECT at #{ect_at_school_period.school.name} " \
+        "#{describe_period_duration(ect_at_school_period)} #{suffix}",
+        indent: 4
+      )
+    end
+
+    def log_mentor_at_school_period(mentor_at_school_period:)
+      suffix = "(mentor at school period)"
+      log_seed_info(
+        "* was a mentor at #{mentor_at_school_period.school.name} " \
+        "from #{mentor_at_school_period.started_on} " \
+        "#{describe_period_duration(mentor_at_school_period)} #{suffix}",
+        indent: 4
+      )
+    end
+
+    def log_training_period(training_period:)
+      prefix = training_period.started_on.future? ? "will be" : "was"
+
+      return unless training_period.provider_led_training_programme? && training_period.school_partnership.present?
+
+      training_status = ::API::TrainingPeriods::TrainingStatus.new(training_period:).status
+      suffix = "(training period - provider-led - #{training_status})"
+
+      delivery_partnership = training_period.school_partnership.lead_provider_delivery_partnership
+
+      lead_provider_name = delivery_partnership.active_lead_provider.lead_provider.name
+      delivery_partner_name = delivery_partnership.delivery_partner.name
+
+      log_seed_info(
+        "* #{prefix} trained by #{lead_provider_name} (LP) " \
+        "and #{delivery_partner_name} (DP) " \
+        "#{describe_period_duration(training_period)} #{suffix}",
+        indent: 4,
+        colour: TRAINING_STATUS_COLOURS[training_status]
+      )
+    end
+
+    def describe_period_duration(period)
+      case
+      when period.started_on.future?
+        "from #{period.started_on}"
+      when period.finished_on
+        "between #{period.started_on} and #{period.finished_on}"
+      else
+        "since #{period.started_on}"
+      end
+    end
+  end
+end

--- a/app/services/sandbox_seed_data/helpers/trn_generator.rb
+++ b/app/services/sandbox_seed_data/helpers/trn_generator.rb
@@ -1,0 +1,37 @@
+ALL_TRNS = (1111..9_999_999) unless defined?(ALL_TRNS)
+
+module SandboxSeedData
+  module Helpers
+    class TRNGenerator
+      class << self
+        def next
+          next_trn = next_from_available_stack
+          add_to_taken_stack(next_trn)
+          sprintf("%07d", next_trn)
+        end
+
+      private
+
+        def add_to_taken_stack(next_trn)
+          taken.push(next_trn)
+        end
+
+        def next_from_available_stack
+          available.pop || (raise "TRN available list exhausted")
+        end
+
+        def available
+          @available.presence || reseed
+        end
+
+        def reseed
+          @available = (Array.new(10_000) { rand(ALL_TRNS) }.uniq - taken)
+        end
+
+        def taken
+          @taken ||= ::Teacher.where.not(trn: nil).pluck(:trn).map(&:to_i)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/sandbox_seed_data.rake
+++ b/lib/tasks/sandbox_seed_data.rake
@@ -11,11 +11,16 @@ namespace :sandbox_seed_data do
       SandboxSeedData::SchoolPartnerships,
       SandboxSeedData::Teachers,
       SandboxSeedData::TeacherHistories,
+      SandboxSeedData::APITeachersWithHistories,
     ]
 
-    seeds.each do |seed_class|
-      seed = seed_class.new
-      seed.plant
+    DeclarativeUpdates.skip(:metadata) do
+      seeds.each do |seed_class|
+        seed = seed_class.new
+        seed.plant
+      end
     end
+
+    Metadata::Manager.refresh_all_metadata!(async: true)
   end
 end

--- a/spec/services/sandbox_seed_data/api_teachers_with_histories_spec.rb
+++ b/spec/services/sandbox_seed_data/api_teachers_with_histories_spec.rb
@@ -1,0 +1,215 @@
+RSpec.describe SandboxSeedData::APITeachersWithHistories do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+  let!(:school_partnerships) { FactoryBot.create_list(:school_partnership, 5) }
+  let!(:appropriate_bodies) { FactoryBot.create_list(:appropriate_body, 5) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+
+    stub_const("#{described_class}::NUMBER_OF_RECORDS", 2)
+
+    # Ensure the default and other schedules exist for some contract periods
+    school_partnerships.each do |school_partnership|
+      FactoryBot.create(:schedule, contract_period: school_partnership.contract_period)
+      FactoryBot.create(:schedule, contract_period: school_partnership.contract_period, identifier: Schedule.identifiers.keys.sample)
+    end
+  end
+
+  describe "#plant" do
+    subject(:plant) { instance.plant }
+
+    context "when creating teachers in every contract period" do
+      it "creates correct data" do
+        plant
+
+        expect(SchoolPartnership.all.map(&:contract_period).uniq).to match_array(TrainingPeriod.all.map(&:contract_period).uniq)
+      end
+    end
+
+    context "when creating teachers with uplifts" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+      end
+
+      it "creates correct data" do
+        plant
+
+        expect(Teacher.all.map(&:ect_pupil_premium_uplift).uniq).to contain_exactly(true, false)
+      end
+    end
+
+    context "when creating teachers with different schedules" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.8).and_return(false)
+      end
+
+      it "creates correct data" do
+        plant
+
+        expect(TrainingPeriod.provider_led_training_programme.map(&:schedule).map(&:identifier).uniq.size).to be > 1
+      end
+    end
+
+    context "when creating teachers with `training_record_id`" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.15).and_return(false)
+      end
+
+      it "creates correct data" do
+        plant
+
+        expect(Teacher.where(api_ect_training_record_id: nil, api_mentor_training_record_id: nil)).to be_empty
+      end
+    end
+
+    context "when creating teachers with `cohort_changed_after_payments_frozen`" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.1).and_return(true)
+      end
+
+      it "creates correct data" do
+        plant
+
+        expect(Teacher.all.map(&:ect_payments_frozen_year).uniq).not_to be_nil
+      end
+    end
+
+    context "when creating teachers with `teacher_id_changes`" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.15).and_return(true)
+      end
+
+      it "creates correct data" do
+        expect {
+          plant
+        }.to change(TeacherIdChange, :count)
+      end
+    end
+
+    context "when creating teachers with two enrolments" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.1).and_return(true)
+      end
+
+      it "creates correct data" do
+        plant
+
+        expect(Teacher.joins(:ect_at_school_periods, :mentor_at_school_periods).count).to be > 0
+      end
+    end
+
+    context "when creating ECTAtSchoolPeriod records" do
+      before { allow(Faker::Boolean).to receive(:boolean).and_return(true) }
+
+      it { expect { plant }.to change(ECTAtSchoolPeriod, :count).by(10) }
+    end
+
+    context "when creating MentorAtSchoolPeriod records" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.20).and_return(true)
+      end
+
+      it { expect { plant }.to change(MentorAtSchoolPeriod, :count).by(10) }
+    end
+
+    context "when assigning ECTs to Mentors" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.30).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.20).and_return(true)
+
+        # Create some ongoing ECT periods in the future to increase chances of assignment
+        school_partnerships.each do |school_partnership|
+          school = school_partnership.school
+          FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: 6.months.from_now)
+        end
+      end
+
+      it { expect { plant }.to change(MentorshipPeriod, :count).by(5) }
+    end
+
+    context "when creating TrainingPeriod records without a finished_on" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.3).and_return(true)
+      end
+
+      it { expect { plant }.to change(TrainingPeriod.where(finished_on: nil), :count).by(20) }
+    end
+
+    context "when creating TrainingPeriod records with a finished_on" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.3).and_return(false)
+      end
+
+      it { expect { plant }.to change(TrainingPeriod.where.not(finished_on: nil), :count).by(20) }
+    end
+
+    context "when creating withdrawn TrainingPeriod records" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.2).and_return(true)
+      end
+
+      it { expect { plant }.to change(TrainingPeriod.where.not(withdrawn_at: nil), :count).by(20) }
+    end
+
+    context "when creating deferred TrainingPeriod records" do
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.2).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.15).and_return(true)
+      end
+
+      it { expect { plant }.to change(TrainingPeriod.where.not(deferred_at: nil), :count).by(20) }
+    end
+
+    context "when creating active TrainingPeriod records" do
+      let!(:teachers) { FactoryBot.create_list(:teacher, 1) }
+
+      before do
+        allow(Faker::Boolean).to receive(:boolean).and_return(true)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.2).and_return(false)
+        allow(Faker::Boolean).to receive(:boolean).with(true_ratio: 0.15).and_return(false)
+      end
+
+      it { expect { plant }.to change(TrainingPeriod.where(deferred_at: nil, withdrawn_at: nil), :count).by(20) }
+    end
+
+    it "logs the creation of api teachers records" do
+      plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting api teachers with histories/).once
+
+      training_period = TrainingPeriod.all.sample
+      training_status = ::API::TrainingPeriods::TrainingStatus.new(training_period:).status
+      expect(logger).to have_received(:info).with(/(training period - provider-led - #{training_status})/).at_least(:once)
+      expect(logger).to have_received(:info).with(/trained by #{training_period.school_partnership.active_lead_provider.lead_provider.name} \(LP\)/).at_least(:once)
+      expect(logger).to have_received(:info).with(/and #{training_period.school_partnership.delivery_partner.name} \(DP\)/).at_least(:once)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any teachers, training periods or school periods" do
+        expect { instance.plant }.not_to change(Teacher, :count)
+        expect { instance.plant }.not_to change(TrainingPeriod, :count)
+        expect { instance.plant }.not_to change(ECTAtSchoolPeriod, :count)
+        expect { instance.plant }.not_to change(MentorAtSchoolPeriod, :count)
+      end
+    end
+  end
+end

--- a/spec/services/sandbox_seed_data/helpers/trn_generator_spec.rb
+++ b/spec/services/sandbox_seed_data/helpers/trn_generator_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SandboxSeedData::Helpers::TRNGenerator, type: :helper do
+  describe ".next" do
+    it "produces new unassigned TRNs every time" do
+      1000.times do
+        expect(::Teacher.pluck(:trn)).not_to include(described_class.next)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [2367](https://github.com/DFE-Digital/register-ects-project-board/issues/2367)

Lead providers need to be able to test the APIs in sandbox before using them in a live environment.

### Changes proposed in this pull request

- Add participants to `sandbox_seed_data.rake`
- Created a file called `api_teachers` in order to create teachers in specific scenarios for the API (so we can run in separate and not mix up with existing teachers / teacher histories that it was already run)
- Make sure we disable metadata refreshes during the run, running it in the end to speed up the process
- Added a `TRNGenerator`, so we make sure we don't clash with existing TRNs (as the factories use sequences for TRN, I had issues with it)
- Mix of participants in:
  - Ensure there are participants in every cohort
  - set pupil_premium_uplift and sparsity_uplift only on ECTs as true/false
  - add different schedule_identifier values
  - ensure dates are different and make sense
  - ensure when setting cohort_changed_after_payments_frozen to true that participants come from cohort 2021 or 2022 and are in 2024
  - Participants with teacher id changes
  - Participants with two enrolments

### Guidance to review

I'll run it in review app for testing. After reviewed, we can run the same in sandbox.

```
Rails.logger.silence do
  ActiveRecord::Base.transaction do
    DeclarativeUpdates.skip do
      SandboxSeedData::APITeachersWithHistories.new.plant
    end
  end
  Metadata::Manager.refresh_all_metadata!(async: true)
end
```