### PR TITLE
Prevent school-led training periods from being migrated for mentors

### DIFF
--- a/app/migration/builders/mentor/training_periods.rb
+++ b/app/migration/builders/mentor/training_periods.rb
@@ -15,6 +15,8 @@ module Builders
         period_date = Data.define(:started_on, :finished_on)
 
         training_period_data.each do |period|
+          next if period.training_programme == "school_led"
+
           period_dates = period_date.new(started_on: period.start_date, finished_on: period.end_date)
           school = find_school_by_urn!(period.school_urn)
 

--- a/spec/migration/builders/mentor/training_periods_spec.rb
+++ b/spec/migration/builders/mentor/training_periods_spec.rb
@@ -46,6 +46,16 @@ describe Builders::Mentor::TrainingPeriods do
       expect(periods.last.ecf_end_induction_record_id).to eq training_period_2.end_source_id
     end
 
+    context "when a mentor training period is school-led" do
+      let(:training_period_2) { FactoryBot.build(:training_period_data, school_urn: school_2.urn, cohort_year: contract_period.year, lead_provider: partnership_2.lead_provider.name, delivery_partner: partnership_2.delivery_partner.name, training_programme: "school_led", start_date: school_period_2.started_on, end_date: nil) }
+
+      it "does not create a TeacherMigrationFailure record" do
+        expect {
+          service.build
+        }.not_to(change { TeacherMigrationFailure.count })
+      end
+    end
+
     context "when there is no MentorAtSchoolPeriod that contains the training dates" do
       let(:training_period_1) { FactoryBot.build(:training_period_data, cohort_year: contract_period.year, lead_provider: partnership_1.lead_provider.name, delivery_partner: partnership_1.delivery_partner.name, start_date: 14.months.ago.to_date, end_date: 1.month.ago.to_date) }
 


### PR DESCRIPTION
### Context
TickeT: https://github.com/DFE-Digital/register-ects-project-board/issues/2280

This PR fixes the migration errors created when migrating school-led training periods for mentors.

Mentors can only have provider-led training periods, and there is a validation in the TrainingPeriod model to enforce this rule. When the migrations encounter school-led periods, they attempt to create invalid records, which results in unnecessary migration errors.

### Changes proposed in this pull request
- Update the `Builders::Mentor::TrainingPeriods` to skip `school-led` training periods for mentors

### Guidance to review
