### PR TITLE
Save TRS DoB 

### DIFF
--- a/app/wizards/schools/register_ect_wizard/ect.rb
+++ b/app/wizards/schools/register_ect_wizard/ect.rb
@@ -54,7 +54,7 @@ module Schools
       end
 
       def prohibited_from_teaching?
-        prohibited_from_teaching == true
+        trs_prohibited_from_teaching == true
       end
 
       def registered?

--- a/app/wizards/schools/register_ect_wizard/find_ect_step.rb
+++ b/app/wizards/schools/register_ect_wizard/find_ect_step.rb
@@ -19,7 +19,7 @@ module Schools
         return :induction_completed if ect.induction_completed?
         return :induction_exempt if ect.induction_exempt?
         return :induction_failed if ect.induction_failed?
-        return :cannot_register_ect if trs_teacher.prohibited_from_teaching?
+        return :cannot_register_ect if ect.prohibited_from_teaching?
 
         :review_ect_details
       end
@@ -30,12 +30,7 @@ module Schools
         ect.update(trn: formatted_trn,
                    date_of_birth: date_of_birth.values.join("-"),
                    trs_national_insurance_number: trs_teacher.trs_national_insurance_number,
-                   trs_date_of_birth: trs_teacher.date_of_birth,
-                   trs_trn: trs_teacher.trn,
-                   trs_first_name: trs_teacher.trs_first_name,
-                   trs_last_name: trs_teacher.trs_last_name,
-                   trs_induction_status: trs_teacher.trs_induction_status,
-                   prohibited_from_teaching: trs_teacher.prohibited_from_teaching?)
+                   **trs_teacher.to_h)
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_ect_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_ect_wizard/national_insurance_number_step.rb
@@ -26,12 +26,8 @@ module Schools
 
       def persist
         ect.update(national_insurance_number:,
-                   trs_date_of_birth: trs_teacher.date_of_birth,
                    trs_national_insurance_number: trs_teacher.trs_national_insurance_number,
-                   trs_first_name: trs_teacher.trs_first_name,
-                   trs_last_name: trs_teacher.trs_last_name,
-                   trs_induction_status: trs_teacher.trs_induction_status,
-                   prohibited_from_teaching: trs_teacher.prohibited_from_teaching?)
+                   **trs_teacher.to_h)
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/find_mentor_step.rb
@@ -17,7 +17,7 @@ module Schools
         return :cannot_mentor_themself if mentor.trn == ect.trn
         return :national_insurance_number unless mentor.matches_trs_dob?
         return :already_active_at_school if mentor.active_at_school?
-        return :cannot_register_mentor if mentor.prohibited_from_teaching
+        return :cannot_register_mentor if mentor.prohibited_from_teaching?
 
         :review_mentor_details
       end
@@ -31,10 +31,7 @@ module Schools
       def persist
         mentor.update(trn: formatted_trn,
                       date_of_birth: date_of_birth.values.join("-"),
-                      prohibited_from_teaching: trs_teacher.prohibited_from_teaching?,
-                      trs_date_of_birth: trs_teacher.date_of_birth,
-                      trs_first_name: trs_teacher.trs_first_name,
-                      trs_last_name: trs_teacher.trs_last_name)
+                      **trs_teacher.to_h)
       end
 
       def pre_populate_attributes

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -68,6 +68,10 @@ module Schools
         @trs_full_name ||= [trs_first_name, trs_last_name].join(" ")
       end
 
+      def prohibited_from_teaching?
+        trs_prohibited_from_teaching == true
+      end
+
       def ect
         @ect ||= ECTAtSchoolPeriod.find(store["ect_id"]) if store["ect_id"].present?
       end

--- a/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/national_insurance_number_step.rb
@@ -25,10 +25,10 @@ module Schools
 
       def persist
         mentor.update(national_insurance_number:,
-                      prohibited_from_teaching: trs_teacher.prohibited_from_teaching?,
-                      trs_date_of_birth: trs_teacher.date_of_birth,
+                      trs_date_of_birth: trs_teacher.trs_date_of_birth,
                       trs_first_name: trs_teacher.trs_first_name,
-                      trs_last_name: trs_teacher.trs_last_name)
+                      trs_last_name: trs_teacher.trs_last_name,
+                      trs_prohibited_from_teaching: trs_teacher.trs_prohibited_from_teaching)
       end
 
       def trs_teacher

--- a/app/wizards/schools/register_mentor_wizard/wizard.rb
+++ b/app/wizards/schools/register_mentor_wizard/wizard.rb
@@ -65,7 +65,7 @@ module Schools
               return [:confirmation]
             end
 
-            return steps + %i[cannot_register_mentor] if mentor.prohibited_from_teaching
+            return steps + %i[cannot_register_mentor] if mentor.prohibited_from_teaching?
 
             steps << :review_mentor_details
             return steps unless mentor.change_name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -265,6 +265,7 @@
   - confirmed_at
   - trs_first_name
   - trs_last_name
+  - trs_date_of_birth
   - trs_alerts
   - trs_email_address
   - trs_prohibited_from_teaching

--- a/db/migrate/20251015110055_add_trs_do_b_to_pending_induction_submissions.rb
+++ b/db/migrate/20251015110055_add_trs_do_b_to_pending_induction_submissions.rb
@@ -1,0 +1,5 @@
+class AddTRSDoBToPendingInductionSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :pending_induction_submissions, :trs_date_of_birth, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_14_131805) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_15_110055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -541,6 +541,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_14_131805) do
     t.enum "training_programme", enum_type: "training_programme"
     t.boolean "trs_prohibited_from_teaching"
     t.date "trs_induction_completed_date"
+    t.date "trs_date_of_birth"
     t.index ["appropriate_body_id"], name: "index_pending_induction_submissions_on_appropriate_body_id"
     t.index ["pending_induction_submission_batch_id"], name: "idx_on_pending_induction_submission_batch_id_bb4509358d"
     t.index ["trn"], name: "index_pending_induction_submissions_on_trn"

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -11,8 +11,8 @@ module TRS
     ELIGIBLE_INDUCTION_STATUSES = %w[None RequiredToComplete InProgress].freeze
     INDUCTION_STATUSES = (ELIGIBLE_INDUCTION_STATUSES + INELIGIBLE_INDUCTION_STATUSES).freeze
 
-    attr_reader :trn,
-                :date_of_birth,
+    attr_reader :trs_trn,
+                :trs_date_of_birth,
                 :trs_first_name,
                 :trs_last_name,
                 :trs_email_address,
@@ -29,8 +29,8 @@ module TRS
 
     # @param data [Hash{String=>Mixed}] TRS API response
     def initialize(data)
-      @trn = data['trn']
-      @date_of_birth = data['dateOfBirth']
+      @trs_trn = data['trn']
+      @trs_date_of_birth = data['dateOfBirth']
       @trs_first_name = data['firstName']
       @trs_last_name = data['lastName']
       @trs_email_address = data['emailAddress']
@@ -50,6 +50,8 @@ module TRS
     def prohibited_from_teaching?
       PROHIBITED_FROM_TEACHING_CATEGORY_ID.in?(trs_alerts)
     end
+
+    alias_method :trs_prohibited_from_teaching, :prohibited_from_teaching?
 
     # @return [Boolean]
     def no_qts?
@@ -76,11 +78,10 @@ module TRS
       true
     end
 
-    # @return [Hash] saved to PendingInductionSubmission record
+    # @return [Hash] splatted into PendingInductionSubmissions and wizard SessionRepositories
     def to_h
       {
-        trn:,
-        date_of_birth:,
+        trs_date_of_birth:,
         trs_first_name:,
         trs_last_name:,
         trs_email_address:,
@@ -93,7 +94,7 @@ module TRS
         trs_initial_teacher_training_provider_name:,
         trs_initial_teacher_training_end_date:,
         trs_alerts:,
-        trs_prohibited_from_teaching: prohibited_from_teaching?,
+        trs_prohibited_from_teaching:,
       }
     end
   end

--- a/spec/lib/trs/api_client_spec.rb
+++ b/spec/lib/trs/api_client_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe TRS::APIClient do
 
         expect(teacher).to be_a(TRS::Teacher)
         expect(teacher.to_h.compact).to eq({
-          trn: "1234567",
           trs_alerts: [],
           trs_first_name: "John",
           trs_prohibited_from_teaching: false
@@ -55,7 +54,6 @@ RSpec.describe TRS::APIClient do
 
         expect(teacher).to be_a(TRS::Teacher)
         expect(teacher.to_h.compact).to eq({
-          trn: "1234567",
           trs_alerts: [],
           trs_first_name: "John",
           trs_prohibited_from_teaching: false

--- a/spec/lib/trs/teacher_spec.rb
+++ b/spec/lib/trs/teacher_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe TRS::Teacher do
   describe '#to_h' do
     it 'returns a hash of attributes' do
       expect(service.to_h).to eq({
-        trn: '1234567',
-        date_of_birth: '1980-01-01',
+        trs_date_of_birth: '1980-01-01',
         trs_first_name: 'John',
         trs_last_name: 'Doe',
         trs_email_address: 'john.doe@example.com',

--- a/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
           date_of_birth: '1990-01-01',
           trs_first_name: 'John',
           trs_date_of_birth: '1990-01-01',
-          prohibited_from_teaching: true
+          trs_prohibited_from_teaching: true
         )
         allow(wizard.ect).to receive_messages(in_trs?: true, matches_trs_dob?: true, active_at_school?: false)
       end

--- a/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/wizard_spec.rb
@@ -5,7 +5,7 @@ describe Schools::RegisterMentorWizard::Wizard do
   let(:ect_id) { ect.id }
   let(:mentor_trn) { "1234567" }
   let(:mentor_date_of_birth) { "1977-02-03" }
-  let(:prohibited_from_teaching) { false }
+  let(:trs_prohibited_from_teaching) { false }
   let(:school_urn) { '1212121' }
   let(:trs_date_of_birth) { "1977-02-03" }
   let(:trs_first_name) { "Mentor" }
@@ -39,14 +39,14 @@ describe Schools::RegisterMentorWizard::Wizard do
                          school_urn:,
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:)
       end
 
       context 'when the mentor has not been found in TRS' do
-        let(:prohibited_from_teaching) { nil }
+        let(:trs_prohibited_from_teaching) { nil }
         let(:trs_date_of_birth) { nil }
         let(:trs_first_name) { nil }
         let(:trs_last_name) { nil }
@@ -75,7 +75,7 @@ describe Schools::RegisterMentorWizard::Wizard do
       end
 
       context 'when the mentor is prohibited from teaching' do
-        let(:prohibited_from_teaching) { true }
+        let(:trs_prohibited_from_teaching) { true }
 
         it { is_expected.to eq(%i[find_mentor cannot_register_mentor]) }
       end
@@ -92,7 +92,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          school_urn:,
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,
@@ -100,7 +100,7 @@ describe Schools::RegisterMentorWizard::Wizard do
       end
 
       context 'when the mentor has not been found in TRS' do
-        let(:prohibited_from_teaching) { nil }
+        let(:trs_prohibited_from_teaching) { nil }
         let(:trs_date_of_birth) { nil }
         let(:trs_first_name) { nil }
         let(:trs_last_name) { nil }
@@ -117,7 +117,7 @@ describe Schools::RegisterMentorWizard::Wizard do
       end
 
       context 'when the mentor is prohibited from teaching' do
-        let(:prohibited_from_teaching) { true }
+        let(:trs_prohibited_from_teaching) { true }
 
         it { is_expected.to eq(%i[find_mentor national_insurance_number cannot_register_mentor]) }
       end
@@ -137,7 +137,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          school_urn:,
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,
@@ -158,7 +158,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          school_urn:,
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,
@@ -175,7 +175,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          school_urn:,
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,
@@ -193,7 +193,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
                          national_insurance_number: 'ZZ123456A',
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,
@@ -210,7 +210,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          school_urn:,
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,
@@ -259,7 +259,7 @@ describe Schools::RegisterMentorWizard::Wizard do
                          trn: mentor_trn,
                          date_of_birth: mentor_date_of_birth,
                          national_insurance_number: 'ZZ123456A',
-                         prohibited_from_teaching:,
+                         trs_prohibited_from_teaching:,
                          trs_date_of_birth:,
                          trs_first_name:,
                          trs_last_name:,


### PR DESCRIPTION
### Context

#1545 omitted renaming DoB because it was not being stored

### Changes proposed in this pull request

This PR finishes off ensuring that whenever a TRS::Teacher is consumed it is unambiguous which value was retrieved via the API and which has been submitted by a user. For parity the DoB field has been added to pending submission records.

### Guidance to review
