### PR TITLE
Optimise `Teachers::Query`

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,12 +1,69 @@
 module API
   module V3
     class ParticipantsController < APIController
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
+      def index
+        conditions = {
+          contract_period_years: extract_conditions(contract_period_years, integers: true),
+          updated_since:,
+          training_status:,
+          api_from_teacher_id:,
+          sort:
+        }
+        paginated_teachers = teachers_query(conditions:).teachers { paginate(it) }
+
+        render json: to_json(paginated_teachers)
+      end
+
+      def show
+        render json: to_json(teachers_query.teacher_by_api_id(api_id))
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
+
+    private
+
+      def teachers_query(conditions: {})
+        API::Teachers::Query.new(**(default_query_conditions.merge(conditions)).compact)
+      end
+
+      def default_query_conditions
+        @default_query_conditions ||= {
+          lead_provider_id: current_lead_provider.id,
+        }
+      end
+
+      def serializer_options
+        @serializer_options ||= {
+          lead_provider_id: current_lead_provider.id
+        }
+      end
+
+      def participants_params
+        params.permit(:api_id, :sort, filter: %i[training_status from_participant_id])
+      end
+
+      def api_from_teacher_id
+        participants_params.dig(:filter, :from_participant_id)
+      end
+
+      def training_status
+        participants_params.dig(:filter, :training_status)
+      end
+
+      def api_id
+        participants_params[:api_id]
+      end
+
+      def sort
+        sort_order(sort: participants_params[:sort], model: Teacher, default: { created_at: :asc })
+      end
+
+      def to_json(obj)
+        API::TeacherSerializer.render(obj, root: "data", **serializer_options)
+      end
     end
   end
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -57,10 +57,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
     })
     .where(contract_periods: { year: })
   }
-  scope :with_expressions_of_interest_for_lead_provider_and_contract_period, ->(year, lead_provider_id) {
-    with_expressions_of_interest_for_contract_period(year)
-    .where(expression_of_interest: { lead_provider_id: })
-  }
 
   def school_reported_appropriate_body_name = school_reported_appropriate_body&.name
 

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -45,10 +45,6 @@ class MentorAtSchoolPeriod < ApplicationRecord
     })
     .where(contract_periods: { year: })
   }
-  scope :with_expressions_of_interest_for_lead_provider_and_contract_period, ->(year, lead_provider_id) {
-    with_expressions_of_interest_for_contract_period(year)
-    .where(expression_of_interest: { lead_provider_id: })
-  }
 
   # Instance methods
   def siblings

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -133,7 +133,14 @@ class School < ApplicationRecord
   def to_param = urn
 
   def training_programme_for(contract_period_year)
-    Schools::TrainingProgramme.new(school: self, contract_period_year:).training_programme
+    training_programme.training_programme_for(contract_period_year:)
+  end
+
+  def expressions_of_interest
+    ActiveLeadProvider
+      .joins(expressions_of_interest: %i[ect_at_school_period mentor_at_school_period])
+      .where('ect_at_school_periods.school_id = ? OR mentor_at_school_periods.school_id = ?', id, id)
+      .distinct
   end
 
   def expression_of_interest_for?(lead_provider_id, contract_period_year)
@@ -142,5 +149,11 @@ class School < ApplicationRecord
       .where(expression_of_interest: { lead_provider_id:, contract_period_year: })
       .where("ect_at_school_periods.school_id = ? OR mentor_at_school_periods.school_id = ?", id, id)
       .exists?
+  end
+
+private
+
+  def training_programme
+    @training_programme ||= Schools::TrainingProgramme.new(school: self)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -137,8 +137,10 @@ class School < ApplicationRecord
   end
 
   def expression_of_interest_for?(lead_provider_id, contract_period_year)
-    [ect_at_school_periods, mentor_at_school_periods].any? do |periods|
-      periods.with_expressions_of_interest_for_lead_provider_and_contract_period(contract_period_year, lead_provider_id).exists?
-    end
+    TrainingPeriod
+      .left_joins(:ect_at_school_period, :mentor_at_school_period, expression_of_interest: :contract_period)
+      .where(expression_of_interest: { lead_provider_id:, contract_period_year: })
+      .where("ect_at_school_periods.school_id = ? OR mentor_at_school_periods.school_id = ?", id, id)
+      .exists?
   end
 end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -76,14 +76,29 @@ class TrainingPeriod < ApplicationRecord
   }
 
   scope :ect_training_periods_latest_first, ->(teacher:, lead_provider:) {
-    includes(:ect_at_school_period, :lead_provider)
+    includes(:ect_at_school_period, lead_provider_delivery_partnership: { active_lead_provider: :lead_provider })
     .where(ect_at_school_period: { teacher: }, lead_provider: { id: lead_provider })
     .latest_first
   }
+  scope :latest_ect_training_periods_by_lead_provider, ->(teacher:) {
+    includes(:ect_at_school_period, lead_provider_delivery_partnership: { active_lead_provider: :lead_provider })
+      .where(ect_at_school_period: { teacher: })
+      .select("DISTINCT ON (lead_provider_id) #{table_name}.*")
+      .order("lead_provider_id, #{table_name}.started_on DESC")
+      .index_by { it.lead_provider&.id }
+  }
+
   scope :mentor_training_periods_latest_first, ->(teacher:, lead_provider:) {
-    includes(:mentor_at_school_period, :lead_provider)
+    includes(:mentor_at_school_period, lead_provider_delivery_partnership: { active_lead_provider: :lead_provider })
     .where(mentor_at_school_period: { teacher: }, lead_provider: { id: lead_provider })
     .latest_first
+  }
+  scope :latest_mentor_training_periods_by_lead_provider, ->(teacher:) {
+    includes(:mentor_at_school_period, lead_provider_delivery_partnership: { active_lead_provider: :lead_provider })
+      .where(mentor_at_school_period: { teacher: })
+      .select("DISTINCT ON (lead_provider_id) #{table_name}.*")
+      .order("lead_provider_id, #{table_name}.started_on DESC")
+      .index_by { it.lead_provider&.id }
   }
 
   # Delegations

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -138,9 +138,35 @@ module API::Teachers
     end
 
     def where_training_status_is(training_status)
-      nil if ignore?(filter: training_status)
+      return if ignore?(filter: training_status)
 
-      # TODO: implement when we have the training status field
+      @scope = scope
+          .left_joins(
+            lead_provider_metadata: %i[latest_ect_training_period latest_mentor_training_period]
+          )
+
+      # The latest_ect_training_period is joined as training_period and
+      # latest_mentor_training_period as latest_mentor_training_periods_metadata_teachers_lead_providers
+      # (using the alias names Rails creates for the join tables).
+      case training_status.to_sym
+      when :withdrawn
+        @scope = scope.where(
+          "training_periods.withdrawn_at IS NOT NULL
+            OR latest_mentor_training_periods_metadata_teachers_lead_providers.withdrawn_at IS NOT NULL"
+        )
+      when :deferred
+        @scope = scope.where(
+          "training_periods.deferred_at IS NOT NULL
+            OR latest_mentor_training_periods_metadata_teachers_lead_providers.deferred_at IS NOT NULL"
+        )
+      when :active
+        @scope = scope.where(
+          "(training_periods.id IS NOT NULL AND training_periods.withdrawn_at IS NULL AND training_periods.deferred_at IS NULL)
+            OR (latest_mentor_training_periods_metadata_teachers_lead_providers.id IS NOT NULL AND
+            latest_mentor_training_periods_metadata_teachers_lead_providers.deferred_at IS NULL AND
+            latest_mentor_training_periods_metadata_teachers_lead_providers.withdrawn_at IS NULL)"
+        )
+      end
     end
 
     def where_api_from_teacher_id_is(api_from_teacher_id)

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -54,18 +54,16 @@ module API::Teachers
         .eager_load(
           lead_provider_metadata: {
             latest_ect_training_period: {
-              school_partnership: %i[
-                school
-                contract_period
-                delivery_partner
+              school_partnership: [
+                :school,
+                { lead_provider_delivery_partnership: %i[delivery_partner active_lead_provider] }
               ],
               ect_at_school_period: []
             },
             latest_mentor_training_period: {
-              school_partnership: %i[
-                school
-                contract_period
-                delivery_partner
+              school_partnership: [
+                :school,
+                { lead_provider_delivery_partnership: %i[delivery_partner active_lead_provider] }
               ],
               mentor_at_school_period: []
             }

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -13,7 +13,7 @@ module API::Teachers
       sort: { created_at: :asc }
     )
       @lead_provider_id = lead_provider_id
-      @scope = Teacher.distinct
+      @scope = Teacher
 
       where_lead_provider_is(lead_provider_id)
       where_contract_period_year_in(contract_period_years)
@@ -90,6 +90,7 @@ module API::Teachers
       return if ignore?(filter: contract_period_years)
 
       @scope = scope
+          .distinct
           .left_joins(
             lead_provider_metadata: {
               latest_ect_training_period: {
@@ -119,6 +120,7 @@ module API::Teachers
       return if ignore?(filter: training_status)
 
       @scope = scope
+          .distinct
           .left_joins(
             lead_provider_metadata: %i[latest_ect_training_period latest_mentor_training_period]
           )
@@ -151,6 +153,7 @@ module API::Teachers
       return if ignore?(filter: api_from_teacher_id)
 
       @scope = scope
+        .distinct
         .joins(:teacher_id_changes)
         .where(teacher_id_changes: { api_from_teacher_id: })
     end

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -45,7 +45,11 @@ module API::Teachers
       preloaded_results = results
         .strict_loading
         .includes(
-          :teacher_id_changes
+          :teacher_id_changes,
+          :started_induction_period,
+          :finished_induction_period,
+          :earliest_ect_at_school_period,
+          :earliest_mentor_at_school_period
         )
         .eager_load(
           lead_provider_metadata: {
@@ -55,14 +59,7 @@ module API::Teachers
                 contract_period
                 delivery_partner
               ],
-              ect_at_school_period: {
-                teacher: %i[
-                  started_induction_period
-                  finished_induction_period
-                  earliest_ect_at_school_period
-                  earliest_mentor_at_school_period
-                ]
-              }
+              ect_at_school_period: []
             },
             latest_mentor_training_period: {
               school_partnership: %i[
@@ -70,14 +67,7 @@ module API::Teachers
                 contract_period
                 delivery_partner
               ],
-              mentor_at_school_period: {
-                teacher: %i[
-                  started_induction_period
-                  finished_induction_period
-                  earliest_ect_at_school_period
-                  earliest_mentor_at_school_period
-                ]
-              }
+              mentor_at_school_period: []
             }
           }
         )

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -44,10 +44,10 @@ module API::Teachers
     def preload_associations(results)
       preloaded_results = results
         .strict_loading
+        .includes(
+          :teacher_id_changes
+        )
         .eager_load(
-          :earliest_ect_at_school_period,
-          :earliest_mentor_at_school_period,
-          :teacher_id_changes,
           lead_provider_metadata: {
             latest_ect_training_period: {
               school_partnership: %i[
@@ -59,6 +59,8 @@ module API::Teachers
                 teacher: %i[
                   started_induction_period
                   finished_induction_period
+                  earliest_ect_at_school_period
+                  earliest_mentor_at_school_period
                 ]
               }
             },
@@ -72,6 +74,8 @@ module API::Teachers
                 teacher: %i[
                   started_induction_period
                   finished_induction_period
+                  earliest_ect_at_school_period
+                  earliest_mentor_at_school_period
                 ]
               }
             }

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -42,16 +42,14 @@ module API::Teachers
   private
 
     def preload_associations(results)
-      preloaded_results = results
+      results
         .strict_loading
         .includes(
           :teacher_id_changes,
           :started_induction_period,
           :finished_induction_period,
           :earliest_ect_at_school_period,
-          :earliest_mentor_at_school_period
-        )
-        .eager_load(
+          :earliest_mentor_at_school_period,
           lead_provider_metadata: {
             latest_ect_training_period: {
               school_partnership: [
@@ -69,14 +67,6 @@ module API::Teachers
             }
           }
         )
-
-      unless ignore?(filter: lead_provider_id)
-        preloaded_results = preloaded_results
-          .references(:lead_provider_metadata)
-          .where(lead_provider_metadata: { lead_provider_id: })
-      end
-
-      preloaded_results
     end
 
     def where_lead_provider_is(lead_provider_id)

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -28,25 +28,17 @@ module Metadata::Handlers
 
   protected
 
-    def upsert(metadata, attributes)
-      metadata.assign_attributes(attributes)
-      return unless metadata.changed?
-
-      metadata.save!
-      alert_on_changes(metadata:, attributes:)
-    end
-
     def lead_provider_ids
       @lead_provider_ids ||= LeadProvider.pluck(:id)
     end
 
-    def alert_on_changes(metadata:, attributes:)
+    def alert_on_changes(metadata:, changes:)
       return unless @alert_on_changes
 
       attrs = {
         class: metadata.class.name,
         id: metadata.id,
-        attributes:,
+        changes:,
       }
 
       Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")

--- a/app/services/metadata/handlers/delivery_partner.rb
+++ b/app/services/metadata/handlers/delivery_partner.rb
@@ -19,14 +19,29 @@ module Metadata::Handlers
   private
 
     def upsert_lead_provider_metadata!
-      lead_provider_ids.each do |lead_provider_id|
-        metadata = Metadata::DeliveryPartnerLeadProvider.find_or_initialize_by(
-          delivery_partner:,
-          lead_provider_id:
-        )
+      existing_metadata = Metadata::DeliveryPartnerLeadProvider
+              .where(delivery_partner:, lead_provider_id: lead_provider_ids)
+              .index_by(&:lead_provider_id)
 
-        upsert(metadata, contract_period_years: contract_period_years(lead_provider_id))
+      changes_to_upsert = []
+
+      lead_provider_ids.each do |lead_provider_id|
+        metadata = existing_metadata[lead_provider_id] ||
+          Metadata::DeliveryPartnerLeadProvider.new(delivery_partner:, lead_provider_id:)
+
+        changes = {
+          delivery_partner_id: delivery_partner.id,
+          lead_provider_id:,
+          contract_period_years: contract_period_years(lead_provider_id)
+        }
+
+        next if metadata.attributes.slice(*changes.keys) == changes
+
+        alert_on_changes(metadata:, changes:)
+        changes_to_upsert << changes
       end
+
+      Metadata::DeliveryPartnerLeadProvider.upsert_all(changes_to_upsert, unique_by: %i[delivery_partner_id lead_provider_id])
     end
 
     def contract_period_years(lead_provider_id)

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -29,8 +29,8 @@ module Metadata::Handlers
         metadata = existing_metadata[lead_provider_id] ||
           Metadata::TeacherLeadProvider.new(teacher:, lead_provider_id:)
 
-        latest_ect_training_period = TrainingPeriod.ect_training_periods_latest_first(teacher:, lead_provider: lead_provider_id).first
-        latest_mentor_training_period = TrainingPeriod.mentor_training_periods_latest_first(teacher:, lead_provider: lead_provider_id).first
+        latest_ect_training_period = latest_ect_training_period_by_lead_provider(teacher:)[lead_provider_id]
+        latest_mentor_training_period = latest_mentor_training_period_by_lead_provider(teacher:)[lead_provider_id]
         api_mentor_id = latest_ect_training_period&.trainee&.latest_mentorship_period&.mentor&.teacher&.api_id
 
         changes = {
@@ -48,6 +48,14 @@ module Metadata::Handlers
       end
 
       Metadata::TeacherLeadProvider.upsert_all(changes_to_upsert, unique_by: %i[teacher_id lead_provider_id])
+    end
+
+    def latest_ect_training_period_by_lead_provider(teacher:)
+      @latest_ect_training_period_by_lead_provider ||= TrainingPeriod.latest_ect_training_periods_by_lead_provider(teacher:)
+    end
+
+    def latest_mentor_training_period_by_lead_provider(teacher:)
+      @latest_mentor_training_period_by_lead_provider ||= TrainingPeriod.latest_mentor_training_periods_by_lead_provider(teacher:)
     end
   end
 end

--- a/app/services/schools/training_programme.rb
+++ b/app/services/schools/training_programme.rb
@@ -1,43 +1,61 @@
 module Schools
   class TrainingProgramme
-    def initialize(school:, contract_period_year:)
+    def initialize(school:)
       @school = school
-      @contract_period_year = contract_period_year.to_i
     end
 
-    def training_programme
-      return provider_led if mentors_at_school?
+    def training_programme_for(contract_period_year:)
+      return provider_led if mentors_at_school?(contract_period_year:)
 
-      ect_training_programme || not_yet_known
+      ect_training_programme(contract_period_year:) || not_yet_known
     end
 
   private
 
     attr_reader :school, :contract_period_year
 
-    def ects_expressions_of_interest
-      @ects_expressions_of_interest ||= school.ect_at_school_periods.with_expressions_of_interest_for_contract_period(contract_period_year)
+    def ect_expressions_of_interest_ids_by_contract_period_year
+      @ect_expressions_of_interest_ids_by_contract_period_year ||= school
+        .ect_at_school_periods
+        .joins(training_periods: { expression_of_interest: :contract_period })
+        .pluck(:contract_period_year, :id)
+        .group_by(&:first)
+        .transform_values { |pairs| pairs.map(&:last) }
     end
 
-    def mentors_expressions_of_interest
-      @mentors_expressions_of_interest ||= school.mentor_at_school_periods.with_expressions_of_interest_for_contract_period(contract_period_year)
+    def mentors_expressions_of_interest_contract_period_years
+      @mentors_expressions_of_interest_contract_period_years ||= school.mentor_at_school_periods.joins(training_periods: {
+        expression_of_interest: :contract_period
+      }).pluck(:contract_period_year)
     end
 
-    def ect_at_school_periods
-      @ect_at_school_periods ||= school.ect_at_school_periods.with_partnerships_for_contract_period(contract_period_year)
+    def ect_at_school_period_ids_by_contract_period_year
+      @ect_at_school_period_ids_by_contract_period_year ||= school
+        .ect_at_school_periods
+        .joins(training_periods: { school_partnership: { lead_provider_delivery_partnership: :active_lead_provider } })
+        .pluck(:contract_period_year, :id)
+        .group_by(&:first)
+        .transform_values { |pairs| pairs.map(&:last) }
     end
 
-    def mentors_at_school_periods
-      @mentors_at_school_periods ||= school.mentor_at_school_periods.with_partnerships_for_contract_period(contract_period_year)
+    def mentors_at_school_periods_contract_period_years
+      @mentors_at_school_periods_contract_period_years ||= school
+        .mentor_at_school_periods
+        .joins(training_periods: { school_partnership: { lead_provider_delivery_partnership: :active_lead_provider } })
+        .pluck(:contract_period_year)
     end
 
-    def mentors_at_school?
-      mentors_expressions_of_interest.exists? || mentors_at_school_periods.exists?
+    def mentors_at_school?(contract_period_year:)
+      contract_period_year.in?(mentors_expressions_of_interest_contract_period_years) || contract_period_year.in?(mentors_at_school_periods_contract_period_years)
     end
 
-    def ect_training_programme
+    def ect_training_programme(contract_period_year:)
+      ect_at_school_period_id = ((ect_expressions_of_interest_ids_by_contract_period_year[contract_period_year] || []) +
+        (ect_at_school_period_ids_by_contract_period_year[contract_period_year] || []) +
+        school_led_ect_at_school_period_ids).compact
+
       TrainingPeriod
-        .where(ect_at_school_period_id: ects_expressions_of_interest.pluck(:id) + ect_at_school_periods.pluck(:id) + school_led_ect_at_school_periods.pluck(:id))
+        .where(ect_at_school_period_id:)
         .order(training_programme: :asc)
         .pick(:training_programme)
     end
@@ -48,6 +66,14 @@ module Schools
 
     def provider_led
       "provider_led"
+    end
+
+    def school_led_ect_at_school_period_ids
+      @school_led_ect_at_school_period_ids ||= school.ect_at_school_periods.joins(:training_periods)
+        .where(training_periods: { training_programme: 'school_led' })
+        .where(training_periods: { expression_of_interest_id: nil, school_partnership_id: nil })
+        .distinct
+        .pluck(:id)
     end
 
     def school_led_ect_at_school_periods

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -6,12 +6,14 @@ constraints -> { Rails.application.config.enable_api } do
     get "docs/:version", to: "documentation#index", as: :documentation
 
     namespace :v3 do
-      resources :participants, only: %i[index show] do
-        put :change_schedule, path: "change-schedule"
-        put :defer
-        put :resume
-        put :withdraw
-        get :transfers, to: "transfers#show"
+      resources :participants, only: %i[index show], param: :api_id do
+        member do
+          put :change_schedule, path: "change-schedule"
+          put :defer
+          put :resume
+          put :withdraw
+          get :transfers, to: "transfers#show"
+        end
 
         collection do
           resources :transfers, only: %i[index]

--- a/db/migrate/20251015212520_add_unique_index_to_metadata_teacher_lead_providers.rb
+++ b/db/migrate/20251015212520_add_unique_index_to_metadata_teacher_lead_providers.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMetadataTeacherLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    add_index :metadata_teachers_lead_providers, %i[teacher_id lead_provider_id], unique: true
+  end
+end

--- a/db/migrate/20251018153449_add_indexes_to_improve_teachers_query.rb
+++ b/db/migrate/20251018153449_add_indexes_to_improve_teachers_query.rb
@@ -1,0 +1,26 @@
+class AddIndexesToImproveTeachersQuery < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :metadata_teachers_lead_providers,
+              %i[lead_provider_id teacher_id],
+              where: "latest_ect_training_period_id IS NOT NULL OR latest_mentor_training_period_id IS NOT NULL",
+              algorithm: :concurrently
+
+    add_index :teachers,
+              :created_at,
+              algorithm: :concurrently
+
+    add_index :induction_periods,
+              %i[teacher_id started_on],
+              algorithm: :concurrently
+
+    add_index :ect_at_school_periods,
+              %i[teacher_id started_on],
+              algorithm: :concurrently
+
+    add_index :mentor_at_school_periods,
+              %i[teacher_id started_on],
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20251020070312_add_more_indexes_to_improve_teachers_query.rb
+++ b/db/migrate/20251020070312_add_more_indexes_to_improve_teachers_query.rb
@@ -1,0 +1,26 @@
+class AddMoreIndexesToImproveTeachersQuery < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Withdrawn scopes
+    add_index :training_periods,
+              :id,
+              name: "idx_training_periods_withdrawn",
+              where: "withdrawn_at IS NOT NULL",
+              algorithm: :concurrently
+
+    # Deferred scopes
+    add_index :training_periods,
+              :id,
+              name: "idx_training_periods_deferred",
+              where: "deferred_at IS NOT NULL",
+              algorithm: :concurrently
+
+    # Active scopes (neither withdrawn nor deferred)
+    add_index :training_periods,
+              :id,
+              name: "idx_training_periods_active",
+              where: "withdrawn_at IS NULL AND deferred_at IS NULL",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_18_153449) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_20_070312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -824,6 +824,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_18_153449) do
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"
     t.index ["expression_of_interest_id"], name: "index_training_periods_on_expression_of_interest_id"
+    t.index ["id"], name: "idx_training_periods_active", where: "((withdrawn_at IS NULL) AND (deferred_at IS NULL))"
+    t.index ["id"], name: "idx_training_periods_deferred", where: "(deferred_at IS NOT NULL)"
+    t.index ["id"], name: "idx_training_periods_withdrawn", where: "(withdrawn_at IS NOT NULL)"
     t.index ["mentor_at_school_period_id"], name: "index_training_periods_on_mentor_at_school_period_id"
     t.index ["schedule_id"], name: "index_training_periods_on_schedule_id"
     t.index ["school_partnership_id", "ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "provider_partnership_trainings", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_18_153449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
+    t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_and_started_on"
     t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
   end
@@ -309,6 +310,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
     t.enum "outcome", enum_type: "induction_outcomes"
     t.enum "training_programme", enum_type: "training_programme"
     t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
+    t.index ["teacher_id", "started_on"], name: "index_induction_periods_on_teacher_id_and_started_on"
     t.index ["teacher_id"], name: "index_induction_periods_on_teacher_id"
   end
 
@@ -347,6 +349,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
+    t.index ["teacher_id", "started_on"], name: "index_mentor_at_school_periods_on_teacher_id_and_started_on"
     t.index ["teacher_id"], name: "index_mentor_at_school_periods_on_teacher_id"
   end
 
@@ -413,6 +416,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
     t.uuid "api_mentor_id"
     t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
     t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
+    t.index ["lead_provider_id", "teacher_id"], name: "idx_on_lead_provider_id_teacher_id_74c7a13188", where: "((latest_ect_training_period_id IS NOT NULL) OR (latest_mentor_training_period_id IS NOT NULL))"
     t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"
     t.index ["teacher_id", "lead_provider_id"], name: "idx_on_teacher_id_lead_provider_id_23bbab847a", unique: true
     t.index ["teacher_id"], name: "index_metadata_teachers_lead_providers_on_teacher_id"
@@ -791,6 +795,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
+    t.index ["created_at"], name: "index_teachers_on_created_at"
     t.index ["search"], name: "index_teachers_on_search", using: :gin
     t.index ["trn"], name: "index_teachers_on_trn", unique: true
     t.index ["trs_first_name", "trs_last_name", "corrected_name"], name: "idx_on_trs_first_name_trs_last_name_corrected_name_6d0edad502", opclass: :gin_trgm_ops, using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_15_110055) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_15_212520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -414,6 +414,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_110055) do
     t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
     t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
     t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"
+    t.index ["teacher_id", "lead_provider_id"], name: "idx_on_teacher_id_lead_provider_id_23bbab847a", unique: true
     t.index ["teacher_id"], name: "index_metadata_teachers_lead_providers_on_teacher_id"
   end
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -348,21 +348,6 @@ describe ECTAtSchoolPeriod do
         expect(described_class.with_expressions_of_interest_for_contract_period(training_period.expression_of_interest.contract_period.id)).to match_array([period_2])
       end
     end
-
-    describe ".with_expressions_of_interest_for_lead_provider_and_contract_period" do
-      let!(:training_period) do
-        FactoryBot.create(:training_period,
-                          :with_only_expression_of_interest,
-                          :for_ect,
-                          ect_at_school_period: period_2,
-                          started_on: period_2.started_on,
-                          finished_on: period_2.finished_on)
-      end
-
-      it "returns ect in training periods only for the specified contract period and lead provider" do
-        expect(described_class.with_expressions_of_interest_for_lead_provider_and_contract_period(training_period.expression_of_interest.contract_period.id, training_period.expression_of_interest.lead_provider_id)).to match_array([period_2])
-      end
-    end
   end
 
   describe "#siblings" do

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -123,21 +123,6 @@ describe MentorAtSchoolPeriod do
         expect(described_class.with_expressions_of_interest_for_contract_period(training_period.expression_of_interest.contract_period.id)).to match_array([period_2])
       end
     end
-
-    describe ".with_expressions_of_interest_for_lead_provider_and_contract_period" do
-      let!(:training_period) do
-        FactoryBot.create(:training_period,
-                          :with_only_expression_of_interest,
-                          :for_mentor,
-                          mentor_at_school_period: period_2,
-                          started_on: period_2.started_on,
-                          finished_on: period_2.finished_on)
-      end
-
-      it "returns mentor in training periods only for the specified contract period and lead provider" do
-        expect(described_class.with_expressions_of_interest_for_lead_provider_and_contract_period(training_period.expression_of_interest.contract_period.id, training_period.expression_of_interest.lead_provider_id)).to match_array([period_2])
-      end
-    end
   end
 
   describe "#siblings" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -232,8 +232,8 @@ describe School do
     it "calls Schools::TrainingProgramme service with correct params" do
       training_programme_service = instance_double(Schools::TrainingProgramme)
 
-      allow(Schools::TrainingProgramme).to receive(:new).with(school:, contract_period_year:).and_return(training_programme_service)
-      expect(training_programme_service).to receive(:training_programme)
+      allow(Schools::TrainingProgramme).to receive(:new).with(school:).and_return(training_programme_service)
+      expect(training_programme_service).to receive(:training_programme_for).with(contract_period_year:)
 
       training_programme_for
     end

--- a/spec/requests/api/v3/participant_transfers_spec.rb
+++ b/spec/requests/api/v3/participant_transfers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Participant transfers API", type: :request do
   end
 
   describe "#show" do
-    let(:path) { api_v3_participant_transfers_path(123) }
+    let(:path) { transfers_api_v3_participant_path(123) }
 
     it_behaves_like "a token authenticated endpoint", :get
 

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "Participants API", :with_metadata, type: :request do
   def create_resource(active_lead_provider:, from_participant_id: nil, training_status: nil)
     lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
     school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
-    training_period = FactoryBot.create(:training_period, school_partnership:)
+    ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: nil)
+    training_period = FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.year.ago, finished_on: nil, school_partnership:)
     training_period.update!(withdrawn_at: 1.day.ago, withdrawal_reason: :other) if training_status == :withdrawn
     training_period.update!(deferred_at: 1.day.ago, deferral_reason: :other) if training_status == :deferred
 

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,28 +1,47 @@
-RSpec.describe "Participants API", type: :request do
+RSpec.describe "Participants API", :with_metadata, type: :request do
+  let(:serializer) { API::TeacherSerializer }
+  let(:serializer_options) { { lead_provider_id: lead_provider.id } }
+  let(:query) { API::Teachers::Query }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:lead_provider) { active_lead_provider.lead_provider }
+
+  def create_resource(active_lead_provider:, from_participant_id: nil)
+    lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+    school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+    FactoryBot.create(:training_period, school_partnership:).trainee.teacher.tap do |teacher|
+      FactoryBot.create(:teacher_id_change, teacher:, api_from_teacher_id: from_participant_id) if from_participant_id
+    end
+  end
+
   describe "#index" do
     let(:path) { api_v3_participants_path }
 
-    it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
+    def apply_expected_order(resources)
+      resources.sort_by(&:created_at)
     end
+
+    it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "an index endpoint"
+    it_behaves_like "a paginated endpoint"
+    it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
+    it_behaves_like "a filter by from_participant_id endpoint"
+    # it_behaves_like "a filter by training_status endpoint" TODO: implement when we have a training_status field
+    # it_behaves_like "a filter by updated_since endpoint" TODO: uncomment when Teacher has an api_updated_at
+    # it_behaves_like "a sortable endpoint" TODO: uncomment when Teacher has an api_updated_at
   end
 
   describe "#show" do
-    let(:path) { api_v3_participant_path(123) }
+    let(:resource) { create_resource(active_lead_provider:) }
+    let(:path_id) { resource.api_id }
+    let(:path) { api_v3_participant_path(path_id) }
 
     it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
-    end
+    it_behaves_like "a show endpoint"
+    # it_behaves_like "a does not filter by updated_since endpoint" # TODO: uncomment when Teacher has an api_updated_at
   end
 
   describe "#change_schedule" do
-    let(:path) { api_v3_participant_change_schedule_path(123) }
+    let(:path) { change_schedule_api_v3_participant_path(123) }
 
     it_behaves_like "a token authenticated endpoint", :put
 
@@ -33,7 +52,7 @@ RSpec.describe "Participants API", type: :request do
   end
 
   describe "#defer" do
-    let(:path) { api_v3_participant_defer_path(123) }
+    let(:path) { defer_api_v3_participant_path(123) }
 
     it_behaves_like "a token authenticated endpoint", :put
 
@@ -44,7 +63,7 @@ RSpec.describe "Participants API", type: :request do
   end
 
   describe "#resume" do
-    let(:path) { api_v3_participant_resume_path(123) }
+    let(:path) { resume_api_v3_participant_path(123) }
 
     it_behaves_like "a token authenticated endpoint", :put
 
@@ -55,7 +74,7 @@ RSpec.describe "Participants API", type: :request do
   end
 
   describe "#withdraw" do
-    let(:path) { api_v3_participant_withdraw_path(123) }
+    let(:path) { withdraw_api_v3_participant_path(123) }
 
     it_behaves_like "a token authenticated endpoint", :put
 

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -5,7 +5,14 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
   end
 
   let!(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
+  let(:teacher) do
+    FactoryBot.create(:teacher,
+                      :with_sparsity_uplift,
+                      :with_pupil_premium_uplift,
+                      :ineligible_for_mentor_funding,
+                      api_ect_training_record_id: SecureRandom.uuid,
+                      api_mentor_training_record_id: SecureRandom.uuid)
+  end
 
   before do
     # Ensure other metadata exists for another lead provider.
@@ -14,6 +21,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
   describe "core attributes" do
     it "serializes `id`" do
+      expect(response["id"]).to be_present
       expect(response["id"]).to eq(teacher.api_id)
     end
 
@@ -26,14 +34,17 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
     subject(:attributes) { response["attributes"] }
 
     it "serializes `full_name`" do
+      expect(attributes["full_name"]).to be_present
       expect(attributes["full_name"]).to eq(Teachers::Name.new(teacher).full_name_in_trs)
     end
 
     it "serializes `updated_at`" do
+      expect(attributes["updated_at"]).to be_present
       expect(attributes["updated_at"]).to eq(teacher.updated_at.utc.rfc3339)
     end
 
     it "serializes `teacher_reference_number`" do
+      expect(attributes["teacher_reference_number"]).to be_present
       expect(attributes["teacher_reference_number"]).to eq(teacher.trn)
     end
 
@@ -49,16 +60,25 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
         it { expect(participant_id_changes.count).to eq(2) }
 
         it "serializes `from_participant_id`" do
+          expect(participant_id_changes[0]["from_participant_id"]).to be_present
+          expect(participant_id_changes[1]["from_participant_id"]).to be_present
+
           expect(participant_id_changes[0]["from_participant_id"]).to eq(teacher_id_change_1.api_from_teacher_id)
           expect(participant_id_changes[1]["from_participant_id"]).to eq(teacher_id_change_2.api_from_teacher_id)
         end
 
         it "serializes `to_participant_id`" do
+          expect(participant_id_changes[0]["to_participant_id"]).to be_present
+          expect(participant_id_changes[1]["to_participant_id"]).to be_present
+
           expect(participant_id_changes[0]["to_participant_id"]).to eq(teacher_id_change_1.api_to_teacher_id)
           expect(participant_id_changes[1]["to_participant_id"]).to eq(teacher_id_change_2.api_to_teacher_id)
         end
 
         it "serializes `changed_at`" do
+          expect(participant_id_changes[0]["changed_at"]).to be_present
+          expect(participant_id_changes[1]["changed_at"]).to be_present
+
           expect(participant_id_changes[0]["changed_at"]).to eq(teacher_id_change_1.created_at.utc.rfc3339)
           expect(participant_id_changes[1]["changed_at"]).to eq(teacher_id_change_2.created_at.utc.rfc3339)
         end
@@ -98,14 +118,17 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           subject(:ect_enrolment) { response["attributes"]["ecf_enrolments"][0] }
 
           it "serializes `training_record_id`" do
+            expect(ect_enrolment["training_record_id"]).to be_present
             expect(ect_enrolment["training_record_id"]).to eq(teacher.api_ect_training_record_id)
           end
 
           it "serializes `email`" do
+            expect(ect_enrolment["email"]).to be_present
             expect(ect_enrolment["email"]).to eq(ect_at_school_period.email)
           end
 
           it "serializes `mentor_id`" do
+            expect(ect_enrolment["mentor_id"]).to be_present
             expect(ect_enrolment["mentor_id"]).to eq(latest_mentorship_period.mentor.teacher.api_id)
           end
 
@@ -118,6 +141,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `school_urn`" do
+            expect(ect_enrolment["school_urn"]).to be_present
             expect(ect_enrolment["school_urn"]).to eq(ect_training_period.school_partnership.school.urn)
           end
 
@@ -126,6 +150,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `cohort`" do
+            expect(ect_enrolment["cohort"]).to be_present
             expect(ect_enrolment["cohort"]).to eq(ect_training_period.school_partnership.contract_period.year)
           end
 
@@ -174,10 +199,12 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `pupil_premium_uplift`" do
+            expect(ect_enrolment["pupil_premium_uplift"]).to be_present
             expect(ect_enrolment["pupil_premium_uplift"]).to eq(teacher.ect_pupil_premium_uplift)
           end
 
           it "serializes `sparsity_uplift`" do
+            expect(ect_enrolment["sparsity_uplift"]).to be_present
             expect(ect_enrolment["sparsity_uplift"]).to eq(teacher.ect_sparsity_uplift)
           end
 
@@ -186,6 +213,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `delivery_partner_id`" do
+            expect(ect_enrolment["delivery_partner_id"]).to be_present
             expect(ect_enrolment["delivery_partner_id"]).to eq(ect_training_period.school_partnership.delivery_partner.api_id)
           end
 
@@ -232,10 +260,12 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           subject(:mentor_enrolment) { response["attributes"]["ecf_enrolments"][1] }
 
           it "serializes `training_record_id`" do
+            expect(mentor_enrolment["training_record_id"]).to be_present
             expect(mentor_enrolment["training_record_id"]).to eq(teacher.api_mentor_training_record_id)
           end
 
           it "serializes `email`" do
+            expect(mentor_enrolment["email"]).to be_present
             expect(mentor_enrolment["email"]).to eq(mentor_at_school_period.email)
           end
 
@@ -244,6 +274,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `school_urn`" do
+            expect(mentor_enrolment["school_urn"]).to be_present
             expect(mentor_enrolment["school_urn"]).to eq(mentor_training_period.school_partnership.school.urn)
           end
 
@@ -252,6 +283,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `cohort`" do
+            expect(mentor_enrolment["cohort"]).to be_present
             expect(mentor_enrolment["cohort"]).to eq(mentor_training_period.school_partnership.contract_period.year)
           end
 
@@ -312,6 +344,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `delivery_partner_id`" do
+            expect(mentor_enrolment["delivery_partner_id"]).to be_present
             expect(mentor_enrolment["delivery_partner_id"]).to eq(mentor_training_period.school_partnership.delivery_partner.api_id)
           end
 
@@ -354,6 +387,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           it "serializes `mentor_ineligible_for_funding_reason`" do
+            expect(mentor_enrolment["mentor_ineligible_for_funding_reason"]).to be_present
             expect(mentor_enrolment["mentor_ineligible_for_funding_reason"]).to eq(teacher.mentor_became_ineligible_for_funding_reason)
           end
 

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe API::Teachers::Query, :with_metadata do
   describe "preloading relationships" do
     shared_examples "preloaded associations" do
       it { expect(result.association(:teacher_id_changes)).to be_loaded }
+      it { expect(result.association(:started_induction_period)).to be_loaded }
+      it { expect(result.association(:finished_induction_period)).to be_loaded }
       it { expect(result.association(:lead_provider_metadata)).to be_loaded }
+      it { expect(result.association(:earliest_ect_at_school_period)).to be_loaded }
+      it { expect(result.association(:earliest_mentor_at_school_period)).to be_loaded }
 
       it { expect(result.lead_provider_metadata.map { |metadata| metadata.association(:latest_ect_training_period) }).to all(be_loaded) }
       it { expect(result.lead_provider_metadata.map { |metadata| metadata.association(:latest_mentor_training_period) }).to all(be_loaded) }
@@ -27,18 +31,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
 
           if training_period.for_ect?
             expect(training_period.association(:ect_at_school_period)).to be_loaded
-            expect(training_period.ect_at_school_period.association(:teacher)).to be_loaded
-            expect(training_period.ect_at_school_period.teacher.association(:started_induction_period)).to be_loaded
-            expect(training_period.ect_at_school_period.teacher.association(:finished_induction_period)).to be_loaded
-            expect(training_period.ect_at_school_period.teacher.association(:earliest_ect_at_school_period)).to be_loaded
-            expect(training_period.ect_at_school_period.teacher.association(:earliest_mentor_at_school_period)).to be_loaded
           elsif training_period.for_mentor?
             expect(training_period.association(:mentor_at_school_period)).to be_loaded
-            expect(training_period.mentor_at_school_period.association(:teacher)).to be_loaded
-            expect(training_period.mentor_at_school_period.teacher.association(:started_induction_period)).to be_loaded
-            expect(training_period.mentor_at_school_period.teacher.association(:finished_induction_period)).to be_loaded
-            expect(training_period.mentor_at_school_period.teacher.association(:earliest_ect_at_school_period)).to be_loaded
-            expect(training_period.mentor_at_school_period.teacher.association(:earliest_mentor_at_school_period)).to be_loaded
           end
         end
       end

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe API::Teachers::Query, :with_metadata do
         latest_training_periods.each do |training_period|
           expect(training_period.association(:school_partnership)).to be_loaded
           expect(training_period.school_partnership.association(:school)).to be_loaded
-          expect(training_period.school_partnership.association(:contract_period)).to be_loaded
-          expect(training_period.school_partnership.association(:delivery_partner)).to be_loaded
+          expect(training_period.school_partnership.association(:lead_provider_delivery_partnership)).to be_loaded
+
+          expect(training_period.school_partnership.lead_provider_delivery_partnership.association(:delivery_partner)).to be_loaded
+          expect(training_period.school_partnership.lead_provider_delivery_partnership.association(:active_lead_provider)).to be_loaded
 
           if training_period.for_ect?
             expect(training_period.association(:ect_at_school_period)).to be_loaded

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -38,33 +38,19 @@ RSpec.describe API::Teachers::Query, :with_metadata do
           end
         end
       end
-
-      context "when a lead_provider_id is specified" do
-        let(:lead_provider_id) { lead_provider.id }
-
-        before { FactoryBot.create(:teacher_lead_provider_metadata, lead_provider:, teacher:) }
-
-        it "only contains relevant metadata" do
-          expect(result.lead_provider_metadata).to contain_exactly(lead_provider_metadata)
-        end
-      end
     end
 
-    let(:lead_provider_id) { :ignore }
-    let(:instance) { described_class.new(lead_provider_id:) }
-
-    let!(:teacher) { FactoryBot.create(:teacher) }
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
-    let!(:lead_provider_metadata) { FactoryBot.create(:teacher_lead_provider_metadata, :with_latest_ect_training_period, :with_latest_mentor_training_period, teacher:, lead_provider:) }
-
-    before do
-      # Ensure other metadata exists.
-      other_lead_provider = FactoryBot.create(:lead_provider)
-      FactoryBot.create(:teacher_lead_provider_metadata, teacher:, lead_provider: other_lead_provider)
-    end
+    let(:instance) { described_class.new }
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: 1.year.ago, finished_on: nil) }
+    let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 1.year.ago, finished_on: nil) }
+    let!(:latest_ect_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
+    let!(:latest_mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
 
     describe "#teachers" do
-      subject(:result) { instance.teachers.first }
+      subject(:result) do
+        instance.teachers.first
+      end
 
       include_context "preloaded associations"
     end

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -1,5 +1,5 @@
 describe Schools::TrainingProgramme do
-  subject { described_class.new(school:, contract_period_year:) }
+  subject { described_class.new(school:).training_programme_for(contract_period_year:) }
 
   let(:school) { FactoryBot.create(:school, urn: "123456") }
   let(:contract_period) { FactoryBot.create(:contract_period) }
@@ -8,7 +8,7 @@ describe Schools::TrainingProgramme do
   describe "#training_programme" do
     context "when school has no ects or mentors for the given contract period" do
       it "returns `not_yet_known`" do
-        expect(subject.training_programme).to eq("not_yet_known")
+        expect(subject).to eq("not_yet_known")
       end
     end
 
@@ -33,7 +33,7 @@ describe Schools::TrainingProgramme do
         end
 
         it "returns the correct `training_programme` choice" do
-          expect(subject.training_programme).to eq("provider_led")
+          expect(subject).to eq("provider_led")
         end
       end
 
@@ -59,7 +59,7 @@ describe Schools::TrainingProgramme do
         end
 
         it "returns the correct `training_programme` choice" do
-          expect(subject.training_programme).to eq("not_yet_known")
+          expect(subject).to eq("not_yet_known")
         end
       end
 
@@ -80,7 +80,7 @@ describe Schools::TrainingProgramme do
         end
 
         it "returns the correct `training_programme` choice" do
-          expect(subject.training_programme).to eq("provider_led")
+          expect(subject).to eq("provider_led")
         end
       end
 
@@ -102,7 +102,7 @@ describe Schools::TrainingProgramme do
           end
 
           it "returns the correct `training_programme` choice" do
-            expect(subject.training_programme).to eq("provider_led")
+            expect(subject).to eq("provider_led")
           end
         end
 
@@ -122,7 +122,7 @@ describe Schools::TrainingProgramme do
           end
 
           it "returns the correct `training_programme` choice" do
-            expect(subject.training_programme).to eq("school_led")
+            expect(subject).to eq("school_led")
           end
         end
 
@@ -157,7 +157,7 @@ describe Schools::TrainingProgramme do
           end
 
           it "returns the correct `training_programme` choice" do
-            expect(subject.training_programme).to eq("provider_led")
+            expect(subject).to eq("provider_led")
           end
         end
       end
@@ -178,7 +178,7 @@ describe Schools::TrainingProgramme do
         end
 
         it "returns the correct `training_programme` choice" do
-          expect(subject.training_programme).to eq("school_led")
+          expect(subject).to eq("school_led")
         end
       end
     end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -165,6 +165,36 @@ RSpec.shared_examples "a filter by urn endpoint" do
   end
 end
 
+RSpec.shared_examples "a filter by from_participant_id endpoint" do
+  it "returns only resources that have the specified from_participant_id" do
+    teacher = FactoryBot.create(:teacher)
+    resource = create_resource(active_lead_provider:, from_participant_id: teacher.api_id)
+
+    # Resource with another from_participant_id should not be included.
+    other_teacher = FactoryBot.create(:teacher)
+    create_resource(active_lead_provider:, from_participant_id: other_teacher.api_id)
+
+    params = { filter: { from_participant_id: teacher.api_id } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([resource.reload], root: "data", **serializer_options))
+  end
+
+  it "returns no resources if the from_participant_id is not found" do
+    teacher = FactoryBot.create(:teacher)
+    create_resource(active_lead_provider:, from_participant_id: teacher.api_id)
+
+    params = { filter: { from_participant_id: SecureRandom.uuid } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([], root: "data", **serializer_options))
+  end
+end
+
 RSpec.shared_examples "a does not filter by cohort endpoint" do
   it "returns the resources, ignoring the `cohort`" do
     different_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -195,6 +195,34 @@ RSpec.shared_examples "a filter by from_participant_id endpoint" do
   end
 end
 
+RSpec.shared_examples "a filter by training_status endpoint" do
+  it "returns only resources that have the specified training_status" do
+    deferred_resource = create_resource(active_lead_provider:, training_status: :deferred)
+
+    # Resource with another training_status should not be included.
+    create_resource(active_lead_provider:, training_status: :withdrawn)
+
+    params = { filter: { training_status: :deferred } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([deferred_resource.reload], root: "data", **serializer_options))
+  end
+
+  it "returns no resources if the training_status is not found" do
+    deferred_resource = create_resource(active_lead_provider:, training_status: :deferred)
+    withdrawn_resource = create_resource(active_lead_provider:, training_status: :withdrawn)
+
+    params = { filter: { training_status: "invalid" } }
+    authenticated_api_get(path, params:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([deferred_resource, withdrawn_resource], root: "data", **serializer_options))
+  end
+end
+
 RSpec.shared_examples "a does not filter by cohort endpoint" do
   it "returns the resources, ignoring the `cohort`" do
     different_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period.year + 1)


### PR DESCRIPTION
### Context

The participants related specs are often timing out in CI; we want to find out what is causing this and fix it.

### Changes proposed in this pull request

- Optimise Teachers::Query

We were using `eager_load` here in order to filter joined metadata to only the lead provider we care about, however this results in a lot of `LEFT OUTER JOINS` and a large/inefficient query.

Switch to `include` to improve the query and drop the filtering by lead provider as we can't do this with `includes` here and the trade off is worth it.

Oddly in other query services we can filter by LP metadata with `include`; it seems to be a side effect of this more complicated series of joins causing it to not work, but I haven't dug into the actual issue further.

- Add missing composite index to Metadata::TeacherLeadProvider

- Optimise handler queries

Instead of running multiple queries as we loop through the products of the join tables we can run a single query to find existing metadata and another single query to update all in one go.

- Optimise `#expression_of_interest_for?`

Previously we were calculating expression of interest using two separate queries. It should be more efficient to query this from the `TrainingPeriod` up as a single query, joining `ect_at_school_period` and `mentor_at_school_period`.

- More handler query optimisations

Will need tidying up, but this has a decent bump on the performance.

Before this change the serializer specs (which are metadata heavy) took ~ 50s to run, after the run in ~ 9s). It knocks about 1m off the test run time (~ %17 faster)

- Add indexes to improve performance

Testing a bunch of indexes that should improve the query plan for teachers.

- Only use distinct when needed

The `distinct` will slow down the query; only add it in when we join/filter on a to-many relationship that might pull in multiple records for a teacher.