### PR TITLE
Add serializer logic for api_updated_at

### DIFF
--- a/app/migration/migrators/school_partnership.rb
+++ b/app/migration/migrators/school_partnership.rb
@@ -39,12 +39,21 @@ module Migrators
       school_partnership.lead_provider_delivery_partnership = lpdp
       school_partnership.school = find_school_by_urn!(partnership.school.urn)
       school_partnership.created_at = partnership.created_at
-      school_partnership.api_updated_at = partnership.updated_at
+      school_partnership.api_updated_at = calc_api_updated_at(partnership)
       school_partnership.save!
       school_partnership
     end
 
   private
+
+    def calc_api_updated_at(partnership)
+      [
+        partnership.updated_at,
+        partnership.school.updated_at,
+        partnership.delivery_partner&.updated_at,
+        partnership.school.induction_coordinators&.first&.updated_at,
+      ].compact.max.rfc3339
+    end
 
     def preload_caches
       cache_manager.cache_lead_providers_by_ecf_id

--- a/spec/migration/migrators/school_partnership_spec.rb
+++ b/spec/migration/migrators/school_partnership_spec.rb
@@ -34,12 +34,19 @@ describe Migrators::SchoolPartnership do
           delivery_partner = school_partnership.lead_provider_delivery_partnership.delivery_partner
           school = school_partnership.school
 
+          expected_api_updated_at = [
+            partnership.updated_at,
+            partnership.school.updated_at,
+            partnership.delivery_partner.updated_at,
+            partnership.school.induction_coordinators&.first&.updated_at,
+          ].compact.max.rfc3339
+
           expect(lead_provider.ecf_id).to eq partnership.lead_provider_id
           expect(delivery_partner.api_id).to eq partnership.delivery_partner_id
           expect(year).to eq partnership.cohort.start_year
           expect(school.urn.to_s).to eq partnership.school.urn
           expect(school_partnership.created_at).to eq partnership.created_at
-          expect(school_partnership.api_updated_at).to eq partnership.updated_at
+          expect(school_partnership.api_updated_at).to eq expected_api_updated_at
         end
       end
     end


### PR DESCRIPTION
### Context

To ensure we have the correct value for `api_updated_at` that reflects the value used in the ECF1 API we need to user the logic from the API serializer when setting this timestamp in the `SchoolPartnership` migrator.

### Changes proposed in this pull request

Updates the `SchoolPartnership` migrator to use the serializer logic from ECF1 to calculate the correct value for `api_updated_at`

### Guidance to review
