### PR TITLE
Return no results when filtering on only invalid contract periods

### DIFF
--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -3,7 +3,7 @@ module API
     class PartnershipsController < APIController
       def index
         conditions = {
-          contract_period_years: extract_conditions(contract_period_years),
+          contract_period_years: extract_conditions(contract_period_years, integers: true),
           updated_since:,
           delivery_partner_api_ids: extract_conditions(delivery_partner_api_ids),
           sort:

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -3,7 +3,7 @@ module API
     class StatementsController < APIController
       def index
         conditions = {
-          contract_period_years: extract_conditions(contract_period_years),
+          contract_period_years: extract_conditions(contract_period_years, integers: true),
           updated_since:,
         }
         paginated_statements = statements_query(conditions:).statements { paginate(it) }

--- a/app/services/api/delivery_partners/query.rb
+++ b/app/services/api/delivery_partners/query.rb
@@ -56,7 +56,7 @@ module API::DeliveryPartners
     end
 
     def where_contract_period_year_in(contract_period_years)
-      return if ignore?(filter: contract_period_years)
+      return if ignore?(filter: contract_period_years, ignore_empty_array: false)
 
       delivery_partners_with_contract_periods = DeliveryPartner
         .joins(lead_provider_delivery_partnerships: { active_lead_provider: :contract_period })

--- a/app/services/api/school_partnerships/query.rb
+++ b/app/services/api/school_partnerships/query.rb
@@ -52,7 +52,7 @@ module API::SchoolPartnerships
     end
 
     def where_contract_period_year_in(contract_period_years)
-      return if ignore?(filter: contract_period_years)
+      return if ignore?(filter: contract_period_years, ignore_empty_array: false)
 
       @scope = scope
         .joins(:active_lead_provider)

--- a/app/services/api/statements/query.rb
+++ b/app/services/api/statements/query.rb
@@ -47,7 +47,7 @@ module API::Statements
     end
 
     def where_contract_period_year_in(contract_period_years)
-      return if ignore?(filter: contract_period_years)
+      return if ignore?(filter: contract_period_years, ignore_empty_array: false)
 
       @scope = scope.joins(:active_lead_provider).where(active_lead_provider: { contract_period_year: contract_period_years })
     end

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -87,7 +87,7 @@ module API::Teachers
     end
 
     def where_contract_period_year_in(contract_period_years)
-      return if ignore?(filter: contract_period_years)
+      return if ignore?(filter: contract_period_years, ignore_empty_array: false)
 
       @scope = scope
           .left_joins(

--- a/app/services/concerns/queries/filter_ignorable.rb
+++ b/app/services/concerns/queries/filter_ignorable.rb
@@ -2,7 +2,9 @@ module Queries
   module FilterIgnorable
     extend ActiveSupport::Concern
 
-    def ignore?(filter:)
+    def ignore?(filter:, ignore_empty_array: true)
+      return false if !ignore_empty_array && filter == []
+
       filter == :ignore || (!filter.nil? && filter.blank? && filter != false)
     end
   end

--- a/spec/services/api/delivery_partners/query_spec.rb
+++ b/spec/services/api/delivery_partners/query_spec.rb
@@ -140,9 +140,28 @@ RSpec.describe API::DeliveryPartners::Query do
         end
 
         it "returns no delivery partners if no `contract_period_years` are found" do
+          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+
           query = described_class.new(contract_period_years: "0000")
 
           expect(query.delivery_partners).to be_empty
+        end
+
+        it "returns no delivery partners if `contract_period_years` is an empty array" do
+          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+
+          query = described_class.new(contract_period_years: [])
+
+          expect(query.delivery_partners).to be_empty
+        end
+
+        it "returns all delivery partners if `contract_period_years` is an empty string" do
+          delivery_partner1 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider1).delivery_partner
+          delivery_partner2 = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider2).delivery_partner
+
+          query = described_class.new(contract_period_years: "")
+
+          expect(query.delivery_partners).to contain_exactly(delivery_partner1, delivery_partner2)
         end
 
         it "ignores invalid `contract_period_years`" do

--- a/spec/services/api/school_partnerships/query_spec.rb
+++ b/spec/services/api/school_partnerships/query_spec.rb
@@ -127,6 +127,12 @@ describe API::SchoolPartnerships::Query do
           expect(query.school_partnerships).to be_empty
         end
 
+        it "returns no school partnerships if `contract_period_years` is an empty array" do
+          query = described_class.new(contract_period_years: [])
+
+          expect(query.school_partnerships).to be_empty
+        end
+
         it "ignores invalid `contract_period_years`" do
           query = described_class.new(contract_period_years: [contract_period1.year, 1099])
 

--- a/spec/services/api/statements/query_spec.rb
+++ b/spec/services/api/statements/query_spec.rb
@@ -118,7 +118,17 @@ RSpec.describe API::Statements::Query do
         end
 
         it "returns no statements if no `contract_period_years` are found" do
+          FactoryBot.create(:statement, contract_period: contract_period1)
+
           query = described_class.new(contract_period_years: "0000")
+
+          expect(query.statements).to be_empty
+        end
+
+        it "returns no statements if `contract_period_years` is an empty array" do
+          FactoryBot.create(:statement, contract_period: contract_period1)
+
+          query = described_class.new(contract_period_years: [])
 
           expect(query.statements).to be_empty
         end

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -150,8 +150,14 @@ RSpec.describe API::Teachers::Query, :with_metadata do
           expect(query2.teachers).to contain_exactly(teacher2, teacher3)
         end
 
-        it "returns no delivery partners if no `contract_period_years` are found" do
+        it "returns no teachers if no `contract_period_years` are found" do
           query = described_class.new(contract_period_years: "0000")
+
+          expect(query.teachers).to be_empty
+        end
+
+        it "returns no teachers if `contract_period_years` is an empty array" do
+          query = described_class.new(contract_period_years: [])
 
           expect(query.teachers).to be_empty
         end

--- a/spec/services/concerns/queries/filter_ignorable_spec.rb
+++ b/spec/services/concerns/queries/filter_ignorable_spec.rb
@@ -9,8 +9,19 @@ RSpec.describe Queries::FilterIgnorable do
     it { expect(query).to be_ignore(filter: " ") }
     it { expect(query).to be_ignore(filter: "") }
     it { expect(query).to be_ignore(filter: :ignore) }
+    it { expect(query).to be_ignore(filter: []) }
     it { expect(query).not_to be_ignore(filter: nil) }
     it { expect(query).not_to be_ignore(filter: "value") }
     it { expect(query).not_to be_ignore(filter: false) }
+
+    context "when ignore_empty_array is false" do
+      it { expect(query).to be_ignore(filter: " ", ignore_empty_array: false) }
+      it { expect(query).to be_ignore(filter: "", ignore_empty_array: false) }
+      it { expect(query).to be_ignore(filter: :ignore, ignore_empty_array: false) }
+      it { expect(query).not_to be_ignore(filter: [], ignore_empty_array: false) }
+      it { expect(query).not_to be_ignore(filter: nil, ignore_empty_array: false) }
+      it { expect(query).not_to be_ignore(filter: "value", ignore_empty_array: false) }
+      it { expect(query).not_to be_ignore(filter: false, ignore_empty_array: false) }
+    end
   end
 end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -45,6 +45,16 @@ RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpo
     expect(response.content_type).to eql("application/json; charset=utf-8")
     expect(response.body).to eq(serializer.render([resource.reload], root: "data", **options))
   end
+
+  it "returns no resources when cohort contains no valid contract period years" do
+    create_resource(active_lead_provider:)
+
+    authenticated_api_get(path, params: { filter: { cohort: "invalid" } })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eql("application/json; charset=utf-8")
+    expect(response.body).to eq(serializer.render([], root: "data", **options))
+  end
 end
 
 RSpec.shared_examples "a filter by updated_since endpoint" do


### PR DESCRIPTION
To be consistent with ECF we want to return no results if only an invalid cohort is provided when filtering. At the moment, this will be the case if the cohort is numerical, so `1999` or `0000`, however non-numerical cohorts are stripped out via `extract_conditions(..., integer: true)`.

This means we end up passing an empty array into the query, which is ignored via `ignore?(filter:)`.

To get around this, we can now pass `ignore_empty_array: false` to `ignore?(filter:)` and use this in the query services to join on an empty array which will return 0 results and is consistent with ECF.

Extra tests added to shared request specs to ensure consistency.