### PR TITLE
[2491] Display TRS name if user chooses to use them

### DIFF
--- a/app/wizards/schools/register_ect_wizard/review_ect_details_step.rb
+++ b/app/wizards/schools/register_ect_wizard/review_ect_details_step.rb
@@ -17,6 +17,14 @@ module Schools
       def previous_step
         :find_ect
       end
+
+    private
+
+      def persist
+        return super if change_name == 'yes'
+
+        ect.update!(corrected_name: nil, change_name: 'no')
+      end
     end
   end
 end

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe 'Registering an ECT', :enable_schools_interface do
   end
 
   def and_i_should_see_the_ect_i_registered
-    expect(page.get_by_role('link', name: 'Kirk Van Damme')).to be_visible
+    expect(page.get_by_role('link', name: 'Kirk Van Houten')).to be_visible
   end
 
   def then_i_should_be_taken_to_the_confirmation_page

--- a/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/review_ect_details_step_spec.rb
@@ -118,5 +118,24 @@ describe Schools::RegisterECTWizard::ReviewECTDetailsStep, type: :model do
                        .from(nil).to('yes')
       end
     end
+
+    context 'when change_name is "no"' do
+      before { subject.ect.update!(corrected_name: 'Old Name', change_name: 'yes') }
+
+      let(:step_params) do
+        ActionController::Parameters.new(
+          "review_ect_details" => {
+            "change_name" => "no",
+            "corrected_name" => "Should be cleared",
+          }
+        )
+      end
+
+      it 'clears corrected_name and sets change_name to no' do
+        expect { subject.save! }
+          .to change(subject.ect, :corrected_name).to(nil)
+          .and change(subject.ect, :change_name).to('no')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

If the user has changed the name to something else then goes back and chooses to use the one from the TRS instead,
the user should see the name from the TRS on the CYA page.

### Changes

- Display TRS name if the user has changed the name to something else then goes back and chooses to use the one from the TRS
- Clear corrected name if user chooses to use TRS name

### Guidance to review

- Start journey for registering an ECT and find an ECT.
- Say 'no I'll update their name' and type a corrected name and continue to the next page.
- Change your mind and go back to name page, either by clicking 'back' or from CYA.
- Switch answer on corrected name question from 'no I'll update their name' to 'yes'.
- See that name shows the original from TRS.
