### PR TITLE
[2437] Use `started_on` instead of` created_at` when ordering ECTs

### DIFF
--- a/app/services/teachers/search.rb
+++ b/app/services/teachers/search.rb
@@ -21,15 +21,15 @@ module Teachers
 
     def order
       case @sort_order
-      when :mentorless_first_then_by_registration_date
-        # mentorless teachers first, sorted by the registration date
+      when :mentorless_first_then_by_school_start_date
+        # mentorless teachers first, sorted by the school start date
         # at the school, latest first
         [
           Arel::Nodes::Case.new
                           .when(MentorshipPeriod.arel_table[:id].eq(nil)).then(0)
                           .else(1)
                           .asc,
-          { ect_at_school_periods: { created_at: 'desc' } }
+          { ect_at_school_periods: { started_on: :desc } }
         ]
       else
         %i[trs_last_name trs_first_name id]
@@ -71,7 +71,7 @@ module Teachers
           .where(ect_at_school_periods: { school: })
       )
 
-      @sort_order = :mentorless_first_then_by_registration_date
+      @sort_order = :mentorless_first_then_by_school_start_date
     end
 
     def where_mentor_at(school)

--- a/spec/services/teachers/search_spec.rb
+++ b/spec/services/teachers/search_spec.rb
@@ -271,25 +271,26 @@ describe Teachers::Search do
       end
 
       describe 'ordering the results' do
-        let(:started_on) { 2.years.ago }
+        let(:earlier_start_date) { Date.new(2022, 12, 25) }
+        let(:later_start_date) { earlier_start_date + 1 }
 
         let(:school1) { FactoryBot.create(:school) }
         let(:mentored_teacher1) { FactoryBot.create(:teacher) }
         let(:mentored_teacher2) { FactoryBot.create(:teacher) }
 
         # unmentored
-        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher1, school: school1, started_on:, created_at: 2.days.ago) }
-        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher2, school: school1, started_on:, created_at: 1.day.ago) }
+        let!(:ect_at_school_period1) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher1, school: school1, started_on: earlier_start_date) }
+        let!(:ect_at_school_period2) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: teacher2, school: school1, started_on: later_start_date) }
 
         # mentored
-        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: teacher3, school: school1, started_on:) }
-        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher1, school: school1, started_on:, created_at: 2.days.ago) }
-        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher2, school: school1, started_on:, created_at: 1.day.ago) }
+        let!(:mentor_at_school_period1) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: teacher3, school: school1, started_on: earlier_start_date) }
+        let!(:ect_at_school_period3) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher1, school: school1, started_on: earlier_start_date) }
+        let!(:ect_at_school_period4) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentored_teacher2, school: school1, started_on: later_start_date) }
 
-        let!(:mentorship_period1) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on:) }
-        let!(:mentorship_period2) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on:) }
+        let!(:mentorship_period1) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period3, mentor: mentor_at_school_period1, started_on: earlier_start_date) }
+        let!(:mentorship_period2) { FactoryBot.create(:mentorship_period, mentee: ect_at_school_period4, mentor: mentor_at_school_period1, started_on: later_start_date) }
 
-        it 'orders with unmentored teachers first, then by registration date' do
+        it 'orders with unmentored teachers first, then by started_on (newest first)' do
           results = Teachers::Search.new(ect_at_school: school1).search
 
           expect(results).to eq([teacher2, teacher1, mentored_teacher2, mentored_teacher1])


### PR DESCRIPTION
### Context

ECTs should be ordered by those who have unassigned mentors first, then by their start date at the school.  
The search results were previously ordered by `created_at`.

### Changes proposed in this pull request

- Replace `created_at` with `started_on` when ordering ECTs on the index page
- Keep mentorless ECTs first in the list

### Guidance to review

- Check that mentorless ECTs appear before mentored ones.
- Within each group, later `started_on` dates should appear first.
- Confirm that no other ordering behaviour has changed.

