### PR TITLE
Fix swagger documentation for participants/errors

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -18,7 +18,7 @@ class API::TeacherSerializer < Blueprinter::Base
       field(:mentor_id) do |(training_period, _, metadata)|
         metadata.api_mentor_id if training_period.for_ect?
       end
-      field(:school_urn) { |(training_period, _, _)| training_period.school_partnership.school.urn }
+      field(:school_urn) { |(training_period, _, _)| training_period.school_partnership.school.urn.to_s }
       field(:participant_type) { |(training_period, _, _)| training_period.for_ect? ? "ect" : "mentor" }
       field(:cohort) do |(training_period, _, _)|
         training_period
@@ -26,6 +26,7 @@ class API::TeacherSerializer < Blueprinter::Base
           .lead_provider_delivery_partnership
           .active_lead_provider
           .contract_period_year
+          .to_s
       end
       field(:training_status) { |(training_period, _, _)| API::TrainingPeriods::TrainingStatus.new(training_period:).status }
       field(:participant_status) { "active" } # TODO: implement when we have participant status service

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -116,7 +116,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        enrolments:
+                        ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
@@ -178,7 +178,7 @@ paths:
                       attributes:
                         full_name: John Doe
                         teacher_reference_number: '1234567'
-                        enrolments:
+                        ecf_enrolments:
                         - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           email: jane.smith@example.com
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
@@ -540,11 +540,17 @@ components:
       description: The requested resource was not found.
       type: object
       properties:
-        error:
-          type: string
-          description: Resource not found
-      example:
-        error: Resource not found
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+                example: Resource not found
+              detail:
+                type: string
+                example: Nothing could be found for the provided details
     BadRequestResponse:
       description: The request body did not match the expected payload.
       type: object
@@ -1088,11 +1094,11 @@ components:
               type: string
               nullable: true
               example: '1234567'
-            enrolments:
+            ecf_enrolments:
               type: array
               nullable: false
               items:
-                "$ref": "#/components/schemas/ParticipantEnrolment"
+                "$ref": "#/components/schemas/ParticipantECFEnrolment"
             participant_id_changes:
               type: array
               nullable: false
@@ -1147,7 +1153,7 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Participant"
-    ParticipantEnrolment:
+    ParticipantECFEnrolment:
       description: The details of a participant enrolment
       type: object
       required:
@@ -1334,6 +1340,7 @@ components:
         mentor_ineligible_for_funding_reason:
           description: The reason why funding for a mentor's training has ended
           type: string
+          nullable: true
           enum:
           - completed_declaration_received
           - completed_during_early_roll_out

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -45,9 +45,9 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   } do
                     let(:response_example) do
                       extract_swagger_example(schema: "#/components/schemas/ParticipantsResponse", version: :v3).tap do |example|
-                        example[:data][0][:attributes][:enrolments][0][:training_status] = "active"
-                        example[:data][0][:attributes][:enrolments][0][:deferral] = nil
-                        example[:data][0][:attributes][:enrolments][0][:withdrawal] = nil
+                        example[:data][0][:attributes][:ecf_enrolments][0][:training_status] = "active"
+                        example[:data][0][:attributes][:ecf_enrolments][0][:deferral] = nil
+                        example[:data][0][:attributes][:ecf_enrolments][0][:withdrawal] = nil
                       end
                     end
                   end
@@ -61,9 +61,9 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   } do
                     let(:response_example) do
                       extract_swagger_example(schema: "#/components/schemas/ParticipantResponse", version: :v3).tap do |example|
-                        example[:data][:attributes][:enrolments][0][:training_status] = "active"
-                        example[:data][:attributes][:enrolments][0][:deferral] = nil
-                        example[:data][:attributes][:enrolments][0][:withdrawal] = nil
+                        example[:data][:attributes][:ecf_enrolments][0][:training_status] = "active"
+                        example[:data][:attributes][:ecf_enrolments][0][:deferral] = nil
+                        example[:data][:attributes][:ecf_enrolments][0][:withdrawal] = nil
                       end
                     end
                   end

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -142,7 +142,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           it "serializes `school_urn`" do
             expect(ect_enrolment["school_urn"]).to be_present
-            expect(ect_enrolment["school_urn"]).to eq(ect_training_period.school_partnership.school.urn)
+            expect(ect_enrolment["school_urn"]).to eq(ect_training_period.school_partnership.school.urn.to_s)
           end
 
           it "serializes `participant_type`" do
@@ -151,7 +151,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           it "serializes `cohort`" do
             expect(ect_enrolment["cohort"]).to be_present
-            expect(ect_enrolment["cohort"]).to eq(ect_training_period.school_partnership.contract_period.year)
+            expect(ect_enrolment["cohort"]).to eq(ect_training_period.school_partnership.contract_period.year.to_s)
           end
 
           it "serializes `training_status`" do
@@ -275,7 +275,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           it "serializes `school_urn`" do
             expect(mentor_enrolment["school_urn"]).to be_present
-            expect(mentor_enrolment["school_urn"]).to eq(mentor_training_period.school_partnership.school.urn)
+            expect(mentor_enrolment["school_urn"]).to eq(mentor_training_period.school_partnership.school.urn.to_s)
           end
 
           it "serializes `participant_type`" do
@@ -284,7 +284,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           it "serializes `cohort`" do
             expect(mentor_enrolment["cohort"]).to be_present
-            expect(mentor_enrolment["cohort"]).to eq(mentor_training_period.school_partnership.contract_period.year)
+            expect(mentor_enrolment["cohort"]).to eq(mentor_training_period.school_partnership.contract_period.year.to_s)
           end
 
           it "serializes `training_status`" do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -8,6 +8,9 @@ RSpec.configure do |config|
   # to ensure that it's configured to serve Swagger from the same folder
   config.openapi_root = Rails.root.join("public/api/docs").to_s
 
+  # This will catch if we misname any properties in our schemas.
+  config.openapi_no_additional_properties = true
+
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
   # be generated at the provided relative path under openapi_root
@@ -78,7 +81,7 @@ RSpec.configure do |config|
           ParticipantsFilter: PARTICIPANTS_FILTER,
           ParticipantResponse: PARTICIPANT_RESPONSE,
           ParticipantsResponse: PARTICIPANTS_RESPONSE,
-          ParticipantEnrolment: PARTICIPANT_ENROLMENT,
+          ParticipantECFEnrolment: PARTICIPANT_ECF_ENROLMENT,
           ParticipantIDChange: PARTICIPANT_ID_CHANGE,
         }
       }

--- a/spec/swagger_schemas/models/participant.rb
+++ b/spec/swagger_schemas/models/participant.rb
@@ -28,11 +28,11 @@ PARTICIPANT = {
           nullable: true,
           example: "1234567",
         },
-        enrolments: {
+        ecf_enrolments: {
           type: :array,
           nullable: false,
           items: {
-            "$ref": "#/components/schemas/ParticipantEnrolment"
+            "$ref": "#/components/schemas/ParticipantECFEnrolment"
           }
         },
         participant_id_changes: {

--- a/spec/swagger_schemas/models/participants/ecf_enrolment.rb
+++ b/spec/swagger_schemas/models/participants/ecf_enrolment.rb
@@ -1,4 +1,4 @@
-PARTICIPANT_ENROLMENT = {
+PARTICIPANT_ECF_ENROLMENT = {
   description: "The details of a participant enrolment",
   type: :object,
   required: %i[
@@ -166,6 +166,7 @@ PARTICIPANT_ENROLMENT = {
     mentor_ineligible_for_funding_reason: {
       description: "The reason why funding for a mentor's training has ended",
       type: :string,
+      nullable: true,
       enum: Teacher.mentor_became_ineligible_for_funding_reasons.keys,
       example: "completed_declaration_received"
     }

--- a/spec/swagger_schemas/responses/not_found.rb
+++ b/spec/swagger_schemas/responses/not_found.rb
@@ -2,12 +2,21 @@ NOT_FOUND_RESPONSE = {
   description: "The requested resource was not found.",
   type: :object,
   properties: {
-    error: {
-      type: :string,
-      description: "Resource not found",
+    errors: {
+      type: :array,
+      items: {
+        type: :object,
+        properties: {
+          title: {
+            type: :string,
+            example: "Resource not found",
+          },
+          detail: {
+            type: :string,
+            example: "Nothing could be found for the provided details",
+          },
+        },
+      },
     },
-  },
-  example: {
-    error: "Resource not found",
   },
 }.freeze


### PR DESCRIPTION
We had the `ecf_enrolments` attribute listed as `enrolments` in the swagger schema, however we are still using `ecf_enrolments` in the serializer (and want to continue to for now).

This was missed because rswag ignores extra response keys by default.

Switch rswag to raise on extra response keys.

Rename `enrolments` to `ecf_enrolments` to match serializer.

Fix other type mismatches in the participants serializer.

Correct 404 response schema to match what we actually return/what ECF uses.
