### PR TITLE
[2526] Add defer participants PUT endpoint

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -19,7 +19,18 @@ module API
       end
 
       def change_schedule = head(:method_not_allowed)
-      def defer = head(:method_not_allowed)
+
+      def defer
+        service = API::Teachers::Defer.new(
+          lead_provider_id: current_lead_provider.id,
+          teacher_api_id: teacher.api_id,
+          reason: defer_participant_params[:reason],
+          course_identifier: defer_participant_params[:course_identifier]
+        )
+
+        respond_with_service(service:, action: :defer)
+      end
+
       def resume = head(:method_not_allowed)
 
       def withdraw
@@ -53,6 +64,10 @@ module API
 
       def participants_params
         params.permit(:api_id, :sort, filter: %i[training_status from_participant_id])
+      end
+
+      def defer_participant_params
+        params.require(:data).expect({ attributes: %i[course_identifier reason] })
       end
 
       def withdraw_participant_params

--- a/app/services/teachers/defer.rb
+++ b/app/services/teachers/defer.rb
@@ -19,6 +19,8 @@ module Teachers
 
         record_deferred_event!
       end
+
+      teacher
     end
 
   private

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -57,14 +57,34 @@ RSpec.describe "Participants API", :with_metadata, type: :request do
   end
 
   describe "#defer" do
-    let(:path) { defer_api_v3_participant_path(123) }
+    let(:path) { defer_api_v3_participant_path(resource.api_id) }
+    let(:service) { API::Teachers::Defer }
+    let(:resource_type) { Teacher }
+    let(:resource) { create_resource(active_lead_provider:) }
+    let(:reason) { service::DEFERRAL_REASONS.sample }
+    let(:course_identifier) { "ecf-induction" }
+    let(:service_args) do
+      {
+        lead_provider_id: lead_provider.id,
+        teacher_api_id: resource.api_id,
+        reason:,
+        course_identifier:
+      }
+    end
+    let(:params) do
+      {
+        data: {
+          type: "participant-defer",
+          attributes: {
+            reason:,
+            course_identifier:,
+          }
+        }
+      }
+    end
 
     it_behaves_like "a token authenticated endpoint", :put
-
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
-    end
+    it_behaves_like "an API update endpoint"
   end
 
   describe "#resume" do

--- a/spec/services/api/teachers/defer_spec.rb
+++ b/spec/services/api/teachers/defer_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe API::Teachers::Defer, type: :model do
           context "when valid" do
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
+            it "returns teacher" do
+              expect(instance.defer).to eq(teacher)
+            end
+
             it "defers the training period via defer service" do
               defer_service = double("Teachers::Defer")
               author = an_instance_of(Events::LeadProviderAPIAuthor)


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2526

### Changes proposed in this pull request

* Updated controller `defer` action to use `API::Teachers::Defer` service class
* Updated API request spec for defer

### Guidance to review
