### PR TITLE
Add indexes to improve `Teachers::Query` performance

### DIFF
--- a/db/migrate/20251023134806_add_indexes_to_improve_teachers_query.rb
+++ b/db/migrate/20251023134806_add_indexes_to_improve_teachers_query.rb
@@ -1,0 +1,16 @@
+class AddIndexesToImproveTeachersQuery < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Targets join on lead_provider_metadata to filter teachers by lead provider.
+    add_index :metadata_teachers_lead_providers,
+              %i[lead_provider_id teacher_id],
+              where: "latest_ect_training_period_id IS NOT NULL OR latest_mentor_training_period_id IS NOT NULL",
+              algorithm: :concurrently
+
+    # Targets default sort order.
+    add_index :teachers,
+              :created_at,
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_23_080952) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_23_134806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -413,6 +413,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_23_080952) do
     t.uuid "api_mentor_id"
     t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
     t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
+    t.index ["lead_provider_id", "teacher_id"], name: "idx_on_lead_provider_id_teacher_id_74c7a13188", where: "((latest_ect_training_period_id IS NOT NULL) OR (latest_mentor_training_period_id IS NOT NULL))"
     t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"
     t.index ["teacher_id", "lead_provider_id"], name: "idx_on_teacher_id_lead_provider_id_23bbab847a", unique: true
     t.index ["teacher_id"], name: "index_metadata_teachers_lead_providers_on_teacher_id"
@@ -791,6 +792,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_23_080952) do
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
+    t.index ["created_at"], name: "index_teachers_on_created_at"
     t.index ["search"], name: "index_teachers_on_search", using: :gin
     t.index ["trn"], name: "index_teachers_on_trn", unique: true
     t.index ["trs_first_name", "trs_last_name", "corrected_name"], name: "idx_on_trs_first_name_trs_last_name_corrected_name_6d0edad502", opclass: :gin_trgm_ops, using: :gin


### PR DESCRIPTION
The teachers query is currently quite slow (~1.5s response time).

Our query itself is fairly optimal as it stands, but we're lacking indexes in a couple of places to avoid full table scans and to speed it up.

Add a minimal amount of indexes; in testing this brings the response time down to 5-600ms, which I think is faster than ECF so we can stop there for now.

There is an upcoming PR to stamp contract period on the metadata which will improve that query/response time.
