### PR TITLE
Withdraw participant API documentation

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -56,7 +56,7 @@ class API::TeacherSerializer < Blueprinter::Base
         training_status = API::TrainingPeriods::TrainingStatus.new(training_period:).status
         if training_status == :withdrawn
           {
-            "withdrawn_at" => training_period.withdrawn_at.utc.rfc3339,
+            "date" => training_period.withdrawn_at.utc.rfc3339,
             "reason" => training_period.withdrawal_reason.dasherize
           }
         end

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -219,6 +219,93 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
+  "/api/v3/participants/{id}/withdraw":
+    put:
+      summary: Update a participant
+      tags:
+      - Participants
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The updated participant
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    data:
+                      id: d0b4a32e-a272-489e-b30a-cb17131457fc
+                      type: participant
+                      attributes:
+                        full_name: John Doe
+                        teacher_reference_number: '1234567'
+                        ecf_enrolments:
+                        - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          email: jane.smith@example.com
+                          mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          school_urn: '123456'
+                          participant_type: ect
+                          cohort: '2021'
+                          training_status: withdrawn
+                          participant_status: active
+                          eligible_for_funding: true
+                          pupil_premium_uplift: true
+                          sparsity_uplift: true
+                          schedule_identifier: ecf-standard-january
+                          delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          withdrawal:
+                            reason: moved-school
+                            date: '2021-05-31T02:22:32.000Z'
+                          deferral:
+                          created_at: '2023-01-01T00:00:00Z'
+                          induction_end_date: '2023-01-01'
+                          overall_induction_start_date: '2023-01-01'
+                          mentor_funding_end_date: '2023-01-01'
+                          cohort_changed_after_payments_frozen: true
+                          mentor_ineligible_for_funding_reason: completed_declaration_received
+                        participant_id_changes:
+                        - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
+                          to_participant_id: ac3d1243-7308-4879-942a-c4a70ced400a
+                          changed_at: '2023-01-01T12:00:00Z'
+                        updated_at: '2021-05-31T02:22:32.000Z'
+              schema:
+                "$ref": "#/components/schemas/ParticipantResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ParticipantWithdrawRequest"
   "/api/v3/partnerships":
     get:
       summary: Retrieve multiple partnerships
@@ -1143,6 +1230,51 @@ components:
       properties:
         data:
           "$ref": "#/components/schemas/Participant"
+    ParticipantWithdrawRequest:
+      description: Withdraw a participant from training
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          description: A participant withdrawal
+          type: object
+          required:
+          - type
+          - attributes
+          properties:
+            type:
+              type: string
+              required: true
+              enum:
+              - participant-withdraw
+              example: participant-withdraw
+            attributes:
+              description: A participant withdrawal action
+              type: object
+              required:
+              - reason
+              - course_identifier
+              properties:
+                reason:
+                  description: The reason for the withdrawal
+                  type: string
+                  required: true
+                  enum:
+                  - left-teaching-profession
+                  - moved-school
+                  - mentor-no-longer-being-mentor
+                  - switched-to-school-led
+                  - other
+                  example: left-teaching-profession
+                course_identifier:
+                  description: The type of course the participant is enrolled in
+                  type: string
+                  required: true
+                  enum:
+                  - ecf-mentor
+                  - ecf-induction
+                  example: ecf-mentor
     ParticipantsResponse:
       description: A list of participants.
       type: object

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -16,7 +16,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
     FactoryBot.create(
       :ect_at_school_period,
       :ongoing,
-      school: school_partnership.school
+      school: school_partnership.school,
+      started_on: 6.months.ago
     )
   end
   let!(:training_period) do
@@ -65,6 +66,46 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                         example[:data][:attributes][:ecf_enrolments][0][:deferral] = nil
                         example[:data][:attributes][:ecf_enrolments][0][:withdrawal] = nil
                       end
+                    end
+                  end
+
+  it_behaves_like "an API update endpoint documentation",
+                  {
+                    url: "/api/v3/participants/{id}/withdraw",
+                    tag: "Participants",
+                    resource_description: "participant",
+                    request_schema_ref: "#/components/schemas/ParticipantWithdrawRequest",
+                    response_schema_ref: "#/components/schemas/ParticipantResponse",
+                  } do
+                    let(:response_example) do
+                      extract_swagger_example(schema: "#/components/schemas/ParticipantResponse", version: :v3).tap do |example|
+                        example[:data][:attributes][:ecf_enrolments][0][:training_status] = "withdrawn"
+                        example[:data][:attributes][:ecf_enrolments][0][:deferral] = nil
+                      end
+                    end
+
+                    let(:params) do
+                      {
+                        data: {
+                          type: "participant-withdraw",
+                          attributes: {
+                            course_identifier: "ecf-induction",
+                            reason: "moved-school"
+                          }
+                        }
+                      }
+                    end
+
+                    let(:invalid_params) do
+                      {
+                        data: {
+                          type: "participant-withdraw",
+                          attributes: {
+                            course_identifier: "something-invalid",
+                            reason: "invalid-reason"
+                          }
+                        }
+                      }
                     end
                   end
 end

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -36,20 +36,7 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
       response "200", "A list of #{params[:resource_description]}" do
         schema({ "$ref": params[:response_schema_ref] })
 
-        after do |example|
-          if defined?(response_example)
-            example_spec = {
-              "application/json" => {
-                examples: {
-                  success: {
-                    value: response_example,
-                  },
-                },
-              },
-            }
-            example.metadata[:response][:content] = example_spec
-          end
-        end
+        after { override_response_content!(it) }
 
         run_test!
       end

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -28,20 +28,7 @@ RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |p
 
         schema({ "$ref": params[:response_schema_ref] })
 
-        after do |example|
-          if defined?(response_example)
-            example_spec = {
-              "application/json" => {
-                examples: {
-                  success: {
-                    value: response_example,
-                  },
-                },
-              },
-            }
-            example.metadata[:response][:content] = example_spec
-          end
-        end
+        after { override_response_content!(it) }
 
         run_test!
       end

--- a/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
@@ -26,6 +26,8 @@ RSpec.shared_context "an API update endpoint documentation", :exceptions_app do 
       response "200", "The updated #{options[:resource_description]}" do
         schema({ "$ref": options[:response_schema_ref] })
 
+        after { override_response_content!(it) }
+
         run_test!
       end
 

--- a/spec/support/swagger_example_parser.rb
+++ b/spec/support/swagger_example_parser.rb
@@ -54,4 +54,19 @@ module SwaggerExampleParser
       end
     end
   end
+
+  def override_response_content!(example)
+    if defined?(response_example)
+      example_spec = {
+        "application/json" => {
+          examples: {
+            success: {
+              value: response_example,
+            },
+          },
+        },
+      }
+      example.metadata[:response][:content] = example_spec
+    end
+  end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -80,6 +80,7 @@ RSpec.configure do |config|
           Participant: PARTICIPANT,
           ParticipantsFilter: PARTICIPANTS_FILTER,
           ParticipantResponse: PARTICIPANT_RESPONSE,
+          ParticipantWithdrawRequest: PARTICIPANT_WITHDRAW_REQUEST,
           ParticipantsResponse: PARTICIPANTS_RESPONSE,
           ParticipantECFEnrolment: PARTICIPANT_ECF_ENROLMENT,
           ParticipantIDChange: PARTICIPANT_ID_CHANGE,

--- a/spec/swagger_schemas/requests/participant_withdraw.rb
+++ b/spec/swagger_schemas/requests/participant_withdraw.rb
@@ -1,0 +1,41 @@
+PARTICIPANT_WITHDRAW_REQUEST = {
+  description: "Withdraw a participant from training",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "A participant withdrawal",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[participant-withdraw],
+          example: "participant-withdraw",
+        },
+        attributes: {
+          description: "A participant withdrawal action",
+          type: :object,
+          required: %w[reason course_identifier],
+          properties: {
+            reason: {
+              description: "The reason for the withdrawal",
+              type: :string,
+              required: true,
+              enum: TrainingPeriod.withdrawal_reasons.keys.map(&:dasherize),
+              example: "left-teaching-profession",
+            },
+            course_identifier: {
+              description: "The type of course the participant is enrolled in",
+              type: :string,
+              required: true,
+              enum: %w[ecf-mentor ecf-induction],
+              example: "ecf-mentor"
+            }
+          }
+        }
+      },
+    }
+  }
+}.freeze


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2524

### Changes proposed in this pull request

This adds swagger documentation for the PUT participant `/withdraw` API endpoint.

The example response has been overriden to return a participant with a training status of "withdrawn", no deferral and a withdrawal.

### Guidance to review

- [ ] Docs appear as expected with appropriate content
