### PR TITLE
Refresh metadata when school partnership is set

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -44,8 +44,8 @@ class TrainingPeriod < ApplicationRecord
   has_many :declarations, inverse_of: :training_period
   has_many :events
 
-  refresh_metadata -> { school_partnership&.school }, on_event: %i[create destroy update]
-  refresh_metadata -> { trainee&.teacher }, on_event: %i[create destroy update], when_changing: %i[started_on finished_on]
+  refresh_metadata -> { school_partnership&.school }, on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id]
+  refresh_metadata -> { trainee&.teacher }, on_event: %i[create destroy update], when_changing: %i[started_on finished_on school_partnership_id]
 
   # Validations
   validates :started_on,

--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples "a declarative touch model", :with_touches do |when_changi
         context "when the #{attribute_to_change} attribute changes" do
           let(:new_value) { generate_new_value(attribute_to_change:) }
 
-          before { will_change_attribute(attribute_to_change:, new_value:) if defined?(will_change_attribute) }
+          before { DeclarativeUpdates.skip(:metadata) { will_change_attribute(attribute_to_change:, new_value:) if defined?(will_change_attribute) } }
 
           it "touches the #{timestamp_attribute} of the associated model(s)" do
             expect {
@@ -192,7 +192,7 @@ RSpec.shared_examples "a declarative metadata model", :with_metadata do |when_ch
         context "when the #{attribute_to_change} attribute changes" do
           let(:new_value) { generate_new_value(attribute_to_change:) }
 
-          before { will_change_attribute(attribute_to_change:, new_value:) if defined?(will_change_attribute) }
+          before { DeclarativeUpdates.skip(:metadata) { will_change_attribute(attribute_to_change:, new_value:) if defined?(will_change_attribute) } }
 
           it "refreshes the metadata of the associated model(s)" do
             instance.update!(attribute_to_change => new_value)


### PR DESCRIPTION
We hit a bug during PO review whereby when we create a `SchoolPartnership` and it is later assigned to a `TrainingPeriod`, the `Metadata::TeacherLeadProvider` metadata was not being refreshed.

Update to refresh when `school_partnership_id` is changed to cover this scenario.

Update school metadata refresh to only happen when `school_partnership_id` or `expression_of_interest_id` is changed; this should avoid unnecessary updates.

Skip metadata updates on `will_change_attribute` to avoid extra fixture creation messing with the assertion counts.