### PR TITLE
Defer participant API documentation

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -65,7 +65,7 @@ class API::TeacherSerializer < Blueprinter::Base
         training_status = API::TrainingPeriods::TrainingStatus.new(training_period:).status
         if training_status == :deferred
           {
-            "deferred_at" => training_period.deferred_at.utc.rfc3339,
+            "date" => training_period.deferred_at.utc.rfc3339,
             "reason" => training_period.deferral_reason.dasherize
           }
         end

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -306,6 +306,93 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/ParticipantWithdrawRequest"
+  "/api/v3/participants/{id}/defer":
+    put:
+      summary: Update a participant
+      tags:
+      - Participants
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The updated participant
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    data:
+                      id: d0b4a32e-a272-489e-b30a-cb17131457fc
+                      type: participant
+                      attributes:
+                        full_name: John Doe
+                        teacher_reference_number: '1234567'
+                        ecf_enrolments:
+                        - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          email: jane.smith@example.com
+                          mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          school_urn: '123456'
+                          participant_type: ect
+                          cohort: '2021'
+                          training_status: deferred
+                          participant_status: active
+                          eligible_for_funding: true
+                          pupil_premium_uplift: true
+                          sparsity_uplift: true
+                          schedule_identifier: ecf-standard-january
+                          delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          withdrawal:
+                          deferral:
+                            reason: career-break
+                            date: '2021-05-31T02:22:32.000Z'
+                          created_at: '2023-01-01T00:00:00Z'
+                          induction_end_date: '2023-01-01'
+                          overall_induction_start_date: '2023-01-01'
+                          mentor_funding_end_date: '2023-01-01'
+                          cohort_changed_after_payments_frozen: true
+                          mentor_ineligible_for_funding_reason: completed_declaration_received
+                        participant_id_changes:
+                        - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
+                          to_participant_id: ac3d1243-7308-4879-942a-c4a70ced400a
+                          changed_at: '2023-01-01T12:00:00Z'
+                        updated_at: '2021-05-31T02:22:32.000Z'
+              schema:
+                "$ref": "#/components/schemas/ParticipantResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ParticipantDeferRequest"
   "/api/v3/partnerships":
     get:
       summary: Retrieve multiple partnerships
@@ -1265,6 +1352,51 @@ components:
                   - moved-school
                   - mentor-no-longer-being-mentor
                   - switched-to-school-led
+                  - other
+                  example: left-teaching-profession
+                course_identifier:
+                  description: The type of course the participant is enrolled in
+                  type: string
+                  required: true
+                  enum:
+                  - ecf-mentor
+                  - ecf-induction
+                  example: ecf-mentor
+    ParticipantDeferRequest:
+      description: Defer a participant from training
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          description: A participant deferral
+          type: object
+          required:
+          - type
+          - attributes
+          properties:
+            type:
+              type: string
+              required: true
+              enum:
+              - participant-defer
+              example: participant-defer
+            attributes:
+              description: A participant deferral action
+              type: object
+              required:
+              - reason
+              - course_identifier
+              properties:
+                reason:
+                  description: The reason for the deferral
+                  type: string
+                  required: true
+                  enum:
+                  - bereavement
+                  - long-term-sickness
+                  - parental-leave
+                  - career-break
                   - other
                   example: left-teaching-profession
                 course_identifier:

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -108,4 +108,44 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                       }
                     end
                   end
+
+  it_behaves_like "an API update endpoint documentation",
+                  {
+                    url: "/api/v3/participants/{id}/defer",
+                    tag: "Participants",
+                    resource_description: "participant",
+                    request_schema_ref: "#/components/schemas/ParticipantDeferRequest",
+                    response_schema_ref: "#/components/schemas/ParticipantResponse",
+                  } do
+                    let(:response_example) do
+                      extract_swagger_example(schema: "#/components/schemas/ParticipantResponse", version: :v3).tap do |example|
+                        example[:data][:attributes][:ecf_enrolments][0][:training_status] = "deferred"
+                        example[:data][:attributes][:ecf_enrolments][0][:withdrawal] = nil
+                      end
+                    end
+
+                    let(:params) do
+                      {
+                        data: {
+                          type: "participant",
+                          attributes: {
+                            course_identifier: "ecf-induction",
+                            reason: "career-break"
+                          }
+                        }
+                      }
+                    end
+
+                    let(:invalid_params) do
+                      {
+                        data: {
+                          type: "participant",
+                          attributes: {
+                            course_identifier: "something-invalid",
+                            reason: "invalid-reason"
+                          }
+                        }
+                      }
+                    end
+                  end
 end

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -220,7 +220,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
             it "serializes the deferral" do
               expect(ect_enrolment["training_status"]).to eq("deferred")
-              expect(ect_enrolment["deferral"]).to eq({ "deferred_at" => ect_training_period.deferred_at.utc.rfc3339, "reason" => "bereavement" })
+              expect(ect_enrolment["deferral"]).to eq({ "date" => ect_training_period.deferred_at.utc.rfc3339, "reason" => "bereavement" })
             end
           end
         end
@@ -330,7 +330,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
             it "serializes the deferral" do
               expect(mentor_enrolment["training_status"]).to eq("deferred")
-              expect(mentor_enrolment["deferral"]).to eq({ "deferred_at" => mentor_training_period.deferred_at.utc.rfc3339, "reason" => "bereavement" })
+              expect(mentor_enrolment["deferral"]).to eq({ "date" => mentor_training_period.deferred_at.utc.rfc3339, "reason" => "bereavement" })
             end
           end
         end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -81,6 +81,7 @@ RSpec.configure do |config|
           ParticipantsFilter: PARTICIPANTS_FILTER,
           ParticipantResponse: PARTICIPANT_RESPONSE,
           ParticipantWithdrawRequest: PARTICIPANT_WITHDRAW_REQUEST,
+          ParticipantDeferRequest: PARTICIPANT_DEFER_REQUEST,
           ParticipantsResponse: PARTICIPANTS_RESPONSE,
           ParticipantECFEnrolment: PARTICIPANT_ECF_ENROLMENT,
           ParticipantIDChange: PARTICIPANT_ID_CHANGE,

--- a/spec/swagger_schemas/requests/participant_defer.rb
+++ b/spec/swagger_schemas/requests/participant_defer.rb
@@ -1,0 +1,41 @@
+PARTICIPANT_DEFER_REQUEST = {
+  description: "Defer a participant from training",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "A participant deferral",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[participant-defer],
+          example: "participant-defer",
+        },
+        attributes: {
+          description: "A participant deferral action",
+          type: :object,
+          required: %w[reason course_identifier],
+          properties: {
+            reason: {
+              description: "The reason for the deferral",
+              type: :string,
+              required: true,
+              enum: TrainingPeriod.deferral_reasons.keys.map(&:dasherize),
+              example: "left-teaching-profession",
+            },
+            course_identifier: {
+              description: "The type of course the participant is enrolled in",
+              type: :string,
+              required: true,
+              enum: %w[ecf-mentor ecf-induction],
+              example: "ecf-mentor"
+            }
+          }
+        }
+      },
+    }
+  }
+}.freeze


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2527

### Changes proposed in this pull request

This adds swagger documentation for the PUT participant `/defer` API endpoint.

The example response has been overriden to return a participant with a training
status of "deferred", no withdrawal and a deferral.

### Guidance to review

- [ ] Docs appear as expected with appropriate content
