### PR TITLE
Resume participants PUT endpoint

### DIFF
--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -33,7 +33,17 @@ module API
         respond_with_service(service:, action: :defer)
       end
 
-      def resume = head(:method_not_allowed)
+      def resume
+        validate_resume_participant_params!
+
+        service = API::Teachers::Resume.new(
+          lead_provider_id: current_lead_provider.id,
+          teacher_api_id: teacher.api_id,
+          teacher_type:
+        )
+
+        respond_with_service(service:, action: :resume)
+      end
 
       def withdraw
         service = API::Teachers::Withdraw.new(
@@ -71,6 +81,12 @@ module API
       def defer_participant_params
         params.require(:data).expect({ attributes: %i[reason] })
       end
+
+      def resume_participant_params
+        params.require(:data).expect({ attributes: %i[course_identifier] })
+      end
+
+      def validate_resume_participant_params! = resume_participant_params
 
       def withdraw_participant_params
         params.require(:data).expect({ attributes: %i[reason] })


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2529

### Changes proposed in this pull request

Similarly to #1610 and #1597, this implements the `/resume` participants API endpoint.

Now, lead providers can make a PUT request to the API endpoint to resume a participant's training.

Since https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1638, the `course_identifier` param given by providers is extracted to
the `teacher_type` by the `API::TeacherType` concern.

For this controller action, there are no other params. This means we don't
respond with `400 Bad Request` when the incorrect JSON structure is used in the
request body. Now, we need to validate the controller params explicitly.

### Guidance to review
