### PR TITLE
Fix flaky test

### DIFF
--- a/spec/services/training_periods/search_spec.rb
+++ b/spec/services/training_periods/search_spec.rb
@@ -65,7 +65,7 @@ describe TrainingPeriods::Search do
     let(:matching_expression_of_interest) do
       FactoryBot.create(:active_lead_provider,
                         lead_provider:,
-                        contract_period_year: contract_period.year)
+                        contract_period:)
     end
 
     let!(:linkable_tp) do


### PR DESCRIPTION
As seen [here], sometimes the matching training period is created with an expression of interest for a contract period in the future and isn't returned by the query.

This explicitly passes the contract period when creating the expression of interest so it is always returned by the query.

[here]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/18850956986/job/53787135580?pr=1619