### PR TITLE
[1605] Group Bundler updates for Sentry gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         patterns:
           - govuk-components
           - govuk_design_system_formbuilder
+      sentry-gems:
+        patterns:
+          - sentry-ruby
+          - sentry-rails
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
### Context

Group Sentry Dependabot updates so they come as a single PR in future runs.

This will group:

- `sentry-ruby`
- `sentry-rails`
