### PR TITLE
move plantuml to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN apk add --update --no-cache tzdata && \
 # postgresql-dev: postgres driver and libraries
 RUN apk add --no-cache build-base yaml-dev nodejs npm postgresql16-dev
 
-RUN apk add --no-cache plantuml # FIXME can be removed once the migration is done
-
 # Install gems defined in Gemfile
 COPY .ruby-version Gemfile Gemfile.lock ./
 
@@ -79,6 +77,8 @@ RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
 
 # libpq: required to run postgres
 RUN apk add --no-cache libpq
+
+RUN apk add --no-cache plantuml # FIXME can be removed once the migration is done
 
 # Copy files generated in the builder image
 COPY --from=builder /app /app


### PR DESCRIPTION
### Context

In the PR that added `plantuml` (#1590)  the dependency was put into the "builder" image in the Dockerfile but it was not present in the runtime image deployed so charts could not be built.  This moves the `plantuml` install into the "runtime" image instead.

### Changes proposed in this pull request


### Guidance to review
