### PR TITLE
fix more issues causing teacher view to fail

### DIFF
--- a/app/components/migration/mentorship_period_component.rb
+++ b/app/components/migration/mentorship_period_component.rb
@@ -11,7 +11,7 @@ module Migration
     end
 
     def mentor_name
-      @mentor_name ||= Teachers::Name.new(mentorship_period.mentor.teacher).full_name
+      @mentor_name ||= ::Teachers::Name.new(mentorship_period.mentor.teacher).full_name
     end
 
     def period_dates

--- a/app/components/migration/training_period_component.rb
+++ b/app/components/migration/training_period_component.rb
@@ -11,11 +11,11 @@ module Migration
     end
 
     def lead_provider_name
-      training_period.school_partnership.lead_provider.name
+      training_period.school_partnership&.lead_provider&.name
     end
 
     def delivery_partner_name
-      training_period.school_partnership.delivery_partner.name
+      training_period.school_partnership&.delivery_partner&.name
     end
 
     def period_dates

--- a/app/controllers/migration/teachers_controller.rb
+++ b/app/controllers/migration/teachers_controller.rb
@@ -42,19 +42,23 @@ private
   end
 
   def ect_profile
-    @ect_profile = if teacher.api_ect_training_record_id.present?
-                     Migration::ParticipantProfilePresenter.new(
-                       Migration::ParticipantProfile.find(teacher.api_ect_training_record_id)
-                     )
-                   end
+    @ect_profile ||= if teacher.api_ect_training_record_id.present?
+                       Migration::ParticipantProfilePresenter.new(
+                         Migration::ParticipantProfile.find(teacher.api_ect_training_record_id)
+                       )
+                     end
   end
 
   def mentor_profile
-    @mentor_profile = if teacher.api_mentor_training_record_id.present?
-                        Migration::ParticipantProfilePresenter.new(
-                          Migration::ParticipantProfile.find(teacher.api_mentor_training_record_id)
-                        )
-                      end
+    @mentor_profile ||= if teacher.api_mentor_training_record_id.present?
+                          Migration::ParticipantProfilePresenter.new(
+                            Migration::ParticipantProfile.find(teacher.api_mentor_training_record_id)
+                          )
+                        end
+  end
+
+  def make_gantt_chart?
+    ect_profile&.induction_records&.any? || mentor_profile&.induction_records&.any?
   end
 
   def user
@@ -64,4 +68,6 @@ private
   def teacher
     @teacher ||= Admin::TeacherPresenter.new(Teacher.find(params[:id]))
   end
+
+  helper_method :make_gantt_chart?
 end

--- a/app/views/migration/teachers/show.html.erb
+++ b/app/views/migration/teachers/show.html.erb
@@ -13,6 +13,7 @@
 <%= render partial: "mentor_records", locals: { profile: @mentor_profile } %>
 <%= render partial: "failures", locals: { failures: @failures } %>
 
-<h2 class="govuk-heading-m">ECT induction record data</h2>
-
-<%= tag.img(src: migration_teacher_legacy_ect_gantt_path(@teacher), class: 'migration-gantt') %>
+<% if make_gantt_chart? %>
+  <h2 class="govuk-heading-m">ECT induction record data</h2>
+  <%= tag.img(src: migration_teacher_legacy_ect_gantt_path(@teacher), class: 'migration-gantt') %>
+<% end %>


### PR DESCRIPTION
### Context

There were a number of issues causing page crashes in migration when viewing a teachers migrated data.  This PR fixes these, generally issues referencing `nil` objects but also issue trying to build/render gantt charts when there was no data.

### Changes proposed in this pull request

A few fixes to protect against instances where there is no data.

### Guidance to review
