### PR TITLE
Fix flaky test

### DIFF
--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -41,11 +41,11 @@ describe Teachers::RefreshTRSAttributes do
       service.refresh!
       perform_enqueued_jobs
 
-      expect(teacher.events.map(&:event_type)).to eql(%w[
-        teacher_name_updated_by_trs
-        teacher_trs_induction_status_updated
-        teacher_trs_attributes_updated
-      ])
+      expect(teacher.events.map(&:event_type)).to contain_exactly(
+        "teacher_name_updated_by_trs",
+        "teacher_trs_induction_status_updated",
+        "teacher_trs_attributes_updated"
+      )
     end
 
     describe 'delegation' do


### PR DESCRIPTION
Sometimes the events are returned in a different order in tests, so this loosens the expectation.

As seen [here].

[here]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/18876503475/job/53873348234