### PR TITLE
Add release note for participants endpoints in sandbox

### DIFF
--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -22,13 +22,13 @@
 #     **bold** and _italic_ text
 
 - title: GET participants endpoints added to sandbox   
-  date: 2025-01-21
+  date: 2025-11-07
   tags: 
     - sandbox-release 
     - new-field 
     - removed-field
   body: |
-    We’ve added the participants endpoints to the ‘Register early career teachers’ API sandbox: 
+    We’ve added the `GET /participants` endpoints to the ‘Register early career teachers’ API sandbox:
     
     * `GET /participants` to retrieve data for multiple participants 
     * `GET /participants/{id}` to get information about a single participant 


### PR DESCRIPTION
> ⚠️ Re-raised from #1582 as the branch name has an invalid character in it.

Please don't merge until copy has been reviewed by @claire-hughez.

Changes proposed in this pull request
Add the following release note: 'GET participants endpoints added to sandbox'

Outstanding tickets that factor into this release note:

In PO review:

- funding eligibility
- schedule identifier
- sandbox seed data

In development:

- accurate updated_at values