### PR TITLE
[2557] Add GET Participants to Parity check

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -83,6 +83,8 @@ module ParityCheck
                                                            .distinct(false)
                                                            .reorder("RANDOM()")
                                                            .pick(:api_id)
+    end
+
     # Request body methods
 
     def partnership_create_body

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -165,6 +165,24 @@ get:
       ecf_path: "/api/v3/participants/ecf"
       paginate: true
       query:
+        filter:
+          updated_since: "2025-04-13T11:21:55Z"
+  - "/api/v3/participants":
+      ecf_path: "/api/v3/participants/ecf"
+      paginate: true
+      query:
+        filter:
+          training_status: "withdrawn"
+  - "/api/v3/participants":
+      ecf_path: "/api/v3/participants/ecf"
+      paginate: true
+      query:
+        filter:
+          from_participant_id: ":from_teacher_api_id"
+  - "/api/v3/participants":
+      ecf_path: "/api/v3/participants/ecf"
+      paginate: true
+      query:
         sort: "-updated_at"
   - "/api/v3/participants":
       ecf_path: "/api/v3/participants/ecf"
@@ -195,12 +213,6 @@ get:
           cohort: "2023,2024"
           updated_since: "2025-04-13T11:21:55Z"
           training_status: "deferred"
-  - "/api/v3/participants":
-      ecf_path: "/api/v3/participants/ecf"
-      paginate: true
-      query:
-        filter:
-          from_participant_id: ":from_teacher_api_id"
   - "/api/v3/participants/:id":
       ecf_path: "/api/v3/participants/ecf/:id"
       id: ":teacher_api_id"

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -94,11 +94,14 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:from_teacher) { FactoryBot.create(:teacher) }
 
       before do
+        # Should return results from this teacher_id_change
         FactoryBot.create(:teacher_id_change, teacher:, api_from_teacher_id: from_teacher.api_id)
 
-        # Participants for different lead providers should not be used.
-        FactoryBot.create(:training_period, :for_ect, :ongoing)
-        FactoryBot.create(:training_period, :for_mentor, :ongoing)
+        # Participants with teacher_id_change for different lead providers should not be used.
+        unused_teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher
+        FactoryBot.create(:teacher_id_change, teacher: unused_teacher1)
+        unused_teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher
+        FactoryBot.create(:teacher_id_change, teacher: unused_teacher2)
       end
 
       it { is_expected.to eq(from_teacher.api_id) }


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2557

### Changes proposed in this pull request

* Parity check for single participant endpoint
* Parity check for multiple participants endpoint, with various filter options

### Guidance to review
