### PR TITLE
Resume participant API documentation

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -393,6 +393,91 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/ParticipantDeferRequest"
+  "/api/v3/participants/{id}/resume":
+    put:
+      summary: Update a participant
+      tags:
+      - Participants
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The updated participant
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    data:
+                      id: d0b4a32e-a272-489e-b30a-cb17131457fc
+                      type: participant
+                      attributes:
+                        full_name: John Doe
+                        teacher_reference_number: '1234567'
+                        ecf_enrolments:
+                        - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          email: jane.smith@example.com
+                          mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          school_urn: '123456'
+                          participant_type: ect
+                          cohort: '2021'
+                          training_status: active
+                          participant_status: active
+                          eligible_for_funding: true
+                          pupil_premium_uplift: true
+                          sparsity_uplift: true
+                          schedule_identifier: ecf-standard-january
+                          delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          withdrawal:
+                          deferral:
+                          created_at: '2023-01-01T00:00:00Z'
+                          induction_end_date: '2023-01-01'
+                          overall_induction_start_date: '2023-01-01'
+                          mentor_funding_end_date: '2023-01-01'
+                          cohort_changed_after_payments_frozen: true
+                          mentor_ineligible_for_funding_reason: completed_declaration_received
+                        participant_id_changes:
+                        - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
+                          to_participant_id: ac3d1243-7308-4879-942a-c4a70ced400a
+                          changed_at: '2023-01-01T12:00:00Z'
+                        updated_at: '2021-05-31T02:22:32.000Z'
+              schema:
+                "$ref": "#/components/schemas/ParticipantResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ParticipantResumeRequest"
   "/api/v3/partnerships":
     get:
       summary: Retrieve multiple partnerships
@@ -1399,6 +1484,39 @@ components:
                   - career-break
                   - other
                   example: left-teaching-profession
+                course_identifier:
+                  description: The type of course the participant is enrolled in
+                  type: string
+                  required: true
+                  enum:
+                  - ecf-mentor
+                  - ecf-induction
+                  example: ecf-mentor
+    ParticipantResumeRequest:
+      description: Resume a participant's training
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          description: A participant resumption
+          type: object
+          required:
+          - type
+          - attributes
+          properties:
+            type:
+              type: string
+              required: true
+              enum:
+              - participant-resume
+              example: participant-resume
+            attributes:
+              description: A participant resumption action
+              type: object
+              required:
+              - course_identifier
+              properties:
                 course_identifier:
                   description: The type of course the participant is enrolled in
                   type: string

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -127,7 +127,7 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                     let(:params) do
                       {
                         data: {
-                          type: "participant",
+                          type: "participant-defer",
                           attributes: {
                             course_identifier: "ecf-induction",
                             reason: "career-break"
@@ -139,7 +139,56 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                     let(:invalid_params) do
                       {
                         data: {
-                          type: "participant",
+                          type: "participant-defer",
+                          attributes: {
+                            course_identifier: "something-invalid",
+                            reason: "invalid-reason"
+                          }
+                        }
+                      }
+                    end
+                  end
+
+  it_behaves_like "an API update endpoint documentation",
+                  {
+                    url: "/api/v3/participants/{id}/resume",
+                    tag: "Participants",
+                    resource_description: "participant",
+                    request_schema_ref: "#/components/schemas/ParticipantResumeRequest",
+                    response_schema_ref: "#/components/schemas/ParticipantResponse",
+                  } do
+                    before do
+                      training_period.update!(
+                        withdrawn_at: 1.day.ago,
+                        finished_on: 1.day.ago,
+                        withdrawal_reason: :other
+                      )
+                    end
+
+                    let(:response_example) do
+                      extract_swagger_example(schema: "#/components/schemas/ParticipantResponse", version: :v3).tap do |example|
+                        example[:data][:attributes][:ecf_enrolments][0][:training_status] = "active"
+                        example[:data][:attributes][:ecf_enrolments][0][:deferral] = nil
+                        example[:data][:attributes][:ecf_enrolments][0][:withdrawal] = nil
+                      end
+                    end
+
+                    let(:params) do
+                      {
+                        data: {
+                          type: "participant-resume",
+                          attributes: {
+                            course_identifier: "ecf-induction",
+                            reason: "moved-school"
+                          }
+                        }
+                      }
+                    end
+
+                    let(:invalid_params) do
+                      {
+                        data: {
+                          type: "participant-resume",
                           attributes: {
                             course_identifier: "something-invalid",
                             reason: "invalid-reason"

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -82,6 +82,7 @@ RSpec.configure do |config|
           ParticipantResponse: PARTICIPANT_RESPONSE,
           ParticipantWithdrawRequest: PARTICIPANT_WITHDRAW_REQUEST,
           ParticipantDeferRequest: PARTICIPANT_DEFER_REQUEST,
+          ParticipantResumeRequest: PARTICIPANT_RESUME_REQUEST,
           ParticipantsResponse: PARTICIPANTS_RESPONSE,
           ParticipantECFEnrolment: PARTICIPANT_ECF_ENROLMENT,
           ParticipantIDChange: PARTICIPANT_ID_CHANGE,

--- a/spec/swagger_schemas/requests/participant_resume.rb
+++ b/spec/swagger_schemas/requests/participant_resume.rb
@@ -1,0 +1,34 @@
+PARTICIPANT_RESUME_REQUEST = {
+  description: "Resume a participant's training",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "A participant resumption",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[participant-resume],
+          example: "participant-resume",
+        },
+        attributes: {
+          description: "A participant resumption action",
+          type: :object,
+          required: %w[course_identifier],
+          properties: {
+            course_identifier: {
+              description: "The type of course the participant is enrolled in",
+              type: :string,
+              required: true,
+              enum: %w[ecf-mentor ecf-induction],
+              example: "ecf-mentor"
+            }
+          }
+        }
+      }
+    }
+  }
+}.freeze


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2530

### Changes proposed in this pull request

This adds swagger documentation for the PUT participant `/resume` API endpoint.

The example response has been overriden to return a participant with a training status of "active" without a withdrawal or a deferral.

### Guidance to review

- [ ] Docs appear as expected with appropriate content
