### PR TITLE
Add additional seeds for testing

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -25,14 +25,14 @@ class TestGuidanceComponent < ApplicationComponent
   end
 
   class TRSExampleTeacherDetails < ApplicationComponent
-    NO_QTS                     = "No QTS"
-    NO_MENTOR_FUNDING          = "No mentor funding"
-    PASSED_INDUCTION           = "Passed induction"
-    EXEMPT_FROM_INDUCTION      = "Exempt from induction"
-    FAILED_INDUCTION           = "Failed induction"
-    FAILED_INDUCTION_IN_WALES  = "Failed induction in Wales"
-    PROHIBITED_IN_PROGRESS     = "Prohibited from teaching (In progress)"
-    PROHIBITED_PASSED          = "Prohibited from teaching (Passed)"
+    EXEMPT_FROM_INDUCTION     = "Exempt from induction"
+    FAILED_INDUCTION          = "Failed induction"
+    FAILED_INDUCTION_IN_WALES = "Failed induction in Wales"
+    NO_MENTOR_FUNDING         = "No mentor funding"
+    NO_QTS                    = "No QTS"
+    PASSED_INDUCTION          = "Passed induction"
+    PROHIBITED_IN_PROGRESS    = "Prohibited from teaching (In progress)"
+    PROHIBITED_PASSED         = "Prohibited from teaching (Passed)"
 
     def head
       ["Name", "TRN", "Date of birth", "National Insurance Number", "Notes", ""]


### PR DESCRIPTION
### Context
On review apps - there aren't enough ECTs who are able to be registered at schools. This PR adds in 11 additional no QTC candidates

### Changes proposed in this pull request
Additional seeds added to app/components/test_guidance_component.rb

### Guidance to review
Seeds should correspond with 
* 3012235, Claire Cool, 03/01/1993, BB123456C
* 3012238, Linda Belcher, 01/12/1980, QQ 12 34 56 C
* 3012239, James Rocket, 26/11/1976, AA223456C
* 3012240, Buffy Summers, 09/09/1987, AA333456C
* 3012241, Ash Ketchum, 25/01/2000, QQ553456C
* 3012242, Jigglypuff Jewels, 05/01/1993, QQ773456C
* 3012243, Clefairy Cuddles, 09/01/1993, QQ993456C
* 3012244, Bulbasaur Brown, 19/01/1992, QQ893456C
* 3012245, Squirtle Samuels, 19/03/1992, QQ123445C
* 3012246, Ditto Debbie, 28/04/1970, QQ783445C
* 3012247, Butterfree Barnaby, 18/06/2002, QQ799445C

