### PR TITLE
Fix partnerships parity check

### DIFF
--- a/spec/migration/parity_check/client_spec.rb
+++ b/spec/migration/parity_check/client_spec.rb
@@ -147,8 +147,12 @@ RSpec.describe ParityCheck::Client do
       before do
         # Create some data to be used in the request body
         FactoryBot.create_list(:lead_provider_delivery_partnership, 2, active_lead_provider:)
+
         FactoryBot.create_list(:school, 2, :eligible)
-        FactoryBot.create_list(:school_partnership, 2, lead_provider_delivery_partnership:)
+
+        school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, active_lead_provider:)
+        ecf_lead_provider = FactoryBot.create(:migration_lead_provider, id: lead_provider.ecf_id)
+        FactoryBot.create(:migration_partnership, id: school_partnership.api_id, lead_provider: ecf_lead_provider)
       end
 
       context "when performing a POST request" do

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -58,15 +58,19 @@ RSpec.describe ParityCheck::DynamicRequestContent do
 
     context "when fetching `partnership_id`" do
       let(:identifier) { :partnership_id }
-      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
-      let!(:partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+      let(:ecf_lead_provider) { FactoryBot.create(:migration_lead_provider, id: lead_provider.ecf_id) }
+      let!(:ecf_partnership) { FactoryBot.create(:migration_partnership, lead_provider: ecf_lead_provider) }
 
       before do
         # Partnership for different lead provider should not be used.
-        FactoryBot.create(:school_partnership)
+        FactoryBot.create(:migration_partnership)
+        # Challenged.
+        FactoryBot.create(:migration_partnership, lead_provider: ecf_lead_provider, challenged_at: Time.current)
+        # Relationship.
+        FactoryBot.create(:migration_partnership, lead_provider: ecf_lead_provider, relationship: true)
       end
 
-      it { is_expected.to eq(partnership.api_id) }
+      it { is_expected.to eq(ecf_partnership.id) }
     end
 
     context "when fetching partnership_create_body" do
@@ -122,17 +126,20 @@ RSpec.describe ParityCheck::DynamicRequestContent do
 
     context "when fetching partnership_update_body" do
       let(:identifier) { :partnership_update_body }
+      let(:cohort) { FactoryBot.create(:migration_cohort, start_year: active_lead_provider.contract_period_year) }
+      let(:ecf_lead_provider) { FactoryBot.create(:migration_lead_provider, id: lead_provider.ecf_id) }
+      let!(:ecf_partnership) { FactoryBot.create(:migration_partnership, cohort:, lead_provider: ecf_lead_provider) }
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
-      let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+      let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, api_id: ecf_partnership.id) }
       let!(:other_delivery_partner) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:).delivery_partner }
 
       before do
         # Different lead provider.
-        FactoryBot.create(:lead_provider_delivery_partnership)
-        # Different contract period.
-        other_contract_period = FactoryBot.create(:contract_period, year: active_lead_provider.contract_period_year - 1)
-        other_active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: other_contract_period)
-        FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: other_active_lead_provider)
+        FactoryBot.create(:migration_partnership, cohort:)
+        # Challenged.
+        FactoryBot.create(:migration_partnership, lead_provider: ecf_lead_provider, challenged_at: Time.current)
+        # Relationship.
+        FactoryBot.create(:migration_partnership, lead_provider: ecf_lead_provider, relationship: true)
       end
 
       it "returns a partnership update body" do


### PR DESCRIPTION
We need to select partnerships that are unchallenged and not relationship; this is because RECT ignores challenged partnerships (and ECF returns them) and ECF doesn't return relationship partnerships (but RECT does).

Switches to querying the partnership from ECF rather than RECT as we don't have challenged/relationship fields in RECT.