### PR TITLE
Fix column order in CSV export

### DIFF
--- a/app/services/migration/induction_record_exporter.rb
+++ b/app/services/migration/induction_record_exporter.rb
@@ -9,6 +9,7 @@ module Migration
       :start_date,
       :end_date,
       :right_way_round,
+      :duration,
       :training_status,
       :school_transfer,
       :induction_record_created,
@@ -17,7 +18,6 @@ module Migration
       :urn,
       :challenged,
       :lead_provider_name,
-      :duration,
       keyword_init: true
     ) do
       def range = start_date..end_date


### PR DESCRIPTION
### Context

A recent bit of refactoring changed the position of one of the columns for the induction record data export.
This puts it back in the correct order.

### Changes proposed in this pull request

Move `duration` to correct position in struct initializer params list.

### Guidance to review
