### PR TITLE
[2528] Add PUT participant withdraw to parity check

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -52,20 +52,20 @@ module ParityCheck
         .pick(:api_id)
     end
 
-    def teacher_api_id_for_withdraw
-      @teacher_api_id_for_withdraw ||= API::Teachers::Query.new(lead_provider_id: lead_provider.id, training_status: "active")
-                                      .teachers
-                                      .distinct(false)
-                                      .reorder("RANDOM()")
-                                      .pick(:api_id)
+    def active_teacher_api_id_for_participant_action
+      @active_teacher_api_id_for_participant_action ||= API::Teachers::Query.new(lead_provider_id: lead_provider.id, training_status: "active")
+                                                        .teachers
+                                                        .distinct(false)
+                                                        .reorder("RANDOM()")
+                                                        .pick(:api_id)
     end
 
-    def withdrawn_teacher_api_id_for_withdraw
-      @withdrawn_teacher_api_id_for_withdraw ||= API::Teachers::Query.new(lead_provider_id: lead_provider.id, training_status: "withdrawn")
-                                                .teachers
-                                                .distinct(false)
-                                                .reorder("RANDOM()")
-                                                .pick(:api_id)
+    def withdrawn_teacher_api_id_for_participant_action
+      @withdrawn_teacher_api_id_for_participant_action ||= API::Teachers::Query.new(lead_provider_id: lead_provider.id, training_status: "withdrawn")
+                                                           .teachers
+                                                           .distinct(false)
+                                                           .reorder("RANDOM()")
+                                                           .pick(:api_id)
     end
 
     # Request body methods
@@ -127,14 +127,14 @@ module ParityCheck
       }
     end
 
-    def participant_withdraw_body
-      participant = Teacher.find_by(api_id: teacher_api_id_for_withdraw)
+    def active_participant_withdraw_body
+      participant = Teacher.find_by(api_id: active_teacher_api_id_for_participant_action)
 
       participant_withdraw_payload(participant)
     end
 
     def withdrawn_participant_withdraw_body
-      participant = Teacher.find_by(api_id: withdrawn_teacher_api_id_for_withdraw)
+      participant = Teacher.find_by(api_id: withdrawn_teacher_api_id_for_participant_action)
 
       participant_withdraw_payload(participant)
     end

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -164,9 +164,9 @@ put:
       body: partnership_update_body
   - "/api/v3/participants/:id/withdraw":
       ecf_path: "/api/v3/participants/ecf/:id/withdraw"
-      id: ":teacher_api_id_for_withdraw"
-      body: participant_withdraw_body
+      id: ":active_teacher_api_id_for_participant_action"
+      body: active_participant_withdraw_body
   - "/api/v3/participants/:id/withdraw":
       ecf_path: "/api/v3/participants/ecf/:id/withdraw"
-      id: ":withdrawn_teacher_api_id_for_withdraw"
+      id: ":withdrawn_teacher_api_id_for_participant_action"
       body: withdrawn_participant_withdraw_body

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -170,8 +170,8 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       end
     end
 
-    context "when fetching `teacher_api_id_for_withdraw`" do
-      let(:identifier) { :teacher_api_id_for_withdraw }
+    context "when fetching `active_teacher_api_id_for_participant_action`" do
+      let(:identifier) { :active_teacher_api_id_for_participant_action }
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
@@ -189,8 +189,8 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       it { is_expected.to eq(teacher.api_id) }
     end
 
-    context "when fetching `withdrawn_teacher_api_id_for_withdraw`" do
-      let(:identifier) { :withdrawn_teacher_api_id_for_withdraw }
+    context "when fetching `withdrawn_teacher_api_id_for_participant_action`" do
+      let(:identifier) { :withdrawn_teacher_api_id_for_participant_action }
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
@@ -208,8 +208,8 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       it { is_expected.to eq(teacher.api_id) }
     end
 
-    context "when fetching `participant_withdraw_body`" do
-      let(:identifier) { :participant_withdraw_body }
+    context "when fetching `active_participant_withdraw_body`" do
+      let(:identifier) { :active_participant_withdraw_body }
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
@@ -220,6 +220,8 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:)
         # Deferred participant for current lead provider
         FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:)
+        # Mentor participant for current lead provider
+        FactoryBot.create(:training_period, :for_mentor, :ongoing, :deferred, school_partnership:)
         # Participant for different lead providers should not be used.
         FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn)
         # Stub withdrawal reasons so we have a predictable value
@@ -251,6 +253,8 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:)
         # Deferred participant for current lead provider
         FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:)
+        # Mentor participant for current lead provider
+        FactoryBot.create(:training_period, :for_mentor, :ongoing, :deferred, school_partnership:)
         # Participant for different lead providers should not be used.
         FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn)
         # Stub withdrawal reasons so we have a predictable value


### PR DESCRIPTION
### Context

We'd like to add participant endpoints to parity check so we can test the results of the data compared to ECF1.

### Changes proposed in this pull request

- Parity check for successful withdrawing a participant
- Parity check for withdrawing a participant that is already withdrawn

### Guidance to review

Parity check env