### PR TITLE
Fix seeds (local and review app seeds)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ priority_seeds = %w[
   schools
   lead_provider_delivery_partnerships
   school_partnerships
+  schedules_and_milestones
   teachers
   metadata
 ]

--- a/db/seeds/schedules_and_milestones.rb
+++ b/db/seeds/schedules_and_milestones.rb
@@ -310,6 +310,32 @@ def schedule_and_milestone_data
     build(identifier: "ecf-standard-september", contract_period_year: 2025, start_date: "2025-06-01"),
     build(identifier: "ecf-standard-january", contract_period_year: 2025, start_date: "2026-01-01"),
     build(identifier: "ecf-standard-april", contract_period_year: 2025, start_date: "2026-04-01"),
+
+    # 2026
+
+    ## Extended
+
+    build(identifier: "ecf-extended-september", contract_period_year: 2026, start_date: "2026-09-01"),
+    build(identifier: "ecf-extended-january", contract_period_year: 2026, start_date: "2027-01-01"),
+    build(identifier: "ecf-extended-april", contract_period_year: 2026, start_date: "2027-04-01"),
+
+    ## Reduced
+
+    build(identifier: "ecf-reduced-september", contract_period_year: 2026, start_date: "2026-09-01"),
+    build(identifier: "ecf-reduced-january", contract_period_year: 2026, start_date: "2027-01-01"),
+    build(identifier: "ecf-reduced-april", contract_period_year: 2026, start_date: "2027-04-01"),
+
+    ## Replacement
+
+    build(identifier: "ecf-replacement-september", contract_period_year: 2026, start_date: "2026-09-01"),
+    build(identifier: "ecf-replacement-january", contract_period_year: 2026, start_date: "2027-01-01"),
+    build(identifier: "ecf-replacement-april", contract_period_year: 2026, start_date: "2027-04-01"),
+
+    ## Standard
+
+    build(identifier: "ecf-standard-september", contract_period_year: 2026, start_date: "2026-06-01"),
+    build(identifier: "ecf-standard-january", contract_period_year: 2026, start_date: "2027-01-01"),
+    build(identifier: "ecf-standard-april", contract_period_year: 2026, start_date: "2027-04-01"),
   ]
 end
 


### PR DESCRIPTION
### Context

Calls to participants endpoint in review apps is broken due the seeds creating teachers training periods not linked to schedules. The serializer always expects a schedule (which is correct, I guess as all `provider-led` training periods)

```
    field(:schedule_identifier) do |(training_period, _, _)|
        training_period.schedule.identifier
    end
```
### Changes proposed in this pull request

- Move `schedules_and_milestones` to run as priority seeds (as it's needed for the other seeds in the sequence);
- Add schedules data for contract period 2026 as some teachers are being created for contract period 2026;
- With those changes we make sure every `provider-led` training period has a schedule attached to it in the seeds;

### Guidance to review

- Calls to participants endpoint in review app should not fail.
- We should not see any provider-led training period without schedule in seeds.

Main branch:
```
TrainingPeriod.provider_led_training_programme.where(schedule_id: nil).size
=> 174
TrainingPeriod.provider_led_training_programme.joins(:contract_period).where(schedule_id: nil, contra
ct_period: { year: 2026 }).size
=> 6
```
This branch:
```
TrainingPeriod.provider_led_training_programme.where(schedule_id: nil).size
=> 0
TrainingPeriod.provider_led_training_programme.joins(:contract_period).where(schedule_id: nil, contra
ct_period: { year: 2026 }).size
=> 0
```