### PR TITLE
Fix foreign key values in declarative update specs

### DIFF
--- a/spec/support/shared_examples/declarative_updates.rb
+++ b/spec/support/shared_examples/declarative_updates.rb
@@ -10,6 +10,10 @@ def generate_new_value(attribute_to_change:)
     (instance[attribute_to_change] || Date.current) + 1.day
   elsif attribute_to_change == :finished_on
     (instance[attribute_to_change] || Date.current) - 1.day
+  elsif attribute_to_change.to_s.end_with?("_id")
+    association_name = attribute_to_change.to_s.delete_suffix("_id").to_sym
+    klass = instance.class.reflect_on_association(association_name).klass
+    ActiveRecord::Base.connection.select_value("SELECT last_value FROM #{klass.sequence_name}") + 1
   else
     Faker::Types.send("rb_#{column.type}")
   end


### PR DESCRIPTION
Previously, we generated a `new_value` just based on the `integer` column type via `rb_integer`, however this can lead to generating ID values that already exist in the database.

Instead, we can use reflection to find the type of model for the association and query the next `id` in the sequence from the database, ensuring we'll always be able to create the associated model.

Thanks @cpjmcquillan for spotting!
