### PR TITLE
Deep merge filter hash keys

### DIFF
--- a/app/models/parity_check/filter/response_body.rb
+++ b/app/models/parity_check/filter/response_body.rb
@@ -23,7 +23,7 @@ module ParityCheck::Filter
     #  }
     # }
     def filterable_key_hash
-      rect_key_hash.merge(ecf_key_hash)
+      rect_key_hash.deep_merge(ecf_key_hash)
     end
 
     # Checks if a key path has been selected for filtering, for example:

--- a/spec/models/parity_check/filter/response_body_spec.rb
+++ b/spec/models/parity_check/filter/response_body_spec.rb
@@ -62,7 +62,7 @@ describe ParityCheck::Filter::ResponseBody do
 
       context "when the JSON contains arrays of objects" do
         let(:ecf_body) { { key1: [{ subkey: "value1", other_subkey: [{ subsubkey: "value4" }] }, { subkey: "value2" }] }.to_json }
-        let(:rect_body) { { key2: "value" }.to_json }
+        let(:rect_body) { { key1: [{ different_subkey: "value" }] }.to_json }
 
         it "returns a hash of the key structure with arrays" do
           expect(key_hash).to eq(
@@ -70,9 +70,9 @@ describe ParityCheck::Filter::ResponseBody do
               subkey: {},
               other_subkey: {
                 subsubkey: {}
-              }
-            },
-            key2: {}
+              },
+              different_subkey: {}
+            }
           )
         end
       end


### PR DESCRIPTION
We weren't deep-merging the filter hash keys, which means when you have an object with an array of objects (as we do when returning multiple from the API) you lose some of the nested keys.
