### PR TITLE
Add PUT participant resume to parity check

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -146,7 +146,7 @@ module ParityCheck
           type: "participant-withdraw",
           attributes: {
             reason: TrainingPeriod.withdrawal_reasons.values.map(&:dasherize).sample,
-            course_identifier: participant.api_ect_training_record_id.present? ? "ecf-induction" : "ecf-mentor",
+            course_identifier: course_identifier_for(participant),
           },
         },
       }
@@ -170,7 +170,7 @@ module ParityCheck
           type: "participant-defer",
           attributes: {
             reason: TrainingPeriod.deferral_reasons.values.map(&:dasherize).sample,
-            course_identifier: participant.api_ect_training_record_id.present? ? "ecf-induction" : "ecf-mentor",
+            course_identifier: course_identifier_for(participant),
           },
         },
       }
@@ -186,6 +186,43 @@ module ParityCheck
       participant = Teacher.find_by(api_id: deferred_teacher_api_id_for_participant_action)
 
       participant_defer_payload(participant)
+    end
+
+    def participant_resume_payload(participant)
+      {
+        data: {
+          type: "participant-resume",
+          attributes: {
+            course_identifier: course_identifier_for(participant),
+          }
+        }
+      }
+    end
+
+    def withdrawn_participant_resume_body
+      participant = Teacher.find_by(api_id: withdrawn_teacher_api_id_for_participant_action)
+
+      participant_resume_payload(participant)
+    end
+
+    def deferred_participant_resume_body
+      participant = Teacher.find_by(api_id: deferred_teacher_api_id_for_participant_action)
+
+      participant_resume_payload(participant)
+    end
+
+    def active_participant_resume_body
+      participant = Teacher.find_by(api_id: active_teacher_api_id_for_participant_action)
+
+      participant_resume_payload(participant)
+    end
+
+    def course_identifier_for(participant)
+      if participant.api_ect_training_record_id.present?
+        "ecf-induction"
+      else
+        "ecf-mentor"
+      end
     end
 
     # Helpers

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -28,7 +28,7 @@ get:
       id: ":statement_id"
       exclude:
         - type
-        
+
   - "/api/v3/schools":
       ecf_path: "/api/v3/schools/ecf"
       paginate: true
@@ -306,7 +306,7 @@ put:
         - challenged_at
         - challenged_reason
         - status
-        
+
   - "/api/v3/participants/:id/withdraw":
       ecf_path: "/api/v3/participants/ecf/:id/withdraw"
       id: ":active_teacher_api_id_for_participant_action"
@@ -324,3 +324,16 @@ put:
       ecf_path: "/api/v3/participants/ecf/:id/defer"
       id: ":deferred_teacher_api_id_for_participant_action"
       body: deferred_participant_defer_body
+
+  - "/api/v3/participants/:id/resume":
+      ecf_path: "/api/v3/participants/ecf/:id/resume"
+      id: ":withdrawn_teacher_api_id_for_participant_action"
+      body: withdrawn_participant_resume_body
+  - "/api/v3/participants/:id/resume":
+      ecf_path: "/api/v3/participants/ecf/:id/resume"
+      id: ":deferred_teacher_api_id_for_participant_action"
+      body: deferred_participant_resume_body
+  - "/api/v3/participants/:id/resume":
+      ecf_path: "/api/v3/participants/ecf/:id/resume"
+      id: ":active_teacher_api_id_for_participant_action"
+      body: active_participant_resume_body

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -399,5 +399,104 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         })
       end
     end
+
+    context "when fetching `withdrawn_participant_resume_body`" do
+      let(:identifier) { :withdrawn_participant_resume_body }
+      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+      let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
+      let(:teacher) { training_period.trainee.teacher }
+
+      before do
+        # Active participant for current lead provider
+        FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:)
+        # Deferred participant for current lead provider
+        FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:)
+        # Participant for different lead providers should not be used.
+        FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn)
+      end
+
+      it "returns a participant resume body for withdrawn participant" do
+        expect(Teacher)
+          .to receive(:find_by)
+          .with(api_id: teacher.api_id)
+          .and_call_original
+
+        expect(fetch).to eq({
+          data: {
+            type: "participant-resume",
+            attributes: {
+              course_identifier: "ecf-induction"
+            },
+          },
+        })
+      end
+    end
+
+    context "when fetching `deferred_participant_resume_body`" do
+      let(:identifier) { :deferred_participant_resume_body }
+      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+      let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :deferred, school_partnership:) }
+      let(:teacher) { training_period.trainee.teacher }
+
+      before do
+        # Active participant for current lead provider
+        FactoryBot.create(:training_period, :for_mentor, :ongoing, :active, school_partnership:)
+        # Withdrawn participant for current lead provider
+        FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:)
+        # Deferred participant for different lead provider
+        FactoryBot.create(:training_period, :for_mentor, :ongoing, :deferred)
+      end
+
+      it "returns a participant resume body for deferred participant" do
+        expect(Teacher)
+          .to receive(:find_by)
+          .with(api_id: teacher.api_id)
+          .and_call_original
+
+        expect(fetch).to eq({
+          data: {
+            type: "participant-resume",
+            attributes: {
+              course_identifier: "ecf-mentor"
+            },
+          },
+        })
+      end
+    end
+
+    context "when fetching `active_participant_resume_body`" do
+      let(:identifier) { :active_participant_resume_body }
+      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+      let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
+      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
+      let(:teacher) { training_period.trainee.teacher }
+
+      before do
+        # Deferred participant for current lead provider
+        FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:)
+        # Withdrawn participant for current lead provider
+        FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:)
+        # Participants for different lead providers should not be used
+        FactoryBot.create(:training_period, :for_ect, :ongoing)
+      end
+
+      it "returns a participant resume body for active participant" do
+        expect(Teacher)
+          .to receive(:find_by)
+          .with(api_id: teacher.api_id)
+          .and_call_original
+
+        expect(fetch).to eq({
+          data: {
+            type: "participant-resume",
+            attributes: {
+              course_identifier: "ecf-induction"
+            },
+          },
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2560

### Changes proposed in this pull request

This adds two requests to the parity check for the participant `/resume` endpoint.

One request compares responses when attempting to resume a withdrawn participant (i.e valid), and one request compares responses when attempting to resume a participant that is already active (i.e error).

### Guidance to review

Parity check (wait for #1620 to be merged and rebase)