### PR TITLE
[2415] Missing school navbar when impersonating

### DIFF
--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -29,6 +29,8 @@ module Navigation
     def navigation_area
       if current_path.start_with?('/api/guidance')
         :api_guidance
+      elsif current_user_type == :dfe_user_impersonating_school_user
+        :school_user
       else
         current_user_type
       end

--- a/spec/components/navigation/primary_navigation_component_spec.rb
+++ b/spec/components/navigation/primary_navigation_component_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Navigation::PrimaryNavigationComponent, type: :component do
   def validate_navigation_items(expected_items)
     expect(rendered_content).to have_css(nav_list_selector)
 
+    expect(page).to have_css('nav[aria-label="Menu"] a.govuk-service-navigation__link', count: expected_items.count)
+
     expected_items.each do |item|
       expect(rendered_content).to have_link(item[:text], href: item[:href])
     end
@@ -63,6 +65,7 @@ RSpec.describe Navigation::PrimaryNavigationComponent, type: :component do
 
         expected_items = [
           { text: "ECTs", href: "/school/home/ects" },
+          { text: "Mentors", href: "/school/home/mentors" }
         ]
 
         validate_navigation_items(expected_items)
@@ -116,6 +119,22 @@ RSpec.describe Navigation::PrimaryNavigationComponent, type: :component do
         ["Swagger API documentation", "Release notes", "Sandbox", "Guidance"].each do |other_page|
           expect(rendered_content).to have_css(".govuk-service-navigation__link", text: other_page)
         end
+      end
+    end
+
+    context "when dfe user is impersonating a school user" do
+      let(:current_user_type) { :dfe_user_impersonating_school_user }
+      let(:current_path) { "/schools" }
+
+      it "renders the same items a school user would see" do
+        render_inline(subject)
+
+        expected_items = [
+          { text: "ECTs", href: "/school/home/ects" },
+          { text: "Mentors", href: "/school/home/mentors" }
+        ]
+
+        validate_navigation_items(expected_items)
       end
     end
   end

--- a/spec/features/admin/schools/impersonating_a_school_spec.rb
+++ b/spec/features/admin/schools/impersonating_a_school_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Impersonating a school user', :enable_schools_interface do
     when_i_click_sign_in_as_school
     then_i_should_be_on_the_schools_home_page
     and_i_should_be_impersonating_the_school
+    and_i_should_see_the_same_navbar_a_school_sees
 
     when_i_click_sign_out
     then_i_should_be_on_the_admin_school_show_page
@@ -49,6 +50,11 @@ private
     body = page.locator('body')
 
     expect(body).to have_text("You are signed in as #{@school.name}")
+  end
+
+  def and_i_should_see_the_same_navbar_a_school_sees
+    expect(page.get_by_role('link', name: 'ECTs')).to be_visible
+    expect(page.get_by_role('link', name: 'Mentors')).to be_visible
   end
 
   def when_i_click_sign_out


### PR DESCRIPTION
### Context
DfE Users can "impersonate" school users, by signing in as them.  When they do that, they should see what a school sees.  But the nav bar was missing the ECTs and Mentors menu links, because the component picks this based on the `current_user`s type.

### Changes proposed in this pull request
Links now visible as per this screenshot:
![impersonating](https://github.com/user-attachments/assets/94d4fbce-d086-47f7-81bd-b3a4b5643d74)

Since there is only one user type a DfE user can impersonate, we simply add an exception in the component for this.
Also, the method in the tests for this component only tests that the named links appear on the page, not that there are the right number of links.  This means if a new nav-bar link is added the test will still trivially pass, as must have happened when the mentor link was added.

### Guidance to review
