### PR TITLE
[SPIKE] Add SIT details to school serializer

### DIFF
--- a/app/serializers/api/school_serializer.rb
+++ b/app/serializers/api/school_serializer.rb
@@ -16,12 +16,23 @@ class API::SchoolSerializer < Blueprinter::Base
       contract_period_metadata(school:, options:).induction_programme_choice
     end
     field(:expression_of_interest) do |school, options|
-      lead_provider_contract_period_metadata(school:, options:).expression_of_interest_or_school_partnership
+      expression_of_interest_or_school_partnership(school:, options:)
+    end
+    field :induction_tutor_name do |school, options|
+      school.induction_tutor_name if expression_of_interest_or_school_partnership(school:, options:)
+    end
+    field :induction_tutor_email do |school, options|
+      school.induction_tutor_email if expression_of_interest_or_school_partnership(school:, options:)
     end
     field :created_at
     field(:api_updated_at, name: :updated_at)
 
     class << self
+      def expression_of_interest_or_school_partnership(school:, options:)
+        @expression_of_interest_or_school_partnership ||= {}
+        @expression_of_interest_or_school_partnership["#{school},#{options}"] ||= lead_provider_contract_period_metadata(school:, options:).expression_of_interest_or_school_partnership
+      end
+
       def contract_period_metadata(school:, options:)
         school.contract_period_metadata.select { it.contract_period_year == options[:contract_period_year] }.sole
       end


### PR DESCRIPTION
### Context

This is a draft PR, please do not merge

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2151

SIT name and email is shown to lead providers after they've created a partnership.
However, now we've introduced expression_of_interest, we think this isn't sufficient. If a school has indicated a lead provider is training one of their ECTs or mentors, expression_of_interest turns TRUE.
There is a chance here that a school might indicate the wrong lead provider. In this case, the lead provider needs to contact the school to state they're not working with them. This would happen off-service.

### Changes proposed in this pull request

- Add SIT details in the schools serializer but only display it when expression of interest is true

### Guidance to review
