### PR TITLE
Ensure participants cannot be resumed with ongoing training

### DIFF
--- a/app/services/api/teachers/resume.rb
+++ b/app/services/api/teachers/resume.rb
@@ -3,6 +3,7 @@ module API::Teachers
     include API::Concerns::Teachers::SharedAction
 
     validate :not_already_active
+    validate :no_ongoing_today_training_period
     validate :school_period_ongoing_today
 
     def resume
@@ -22,6 +23,19 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
 
       errors.add(:teacher_api_id, "The '#/teacher_api_id' is already active.") if training_status&.active?
+    end
+
+    def no_ongoing_today_training_period
+      return if errors[:teacher_api_id].any?
+
+      school_period = training_period.trainee
+
+      if school_period.training_periods
+        .ongoing_today
+        .without(training_period)
+        .exists?
+        errors.add(:teacher_api_id, "The '#/teacher_api_id' is already active.")
+      end
     end
 
     def school_period_ongoing_today


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2723

### Changes proposed in this pull request

Before, it was possible for a participant to be resumed even when they had an ongoing training period at another lead provider.

This shouldn't be possible, because their training status for that lead provider is "active".

This change adds an extra validation that checks whether there are any other training periods that are "ongoing today" associated with the school period.

Now, when a participant is undergoing training at another lead provider they can no longer be "resumed" by another lead provider where their latest training period at that provider is "withdrawn" or "deferred".

### Guidance to review

- [ ] Try to resume a participant with ongoing training at another lead provider (before it would error, now we return `422`)
