### PR TITLE
[2727] Prevent participant actions against TPs that have not yet started

### DIFF
--- a/app/services/api/teachers/defer.rb
+++ b/app/services/api/teachers/defer.rb
@@ -14,7 +14,7 @@ module API::Teachers
               }, allow_blank: true
     validate :not_already_deferred
     validate :not_already_withdrawn
-    validate :not_started_yet
+    validate :training_period_has_started
 
     def defer
       return false if invalid?
@@ -44,11 +44,11 @@ module API::Teachers
       errors.add(:teacher_api_id, "The '#/teacher_api_id' is already deferred.")
     end
 
-    def not_started_yet
+    def training_period_has_started
       return if errors[:teacher_api_id].any?
       return unless training_period&.started_on&.future?
 
-      errors.add(:teacher_api_id, "The '#/teacher_api_id' has not yet started their training so cannot be deferred")
+      errors.add(:teacher_api_id, "You cannot defer '#/teacher_api_id'. This is because they've not started their training.")
     end
   end
 end

--- a/app/services/api/teachers/withdraw.rb
+++ b/app/services/api/teachers/withdraw.rb
@@ -12,7 +12,7 @@ module API::Teachers
       message: "The entered '#/reason' is not recognised for the given participant. Check details and try again."
     }, allow_blank: true
     validate :not_already_withdrawn
-    validate :not_started_yet
+    validate :training_period_has_started
 
     def withdraw
       return false unless valid?
@@ -35,11 +35,11 @@ module API::Teachers
       errors.add(:teacher_api_id, "The '#/teacher_api_id' is already withdrawn.")
     end
 
-    def not_started_yet
+    def training_period_has_started
       return if errors[:teacher_api_id].any?
       return unless training_period&.started_on&.future?
 
-      errors.add(:teacher_api_id, "The '#/teacher_api_id' has not yet started their training so cannot be withdrawn")
+      errors.add(:teacher_api_id, "You cannot withdraw '#/teacher_api_id'. This is because they've not started their training.")
     end
   end
 end

--- a/spec/services/api/teachers/defer_spec.rb
+++ b/spec/services/api/teachers/defer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
             let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "The '#/teacher_api_id' has not yet started their training so cannot be deferred") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot defer '#/teacher_api_id'. This is because they've not started their training.") }
           end
 
           context "guarded error messages" do

--- a/spec/services/api/teachers/withdraw_spec.rb
+++ b/spec/services/api/teachers/withdraw_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
             let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "The '#/teacher_api_id' has not yet started their training so cannot be withdrawn") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot withdraw '#/teacher_api_id'. This is because they've not started their training.") }
           end
 
           context "guarded error messages" do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2727

### Changes proposed in this pull request

* New validation for defer/withdraw endpoint to check if training period has started

### Guidance to review
