### PR TITLE
Adjust first period start date

### DIFF
--- a/app/migration/data_fixes.rb
+++ b/app/migration/data_fixes.rb
@@ -1,0 +1,6 @@
+module DataFixes
+  # FIXME: this doesn't account for groups so will set the first of each group
+  def earliest_initial_start_date(induction_record:)
+    [induction_record.start_date, induction_record.created_at].min
+  end
+end

--- a/app/migration/migrators/ect_at_school_period.rb
+++ b/app/migration/migrators/ect_at_school_period.rb
@@ -38,16 +38,11 @@ module Migrators
         .ect
         .eager_load(:schedule, induction_records: [induction_programme: [school_cohort: %i[school cohort]]])
         .find_each do |participant_profile|
-          sanitizer = InductionRecordSanitizer.new(participant_profile:, group_by: :school)
-
-          school_periods = []
+          # testing data fixes so remove grouping
+          sanitizer = InductionRecordSanitizer.new(participant_profile:)
 
           if sanitizer.valid?
-            sanitizer.induction_records.each_value do |induction_records_group|
-              school_periods << SchoolPeriodExtractor.new(induction_records: induction_records_group).school_periods
-            end
-
-            school_periods.flatten!
+            school_periods = SchoolPeriodExtractor.new(induction_records: sanitizer).school_periods
 
             ect_payments_frozen_year = participant_profile.previous_payments_frozen_cohort_start_year
             teacher.ect_payments_frozen_year = ect_payments_frozen_year if ect_payments_frozen_year

--- a/app/migration/school_period_extractor.rb
+++ b/app/migration/school_period_extractor.rb
@@ -1,5 +1,6 @@
 class SchoolPeriodExtractor
   include Enumerable
+  include DataFixes
 
   attr_reader :induction_records
 
@@ -28,6 +29,7 @@ private
   def build_school_periods_from_induction_records
     current_period = nil
     current_school = nil
+    first_record = true
 
     induction_records.each_with_object([]) do |induction_record, periods|
       record_school = induction_record.induction_programme.school_cohort.school
@@ -36,8 +38,15 @@ private
       if current_school != record_school
         current_school = record_school
 
+        start_date = if first_record
+                       first_record = false
+                       earliest_initial_start_date(induction_record:)
+                     else
+                       induction_record.start_date
+                     end
+
         current_period = Migration::SchoolPeriod.new(urn: current_school.urn,
-                                                     start_date: induction_record.start_date,
+                                                     start_date:,
                                                      end_date: induction_record.end_date,
                                                      start_source_id: induction_record.id,
                                                      end_source_id: induction_record.id,

--- a/app/migration/training_period_extractor.rb
+++ b/app/migration/training_period_extractor.rb
@@ -1,5 +1,6 @@
 class TrainingPeriodExtractor
   include Enumerable
+  include DataFixes
 
   def initialize(induction_records:)
     @induction_records = induction_records
@@ -20,6 +21,7 @@ private
   def build_training_periods
     current_period = nil
     current_programme = nil
+    first_record = true
 
     @induction_records.each_with_object([]) do |induction_record, periods|
       record_programme = induction_record.induction_programme
@@ -42,13 +44,20 @@ private
         core_materials = current_programme.core_induction_programme&.name
         school_urn = current_programme.school_cohort.school.urn
 
+        start_date = if first_record
+                       first_record = false
+                       earliest_initial_start_date(induction_record:)
+                     else
+                       induction_record.start_date
+                     end
+
         current_period = Migration::TrainingPeriodData.new(training_programme:,
                                                            school_urn:,
                                                            lead_provider:,
                                                            delivery_partner:,
                                                            core_materials:,
                                                            cohort_year: induction_record.schedule.cohort.start_year,
-                                                           start_date: induction_record.start_date,
+                                                           start_date:,
                                                            end_date: induction_record.end_date,
                                                            start_source_id: induction_record.id,
                                                            end_source_id: induction_record.id)

--- a/spec/factories/migration/core_induction_programme_factory.rb
+++ b/spec/factories/migration/core_induction_programme_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :migration_core_induction_programme, class: "Migration::CoreInductionProgramme" do
+    sequence(:name) { |n| "Migration Core Induction Programme #{n}" }
+  end
+end

--- a/spec/factories/migration/induction_programme_factory.rb
+++ b/spec/factories/migration/induction_programme_factory.rb
@@ -2,5 +2,17 @@ FactoryBot.define do
   factory :migration_induction_programme, class: "Migration::InductionProgramme" do
     training_programme { :full_induction_programme }
     school_cohort { FactoryBot.create(:migration_school_cohort, induction_programme_choice: training_programme) }
+
+    trait :provider_led do
+      training_programme { :full_induction_programme }
+      core_induction_programme { nil }
+      partnership { FactoryBot.create(:migration_partnership) }
+    end
+
+    trait :school_led do
+      training_programme { :core_induction_programme }
+      core_induction_programme { FactoryBot.create(:migration_core_induction_programme) }
+      partnership { nil }
+    end
   end
 end

--- a/spec/migration/migrators/ect_at_school_period_spec.rb
+++ b/spec/migration/migrators/ect_at_school_period_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe Migrators::ECTAtSchoolPeriod do
           teacher_profile.participant_profiles.first.induction_records.each do |induction_record|
             expect(teacher.ect_pupil_premium_uplift).to eq(teacher_profile.participant_profiles.first.pupil_premium_uplift)
             expect(teacher.ect_sparsity_uplift).to eq(teacher_profile.participant_profiles.first.sparsity_uplift)
-            expect(teacher.ect_at_school_periods.first.started_on.to_date).to eq induction_record.start_date.to_date
+
+            earliest_start_date = [induction_record.start_date, induction_record.created_at].min.to_date
+            expect(teacher.ect_at_school_periods.first.started_on.to_date).to eq earliest_start_date
+
             expect(teacher.ect_at_school_periods.first.school.urn).to eq induction_record.induction_programme.school_cohort.school.urn.to_i
           end
         end

--- a/spec/migration/school_period_extractor_spec.rb
+++ b/spec/migration/school_period_extractor_spec.rb
@@ -1,0 +1,74 @@
+describe SchoolPeriodExtractor do
+  subject(:service) { described_class.new(induction_records:) }
+
+  let(:induction_programme_1) { FactoryBot.create(:migration_induction_programme, :provider_led) }
+  let(:induction_programme_2) { FactoryBot.create(:migration_induction_programme, :provider_led) }
+
+  let(:induction_record_1) do
+    FactoryBot.create(:migration_induction_record,
+                      induction_programme: induction_programme_1,
+                      end_date: 1.week.ago)
+  end
+  let(:induction_record_2) do
+    FactoryBot.create(:migration_induction_record,
+                      participant_profile:,
+                      induction_programme: induction_programme_2)
+  end
+  let(:participant_profile) { induction_record_1.participant_profile }
+  let(:induction_records) { [induction_record_1, induction_record_2] }
+
+  let(:school_1) { induction_programme_1.school_cohort.school }
+  let(:school_2) { induction_programme_2.school_cohort.school }
+
+  before do
+    CacheManager.instance.clear_all_caches!
+  end
+
+  describe "#school_periods" do
+    it "extracts school periods from the induction_records" do
+      periods = service.school_periods
+
+      expect(periods.count).to eq 2
+    end
+
+    it "sets the correct values in the periods" do
+      periods = service.school_periods
+
+      expect(periods[0].urn).to eq school_1.urn
+      expect(periods[0].start_date).to eq induction_record_1.start_date
+      expect(periods[0].end_date).to eq induction_record_1.end_date
+      expect(periods[0].start_source_id).to eq induction_record_1.id
+      expect(periods[0].end_source_id).to eq induction_record_1.id
+      expect(periods[0].training_programme).to eq "provider_led"
+
+      expect(periods[1].urn).to eq school_2.urn
+      expect(periods[1].start_date).to eq induction_record_2.start_date
+      expect(periods[1].end_date).to eq induction_record_2.end_date
+      expect(periods[1].start_source_id).to eq induction_record_2.id
+      expect(periods[1].end_source_id).to eq induction_record_2.id
+      expect(periods[1].training_programme).to eq "provider_led"
+    end
+
+    context "when the first induction record created_at is earlier than the start_date" do
+      let(:induction_record_1) do
+        FactoryBot.create(:migration_induction_record,
+                          induction_programme: induction_programme_1,
+                          created_at: 6.months.ago,
+                          start_date: 1.month.ago,
+                          end_date: 1.week.ago)
+      end
+
+      it "adjusts the first period start to be the created_at" do
+        periods = service.school_periods
+
+        expect(periods[0].start_date).to eq induction_record_1.created_at
+      end
+
+      it "does not adjust subsequent periods" do
+        periods = service.school_periods
+
+        expect(periods[1].start_date).to eq induction_record_2.start_date
+      end
+    end
+  end
+end

--- a/spec/migration/training_period_extractor_spec.rb
+++ b/spec/migration/training_period_extractor_spec.rb
@@ -1,0 +1,86 @@
+describe TrainingPeriodExtractor do
+  subject(:service) { described_class.new(induction_records:) }
+
+  let(:induction_programme_1) { FactoryBot.create(:migration_induction_programme, :provider_led) }
+  let(:induction_programme_2) { FactoryBot.create(:migration_induction_programme, :provider_led) }
+
+  let(:induction_record_1) do
+    FactoryBot.create(:migration_induction_record,
+                      induction_programme: induction_programme_1,
+                      end_date: 1.week.ago)
+  end
+  let(:induction_record_2) do
+    FactoryBot.create(:migration_induction_record,
+                      participant_profile:,
+                      induction_programme: induction_programme_2)
+  end
+  let(:participant_profile) { induction_record_1.participant_profile }
+  let(:induction_records) { [induction_record_1, induction_record_2] }
+
+  let(:school_1) { induction_programme_1.school_cohort.school }
+  let(:school_2) { induction_programme_2.school_cohort.school }
+
+  let(:lead_provider_1) { induction_programme_1.partnership.lead_provider.name }
+  let(:delivery_partner_1) { induction_programme_1.partnership.delivery_partner.name }
+
+  let(:lead_provider_2) { induction_programme_2.partnership.lead_provider.name }
+  let(:delivery_partner_2) { induction_programme_2.partnership.delivery_partner.name }
+
+  before do
+    CacheManager.instance.clear_all_caches!
+  end
+
+  describe "#training_periods" do
+    it "extracts training periods from the induction_records" do
+      periods = service.training_periods
+
+      expect(periods.count).to eq 2
+    end
+
+    it "sets the correct values in the periods" do
+      periods = service.training_periods
+
+      expect(periods[0].school_urn).to eq school_1.urn
+      expect(periods[0].start_date).to eq induction_record_1.start_date
+      expect(periods[0].end_date).to eq induction_record_1.end_date
+      expect(periods[0].training_programme).to eq "provider_led"
+      expect(periods[0].lead_provider).to eq lead_provider_1
+      expect(periods[0].delivery_partner).to eq delivery_partner_1
+      expect(periods[0].cohort_year).to eq induction_record_1.schedule.cohort.start_year
+      expect(periods[0].start_source_id).to eq induction_record_1.id
+      expect(periods[0].end_source_id).to eq induction_record_1.id
+
+      expect(periods[1].school_urn).to eq school_2.urn
+      expect(periods[1].start_date).to eq induction_record_2.start_date
+      expect(periods[1].end_date).to eq induction_record_2.end_date
+      expect(periods[1].training_programme).to eq "provider_led"
+      expect(periods[1].lead_provider).to eq lead_provider_2
+      expect(periods[1].delivery_partner).to eq delivery_partner_2
+      expect(periods[1].cohort_year).to eq induction_record_2.schedule.cohort.start_year
+      expect(periods[1].start_source_id).to eq induction_record_2.id
+      expect(periods[1].end_source_id).to eq induction_record_2.id
+    end
+
+    context "when the first induction record created_at is earlier than the start_date" do
+      let(:induction_record_1) do
+        FactoryBot.create(:migration_induction_record,
+                          induction_programme: induction_programme_1,
+                          created_at: 6.months.ago,
+                          start_date: 1.month.ago,
+                          end_date: 1.week.ago)
+      end
+
+      it "adjusts the first period start to be the created_at" do
+        periods = service.training_periods
+
+        expect(periods[0].start_date).to eq induction_record_1.created_at
+      end
+
+      it "does not adjust subsequent periods" do
+        periods = service.training_periods
+
+        expect(periods[1].start_date).to eq induction_record_2.start_date
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

From the data analysis we've been performing it appears that it would be beneficial to try to adjust a teachers first period start date to be either the designated `start_date` or the `created_at` date from the first induction record, whichever is the earliest.  This should help us manage other periods and declaration dates.

### Changes proposed in this pull request

Adjust the start date to be the earliest date between `start_date` and `created_at` from the first induction record for the first at_school and training periods.

### Guidance to review
