### PR TITLE
[2739] Add `api_unfunded_mentor_updated_at` to teachers

### DIFF
--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -15,6 +15,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: 'TrainingPeriod'
 
   touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_updated_at
+  touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -53,6 +53,15 @@ class Teacher < ApplicationRecord
           mentor_payments_frozen_year
         ]
 
+  touch -> { self },
+        on_event: :update,
+        timestamp_attribute: :api_unfunded_mentor_updated_at,
+        when_changing: %i[
+          trs_first_name
+          trs_last_name
+          trn
+        ]
+
   refresh_metadata -> { self }, on_event: %i[create update]
 
   # Validations

--- a/app/serializers/api/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/unfunded_mentor_serializer.rb
@@ -1,0 +1,20 @@
+class API::UnfundedMentorSerializer < Blueprinter::Base
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name_in_trs }
+    field(:email) do |teacher, _options|
+      teacher.latest_mentor_at_school_period.email
+    end
+    field(:trn, name: :teacher_reference_number)
+    field :created_at
+    field(:api_unfunded_mentor_updated_at, name: :updated_at)
+  end
+
+  identifier :api_id, name: :id
+  field(:type) { "unfunded-mentor" }
+
+  association :attributes, blueprint: AttributesSerializer do |teacher|
+    teacher
+  end
+end

--- a/db/migrate/20251107160952_add_api_unfunded_mentor_updated_at_to_teachers.rb
+++ b/db/migrate/20251107160952_add_api_unfunded_mentor_updated_at_to_teachers.rb
@@ -1,0 +1,8 @@
+class AddAPIUnfundedMentorUpdatedAtToTeachers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :teachers, :api_unfunded_mentor_updated_at, :datetime, default: -> { "CURRENT_TIMESTAMP" }
+    add_index :teachers, :api_unfunded_mentor_updated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_03_152540) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_07_160952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -792,9 +792,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_03_152540) do
     t.datetime "mentor_first_became_eligible_for_training_at"
     t.boolean "trnless", default: false, null: false
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
+    t.index ["api_unfunded_mentor_updated_at"], name: "index_teachers_on_api_unfunded_mentor_updated_at"
     t.index ["api_updated_at"], name: "index_teachers_on_api_updated_at"
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["created_at"], name: "index_teachers_on_created_at"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -157,6 +157,7 @@ erDiagram
     datetime mentor_first_became_eligible_for_training_at
     boolean trnless
     datetime api_updated_at
+    datetime api_unfunded_mentor_updated_at
   }
   PendingInductionSubmission {
     integer id


### PR DESCRIPTION
### Context

**This is only a spike PR, please do not merge.**

Ticket: [2739](https://github.com/DFE-Digital/register-ects-project-board/issues/2739
)

The updated_at in ECF for unfunded mentors isn't accurate; we filter on the User#updated_at, however this will not change relative to the serialized response.

### Changes proposed in this pull request

- Add api_unfunded_mentor_updated_at to teachers

### Guidance to review
