### PR TITLE
[2775] Add a teacher type attribute to Schedule

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,10 @@
 class Schedule < ApplicationRecord
+  MENTOR_TEACHER_TYPE_IDENTIFIERS = %w[
+    ecf-replacement-april
+    ecf-replacement-january
+    ecf-replacement-september
+  ].freeze
+
   enum :identifier,
        {
          'ecf-extended-april' => 'ecf-extended-april',
@@ -28,4 +34,8 @@ class Schedule < ApplicationRecord
               message: 'Can be used once per contract period',
               scope: :contract_period_year
             }
+
+  def teacher_type
+    @teacher_type ||= MENTOR_TEACHER_TYPE_IDENTIFIERS.include?(identifier) ? :mentor : :ect
+  end
 end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -25,4 +25,40 @@ describe Schedule do
       expect(duplicate.errors.messages.fetch(:identifier)).to include('Can be used once per contract period')
     end
   end
+
+  describe '.teacher_type' do
+    %w[
+      ecf-extended-april
+      ecf-extended-january
+      ecf-extended-september
+      ecf-reduced-april
+      ecf-reduced-january
+      ecf-reduced-september
+      ecf-standard-april
+      ecf-standard-january
+      ecf-standard-september
+    ].each do |identifier|
+      context "when identifier is '#{identifier}'" do
+        subject(:schedule) { FactoryBot.build(:schedule, identifier:) }
+
+        it "returns :ect teacher type" do
+          expect(schedule.teacher_type).to eq(:ect)
+        end
+      end
+    end
+
+    %w[
+      ecf-replacement-april
+      ecf-replacement-january
+      ecf-replacement-september
+    ].each do |identifier|
+      context "when identifier is '#{identifier}'" do
+        subject(:schedule) { FactoryBot.build(:schedule, identifier:) }
+
+        it "returns :mentor teacher type" do
+          expect(schedule.teacher_type).to eq(:mentor)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2775

### Changes proposed in this pull request

* Hardcode `teacher_type` method on `Schedule` to return `:ect`/`:mentor`

### Guidance to review
