### PR TITLE
Prevent ECT training periods from being associated with replacement schedules

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,10 @@
 class Schedule < ApplicationRecord
+  REPLACEMENT_SCHEDULE_IDENTIFIERS = %w[
+    ecf-replacement-april
+    ecf-replacement-january
+    ecf-replacement-september
+  ].freeze
+
   enum :identifier,
        {
          'ecf-extended-april' => 'ecf-extended-april',
@@ -28,4 +34,12 @@ class Schedule < ApplicationRecord
               message: 'Can be used once per contract period',
               scope: :contract_period_year
             }
+
+  scope :excluding_replacement_schedules, -> {
+    where.not(identifier: REPLACEMENT_SCHEDULE_IDENTIFIERS)
+  }
+
+  def replacement_schedule?
+    identifier.in?(REPLACEMENT_SCHEDULE_IDENTIFIERS)
+  end
 end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -81,6 +81,7 @@ class TrainingPeriod < ApplicationRecord
   validates :deferral_reason, presence: true, if: -> { deferred_at.present? }
   validate :schedule_contract_period_matches, if: :provider_led_training_programme?
   validate :schedule_absent_for_school_led, if: :school_led_training_programme?
+  validate :schedule_applicable_for_trainee
 
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
@@ -188,5 +189,12 @@ private
     return if schedule.blank?
 
     errors.add(:schedule, 'Schedule must be absent for school-led training programmes')
+  end
+
+  def schedule_applicable_for_trainee
+    return if schedule.blank?
+    return unless for_ect?
+
+    errors.add(:schedule, "Only mentors can be assigned to replacement schedules") if schedule.replacement_schedule?
   end
 end

--- a/app/services/sandbox_seed_data/api_teachers_with_histories.rb
+++ b/app/services/sandbox_seed_data/api_teachers_with_histories.rb
@@ -105,6 +105,7 @@ module SandboxSeedData
       end
 
       Schedule
+        .excluding_replacement_schedules
         .where(contract_period:)
         .order(Arel.sql("RANDOM()"))
         .first

--- a/db/seeds/api_teachers_with_histories.rb
+++ b/db/seeds/api_teachers_with_histories.rb
@@ -103,7 +103,19 @@ ActiveLeadProvider.find_each do |active_lead_provider|
       ).tap { |sp| send(:"describe_#{trainee_type}_at_school_period", sp) }
 
       school_partnership = random_school_partnership(active_lead_provider:)
-      schedule = Schedule.where(contract_period:).order("RANDOM()").first
+
+      schedule = if trainee_type == :mentor
+                   Schedule
+                    .where(contract_period:)
+                    .order("RANDOM()")
+                    .first
+                 else
+                   Schedule
+                    .excluding_replacement_schedules
+                    .where(contract_period:)
+                    .order("RANDOM()")
+                    .first
+                 end
 
       FactoryBot.create(
         :training_period,

--- a/spec/factories/schedule_factory.rb
+++ b/spec/factories/schedule_factory.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     initialize_with do
       Schedule.find_or_create_by(contract_period:, identifier:)
     end
+
+    trait :replacement_schedule do
+      identifier { 'ecf-replacement-september' }
+    end
   end
 end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -25,4 +25,29 @@ describe Schedule do
       expect(duplicate.errors.messages.fetch(:identifier)).to include('Can be used once per contract period')
     end
   end
+
+  describe "scopes" do
+    describe ".excluding_replacement_schedules" do
+      subject { Schedule.excluding_replacement_schedules }
+
+      let!(:replacement_schedule) { FactoryBot.create(:schedule, identifier: 'ecf-replacement-april') }
+      let!(:standard_schedule) { FactoryBot.create(:schedule, identifier: 'ecf-standard-april') }
+
+      it 'returns only standard schedules' do
+        expect(subject).to contain_exactly(standard_schedule)
+      end
+    end
+  end
+
+  describe "#replacement_schedule?" do
+    it "returns true for replacement schedules" do
+      schedule = Schedule.new(identifier: 'ecf-replacement-april')
+      expect(schedule).to be_replacement_schedule
+    end
+
+    it "returns false for non-replacement schedules" do
+      schedule = Schedule.new(identifier: 'ecf-standard-april')
+      expect(schedule).not_to be_replacement_schedule
+    end
+  end
 end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -505,6 +505,29 @@ describe TrainingPeriod do
         end
       end
     end
+
+    describe "schedule applicable for trainee" do
+      it "adds an error when an ECT is assigned to a replacement schedule" do
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
+        training_period = FactoryBot.build(:training_period, :for_ect, ect_at_school_period:, schedule: FactoryBot.create(:schedule, :replacement_schedule))
+        training_period.valid?
+        expect(training_period.errors[:schedule]).to include("Only mentors can be assigned to replacement schedules")
+      end
+
+      it "does not add an error when a mentor is assigned to a replacement schedule" do
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
+        training_period = FactoryBot.build(:training_period, :for_mentor, mentor_at_school_period:, schedule: FactoryBot.create(:schedule, :replacement_schedule))
+        training_period.valid?
+        expect(training_period.errors[:schedule]).to be_empty
+      end
+
+      it "does not add an error when an ECT is assigned to a non-replacement schedule" do
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
+        training_period = FactoryBot.build(:training_period, :for_ect, ect_at_school_period:, schedule: FactoryBot.create(:schedule))
+        training_period.valid?
+        expect(training_period.errors[:schedule]).to be_empty
+      end
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
Reverts DFE-Digital/register-early-career-teachers-public#1694

Initially, we thought that mentors could only transfer to replacement schedules however looking at ECF again that's not actually the case. A mentor can transfer to _any_ schedule but an ECT can't transfer to a replacement schedule.

Reverting this as I think it makes more sense to implement this check in the `ChangeSchedule` service and impose validation in the `TrainingPeriod` to ensure it.

- Prevent ECTs from being assigned to replacement schedules

We only allow mentors to be assigned to replacement schedules.

**Note: before this goes out we'll potentially need to fix any bad data in staging/sandbox where an ECT is assigned to a replacement schedule** done ✅ 

Script to update staging/sandbox:

```
ActiveRecord::Base.transaction do
  replacement_identifiers = %w[ecf-replacement-april ecf-replacement-january ecf-replacement-september]
  replacement_schedules = Schedule.where(identifier: replacement_identifiers)

  ect_training_periods = []
  replacement_schedules.each do |schedule|
    ect_training_periods += schedule.training_periods.select(&:for_ect?)
  end

  ect_training_periods.each do |tp|
    contract_period = tp.schedule.contract_period
    schedule = Schedule.find_by(
      contract_period:,
      identifier: "ecf-standard-september"
    )

    if Faker::Boolean.boolean(true_ratio: 0.2)
      schedule = Schedule
        .where.not(identifier: replacement_identifiers)
        .where(contract_period:)
        .order(Arel.sql("RANDOM()"))
        .first
    end

    tp.update!(schedule:)
  end
end
```