### PR TITLE
Rename `govuk_date_of_birth` method to `formatted_date_of_birth`

### DIFF
--- a/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
+++ b/app/views/schools/register_ect_wizard/_review_ect_details.html.erb
@@ -21,7 +21,7 @@
   if @ect.matches_trs_dob?
     summary_list.with_row do |row|
       row.with_key(text: 'Date of birth')
-      row.with_value(text: @ect.govuk_date_of_birth)
+      row.with_value(text: @ect.formatted_date_of_birth)
     end
   else
     summary_list.with_row do |row|

--- a/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
+++ b/app/views/schools/register_mentor_wizard/_review_mentor_details.html.erb
@@ -18,7 +18,7 @@
   if @mentor.matches_trs_dob?
     summary_list.with_row do |row|
       row.with_key(text: 'Date of birth')
-      row.with_value(text: @mentor.govuk_date_of_birth)
+      row.with_value(text: @mentor.formatted_date_of_birth)
     end
   else
     summary_list.with_row do |row|

--- a/app/wizards/schools/register_ect_wizard/registration_session.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_session.rb
@@ -21,7 +21,7 @@ module Schools
 
       delegate :full_name,
                :formatted_working_pattern,
-               :govuk_date_of_birth,
+               :formatted_date_of_birth,
                to: :presenter
 
       delegate :previous_school,

--- a/app/wizards/schools/register_ect_wizard/registration_session/presenter.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_session/presenter.rb
@@ -14,7 +14,7 @@ module Schools
           registration_session.working_pattern&.humanize
         end
 
-        def govuk_date_of_birth
+        def formatted_date_of_birth
           registration_session.trs_date_of_birth&.to_date&.to_formatted_s(:govuk)
         end
 

--- a/app/wizards/schools/register_mentor_wizard/mentor.rb
+++ b/app/wizards/schools/register_mentor_wizard/mentor.rb
@@ -27,7 +27,7 @@ module Schools
         @full_name ||= (corrected_name || trs_full_name).strip
       end
 
-      def govuk_date_of_birth
+      def formatted_date_of_birth
         trs_date_of_birth.to_date&.to_formatted_s(:govuk)
       end
 

--- a/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
+++ b/spec/views/schools/register_ect_wizard/shared_examples/use_previous_ect_choices_view.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "a use previous ect choices view" do |current_step:, back_
                      full_name: 'John Doe',
                      trn: '123456',
                      email: 'foo@bar.com',
-                     govuk_date_of_birth: '12 January 1931',
+                     formatted_date_of_birth: '12 January 1931',
                      start_date: 'September 2022',
                      training_programme: 'school_led',
                      appropriate_body_type: 'teaching_school_hub',

--- a/spec/wizards/schools/register_ect_wizard/registration_session/presenter_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_session/presenter_spec.rb
@@ -47,16 +47,16 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationSession::Presenter do
     end
   end
 
-  describe '#govuk_date_of_birth' do
+  describe '#formatted_date_of_birth' do
     it 'formats the TRS date of birth' do
-      expect(presenter.govuk_date_of_birth).to eq('12 May 1980')
+      expect(presenter.formatted_date_of_birth).to eq('12 May 1980')
     end
 
     context 'when TRS date of birth is missing' do
       let(:trs_date_of_birth) { nil }
 
       it 'returns nil' do
-        expect(presenter.govuk_date_of_birth).to be_nil
+        expect(presenter.formatted_date_of_birth).to be_nil
       end
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/registration_session_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_session_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationSession do
     end
   end
 
-  describe '#govuk_date_of_birth' do
+  describe '#formatted_date_of_birth' do
     it 'formats the date of birth in the govuk format' do
-      expect(registration_session.govuk_date_of_birth).to eq("11 October 1945")
+      expect(registration_session.formatted_date_of_birth).to eq("11 October 1945")
     end
   end
 

--- a/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/mentor_spec.rb
@@ -103,9 +103,9 @@ describe Schools::RegisterMentorWizard::Mentor do
     end
   end
 
-  describe '#govuk_date_of_birth' do
+  describe '#formatted_date_of_birth' do
     it 'formats the date of birth in the govuk format' do
-      expect(mentor.govuk_date_of_birth).to eq("11 October 1945")
+      expect(mentor.formatted_date_of_birth).to eq("11 October 1945")
     end
   end
 


### PR DESCRIPTION
### Context

The current method name makes it sound like it's the canonical source, changing the name to `formatted_date_of_birth` removes that ambiguity.

### Changes proposed in this pull request

`govuk_date_of_birth` -> `formatted_date_of_birth`

### Guidance to review

:shipit: 
