### PR TITLE
Fix flakey spec making sure we create non-replacement schedules in the setup

### DIFF
--- a/spec/services/sandbox_seed_data/api_teachers_with_histories_spec.rb
+++ b/spec/services/sandbox_seed_data/api_teachers_with_histories_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SandboxSeedData::APITeachersWithHistories do
     # Ensure the default and other schedules exist for some contract periods
     school_partnerships.each do |school_partnership|
       FactoryBot.create(:schedule, contract_period: school_partnership.contract_period)
-      FactoryBot.create(:schedule, contract_period: school_partnership.contract_period, identifier: Schedule.identifiers.keys.sample)
+      FactoryBot.create(:schedule, contract_period: school_partnership.contract_period, identifier: Schedule.excluding_replacement_schedules.identifiers.keys.sample)
     end
   end
 


### PR DESCRIPTION
### Context

`spec/services/sandbox_seed_data/api_teachers_with_histories_spec.rb:50` is flakey. [Failed run](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/19329382744/job/55288426974) 

We're now [excluding replacement schedules from the data generator](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/app/services/sandbox_seed_data/api_teachers_with_histories.rb#L108), so we need to make sure we create a non-replacement schedule in the spec setup. It was creating replacement schedules sometimes as the identifier is random selected.

### Changes proposed in this pull request

- Fix flakey spec;

### Guidance to review
