### PR TITLE
Don't retain `expression_of_interest` across training periods on `Resume`

### DIFF
--- a/app/services/teachers/resume.rb
+++ b/app/services/teachers/resume.rb
@@ -16,7 +16,7 @@ module Teachers
           started_on: Time.zone.today,
           finished_on: training_period.trainee.finished_on,
           school_partnership: training_period.school_partnership,
-          expression_of_interest: training_period.expression_of_interest,
+          expression_of_interest: nil,
           schedule: training_period.schedule,
           author:
         ).call

--- a/spec/services/teachers/resume_spec.rb
+++ b/spec/services/teachers/resume_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Teachers::Resume do
             expect(created_training_period.started_on).to eq(Time.zone.today)
             expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
-            expect(created_training_period.expression_of_interest).to eq(training_period.expression_of_interest)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
         end
@@ -82,7 +81,6 @@ RSpec.describe Teachers::Resume do
             expect(created_training_period.started_on).to eq(Time.zone.today)
             expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
-            expect(created_training_period.expression_of_interest).to eq(training_period.expression_of_interest)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
         end
@@ -104,7 +102,6 @@ RSpec.describe Teachers::Resume do
             expect(created_training_period.started_on).to eq(Time.zone.today)
             expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
-            expect(created_training_period.expression_of_interest).to eq(training_period.expression_of_interest)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
         end
@@ -127,7 +124,6 @@ RSpec.describe Teachers::Resume do
             expect(created_training_period.started_on).to eq(Time.zone.today)
             expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
-            expect(created_training_period.expression_of_interest).to eq(training_period.expression_of_interest)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
         end
@@ -153,7 +149,6 @@ RSpec.describe Teachers::Resume do
             expect(created_training_period.started_on).to eq(Time.zone.today)
             expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
-            expect(created_training_period.expression_of_interest).to eq(training_period.expression_of_interest)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
         end


### PR DESCRIPTION
When a new training period is created on `Resume` we don't want to bring across the `expression_of_interest`. We surface this in the API if _any_ training period has it set relative to a school and it only makes sense to set it on the training period that it was originally actioned on.
