### PR TITLE
[2737] Add unfunded mentors endpoints to swagger docs

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -776,6 +776,76 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
+  "/api/v3/unfunded-mentors":
+    get:
+      summary: Retrieve multiple unfunded mentors
+      tags:
+      - Unfunded mentors
+      security:
+      - api_key: []
+      parameters:
+      - name: filter
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/UnfundedMentorsFilter"
+        style: deepObject
+      - name: page
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
+      - name: sort
+        in: query
+        required: false
+        schema:
+          "$ref": "#/components/schemas/SortingTimestamps"
+      responses:
+        '200':
+          description: A list of unfunded mentors
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnfundedMentorsResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+  "/api/v3/unfunded-mentors/{id}":
+    get:
+      summary: Retrieve a single unfunded mentor
+      tags:
+      - Unfunded mentors
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: A single unfunded mentor
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnfundedMentorResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
 components:
   securitySchemes:
     api_key:
@@ -1764,3 +1834,72 @@ components:
           type: string
           format: date_time
           example: '2023-01-01T12:00:00Z'
+    UnfundedMentor:
+      description: An unfunded mentor
+      type: object
+      required:
+      - id
+      - type
+      - attributes
+      properties:
+        id:
+          "$ref": "#/components/schemas/IDAttribute"
+        type:
+          description: The data type.
+          type: string
+          example: unfunded-mentor
+          enum:
+          - unfunded-mentor
+        attributes:
+          properties:
+            full_name:
+              description: The full name of this unfunded mentor
+              type: string
+              nullable: false
+              example: John Doe
+            email:
+              description: The email address registered for this unfunded mentor
+              type: string
+              example: jane.smith@example.com
+            teacher_reference_number:
+              description: The Teacher Reference Number (TRN) for this unfunded mentor
+              type: string
+              nullable: true
+              example: '1234567'
+            created_at:
+              description: The date and time the unfunded mentor was created
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+            updated_at:
+              description: The date and time the unfunded mentor was last updated
+              type: string
+              format: date-time
+              example: '2021-05-31T02:22:32.000Z'
+    UnfundedMentorsFilter:
+      description: Filter unfunded mentors to return more specific results
+      type: object
+      properties:
+        updated_since:
+          description: Return only records that have been updated since this date
+            and time (ISO 8601 date format)
+          type: string
+          example: '2021-05-13T11:21:55Z'
+    UnfundedMentorResponse:
+      description: A single unfunded mentor.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          "$ref": "#/components/schemas/UnfundedMentor"
+    UnfundedMentorsResponse:
+      description: A list of unfunded mentors.
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/UnfundedMentor"

--- a/spec/requests/api/docs/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/docs/v3/unfunded_mentors_spec.rb
@@ -1,0 +1,41 @@
+require "swagger_helper"
+
+describe "Unfunded mentors endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml" do
+  include MentorshipPeriodHelpers
+
+  include_context "with authorization for api doc request"
+
+  let(:lead_provider_delivery_partnership) do
+    FactoryBot.create(
+      :lead_provider_delivery_partnership,
+      active_lead_provider:
+    )
+  end
+  let(:school_partnership) do
+    FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+  end
+  let!(:unfunded_mentor) do
+    create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher
+  end
+
+  let(:resource) { unfunded_mentor }
+
+  it_behaves_like "an API index endpoint documentation",
+                  {
+                    url: "/api/v3/unfunded-mentors",
+                    tag: "Unfunded mentors",
+                    resource_description: "unfunded mentors",
+                    response_schema_ref: "#/components/schemas/UnfundedMentorsResponse",
+                    filter_schema_ref: "#/components/schemas/UnfundedMentorsFilter",
+                    sorting_schema_ref: "#/components/schemas/SortingTimestamps",
+                  }
+
+  it_behaves_like "an API show endpoint documentation",
+                  {
+                    url: "/api/v3/unfunded-mentors/{id}",
+                    tag: "Unfunded mentors",
+                    resource_description: "unfunded mentor",
+                    response_schema_ref: "#/components/schemas/UnfundedMentorResponse",
+                  } do
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -86,6 +86,13 @@ RSpec.configure do |config|
           ParticipantsResponse: PARTICIPANTS_RESPONSE,
           ParticipantECFEnrolment: PARTICIPANT_ECF_ENROLMENT,
           ParticipantIDChange: PARTICIPANT_ID_CHANGE,
+
+          # Unfunded mentors
+          UnfundedMentor: UNFUNDED_MENTOR,
+          UnfundedMentorsFilter: UNFUNDED_MENTORS_FILTER,
+          UnfundedMentorResponse: UNFUNDED_MENTOR_RESPONSE,
+          UnfundedMentorsResponse: UNFUNDED_MENTORS_RESPONSE,
+
         }
       }
     }

--- a/spec/swagger_schemas/filters/unfunded_mentors.rb
+++ b/spec/swagger_schemas/filters/unfunded_mentors.rb
@@ -1,0 +1,11 @@
+UNFUNDED_MENTORS_FILTER = {
+  description: "Filter unfunded mentors to return more specific results",
+  type: "object",
+  properties: {
+    updated_since: {
+      description: "Return only records that have been updated since this date and time (ISO 8601 date format)",
+      type: "string",
+      example: "2021-05-13T11:21:55Z",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/models/unfunded_mentor.rb
+++ b/spec/swagger_schemas/models/unfunded_mentor.rb
@@ -1,0 +1,51 @@
+UNFUNDED_MENTOR = {
+  description: "An unfunded mentor",
+  type: :object,
+  required: %i[id type attributes],
+  properties: {
+    id: {
+      "$ref": "#/components/schemas/IDAttribute",
+    },
+    type: {
+      description: "The data type.",
+      type: :string,
+      example: "unfunded-mentor",
+      enum: %w[
+        unfunded-mentor
+      ],
+    },
+    attributes: {
+      properties: {
+        full_name: {
+          description: "The full name of this unfunded mentor",
+          type: :string,
+          nullable: false,
+          example: "John Doe",
+        },
+        email: {
+          description: "The email address registered for this unfunded mentor",
+          type: :string,
+          example: "jane.smith@example.com"
+        },
+        teacher_reference_number: {
+          description: "The Teacher Reference Number (TRN) for this unfunded mentor",
+          type: :string,
+          nullable: true,
+          example: "1234567",
+        },
+        created_at: {
+          description: "The date and time the unfunded mentor was created",
+          type: :string,
+          format: :"date-time",
+          example: "2021-05-31T02:22:32.000Z",
+        },
+        updated_at: {
+          description: "The date and time the unfunded mentor was last updated",
+          type: :string,
+          format: :"date-time",
+          example: "2021-05-31T02:22:32.000Z",
+        },
+      }
+    }
+  }
+}.freeze

--- a/spec/swagger_schemas/responses/unfunded_mentor.rb
+++ b/spec/swagger_schemas/responses/unfunded_mentor.rb
@@ -1,0 +1,10 @@
+UNFUNDED_MENTOR_RESPONSE = {
+  description: "A single unfunded mentor.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      "$ref": "#/components/schemas/UnfundedMentor",
+    },
+  },
+}.freeze

--- a/spec/swagger_schemas/responses/unfunded_mentors.rb
+++ b/spec/swagger_schemas/responses/unfunded_mentors.rb
@@ -1,0 +1,11 @@
+UNFUNDED_MENTORS_RESPONSE = {
+  description: "A list of unfunded mentors.",
+  type: :object,
+  required: %i[data],
+  properties: {
+    data: {
+      type: :array,
+      items: { "$ref": "#/components/schemas/UnfundedMentor" },
+    },
+  },
+}.freeze


### PR DESCRIPTION
### Context

Ticket: [2737](https://github.com/DFE-Digital/register-ects-project-board/issues/2737)

We need to provide LPs enough information on the parameters for the GET unfunded-mentors and GET unfunded-mentors/{id} and how the response looks like.

### Changes proposed in this pull request

- Add unfunded mentors endpoints to swagger docs

### Guidance to review

[Review app swagger docs](https://cpd-ec2-review-1726-web.test.teacherservices.cloud/api/docs/v3)