### PR TITLE
remove single IR restriction

### DIFF
--- a/app/migration/migrators/mentorship_period.rb
+++ b/app/migration/migrators/mentorship_period.rb
@@ -10,8 +10,6 @@ module Migrators
 
     def self.ects
       ::Migration::ParticipantProfile.ect
-        .where(id: Migration::InductionRecord.group(:participant_profile_id).having("count(participant_profile_id) = 1").count.keys)
-        .distinct
     end
 
     def self.dependencies

--- a/app/migration/migrators/teacher.rb
+++ b/app/migration/migrators/teacher.rb
@@ -9,8 +9,7 @@ module Migrators
     end
 
     def self.teachers
-      ::Migration::TeacherProfile.where(id: ::Migration::ParticipantProfile.ect_or_mentor
-        .where(id: Migration::InductionRecord.group(:participant_profile_id).having("count(participant_profile_id) = 1").count.keys).select(:teacher_profile_id)).distinct
+      ::Migration::TeacherProfile.joins(:participant_profiles).merge(::Migration::ParticipantProfile.ect_or_mentor).distinct
     end
 
     def self.dependencies


### PR DESCRIPTION
### Context

We'd set up migration to suit the "single induction record" data queries and fixes we're working on but we need to do the full set to have the rest of the data migrated for analysts to examine for the forthcoming tennis matches 🎾 

### Changes proposed in this pull request

Remove the single induction record restriction on the teacher related queries for the migrators.

### Guidance to review
