### PR TITLE
[2760] Add unfunded mentors to parity check endpoints

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -93,6 +93,14 @@ module ParityCheck
                                                            .pick(:api_id)
     end
 
+    def unfunded_mentor_teacher_api_id
+      API::Teachers::UnfundedMentors::Query.new(lead_provider_id: lead_provider.id)
+        .unfunded_mentors
+        .distinct(false)
+        .reorder("RANDOM()")
+        .pick(:api_id)
+    end
+
     # Request body methods
 
     def partnership_create_body

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -320,6 +320,31 @@ get:
         - teacher_reference_number_validated
         - overall_induction_start_date
 
+  - "/api/v3/unfunded-mentors":
+      ecf_path: "/api/v3/unfunded-mentors/ecf"
+      paginate: true
+  - "/api/v3/unfunded-mentors":
+      ecf_path: "/api/v3/unfunded-mentors/ecf"
+      paginate: true
+      query:
+        filter:
+          updated_since: "2025-04-13T11:21:55Z"
+  - "/api/v3/unfunded-mentors":
+      ecf_path: "/api/v3/unfunded-mentors/ecf"
+      paginate: true
+      query:
+        sort: "-updated_at"
+  - "/api/v3/unfunded-mentors":
+      ecf_path: "/api/v3/unfunded-mentors/ecf"
+      paginate: true
+      query:
+        filter:
+          updated_since: "2025-04-13T11:21:55Z"
+        sort: "+created_at"
+  - "/api/v3/unfunded-mentors/:id":
+      ecf_path: "/api/v3/unfunded-mentors/ecf/:id"
+      id: ":unfunded_mentor_teacher_api_id"
+
 post:
   - "/api/v3/partnerships":
       ecf_path: "/api/v3/partnerships/ecf"
@@ -369,7 +394,7 @@ put:
       exclude:
         - teacher_reference_number_validated
         - overall_induction_start_date
-        
+
   - "/api/v3/participants/:id/resume":
       ecf_path: "/api/v3/participants/ecf/:id/resume"
       id: ":withdrawn_teacher_api_id_for_participant_action"

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
+  include MentorshipPeriodHelpers
+
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
   let(:instance) { described_class.new(lead_provider:) }
@@ -497,6 +499,21 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
           },
         })
       end
+    end
+
+    context "when fetching `unfunded_mentor_teacher_api_id`" do
+      let(:identifier) { :unfunded_mentor_teacher_api_id }
+      let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
+      let(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+      let(:other_school_partnership) { FactoryBot.create(:school_partnership) }
+      let!(:unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
+
+      before do
+        # Unfunded mentor for different lead providers should not be used.
+        create_mentorship_period_for(mentee_school_partnership: FactoryBot.create(:school_partnership))
+      end
+
+      it { is_expected.to eq(unfunded_mentor.api_id) }
     end
   end
 end

--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -10,10 +10,9 @@ RSpec.describe "Unfunded mentors API", :with_metadata, type: :request do
   def create_resource(active_lead_provider:)
     lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
     school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
-    other_school_partnership = FactoryBot.create(:school_partnership)
 
     # Unfunded mentor associated with the lead provider (should be returned)
-    create_mentorship_period_for(mentor_school_partnership: other_school_partnership, mentee_school_partnership: school_partnership).mentor.teacher
+    create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher
   end
 
   describe "#index" do

--- a/spec/services/api/teachers/unfunded_mentors/query_spec.rb
+++ b/spec/services/api/teachers/unfunded_mentors/query_spec.rb
@@ -3,8 +3,7 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
 
   let(:lead_provider_id) { school_partnership.lead_provider.id }
   let(:school_partnership) { FactoryBot.create(:school_partnership) }
-  let(:other_school_partnership) { FactoryBot.create(:school_partnership) }
-  let!(:unfunded_mentor) { create_mentorship_period_for(mentor_school_partnership: other_school_partnership, mentee_school_partnership: school_partnership).mentor.teacher }
+  let!(:unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
   let(:query) { described_class.new(lead_provider_id:) }
 
   it_behaves_like "a query that avoids includes" do
@@ -38,13 +37,13 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
   describe "#unfunded_mentors" do
     describe "filtering" do
       describe "by `lead_provider`" do
-        let!(:other_unfunded_mentor) { create_mentorship_period_for(mentor_school_partnership: other_school_partnership, mentee_school_partnership: school_partnership).mentor.teacher }
+        let!(:other_unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
 
         before do
           # Mentor associated with the lead provider (so not unfunded and should be ignored)
           create_mentorship_period_for(mentor_school_partnership: school_partnership, mentee_school_partnership: school_partnership)
           # Unfunded mentor for another lead provider (should be ignored)
-          create_mentorship_period_for(mentor_school_partnership: other_school_partnership, mentee_school_partnership: other_school_partnership)
+          create_mentorship_period_for(mentee_school_partnership: FactoryBot.create(:school_partnership))
         end
 
         it "filters by `lead_provider`" do
@@ -71,7 +70,7 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
       end
 
       describe "by `updated_since`" do
-        let!(:other_unfunded_mentor) { create_mentorship_period_for(mentor_school_partnership: other_school_partnership, mentee_school_partnership: school_partnership).mentor.teacher }
+        let!(:other_unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
 
         before do
           unfunded_mentor.update!(api_updated_at: 3.days.ago)
@@ -97,7 +96,7 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
     end
 
     describe "ordering" do
-      let!(:other_unfunded_mentor) { create_mentorship_period_for(mentor_school_partnership: other_school_partnership, mentee_school_partnership: school_partnership).mentor.teacher }
+      let!(:other_unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
 
       before do
         unfunded_mentor.update!(api_updated_at: 1.day.ago)

--- a/spec/support/mentorship_period_helpers.rb
+++ b/spec/support/mentorship_period_helpers.rb
@@ -1,5 +1,5 @@
 module MentorshipPeriodHelpers
-  def create_mentorship_period_for(mentor_school_partnership:, mentee_school_partnership:)
+  def create_mentorship_period_for(mentee_school_partnership:, mentor_school_partnership: FactoryBot.create(:school_partnership))
     mentee = FactoryBot.create(:teacher)
     mentee_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, teacher: mentee, started_on: 2.months.ago)
     FactoryBot.create(:training_period, :for_ect, started_on: 1.month.ago, ect_at_school_period: mentee_school_period, school_partnership: mentee_school_partnership)


### PR DESCRIPTION
### Context

Ticket: [2760](https://github.com/DFE-Digital/register-ects-project-board/issues/2760)

We need to check parity check results for unfunded mentors endpoints.

### Changes proposed in this pull request

- Add endpoints to the parity check to support unfunded mentors. 

### Guidance to review

Tested in the [parity check env](https://cpd-ec2-paritycheck-web.teacherservices.cloud/migration/parity-checks/37).
