### PR TITLE
Simplify `#previously_registered?`

### DIFF
--- a/app/wizards/schools/register_ect_wizard/registration_store.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store.rb
@@ -81,7 +81,7 @@ module Schools
       end
 
       def previously_registered?
-        previous_registration.present?
+        queries.previous_ect_at_school_period.present?
       end
 
       def trs_full_name

--- a/app/wizards/schools/register_ect_wizard/registration_store/previous_registration.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/previous_registration.rb
@@ -7,9 +7,6 @@ module Schools
           @queries = queries
         end
 
-        # previous_registration.present? is true if there is a previous ECT at school period
-        delegate :present?, to: :ect_at_school_period
-
         def previous_appropriate_body_name
           previous_appropriate_body&.name
         end

--- a/spec/wizards/schools/register_ect_wizard/registration_store/previous_registration_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/previous_registration_spec.rb
@@ -14,22 +14,6 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::PreviousRegistrati
     allow(queries).to receive_messages(previous_ect_at_school_period: previous_ect_period, previous_training_period:, previous_appropriate_body:, previous_delivery_partner:, previous_lead_provider:)
   end
 
-  describe '#present?' do
-    context 'when there is a previous ECT period' do
-      let(:previous_ect_period) { instance_double(ECTAtSchoolPeriod) }
-
-      it 'returns true' do
-        expect(previous_registration.present?).to be(true)
-      end
-    end
-
-    context 'when there is no previous ECT period' do
-      it 'returns false' do
-        expect(previous_registration.present?).to be(false)
-      end
-    end
-  end
-
   describe '#previous_school_name' do
     let(:previous_ect_period) { instance_double(ECTAtSchoolPeriod, school:) }
 

--- a/spec/wizards/schools/register_ect_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store_spec.rb
@@ -734,4 +734,24 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore do
       end
     end
   end
+
+  describe '#previously_registered?' do
+    context 'when there is a previous registration' do
+      before { store.trn = teacher.trn }
+
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      let!(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:) }
+
+      it 'returns true' do
+        expect(registration_store.previously_registered?).to be true
+      end
+    end
+
+    context 'when there is no previous training' do
+      it 'returns false' do
+        expect(registration_store.previously_registered?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

@ericaporter made a [great suggestion](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1713#discussion_r2523841052) to remove the delegation here to simply things and make the intent clearer.

### Changes proposed

- Call `queries.previous_ect_at_school_period.present?` explicitly instead of delegating.

### Changes proposed 

:shipit: 