### PR TITLE
Add swagger docs for change schedule endpoint

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -35,7 +35,7 @@ module API::Teachers
     end
 
     def fallback_contract_period
-      training_period.contract_period
+      training_period&.contract_period
     end
 
     def schedule

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -478,6 +478,95 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/ParticipantResumeRequest"
+  "/api/v3/participants/{id}/change-schedule":
+    put:
+      summary: Update a participant
+      tags:
+      - Participants
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The updated participant
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    data:
+                      id: d0b4a32e-a272-489e-b30a-cb17131457fc
+                      type: participant
+                      attributes:
+                        full_name: John Doe
+                        teacher_reference_number: '1234567'
+                        ecf_enrolments:
+                        - training_record_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          email: jane.smith@example.com
+                          mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          school_urn: '123456'
+                          participant_type: ect
+                          cohort: '2021'
+                          training_status: active
+                          participant_status: active
+                          eligible_for_funding: true
+                          pupil_premium_uplift: true
+                          sparsity_uplift: true
+                          schedule_identifier: ecf-extended-september
+                          delivery_partner_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
+                          withdrawal:
+                            reason: moved-school
+                            date: '2021-05-31T02:22:32.000Z'
+                          deferral:
+                            reason: career-break
+                            date: '2021-05-31T02:22:32.000Z'
+                          created_at: '2023-01-01T00:00:00Z'
+                          induction_end_date: '2023-01-01'
+                          overall_induction_start_date: '2023-01-01'
+                          mentor_funding_end_date: '2023-01-01'
+                          cohort_changed_after_payments_frozen: true
+                          mentor_ineligible_for_funding_reason: completed_declaration_received
+                        participant_id_changes:
+                        - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
+                          to_participant_id: ac3d1243-7308-4879-942a-c4a70ced400a
+                          changed_at: '2023-01-01T12:00:00Z'
+                        updated_at: '2021-05-31T02:22:32.000Z'
+              schema:
+                "$ref": "#/components/schemas/ParticipantResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ParticipantChangeScheduleRequest"
   "/api/v3/partnerships":
     get:
       summary: Retrieve multiple partnerships
@@ -1606,6 +1695,66 @@ components:
                   - ecf-mentor
                   - ecf-induction
                   example: ecf-mentor
+    ParticipantChangeScheduleRequest:
+      description: Notify that a participant is changing training schedule
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          description: The change schedule request for a participant
+          type: object
+          required:
+          - type
+          - attributes
+          properties:
+            type:
+              type: string
+              required: true
+              enum:
+              - participant-change-schedule
+              example: participant-change-schedule
+            attributes:
+              description: A participant change schedule action
+              type: object
+              required:
+              - schedule_identifier
+              - course_identifier
+              properties:
+                schedule_identifier:
+                  description: The new schedule of the participant
+                  type: string
+                  required: true
+                  enum:
+                  - ecf-extended-april
+                  - ecf-extended-january
+                  - ecf-extended-september
+                  - ecf-reduced-april
+                  - ecf-reduced-january
+                  - ecf-reduced-september
+                  - ecf-replacement-april
+                  - ecf-replacement-january
+                  - ecf-replacement-september
+                  - ecf-standard-april
+                  - ecf-standard-january
+                  - ecf-standard-september
+                  example: ecf-extended-september
+                course_identifier:
+                  description: The type of course the participant is enrolled in
+                  type: string
+                  required: true
+                  enum:
+                  - ecf-mentor
+                  - ecf-induction
+                  example: ecf-mentor
+                cohort:
+                  description: Providers may not change the current value for ECF
+                    participants. Indicates which call-off contract funds this participant’s
+                    training. 2021 indicates a participant that has started, or will
+                    start, their training in the 2021/22 academic year.
+                  type: string
+                  required: false
+                  example: '2021'
     ParticipantsResponse:
       description: A list of participants.
       type: object

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -197,4 +197,52 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                       }
                     end
                   end
+
+  it_behaves_like "an API update endpoint documentation",
+                  {
+                    url: "/api/v3/participants/{id}/change-schedule",
+                    tag: "Participants",
+                    resource_description: "participant",
+                    request_schema_ref: "#/components/schemas/ParticipantChangeScheduleRequest",
+                    response_schema_ref: "#/components/schemas/ParticipantResponse",
+                  } do
+                    let(:new_schedule) do
+                      FactoryBot.create(
+                        :schedule,
+                        identifier: "ecf-extended-september",
+                        contract_period: school_partnership.contract_period
+                      )
+                    end
+                    let(:response_example) do
+                      extract_swagger_example(schema: "#/components/schemas/ParticipantResponse", version: :v3).tap do |example|
+                        example[:data][:attributes][:ecf_enrolments][0][:schedule_identifier] = new_schedule.identifier
+                        example[:data][:attributes][:ecf_enrolments][0][:cohort] = "2021"
+                      end
+                    end
+                    let(:params) do
+                      {
+                        data: {
+                          type: "participant-change-schedule",
+                          attributes: {
+                            schedule_identifier: new_schedule.identifier,
+                            course_identifier: "ecf-induction",
+                            cohort: active_lead_provider.contract_period_year
+                          }
+                        }
+                      }
+                    end
+
+                    let(:invalid_params) do
+                      {
+                        data: {
+                          type: "participant-change-schedule",
+                          attributes: {
+                            schedule_identifier: new_schedule.identifier,
+                            course_identifier: "invalid-course",
+                            cohort: active_lead_provider.contract_period_year
+                          }
+                        }
+                      }
+                    end
+                  end
 end

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             it { is_expected.to be_valid }
           end
 
+          context "when the contract_period_year is not specified and the teacher_type is invalid" do
+            let(:contract_period_year) { nil }
+            let(:teacher_type) { "invalid" }
+
+            it { is_expected.to have_one_error_per_attribute }
+            it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
+          end
+
           context "guarded error messages" do
             subject(:instance) { described_class.new }
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -83,6 +83,7 @@ RSpec.configure do |config|
           ParticipantWithdrawRequest: PARTICIPANT_WITHDRAW_REQUEST,
           ParticipantDeferRequest: PARTICIPANT_DEFER_REQUEST,
           ParticipantResumeRequest: PARTICIPANT_RESUME_REQUEST,
+          ParticipantChangeScheduleRequest: PARTICIPANT_CHANGE_SCHEDULE_REQUEST,
           ParticipantsResponse: PARTICIPANTS_RESPONSE,
           ParticipantECFEnrolment: PARTICIPANT_ECF_ENROLMENT,
           ParticipantIDChange: PARTICIPANT_ID_CHANGE,

--- a/spec/swagger_schemas/requests/participant_change_schedule.rb
+++ b/spec/swagger_schemas/requests/participant_change_schedule.rb
@@ -1,0 +1,49 @@
+PARTICIPANT_CHANGE_SCHEDULE_REQUEST = {
+  description: "Notify that a participant is changing training schedule",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "The change schedule request for a participant",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[participant-change-schedule],
+          example: "participant-change-schedule",
+        },
+        attributes: {
+          description: "A participant change schedule action",
+          type: :object,
+          required: %w[schedule_identifier course_identifier],
+          properties: {
+            schedule_identifier: {
+              description: "The new schedule of the participant",
+              type: :string,
+              required: true,
+              enum: Schedule.identifiers.keys,
+              example: "ecf-extended-september",
+            },
+            course_identifier: {
+              description: "The type of course the participant is enrolled in",
+              type: :string,
+              required: true,
+              enum: %w[ecf-mentor ecf-induction],
+              example: "ecf-mentor"
+            },
+            cohort: {
+              description: "Providers may not change the current value for ECF participants. " \
+              "Indicates which call-off contract funds this participant’s training. "\
+              "2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.",
+              type: :string,
+              required: false,
+              example: "2021"
+            }
+          }
+        }
+      },
+    }
+  }
+}.freeze


### PR DESCRIPTION
### Context

Following the other participant actions, this adds the documentation for the change schedule endpoint.

Link to docs: https://cpd-ec2-review-1740-web.test.teacherservices.cloud/api/docs/v3