### PR TITLE
Keep wizard status objects pure boolean

### DIFF
--- a/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
@@ -26,7 +26,7 @@ module Schools
           @contract_start_date ||= ContractPeriod.containing_date(registration_store.start_date&.to_date)
         end
 
-        def lead_provider_partnership_for_contract_period(school:)
+        def lead_provider_partnerships_for_contract_period(school:)
           contract_period = contract_start_date
 
           return SchoolPartnership.none unless previous_lead_provider && contract_period && school

--- a/app/wizards/schools/register_ect_wizard/registration_store/status.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/status.rb
@@ -54,7 +54,7 @@ module Schools
         end
 
         def lead_provider_has_confirmed_partnership_for_contract_period?(school)
-          queries.lead_provider_partnership_for_contract_period(school:).exists?
+          queries.lead_provider_partnerships_for_contract_period(school:).exists?
         end
 
       private

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     end
   end
 
-  describe "#lead_provider_partnership_for_contract_period" do
+  describe "#lead_provider_partnerships_for_contract_period" do
     let(:contract_period) { FactoryBot.create(:contract_period, year: 2026) }
     let(:start_date) { (contract_period.started_on + 1.day) }
     let(:school) { FactoryBot.create(:school) }
@@ -109,11 +109,11 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     end
 
     it "returns partnerships scoped by previous lead provider, contract period and school" do
-      expect(queries.lead_provider_partnership_for_contract_period(school:)).to include(school_partnership)
+      expect(queries.lead_provider_partnerships_for_contract_period(school:)).to include(school_partnership)
     end
 
     it "returns an empty scope when prerequisites are missing" do
-      expect(queries.lead_provider_partnership_for_contract_period(school: nil)).to be_empty
+      expect(queries.lead_provider_partnerships_for_contract_period(school: nil)).to be_empty
     end
   end
 

--- a/spec/wizards/schools/register_ect_wizard/registration_store/status_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/status_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Status do
     instance_double(Schools::RegisterECTWizard::RegistrationStore::Queries,
                     previous_training_period:,
                     previous_lead_provider:,
-                    lead_provider_partnership_for_contract_period: lead_provider_partnership_scope)
+                    lead_provider_partnerships_for_contract_period: lead_provider_partnership_scope)
   end
   let(:previous_training_period) { nil }
   let(:previous_lead_provider) { nil }


### PR DESCRIPTION
### Context

For better separation of concerns we want to try and keep `status.rb` pure boolean, any heavy query logic should be moved into `queries.rb`.

### Changes proposed in this pull request

Move some of the query logic from `status.rb` into `queries.rb`

### Guidance to review

Does this structure make sense to people? Do you agree with it?
