### PR TITLE
[1748] Fix blazer links to admin induction

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -21,7 +21,7 @@ data_sources:
     # https://blazer.dokkuapp.com/queries/3-linked-column
     linked_columns:
       appropriate_body_id: "/admin/organisations/appropriate-bodies/{value}"
-      teacher_id: "/admin/teachers/{value}"
+      teacher_id: "/admin/teachers/{value}/induction"
       pending_induction_submission_batch_id: "/admin/bulk/batches/{value}"
       induction_period_id: "/admin/teachers/N/induction-periods/{value}/edit"
       zendesk_ticket_id: "https://becomingateacher.zendesk.com/agent/tickets/{value}"


### PR DESCRIPTION
### Context

I changed the routes from `admin/teachers/:id` -> `admin/teachers/:id/induction` in #1735 and missed the hardcoded blazer link, so this change brings Blazer links in line with that change.

Sorry!

### Changes proposed

- Update hard coded blazer url to point to the new (correct) one


### Guidance to review

Select an induction record in Blazer:

```
select teacher_id from induction_periods limit 5;
```
Try to follow the hyperlink in the `teacher_id` column.

<img width="983" height="316" alt="image" src="https://github.com/user-attachments/assets/150e8f8c-a5e5-4345-a599-dd8d22a70c04" />
