### PR TITLE
Add a notes column to test fixtures CSV

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -35,13 +35,14 @@ class TestGuidanceComponent < ApplicationComponent
         "Date of birth",
         "Induction status",
         active_period_with_header,
+        "Notes",
         ""
       ]
     end
 
     # @return [Array<Array>]
     def rows
-      teachers.map do |name, trn, dob, ni_number, status, *|
+      teachers.map do |name, trn, dob, ni_number, status, note, *|
         teacher = Teacher.find_by(trn:)
 
         next if exhausted?(teacher)
@@ -52,6 +53,7 @@ class TestGuidanceComponent < ApplicationComponent
           dob,
           status_indicator(status, teacher),
           active_period_with(teacher),
+          note.to_s,
           populate_button(trn, dob, ni_number)
         ]
       end
@@ -62,7 +64,8 @@ class TestGuidanceComponent < ApplicationComponent
       CSV.read(file_path, headers: true).map(&:values_at)
     end
 
-    def file_path = Rails.root.join("spec/fixtures/seeds_trs.csv")
+    # @return [Pathname]
+    def file_path = Rails.application.config.test_guidance_fixtures
 
     # Once used by RIAB the status changes to "In progress" if active or "Induction paused" once released
     def status_indicator(trs_induction_status, teacher)

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,8 @@ module RegisterEarlyCareerTeachers
     config.active_record.encryption.key_derivation_salt = ENV["ENCRYPTION_DERIVATION_SALT"]
 
     # Custom config
+
+    config.test_guidance_fixtures = Rails.root.join("spec/fixtures/seeds_trs.csv")
     config.enable_test_guidance = ActiveModel::Type::Boolean.new.cast(ENV.fetch("TEST_GUIDANCE", false))
     config.enable_fake_trs_api = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_FAKE_TRS_API", false))
     config.enable_personas = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_PERSONAS", false))

--- a/lib/tasks/product_review.rake
+++ b/lib/tasks/product_review.rake
@@ -6,10 +6,10 @@ namespace :product_review do
     abort("Only available for pre-production TRS") unless Rails.application.config.trs_api_base_url.include?("preprod")
 
     api_client = TRS::APIClient.build
-    file_path = Rails.root.join("spec/fixtures/seeds_trs.csv")
+    file_path = Rails.application.config.test_guidance_fixtures
 
     CSV.foreach(file_path, headers: true) do |row|
-      _name, trn, _dob, _ni_number, status = row.to_h.values
+      _name, trn, _dob, _ni_number, status, _note = row.to_h.values
       api_client.reset_teacher_induction!(trn:) if status.eql?("RequiredToComplete")
     end
   end

--- a/spec/fixtures/seeds_trs.csv
+++ b/spec/fixtures/seeds_trs.csv
@@ -1,33 +1,33 @@
-Name,TRN,Date of birth,NI number,Status
-Chloe Nolan,3002586,1977-02-03,OA647867D,RequiredToComplete
-Delilah Frost,3002585,1966-01-02,MA251209B,RequiredToComplete
-Theo Willis,3002584,1955-11-24,RE937588C,RequiredToComplete
-Marvin Fuller,3002583,1977-09-24,PG050037C,RequiredToComplete
-Daisy Dudley,3002576,1999-03-04,GE377928A,RequiredToComplete
-Jonas Bloggs,3002577,2000-12-02,BT524135A,RequiredToComplete
-Cynthia Parks,3002578,1977-09-10,CB196295D,RequiredToComplete
-Taylor Hawkins,3002579,2001-08-01,WJ584009B,RequiredToComplete
-Muhammed Ali (no mentor funding),3002580,1955-03-04,BJ833983C,RequiredToComplete
-Robson Scottie (no mentor funding),3002582,1980-05-11,WX999679C,RequiredToComplete
-Rebecca Jones (ineligible),1209937,1993-10-12,J698546XA,Passed
-Joseph Waller (ineligible),1062313,1988-05-30,1A7T689J2,Passed
-Jacqueline Bartlett (ineligible),2057184,1976-08-31,82063AJE7,Exempt
-George James (ineligible),2136110,1968-07-29,BN19500R8,Exempt
-Carol Burns (ineligible),1058354,1991-04-02,27313BJL9,Failed
-Nicola Borschmann (ineligible),2467487,1975-02-02,532B10J1A,Failed
-John Smith (ineligible),1247646,1986-06-19,6J8B903G8,FailedInWales
-Jim Laney (ineligible),3002065,1990-01-01,OA046772B,FailedInWales
-George Orwell (prohibited),2632412,1984-02-16,,InProgress
-Neils Clarke-Dolan (prohibited),2908239,1978-08-12,,Passed
-Dona Msa (no QTS),3003943,1964-02-02,AB722128C,None
-Claire Cool (no QTS),3012235,1993-01-03,BB123456C,None
-Linda Belcher (no QTS),3012238,1980-12-01,QQ123456C,None
-James Rocket (no QTS),3012239,1976-11-26,AA223456C,None
-Buffy Summers (no QTS),3012240,1987-09-09,AA333456C,None
-Ash Ketchum (no QTS),3012241,2000-01-25,QQ553456C,None
-Jigglypuff Jewels (no QTS),3012242,1993-01-05,QQ773456C,None
-Clefairy Cuddles (no QTS),3012243,1993-01-09,QQ993456C,None
-Bulbasaur Brown (no QTS),3012244,1992-01-19,QQ893456C,None
-Squirtle Samuels (no QTS),3012245,1992-03-19,QQ123445C,None
-Ditto Debbie (no QTS),3012246,1970-04-28,QQ783445C,None
-Butterfree Barnaby (no QTS),3012247,2002-06-18,QQ799445C,None
+Name,TRN,Date of birth,NI number,Status,Notes
+Chloe Nolan,3002586,1977-02-03,OA647867D,RequiredToComplete,
+Delilah Frost,3002585,1966-01-02,MA251209B,RequiredToComplete,
+Theo Willis,3002584,1955-11-24,RE937588C,RequiredToComplete,
+Marvin Fuller,3002583,1977-09-24,PG050037C,RequiredToComplete,
+Daisy Dudley,3002576,1999-03-04,GE377928A,RequiredToComplete,
+Jonas Bloggs,3002577,2000-12-02,BT524135A,RequiredToComplete,
+Cynthia Parks,3002578,1977-09-10,CB196295D,RequiredToComplete,
+Taylor Hawkins,3002579,2001-08-01,WJ584009B,RequiredToComplete,
+Muhammed Ali,3002580,1955-03-04,BJ833983C,RequiredToComplete,no mentor funding
+Robson Scottie,3002582,1980-05-11,WX999679C,RequiredToComplete,no mentor funding
+Rebecca Jones,1209937,1993-10-12,J698546XA,Passed,ineligible
+Joseph Waller,1062313,1988-05-30,1A7T689J2,Passed,ineligible
+Jacqueline Bartlett,2057184,1976-08-31,82063AJE7,Exempt,ineligible
+George James,2136110,1968-07-29,BN19500R8,Exempt,ineligible
+Carol Burns,1058354,1991-04-02,27313BJL9,Failed,ineligible
+Nicola Borschmann,2467487,1975-02-02,532B10J1A,Failed,ineligible
+John Smith,1247646,1986-06-19,6J8B903G8,FailedInWales,ineligible
+Jim Laney,3002065,1990-01-01,OA046772B,FailedInWales,ineligible
+George Orwell,2632412,1984-02-16,,InProgress,prohibited
+Neils Clarke-Dolan,2908239,1978-08-12,,Passed,prohibited
+Dona Msa,3003943,1964-02-02,AB722128C,None,no QTS
+Claire Cool,3012235,1993-01-03,BB123456C,None,no QTS
+Linda Belcher,3012238,1980-12-01,QQ123456C,None,no QTS
+James Rocket,3012239,1976-11-26,AA223456C,None,no QTS
+Buffy Summers,3012240,1987-09-09,AA333456C,None,no QTS
+Ash Ketchum,3012241,2000-01-25,QQ553456C,None,no QTS
+Jigglypuff Jewels,3012242,1993-01-05,QQ773456C,None,no QTS
+Clefairy Cuddles,3012243,1993-01-09,QQ993456C,None,no QTS
+Bulbasaur Brown,3012244,1992-01-19,QQ893456C,None,no QTS
+Squirtle Samuels,3012245,1992-03-19,QQ123445C,None,no QTS
+Ditto Debbie,3012246,1970-04-28,QQ783445C,None,no QTS
+Butterfree Barnaby,3012247,2002-06-18,QQ799445C,None,no QTS


### PR DESCRIPTION
### Context

The full width page gives us room to restore the notes column

### Changes proposed in this pull request

Update test guidance fixtures and component so contextual note for the fixture is in a separate cell

### Guidance to review

<img height="8614" alt="cpd-ec2-review-1757-web test teacherservices cloud_school_register-ect_find-ect" src="https://github.com/user-attachments/assets/e12bbe25-89f7-468e-a72e-218b7e4fe320" />

