### PR TITLE
Remove the escaping of quotes to improve readiblity

### DIFF
--- a/app/components/concerns/empty_state_message.rb
+++ b/app/components/concerns/empty_state_message.rb
@@ -10,7 +10,7 @@ private
   end
 
   def message_with_query(base_message)
-    "#{base_message} matching \"#{highlighted_query}\".".html_safe
+    %(#{base_message} matching "#{highlighted_query}".).html_safe
   end
 
   def highlighted_query

--- a/app/components/teachers_index/header_section_component.rb
+++ b/app/components/teachers_index/header_section_component.rb
@@ -17,7 +17,7 @@ module TeachersIndex
 
     def heading_text
       if current_count.zero? && query.present?
-        "No #{status} inductions for \"#{query}\""
+        %(No #{status} inductions for "#{query}")
       else
         pluralize(current_count, "#{status} induction")
       end

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ParityCheckHelper, type: :helper do
 
     before { allow(run).to receive(:request_group_names).and_return(%i[participant-declarations users]) }
 
-    it { is_expected.to eq(%(<ul class=\"govuk-list\"><li>Participant declarations</li><li>Users</li></ul>)) }
+    it { is_expected.to eq(%(<ul class="govuk-list"><li>Participant declarations</li><li>Users</li></ul>)) }
   end
 
   describe "#id_count_in_words" do
@@ -92,7 +92,7 @@ RSpec.describe ParityCheckHelper, type: :helper do
       context "when match rate is #{match_rate}%" do
         subject { helper.match_rate_tag(match_rate) }
 
-        it { is_expected.to eq(%(<strong class=\"govuk-tag govuk-tag--#{colour}\">#{match_rate}%</strong>)) }
+        it { is_expected.to eq(%(<strong class="govuk-tag govuk-tag--#{colour}">#{match_rate}%</strong>)) }
       end
     end
   end
@@ -108,7 +108,7 @@ RSpec.describe ParityCheckHelper, type: :helper do
       context "when status code is #{status_code}%" do
         subject { helper.status_code_tag(status_code) }
 
-        it { is_expected.to eq(%(<strong class=\"govuk-tag govuk-tag--#{colour}\">#{status_code}</strong>)) }
+        it { is_expected.to eq(%(<strong class="govuk-tag govuk-tag--#{colour}">#{status_code}</strong>)) }
       end
     end
   end

--- a/spec/requests/admin/delivery_partners_spec.rb
+++ b/spec/requests/admin/delivery_partners_spec.rb
@@ -212,8 +212,8 @@ RSpec.describe "Admin delivery partners", type: :request do
 
           it "excludes already assigned lead providers from checkboxes" do
             get new_path
-            expect(response.body).not_to include("value=\"#{active_lead_provider_1.id}\"")
-            expect(response.body).to include("value=\"#{active_lead_provider_2.id}\"")
+            expect(response.body).not_to include(%(value="#{active_lead_provider_1.id}"))
+            expect(response.body).to include(%(value="#{active_lead_provider_2.id}"))
           end
         end
       end
@@ -348,8 +348,8 @@ RSpec.describe "Admin delivery partners", type: :request do
 
             # Check that existing partnerships are shown as checked
             expect(response.body).to include("checked")
-            expect(response.body).to include("value=\"#{active_lead_provider_1.id}\"")
-            expect(response.body).to include("value=\"#{active_lead_provider_2.id}\"")
+            expect(response.body).to include(%(value="#{active_lead_provider_1.id}"))
+            expect(response.body).to include(%(value="#{active_lead_provider_2.id}"))
           end
 
           it "persists checkbox state after form submission and reopening" do

--- a/spec/support/matchers/have_error_matcher.rb
+++ b/spec/support/matchers/have_error_matcher.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :have_error do |attribute, message, context|
 
   failure_message do |actual|
     actual.errors.map { |error|
-      "expected error on :#{attribute} with message \"#{message}\", but got :#{error.attribute} with message \"#{error.message}\""
+      %(expected error on :#{attribute} with message "#{message}", but got :#{error.attribute} with message "#{error.message}")
     }.join(" and ")
   end
 end

--- a/spec/support/matchers/have_summary_list_row.rb
+++ b/spec/support/matchers/have_summary_list_row.rb
@@ -37,14 +37,14 @@ module HaveSummaryListRow
       if @rows.present? && @matching_row.blank?
         <<~TXT.squish
           Found #{@rows.size} #{'summary list row'.pluralize(@rows.size)} with
-          keys: #{@rows.map { "\"#{it.text}\"" }.join(', ')}.
+          keys: #{@rows.map { %("#{it.text}") }.join(', ')}.
         TXT
       end
     end
 
     def sibling_failure_message
       if @matching_row.present?
-        "Found matching summary list row, but its value is \"#{@sibling.text}\"."
+        %(Found matching summary list row, but its value is "#{@sibling.text}".)
       end
     end
   end

--- a/spec/support/shared_examples/migrator_support.rb
+++ b/spec/support/shared_examples/migrator_support.rb
@@ -154,8 +154,8 @@ RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: tr
 
     it "logs out as it runs" do
       allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with("Migration started: [{model: \"#{model_name}\", worker: 0, processed_count: 0, total_count: 2}]")
-      expect(Rails.logger).to receive(:info).with("Migration completed: [{model: \"#{model_name}\", worker: 0, processed_count: 2, total_count: 2}]")
+      expect(Rails.logger).to receive(:info).with(%(Migration started: [{model: "#{model_name}", worker: 0, processed_count: 0, total_count: 2}]))
+      expect(Rails.logger).to receive(:info).with(%(Migration completed: [{model: "#{model_name}", worker: 0, processed_count: 2, total_count: 2}]))
       migrate!
     end
 
@@ -215,8 +215,8 @@ RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: tr
 
         it "logs out as it runs" do
           allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with("Migration started: [{model: \"#{model_name}\", worker: 0, processed_count: 0, total_count: 1}]")
-          expect(Rails.logger).to receive(:info).with("Migration completed: [{model: \"#{model_name}\", worker: 0, processed_count: 1, total_count: 1}]")
+          expect(Rails.logger).to receive(:info).with(%(Migration started: [{model: "#{model_name}", worker: 0, processed_count: 0, total_count: 1}]))
+          expect(Rails.logger).to receive(:info).with(%(Migration completed: [{model: "#{model_name}", worker: 0, processed_count: 1, total_count: 1}]))
           migrate!
         end
 

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotifyEmailValidator, type: :model do
       email@domain.com
       email@domain.COM
       firstname.lastname@domain.com
-      firstname.o\'lastname@domain.com
+      firstname.o'lastname@domain.com
       email@subdomain.domain.com
       firstname+lastname@domain.com
       1234567890@domain.com


### PR DESCRIPTION
Escaping makes strings hard to read, this should ease things a bit.
