### PR TITLE
Re-add choices made by school row and make conditional

### DIFF
--- a/app/decorators/schools/decorated_school.rb
+++ b/app/decorators/schools/decorated_school.rb
@@ -24,19 +24,7 @@ module Schools
       latest_registration_choices&.lead_provider&.name
     end
 
-    def show_previous_programme_choices_row?(wizard)
-      last_programme_choices? &&
-        reuse_previous_choices_step_allowed?(wizard) &&
-        wizard.ect.use_previous_ect_choices
-    end
-
   private
-
-    def reuse_previous_choices_step_allowed?(wizard)
-      Schools::RegisterECTWizard::UsePreviousECTChoicesStep
-        .new(wizard:)
-        .allowed?
-    end
 
     def lacks_partnership_with?(lead_provider:, contract_period:)
       !has_partnership_with?(lead_provider:, contract_period:)

--- a/app/views/schools/register_ect_wizard/check_answers.html.erb
+++ b/app/views/schools/register_ect_wizard/check_answers.html.erb
@@ -44,13 +44,15 @@ end %>
 <h2 class="govuk-heading-m">Programme details</h2>
 
 <%= govuk_summary_list do |summary_list|
-  if @decorated_school&.show_previous_programme_choices_row?(@wizard)
+  if @wizard.current_step.show_previous_programme_choices_row?
     summary_list.with_row do |row|
-      row.with_key(text: 'Choices used by your school previously')
+      row.with_key(text: "Choices used by your school previously")
       row.with_value(text: previous_choice_message(@ect.use_previous_ect_choices))
-      row.with_action(text: 'Change',
-                      href: schools_register_ect_wizard_change_use_previous_ect_choices_path,
-                      visually_hidden_text: 'choices used by your school previously')
+      row.with_action(
+        text: "Change",
+        href: schools_register_ect_wizard_change_use_previous_ect_choices_path,
+        visually_hidden_text: "choices used by your school previously"
+      )
     end
   end
 

--- a/app/wizards/schools/register_ect_wizard/check_answers_step.rb
+++ b/app/wizards/schools/register_ect_wizard/check_answers_step.rb
@@ -11,6 +11,11 @@ module Schools
         ect.provider_led? ? :lead_provider : :training_programme
       end
 
+      def show_previous_programme_choices_row?
+        school.last_programme_choices? &&
+          wizard.use_previous_choices_allowed?
+      end
+
     private
 
       def persist

--- a/spec/support/reusable_partnership_helpers.rb
+++ b/spec/support/reusable_partnership_helpers.rb
@@ -1,0 +1,61 @@
+module ReusablePartnershipHelpers
+  ReusablePartnershipContext = Struct.new(
+    :school,
+    :current_contract_period,
+    :previous_school_partnership,
+    :last_chosen_lead_provider,
+    :previous_year_delivery_partner,
+    keyword_init: true
+  )
+
+  def build_school_with_reusable_provider_led_partnership
+    current_year  = Time.zone.today.year
+    previous_year = current_year - 1
+
+    current_contract_period  = FactoryBot.create(:contract_period, :with_schedules, year: current_year)
+    previous_contract_period = FactoryBot.create(:contract_period, :with_schedules, year: previous_year)
+
+    lead_provider    = FactoryBot.create(:lead_provider, name: "Orange Institute")
+    delivery_partner = FactoryBot.create(:delivery_partner, name: "Jaskolski College Delivery Partner 1")
+
+    previous_year_active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      lead_provider:,
+      contract_period: previous_contract_period
+    )
+
+    FactoryBot.create(
+      :active_lead_provider,
+      lead_provider:,
+      contract_period: current_contract_period
+    )
+
+    previous_year_delivery_partnership = FactoryBot.create(
+      :lead_provider_delivery_partnership,
+      active_lead_provider: previous_year_active_lead_provider,
+      delivery_partner:
+    )
+
+    school = FactoryBot.create(
+      :school,
+      :state_funded,
+      :provider_led_last_chosen,
+      :teaching_school_hub_ab_last_chosen,
+      last_chosen_lead_provider: lead_provider
+    )
+
+    previous_school_partnership = FactoryBot.create(
+      :school_partnership,
+      school:,
+      lead_provider_delivery_partnership: previous_year_delivery_partnership
+    )
+
+    ReusablePartnershipContext.new(
+      school:,
+      current_contract_period:,
+      previous_school_partnership:,
+      last_chosen_lead_provider: lead_provider,
+      previous_year_delivery_partner: delivery_partner
+    )
+  end
+end

--- a/spec/views/schools/register_ect_wizard/check_answers.html.erb_spec.rb
+++ b/spec/views/schools/register_ect_wizard/check_answers.html.erb_spec.rb
@@ -1,18 +1,28 @@
 RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
   let(:use_previous_ect_choices) { nil }
-  let(:store) { FactoryBot.build(:session_repository, working_pattern: "Full time", use_previous_ect_choices:, training_programme: "provider_led") }
+
+  let(:store) do
+    FactoryBot.build(
+      :session_repository,
+      working_pattern: "Full time",
+      use_previous_ect_choices:,
+      training_programme: "provider_led"
+    )
+  end
 
   let(:wizard) do
-    FactoryBot.build(:register_ect_wizard, current_step: :check_answers, store:)
+    FactoryBot.build(
+      :register_ect_wizard,
+      current_step: :check_answers,
+      store:
+    )
   end
 
   let(:school) { wizard.school }
-  let(:decorated_school) { Schools::DecoratedSchool.new(wizard.school) }
 
   before do
     assign(:ect, wizard.ect)
     assign(:school, school)
-    assign(:decorated_school, decorated_school)
     assign(:wizard, wizard)
   end
 
@@ -41,10 +51,10 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
 
   describe "programme details section" do
     describe "previous programme choices row" do
-      context "when the decorator says the row should be shown" do
+      context "when the current step says the row should be shown" do
         before do
-          allow(decorated_school).to receive(:show_previous_programme_choices_row?)
-            .with(wizard)
+          allow(wizard.current_step)
+            .to receive(:show_previous_programme_choices_row?)
             .and_return(true)
         end
 
@@ -54,10 +64,10 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
         end
       end
 
-      context "when the decorator says the row should not be shown" do
+      context "when the current step says the row should not be shown" do
         before do
-          allow(decorated_school).to receive(:show_previous_programme_choices_row?)
-            .with(wizard)
+          allow(wizard.current_step)
+            .to receive(:show_previous_programme_choices_row?)
             .and_return(false)
         end
 
@@ -72,22 +82,30 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
       let(:use_previous_ect_choices) { true }
 
       before do
-        allow(decorated_school).to receive(:show_previous_programme_choices_row?)
-          .with(wizard)
+        allow(wizard.current_step)
+          .to receive(:show_previous_programme_choices_row?)
           .and_return(true)
       end
 
       it "hides change links for appropriate body and lead provider" do
         render
-        expect(rendered).not_to have_link("Change", href: schools_register_ect_wizard_change_state_school_appropriate_body_path)
-        expect(rendered).not_to have_link("Change", href: schools_register_ect_wizard_change_lead_provider_path)
+        expect(rendered).not_to have_link(
+          "Change",
+          href: schools_register_ect_wizard_change_state_school_appropriate_body_path
+        )
+        expect(rendered).not_to have_link(
+          "Change",
+          href: schools_register_ect_wizard_change_lead_provider_path
+        )
       end
 
       context "when ECT has a provider-led programme and a confirmed partnership" do
         before do
           allow(wizard.ect).to receive(:provider_led?).and_return(true)
-          allow(wizard.ect).to receive(:lead_provider_has_confirmed_partnership_for_contract_period?)
+          allow(wizard.ect)
+            .to receive(:lead_provider_has_confirmed_partnership_for_contract_period?)
             .with(school).and_return(true)
+
           allow(wizard.ect).to receive_messages(
             lead_provider_name: "Confirmed LP",
             delivery_partner_name: "Confirmed DP"
@@ -96,7 +114,10 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
 
         it "hides the change link for training programme" do
           render
-          expect(rendered).not_to have_link("Change", href: schools_register_ect_wizard_change_training_programme_path)
+          expect(rendered).not_to have_link(
+            "Change",
+            href: schools_register_ect_wizard_change_training_programme_path
+          )
         end
 
         it "renders the delivery partner name from confirmed previous choices" do
@@ -111,15 +132,21 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
       let(:use_previous_ect_choices) { false }
 
       before do
-        allow(decorated_school).to receive(:show_previous_programme_choices_row?)
-          .with(wizard)
+        allow(wizard.current_step)
+          .to receive(:show_previous_programme_choices_row?)
           .and_return(true)
       end
 
       it "shows change links for appropriate body and lead provider" do
         render
-        expect(rendered).to have_link("Change", href: schools_register_ect_wizard_change_state_school_appropriate_body_path)
-        expect(rendered).to have_link("Change", href: schools_register_ect_wizard_change_lead_provider_path)
+        expect(rendered).to have_link(
+          "Change",
+          href: schools_register_ect_wizard_change_state_school_appropriate_body_path
+        )
+        expect(rendered).to have_link(
+          "Change",
+          href: schools_register_ect_wizard_change_lead_provider_path
+        )
       end
 
       context "when ECT has a provider-led programme" do
@@ -129,15 +156,19 @@ RSpec.describe "schools/register_ect_wizard/check_answers.html.erb" do
 
         it "shows change link for training programme" do
           render
-          expect(rendered).to have_link("Change", href: schools_register_ect_wizard_change_training_programme_path)
+          expect(rendered).to have_link(
+            "Change",
+            href: schools_register_ect_wizard_change_training_programme_path
+          )
         end
       end
     end
 
     context "when the previous programme choices row is not shown at all" do
       before do
-        allow(decorated_school).to receive(:show_previous_programme_choices_row?)
-          .with(wizard).and_return(false)
+        allow(wizard.current_step)
+          .to receive(:show_previous_programme_choices_row?)
+          .and_return(false)
 
         allow(wizard.ect).to receive(:use_previous_ect_choices).and_return(false)
       end

--- a/spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/check_answers_step_spec.rb
@@ -1,32 +1,44 @@
 describe Schools::RegisterECTWizard::CheckAnswersStep, type: :model do
-  subject { wizard.current_step }
+  subject(:step) { wizard.current_step }
 
   let(:training_programme) { "provider_led" }
   let(:use_previous_ect_choices) { true }
   let(:school) { FactoryBot.build(:school, :independent) }
-  let(:store) { FactoryBot.build(:session_repository, use_previous_ect_choices:, training_programme:) }
-  let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :check_answers, store:, school:) }
+  let(:store)  { FactoryBot.build(:session_repository, use_previous_ect_choices:, training_programme:) }
+
+  let(:wizard) do
+    FactoryBot.build(
+      :register_ect_wizard,
+      current_step: :check_answers,
+      store:,
+      school:
+    )
+  end
 
   describe "steps" do
     describe "#next_step" do
-      it { expect(subject.next_step).to eq(:confirmation) }
+      it "always goes to confirmation" do
+        expect(step.next_step).to eq(:confirmation)
+      end
     end
 
     describe "#previous_step" do
-      context "when school choices has been used" do
+      context "when school choices have been used" do
         let(:use_previous_ect_choices) { true }
 
-        it { expect(subject.previous_step).to eq(:use_previous_ect_choices) }
+        it "returns :use_previous_ect_choices" do
+          expect(step.previous_step).to eq(:use_previous_ect_choices)
+        end
       end
 
-      context "when school choices has not been used" do
+      context "when school choices have not been used" do
         let(:use_previous_ect_choices) { false }
 
         context "when the ect training_programme is school_led" do
           let(:training_programme) { "school_led" }
 
           it "returns :training_programme" do
-            expect(subject.previous_step).to eq(:training_programme)
+            expect(step.previous_step).to eq(:training_programme)
           end
         end
 
@@ -34,7 +46,7 @@ describe Schools::RegisterECTWizard::CheckAnswersStep, type: :model do
           let(:training_programme) { "provider_led" }
 
           it "returns :lead_provider" do
-            expect(subject.previous_step).to eq(:lead_provider)
+            expect(step.previous_step).to eq(:lead_provider)
           end
         end
       end
@@ -44,23 +56,60 @@ describe Schools::RegisterECTWizard::CheckAnswersStep, type: :model do
   describe "#save!" do
     context "when the step is not valid" do
       before do
-        allow(subject).to receive(:valid?).and_return(false)
+        allow(step).to receive(:valid?).and_return(false)
       end
 
       it "does not update any data in the wizard ect" do
-        expect { subject.save! }.not_to change(subject.ect, :ect_at_school_period_id)
+        expect { step.save! }.not_to change(step.ect, :ect_at_school_period_id)
       end
     end
 
     context "when the step is valid" do
       before do
-        allow(subject).to receive(:valid?).and_return(true)
-        allow(subject.ect).to receive(:register!).and_return(OpenStruct.new(id: 1))
+        allow(step).to receive(:valid?).and_return(true)
+        allow(step.ect).to receive(:register!).and_return(OpenStruct.new(id: 1))
       end
 
       it "updates the wizard ect ect_at_school_period_id" do
-        expect { subject.save! }
-          .to change(subject.ect, :ect_at_school_period_id).from(nil).to(1)
+        expect { step.save! }
+          .to change(step.ect, :ect_at_school_period_id).from(nil).to(1)
+      end
+    end
+  end
+
+  describe "#show_previous_programme_choices_row?" do
+    before do
+      allow(wizard).to receive(:use_previous_choices_allowed?).and_return(true)
+    end
+
+    context "when the school has last programme choices and reuse step is allowed" do
+      before do
+        allow(school).to receive(:last_programme_choices?).and_return(true)
+      end
+
+      it "returns true" do
+        expect(step.show_previous_programme_choices_row?).to be(true)
+      end
+    end
+
+    context "when the school does not have last programme choices" do
+      before do
+        allow(school).to receive(:last_programme_choices?).and_return(false)
+      end
+
+      it "returns false" do
+        expect(step.show_previous_programme_choices_row?).to be(false)
+      end
+    end
+
+    context "when reuse previous choices step is not allowed" do
+      before do
+        allow(school).to receive(:last_programme_choices?).and_return(true)
+        allow(wizard).to receive(:use_previous_choices_allowed?).and_return(false)
+      end
+
+      it "returns false" do
+        expect(step.show_previous_programme_choices_row?).to be(false)
       end
     end
   end


### PR DESCRIPTION
### Context
Following on from [#2205](https://github.com/DFE-Digital/register-ects-project-board/issues/2205) (which implements the updated reuse behaviour)

This PR re-adds the Choices used by your school previously block as part of the check & confirm page updating the logic so that it only appears when the reuse journey is followed

### Changes proposed in this pull request
**1. Adding a `Schools::DecoratedSchool#show_previous_programme_choices_row?` method which encapsulates:**
- school has last programme choices
- reuse step is allowed in the wizard
- the ECT selected "reuse previous choices"

**2. Updating Check Answers view to use `@decorated_school.show_previous_programme_choices_row?(@wizard)`**

**3. Introducing view specs covering:**
- row shown vs hidden
- correct behaviour when reuse is on/off
- correct behaviour when the reuse step is not allowed
- delivery partner row visibility

**4. Updating DecoratedSchool spec & feature specs to reflect new flow**

### Guidance to review
Check DecoratedSchool#show_previous_programme_choices_row? reflects core logic
Review the view conditionals around the Programme Details summary list
Check spec coverage covers update