### PR TITLE
Update error messages in `Resume` participant

### DIFF
--- a/app/services/api/teachers/resume.rb
+++ b/app/services/api/teachers/resume.rb
@@ -34,7 +34,7 @@ module API::Teachers
         .ongoing_today
         .without(training_period)
         .exists?
-        errors.add(:teacher_api_id, "The '#/teacher_api_id' is already active.")
+        errors.add(:teacher_api_id, "This participant cannot be resumed because they are already active with another provider.")
       end
     end
 
@@ -42,7 +42,7 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
 
       school_period = training_period.trainee
-      errors.add(:teacher_api_id, "The '#/teacher_api_id' is already active.") unless school_period.ongoing_today?
+      errors.add(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") unless school_period.ongoing_today?
     end
   end
 end


### PR DESCRIPTION
These were intentionally set to match the only error ECF returns for the sake of the partiy check. Updating now to make more sense to lead providers.

Also adds a spec for clarity around resuming when the school period finishes today (and there's not space left for a training period as it would be zero-day).