### PR TITLE
[2794] Add `api_unfunded_mentor_updated_at` to teachers

### DIFF
--- a/app/controllers/api/v3/unfunded_mentors_controller.rb
+++ b/app/controllers/api/v3/unfunded_mentors_controller.rb
@@ -39,6 +39,10 @@ module API
       def to_json(obj)
         API::Teachers::UnfundedMentorSerializer.render(obj, root: "data")
       end
+
+      def updated_at_attribute
+        "api_unfunded_mentor_updated_at"
+      end
     end
   end
 end

--- a/app/controllers/concerns/api/orderable.rb
+++ b/app/controllers/concerns/api/orderable.rb
@@ -30,9 +30,13 @@ module API
     end
 
     def transform_sort_attribute(attribute)
-      return "api_updated_at" if attribute == "updated_at"
+      return attribute unless attribute == "updated_at"
 
-      attribute
+      updated_at_attribute
+    end
+
+    def updated_at_attribute
+      "api_updated_at"
     end
   end
 end

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -17,6 +17,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_one :latest_training_period, -> { latest_first }, class_name: "TrainingPeriod"
 
   touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_updated_at
+  touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at, if: :latest_mentor_at_school_period?
 
   refresh_metadata -> { school }, on_event: %i[create destroy update]
 
@@ -69,5 +70,9 @@ private
 
   def teacher_school_distinct_period
     overlap_validation(name: "Teacher School Mentor")
+  end
+
+  def latest_mentor_at_school_period?
+    teacher.latest_mentor_at_school_period == self
   end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -57,6 +57,15 @@ class Teacher < ApplicationRecord
           mentor_payments_frozen_year
         ]
 
+  touch -> { self },
+        on_event: :update,
+        timestamp_attribute: :api_unfunded_mentor_updated_at,
+        when_changing: %i[
+          trs_first_name
+          trs_last_name
+          trn
+        ]
+
   refresh_metadata -> { self }, on_event: %i[create update]
 
   # Validations

--- a/app/serializers/api/teachers/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/teachers/unfunded_mentor_serializer.rb
@@ -8,9 +8,7 @@ class API::Teachers::UnfundedMentorSerializer < Blueprinter::Base
     end
     field(:trn, name: :teacher_reference_number)
     field :created_at
-
-    # TODO: use `api_unfunded_mentor_updated_at` once we have added it
-    field(:api_updated_at, name: :updated_at)
+    field(:api_unfunded_mentor_updated_at, name: :updated_at)
   end
 
   identifier :api_id, name: :id

--- a/app/services/api/teachers/unfunded_mentors/query.rb
+++ b/app/services/api/teachers/unfunded_mentors/query.rb
@@ -64,7 +64,7 @@ module API::Teachers::UnfundedMentors
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      @scope = scope.where(api_updated_at: updated_since..)
+      @scope = scope.where(api_unfunded_mentor_updated_at: updated_since..)
     end
 
     def set_sort_by(sort)

--- a/app/services/sandbox_seed_data/unfunded_mentors.rb
+++ b/app/services/sandbox_seed_data/unfunded_mentors.rb
@@ -54,8 +54,20 @@ module SandboxSeedData
         mentee_school_partnership = mentee_partnerships_cycle.next
         mentor_school_partnership = mentor_partnerships_cycle.next
 
-        mentee = FactoryBot.create(:teacher, :with_realistic_name, trn: Helpers::TRNGenerator.next)
-        mentor = FactoryBot.create(:teacher, :with_realistic_name, trn: Helpers::TRNGenerator.next)
+        random_date = rand(1..100).days.ago
+
+        mentee = FactoryBot.create(:teacher,
+                                   :with_realistic_name,
+                                   trn: Helpers::TRNGenerator.next,
+                                   created_at: random_date,
+                                   updated_at: random_date,
+                                   api_unfunded_mentor_updated_at: random_date)
+        mentor = FactoryBot.create(:teacher,
+                                   :with_realistic_name,
+                                   trn: Helpers::TRNGenerator.next,
+                                   created_at: random_date,
+                                   updated_at: random_date,
+                                   api_unfunded_mentor_updated_at: random_date)
 
         mentorship_period = create_mentorship_period_for(
           mentee:,

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -241,6 +241,7 @@
   - ect_first_became_eligible_for_training_at
   - mentor_first_became_eligible_for_training_at
   - api_updated_at
+  - api_unfunded_mentor_updated_at
   :metadata_teachers_lead_providers:
   - id
   - teacher_id

--- a/db/migrate/20251120115336_add_api_unfunded_mentor_updated_at_to_teachers.rb
+++ b/db/migrate/20251120115336_add_api_unfunded_mentor_updated_at_to_teachers.rb
@@ -1,0 +1,8 @@
+class AddAPIUnfundedMentorUpdatedAtToTeachers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :teachers, :api_unfunded_mentor_updated_at, :datetime, default: -> { "CURRENT_TIMESTAMP" }
+    add_index :teachers, :api_unfunded_mentor_updated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_07_093813) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_20_115336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -793,9 +793,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_07_093813) do
     t.datetime "mentor_first_became_eligible_for_training_at"
     t.boolean "trnless", default: false, null: false
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true
+    t.index ["api_unfunded_mentor_updated_at"], name: "index_teachers_on_api_unfunded_mentor_updated_at"
     t.index ["api_updated_at"], name: "index_teachers_on_api_updated_at"
     t.index ["corrected_name"], name: "index_teachers_on_corrected_name"
     t.index ["created_at"], name: "index_teachers_on_created_at"

--- a/db/seeds/api_teachers_with_histories.rb
+++ b/db/seeds/api_teachers_with_histories.rb
@@ -57,7 +57,8 @@ def create_teacher(attrs:)
     it.update!(
       created_at: random_date,
       updated_at: random_date,
-      api_updated_at: random_date
+      api_updated_at: random_date,
+      api_unfunded_mentor_updated_at: random_date
     )
   end
 end

--- a/db/seeds/unfunded_mentors.rb
+++ b/db/seeds/unfunded_mentors.rb
@@ -50,7 +50,22 @@ module UnfundedMentorsSeeder
         mentee_school_partnership = mentee_partnerships_cycle.next
         mentor_school_partnership = mentor_partnerships_cycle.next
 
+        random_date = rand(1..100).days.ago
+
+        mentee = FactoryBot.create(:teacher,
+                                   :with_realistic_name,
+                                   created_at: random_date,
+                                   updated_at: random_date,
+                                   api_unfunded_mentor_updated_at: random_date)
+        mentor = FactoryBot.create(:teacher,
+                                   :with_realistic_name,
+                                   created_at: random_date,
+                                   updated_at: random_date,
+                                   api_unfunded_mentor_updated_at: random_date)
+
         mentorship_period = create_mentorship_period_for(
+          mentee:,
+          mentor:,
           mentee_school_partnership:,
           mentor_school_partnership:
         )

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -157,6 +157,7 @@ erDiagram
     datetime mentor_first_became_eligible_for_training_at
     boolean trnless
     datetime api_updated_at
+    datetime api_unfunded_mentor_updated_at
   }
   PendingInductionSubmission {
     integer id

--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "Unfunded mentors API", :with_metadata, type: :request do
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "an index endpoint"
     it_behaves_like "a paginated endpoint"
-    it_behaves_like "a filter by updated_since endpoint"
-    it_behaves_like "a sortable endpoint"
+    it_behaves_like "a filter by updated_since endpoint", updated_at_column: :api_unfunded_mentor_updated_at
+    it_behaves_like "a sortable endpoint", updated_at_column: :api_unfunded_mentor_updated_at
   end
 
   describe "#show" do

--- a/spec/serializers/api/teachers/unfunded_mentor_serializer_spec.rb
+++ b/spec/serializers/api/teachers/unfunded_mentor_serializer_spec.rb
@@ -6,12 +6,12 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
 
   let!(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:created_at) { Time.utc(2023, 7, 1, 12, 0, 0) }
-  let(:api_updated_at) { Time.utc(2023, 7, 2, 12, 0, 0) }
+  let(:api_unfunded_mentor_updated_at) { Time.utc(2023, 7, 2, 12, 0, 0) }
   let(:unfunded_mentor_teacher) do
     FactoryBot.create(
       :teacher,
       created_at:,
-      api_updated_at:
+      api_unfunded_mentor_updated_at:
     )
   end
 
@@ -42,7 +42,7 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
       expect(attributes["created_at"]).to be_present
       expect(attributes["created_at"]).to eq(created_at.utc.rfc3339)
       expect(attributes["updated_at"]).to be_present
-      expect(attributes["updated_at"]).to eq(api_updated_at.utc.rfc3339)
+      expect(attributes["updated_at"]).to eq(api_unfunded_mentor_updated_at.utc.rfc3339)
     end
   end
 end

--- a/spec/services/api/teachers/unfunded_mentors/query_spec.rb
+++ b/spec/services/api/teachers/unfunded_mentors/query_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
         let!(:other_unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
 
         before do
-          unfunded_mentor.update!(api_updated_at: 3.days.ago)
-          other_unfunded_mentor.update!(api_updated_at: 1.day.ago)
+          unfunded_mentor.update!(api_unfunded_mentor_updated_at: 3.days.ago)
+          other_unfunded_mentor.update!(api_unfunded_mentor_updated_at: 1.day.ago)
         end
 
         it "filters by `updated_since`" do
@@ -99,8 +99,8 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
       let!(:other_unfunded_mentor) { create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher }
 
       before do
-        unfunded_mentor.update!(api_updated_at: 1.day.ago)
-        other_unfunded_mentor.update!(api_updated_at: 4.days.ago)
+        unfunded_mentor.update!(api_unfunded_mentor_updated_at: 1.day.ago)
+        other_unfunded_mentor.update!(api_unfunded_mentor_updated_at: 4.days.ago)
       end
 
       describe "default order" do
@@ -118,14 +118,14 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
 
       describe "order by updated_at, in ascending order" do
         it "returns unfunded mentors in correct order" do
-          query = described_class.new(lead_provider_id:, sort: { api_updated_at: :asc })
+          query = described_class.new(lead_provider_id:, sort: { api_unfunded_mentor_updated_at: :asc })
           expect(query.unfunded_mentors).to eq([other_unfunded_mentor, unfunded_mentor])
         end
       end
 
       describe "order by updated_at, in descending order" do
         it "returns unfunded mentors in correct order" do
-          query = described_class.new(lead_provider_id:, sort: { api_updated_at: :desc })
+          query = described_class.new(lead_provider_id:, sort: { api_unfunded_mentor_updated_at: :desc })
           expect(query.unfunded_mentors).to eq([unfunded_mentor, other_unfunded_mentor])
         end
       end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -57,14 +57,14 @@ RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpo
   end
 end
 
-RSpec.shared_examples "a filter by updated_since endpoint" do
+RSpec.shared_examples "a filter by updated_since endpoint" do |updated_at_column: :api_updated_at|
   let(:options) { defined?(serializer_options) ? serializer_options : {} }
-  let!(:resource_updated_one_week_ago) { create_resource(active_lead_provider:).tap { it.update_columns(api_updated_at: 1.week.ago) } }
-  let!(:resource_updated_one_month_ago) { create_resource(active_lead_provider:).tap { it.update_columns(api_updated_at: 1.month.ago) } }
+  let!(:resource_updated_one_week_ago) { create_resource(active_lead_provider:).tap { it.update_columns("#{updated_at_column}": 1.week.ago) } }
+  let!(:resource_updated_one_month_ago) { create_resource(active_lead_provider:).tap { it.update_columns("#{updated_at_column}": 1.month.ago) } }
 
   before do
     # Resource updated more than two months ago should not be included.
-    create_resource(active_lead_provider:).update_columns(api_updated_at: 3.months.ago)
+    create_resource(active_lead_provider:).update_columns("#{updated_at_column}": 3.months.ago)
   end
 
   it "returns only resource that have been updated since the provided date" do

--- a/spec/support/shared_contexts/api/sortable_endpoint.rb
+++ b/spec/support/shared_contexts/api/sortable_endpoint.rb
@@ -1,16 +1,19 @@
-RSpec.shared_examples "a sortable endpoint" do |additional_sorts = []|
+RSpec.shared_examples "a sortable endpoint" do |additional_sorts = [], updated_at_column: :api_updated_at|
   let!(:resources) do
     [
-      travel_to(2.days.ago) { create_resource(active_lead_provider:) }.tap { it.update!(updated_at: 1.day.ago, api_updated_at: 2.hours.ago) },
-      create_resource(active_lead_provider:).tap { it.update!(updated_at: 1.minute.ago, api_updated_at: 3.hours.ago) },
-      travel_to(5.days.ago) { create_resource(active_lead_provider:) }.tap { it.update!(updated_at: 5.days.ago, api_updated_at: 1.day.ago) },
+      travel_to(2.days.ago) { create_resource(active_lead_provider:) }.tap { it.update!("#{updated_at_column}": 2.hours.ago) },
+      create_resource(active_lead_provider:).tap { it.update!("#{updated_at_column}": 3.hours.ago) },
+      travel_to(5.days.ago) { create_resource(active_lead_provider:) }.tap { it.update!("#{updated_at_column}": 1.day.ago) },
     ]
   end
+  let(:updated_at_sort_attribute) { updated_at_column.to_s }
 
   def transform_sort_attribute(sort_attribute)
-    return "api_updated_at" if sort_attribute == "updated_at"
-
-    sort_attribute
+    if sort_attribute == "updated_at"
+      updated_at_sort_attribute
+    else
+      sort_attribute
+    end
   end
 
   sorts = %i[created_at updated_at]


### PR DESCRIPTION
### Context

Ticket: [2794](https://github.com/DFE-Digital/register-ects-project-board/issues/2794)

We need a timestamp for the unfunded mentors endpoint. This endpoint returns Teacher records, however we already have an `api_updated_at` on Teacher. Instead, we need to add a new timestamp attribute for the unfunded mentor serializer; `api_unfunded_mentor_updated_at`.

### Changes proposed in this pull request

- Add `api_unfunded_mentor_updated_at` to Teacher, defaulting to the `CURRENT_TIMESTAMP`;
- Update the query and serializer to use the new timestamp attribute;
- Update the request specs to work with filtering on attributes other than `api_updated_at`;
- Update the factory to populate a random `api_unfunded_mentor_updated_at`;
- Update the existing seed data in sandbox with random values

### Guidance to review
