### PR TITLE
Remove default `:independent_school` trait from the ECT at school period factory

### DIFF
--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   let(:school) { FactoryBot.create(:school) }
   let(:started_on) { Date.new(2023, 9, 1) }
   let(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on:, finished_on: nil) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :local_authority_ab, teacher:, school:, started_on:, finished_on: nil) }
   let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:, started_on:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: nil) }
 

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       end
     end
 
-    independent_school
+    association :school
 
     started_on { start_date }
     finished_on { end_date }


### PR DESCRIPTION
The :ect_at_school_period_factory defaulted to the :independent_school type which also creates an AB via the :national_ab trait.

Now we're using factories for seeds we don't want them, so default to just creating a default school.

This takes the number of ABs generated by the seeds down from 100+ to 10.
