### PR TITLE
Set permission `contents: read` on rspec job

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,9 +7,15 @@ on:
         type: string
         required: false
         default: "3.4.7"
+
+permissions:
+  contents: read
+
 jobs:
   backend-tests:
     name: Run rspec
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
It's set at the workflow level too in case extra jobs are added in the future that are missing permissions.