### PR TITLE
Fix flaky `ActiveLeadProvider` spec

### DIFF
--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -46,7 +46,7 @@ describe ActiveLeadProvider do
       let!(:available_alp_1) { FactoryBot.create(:active_lead_provider, contract_period:) }
       let!(:available_alp_2) { FactoryBot.create(:active_lead_provider, contract_period:) }
       let!(:assigned_alp) { FactoryBot.create(:active_lead_provider, contract_period:) }
-      let!(:different_year_alp) { FactoryBot.create(:active_lead_provider) }
+      let!(:different_year_alp) { FactoryBot.create(:active_lead_provider, :for_year, year: contract_period.year + 1) }
 
       # Create an existing partnership for one of the ALPs
       let!(:existing_partnership) do


### PR DESCRIPTION
### Context

This is failing intermittently because `different_year_alp` used a default contract period sequence. The contract period is created as 2021 then incrementally increases eventually reaching 2025 which is the contract period that we're intentionally trying to avoid.

[See failure here](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/19575024650/job/56057918455).
### Changes proposed in this pull request

The fix is to use a relative contract period year to the original contract period, that way they can never be the same.

### Guidance to review

Run the test as many times as you can bare to, the seed it failed with is `17650`.
