### PR TITLE
Prevent zero day training periods from participant actions

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -74,7 +74,6 @@ class TrainingPeriod < ApplicationRecord
   validate :trainee_distinct_period
   validate :enveloped_by_trainee_at_school_period
   validate :only_provider_led_mentor_training
-  validate :withdrawn_deferred_are_mutually_exclusive
   validates :withdrawn_at, presence: true, if: -> { withdrawal_reason.present? }
   validates :withdrawal_reason, presence: true, if: -> { withdrawn_at.present? }
   validates :deferred_at, presence: true, if: -> { deferral_reason.present? }
@@ -167,12 +166,6 @@ private
     return if school_partnership.blank?
 
     errors.add(:school_partnership, "School partnership must be absent for school-led training programmes")
-  end
-
-  def withdrawn_deferred_are_mutually_exclusive
-    return unless withdrawn_at.present? && deferred_at.present?
-
-    errors.add(:base, "A training period cannot be both withdrawn and deferred")
   end
 
   def schedule_contract_period_matches

--- a/app/services/api/teachers/defer.rb
+++ b/app/services/api/teachers/defer.rb
@@ -15,6 +15,7 @@ module API::Teachers
     validate :not_already_deferred
     validate :not_already_withdrawn
     validate :training_period_has_started
+    validate :training_for_at_least_one_day
 
     def defer
       return false if invalid?
@@ -48,7 +49,15 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period&.started_on&.future?
 
-      errors.add(:teacher_api_id, "You cannot defer '#/teacher_api_id'. This is because they've not started their training.")
+      errors.add(:teacher_api_id, "You cannot defer #/teacher_api_id. This is because they have not been training with you for at least one day.")
+    end
+
+    def training_for_at_least_one_day
+      return if errors[:teacher_api_id].any?
+      return unless training_period&.started_on&.today?
+      return if training_period.predecessors.any? { it.lead_provider.id == lead_provider_id }
+
+      errors.add(:teacher_api_id, "You cannot defer #/teacher_api_id. This is because they have not been training with you for at least one day.")
     end
   end
 end

--- a/app/services/api/teachers/withdraw.rb
+++ b/app/services/api/teachers/withdraw.rb
@@ -13,6 +13,7 @@ module API::Teachers
     }, allow_blank: true
     validate :not_already_withdrawn
     validate :training_period_has_started
+    validate :training_for_at_least_one_day
 
     def withdraw
       return false unless valid?
@@ -39,7 +40,15 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period&.started_on&.future?
 
-      errors.add(:teacher_api_id, "You cannot withdraw '#/teacher_api_id'. This is because they've not started their training.")
+      errors.add(:teacher_api_id, "You cannot withdraw #/teacher_api_id. This is because they have not been training with you for at least one day.")
+    end
+
+    def training_for_at_least_one_day
+      return if errors[:teacher_api_id].any?
+      return unless training_period&.started_on&.today?
+      return if training_period.predecessors.any? { it.lead_provider.id == lead_provider_id }
+
+      errors.add(:teacher_api_id, "You cannot withdraw #/teacher_api_id. This is because they have not been training with you for at least one day.")
     end
   end
 end

--- a/app/services/api/training_periods/training_status.rb
+++ b/app/services/api/training_periods/training_status.rb
@@ -7,13 +7,15 @@ module API::TrainingPeriods
     end
 
     def status
-      if training_period.withdrawn_at
-        :withdrawn
-      elsif training_period.deferred_at
-        :deferred
-      else
-        :active
-      end
+      return :active unless training_period.withdrawn_at || training_period.deferred_at
+
+      {
+        withdrawn: training_period.withdrawn_at,
+        deferred: training_period.deferred_at
+      }
+      .compact
+      .max_by(&:last)
+      .first
     end
 
     def active?

--- a/app/services/teachers/defer.rb
+++ b/app/services/teachers/defer.rb
@@ -11,6 +11,8 @@ module Teachers
     end
 
     def defer
+      rollback_redundant_training_period!
+
       ActiveRecord::Base.transaction do
         training_period.deferred_at = Time.zone.now
         training_period.deferral_reason = reason.underscore
@@ -24,6 +26,20 @@ module Teachers
     end
 
   private
+
+    def rollback_redundant_training_period!
+      return unless training_period.started_on.today? && previous_training_period_for_lead_provider
+
+      training_period.destroy!
+      @training_period = previous_training_period_for_lead_provider
+    end
+
+    def previous_training_period_for_lead_provider
+      @previous_training_period_for_lead_provider ||= training_period
+        .predecessors
+        .latest_first
+        .find { it.lead_provider == lead_provider }
+    end
 
     def record_deferred_event!
       return unless training_period.saved_changes?

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -142,15 +142,6 @@ describe TrainingPeriod do
     it { is_expected.not_to validate_presence_of(:deferral_reason) }
     it { is_expected.to validate_presence_of(:started_on) }
 
-    context "when deferred_at and withdrawn_at are both present" do
-      subject { FactoryBot.build(:training_period, deferred_at: Time.zone.now, withdrawn_at: Time.zone.now) }
-
-      it "is expected to have an error on base" do
-        subject.valid?
-        expect(subject.errors.messages[:base]).to include("A training period cannot be both withdrawn and deferred")
-      end
-    end
-
     context "when withdrawn_at is present" do
       subject { FactoryBot.build(:training_period, withdrawn_at: Time.zone.now) }
 

--- a/spec/services/api/training_periods/training_status_spec.rb
+++ b/spec/services/api/training_periods/training_status_spec.rb
@@ -30,5 +30,29 @@ RSpec.describe API::TrainingPeriods::TrainingStatus do
       it { expect(service).not_to be_active }
       it { expect(service).not_to be_withdrawn }
     end
+
+    context "when the training period is both withdrawn and deferred" do
+      let(:training_period) { FactoryBot.build(:training_period, withdrawn_at:, deferred_at:) }
+
+      context "when withdrawn_at is more recent than deferred_at" do
+        let(:withdrawn_at) { 2.days.ago }
+        let(:deferred_at) { 5.days.ago }
+
+        it { is_expected.to eq(:withdrawn) }
+        it { expect(service).to be_withdrawn }
+        it { expect(service).not_to be_active }
+        it { expect(service).not_to be_deferred }
+      end
+
+      context "when deferred_at is more recent than withdrawn_at" do
+        let(:withdrawn_at) { 5.days.ago }
+        let(:deferred_at) { 2.days.ago }
+
+        it { is_expected.to eq(:deferred) }
+        it { expect(service).to be_deferred }
+        it { expect(service).not_to be_active }
+        it { expect(service).not_to be_withdrawn }
+      end
+    end
   end
 end

--- a/spec/services/teachers/defer_spec.rb
+++ b/spec/services/teachers/defer_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe Teachers::Defer do
         let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: nil) }
         let(:teacher_type) { trainee_type }
 
-        context "when training period is withdrawn" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :withdrawn, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
-
-          it "raises an error if the training period is withdrawn" do
-            expect {
-              service.defer
-            }.to raise_error(ActiveRecord::RecordInvalid, /A training period cannot be both withdrawn and deferred/)
-          end
-        end
-
         context "when training period is ongoing" do
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 
@@ -90,6 +80,41 @@ RSpec.describe Teachers::Defer do
             expect(training_period.deferred_at).to eq(Time.zone.now)
             expect(training_period.deferral_reason.dasherize).to eq(reason)
             expect(training_period.finished_on).to eq(training_period.deferred_at.to_date)
+          end
+        end
+
+        context "when training period starts today and there is a previous training period" do
+          let!(:previous_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :"for_#{trainee_type}",
+              :withdrawn,
+              "#{trainee_type}_at_school_period": at_school_period,
+              school_partnership: training_period.school_partnership,
+              started_on: 5.months.ago,
+              finished_on: 1.month.ago
+            )
+          end
+          let!(:training_period) do
+            FactoryBot.create(
+              :training_period,
+              :"for_#{trainee_type}",
+              :ongoing,
+              "#{trainee_type}_at_school_period": at_school_period,
+              started_on: Time.zone.today
+            )
+          end
+
+          it "destroys the redundant training period and defers the previous one" do
+            freeze_time
+
+            expect(service.defer).not_to be(false)
+
+            expect(TrainingPeriod).not_to exist(training_period.id)
+
+            previous_training_period.reload
+            expect(previous_training_period.deferred_at).to eq(Time.zone.now)
+            expect(previous_training_period.deferral_reason.dasherize).to eq(reason)
           end
         end
 


### PR DESCRIPTION
### Context

We want to avoid zero-day training periods when a lead provider defers/withdraws and then resumes and defers/withdraws again in quick succession (on the same day).

Currently, this would raise an error/exception as we would eventually end up with a training period that is created/finished on the same day and we require a minimum 1 day duration for all training periods.

We want to handle this by removing the zero-day, resumed training period, for example:

- Provider defers a TP (this sets the finished_on)
- Provider resumes on the same date (this creates a new TP)
- Provider then defers again:
  - Delete the latest, would-be zero-day TP
  - Update deferred reason/date

### Changes proposed in this pull request

- Prevent zero-day training periods on participant actions

As part of this change we are now allowing a training period to be both withdrawn and deferred. We will always take the latest as their training status and only ever surface the latest in the API. We should have allowed this initially anyway as moving a participant from deferred to withdrawn is a valid transition.

Adds a test to ensure a participant can go from withdrawn to deferred.

In the rare case that a lead provider attempts to withdraw/defer a participant on the very first day they start training with them we will return an error (as if we finish the TP it would be zero-day and we have nothing to fallback to).

### Guidance to review

Example journey:

<img width="558" height="249" alt="Screenshot 2025-11-24 at 17 40 40" src="https://github.com/user-attachments/assets/f79ad037-f7e3-47d1-a86d-2662a74561b9" />

Things to test in PO review:

- Withdraw/defer on first day of training with a LP
- Withdraw/defer when later than first day of training with a LP
- Defer, resume then withdraw all on one day
- Defer, resume then defer all on one day
- Withdraw, resume then defer all on one day 
- Withdraw, resume then withdraw all on one day
- Defer then withdraw without resuming (should be possible now)