### PR TITLE
Introduce `API::Teachers::SchoolTransferSerializer`

### DIFF
--- a/app/serializers/api/teachers/school_transfer_serializer.rb
+++ b/app/serializers/api/teachers/school_transfer_serializer.rb
@@ -1,0 +1,66 @@
+class API::Teachers::SchoolTransferSerializer < Blueprinter::Base
+  class TrainingPeriodSerializer < Blueprinter::Base
+    field(:school_urn) do |(data, _options)|
+      data[:school].urn
+    end
+    field(:provider) do |(data, _options)|
+      data[:training_period].lead_provider&.name
+    end
+    field(:date) do |(data, _options)|
+      data[:training_period].finished_on.rfc3339
+    end
+  end
+
+  class TransferSerializer < Blueprinter::Base
+    field(:training_record_id) do |(transfer, teacher, _options)|
+      if transfer.for_ect?
+        teacher.api_ect_training_record_id
+      else
+        teacher.api_mentor_training_record_id
+      end
+    end
+    field(:transfer_type) do |(transfer, _teacher, _options)|
+      transfer.type
+    end
+    field(:status) do |(transfer, _teacher, _options)|
+      transfer.status
+    end
+
+    association :leaving, blueprint: TrainingPeriodSerializer do |(transfer, _teacher, _options)|
+      { training_period: transfer.leaving_training_period, school: transfer.leaving_school }
+    end
+    association :joining, blueprint: TrainingPeriodSerializer do |(transfer, _teacher, _options)|
+      if transfer.joining_training_period.present?
+        { training_period: transfer.joining_training_period, school: transfer.joining_school }
+      end
+    end
+  end
+
+  class AttributesSerializer < Blueprinter::Base
+    exclude :id
+
+    # TODO: use transfer updated at once implemented
+    field(:api_updated_at, name: :updated_at)
+
+    association :transfers, blueprint: TransferSerializer do |teacher, options|
+      ect_transfers = ::Teachers::SchoolTransfers::History.transfers_for(
+        school_periods: teacher.ect_at_school_periods,
+        lead_provider_id: options[:lead_provider_id]
+      )
+      mentor_transfers = ::Teachers::SchoolTransfers::History.transfers_for(
+        school_periods: teacher.mentor_at_school_periods,
+        lead_provider_id: options[:lead_provider_id]
+      )
+      (ect_transfers + mentor_transfers)
+        .sort_by { it.leaving_training_period.started_on }
+        .map { [it, teacher] }
+    end
+  end
+
+  identifier :api_id, name: :id
+  field(:type) { "participant-transfer" }
+
+  association :attributes, blueprint: AttributesSerializer do |teacher|
+    teacher
+  end
+end

--- a/app/services/teachers/school_transfers/transfer.rb
+++ b/app/services/teachers/school_transfers/transfer.rb
@@ -14,7 +14,10 @@ module Teachers::SchoolTransfers
       @joining_school = joining_school
     end
 
-    attr_reader :leaving_training_period, :joining_training_period
+    attr_reader :leaving_training_period,
+                :joining_training_period,
+                :leaving_school,
+                :joining_school
 
     def type
       return :unknown unless joining_training_period

--- a/spec/serializers/api/teachers/school_transfer_serializer_spec.rb
+++ b/spec/serializers/api/teachers/school_transfer_serializer_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe API::Teachers::SchoolTransferSerializer, type: :serializer do
+  include SchoolTransferHelpers
+
+  subject(:response) do
+    options = { lead_provider_id: lead_provider.id }
+    JSON.parse(described_class.render(teacher, **options))
+  end
+
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let(:leaving_training_period) do
+    teacher.ect_at_school_periods.first.latest_training_period
+  end
+  let(:leaving_school) do
+    teacher.ect_at_school_periods.first.school
+  end
+  let(:joining_training_period) do
+    teacher.ect_at_school_periods.second.earliest_training_period
+  end
+  let(:joining_school) do
+    teacher.ect_at_school_periods.second.school
+  end
+
+  before do
+    freeze_time
+    teacher.touch(:api_updated_at, time: 3.days.ago)
+  end
+
+  describe "core attributes" do
+    before do
+      build_new_provider_transfer(teacher:, leaving_lead_provider: lead_provider, joining_lead_provider: other_lead_provider)
+    end
+
+    it "serializes correctly" do
+      expect(response["id"]).to eq(teacher.api_id)
+      expect(response["type"]).to eq("participant-transfer")
+    end
+  end
+
+  describe "nested attributes" do
+    subject(:attributes) { response["attributes"] }
+
+    context "when there is a transfer with both leaving and joining training periods" do
+      before do
+        build_new_provider_transfer(teacher:, leaving_lead_provider: lead_provider, joining_lead_provider: other_lead_provider)
+      end
+
+      it "serializes correctly" do
+        expect(attributes["updated_at"]).to eq(3.days.ago.utc.rfc3339)
+        expect(attributes["transfers"].size).to eq(1)
+
+        transfer = attributes["transfers"].first
+        expect(transfer["training_record_id"]).to eq(teacher.api_ect_training_record_id)
+        expect(transfer["transfer_type"]).to eq("new_provider")
+        expect(transfer["status"]).to eq("complete")
+
+        leaving = transfer["leaving"]
+        expect(leaving["school_urn"]).to be_present
+        expect(leaving["school_urn"]).to eq(leaving_school.urn)
+        expect(leaving["provider"]).to be_present
+        expect(leaving["provider"]).to eq(lead_provider.name)
+        expect(leaving["date"]).to be_present
+        expect(leaving["date"]).to eq(leaving_training_period.finished_on.rfc3339)
+        joining = transfer["joining"]
+        expect(joining["school_urn"]).to be_present
+        expect(joining["school_urn"]).to eq(joining_school.urn)
+        expect(joining["provider"]).to be_present
+        expect(joining["provider"]).to eq(other_lead_provider.name)
+        expect(joining["date"]).to be_present
+        expect(joining["date"]).to eq(joining_training_period.finished_on.rfc3339)
+      end
+    end
+
+    context "when there is a transfer with a school-led joining training period" do
+      before do
+        build_new_provider_transfer(teacher:, leaving_lead_provider: lead_provider)
+      end
+
+      it "serializes correctly" do
+        expect(attributes["updated_at"]).to eq(3.days.ago.utc.rfc3339)
+        expect(attributes["transfers"].size).to eq(1)
+
+        transfer = attributes["transfers"].first
+        expect(transfer["training_record_id"]).to eq(teacher.api_ect_training_record_id)
+        expect(transfer["transfer_type"]).to eq("new_provider")
+        expect(transfer["status"]).to eq("complete")
+
+        leaving = transfer["leaving"]
+        expect(leaving["school_urn"]).to be_present
+        expect(leaving["school_urn"]).to eq(leaving_school.urn)
+        expect(leaving["provider"]).to be_present
+        expect(leaving["provider"]).to eq(lead_provider.name)
+        expect(leaving["date"]).to be_present
+        expect(leaving["date"]).to eq(leaving_training_period.finished_on.rfc3339)
+        joining = transfer["joining"]
+        expect(joining["school_urn"]).to be_present
+        expect(joining["school_urn"]).to eq(joining_school.urn)
+        expect(joining["provider"]).to be_nil
+        expect(joining["date"]).to be_present
+        expect(joining["date"]).to eq(joining_training_period.finished_on.rfc3339)
+      end
+    end
+
+    context "when there is a transfer without a joining_training_period" do
+      before do
+        build_unknown_transfer_for_finished_school_period(teacher:, lead_provider:)
+      end
+
+      it "serializes correctly" do
+        expect(attributes["updated_at"]).to eq(3.days.ago.utc.rfc3339)
+        expect(attributes["transfers"].size).to eq(1)
+
+        transfer = attributes["transfers"].first
+        expect(transfer["training_record_id"]).to eq(teacher.api_ect_training_record_id)
+        expect(transfer["transfer_type"]).to eq("unknown")
+        expect(transfer["status"]).to eq("complete")
+
+        leaving = transfer["leaving"]
+        expect(leaving["school_urn"]).to be_present
+        expect(leaving["school_urn"]).to eq(leaving_school.urn)
+        expect(leaving["provider"]).to be_present
+        expect(leaving["provider"]).to eq(lead_provider.name)
+        expect(leaving["date"]).to be_present
+        expect(leaving["date"]).to eq(leaving_training_period.finished_on.rfc3339)
+        joining = transfer["joining"]
+        expect(joining).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/teachers/school_transfers/transfer_spec.rb
+++ b/spec/services/teachers/school_transfers/transfer_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Teachers::SchoolTransfers::Transfer do
     it { is_expected.to eq(joining_training_period) }
   end
 
+  describe "#leaving_school" do
+    subject { transfer.leaving_school }
+
+    it { is_expected.to eq(leaving_school) }
+  end
+
+  describe "#joining_school" do
+    subject { transfer.joining_school }
+
+    it { is_expected.to eq(joining_school) }
+  end
+
   describe "#type" do
     subject(:type) { transfer.type }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2640

### Changes proposed in this pull request

#### Introduce SchoolTransferHelpers
Before, we used these helper methods to create "school transfers" for teachers
in the `SchoolTransfers::History` specs.

We need to do something similar for the query specs, too.

This abstracts the helpers into a module and tweaks them slightly so we can
create `MentorAtSchoolPeriod` records too.

#### Refactor Teachers::SchoolTransfers::History
In the serializer we will have access to the lead provider ID rather than the
lead provider record, but until now the `History` compared lead provider
records.

This refactors the `relevant_to_lead_provider?` check to compare IDs, and
reworks the initializer so it accepts IDs instead of lead providers.

As part of this change we also added tests to ensure the `History` class can
handle scenarios where there are no transfers or a teacher has no training
periods.

#### 
Introduce API::Teachers::SchoolTransferSerializer
This introduces a serializer for a Teacher's "school
transfers".

This will eventually be used to render the response in the transfers controller.

### Guidance to review
