### PR TITLE
Stop using Faker for appropriate body names

### DIFF
--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:appropriate_body) do
-    sequence(:name) { |n| "#{Faker::Company.name} Appropriate Body #{n}" }
+    sequence(:name) { |n| "Appropriate Body #{n}" }
 
     dfe_sign_in_organisation_id { SecureRandom.uuid }
     teaching_school_hub


### PR DESCRIPTION
### Context

Faker occasionally generates names with apostrophes, which get HTML escaped in the view and broke the response assertion.

[See failure in CI here](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/19665887569/job/56323654120).

### Changes proposed in this pull request

Switch the factory to deterministic names to avoid the escaping mismatch.

### Guidance to review

Run the test as many times as you can bare to: `spec/requests/admin/appropriate_bodies/show_spec.rb:23`

Failed with seed: `25298`
