### PR TITLE
[2712] Refine the API endpoint docs description copy

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -221,7 +221,7 @@ paths:
                 "$ref": "#/components/schemas/NotFoundResponse"
   "/api/v3/participants/{id}/withdraw":
     put:
-      summary: Update a participant
+      summary: Notify that a participant has withdrawn from their course
       tags:
       - Participants
       security:
@@ -234,7 +234,7 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: The updated participant
+          description: The participant being withdrawn
           content:
             application/json:
               examples:
@@ -308,7 +308,7 @@ paths:
               "$ref": "#/components/schemas/ParticipantWithdrawRequest"
   "/api/v3/participants/{id}/defer":
     put:
-      summary: Update a participant
+      summary: Notify that a participant is taking a break from their course
       tags:
       - Participants
       security:
@@ -321,7 +321,7 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: The updated participant
+          description: The participant being deferred
           content:
             application/json:
               examples:
@@ -395,7 +395,7 @@ paths:
               "$ref": "#/components/schemas/ParticipantDeferRequest"
   "/api/v3/participants/{id}/resume":
     put:
-      summary: Update a participant
+      summary: Notify that a participant is resuming their course
       tags:
       - Participants
       security:
@@ -408,7 +408,7 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: The updated participant
+          description: The participant being resumed
           content:
             application/json:
               examples:
@@ -480,7 +480,7 @@ paths:
               "$ref": "#/components/schemas/ParticipantResumeRequest"
   "/api/v3/participants/{id}/change-schedule":
     put:
-      summary: Update a participant
+      summary: Notify that a participant is changing training schedule
       tags:
       - Participants
       security:
@@ -493,7 +493,7 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: The updated participant
+          description: The participant changing schedule
           content:
             application/json:
               examples:
@@ -606,7 +606,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
     post:
-      summary: Create a partnership
+      summary: Create a partnership with a school and delivery partner
       tags:
       - Partnerships
       security:
@@ -675,7 +675,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
     put:
-      summary: Update a partnership
+      summary: Update the delivery partner for an existing partnership in a cohort
       tags:
       - Partnerships
       security:
@@ -800,8 +800,7 @@ paths:
                 "$ref": "#/components/schemas/NotFoundResponse"
   "/api/v3/statements":
     get:
-      summary: Retrieve multiple statements as part of which the DfE will make output
-        payments for participants
+      summary: Retrieve multiple financial statement details
       tags:
       - Statements
       security:
@@ -821,8 +820,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          description: A list of statements as part of which the DfE will make output
-            payments for participants
+          description: A list of financial statements details
           content:
             application/json:
               schema:
@@ -835,7 +833,7 @@ paths:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
   "/api/v3/statements/{id}":
     get:
-      summary: Retrieve a single financial statement
+      summary: Retrieve a single financial statement details
       tags:
       - Statements
       security:
@@ -848,7 +846,7 @@ paths:
           "$ref": "#/components/schemas/IDAttribute"
       responses:
         '200':
-          description: A single financial statement
+          description: A single financial statement details
           content:
             application/json:
               schema:

--- a/spec/requests/api/docs/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/docs/v3/delivery_partners_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Delivery partners endpoint", :with_metadata, openapi_spec: "v3/s
                   {
                     url: "/api/v3/delivery-partners",
                     tag: "Delivery Partners",
-                    resource_description: "delivery partners",
+                    resource_description: "Retrieve multiple delivery partners",
+                    response_description: "A list of delivery partners",
                     response_schema_ref: "#/components/schemas/DeliveryPartnersResponse",
                     filter_schema_ref: "#/components/schemas/DeliveryPartnersFilter",
                     sorting_schema_ref: "#/components/schemas/SortingTimestamps",
@@ -20,7 +21,8 @@ RSpec.describe "Delivery partners endpoint", :with_metadata, openapi_spec: "v3/s
                   {
                     url: "/api/v3/delivery-partners/{id}",
                     tag: "Delivery Partners",
-                    resource_description: "delivery partner",
+                    resource_description: "Retrieve a single delivery partner",
+                    response_description: "A single delivery partner",
                     response_schema_ref: "#/components/schemas/DeliveryPartnerResponse",
                   } do
   end

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -39,7 +39,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants",
                     tag: "Participants",
-                    resource_description: "participants",
+                    resource_description: "Retrieve multiple participants",
+                    response_description: "A list of participants",
                     response_schema_ref: "#/components/schemas/ParticipantsResponse",
                     filter_schema_ref: "#/components/schemas/ParticipantsFilter",
                     sorting_schema_ref: "#/components/schemas/SortingTimestamps",
@@ -57,7 +58,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}",
                     tag: "Participants",
-                    resource_description: "participant",
+                    resource_description: "Retrieve a single participant",
+                    response_description: "A single participant",
                     response_schema_ref: "#/components/schemas/ParticipantResponse",
                   } do
                     let(:response_example) do
@@ -73,7 +75,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/withdraw",
                     tag: "Participants",
-                    resource_description: "participant",
+                    resource_description: "Notify that a participant has withdrawn from their course",
+                    response_description: "The participant being withdrawn",
                     request_schema_ref: "#/components/schemas/ParticipantWithdrawRequest",
                     response_schema_ref: "#/components/schemas/ParticipantResponse",
                   } do
@@ -113,7 +116,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/defer",
                     tag: "Participants",
-                    resource_description: "participant",
+                    resource_description: "Notify that a participant is taking a break from their course",
+                    response_description: "The participant being deferred",
                     request_schema_ref: "#/components/schemas/ParticipantDeferRequest",
                     response_schema_ref: "#/components/schemas/ParticipantResponse",
                   } do
@@ -153,7 +157,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/resume",
                     tag: "Participants",
-                    resource_description: "participant",
+                    resource_description: "Notify that a participant is resuming their course",
+                    response_description: "The participant being resumed",
                     request_schema_ref: "#/components/schemas/ParticipantResumeRequest",
                     response_schema_ref: "#/components/schemas/ParticipantResponse",
                   } do
@@ -202,7 +207,8 @@ describe "Participants endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml
                   {
                     url: "/api/v3/participants/{id}/change-schedule",
                     tag: "Participants",
-                    resource_description: "participant",
+                    resource_description: "Notify that a participant is changing training schedule",
+                    response_description: "The participant changing schedule",
                     request_schema_ref: "#/components/schemas/ParticipantChangeScheduleRequest",
                     response_schema_ref: "#/components/schemas/ParticipantResponse",
                   } do

--- a/spec/requests/api/docs/v3/partnerships_spec.rb
+++ b/spec/requests/api/docs/v3/partnerships_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                   {
                     url: "/api/v3/partnerships",
                     tag: "Partnerships",
-                    resource_description: "partnerships",
+                    resource_description: "Retrieve multiple partnerships",
+                    response_description: "A list of partnerships",
                     response_schema_ref: "#/components/schemas/PartnershipsResponse",
                     filter_schema_ref: "#/components/schemas/PartnershipsFilter",
                     sorting_schema_ref: "#/components/schemas/SortingTimestamps",
@@ -20,7 +21,8 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                   {
                     url: "/api/v3/partnerships/{id}",
                     tag: "Partnerships",
-                    resource_description: "partnership",
+                    resource_description: "Retrieve a single partnership",
+                    response_description: "A single partnership",
                     response_schema_ref: "#/components/schemas/PartnershipResponse",
                   }
 
@@ -28,7 +30,8 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                   {
                     url: "/api/v3/partnerships",
                     tag: "Partnerships",
-                    resource_description: "partnership",
+                    resource_description: "Create a partnership with a school and delivery partner",
+                    response_description: "The created partnership",
                     request_schema_ref: "#/components/schemas/PartnershipCreateRequest",
                     response_schema_ref: "#/components/schemas/PartnershipResponse",
                   } do
@@ -62,7 +65,8 @@ RSpec.describe "Partnerships endpoint", openapi_spec: "v3/swagger.yaml", type: :
                   {
                     url: "/api/v3/partnerships/{id}",
                     tag: "Partnerships",
-                    resource_description: "partnership",
+                    resource_description: "Update the delivery partner for an existing partnership in a cohort",
+                    response_description: "The updated partnership",
                     request_schema_ref: "#/components/schemas/PartnershipUpdateRequest",
                     response_schema_ref: "#/components/schemas/PartnershipResponse",
                   } do

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe "Schools endpoint", :with_metadata, openapi_spec: "v3/swagger.yam
                   {
                     url: "/api/v3/schools",
                     tag: "Schools",
-                    resource_description: "schools scoped to cohort",
+                    resource_description: "Retrieve multiple schools scoped to cohort",
+                    response_description: "A list of schools scoped to cohort",
                     response_schema_ref: "#/components/schemas/SchoolsResponse",
                     filter_schema_ref: "#/components/schemas/SchoolsFilter",
                     sorting_schema_ref: "#/components/schemas/SortingTimestamps",
@@ -44,7 +45,8 @@ RSpec.describe "Schools endpoint", :with_metadata, openapi_spec: "v3/swagger.yam
                   {
                     url: "/api/v3/schools/{id}",
                     tag: "Schools",
-                    resource_description: "school scoped to cohort",
+                    resource_description: "Retrieve a single school scoped to cohort",
+                    response_description: "A single school scoped to cohort",
                     response_schema_ref: "#/components/schemas/SchoolResponse",
                     filter_schema_ref: "#/components/schemas/SchoolFilter",
                   } do

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Statements endpoint", openapi_spec: "v3/swagger.yaml", type: :re
                   {
                     url: "/api/v3/statements",
                     tag: "Statements",
-                    resource_description: "statements as part of which the DfE will make output payments for participants",
+                    resource_description: "Retrieve multiple financial statement details",
+                    response_description: "A list of financial statements details",
                     response_schema_ref: "#/components/schemas/StatementsResponse",
                     filter_schema_ref: "#/components/schemas/StatementsFilter",
                   }
@@ -18,7 +19,8 @@ RSpec.describe "Statements endpoint", openapi_spec: "v3/swagger.yaml", type: :re
                   {
                     url: "/api/v3/statements/{id}",
                     tag: "Statements",
-                    resource_description: "financial statement",
+                    resource_description: "Retrieve a single financial statement details",
+                    response_description: "A single financial statement details",
                     response_schema_ref: "#/components/schemas/StatementResponse",
                   } do
     let(:resource) { statement }

--- a/spec/requests/api/docs/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/docs/v3/unfunded_mentors_spec.rb
@@ -24,7 +24,8 @@ describe "Unfunded mentors endpoint", :with_metadata, openapi_spec: "v3/swagger.
                   {
                     url: "/api/v3/unfunded-mentors",
                     tag: "Unfunded mentors",
-                    resource_description: "unfunded mentors",
+                    resource_description: "Retrieve multiple unfunded mentors",
+                    response_description: "A list of unfunded mentors",
                     response_schema_ref: "#/components/schemas/UnfundedMentorsResponse",
                     filter_schema_ref: "#/components/schemas/UnfundedMentorsFilter",
                     sorting_schema_ref: "#/components/schemas/SortingTimestamps",
@@ -34,7 +35,8 @@ describe "Unfunded mentors endpoint", :with_metadata, openapi_spec: "v3/swagger.
                   {
                     url: "/api/v3/unfunded-mentors/{id}",
                     tag: "Unfunded mentors",
-                    resource_description: "unfunded mentor",
+                    resource_description: "Retrieve a single unfunded mentor",
+                    response_description: "A single unfunded mentor",
                     response_schema_ref: "#/components/schemas/UnfundedMentorResponse",
                   } do
   end

--- a/spec/support/shared_contexts/api/docs/api_create_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_create_endpoint_documentation_support.rb
@@ -1,7 +1,7 @@
-RSpec.shared_context "an API create endpoint documentation", :exceptions_app do |options = {}|
-  path options[:url] do
-    post "Create a #{options[:resource_description]}" do
-      tags options[:tag]
+RSpec.shared_context "an API create endpoint documentation", :exceptions_app do |params = {}|
+  path params[:url] do
+    post params[:resource_description] do
+      tags params[:tag]
       consumes "application/json"
       produces "application/json"
       security [api_key: []]
@@ -11,11 +11,11 @@ RSpec.shared_context "an API create endpoint documentation", :exceptions_app do 
                 style: :deepObject,
                 required: false,
                 schema: {
-                  "$ref": options[:request_schema_ref],
+                  "$ref": params[:request_schema_ref],
                 }
 
-      response "200", "The created #{options[:resource_description]}" do
-        schema({ "$ref": options[:response_schema_ref] })
+      response "200", params[:response_description] do
+        schema({ "$ref": params[:response_schema_ref] })
 
         run_test!
       end

--- a/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_index_endpoint_documentation_support.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |params = {}|
   path params[:url] do
-    get "Retrieve multiple #{params[:resource_description]}" do
+    get params[:resource_description] do
       tags params[:tag]
       consumes "application/json"
       produces "application/json"
@@ -33,7 +33,7 @@ RSpec.shared_context "an API index endpoint documentation", :exceptions_app do |
                   }
       end
 
-      response "200", "A list of #{params[:resource_description]}" do
+      response "200", params[:response_description] do
         schema({ "$ref": params[:response_schema_ref] })
 
         after { override_response_content!(it) }

--- a/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_show_endpoint_documentation_support.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |params = {}|
   path params[:url] do
-    get "Retrieve a single #{params[:resource_description]}" do
+    get params[:resource_description] do
       tags params[:tag]
       consumes "application/json"
       produces "application/json"
@@ -23,7 +23,7 @@ RSpec.shared_context "an API show endpoint documentation", :exceptions_app do |p
                   style: "deepObject"
       end
 
-      response "200", "A single #{params[:resource_description]}" do
+      response "200", params[:response_description] do
         let(:id) { resource.api_id }
 
         schema({ "$ref": params[:response_schema_ref] })

--- a/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
@@ -1,7 +1,7 @@
-RSpec.shared_context "an API update endpoint documentation", :exceptions_app do |options = {}|
-  path options[:url] do
-    put "Update a #{options[:resource_description]}" do
-      tags options[:tag]
+RSpec.shared_context "an API update endpoint documentation", :exceptions_app do |params = {}|
+  path params[:url] do
+    put params[:resource_description] do
+      tags params[:tag]
       consumes "application/json"
       produces "application/json"
       security [api_key: []]
@@ -18,13 +18,13 @@ RSpec.shared_context "an API update endpoint documentation", :exceptions_app do 
                 style: :deepObject,
                 required: false,
                 schema: {
-                  "$ref": options[:request_schema_ref],
+                  "$ref": params[:request_schema_ref],
                 }
 
       let(:id) { resource.api_id }
 
-      response "200", "The updated #{options[:resource_description]}" do
-        schema({ "$ref": options[:response_schema_ref] })
+      response "200", params[:response_description] do
+        schema({ "$ref": params[:response_schema_ref] })
 
         after { override_response_content!(it) }
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2712

The endpoint descriptions on swagger are unhelpful/generic.

### Changes proposed in this pull request

- Endpoint descriptions are aligned with ECF1 for all the endpoints we have implemented so far;

### Guidance to review

[Review app api docs](https://cpd-ec2-review-1799-web.test.teacherservices.cloud/api/docs/v3)