### PR TITLE
[2882] Add link to DfE Sign in support from rect homepage

### DIFF
--- a/app/views/pages/home.md.erb
+++ b/app/views/pages/home.md.erb
@@ -21,6 +21,8 @@ Before you use this service, your school needs to have certain things in place t
 
 Use DfE Sign-in to access the service. You can create an account if you don't have one.
 
+You can get <%= govuk_link_to('help with DfE Sign-in', 'https://edd-help.signin.education.gov.uk/contact', new_tab: true) %>.
+
 <%= govuk_button_link_to('Continue to DfE Sign-in', sign_in_path) %>
 
 For appropriate bodies that need to check training details, [sign in](<%= sign_in_path %>).


### PR DESCRIPTION
### Context

Adding a link to DfE Sign in support from the rect homepage because we think some users might struggle if new to DfE Sign-in.

### Changes proposed

<img width="543" height="680" alt="image" src="https://github.com/user-attachments/assets/5d85b674-2e04-42fb-8651-d1ba25568e96" />


### Guidance to review

🚢 
