### PR TITLE
[2933] Add `payments_frozen_at` to `ContractPeriod`

### DIFF
--- a/app/services/sandbox_seed_data/contract_periods.rb
+++ b/app/services/sandbox_seed_data/contract_periods.rb
@@ -1,22 +1,24 @@
 module SandboxSeedData
   class ContractPeriods < Base
-    DATA = {
-      2021 => false,
-      2022 => false,
-      2023 => true,
-      2024 => true,
-      2025 => true
-    }.freeze
+    # Seed contract periods and attributes same as in production
+    DATA = [
+      { year: 2021, enabled: false, payments_frozen_at: Time.zone.local(2024, 6, 18) },
+      { year: 2022, enabled: false, payments_frozen_at: Time.zone.local(2025, 6, 16) },
+      { year: 2023, enabled: true },
+      { year: 2024, enabled: true },
+      { year: 2025, enabled: true },
+    ].freeze
 
     def plant
       return unless plantable?
 
       log_plant_info("contract_periods")
 
-      DATA.each do |year, enabled|
+      DATA.each do |data|
         FactoryBot.create(:contract_period,
-                          year:,
-                          enabled:).tap do |contract_period|
+                          year: data[:year],
+                          enabled: data[:enabled],
+                          payments_frozen_at: data[:payments_frozen_at]).tap do |contract_period|
           log_seed_info("#{contract_period.year} (running from #{contract_period.started_on} until #{contract_period.finished_on})")
         end
       end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -412,6 +412,7 @@
   - finished_on
   - enabled
   - range
+  - payments_frozen_at
   :active_lead_providers:
   - id
   - lead_provider_id

--- a/db/migrate/20251127221958_add_payments_frozen_at_to_contract_periods.rb
+++ b/db/migrate/20251127221958_add_payments_frozen_at_to_contract_periods.rb
@@ -1,0 +1,5 @@
+class AddPaymentsFrozenAtToContractPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contract_periods, :payments_frozen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_27_221958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
     t.date "finished_on"
     t.boolean "enabled", default: false
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.datetime "payments_frozen_at"
     t.index ["year"], name: "index_contract_periods_on_year", unique: true
   end
 

--- a/db/seeds/contract_periods.rb
+++ b/db/seeds/contract_periods.rb
@@ -2,15 +2,17 @@ def describe_contract_period(cp)
   print_seed_info("#{cp.year} (running from #{cp.started_on} until #{cp.finished_on})", indent: 2)
 end
 
-{
-  2021 => false,
-  2022 => false,
-  2023 => true,
-  2024 => true,
-  2025 => true,
-  2026 => false
-}.each do |year, enabled|
+# Seed contract periods and attributes same as in production
+[
+  { year: 2021, enabled: false, payments_frozen_at: Time.zone.local(2024, 6, 18) },
+  { year: 2022, enabled: false, payments_frozen_at: Time.zone.local(2025, 6, 16) },
+  { year: 2023, enabled: true },
+  { year: 2024, enabled: true },
+  { year: 2025, enabled: true },
+  { year: 2026, enabled: false }
+].each do |data|
   FactoryBot.create(:contract_period,
-                    year:,
-                    enabled:).tap { |cp| describe_contract_period(cp) }
+                    year: data[:year],
+                    enabled: data[:enabled],
+                    payments_frozen_at: data[:payments_frozen_at]).tap { |cp| describe_contract_period(cp) }
 end

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -316,6 +316,7 @@ erDiagram
     date finished_on
     boolean enabled
     daterange range
+    datetime payments_frozen_at
   }
   AppropriateBody {
     integer id

--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-standard-april")
       end
     end
+
+    trait :with_payments_frozen do
+      payments_frozen_at { Time.zone.now }
+    end
   end
 end

--- a/spec/services/sandbox_seed_data/contract_periods_spec.rb
+++ b/spec/services/sandbox_seed_data/contract_periods_spec.rb
@@ -12,11 +12,12 @@ RSpec.describe SandboxSeedData::ContractPeriods do
     it "creates contract_periods with correct attributes" do
       instance.plant
 
-      described_class::DATA.each do |year, enabled|
-        expect(ContractPeriod.find_by!(year:)).to have_attributes(
-          enabled:,
-          started_on: Date.new(year, 6, 1),
-          finished_on: Date.new(year + 1, 5, 31)
+      described_class::DATA.each do |data|
+        expect(ContractPeriod.find_by!(year: data[:year])).to have_attributes(
+          enabled: data[:enabled],
+          started_on: Date.new(data[:year], 6, 1),
+          finished_on: Date.new(data[:year] + 1, 5, 31),
+          payments_frozen_at: data[:payments_frozen_at]
         )
       end
     end
@@ -33,7 +34,7 @@ RSpec.describe SandboxSeedData::ContractPeriods do
       expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
 
       expect(logger).to have_received(:info).with(/Planting contract_periods/).once
-      expect(logger).to have_received(:info).with(/#{described_class::DATA.keys.sample}/).at_least(:once)
+      expect(logger).to have_received(:info).with(/#{described_class::DATA.map(&:keys).sample}/).at_least(:once)
     end
 
     context "when in the production environment" do


### PR DESCRIPTION
### Context

Ticket: [2933](https://github.com/DFE-Digital/register-ects-project-board/issues/2933)

We need a way of determining if a `ContractPeriod` has been payments frozen for when we are changing schedule for these participants.

### Changes proposed in this pull request


- `payments_frozen_at` flag has been added to ContractPeriod
- Factory updated to default it to nil but with a `with_payments_frozen` trait to set it
- `ContractPeriod `seeds updated to match ECF production values on Cohort (dev and sandbox seeds)
- Sandbox ContractPeriods have been updated with correct values as per ECF production
  - Script to run in sandbox (after merge):
      ```
      c1 = ContractPeriod.find(2021)
      c1.update!(payments_frozen_at: "2024-06-18T09:56:51.017427Z")
      c2 = ContractPeriod.find(2022)
      c2.update!(payments_frozen_at: "2025-06-16T00:00:00.000000Z")
      ```
- Flag new attribute to data migration team (@tonyheadford)

### Guidance to review

[Review app](https://cpd-ec2-review-1820-web.test.teacherservices.cloud/)
