### PR TITLE
[2856] Add `mentor_funding_enabled` flag to `ContractPeriod`

### DIFF
--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -25,6 +25,7 @@ class ContractPeriod < ApplicationRecord
   validate :no_overlaps
   validates :started_on, presence: { message: "Enter a start date" }
   validates :finished_on, presence: { message: "Enter an end date" }
+  validates :mentor_funding_enabled, inclusion: { in: [true, false] }
 
   def self.containing_date(date)
     find_by(*date_in_range(date))

--- a/app/services/sandbox_seed_data/contract_periods.rb
+++ b/app/services/sandbox_seed_data/contract_periods.rb
@@ -2,11 +2,11 @@ module SandboxSeedData
   class ContractPeriods < Base
     # Seed contract periods and attributes same as in production
     DATA = [
-      { year: 2021, enabled: false, payments_frozen_at: Time.zone.local(2024, 6, 18) },
-      { year: 2022, enabled: false, payments_frozen_at: Time.zone.local(2025, 6, 16) },
-      { year: 2023, enabled: true },
-      { year: 2024, enabled: true },
-      { year: 2025, enabled: true },
+      { year: 2021, enabled: false, payments_frozen_at: Time.zone.local(2024, 6, 18), mentor_funding_enabled: false },
+      { year: 2022, enabled: false, payments_frozen_at: Time.zone.local(2025, 6, 16), mentor_funding_enabled: false },
+      { year: 2023, enabled: true, mentor_funding_enabled: false },
+      { year: 2024, enabled: true, mentor_funding_enabled: false },
+      { year: 2025, enabled: true, mentor_funding_enabled: true },
     ].freeze
 
     def plant
@@ -18,7 +18,8 @@ module SandboxSeedData
         FactoryBot.create(:contract_period,
                           year: data[:year],
                           enabled: data[:enabled],
-                          payments_frozen_at: data[:payments_frozen_at]).tap do |contract_period|
+                          payments_frozen_at: data[:payments_frozen_at],
+                          mentor_funding_enabled: data[:mentor_funding_enabled]).tap do |contract_period|
           log_seed_info("#{contract_period.year} (running from #{contract_period.started_on} until #{contract_period.finished_on})")
         end
       end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -413,6 +413,7 @@
   - enabled
   - range
   - payments_frozen_at
+  - mentor_funding_enabled
   :active_lead_providers:
   - id
   - lead_provider_id

--- a/db/migrate/20251128105319_add_mentor_funding_enabled_to_contract_periods.rb
+++ b/db/migrate/20251128105319_add_mentor_funding_enabled_to_contract_periods.rb
@@ -1,0 +1,5 @@
+class AddMentorFundingEnabledToContractPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contract_periods, :mentor_funding_enabled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_27_221958) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_28_105319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -138,6 +138,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_27_221958) do
     t.boolean "enabled", default: false
     t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.datetime "payments_frozen_at"
+    t.boolean "mentor_funding_enabled", default: false, null: false
     t.index ["year"], name: "index_contract_periods_on_year", unique: true
   end
 

--- a/db/seeds/contract_periods.rb
+++ b/db/seeds/contract_periods.rb
@@ -4,15 +4,16 @@ end
 
 # Seed contract periods and attributes same as in production
 [
-  { year: 2021, enabled: false, payments_frozen_at: Time.zone.local(2024, 6, 18) },
-  { year: 2022, enabled: false, payments_frozen_at: Time.zone.local(2025, 6, 16) },
-  { year: 2023, enabled: true },
-  { year: 2024, enabled: true },
-  { year: 2025, enabled: true },
-  { year: 2026, enabled: false }
+  { year: 2021, enabled: false, payments_frozen_at: Time.zone.local(2024, 6, 18), mentor_funding_enabled: false },
+  { year: 2022, enabled: false, payments_frozen_at: Time.zone.local(2025, 6, 16), mentor_funding_enabled: false },
+  { year: 2023, enabled: true, mentor_funding_enabled: false },
+  { year: 2024, enabled: true, mentor_funding_enabled: false },
+  { year: 2025, enabled: true, mentor_funding_enabled: true },
+  { year: 2026, enabled: false, mentor_funding_enabled: true }
 ].each do |data|
   FactoryBot.create(:contract_period,
                     year: data[:year],
                     enabled: data[:enabled],
-                    payments_frozen_at: data[:payments_frozen_at]).tap { |cp| describe_contract_period(cp) }
+                    payments_frozen_at: data[:payments_frozen_at],
+                    mentor_funding_enabled: data[:mentor_funding_enabled]).tap { |cp| describe_contract_period(cp) }
 end

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -317,6 +317,7 @@ erDiagram
     boolean enabled
     daterange range
     datetime payments_frozen_at
+    boolean mentor_funding_enabled
   }
   AppropriateBody {
     integer id

--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     enabled { true }
     started_on { Date.new(year, 6, 1) }
     finished_on { Date.new(year.next, 5, 31) }
+    mentor_funding_enabled { true }
 
     initialize_with do
       ContractPeriod.find_or_create_by(year:)

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -15,6 +15,8 @@ describe ContractPeriod do
 
     it { is_expected.to validate_presence_of(:started_on).with_message("Enter a start date") }
     it { is_expected.to validate_presence_of(:finished_on).with_message("Enter an end date") }
+    it { is_expected.to allow_values(true, false).for(:mentor_funding_enabled) }
+    it { is_expected.not_to allow_values(nil, "").for(:mentor_funding_enabled) }
 
     describe "#no_overlaps" do
       before { FactoryBot.create(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 2, 2)) }

--- a/spec/services/sandbox_seed_data/contract_periods_spec.rb
+++ b/spec/services/sandbox_seed_data/contract_periods_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe SandboxSeedData::ContractPeriods do
           enabled: data[:enabled],
           started_on: Date.new(data[:year], 6, 1),
           finished_on: Date.new(data[:year] + 1, 5, 31),
-          payments_frozen_at: data[:payments_frozen_at]
+          payments_frozen_at: data[:payments_frozen_at],
+          mentor_funding_enabled: data[:mentor_funding_enabled]
         )
       end
     end


### PR DESCRIPTION
### Context

Ticket: [2856](https://github.com/DFE-Digital/register-ects-project-board/issues/2856)

When we record a declaration for a mentor we need to determine if the contract period supports mentor_funding - if it does, we do not allow retained declarations to be submitted and different statement calculators are used.

### Changes proposed in this pull request

- `mentor_funding_enabled` flag has been added to `ContractPeriod`
- Factory updated to default it to `true`
- `ContractPeriod` seeds updated to match ECF production values on `Cohort` (dev and sandbox seeds)
- Sandbox `ContractPeriod`s have been updated with correct values as per ECF production
  - Script to run in sandbox (after merge):
      ```
      c1 = ContractPeriod.find(2025)
      c1.update!(mentor_funding_enabled: true)
      ```
- Flag new attribute to the data migration team (@tonyheadford)

### Guidance to review

[Review app](https://cpd-ec2-review-1822-web.test.teacherservices.cloud/)
