### PR TITLE
Modelling for declaration and statement items

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,19 +1,122 @@
 class Declaration < ApplicationRecord
-  enum :declaration_type,
-       {
-         "started" => "started",
-         "retained-1" => "retained-1",
-         "retained-2" => "retained-2",
-         "retained-3" => "retained-3",
-         "retained-4" => "retained-4",
-         "completed" => "completed",
-         "extended-1" => "extended-1",
-         "extended-2" => "extended-2",
-         "extended-3" => "extended-3"
-       },
-       validate: { message: "Choose a valid declaration type" }
-
   belongs_to :training_period
+  belongs_to :voided_by_user, class_name: "User", optional: true
+  belongs_to :mentorship_period, optional: true
+  has_one :statement_payment_item, class_name: "Statement::PaymentItem"
+  has_one :statement_clawback_item, class_name: "Statement::ClawbackItem"
+
+  enum :status, {
+    submitted: "submitted",
+    eligible: "eligible",
+    payable: "payable",
+    paid: "paid",
+    voided: "voided",
+    ineligible: "ineligible",
+    awaiting_clawback: "awaiting_clawback",
+    clawed_back: "clawed_back"
+  }, validate: { message: "Choose a valid status" }, suffix: true
+
+  enum :declaration_type, {
+    started: "started",
+    "retained-1": "retained-1",
+    "retained-2": "retained-2",
+    "retained-3": "retained-3",
+    "retained-4": "retained-4",
+    "extended-1": "extended-1",
+    "extended-2": "extended-2",
+    "extended-3": "extended-3",
+    completed: "completed"
+  }, validate: { message: "Choose a valid declaration type" }
+
+  enum :evidence_type, {
+    "training-event-attended": "training-event-attended",
+    "self-study-material-completed": "self-study-material-completed",
+    "materials-engaged-with-offline": "materials-engaged-with-offline",
+    "75-percent-engagement-met": "75-percent-engagement-met",
+    "75-percent-engagement-met-reduced-induction": "75-percent-engagement-met-reduced-induction",
+    "one-term-induction": "one-term-induction",
+    other: "other"
+  }, validate: { message: "Choose a valid evidence type", allow_nil: true }
+
+  enum :ineligibility_reason, {
+    duplicate: "duplicate"
+  }, validate: { message: "Choose a valid ineligibility reason", allow_nil: true }
+
+  delegate :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
 
   validates :training_period, presence: { message: "Choose a training period" }
+  validates :voided_by_user, presence: { message: "Voided by user must be set as well as the voided date" }, if: :voided_at
+  validates :voided_at, presence: { message: "Voided at must be set as well as the voided by user" }, if: :voided_by_user
+  validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another declaration" }
+  validates :date, presence: { message: "Date must be specified" }
+  validates :declaration_type, inclusion: { in: Declaration.declaration_types.keys, message: "Choose a valid declaration type" }
+  validates :evidence_type, inclusion: { in: Declaration.evidence_types.keys, message: "Choose a valid evidence type" }, allow_nil: true
+  validates :ineligibility_reason, inclusion: { in: Declaration.ineligibility_reasons.keys, message: "Choose a valid ineligibility reason" }, allow_nil: true
+  validates :ineligibility_reason, presence: { message: "Ineligibility reason must be set when the declaration is ineligible" }, if: :ineligible?
+  validates :ineligibility_reason, absence: { message: "Ineligibility reason must not be set unless the declaration is ineligible" }, unless: :ineligible?
+  validates :mentorship_period, absence: { message: "Mentor teacher can only be assigned to declarations for ECTs" }, if: :for_mentor?
+  validate :date_within_milestone
+  validate :mentorship_period_belongs_to_teacher
+
+  state_machine :status, initial: :submitted do
+    before_transition from: :ineligible, do: :clear_ineligibility_reason
+
+    event :mark_as_eligible do
+      transition %i[submitted] => :eligible
+    end
+
+    event :mark_as_payable do
+      transition %i[eligible] => :payable
+    end
+
+    event :mark_as_paid do
+      transition %i[payable] => :paid
+    end
+
+    event :mark_as_ineligible do
+      transition %i[submitted] => :ineligible
+    end
+
+    event :mark_as_awaiting_clawback do
+      transition %i[paid] => :awaiting_clawback
+    end
+
+    event :mark_as_clawed_back do
+      transition %i[awaiting_clawback] => :clawed_back
+    end
+
+    event :mark_as_voided do
+      transition %i[submitted eligible payable ineligible] => :voided
+    end
+  end
+
+private
+
+  def clear_ineligibility_reason
+    self.ineligibility_reason = nil
+  end
+
+  def date_within_milestone
+    return unless milestone && date
+
+    if date < milestone.start_date.beginning_of_day
+      errors.add(:date, "Date must be on or after the milestone start date for the same declaration type")
+    end
+
+    if milestone.milestone_date && milestone.milestone_date.end_of_day <= date
+      errors.add(:date, "Date must be on or before the milestone date for the same declaration type")
+    end
+  end
+
+  def milestone
+    training_period&.schedule&.milestones&.find_by(declaration_type:)
+  end
+
+  def mentorship_period_belongs_to_teacher
+    return unless mentorship_period && training_period
+
+    unless mentorship_period.in?(training_period.trainee.mentorship_periods)
+      errors.add(:mentorship_period, "Mentorship period must belong to the trainee")
+    end
+  end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -5,6 +5,8 @@ class Statement < ApplicationRecord
 
   belongs_to :active_lead_provider
   has_many :adjustments
+  has_many :payment_items
+  has_many :clawback_items
   has_one :lead_provider, through: :active_lead_provider
   has_one :contract_period, through: :active_lead_provider
 

--- a/app/models/statement/clawback_item.rb
+++ b/app/models/statement/clawback_item.rb
@@ -1,0 +1,33 @@
+class Statement::ClawbackItem < ApplicationRecord
+  belongs_to :statement
+  belongs_to :declaration
+
+  enum :status, {
+    awaiting_clawback: "awaiting_clawback",
+    clawed_back: "clawed_back",
+  }, validate: { message: "Choose a valid status" }, suffix: true
+
+  validates :statement_id, presence: { message: "Statement must be specified" }
+  validates :declaration_id, presence: { message: "Declaration must be specified" }
+  validates :declaration_id, uniqueness: { message: "Declaration can only have one clawback item" }
+  validates :ecf_id, uniqueness: { case_sensitive: false, message: "ECF ID must be unique" }, allow_nil: true
+  validate :declaration_has_billable_payment_item
+
+  state_machine :status, initial: :awaiting_clawback do
+    state :awaiting_clawback
+    state :clawed_back
+
+    event :mark_as_clawed_back do
+      transition [:awaiting_clawback] => :clawed_back
+    end
+  end
+
+private
+
+  def declaration_has_billable_payment_item
+    return unless declaration
+    return if declaration.statement_payment_item&.paid?
+
+    errors.add(:declaration_id, "Declaration must have a paid payment item before creating a clawback item")
+  end
+end

--- a/app/models/statement/payment_item.rb
+++ b/app/models/statement/payment_item.rb
@@ -1,0 +1,41 @@
+class Statement::PaymentItem < ApplicationRecord
+  belongs_to :statement
+  belongs_to :declaration
+
+  enum :status, {
+    eligible: "eligible",
+    payable: "payable",
+    paid: "paid",
+    voided: "voided",
+    ineligible: "ineligible",
+  }, validate: { message: "Choose a valid status" }, suffix: true
+
+  validates :statement_id, presence: { message: "Statement must be specified" }
+  validates :declaration_id, presence: { message: "Declaration must be specified" }
+  validates :declaration_id, uniqueness: { message: "Declaration can only have one payment item" }
+  validates :ecf_id, uniqueness: { case_sensitive: false, message: "ECF ID must be unique" }, allow_nil: true
+
+  state_machine :status, initial: :eligible do
+    state :eligible
+    state :payable
+    state :paid
+    state :voided
+    state :ineligible
+
+    event :mark_as_payable do
+      transition [:eligible] => :payable
+    end
+
+    event :mark_as_paid do
+      transition [:payable] => :paid
+    end
+
+    event :mark_as_voided do
+      transition %i[eligible ineligible payable] => :voided
+    end
+
+    event :mark_as_ineligible do
+      transition [:eligible] => :ineligible
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -389,6 +389,16 @@
   - id
   - training_period_id
   - declaration_type
+  - date
+  - voided_at
+  - voided_by_user_id
+  - mentorship_period_id
+  - api_id
+  - evidence_type
+  - status
+  - ineligibility_reason
+  - sparsity_uplift
+  - pupil_premium_uplift
   - created_at
   - updated_at
   :data_migrations:
@@ -440,6 +450,22 @@
   - created_at
   - updated_at
   - api_updated_at
+  :statement_payment_items:
+  - id
+  - statement_id
+  - declaration_id
+  - status
+  - ecf_id
+  - created_at
+  - updated_at
+  :statement_clawback_items:
+  - id
+  - statement_id
+  - declaration_id
+  - status
+  - ecf_id
+  - created_at
+  - updated_at
   :api_tokens:
   - id
   - lead_provider_id

--- a/db/migrate/20251126144215_create_statement_payment_items.rb
+++ b/db/migrate/20251126144215_create_statement_payment_items.rb
@@ -1,0 +1,15 @@
+class CreateStatementPaymentItems < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :statement_payment_item_statuses, %w[eligible payable paid voided ineligible]
+
+    create_table :statement_payment_items do |t|
+      t.references :statement, null: false, foreign_key: true
+      t.references :declaration, null: false, foreign_key: true, index: { unique: true }
+
+      t.enum :status, enum_type: "statement_payment_item_statuses", default: "eligible", null: false
+      t.uuid :ecf_id, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251126144216_create_statement_clawback_items.rb
+++ b/db/migrate/20251126144216_create_statement_clawback_items.rb
@@ -1,0 +1,15 @@
+class CreateStatementClawbackItems < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :statement_clawback_item_statuses, %w[awaiting_clawback clawed_back]
+
+    create_table :statement_clawback_items do |t|
+      t.references :statement, null: false, foreign_key: true
+      t.references :declaration, null: false, foreign_key: true, index: { unique: true }
+
+      t.enum :status, enum_type: "statement_clawback_item_statuses", default: "awaiting_clawback", null: false
+      t.uuid :ecf_id, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251126153633_add_attributes_to_declarations.rb
+++ b/db/migrate/20251126153633_add_attributes_to_declarations.rb
@@ -1,0 +1,28 @@
+class AddAttributesToDeclarations < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :declaration_statuses, %w[submitted eligible payable paid voided ineligible awaiting_clawback clawed_back]
+    create_enum :evidence_types, %w[training-event-attended self-study-material-completed materials-engaged-with-offline 75-percent-engagement-met 75-percent-engagement-met-reduced-induction one-term-induction other]
+    create_enum :ineligibility_reasons, %w[duplicate]
+
+    # There is no data in the declarations table yet, so we can safely remove
+    # the string column and add a new one with enum values.
+    remove_column :declarations, :declaration_type, :string
+
+    change_table :declarations, bulk: true do |t|
+      t.references :voided_by_user, null: true, foreign_key: { to_table: :users }
+      t.references :mentorship_period, null: true
+
+      t.datetime :voided_at
+      t.uuid :api_id, default: -> { "gen_random_uuid()" }, null: false
+      t.datetime :date, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.enum :evidence_type, enum_type: "evidence_types"
+      t.enum :status, enum_type: "declaration_statuses", default: "submitted", null: false
+      t.enum :ineligibility_reason, enum_type: "ineligibility_reasons"
+      t.enum :declaration_type, enum_type: "declaration_types", null: false, default: "started"
+      t.boolean :sparsity_uplift, default: false, null: false
+      t.boolean :pupil_premium_uplift, default: false, null: false
+    end
+
+    add_index :declarations, :api_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_26_153633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -22,22 +22,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
   create_enum "appropriate_body_type", ["local_authority", "national", "teaching_school_hub"]
   create_enum "batch_status", ["pending", "processing", "processed", "completing", "completed", "failed"]
   create_enum "batch_type", ["action", "claim"]
+  create_enum "declaration_statuses", ["submitted", "eligible", "payable", "paid", "voided", "ineligible", "awaiting_clawback", "clawed_back"]
   create_enum "declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed", "extended-1", "extended-2", "extended-3"]
   create_enum "deferral_reasons", ["bereavement", "long_term_sickness", "parental_leave", "career_break", "other"]
   create_enum "dfe_role_type", ["admin", "super_admin", "finance"]
   create_enum "event_author_types", ["appropriate_body_user", "school_user", "dfe_staff_user", "system", "lead_provider_api"]
+  create_enum "evidence_types", ["training-event-attended", "self-study-material-completed", "materials-engaged-with-offline", "75-percent-engagement-met", "75-percent-engagement-met-reduced-induction", "one-term-induction", "other"]
   create_enum "fee_types", ["output", "service"]
   create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
   create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
   create_enum "induction_outcomes", ["fail", "pass"]
   create_enum "induction_programme", ["cip", "fip", "diy", "unknown", "pre_september_2021"]
   create_enum "induction_programme_choice", ["not_yet_known", "provider_led", "school_led"]
+  create_enum "ineligibility_reasons", ["duplicate"]
   create_enum "mentor_became_ineligible_for_funding_reason", ["completed_declaration_received", "completed_during_early_roll_out", "started_not_completed"]
   create_enum "parity_check_request_states", ["pending", "queued", "in_progress", "completed", "failed"]
   create_enum "parity_check_run_modes", ["concurrent", "sequential"]
   create_enum "parity_check_run_states", ["pending", "in_progress", "completed", "failed"]
   create_enum "request_method_types", ["get", "post", "put"]
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
+  create_enum "statement_clawback_item_statuses", ["awaiting_clawback", "clawed_back"]
+  create_enum "statement_payment_item_statuses", ["eligible", "payable", "paid", "voided", "ineligible"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
   create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other"]
@@ -156,10 +161,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
 
   create_table "declarations", force: :cascade do |t|
     t.bigint "training_period_id"
-    t.string "declaration_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "voided_by_user_id"
+    t.bigint "mentorship_period_id"
+    t.datetime "voided_at"
+    t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
+    t.datetime "date", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.enum "evidence_type", enum_type: "evidence_types"
+    t.enum "status", default: "submitted", null: false, enum_type: "declaration_statuses"
+    t.enum "ineligibility_reason", enum_type: "ineligibility_reasons"
+    t.enum "declaration_type", default: "started", null: false, enum_type: "declaration_types"
+    t.boolean "sparsity_uplift", default: false, null: false
+    t.boolean "pupil_premium_uplift", default: false, null: false
+    t.index ["api_id"], name: "index_declarations_on_api_id", unique: true
+    t.index ["mentorship_period_id"], name: "index_declarations_on_mentorship_period_id"
     t.index ["training_period_id"], name: "index_declarations_on_training_period_id"
+    t.index ["voided_by_user_id"], name: "index_declarations_on_voided_by_user_id"
   end
 
   create_table "delivery_partners", force: :cascade do |t|
@@ -723,6 +741,30 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
     t.index ["statement_id"], name: "index_statement_adjustments_on_statement_id"
   end
 
+  create_table "statement_clawback_items", force: :cascade do |t|
+    t.bigint "statement_id", null: false
+    t.bigint "declaration_id", null: false
+    t.enum "status", default: "awaiting_clawback", null: false, enum_type: "statement_clawback_item_statuses"
+    t.uuid "ecf_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["declaration_id"], name: "index_statement_clawback_items_on_declaration_id", unique: true
+    t.index ["ecf_id"], name: "index_statement_clawback_items_on_ecf_id", unique: true
+    t.index ["statement_id"], name: "index_statement_clawback_items_on_statement_id"
+  end
+
+  create_table "statement_payment_items", force: :cascade do |t|
+    t.bigint "statement_id", null: false
+    t.bigint "declaration_id", null: false
+    t.enum "status", default: "eligible", null: false, enum_type: "statement_payment_item_statuses"
+    t.uuid "ecf_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["declaration_id"], name: "index_statement_payment_items_on_declaration_id", unique: true
+    t.index ["ecf_id"], name: "index_statement_payment_items_on_ecf_id", unique: true
+    t.index ["statement_id"], name: "index_statement_payment_items_on_statement_id"
+  end
+
   create_table "statements", force: :cascade do |t|
     t.bigint "active_lead_provider_id", null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
@@ -849,6 +891,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
 
   add_foreign_key "active_lead_providers", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "active_lead_providers", "lead_providers"
+  add_foreign_key "declarations", "users", column: "voided_by_user_id"
   add_foreign_key "ect_at_school_periods", "appropriate_bodies", column: "school_reported_appropriate_body_id"
   add_foreign_key "ect_at_school_periods", "schools"
   add_foreign_key "ect_at_school_periods", "teachers"
@@ -912,6 +955,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_115259) do
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "statement_adjustments", "statements"
+  add_foreign_key "statement_clawback_items", "declarations"
+  add_foreign_key "statement_clawback_items", "statements"
+  add_foreign_key "statement_payment_items", "declarations"
+  add_foreign_key "statement_payment_items", "statements"
   add_foreign_key "statements", "active_lead_providers"
   add_foreign_key "teacher_id_changes", "teachers"
   add_foreign_key "teacher_id_changes", "teachers", column: "api_from_teacher_id", primary_key: "api_id"

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -637,7 +637,8 @@ john_withers_training_period = FactoryBot.create(:training_period,
                                                  school_partnership: teach_first_grain_partnership_2022,
                                                  training_programme: "provider_led").tap { |tp| describe_training_period(tp) }
 
-FactoryBot.create(:declaration, training_period: john_withers_training_period)
+john_withers_declaration_date = john_withers_training_period.schedule.milestones.find_by(declaration_type: :started).start_date
+FactoryBot.create(:declaration, declaration_type: :started, date: john_withers_declaration_date, training_period: john_withers_training_period)
 
 print_seed_info("Ichigo Kurosaki (Mentor)", indent: 2, colour: MENTOR_COLOUR)
 

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -303,11 +303,23 @@ erDiagram
   Declaration {
     integer id
     integer training_period_id
-    string declaration_type
     datetime created_at
     datetime updated_at
+    integer voided_by_user_id
+    integer mentorship_period_id
+    datetime voided_at
+    uuid api_id
+    datetime date
+    enum evidence_type
+    enum status
+    enum ineligibility_reason
+    enum declaration_type
+    boolean sparsity_uplift
+    boolean pupil_premium_uplift
   }
   Declaration }o--|| TrainingPeriod : belongs_to
+  Declaration }o--|| User : belongs_to
+  Declaration }o--|| MentorshipPeriod : belongs_to
   ContractPeriod {
     integer year
     datetime created_at

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -1,6 +1,21 @@
 FactoryBot.define do
   factory(:declaration) do
-    association :training_period
-    declaration_type { "started" }
+    training_period
+    status { :submitted }
+    api_id { SecureRandom.uuid }
+    date { Faker::Date.between(from: Time.zone.now, to: 1.year.from_now) }
+    evidence_type { Declaration.evidence_types.keys.sample }
+    declaration_type { Declaration.declaration_types.keys.first }
+
+    trait :voided_by_user do
+      status { :voided }
+      voided_by_user { FactoryBot.create(:user) }
+      voided_at { Time.zone.now }
+    end
+
+    trait :ineligible do
+      status { :ineligible }
+      ineligibility_reason { Declaration.ineligibility_reasons.keys.sample }
+    end
   end
 end

--- a/spec/factories/statement/clawback_item_factory.rb
+++ b/spec/factories/statement/clawback_item_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory(:statement_clawback_item, class: "Statement::ClawbackItem") do
+    statement
+    declaration { FactoryBot.create(:statement_payment_item, status: :paid).declaration }
+    status { :awaiting_clawback }
+
+    ecf_id { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/statement/payment_item_factory.rb
+++ b/spec/factories/statement/payment_item_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory(:statement_payment_item, class: "Statement::PaymentItem") do
+    statement
+    declaration
+    status { :eligible }
+
+    ecf_id { SecureRandom.uuid }
+  end
+end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -1,12 +1,235 @@
 describe Declaration do
-  let(:declaration_types) { %w[started retained-1 retained-2 retained-3 retained-4 completed extended-1 extended-2 extended-3] }
-
   describe "associations" do
     it { is_expected.to belong_to(:training_period) }
+    it { is_expected.to belong_to(:voided_by_user).class_name("User").optional }
+    it { is_expected.to belong_to(:mentorship_period).optional }
+    it { is_expected.to have_one(:statement_payment_item).class_name("Statement::PaymentItem") }
+    it { is_expected.to have_one(:statement_clawback_item).class_name("Statement::ClawbackItem") }
+  end
+
+  describe "delegations" do
+    it { is_expected.to delegate_method(:for_ect?).to(:training_period).allow_nil }
+    it { is_expected.to delegate_method(:for_mentor?).to(:training_period).allow_nil }
   end
 
   describe "validation" do
+    it { expect(FactoryBot.build(:declaration)).to be_valid }
+
     it { is_expected.to validate_presence_of(:training_period).with_message("Choose a training period") }
-    it { is_expected.to validate_inclusion_of(:declaration_type).in_array(declaration_types).with_message("Choose a valid declaration type") }
+    it { is_expected.to validate_presence_of(:date).with_message("Date must be specified") }
+    it { is_expected.to validate_absence_of(:ineligibility_reason).with_message("Ineligibility reason must not be set unless the declaration is ineligible") }
+    it { is_expected.to validate_inclusion_of(:declaration_type).in_array(described_class.declaration_types.keys).with_message("Choose a valid declaration type") }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
+    it { is_expected.to validate_inclusion_of(:evidence_type).in_array(described_class.evidence_types.keys).with_message("Choose a valid evidence type").allow_nil }
+    it { is_expected.to validate_inclusion_of(:ineligibility_reason).in_array(described_class.ineligibility_reasons.keys).with_message("Choose a valid ineligibility reason").allow_nil }
+    it { is_expected.to validate_uniqueness_of(:api_id).with_message("API id already exists for another declaration").case_insensitive }
+    it { is_expected.not_to validate_presence_of(:voided_by_user) }
+    it { is_expected.not_to validate_presence_of(:voided_at) }
+    it { is_expected.not_to validate_presence_of(:ineligibility_reason) }
+    it { is_expected.not_to validate_absence_of(:mentorship_period) }
+
+    context "when the declaration is for a mentor" do
+      subject { FactoryBot.build(:declaration, training_period:) }
+
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 1.month.ago, finished_on: nil) }
+      let(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 1.month.ago, finished_on: nil) }
+
+      it { is_expected.to validate_absence_of(:mentorship_period).with_message("Mentorship period must belong to the trainee") }
+    end
+
+    context "when voided by a user" do
+      subject { FactoryBot.build(:declaration, :voided_by_user) }
+
+      it { is_expected.to validate_presence_of(:voided_by_user).with_message("Voided by user must be set as well as the voided date") }
+      it { is_expected.to validate_presence_of(:voided_at).with_message("Voided at must be set as well as the voided by user") }
+    end
+
+    context "when ineligible" do
+      subject { FactoryBot.build(:declaration, :ineligible) }
+
+      it { is_expected.to validate_presence_of(:ineligibility_reason).with_message("Ineligibility reason must be set when the declaration is ineligible") }
+    end
+
+    describe "declaration date relative to milestone dates" do
+      subject(:declaration) { FactoryBot.build(:declaration, declaration_type: :started, date:, training_period:) }
+
+      let(:schedule) { FactoryBot.create(:schedule, contract_period: school_partnership.contract_period) }
+      let(:milestone) { FactoryBot.create(:milestone, declaration_type: :started, schedule:) }
+      let(:school_partnership) { FactoryBot.create(:school_partnership) }
+      let(:training_period) { FactoryBot.create(:training_period, schedule:, school_partnership:) }
+
+      context "when the declaration date is within the milestone dates" do
+        let(:date) { Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when the declaration date is before the milestone start_date" do
+        let(:date) { milestone.start_date - 1.day }
+
+        it "is not valid" do
+          expect(declaration).not_to be_valid
+          expect(declaration.errors[:date]).to include("Date must be on or after the milestone start date for the same declaration type")
+        end
+      end
+
+      context "when the declaration date is after the milestone_date" do
+        let(:date) { milestone.milestone_date + 1.day }
+
+        it "is not valid" do
+          expect(declaration).not_to be_valid
+          expect(declaration.errors[:date]).to include("Date must be on or before the milestone date for the same declaration type")
+        end
+      end
+    end
+
+    describe "mentorship_period" do
+      subject(:declaration) { FactoryBot.build(:declaration, mentorship_period:, training_period:) }
+
+      let(:started_on) { 1.month.ago }
+      let(:mentor) { FactoryBot.create(:mentor_at_school_period, started_on:, finished_on: nil) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on:, finished_on: nil) }
+      let(:training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on:, finished_on: nil) }
+
+      context "when the mentorship_period does not belong to the trainee" do
+        let(:mentee) { FactoryBot.create(:ect_at_school_period, started_on:, finished_on: nil) }
+        let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentor:, mentee:, started_on:, finished_on: nil) }
+
+        it "is not valid" do
+          expect(declaration).not_to be_valid
+          expect(declaration.errors[:mentorship_period]).to include("Mentorship period must belong to the trainee")
+        end
+      end
+
+      context "when the mentorship_period does belong to the trainee" do
+        let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: training_period.trainee, finished_on: nil) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+
+  describe "enums" do
+    it "has a status enum" do
+      expect(subject).to define_enum_for(:status)
+        .with_values({
+          submitted: "submitted",
+          eligible: "eligible",
+          payable: "payable",
+          paid: "paid",
+          voided: "voided",
+          ineligible: "ineligible",
+          awaiting_clawback: "awaiting_clawback",
+          clawed_back: "clawed_back"
+        })
+        .validating(allowing_nil: false)
+        .backed_by_column_of_type(:enum)
+        .with_suffix
+    end
+
+    it "has a declaration_type enum" do
+      expect(subject).to define_enum_for(:declaration_type)
+        .with_values({
+          started: "started",
+          "retained-1": "retained-1",
+          "retained-2": "retained-2",
+          "retained-3": "retained-3",
+          "retained-4": "retained-4",
+          "extended-1": "extended-1",
+          "extended-2": "extended-2",
+          "extended-3": "extended-3",
+          completed: "completed"
+        })
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: false)
+    end
+
+    it "has a evidence_type enum" do
+      expect(subject).to define_enum_for(:evidence_type)
+        .with_values({
+          "training-event-attended": "training-event-attended",
+          "self-study-material-completed": "self-study-material-completed",
+          "materials-engaged-with-offline": "materials-engaged-with-offline",
+          "75-percent-engagement-met": "75-percent-engagement-met",
+          "75-percent-engagement-met-reduced-induction": "75-percent-engagement-met-reduced-induction",
+          "one-term-induction": "one-term-induction",
+          other: "other"
+        })
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+    end
+
+    it "has an ineligibility_reason enum" do
+      expect(subject).to define_enum_for(:ineligibility_reason)
+        .with_values({
+          duplicate: "duplicate"
+        })
+        .backed_by_column_of_type(:enum)
+        .validating(allowing_nil: true)
+    end
+  end
+
+  describe "state transitions" do
+    context "when transitioning from submitted to eligible" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :submitted) }
+
+      it { expect { declaration.mark_as_eligible! }.to change(declaration, :status).from("submitted").to("eligible") }
+    end
+
+    context "when transitioning from eligible to payable" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :eligible) }
+
+      it { expect { declaration.mark_as_payable! }.to change(declaration, :status).from("eligible").to("payable") }
+    end
+
+    context "when transitioning from payable to paid" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :payable) }
+
+      it { expect { declaration.mark_as_paid! }.to change(declaration, :status).from("payable").to("paid") }
+    end
+
+    context "when transitioning from eligible to voided" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :eligible) }
+
+      it { expect { declaration.mark_as_voided! }.to change(declaration, :status).from("eligible").to("voided") }
+    end
+
+    context "when transitioning from ineligible to voided" do
+      let(:declaration) { FactoryBot.create(:declaration, :ineligible) }
+
+      it { expect { declaration.mark_as_voided! }.to change(declaration, :status).from("ineligible").to("voided") }
+      it { expect { declaration.mark_as_voided! }.to change(declaration, :ineligibility_reason).to(nil) }
+    end
+
+    context "when transitioning from payable to voided" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :payable) }
+
+      it { expect { declaration.mark_as_voided! }.to change(declaration, :status).from("payable").to("voided") }
+    end
+
+    context "when transitioning from paid to awaiting_clawback" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :paid) }
+
+      it { expect { declaration.mark_as_awaiting_clawback! }.to change(declaration, :status).from("paid").to("awaiting_clawback") }
+    end
+
+    context "when transitioning from awaiting_clawback to clawed_back" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :awaiting_clawback) }
+
+      it { expect { declaration.mark_as_clawed_back! }.to change(declaration, :status).from("awaiting_clawback").to("clawed_back") }
+    end
+
+    context "when transitioning from submitted to ineligible" do
+      let(:reason) { described_class.ineligibility_reasons.keys.sample }
+      let(:declaration) { FactoryBot.create(:declaration, status: :submitted).tap { it.ineligibility_reason = reason } }
+
+      it { expect { declaration.mark_as_ineligible!(reason:) }.to change(declaration, :status).from("submitted").to("ineligible") }
+    end
+
+    context "when transitioning to an invalid state" do
+      let(:declaration) { FactoryBot.create(:declaration, status: :paid) }
+
+      it { expect { declaration.mark_as_payable! }.to raise_error(StateMachines::InvalidTransition) }
+    end
   end
 end

--- a/spec/models/statement/clawback_item_spec.rb
+++ b/spec/models/statement/clawback_item_spec.rb
@@ -1,0 +1,55 @@
+describe Statement::ClawbackItem do
+  describe "associations" do
+    it { is_expected.to belong_to(:statement) }
+    it { is_expected.to belong_to(:declaration) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:statement_clawback_item) }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:statement_id).with_message("Statement must be specified") }
+    it { is_expected.to validate_presence_of(:declaration_id).with_message("Declaration must be specified") }
+    it { is_expected.to validate_uniqueness_of(:declaration_id).with_message("Declaration can only have one clawback item") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
+
+    context "when declaration does not have a payment item" do
+      let(:declaration) { FactoryBot.create(:declaration) }
+      let(:clawback_item) { FactoryBot.build(:statement_clawback_item, declaration:) }
+
+      it "is not valid" do
+        expect(clawback_item).not_to be_valid
+        expect(clawback_item.errors[:declaration_id]).to include("Declaration must have a paid payment item before creating a clawback item")
+      end
+    end
+  end
+
+  describe "enums" do
+    it "has a status enum" do
+      expect(subject).to define_enum_for(:status)
+        .with_values({
+          awaiting_clawback: "awaiting_clawback",
+          clawed_back: "clawed_back"
+        })
+        .validating(allowing_nil: false)
+        .backed_by_column_of_type(:enum)
+        .with_suffix
+    end
+  end
+
+  describe "state transitions" do
+    context "when transitioning from awaiting_clawback to clawed_back" do
+      let(:clawback_item) { FactoryBot.create(:statement_clawback_item, status: :awaiting_clawback) }
+
+      it { expect { clawback_item.mark_as_clawed_back! }.to change(clawback_item, :status).from("awaiting_clawback").to("clawed_back") }
+    end
+
+    context "when transitioning to an invalid state" do
+      let(:clawback_item) { FactoryBot.create(:statement_clawback_item, status: :clawed_back) }
+
+      it { expect { clawback_item.mark_as_clawed_back! }.to raise_error(StateMachines::InvalidTransition) }
+    end
+  end
+end

--- a/spec/models/statement/payment_item_spec.rb
+++ b/spec/models/statement/payment_item_spec.rb
@@ -1,0 +1,78 @@
+describe Statement::PaymentItem do
+  describe "associations" do
+    it { is_expected.to belong_to(:statement) }
+    it { is_expected.to belong_to(:declaration) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:statement_payment_item) }
+
+    it { is_expected.to be_valid }
+
+    it { is_expected.to validate_presence_of(:statement_id).with_message("Statement must be specified") }
+    it { is_expected.to validate_presence_of(:declaration_id).with_message("Declaration must be specified") }
+    it { is_expected.to validate_uniqueness_of(:declaration_id).with_message("Declaration can only have one payment item") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
+  end
+
+  describe "enums" do
+    it "has a status enum" do
+      expect(subject).to define_enum_for(:status)
+        .with_values({
+          eligible: "eligible",
+          payable: "payable",
+          paid: "paid",
+          voided: "voided",
+          ineligible: "ineligible",
+        })
+        .validating(allowing_nil: false)
+        .backed_by_column_of_type(:enum)
+        .with_suffix
+    end
+  end
+
+  describe "state transitions" do
+    context "when transitioning from eligible to payable" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :eligible) }
+
+      it { expect { line_item.mark_as_payable! }.to change(line_item, :status).from("eligible").to("payable") }
+    end
+
+    context "when transitioning from payable to paid" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :payable) }
+
+      it { expect { line_item.mark_as_paid! }.to change(line_item, :status).from("payable").to("paid") }
+    end
+
+    context "when transitioning from eligible to voided" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :eligible) }
+
+      it { expect { line_item.mark_as_voided! }.to change(line_item, :status).from("eligible").to("voided") }
+    end
+
+    context "when transitioning from ineligible to voided" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :ineligible) }
+
+      it { expect { line_item.mark_as_voided! }.to change(line_item, :status).from("ineligible").to("voided") }
+    end
+
+    context "when transitioning from payable to voided" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :payable) }
+
+      it { expect { line_item.mark_as_voided! }.to change(line_item, :status).from("payable").to("voided") }
+    end
+
+    context "when transitioning from eligible to ineligible" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :eligible) }
+
+      it { expect { line_item.mark_as_ineligible! }.to change(line_item, :status).from("eligible").to("ineligible") }
+    end
+
+    context "when transitioning to an invalid state" do
+      let(:line_item) { FactoryBot.create(:statement_payment_item, status: :paid) }
+
+      it { expect { line_item.mark_as_paid! }.to raise_error(StateMachines::InvalidTransition) }
+    end
+  end
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -2,6 +2,8 @@ describe Statement do
   describe "associations" do
     it { is_expected.to belong_to(:active_lead_provider) }
     it { is_expected.to have_many(:adjustments) }
+    it { is_expected.to have_many(:payment_items) }
+    it { is_expected.to have_many(:clawback_items) }
     it { is_expected.to have_one(:lead_provider).through(:active_lead_provider) }
     it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
   end


### PR DESCRIPTION
WIP

### Context

I originally approached this by keeping consistent with the ECF modelling:

- https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1806
- https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1815

On further investigation it became clear that the ECF model is quite unclear with respect to the behaviour of a declaration and its line items.

This PR attempts to rework the modelling to be clearer.

### Changes proposed in this pull request

- Modelling for declaration and statement items

Finishes the `Declaration` model by adding the missing associations and attributes from ECF.

Adds two new models; `Statement::PaymentItem` and `Statement::ClawbackItem`. This diverges from ECF, which has a
single `StatementItem`, however it hopefully makes the intention and behaviour of the models clearer by splitting them up. It aims to avoid unnecessary validation to ensure declarations can only have certain types of statement items at any given time (there should only ever be 0/1 payment item and 0/1 clawback item, and no clawback item unless there is a billable payment item).

A `Declaration` moves through a number of states; when `submitted` it is neither payable or a clawback; but once it changes state it can move through payable and clawback states.

A `Declaration` can only ever have one `PaymentItem` and one `ClawbackItem` (or neither if it remains in the `submitted` state).

### Guidance to review

There are a couple of `DeclarationState` entries in ECF that are ineligible without a reason provided, but I think these are a mistake and it should always be `duplicate` as the reason, so I've enforced that in our validation here.

I thought all ECT declarations might have a mentor_user_id in ECF, but this isn't the case - a lot do not have one, so I've left it as optional here (as `mentorship_period`).

There is 1 mentor declaration in ECF that has a `mentor_user_id`, which must be a mistake so I've enforced that in validation for RECT.

The [state machine documentation](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/7e136d9a1c67b32c86e2ea8421c0afdae2c9f94e/documentation/state-machines.md) hopefully makes it clear how the different declaration/statement item states behave.

Here's the breakdown of declaration statement item states in ECF (the ineligible/paid combination should not be possible):

| Statement Item States              | Declaration Count    |
|-----------------------------|---------:|
| Payable                     | 31       |
| Eligible                    | 21,610   |
| Paid / Clawed Back          | 11,199   |
| Paid / Awaiting Clawback    | 679      |
| Paid / Ineligible           | 1        |
| Voided                      | 8,106    |
| Ineligible                  | 1,676    |
| Paid                        | 804,039  |