### PR TITLE
Speed up unfunded mentors request spec

### DIFF
--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Unfunded mentors API", :with_metadata, type: :request do
+RSpec.describe "Unfunded mentors API", type: :request do
   include MentorshipPeriodHelpers
 
   let(:serializer) { API::Teachers::UnfundedMentorSerializer }
@@ -12,7 +12,12 @@ RSpec.describe "Unfunded mentors API", :with_metadata, type: :request do
     school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
 
     # Unfunded mentor associated with the lead provider (should be returned)
-    create_mentorship_period_for(mentee_school_partnership: school_partnership).mentor.teacher
+    period = create_mentorship_period_for(mentee_school_partnership: school_partnership)
+
+    Metadata::Handlers::Teacher.new(period.mentor.teacher).refresh_metadata!
+    Metadata::Handlers::Teacher.new(period.mentee.teacher).refresh_metadata!
+
+    period.mentor.teacher
   end
 
   describe "#index" do


### PR DESCRIPTION
We are seeing timeout errors when this runs in CI; when we have had these errors in the past it was down to metadata taking too long to setup.

Manually setup metadata; this reduces the runtime of the test from ~15s to ~4s.