### PR TITLE
Add specs to validate job classes referenced in `recurring.yml`

### DIFF
--- a/spec/config/recurring_spec.rb
+++ b/spec/config/recurring_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "recurring.yml" do
+  it "references valid job classes in every entry" do
+    YAML.load_file(Rails.root.join("config/recurring.yml")).each do |env, tasks|
+      tasks.each do |key, task|
+        klass_name = task["class"]
+        next unless klass_name
+
+        expect { klass_name.constantize }.not_to raise_error,
+                                                 "Recurring task #{key.inspect} in #{env.inspect} references missing class #{klass_name}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The `dfe-analytics v1.5.11` bump renamed `DfE::Analytics::EntityTableCheckJob` to `DfE::Analytics::Jobs::EntityTableCheckJob` and the stale reference in `config/recurring.yml` caused workers to die on startup.

This mismatch meant the workers failed instantly.

### Changes proposed in this pull request

Add specs that loads `recurring_spec.yml` and constantizes each class referenced in the file, failing with the env/task reference is a class is missing/renamed.

### Guidance to review

Run the tests with `dfe-analytics` gem on version `v1.15.11` and you'll see it fail.

If you can't be bothered, i've done that and included a screenshot below.

<img width="1031" height="512" alt="image" src="https://github.com/user-attachments/assets/2c7cf354-5b96-4927-a65c-8550b35df5f6"/>
