### PR TITLE
Fix conflicting states on `Declaration`

### DIFF
--- a/db/migrate/20251204142235_change_not_started_status_on_declarations.rb
+++ b/db/migrate/20251204142235_change_not_started_status_on_declarations.rb
@@ -1,0 +1,35 @@
+class ChangeNotStartedStatusOnDeclarations < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      ALTER TYPE declaration_payment_statuses
+      RENAME VALUE 'not_started' TO 'no_payment';
+    SQL
+
+    execute <<~SQL
+      ALTER TYPE declaration_clawback_statuses
+      RENAME VALUE 'not_started' TO 'no_clawback';
+    SQL
+
+    change_table :declarations, bulk: true do |t|
+      t.change_default :payment_status, from: "not_started", to: "no_payment"
+      t.change_default :clawback_status, from: "not_started", to: "no_clawback"
+    end
+  end
+
+  def down
+    execute <<~SQL
+      ALTER TYPE declaration_payment_statuses
+      RENAME VALUE 'no_payment' TO 'not_started';
+    SQL
+
+    execute <<~SQL
+      ALTER TYPE declaration_clawback_statuses
+      RENAME VALUE 'no_clawback' TO 'not_started';
+    SQL
+
+    change_table :declarations, bulk: true do |t|
+      t.change_default :payment_status, from: "no_payment", to: "not_started"
+      t.change_default :clawback_status, from: "no_clawback", to: "not_started"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_02_100021) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_04_142235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -22,8 +22,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_02_100021) do
   create_enum "appropriate_body_type", ["local_authority", "national", "teaching_school_hub"]
   create_enum "batch_status", ["pending", "processing", "processed", "completing", "completed", "failed"]
   create_enum "batch_type", ["action", "claim"]
-  create_enum "declaration_clawback_statuses", ["not_started", "awaiting_clawback", "clawed_back"]
-  create_enum "declaration_payment_statuses", ["not_started", "eligible", "payable", "paid", "voided", "ineligible"]
+  create_enum "declaration_clawback_statuses", ["no_clawback", "awaiting_clawback", "clawed_back"]
+  create_enum "declaration_payment_statuses", ["no_payment", "eligible", "payable", "paid", "voided", "ineligible"]
   create_enum "declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed", "extended-1", "extended-2", "extended-3"]
   create_enum "deferral_reasons", ["bereavement", "long_term_sickness", "parental_leave", "career_break", "other"]
   create_enum "dfe_role_type", ["admin", "super_admin", "finance"]
@@ -173,8 +173,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_02_100021) do
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "declaration_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.enum "evidence_type", enum_type: "evidence_types"
-    t.enum "payment_status", default: "not_started", null: false, enum_type: "declaration_payment_statuses"
-    t.enum "clawback_status", default: "not_started", null: false, enum_type: "declaration_clawback_statuses"
+    t.enum "payment_status", default: "no_payment", null: false, enum_type: "declaration_payment_statuses"
+    t.enum "clawback_status", default: "no_clawback", null: false, enum_type: "declaration_clawback_statuses"
     t.enum "ineligibility_reason", enum_type: "ineligibility_reasons"
     t.enum "declaration_type", default: "started", null: false, enum_type: "declaration_types"
     t.boolean "sparsity_uplift", default: false, null: false

--- a/documentation/state-machines.md
+++ b/documentation/state-machines.md
@@ -32,7 +32,7 @@ A declaration has two state machines, one for payments and one for clawbacks.
 
 The payment states are:
 
-- `not_started` is the initial state of a declaration; if the participant is not eligible for funding and there are no duplicate declarations then the declaration remains in this state.
+- `no_payment` is the initial state of a declaration; if the participant is not eligible for funding and there are no duplicate declarations then the declaration remains in this state.
 - `eligible` is the state of a declaration that will progress towards payment.
 - `payable` once it has been confirmed for payment.
 - `paid` when the declaration has been paid.
@@ -41,30 +41,30 @@ The payment states are:
 
 The clawback states are:
 
-- `not_started` is the initial state of a declaration; it remains this way until a clawback is initiated.
+- `no_clawback` is the initial state of a declaration; it remains this way until a clawback is initiated.
 - `awaiting_clawback` is the state after a clawback has been initiated for a paid declaration.
 - `clawed_back` once the amount has successfully been reclaimed.
 
 There are five payment transitions a declaration can go through:
 
-- `mark_as_eligible` transitions a declaration from `not_started` to `eligible`. This happens on submitting a declaration if there are no duplicates and the participant is eligible for funding.
-- `mark_as_ineligible` transitions a declaration from `not_started` to `ineligible`. This happens when there is a duplicate declaration for the participant.
+- `mark_as_eligible` transitions a declaration from `no_payment` to `eligible`. This happens on submitting a declaration if there are no duplicates and the participant is eligible for funding.
+- `mark_as_ineligible` transitions a declaration from `no_payment` to `ineligible`. This happens when there is a duplicate declaration for the participant.
 - `mark_as_payable` transitions a declaration from `eligible` to `payable`. This happens on a daily job that picks up statements when the `deadline_date` has passed.
 - `mark_as_paid` transitions a declaration from `payable` to `paid`. This happens when a finance user marks a statement as paid in the finance dashboard.
 - `mark_as_voided` transitions a declaration from `eligible`, `ineligible` or `payable` to `voided`. This happens when a lead provider voids an unpaid declaration.
 
 There are two clawback transitions a declaration can go through once in the `paid` payment state:
 
-- `mark_as_awaiting_clawback` transitions a declaration from `not_started` to `awaiting_clawback`. This happens when a paid declaration is voided by a lead provider.
+- `mark_as_awaiting_clawback` transitions a declaration from `no_clawback` to `awaiting_clawback`. This happens when a paid declaration is voided by a lead provider.
 - `mark_as_clawed_back` transitions a declaration from `awaiting_clawback` to `clawed_back`. This happens when a declaration is marked as refunded in the finance dashboard.
 
 ### Payment states
 
 ```mermaid
 stateDiagram-v2
-  [*] --> not_started
-  not_started --> eligible : mark_as_eligible
-  not_started --> ineligible: mark_as_ineligible
+  [*] --> no_payment
+  no_payment --> eligible : mark_as_eligible
+  no_payment --> ineligible: mark_as_ineligible
   eligible --> payable : mark_as_payable
   payable --> paid : mark_as_paid
   eligible --> ineligible : mark_as_ineligible
@@ -77,7 +77,7 @@ stateDiagram-v2
 
 ```mermaid
 stateDiagram-v2
-  [*] --> not_started
-  not_started --> awaiting_clawback : mark_as_awaiting_clawback
+  [*] --> no_clawback
+  no_clawback --> awaiting_clawback : mark_as_awaiting_clawback
   awaiting_clawback --> clawed_back : mark_as_clawed_back
 ```

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -1,14 +1,12 @@
 FactoryBot.define do
   factory(:declaration) do
     training_period
-    payment_status { :not_started }
-    clawback_status { :not_started }
+    payment_status { :no_payment }
+    clawback_status { :no_clawback }
     api_id { SecureRandom.uuid }
     declaration_date { Faker::Date.between(from: Time.zone.now, to: 1.year.from_now) }
     evidence_type { Declaration.evidence_types.keys.sample }
     declaration_type { Declaration.declaration_types.keys.first }
-    payment_statement { nil }
-    clawback_statement { nil }
 
     trait :voided_by_user do
       payment_status { :voided }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -126,7 +126,7 @@ describe Declaration do
     it "has a payment_status enum" do
       expect(subject).to define_enum_for(:payment_status)
         .with_values({
-          not_started: "not_started",
+          no_payment: "no_payment",
           eligible: "eligible",
           payable: "payable",
           paid: "paid",
@@ -141,7 +141,7 @@ describe Declaration do
     it "has a clawback_status enum" do
       expect(subject).to define_enum_for(:clawback_status)
         .with_values({
-          not_started: "not_started",
+          no_clawback: "no_clawback",
           awaiting_clawback: "awaiting_clawback",
           clawed_back: "clawed_back"
         })
@@ -193,10 +193,10 @@ describe Declaration do
   end
 
   describe "payment_status transitions" do
-    context "when transitioning from not_started to eligible" do
+    context "when transitioning from no_payment to eligible" do
       let(:declaration) { FactoryBot.create(:declaration).tap { it.payment_statement = FactoryBot.create(:statement, :open) } }
 
-      it { expect { declaration.mark_as_eligible! }.to change(declaration, :payment_status).from("not_started").to("eligible") }
+      it { expect { declaration.mark_as_eligible! }.to change(declaration, :payment_status).from("no_payment").to("eligible") }
     end
 
     context "when transitioning from eligible to payable" do
@@ -230,7 +230,7 @@ describe Declaration do
       it { expect { declaration.mark_as_voided! }.to change(declaration, :payment_status).from("payable").to("voided") }
     end
 
-    context "when transitioning from not_started to ineligible" do
+    context "when transitioning from no_payment to ineligible" do
       let(:reason) { described_class.ineligibility_reasons.keys.sample }
       let(:declaration) do
         FactoryBot.create(:declaration).tap do
@@ -239,7 +239,7 @@ describe Declaration do
         end
       end
 
-      it { expect { declaration.mark_as_ineligible! }.to change(declaration, :payment_status).from("not_started").to("ineligible") }
+      it { expect { declaration.mark_as_ineligible! }.to change(declaration, :payment_status).from("no_payment").to("ineligible") }
     end
 
     context "when transitioning to an invalid state" do
@@ -250,13 +250,13 @@ describe Declaration do
   end
 
   describe "clawback_status transitions" do
-    context "when transitioning from not_started to awaiting_clawback" do
+    context "when transitioning from no_clawback to awaiting_clawback" do
       let(:declaration) { FactoryBot.create(:declaration, :paid).tap { it.clawback_statement = FactoryBot.create(:statement, :payable) } }
 
-      it { expect { declaration.mark_as_awaiting_clawback! }.to change(declaration, :clawback_status).from("not_started").to("awaiting_clawback") }
+      it { expect { declaration.mark_as_awaiting_clawback! }.to change(declaration, :clawback_status).from("no_clawback").to("awaiting_clawback") }
     end
 
-    context "when transitioning from not_started to awaiting_clawback, when the declaration is not paid" do
+    context "when transitioning from no_clawback to awaiting_clawback, when the declaration is not paid" do
       let(:declaration) { FactoryBot.create(:declaration, :payable).tap { it.clawback_statement = FactoryBot.create(:statement, :payable) } }
 
       it { expect { declaration.mark_as_awaiting_clawback! }.to raise_error(StateMachines::InvalidTransition) }


### PR DESCRIPTION
The state machines gem doesn't like us having a `not_started` state on both `payment_status` and `clawback_status`; presumably because it generates some conflicting method names somewhere. It raises a warning when Rails boots.

Change `not_started` to `no_payment` and `no_clawback` to avoid conflicts.

Thanks to @peterdavidhamilton for flagging!
