### PR TITLE
Only run API seed data when `SEED_API_DATA` env var is truthy

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,6 +26,8 @@ seed_files = Dir["db/seeds/*.rb"].sort_by do |path|
   priority_seeds.index(filename.chomp(".rb")) || Float::INFINITY
 end
 
+SEED_API_DATA = ActiveModel::Type::Boolean.new.cast(ENV.fetch("SEED_API_DATA", false))
+
 DeclarativeUpdates.skip(:metadata) do
   seed_files.each do |seed_file|
     puts "\r\n🪴 planting #{seed_file}"

--- a/db/seeds/api_teachers_with_histories.rb
+++ b/db/seeds/api_teachers_with_histories.rb
@@ -80,134 +80,136 @@ def random_schedule(contract_period:, trainee_type:, excluding_schedule_identifi
   end
 end
 
-# Create extra participants for API review app testing
-# - 5x participants for each lead provider and contract period
-print_seed_info("Adding extra participants for API testing:")
+if SEED_API_DATA
+  # Create extra participants for API review app testing
+  # - 5x participants for each lead provider and contract period
+  print_seed_info("Adding extra participants for API testing:")
 
-teachers = [
-  { types: %i[ect], traits: %i[with_uplifts with_teacher_id_change], frozen_year: 2021 },
-  { types: %i[ect], traits: %i[with_uplifts], frozen_year: 2022 },
-  { types: %i[ect mentor], traits: %i[with_teacher_id_change] },
+  teachers = [
+    { types: %i[ect], traits: %i[with_uplifts with_teacher_id_change], frozen_year: 2021 },
+    { types: %i[ect], traits: %i[with_uplifts], frozen_year: 2022 },
+    { types: %i[ect mentor], traits: %i[with_teacher_id_change] },
 
-  { types: %i[mentor], traits: %i[with_teacher_id_change], frozen_year: 2021 },
-  { types: %i[mentor], traits: %i[] },
-]
+    { types: %i[mentor], traits: %i[with_teacher_id_change], frozen_year: 2021 },
+    { types: %i[mentor], traits: %i[] },
+  ]
 
-ActiveLeadProvider.find_each do |active_lead_provider|
-  contract_period = active_lead_provider.contract_period
+  ActiveLeadProvider.find_each do |active_lead_provider|
+    contract_period = active_lead_provider.contract_period
 
-  teachers.each do |attrs|
-    attrs = attrs.deep_dup
-    trainee_types = attrs.delete(:types)
-    frozen_year = attrs.delete(:frozen_year)
+    teachers.each do |attrs|
+      attrs = attrs.deep_dup
+      trainee_types = attrs.delete(:types)
+      frozen_year = attrs.delete(:frozen_year)
 
-    teacher = create_teacher(attrs:)
-    full_name = "#{teacher.trs_first_name} #{teacher.trs_last_name}"
+      teacher = create_teacher(attrs:)
+      full_name = "#{teacher.trs_first_name} #{teacher.trs_last_name}"
 
-    trainee_types.each do |trainee_type|
-      print_seed_info("#{full_name} (#{trainee_type.upcase})", indent: 2, colour: (trainee_type == :ect ? :magenta : :yellow))
+      trainee_types.each do |trainee_type|
+        print_seed_info("#{full_name} (#{trainee_type.upcase})", indent: 2, colour: (trainee_type == :ect ? :magenta : :yellow))
 
-      if frozen_year && contract_period.year == 2024
-        teacher.update!("#{trainee_type}_payments_frozen_year": frozen_year)
+        if frozen_year && contract_period.year == 2024
+          teacher.update!("#{trainee_type}_payments_frozen_year": frozen_year)
+        end
+
+        started_on = Date.new(contract_period.year, 9, 1) + rand(1..100).days
+
+        school_partnership = random_school_partnership(active_lead_provider:)
+
+        at_school_period = FactoryBot.create(
+          :"#{trainee_type}_at_school_period",
+          school: school_partnership.school,
+          teacher:,
+          started_on:,
+          finished_on: nil
+        ).tap { |sp| send(:"describe_#{trainee_type}_at_school_period", sp) }
+
+        schedule = random_schedule(contract_period:, trainee_type:)
+
+        FactoryBot.create(
+          :training_period,
+          :"for_#{trainee_type}",
+          :provider_led,
+          :with_schedule,
+          "#{trainee_type}_at_school_period": at_school_period,
+          started_on: at_school_period.started_on,
+          finished_on: at_school_period.finished_on,
+          schedule:,
+          school_partnership:
+        ).tap { |tp| describe_training_period(tp) }
       end
-
-      started_on = Date.new(contract_period.year, 9, 1) + rand(1..100).days
-
-      school_partnership = random_school_partnership(active_lead_provider:)
-
-      at_school_period = FactoryBot.create(
-        :"#{trainee_type}_at_school_period",
-        school: school_partnership.school,
-        teacher:,
-        started_on:,
-        finished_on: nil
-      ).tap { |sp| send(:"describe_#{trainee_type}_at_school_period", sp) }
-
-      schedule = random_schedule(contract_period:, trainee_type:)
-
-      FactoryBot.create(
-        :training_period,
-        :"for_#{trainee_type}",
-        :provider_led,
-        :with_schedule,
-        "#{trainee_type}_at_school_period": at_school_period,
-        started_on: at_school_period.started_on,
-        finished_on: at_school_period.finished_on,
-        schedule:,
-        school_partnership:
-      ).tap { |tp| describe_training_period(tp) }
     end
   end
-end
 
-print_seed_info("Add teachers with changed schedule:")
-contract_period = ContractPeriod.find_by(year: 2022)
-variations = [
-  { change_contract_period: false, change_schedule: true },
-  { change_contract_period: true, change_schedule: false },
-  { change_contract_period: true, change_schedule: true },
-]
-ActiveLeadProvider.where(contract_period:).find_each do |active_lead_provider|
-  %i[ect mentor].each do |trainee_type|
-    variations.each do |variation|
-      teacher = create_teacher(attrs: {})
-      full_name = "#{teacher.trs_first_name} #{teacher.trs_last_name}"
-      print_seed_info("#{full_name} (#{trainee_type.upcase}) - #{variation.keep_if { |_k, v| v }.keys.join(', ')}", indent: 2, colour: (trainee_type == :ect ? :magenta : :yellow))
+  print_seed_info("Add teachers with changed schedule:")
+  contract_period = ContractPeriod.find_by(year: 2022)
+  variations = [
+    { change_contract_period: false, change_schedule: true },
+    { change_contract_period: true, change_schedule: false },
+    { change_contract_period: true, change_schedule: true },
+  ]
+  ActiveLeadProvider.where(contract_period:).find_each do |active_lead_provider|
+    %i[ect mentor].each do |trainee_type|
+      variations.each do |variation|
+        teacher = create_teacher(attrs: {})
+        full_name = "#{teacher.trs_first_name} #{teacher.trs_last_name}"
+        print_seed_info("#{full_name} (#{trainee_type.upcase}) - #{variation.keep_if { |_k, v| v }.keys.join(', ')}", indent: 2, colour: (trainee_type == :ect ? :magenta : :yellow))
 
-      started_on = Date.new(contract_period.year, 9, 1) + rand(1..100).days
-      at_school_period = FactoryBot.create(
-        :"#{trainee_type}_at_school_period",
-        teacher:,
-        started_on:,
-        finished_on: nil
-      ).tap { |sp| send(:"describe_#{trainee_type}_at_school_period", sp) }
+        started_on = Date.new(contract_period.year, 9, 1) + rand(1..100).days
+        at_school_period = FactoryBot.create(
+          :"#{trainee_type}_at_school_period",
+          teacher:,
+          started_on:,
+          finished_on: nil
+        ).tap { |sp| send(:"describe_#{trainee_type}_at_school_period", sp) }
 
-      school_partnership = random_school_partnership(active_lead_provider:)
-      schedule = random_schedule(contract_period:, trainee_type:)
-      finished_on = at_school_period.started_on + rand(1..100).days
+        school_partnership = random_school_partnership(active_lead_provider:)
+        schedule = random_schedule(contract_period:, trainee_type:)
+        finished_on = at_school_period.started_on + rand(1..100).days
 
-      # Old training period
-      FactoryBot.create(
-        :training_period,
-        :"for_#{trainee_type}",
-        :provider_led,
-        "#{trainee_type}_at_school_period": at_school_period,
-        started_on: at_school_period.started_on,
-        finished_on:,
-        schedule:,
-        school_partnership:
-      ).tap { |tp| describe_training_period(tp) }
+        # Old training period
+        FactoryBot.create(
+          :training_period,
+          :"for_#{trainee_type}",
+          :provider_led,
+          "#{trainee_type}_at_school_period": at_school_period,
+          started_on: at_school_period.started_on,
+          finished_on:,
+          schedule:,
+          school_partnership:
+        ).tap { |tp| describe_training_period(tp) }
 
-      # With new contract_period
-      if variation[:change_contract_period]
-        school_partnership = SchoolPartnership
-          .includes(:lead_provider, :contract_period)
-          .joins(:lead_provider)
-          .where(
-            school: school_partnership.school,
-            lead_providers: { id: active_lead_provider.lead_provider.id }
-          )
-          .order("RANDOM()")
-          .first!
-        schedule = Schedule.find_by!(contract_period: school_partnership.contract_period, identifier: schedule.identifier)
+        # With new contract_period
+        if variation[:change_contract_period]
+          school_partnership = SchoolPartnership
+            .includes(:lead_provider, :contract_period)
+            .joins(:lead_provider)
+            .where(
+              school: school_partnership.school,
+              lead_providers: { id: active_lead_provider.lead_provider.id }
+            )
+            .order("RANDOM()")
+            .first!
+          schedule = Schedule.find_by!(contract_period: school_partnership.contract_period, identifier: schedule.identifier)
+        end
+
+        # With new schedule
+        if variation[:change_schedule]
+          schedule = random_schedule(contract_period: school_partnership.contract_period, trainee_type:, excluding_schedule_identifier: schedule.identifier)
+        end
+
+        # New training period
+        FactoryBot.create(
+          :training_period,
+          :"for_#{trainee_type}",
+          :provider_led,
+          "#{trainee_type}_at_school_period": at_school_period,
+          started_on: finished_on,
+          finished_on: at_school_period.finished_on,
+          schedule:,
+          school_partnership:
+        ).tap { |tp| describe_training_period(tp) }
       end
-
-      # With new schedule
-      if variation[:change_schedule]
-        schedule = random_schedule(contract_period: school_partnership.contract_period, trainee_type:, excluding_schedule_identifier: schedule.identifier)
-      end
-
-      # New training period
-      FactoryBot.create(
-        :training_period,
-        :"for_#{trainee_type}",
-        :provider_led,
-        "#{trainee_type}_at_school_period": at_school_period,
-        started_on: finished_on,
-        finished_on: at_school_period.finished_on,
-        schedule:,
-        school_partnership:
-      ).tap { |tp| describe_training_period(tp) }
     end
   end
 end

--- a/db/seeds/teacher_transfers.rb
+++ b/db/seeds/teacher_transfers.rb
@@ -107,4 +107,4 @@ module TeacherTransfersSeeder
   end
 end
 
-TeacherTransfersSeeder.seed!
+TeacherTransfersSeeder.seed! if SEED_API_DATA

--- a/db/seeds/unfunded_mentors.rb
+++ b/db/seeds/unfunded_mentors.rb
@@ -86,4 +86,4 @@ module UnfundedMentorsSeeder
   end
 end
 
-UnfundedMentorsSeeder.seed!
+UnfundedMentorsSeeder.seed! if SEED_API_DATA


### PR DESCRIPTION
We're currently seeding contract_periods up to 2230 which is a bit excessive for testing, and the seed process takes a few minutes (added to by the required metadata updates).

With this change, running `SEED_API_DATA=true bundle exec rails db:seed` will create the extra data, but `SEED_API_DATA=false bundle exec rails db:seed` or `bundle exec rails db:seed` won't.

Refs #1699