### PR TITLE
Add API seed data for school transfers

### DIFF
--- a/app/services/api_seed_data/teachers/school_transfers.rb
+++ b/app/services/api_seed_data/teachers/school_transfers.rb
@@ -1,0 +1,138 @@
+require Rails.root.join("db/seeds/support/school_transfer_helpers")
+
+module APISeedData
+  class Teachers::SchoolTransfers < Base
+    include SchoolTransferHelpers
+
+    MIN_SET_OF_TRANSFERS_SCENARIOS_PER_LP = 3
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("teacher school transfers")
+
+      @transferred_teachers = { ect: [], mentor: [] }
+
+      lead_providers.each do |from_lead_provider|
+        log_seed_info("Processing Lead provider: #{from_lead_provider.name}")
+
+        excluded_providers = [from_lead_provider]
+        MIN_SET_OF_TRANSFERS_SCENARIOS_PER_LP.times do
+          to_lead_provider = select_different_lead_provider(excluding_lead_providers: excluded_providers)
+          create_set_of_transfers_scenarios(from_lead_provider, to_lead_provider)
+          excluded_providers << to_lead_provider
+        end
+      end
+    end
+
+  private
+
+    def plantable?
+      existing_school_transfers = lead_providers.any? do
+        API::Teachers::SchoolTransfers::Query
+          .new(lead_provider_id: it.id)
+          .school_transfers
+          .exists?
+      end
+
+      super && !existing_school_transfers
+    end
+
+    def lead_providers
+      @lead_providers ||= ActiveLeadProvider
+        .includes(:lead_provider)
+        .map(&:lead_provider)
+        .uniq
+    end
+
+    def ect_teachers
+      @ect_teachers ||= Teacher.where.missing(:ect_at_school_periods).order("RANDOM()")
+    end
+
+    def mentor_teachers
+      @mentor_teachers ||= Teacher.where.missing(:mentor_at_school_periods).order("RANDOM()")
+    end
+
+    def select_different_lead_provider(excluding_lead_providers: [])
+      # find a different LP randomly
+      (lead_providers - excluding_lead_providers).sample
+    end
+
+    def select_random_teacher(excluding_teachers: [], type: :ect)
+      teachers = type == :ect ? ect_teachers : mentor_teachers
+      teacher = (teachers - excluding_teachers).sample.presence ||
+        FactoryBot.create(:teacher, :with_realistic_name)
+      teacher.tap { @transferred_teachers[type] << it }
+    end
+
+    def create_set_of_transfers_scenarios(from_lead_provider, to_lead_provider)
+      log_seed_info("Creating 5 teachers with transfer scenarios:", indent: 2)
+
+      create_incomplete_transfer_scenario(from_lead_provider, to_lead_provider, Faker::Boolean.boolean(true_ratio: 0.8) ? :ect : :mentor)
+      create_same_lp_transfer_scenario(from_lead_provider, to_lead_provider, Faker::Boolean.boolean(true_ratio: 0.8) ? :ect : :mentor)
+      create_different_lp_transfer_scenario(from_lead_provider, to_lead_provider, Faker::Boolean.boolean(true_ratio: 0.8) ? :ect : :mentor)
+      create_provider_to_school_led_scenario(from_lead_provider)
+      create_school_led_to_provider_scenario(from_lead_provider)
+
+      log_seed_info("=" * 80)
+    end
+
+    # Scenario 1: provider led -> unknown (incomplete transfer)
+    def create_incomplete_transfer_scenario(from_lead_provider, to_lead_provider, type)
+      teacher = select_random_teacher(excluding_teachers: @transferred_teachers[type])
+      school_period1 = create_school_period(teacher, from: 3.years.ago, to: 1.week.ago, type:)
+      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
+      add_training_period(school_period1, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: from_lead_provider)
+      add_training_period(school_period1, from: 1.year.ago, to: 1.week.ago, programme_type: :provider_led, with: to_lead_provider)
+
+      log_seed_info("1. Provider Led -> Unknown (incomplete): #{::Teachers::Name.new(teacher).full_name} (#{type})", indent: 4)
+    end
+
+    # Scenario 2: provider led -> provider led (same LP)
+    def create_same_lp_transfer_scenario(from_lead_provider, to_lead_provider, type)
+      teacher = select_random_teacher(excluding_teachers: @transferred_teachers[type])
+      school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago, type:)
+      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
+      school_period2 = create_school_period(teacher, from: 2.years.ago, type:)
+      @training_period2 = add_training_period(school_period2, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: from_lead_provider)
+      add_training_period(school_period2, from: 1.year.ago, programme_type: :provider_led, with: to_lead_provider)
+
+      log_seed_info("2. Provider Led -> Provider Led (same LP): #{::Teachers::Name.new(teacher).full_name} (#{type})", indent: 4)
+    end
+
+    # Scenario 3: provider led -> provider led (different LP)
+    def create_different_lp_transfer_scenario(from_lead_provider, to_lead_provider, type)
+      teacher = select_random_teacher(excluding_teachers: @transferred_teachers[type])
+      school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago, type:)
+      @training_period1 = add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
+      school_period2 = create_school_period(teacher, from: 2.years.ago, type:)
+      @training_period2 = add_training_period(school_period2, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: to_lead_provider)
+      different_lead_provider = select_different_lead_provider(excluding_lead_providers: [from_lead_provider, to_lead_provider])
+      add_training_period(school_period2, from: 1.year.ago, programme_type: :provider_led, with: different_lead_provider)
+
+      log_seed_info("3. Provider Led -> Provider Led (different LP): #{::Teachers::Name.new(teacher).full_name} (#{type})", indent: 4)
+    end
+
+    # Scenario 4: provider led -> school led (ects only)
+    def create_provider_to_school_led_scenario(from_lead_provider)
+      teacher = select_random_teacher(excluding_teachers: @transferred_teachers[:ect])
+      school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago)
+      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
+      school_period2 = create_school_period(teacher, from: 2.years.ago)
+      add_training_period(school_period2, from: 2.years.ago, programme_type: :school_led)
+
+      log_seed_info("4. Provider Led -> School Led: #{::Teachers::Name.new(teacher).full_name} (ect)", indent: 4)
+    end
+
+    # Scenario 5: school led (ects only) -> provider led
+    def create_school_led_to_provider_scenario(from_lead_provider)
+      teacher = select_random_teacher(excluding_teachers: @transferred_teachers[:ect])
+      school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago)
+      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :school_led)
+      school_period2 = create_school_period(teacher, from: 2.years.ago)
+      add_training_period(school_period2, from: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
+
+      log_seed_info("5. School Led -> Provider Led: #{::Teachers::Name.new(teacher).full_name} (ect)", indent: 4)
+    end
+  end
+end

--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -13,6 +13,7 @@ namespace :api_seed_data do
       APISeedData::TeachersWithHistories,
       APISeedData::UnfundedMentors,
       APISeedData::TeachersWithChangeSchedule,
+      APISeedData::Teachers::SchoolTransfers
     ]
 
     if Rails.env.development? || Rails.env.review?

--- a/spec/services/api_seed_data/teachers/school_transfers_spec.rb
+++ b/spec/services/api_seed_data/teachers/school_transfers_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe APISeedData::Teachers::SchoolTransfers do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+  let!(:active_lead_providers) { FactoryBot.create_list(:active_lead_provider, 3) }
+  let(:lead_provider1) { active_lead_providers.first.lead_provider }
+  let(:lead_provider2) { active_lead_providers.second.lead_provider }
+  let(:lead_provider3) { active_lead_providers.third.lead_provider }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+    stub_const("#{described_class}::MIN_SET_OF_TRANSFERS_SCENARIOS_PER_LP", 1)
+  end
+
+  describe "#plant" do
+    subject(:plant) { instance.plant }
+
+    it "creates the school transfers for each lead provider" do
+      plant
+      refresh_teacher_metadata
+
+      expect(school_transfers_for(lead_provider1)).not_to be_empty
+      expect(school_transfers_for(lead_provider2)).not_to be_empty
+      expect(school_transfers_for(lead_provider3)).not_to be_empty
+    end
+
+    it "does not create data when already present" do
+      expect { instance.plant }.to change(TrainingPeriod, :count)
+      refresh_teacher_metadata
+      expect { instance.plant }.not_to change(TrainingPeriod, :count)
+    end
+  end
+
+private
+
+  def refresh_teacher_metadata
+    Teacher.find_each { Metadata::Handlers::Teacher.new(it).refresh_metadata! }
+  end
+
+  def school_transfers_for(lead_provider)
+    API::Teachers::SchoolTransfers::Query
+      .new(lead_provider_id: lead_provider.id)
+      .school_transfers
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2641

### Changes proposed in this pull request

This builds on #1860 and #1816 to add API seed data for school transfers.

Now, there will be relevant data in sandbox and API review apps to facilitate testing the `/transfers` endpoints.

The seed file is based mostly on the original work in #1816, except now we re-use existing teachers if they exist.

### Guidance to review

- [ ] GET transfers and see relevant data in this review app
