### PR TITLE
Ignore school transfers if a mentor has completed training

### DIFF
--- a/app/services/teachers/school_transfers/history.rb
+++ b/app/services/teachers/school_transfers/history.rb
@@ -16,7 +16,7 @@ module Teachers::SchoolTransfers
 
         next_school_period = @school_periods[index + 1]
         next unless different_school?(school_period, next_school_period)
-        next if teacher_completed_induction?(school_period.teacher, next_school_period)
+        next if teacher_completed_training?(leaving_training_period, next_school_period)
 
         joining_training_period = next_school_period&.earliest_training_period
         next unless relevant_to_lead_provider?(leaving_training_period, joining_training_period)
@@ -36,9 +36,8 @@ module Teachers::SchoolTransfers
       school_period.school != next_school_period&.school
     end
 
-    def teacher_completed_induction?(teacher, next_school_period)
-      finished_induction_period = teacher.finished_induction_period
-      next_school_period.nil? && finished_induction_period&.complete?
+    def teacher_completed_training?(training_period, next_school_period)
+      next_school_period.nil? && training_period.teacher_completed_training?
     end
 
     def relevant_to_lead_provider?(leaving_training_period, joining_training_period)


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2924

### Changes proposed in this pull request

Before, we only ignored transfers if the teacher had completed their ECT
induction.

We want to ignore transfers when mentors have completed their training, too.

This leans on https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1853 and updates `Teachers::SchoolTransfers::History` to ignore
transfers when any teacher has completed their training.

### Guidance to review
