### PR TITLE
Switch API seeds back to async metadata refresh

### DIFF
--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -29,6 +29,6 @@ namespace :api_seed_data do
       end
     end
 
-    Metadata::Manager.refresh_all_metadata!(async: false)
+    Metadata::Manager.refresh_all_metadata!(async: true)
   end
 end


### PR DESCRIPTION
I had changed this when I was updating the API seed data and forgot to put it back.
