### PR TITLE
Fix N+1 on transfers query

### DIFF
--- a/app/services/api/teachers/school_transfers/query.rb
+++ b/app/services/api/teachers/school_transfers/query.rb
@@ -40,26 +40,20 @@ module API::Teachers::SchoolTransfers
         .includes(
           lead_provider_metadata: [],
           finished_induction_period: [],
-          ect_at_school_periods: {
-            earliest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
-            },
-            latest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
+          ect_at_school_periods: [
+            :school,
+            {
+              earliest_training_period: :lead_provider,
+              latest_training_period: :lead_provider
             }
-          },
-          mentor_at_school_periods: {
-            earliest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
-            },
-            latest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
+          ],
+          mentor_at_school_periods: [
+            :school,
+            {
+              earliest_training_period: :lead_provider,
+              latest_training_period: :lead_provider
             }
-          }
+          ]
         )
     end
 

--- a/app/services/teachers/school_transfers/history.rb
+++ b/app/services/teachers/school_transfers/history.rb
@@ -3,7 +3,7 @@ module Teachers::SchoolTransfers
     def self.transfers_for(...) = new(...).transfers
 
     def initialize(school_periods:, lead_provider_id:)
-      @school_periods = school_periods.earliest_first
+      @school_periods = school_periods.sort_by(&:started_on)
       @lead_provider_id = lead_provider_id
     end
 


### PR DESCRIPTION
We weren't preloading the right associations for the `History` service. 

The `History` service was also calling `earliest_first` on the `school_periods`, which returns a new scope and means we don't get all the `includes` from the original query. 

Changing to an in-memory `sort_by` retains the preloading.