### PR TITLE
Fix N+1 on transfers query

### DIFF
--- a/app/services/api/teachers/school_transfers/query.rb
+++ b/app/services/api/teachers/school_transfers/query.rb
@@ -40,26 +40,20 @@ module API::Teachers::SchoolTransfers
         .includes(
           lead_provider_metadata: [],
           finished_induction_period: [],
-          ect_at_school_periods: {
-            earliest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
-            },
-            latest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
+          ect_at_school_periods: [
+            :school,
+            {
+              earliest_training_period: :lead_provider,
+              latest_training_period: :lead_provider
             }
-          },
-          mentor_at_school_periods: {
-            earliest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
-            },
-            latest_training_period: {
-              school_partnership: :school,
-              active_lead_provider: :lead_provider
+          ],
+          mentor_at_school_periods: [
+            :school,
+            {
+              earliest_training_period: :lead_provider,
+              latest_training_period: :lead_provider
             }
-          }
+          ]
         )
     end
 

--- a/app/services/teachers/school_transfers/history.rb
+++ b/app/services/teachers/school_transfers/history.rb
@@ -3,7 +3,7 @@ module Teachers::SchoolTransfers
     def self.transfers_for(...) = new(...).transfers
 
     def initialize(school_periods:, lead_provider_id:)
-      @school_periods = school_periods.earliest_first
+      @school_periods = school_periods.sort_by(&:started_on)
       @lead_provider_id = lead_provider_id
     end
 

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -689,10 +689,16 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
 
       before do
         # Transfer teacher for different lead providers should not be used.
+        other_teacher = FactoryBot.create(:teacher)
         build_new_school_transfer(
-          teacher: FactoryBot.create(:teacher),
+          teacher: other_teacher,
           lead_provider: FactoryBot.create(:lead_provider)
         )
+
+        # We need to manually refresh the metadata as we create lead providers
+        # after training periods in build_new_school_transfer, and we don't
+        # refresh metadata when lead providers are created.
+        Teacher.find_each { Metadata::Handlers::Teacher.new(it).refresh_metadata! }
       end
 
       it { is_expected.to eq(transfer_teacher.api_id) }

--- a/spec/requests/api/docs/v3/transfers_spec.rb
+++ b/spec/requests/api/docs/v3/transfers_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "Tranfers endpoint", :with_metadata, openapi_spec: "v3/swagger.yaml" do
+RSpec.describe "Tranfers endpoint", openapi_spec: "v3/swagger.yaml" do
   include SchoolTransferHelpers
 
   include_context "with authorization for api doc request"
@@ -10,6 +10,11 @@ RSpec.describe "Tranfers endpoint", :with_metadata, openapi_spec: "v3/swagger.ya
 
   before do
     build_new_school_transfer(teacher: transferred_teacher, lead_provider:)
+
+    # We need to manually refresh the metadata as we create lead providers
+    # after training periods in build_new_school_transfer, and we don't
+    # refresh metadata when lead providers are created.
+    Metadata::Handlers::Teacher.new(transferred_teacher).refresh_metadata!
   end
 
   it_behaves_like "an API index endpoint documentation",

--- a/spec/services/api/teachers/school_transfers/query_spec.rb
+++ b/spec/services/api/teachers/school_transfers/query_spec.rb
@@ -19,15 +19,9 @@ RSpec.describe API::Teachers::SchoolTransfers::Query do
       it { expect(result.association(:ect_at_school_periods)).to be_loaded }
       it { expect(result.association(:mentor_at_school_periods)).to be_loaded }
       it { expect(result.ect_at_school_periods.last.association(:earliest_training_period)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.earliest_training_period.association(:school_partnership)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.earliest_training_period.school_partnership.association(:school)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.earliest_training_period.association(:active_lead_provider)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.earliest_training_period.active_lead_provider.association(:lead_provider)).to be_loaded }
+      it { expect(result.ect_at_school_periods.last.earliest_training_period.association(:lead_provider)).to be_loaded }
       it { expect(result.ect_at_school_periods.last.association(:latest_training_period)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.latest_training_period.association(:school_partnership)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.latest_training_period.school_partnership.association(:school)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.latest_training_period.association(:active_lead_provider)).to be_loaded }
-      it { expect(result.ect_at_school_periods.last.latest_training_period.active_lead_provider.association(:lead_provider)).to be_loaded }
+      it { expect(result.ect_at_school_periods.last.latest_training_period.association(:lead_provider)).to be_loaded }
     end
 
     let(:teacher) { FactoryBot.create(:teacher) }


### PR DESCRIPTION
We aren't preloading the right associations for the `History` service in the corresponding `Query`. 

The `History` service was also calling `earliest_first` on the `school_periods`, which returns a new scope and means we don't get all the `includes` from the original query, resulting in N+1s.

Changing to an in-memory `sort_by` retains the preloading.