### PR TITLE
[2870] Update zero-day behaviour for changing schedule

### DIFF
--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -443,18 +443,18 @@ module Events
       new(event_type:, author:, heading:, training_period:, teacher:, lead_provider:, metadata:, happened_at:).record_event!
     end
 
-    def self.record_teacher_schedule_changed_event!(author:, original_training_period:, new_training_period:, teacher:, lead_provider:, happened_at: Time.zone.now)
+    def self.record_teacher_schedule_changed_event!(author:, original_training_period:, original_schedule:, new_training_period:, teacher:, lead_provider:, happened_at: Time.zone.now)
       event_type = :teacher_changes_schedule_training_period
       teacher_name = Teachers::Name.new(teacher).full_name
       training_type = (original_training_period.for_ect?) ? "ECT" : "mentor"
-      heading = "#{teacher_name}’s #{training_type} training changed schedule from #{original_training_period.schedule.description} to #{new_training_period.schedule.description} by #{lead_provider.name}"
+      heading = "#{teacher_name}’s #{training_type} training changed schedule from #{original_schedule.description} to #{new_training_period.schedule.description} by #{lead_provider.name}"
       metadata = {
-        new_training_period_id: new_training_period.id,
-        from_schedule_id: original_training_period.schedule.id,
+        training_period_id: new_training_period.id,
+        from_schedule_id: original_schedule.id,
         to_schedule_id: new_training_period.schedule.id,
       }
 
-      new(event_type:, author:, heading:, training_period: original_training_period, schedule: original_training_period.schedule, teacher:, lead_provider:, metadata:, happened_at:).record_event!
+      new(event_type:, author:, heading:, training_period: original_training_period, schedule: original_schedule, teacher:, lead_provider:, metadata:, happened_at:).record_event!
     end
 
     def self.record_teacher_schedule_assigned_to_training_period!(author:, training_period:, teacher:, schedule:, happened_at: Time.zone.now)

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1278,7 +1278,7 @@ RSpec.describe Events::Record do
     let(:author_params) { { author_name: lead_provider.name, author_type: "lead_provider_api" } }
     let(:metadata) do
       {
-        new_training_period_id: new_training_period.id,
+        training_period_id: new_training_period.id,
         from_schedule_id: original_training_period.schedule.id,
         to_schedule_id: new_training_period.schedule.id
       }
@@ -1287,12 +1287,13 @@ RSpec.describe Events::Record do
     context "when ECT training" do
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 25)) }
       let(:original_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
+      let(:original_schedule) { original_training_period.schedule }
       let(:new_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: Date.new(2025, 7, 20), finished_on: Date.new(2025, 7, 25)) }
       let(:course_identifier) { "ecf-induction" }
 
       it "queues a RecordEventJob with the correct values" do
         freeze_time do
-          Events::Record.record_teacher_schedule_changed_event!(author:, original_training_period:, new_training_period:, teacher:, lead_provider:)
+          Events::Record.record_teacher_schedule_changed_event!(author:, original_training_period:, original_schedule:, new_training_period:, teacher:, lead_provider:)
 
           expect(RecordEventJob).to have_received(:perform_later).with(
             training_period: original_training_period,
@@ -1312,12 +1313,13 @@ RSpec.describe Events::Record do
     context "when Mentor training" do
       let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 25)) }
       let(:original_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
+      let(:original_schedule) { original_training_period.schedule }
       let(:new_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 7, 20), finished_on: Date.new(2025, 7, 25)) }
       let(:course_identifier) { "ecf-mentor" }
 
       it "queues a RecordEventJob with the correct values" do
         freeze_time do
-          Events::Record.record_teacher_schedule_changed_event!(author:, original_training_period:, new_training_period:, teacher:, lead_provider:)
+          Events::Record.record_teacher_schedule_changed_event!(author:, original_training_period:, original_schedule:, new_training_period:, teacher:, lead_provider:)
 
           expect(RecordEventJob).to have_received(:perform_later).with(
             training_period: original_training_period,


### PR DESCRIPTION
### Context

Ticket: [2870](https://github.com/DFE-Digital/register-ects-project-board/issues/2870
)

A `TrainingPeriod` should not be zero-day (have the same `started_on` as `finished_on`). At the moment when we change schedule we create a new `TrainingPeriod`, however this implodes if a lead provider tries to change schedule twice in quick succession (on the same day).

### Changes proposed in this pull request

- We update training periods in place on change-schedule if the `started_on` has not yet passed (so today)
- We create a new training period if the `started_on` has passed
- If the `started_on` has not passed and there are declarations that would result in validation failures if we changed the schedule then we surface a new error to lead providers (**new error message created by @tashonrp**)
- We have test coverage for all of these scenarios

### Guidance to review

Review app
