### PR TITLE
Release note for change schedules

### DIFF
--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -82,7 +82,7 @@
     The change of schedule cannot be applied because a previous change of schedule and a declaration were made on the same day. Applying another change of schedule would invalidate existing declarations. Please contact DfE for assistance.
     ```
 
-    **Participant has completed training or induction
+    **Participant has completed training or induction**
     ```
     You cannot change this participant’s schedule as they have completed their training or induction.
     ```

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,7 +21,7 @@
 #
 #     **bold** and _italic_ text
 - title: Change schedules endpoint released to the Register ECTs sandbox with updated validation rules
-  date: 2025-12-XX
+  date: 2026-01-16
   tags:
     - sandbox-release
   body: |
@@ -45,8 +45,8 @@
 
     Previously, billable declarations prevented any further changes.
 
-    ### You cannot make multiple cohort changes on the same day when submitting a declaration
-    If you submit a declaration for a participant on a given day, you can only make one cohort change on that same day. Further cohort changes will return a validation error.
+    ### Schedule and cohort changes are restricted after a declaration is submitted
+    If you submit a declaration for a participant on a given day, you cannot make any further schedule or cohort changes for that participant until the next day. You can make multiple changes on the same day before you submit a declaration.
 
     Previously, multiple cohort changes could be made on the same day as a declaration.
 
@@ -55,6 +55,7 @@
 
     ## Impact on lead providers
     These changes may affect how you manage schedules and cohorts in some scenarios:
+    
     * you will not be able to update schedules or cohorts for participants you are no longer training
     * you have more flexibility to move participants even when billable declarations exist
     * you may need to wait until the next day to make further cohort changes if you submit a declaration on the same day
@@ -81,9 +82,9 @@
     The change of schedule cannot be applied because a previous change of schedule and a declaration were made on the same day. Applying another change of schedule would invalidate existing declarations. Please contact DfE for assistance.
     ```
 
-    ***Participant has completed training or induction
+    **Participant has completed training or induction
     ```
-    You cannot change this participant’s schedule as they have completed their training.
+    You cannot change this participant’s schedule as they have completed their training or induction.
     ```
     
 - title: Defer, withdraw, and resume endpoints endpoints added to the Register ECTs API with updated validation rules

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -55,10 +55,25 @@
     * If you need to make more than one cohort change and submit a declaration for the same participant, you may have to wait until the next day.
 
     ## Example validation errors
-    These will be added once available.
+    **Not the most recent lead provider**
+    ```
+    You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.
+    ```
 
-    *Example: attempting to change a schedule when you are not the most recent lead provider*  
-    Example validation error responses will be added once available.
+    **Participant is due to start with another lead provider**
+    ```
+    You cannot change this participant’s schedule as they are due to start with another lead provider in the future.
+    ```
+
+    **Moving a participant to a payments frozen cohort they were not previously part of**
+    ```
+    You cannot move a participant to a payments frozen cohort unless they previously belonged to that cohort.
+    ```
+
+    **Schedule change would invalidate declarations**
+    ```
+    The schedule change cannot be applied because it would make existing declarations invalid. Please contact DfE for assistance.
+    ```
     
 - title: Defer, withdraw, and resume endpoints endpoints added to the Register ECTs API with updated validation rules
   date: 2025-11-27

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -20,7 +20,46 @@
 #     [links](https://www.gov.uk)
 #
 #     **bold** and _italic_ text
+- title: Change schedules endpoint released to the Register ECTs sandbox with updated validation rules
+  date: 2025-12-12
+  tags:
+    - sandbox-release
+  body: |
+    The `PUT /participants/{id}/change-schedule` endpoint is now available in the Register ECTs sandbox. We have also updated the validation rules for when lead providers can change a participant’s schedule or cohort.
 
+    These changes are defined in sections 19.1, 19.2 and 19.3 of the API specification.
+
+    ## What’s changed from the existing ‘Manage training for early career teachers’ API?
+
+    ### Only the most recent lead provider can update a participant’s schedule or cohort
+    Lead providers can now only update schedules or cohorts when they are the participant’s most recent lead provider. If you are not the most recent lead provider, the request will return a validation error.
+
+    Previously, any lead provider could update a schedule or cohort as long as there were no billable declarations.
+
+    ### You can now change schedules or cohorts even when there are billable declarations
+    Lead providers can now move participants between schedules or cohorts when billable declarations exist, as long as they are the most recent lead provider for that participant.
+
+    This replaces the previous behaviour where billable declarations prevented any further changes.
+
+    ### You cannot make multiple cohort changes on the same day when submitting a declaration
+    If you submit a declaration for a participant on a given day, you can only make one cohort change on that same day. Further cohort changes will return a validation error.
+
+    Previously, multiple cohort changes could be made on the same day as a declaration.
+
+    ## Why we have made these changes
+    These changes are intended to avoid scenarios where different lead providers could update a participant’s schedule or cohort, ensure the schedule or cohort reflects the most recent lead provider, and provide more flexibility for managing participants who need to move between schedules or cohorts. They also aim to reduce the need for manual adjustments by DfE and lead providers.
+
+    ## Impact on lead providers
+    * You will not be able to update schedules or cohorts for participants you no longer train, but this should not be needed in practice.
+    * You now have greater flexibility to move participants even when billable declarations exist.
+    * If you need to make more than one cohort change and submit a declaration for the same participant, you may have to wait until the next day.
+
+    ## Example validation errors
+    These will be added once available.
+
+    *Example: attempting to change a schedule when you are not the most recent lead provider*  
+    Example validation error responses will be added once available.
+    
 - title: Defer, withdraw, and resume endpoints endpoints added to the Register ECTs API with updated validation rules
   date: 2025-11-27
   tags:

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,7 +21,7 @@
 #
 #     **bold** and _italic_ text
 - title: Change schedules endpoint released to the Register ECTs sandbox with updated validation rules
-  date: 2025-12-12
+  date: 2025-12-XX
   tags:
     - sandbox-release
   body: |
@@ -31,31 +31,37 @@
 
     ## What’s changed from the existing ‘Manage training for early career teachers’ API?
 
-    ### Only the most recent lead provider can update a participant’s schedule or cohort
-    Lead providers can now only update schedules or cohorts when they are the participant’s most recent lead provider. If you are not the most recent lead provider, the request will return a validation error.
-
+    ### Only the current lead provider can update a participant’s schedule or cohort
+    Lead providers can now only update schedules or cohorts when they are the current lead provider training the participant. If you are not the current lead provider, the request will return a validation error.
+    
+    If a participant has a future start date with a different lead provider, the current lead provider will no longer be able to change the schedule or cohort.
+    
+    The new lead provider will not be able to change the schedule or cohort until the participant has started training with them (their start date has elapsed).
+    
     Previously, any lead provider could update a schedule or cohort as long as there were no billable declarations.
 
     ### You can now change schedules or cohorts even when there are billable declarations
-    Lead providers can now move participants between schedules or cohorts when billable declarations exist, as long as they are the most recent lead provider for that participant.
+    Lead providers can now move participants between schedules or cohorts when billable declarations exist, as long as they are the current lead provider for that participant.
 
-    This replaces the previous behaviour where billable declarations prevented any further changes.
+    Previously, billable declarations prevented any further changes.
 
     ### You cannot make multiple cohort changes on the same day when submitting a declaration
     If you submit a declaration for a participant on a given day, you can only make one cohort change on that same day. Further cohort changes will return a validation error.
 
     Previously, multiple cohort changes could be made on the same day as a declaration.
 
-    ## Why we have made these changes
-    These changes are intended to avoid scenarios where different lead providers could update a participant’s schedule or cohort, ensure the schedule or cohort reflects the most recent lead provider, and provide more flexibility for managing participants who need to move between schedules or cohorts. They also aim to reduce the need for manual adjustments by DfE and lead providers.
+    ## Why we’ve made these changes
+    These changes are intended to avoid participants having multiple schedules or cohorts at the same time, and to ensure declarations can be reliably attached to the correct cohort.
 
     ## Impact on lead providers
-    * You will not be able to update schedules or cohorts for participants you no longer train, but this should not be needed in practice.
-    * You now have greater flexibility to move participants even when billable declarations exist.
-    * If you need to make more than one cohort change and submit a declaration for the same participant, you may have to wait until the next day.
+    These changes may affect how you manage schedules and cohorts in some scenarios:
+    * you will not be able to update schedules or cohorts for participants you are no longer training
+    * you have more flexibility to move participants even when billable declarations exist
+    * you may need to wait until the next day to make further cohort changes if you submit a declaration on the same day
 
     ## Example validation errors
-    **Not the most recent lead provider**
+
+    **Not the current lead provider**
     ```
     You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.
     ```
@@ -72,7 +78,12 @@
 
     **Schedule change would invalidate declarations**
     ```
-    The schedule change cannot be applied because it would make existing declarations invalid. Please contact DfE for assistance.
+    The change of schedule cannot be applied because a previous change of schedule and a declaration were made on the same day. Applying another change of schedule would invalidate existing declarations. Please contact DfE for assistance.
+    ```
+
+    ***Participant has completed training or induction
+    ```
+    You cannot change this participant’s schedule as they have completed their training.
     ```
     
 - title: Defer, withdraw, and resume endpoints endpoints added to the Register ECTs API with updated validation rules


### PR DESCRIPTION
### Context
Added detailed release notes for the updated change-schedules endpoint in the Register ECTs sandbox, including validation rules and changes in behavior for lead providers.

### Guidance to review
I'll need to update this once I've received the validation error messages from Ross. The delay is my fault - I completely forgot to follow up with him on this.