### PR TITLE
Update Early Rollout Mentor import to update existing teachers

### DIFF
--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -198,10 +198,9 @@ module Events
       new(event_type:, author:, modifications:, teacher:, heading:, happened_at:).record_event!
     end
 
-    def self.teacher_imported_from_dqt_event!(author:, teacher:, happened_at: Time.zone.now)
+    def self.teacher_imported_from_dqt_event!(author:, teacher:, body:, happened_at: Time.zone.now)
       event_type = :import_from_dqt
       heading = "Early roll-out mentor imported from DQT"
-      body = "Teacher created as part of the Early Roll-out mentor import"
 
       new(event_type:, author:, teacher:, heading:, body:, happened_at:).record_event!
     end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -447,16 +447,39 @@ RSpec.describe Events::Record do
   end
 
   describe ".teacher_imported_from_dqt_event!" do
-    it "queues a RecordEventJob with the correct values" do
+    it "queues a RecordEventJob with the correct values for created teachers" do
       freeze_time do
-        Events::Record.teacher_imported_from_dqt_event!(author:, teacher:)
+        Events::Record.teacher_imported_from_dqt_event!(
+          author:,
+          teacher:,
+          body: "Teacher created with Early Roll-out mentor attributes during the import"
+        )
 
         expect(RecordEventJob).to have_received(:perform_later).with(
           teacher:,
           heading: "Early roll-out mentor imported from DQT",
           event_type: :import_from_dqt,
           happened_at: Time.zone.now,
-          body: "Teacher created as part of the Early Roll-out mentor import",
+          body: "Teacher created with Early Roll-out mentor attributes during the import",
+          **author_params
+        )
+      end
+    end
+
+    it "queues a RecordEventJob with the correct values for updated teachers" do
+      freeze_time do
+        Events::Record.teacher_imported_from_dqt_event!(
+          author:,
+          teacher:,
+          body: "Teacher updated with Early Roll-out mentor attributes during the import"
+        )
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          heading: "Early roll-out mentor imported from DQT",
+          event_type: :import_from_dqt,
+          happened_at: Time.zone.now,
+          body: "Teacher updated with Early Roll-out mentor attributes during the import",
           **author_params
         )
       end


### PR DESCRIPTION
### Context
This follow-up to PR #1847 updates the existing Early Rollout mentors. 

We have overlapping records between teachers already in the system and those that will be imported, so instead of skipping them, we need to update their attributes.

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2873
### Changes proposed in this pull request
- Change `Teachers::ImportEarlyRolloutMentor` to always apply the Early Roll-out attributes, track whether the teacher is new and record the event with the corresponding body
- Update `Events::Record.teacher_imported_from_dqt_event!` to accept the final body string directly

### Guidance to review
