### PR TITLE
Fix link size

### DIFF
--- a/app/views/schools/ects/show.html.erb
+++ b/app/views/schools/ects/show.html.erb
@@ -40,11 +40,13 @@
           training provider (if they’re on a provider-led programme).
         </p>
 
-        <%= govuk_link_to(
-              "Tell us if #{teacher_full_name(@teacher)} is leaving permanently",
-              schools_ects_teacher_leaving_wizard_edit_path(@ect_at_school_period),
-              no_visited_state: true
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            "Tell us if #{teacher_full_name(@teacher)} is leaving permanently",
+            schools_ects_teacher_leaving_wizard_edit_path(@ect_at_school_period),
+            no_visited_state: true
             ) %>.
+        </p>
       <% end %>
   </div>
 </div>

--- a/app/views/schools/mentors/show.html.erb
+++ b/app/views/schools/mentors/show.html.erb
@@ -42,11 +42,13 @@
           (if they’re on a provider-led programme).
         </p>
 
-        <%= govuk_link_to(
-              "Tell us if #{teacher_full_name(@teacher)} is leaving permanently",
-              schools_mentors_teacher_leaving_wizard_edit_path(@mentor),
-              no_visited_state: true
-            ) %>.
+        <p class="govuk-body">
+          <%= govuk_link_to(
+                "Tell us if #{teacher_full_name(@teacher)} is leaving permanently",
+                schools_mentors_teacher_leaving_wizard_edit_path(@mentor),
+                no_visited_state: true
+              ) %>.
+        </p>
       <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context

The links are not inside any GOV.UK typography class, so it's currently inheriting the default 16px.

This fix brings it back up to the standard 19px.

