### PR TITLE
Don't allow leaving date to be the same as the start date for ECTs and mentors

### DIFF
--- a/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
@@ -42,7 +42,7 @@ module Schools
 
         def leaving_after_start_date
           return unless leaving_on_input.valid?
-          return if leaving_on_input.value_as_date >= ect_at_school_period.started_on
+          return if leaving_on_input.value_as_date > ect_at_school_period.started_on
 
           errors.add(
             :leaving_on,

--- a/app/wizards/schools/mentors/teacher_leaving_wizard/edit_step.rb
+++ b/app/wizards/schools/mentors/teacher_leaving_wizard/edit_step.rb
@@ -42,7 +42,7 @@ module Schools
 
         def leaving_after_start_date
           return unless leaving_on_input.valid?
-          return if leaving_on_input.value_as_date >= mentor_at_school_period.started_on
+          return if leaving_on_input.value_as_date > mentor_at_school_period.started_on
 
           errors.add(
             :leaving_on,

--- a/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
@@ -62,5 +62,16 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
         )
       end
     end
+
+    context "when leaving date is the same as the start date" do
+      let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:leaving_on].map(&:squish)).to include(
+          "Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a later date."
+        )
+      end
+    end
   end
 end

--- a/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
@@ -62,5 +62,16 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::EditStep do
         )
       end
     end
+
+    context "when leaving date is the same as the start date" do
+      let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:leaving_on].map(&:squish)).to include(
+          "Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a later date."
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Don't allow an ECT or Mentor leaving date to be the same date as their started on date.
