### PR TITLE
Fix flakey parity check spec

### DIFF
--- a/spec/services/api_seed_data/parity_checks_spec.rb
+++ b/spec/services/api_seed_data/parity_checks_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe APISeedData::ParityChecks do
         expect(logger).to have_received(:info).with(/#{Regexp.escape(endpoint.description)}/).at_least(:once)
       end
 
-      expect(logger).to have_received(:info).with(/Concurrent, *\d+ requests, \d.\dx performance gain, \d+% match rate/).at_least(:once)
-      expect(logger).to have_received(:info).with(/Sequential, *\d+ requests, \d.\dx performance gain, \d+% match rate/).at_least(:once)
+      expect(logger).to have_received(:info).with(/Concurrent, *\d+ requests, -?\d.\dx performance gain, \d+% match rate/).at_least(:once)
+      expect(logger).to have_received(:info).with(/Sequential, *\d+ requests, -?\d.\dx performance gain, \d+% match rate/).at_least(:once)
     end
 
     context "when in the production environment" do


### PR DESCRIPTION
The regex was failing to match on the nengative performance gains as we prefix those with a hyphen.

Add optional hyphen to regex.

Thanks @cpjmcquillan for flagging/suggesting the fix!
