### PR TITLE
[2440] Show leaving ECTs for current mentor

### DIFF
--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -10,7 +10,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_many :declarations, through: :training_periods
   has_many :events
   has_many :currently_assigned_ects,
-           -> { ongoing.includes(:teacher) },
+           -> { ongoing_today.includes(:teacher) },
            through: :mentorship_periods,
            source: :mentee
   has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: "TrainingPeriod"

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -16,6 +16,24 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to have_many(:currently_assigned_ects).through(:mentorship_periods).source(:mentee) }
   end
 
+  describe "#currently_assigned_ects" do
+    subject { mentor.currently_assigned_ects }
+
+    let(:mentor)    { FactoryBot.create(:mentor_at_school_period, started_on: 2.years.ago, finished_on: nil) }
+    let(:finished)  { FactoryBot.create(:ect_at_school_period, finished_on: Time.zone.today) }
+    let(:finishing) { FactoryBot.create(:ect_at_school_period, finished_on: 1.week.from_now) }
+    let(:current)   { FactoryBot.create(:ect_at_school_period, finished_on: nil) }
+    let(:upcoming)  { FactoryBot.create(:ect_at_school_period, started_on: 1.week.from_now) }
+
+    before do
+      [finished, finishing, current, upcoming].each do |mentee|
+        FactoryBot.create(:mentorship_period, mentor:, mentee:)
+      end
+    end
+
+    it { is_expected.to match_array [current, finishing] }
+  end
+
   describe ".current_or_next_training_period" do
     let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 1.year.ago) }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2440

### Changes proposed in this pull request

The scope of `MentorAtSchoolPeriod#currently_assigned_ects` expands to include ECTs with a future `finished_on`
