### PR TITLE
Remove ECT completed check from transfer history

### DIFF
--- a/app/services/teachers/school_transfers/history.rb
+++ b/app/services/teachers/school_transfers/history.rb
@@ -16,7 +16,6 @@ module Teachers::SchoolTransfers
 
         next_school_period = @school_periods[index + 1]
         next unless different_school?(school_period, next_school_period)
-        next if teacher_completed_induction?(school_period.teacher, next_school_period)
 
         joining_training_period = next_school_period&.earliest_training_period
         next unless relevant_to_lead_provider?(leaving_training_period, joining_training_period)
@@ -34,11 +33,6 @@ module Teachers::SchoolTransfers
 
     def different_school?(school_period, next_school_period)
       school_period.school != next_school_period&.school
-    end
-
-    def teacher_completed_induction?(teacher, next_school_period)
-      finished_induction_period = teacher.finished_induction_period
-      next_school_period.nil? && finished_induction_period&.complete?
     end
 
     def relevant_to_lead_provider?(leaving_training_period, joining_training_period)

--- a/spec/services/teachers/school_transfers/history_spec.rb
+++ b/spec/services/teachers/school_transfers/history_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Teachers::SchoolTransfers::History do
       end
     end
 
-    context "when a teacher leaves provider-led training at one school " \
-            "but has not completed their training" do
+    context "when a teacher leaves provider-led training at one school and has " \
+            "not yet started training at another school" do
       let(:lead_provider1) { FactoryBot.create(:lead_provider) }
       let(:lead_provider2) { FactoryBot.create(:lead_provider) }
 
@@ -93,38 +93,6 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period3)
         expect(transfer.joining_training_period).to be_nil
-      end
-    end
-
-    context "when a teacher leaves provider-led training at one school " \
-            "and has completed their training" do
-      let(:lead_provider1) { FactoryBot.create(:lead_provider) }
-      let(:lead_provider2) { FactoryBot.create(:lead_provider) }
-
-      before do
-        school_period1 = create_school_period(teacher, from: 3.years.ago, to: 1.week.ago)
-        add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: lead_provider1)
-        add_training_period(school_period1, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1)
-        @training_period3 = add_training_period(school_period1, from: 1.year.ago, to: 1.week.ago, programme_type: :provider_led, with: lead_provider2)
-        record_completed_induction(teacher, school_period1)
-      end
-
-      it "returns no transfers for lead provider #1" do
-        history = described_class.new(
-          school_periods: teacher.ect_at_school_periods,
-          lead_provider_id: lead_provider1.id
-        )
-
-        expect(history.transfers).to be_empty
-      end
-
-      it "returns no transfers for lead provider #2" do
-        history = described_class.new(
-          school_periods: teacher.ect_at_school_periods,
-          lead_provider_id: lead_provider2.id
-        )
-
-        expect(history.transfers).to be_empty
       end
     end
 
@@ -307,18 +275,6 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(history.transfers).to be_empty
       end
     end
-  end
-
-private
-
-  def record_completed_induction(teacher, school_period)
-    FactoryBot.create(
-      :induction_period,
-      :pass,
-      teacher:,
-      started_on: school_period.started_on,
-      finished_on: school_period.finished_on
-    )
   end
 end
 # rubocop:enable RSpec/InstanceVariable


### PR DESCRIPTION
Originally we thought that if an ECF has completed their training then their last, closed training period shouldn't be classed as a leaving transfer (of type `unknown`).

We don't believe this is the case any longer; an ECT may transfer schools even after they have completed their training. We also don't take into account completion state of ECTs in the ECF service, so dropping this will help us achieve better parity as we migrate from the service.