### PR TITLE
RIAB 3 - [2971] teaching school hub region

### DIFF
--- a/app/components/admin/schools/overview_component.html.erb
+++ b/app/components/admin/schools/overview_component.html.erb
@@ -2,8 +2,9 @@
 
   if Rails.application.config.enable_teaching_school_hubs
     sl.with_row do |row|
-      row.with_key(text: "Leading teaching school hubs")
-      row.with_value(text: govuk_list(school.led_teaching_school_hubs.map(&:name)))
+      row.with_key(text: "Leading teaching school hub")
+      row.with_value(text: school.led_teaching_school_hub&.name || 'Not set')
+      row.with_action(text: "View", href: admin_teaching_school_hub_path(school.led_teaching_school_hub)) if school.led_teaching_school_hub.present?
     end
 
     sl.with_row do |row|

--- a/app/models/appropriate_body_period.rb
+++ b/app/models/appropriate_body_period.rb
@@ -46,8 +46,10 @@ class AppropriateBodyPeriod < ApplicationRecord
 
   # National Bodies only have one unending AB period (TSHs can have many)
   def national_body_limit
-    return if national_body_id.blank?
-    return if NationalBody.find(national_body_id).appropriate_body_period.blank?
+    national_body = NationalBody.find_by(id: national_body_id)
+
+    return if national_body&.appropriate_body_period.blank?
+    return if national_body.appropriate_body_period.eql?(self)
 
     errors.add(:base, "A National Body can only have a single Appropriate Body period")
   end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,0 +1,7 @@
+class Region < ApplicationRecord
+  belongs_to :teaching_school_hub
+
+  # Validations
+  validates :code, presence: true, uniqueness: true
+  validates :districts, presence: true
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -27,10 +27,6 @@ class School < ApplicationRecord
   has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod"
   has_many :training_periods, through: :school_partnerships
 
-  # if RIAB decides to store multiple TSHs and regions
-  has_many :led_teaching_school_hubs, class_name: "TeachingSchoolHub", foreign_key: :lead_school_id, inverse_of: :lead_school
-
-  # if RIAB decides to consolidate TSH activity and ignore regions
   has_one :led_teaching_school_hub, class_name: "TeachingSchoolHub", foreign_key: :lead_school_id, inverse_of: :lead_school
 
   touch -> { self }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
@@ -42,7 +38,7 @@ class School < ApplicationRecord
   refresh_metadata -> { self }, on_event: %i[create]
 
   # Scopes
-  scope :lead_schools, -> { joins(:led_teaching_school_hubs).distinct }
+  scope :lead_schools, -> { joins(:led_teaching_school_hub).distinct }
 
   # Validations
   validates :last_chosen_lead_provider_id,

--- a/app/models/teaching_school_hub.rb
+++ b/app/models/teaching_school_hub.rb
@@ -1,30 +1,21 @@
-# NOTE: We currently only associate one TSH with a lead school, we support many
-# but may decide not to add these records in the future. If we do, a school can only lead
-# up to 3 TSHs.
 class TeachingSchoolHub < ApplicationRecord
   # Associations
   belongs_to :dfe_sign_in_organisation
   belongs_to :lead_school, class_name: "School"
 
   has_many :appropriate_body_periods
+  has_many :regions
 
   # Validations
-  validates :name,
-            presence: true,
-            uniqueness: true
-
-  validate :lead_school_limit
+  validates :name, presence: true, uniqueness: true
+  validates :lead_school, presence: true, uniqueness: true
+  validates :dfe_sign_in_organisation, presence: true, uniqueness: true
 
   # Normalizations
   normalizes :name, with: -> { it.squish }
 
-private
-
-  def lead_school_limit
-    return unless lead_school
-
-    if lead_school.led_teaching_school_hubs.count >= 3 && !lead_school.led_teaching_school_hubs.exists?(id)
-      errors.add(:lead_school, "has reached the maximum of 3 teaching school hubs")
-    end
+  # @return [Array<String>]
+  def districts
+    regions.collect(&:districts).flatten
   end
 end

--- a/app/views/admin/teaching_school_hubs/show.html.erb
+++ b/app/views/admin/teaching_school_hubs/show.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: @teaching_school_hub.name,
+  caption: @teaching_school_hub.districts.to_sentence
 ) %>
 
 <h2 class="govuk-heading-m">Lead school</h2>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -27,6 +27,13 @@
     - lead_school_id
     - created_at
     - updated_at
+  :regions:
+    - id
+    - code
+    - districts
+    - teaching_school_hub_id
+    - created_at
+    - updated_at
   :legacy_appropriate_bodies:
     - id
     - dqt_id

--- a/config/region_mapping.csv
+++ b/config/region_mapping.csv
@@ -1,0 +1,87 @@
+ab_name_ecf1,appropriate_body_id,hub_region,ab_name_riab
+Saffron Teaching School Hub (Saffron Walden County High School),4cb21fcf-d643-4120-9c5b-2d105abcb4af,EE1,Saffron Teaching School Hub
+Inspiration Teaching School Hub,a77df925-7b9e-4957-a3b4-aa9d9318a7cd,EE10,Inspiration Teaching School Hub
+Chafford Hundred Teaching School Hub (Harris Academy Chafford Hundred),c99bfcf6-1dc6-49fd-9a28-abe670720883,EE5,Chafford Hundred Teaching School Hub
+Unity Teaching School Hub (Churchill Special Free School),3162da6d-8b35-4861-9939-48cb85d802f7,EE6/EE2,Unity Teaching School Hub
+Alban Teaching School Hub (Sandringham School),acff7f4a-2967-44c2-8c2a-99b4552dd9a8,EE7,Alban Teaching School Hub
+Chiltern Teaching School Hub (Denbigh High School),1db342ef-4b29-452d-b105-12ae959b631d,EE8&EE9,Chiltern Teaching School Hub
+Leicestershire & Rutland TS Hub (Christ the King Catholic Voluntary Academy),5baa0a83-ccf7-4c25-9564-81754b481337,EM1,Leicestershire & Rutland TS Hub
+Redhill Teaching School Hub (The Carlton Junior Academy),83ebc588-154b-4afc-87d1-cf3f3005e3d9,EM2,Redhill Teaching Hub
+Potentia Teaching School Hub (Swanwick School),287967cc-40f7-4e7e-b1b0-786f1767d06c,EM3,Potentia TSH
+Flying High Teaching School Hub (The Flying High Academy),ec9f0d00-4ab7-44d9-97a9-8057bce3f5b4,EM4,Flying High Teaching School Hub
+Leicester & Leicestershire Teaching School Hub (Rushey Mead Academy),f68d9fe5-fe43-4186-8495-8ea0b182821d,EM5,Leicester & Leicestershire TSH
+L.E.A.D. Teaching School Hub Lincolnshire (Witham St Hughs Academy),742bdf50-5a2b-45d8-9131-36ddaaccbf08,EM6,L.E.A.D. Teaching School Hub Lincolnshire
+Spencer Teaching School Hub (Chetwynd Spencer Academy),a3c3064a-52ba-4bfe-b4b5-3b9991d2b9ce,EM7,Spencer Teaching School Hub
+Northamptonshire Teaching School Hub (Brooke Weston Academy),80d6265f-8ca4-4604-a3cb-b4512b8e4ae2,EM8,Northamptonshire Teaching School Hub
+East London Teaching School Hub (Mulberry School for Girls),e883f73b-48e5-4bb9-b577-d3151f7a94d7,L1,East London Teaching School Hub
+Thames South Teaching School Hub  (Pickhurst Infant Academy),710e9278-b3fe-4bf6-8b26-e118647ae80a,L10,Thames South Teaching School Hub
+London District East Teaching School Hub (Tollgate Primary School),3fbad505-80d8-4aed-b5cb-141270b3e5c7,L2,London District East Teaching School Hub
+Cambridgeshire and Peterborough Teaching School Hub (Histon and Impington Brook Primary School),c14321bb-cd23-4076-bc9d-9b264cf7255b,L3,Cambridgeshire and Peterborough Teaching School Hub
+North East London Teaching School Hub (Harris Chobham Academy),bb014ec5-a974-4173-adcc-8cd9f8573fb0,L3,North East London Teaching School Hub
+North West London Teaching School Hub (NWLTSH) (Wembley High Technology College),7a6fa110-9550-4a54-8952-5d063f5d9d1f,L4,North West London Teaching School Hub
+Teach West London (Twyford Church of England High School),658c4468-30d9-4563-8581-0d20c075220f,L5,Teach West London
+Central London Teaching School Hub (Paddington Academy),6b433d0a-2244-4132-931f-c7c17b8fa68c,L6,Central London Teaching School Hub
+Wandle Teaching School Hub (Chesterton Primary School),cda22c42-2e71-45d0-914a-d2fafadd52ea,L7,Wandle Teaching School Hub
+Harris City Academy Crystal Palace Teaching School Hub (Harris City Academy Crystal Palace),9e78be52-5598-4883-881c-814f63fb91e7,L8,Harris City Academy Crystal Palace Teaching School Hub
+London South Teaching School Hub (Charles Dickens Primary School),da694a86-d043-4aea-b4b1-dfb85a93eb88,L9,London South Teaching School Hub
+The Three Rivers Teaching School Hub (The King Edward VI Academy),9bb3b070-00b9-4881-a118-7c5d71f412de,NE1,The Three Rivers Teaching School Hub
+"Tees Valley Teaching School Hub (St John Vianney Catholic Primary School, Hartlepool)",ff335729-990b-4e0f-9f05-1fb279491a68,NE2,Tees Valley Teaching School Hub
+Northern Lights Teaching School Hub: South Tyne & Wear (Benedict Biscop Church of England Academy),3b9cf79f-5bd4-4b81-b627-0d5ccac8b5bf,NE3,Northern Lights TSH: South Tyne & Wear
+NELT Teaching School Hub (Teesdale School and Sixth Form),cc390aa6-4d13-46a0-8e05-960fe4e198dc,NE4,NELTSH Teaching School Hub
+Inspire Learning Teaching School Hub NW (Our Lady of Pity Catholic Primary School),3028b162-409f-4143-90d7-e312357b1300,NW1,Inspire Learning Teaching School Hub NW
+The East Manchester Teaching School Hub (The Blue Coat CofE School),d4d9529e-aca5-41ff-881b-267a8570aaac,NW10,The East Manchester Teaching Hub
+One Cumbria Teaching School Hub (Queen Elizabeth Grammar School Penrith),53eee9d4-7458-4cce-aaac-2358801d1e91,NW11,One Cumbria Teaching School Hub
+Cheshire Teaching School Hub (St Joseph's College),98634cc2-e894-4959-82b3-ac27cbbbf72d,NW12,Cheshire Teaching School Hub
+Generate Teaching School Hub (Evelyn Street Primary Academy and Nursery),30d88c98-1d82-4e9c-af08-c39bbd78acb0,NW2,Generate Teaching Hub
+"Star Teaching School Hub Bolton, Bury, Rochdale (Eden Boys' School Bolton)",52697507-c765-4445-91df-35e01bbac58d,NW3/NW4/NW5,Star Teaching School Hub Pennine Lancashire
+Star Teaching School Hub North West Lancashire (Eden Boys' School Bolton),3e7e39de-a62c-4940-bdb1-8c47f3970a92,NW3/NW4/NW5,Star Teaching School Hub Pennine Lancashire
+Star Teaching School Hub Pennine Lancashire (Eden Boys' School Bolton),46469655-8d0f-4a8c-9966-0fae6a00162a,NW3/NW4/NW5,Star Teaching School Hub Pennine Lancashire
+Embrace Teaching School Hub (SW Lancashire) (Tor View School),0f6720a7-097c-406a-aa60-29ba7eb1ca21,NW6,Embrace Teaching School Hub (SW Lancashire)
+Bright Futures Teaching School Hub (Altrincham Grammar School for Girls),d39267fc-ded1-49e0-b6ae-1161b3f3b439,NW7/NW9,Bright Futures Teaching School Hub-Salford & Trafford
+Rainbow Teaching School Hub (St Silas Church of England Primary School),4206bdd2-1806-40ff-a44e-41dc52dabd62,NW8,Rainbow Teaching School Hub
+"The Julian Teaching School Hub (Notre Dame High School, Norwich)",f8ab3d0e-8b2f-4156-ab18-267c3b651a1d,NW9,The Julian Teaching School Hub
+STEP Ahead Teaching School Hub (Angel Oak Academy),dadd329c-6055-4e1c-b0ef-8ebc68f064a2,SE1,STEP Ahead Teaching School Hub
+Teaching School Hub Berkshire (Langley Grammar School),21a0cc8d-e737-4ab4-87f4-d9b80c91d5b0,SE10,TSH Berkshire
+SFET Teaching School Hub (South Farnham School),9f914a53-8e75-4671-ad0f-410645a12850,SE11,SFET Teaching School Hub
+Thames Gateway Teaching School Hub (Sir Joseph Williamson's Mathematical School),c3e06654-9827-4ded-9ab5-c6bf7bfb6b0e,SE12,Thames Gateway Teaching School Hub
+Kent Teaching School hub (Bennett Memorial Diocesan School),6ee878a2-2328-4270-951a-368349fabc48,SE2 / SE8,Kent Teaching School Hub
+HISP Teaching School Hub (Thornden School),7ca83340-10da-4525-a8fd-3cb6c14f386c,SE3,HISP Teaching School Hub (Thornden School)
+GLF West Sussex Teaching School Hub (Rosebery School),33f2e3a7-0bf6-4f2f-970f-c5e94c9f2d20,SE4,GLF West Sussex Teaching School Hub
+"Xavier Teaching School Hub (St John the Baptist Catholic Comprehensive School, Woking)",7c59dc41-d732-4367-b236-564c01aee4c1,SE5,Xavier Teaching School Hub
+"Astra Teaching School Hub, Buckinghamshire (Dr Challoner's Grammar School)",77bf65fb-493b-4d3c-86eb-6a2c9839a32d,SE6,"Astra Teaching School Hub, Buckinghamshire"
+HISP Teaching School Hub (Portswood Primary School),db5d0a2e-7bab-45d8-aa98-3de2b0e19c95,SE7,HISP Teaching School Hub (Portswood Primary)
+Oxfordshire Teaching School Hub (The Cherwell School),ac3b03c0-f34e-4221-b6f7-d12b49d4ebb4,SE9,Oxfordshire Teaching School Hub
+South Central Teaching School Hub (The Quay School),cb1611b7-ae1a-4e20-88cf-b7691b69d366,SW1,South Central Teaching School Hub
+Balcarras (Balcarras School),105eee26-443c-4696-9a9b-3458e394cdee,SW10,Balcarras
+One Cornwall Teaching School Hub  (East Cornwall) (The Roseland Academy),87cf3a47-887a-4766-ad15-2b200aa06024,SW11,One Cornwall Teaching School Hub (East Cornwall)
+Odyssey Teaching School Hub  (Pate's Grammar School),dfc0062b-40a6-4fb5-9630-33911bfe024f,SW2,Odyssey Teaching School Hub
+SWIFT Kingsbridge Teaching School Hub (Kingsbridge Academy),3bd3c5fe-8c39-4f9c-af3e-ae992ad0ff30,SW3,Kingsbridge Teaching School Hub
+SWIFT Colyton Teaching School Hub (Colyton Grammar School),e300d8d8-caf0-4f90-9147-bee0d6d40e4b,SW4,Colyton Teaching School Hub
+Five Counties Teaching School Hubs Alliance (Bristol/North Somerset) (Bristol Metropolitan Academy),86ad4e94-0571-4c27-a0fc-15ac35cdb355,SW5/SW9,Five Counties Teaching School Hubs Alliance (Somerset)
+Five Counties Teaching School Hubs Alliance (Somerset) (Bristol Metropolitan Academy),3f3a6140-56bc-453b-b945-5a46a224484e,SW5/SW9,Five Counties Teaching School Hubs Alliance (Somerset)
+Five Counties Teaching School Hub - South Gloucestershire and Bath and North East Somerset  (Mangotsfield Church of England Voluntary Controlled Primary School),6a70cbe0-3df8-4e8b-a80c-5c2cc63a59a2,SW6,Five Counties Teaching School Hubs Alliance (South Glos/BANES)
+Swindon and Wiltshire Teaching School Hub (Glenmoor Academy),d9f1f6de-bcca-44e7-85e7-b6eb6116ad08,SW7,Swindon and Wiltshire Teaching School Hub
+One Cornwall Teaching School Hub (West) (Trenance Learning Academy),c0f863cc-d23c-446a-ab09-01ed3c55f92c,SW8,One Cornwall Teaching School Hub (West)
+Prince Henry's Teaching School Hub (Prince Henry's High School),7fbadaef-a05e-43c4-acda-1ec176c0e781,WM1,Prince Henry's Teaching School Hub
+Star Teaching School Hub Birmingham S (Eden Boys’ School Birmingham),2e51f844-31b7-4483-9fea-2ba68b147375,WM10,Star Teaching School Hub Birmingham South
+STEP (The Priory School),acf178fc-bf68-46b1-9605-47771d82dba8,WM2,STEP
+John Taylor Teaching School Hub  (John Taylor High School),344aadbf-a964-4f9c-ae80-2194a574c236,WM3,John Taylor Teaching School Hub
+"Tudor Grange Teaching School Hub (Tudor Grange Academy, Solihull)",832ff85f-ad31-4598-94c1-548e3f34947e,WM4,Tudor Grange Teaching School Hub
+The Golden Thread Teaching School Hub (Painsley Catholic College),cacab004-f450-41bd-9947-e263481d035a,WM5,The Golden Thread Teaching School Hub
+Coventry and Central Warwickshire Teaching School Hub (Lawrence Sheriff School),98f2a7b6-bc4e-45da-b4fa-6d5424ef1021,WM6,Coventry and Central Warwickshire Teaching School Hub
+Haybridge Teaching School Hub (Haybridge High School and Sixth Form),ab2d6c9d-d5d8-4224-b2ae-0a83c8be6810,WM7,Haybridge Teaching School Hub
+Manor Teaching School Hub (Manor Primary School),f5018a20-0ea5-49f0-8b00-0a51fa478b5b,WM8,Manor Teaching School Hub
+Arthur Terry Teaching School Hub - North Birmingham (The Arthur Terry School),dac3b20c-2fe8-4d9f-bfa9-6bc0db00d1a8,WM9,Arthur Terry Teaching School Hub-North Birmingham
+Exchange Teaching School Hub (Grange Lane Infant Academy),1c80a27a-1167-4a4f-a922-55ae84e1631e,YH1,Exchange Teaching School Hub
+Red Kite Teaching School Hub (Harrogate Grammar School),c21360e8-3dbb-4b06-b2a7-0c189d11d962,YH10,Red Kite Teaching School Hub
+South Yorkshire Teaching School Hub  (Silverdale School),8a0739eb-5a6e-40ae-b466-67cfa81346bf,YH2,South Yorkshire Teaching Hub
+"Pathfinder Teaching School Hub  (Archbishop Holgate's School, A Church of England Academy)",c1496245-02f3-4dbe-b348-eb7eddc76175,YH3,Pathfinder Teaching School Hub
+DRET Teaching School Hub (Humberston Academy),b448a843-3de3-4a0e-9c13-ea4341e08c8d,YH4,DRET Teaching School Hub
+"The Vantage Teaching School Hub North Humber (St Mary's College, Voluntary Catholic Academy)",28a2de7e-0f10-4885-acbd-6bdd88d9e058,YH5,The Vantage Teaching School Hub North Humber
+Exceed Teaching School Hub (Harden Primary Academy School),e5f5a644-6698-441b-8e52-640fa832a1b2,YH6,Exceed Teaching School Hub
+"Calderdale and Kirklees Teaching School Hub (Shelley College, A Share Academy)",afd6665a-654f-4916-b0ec-7883c9ed5e12,YH7,Calderdale and Kirklees Teaching School Hub
+Selby and Wakefield Teaching School Hub (The Vale Primary Academy),ba0947b9-3182-4d62-8d9b-9497019d6b85,YH8,Selby & Wakefield is Exchange TSH
+Leeds Teaching School Hub (The Morley Academy),ac48354f-b75b-417e-b9d4-5ef0d2c674df,YH9,Leeds Teaching School Hub
+Educational Success Partners (ESP),babb1465-bbee-4a68-b3bf-96677e26758c,,Educational Success Partners (ESP)
+Independent Schools Teacher Induction Panel (IStip),2b4166b4-efb9-44ea-a848-318882ef5d3c,,Independent Schools Teacher Induction Panel (ISTIP)
+National Teacher Accreditation (NTA),8fa977bf-20e6-421f-a48c-afe5f3626a0b,,National Teacher Accreditation

--- a/db/migrate/20251211135135_create_region.rb
+++ b/db/migrate/20251211135135_create_region.rb
@@ -1,0 +1,13 @@
+class CreateRegion < ActiveRecord::Migration[8.0]
+  def change
+    create_table :regions do |t|
+      t.string :code, null: false, index: { unique: true }
+      t.string :districts, null: false, array: true
+      t.references :teaching_school_hub, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :regions, :districts, using: "gin"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -732,6 +732,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
     t.index ["trn"], name: "index_pending_induction_submissions_on_trn"
   end
 
+  create_table "regions", force: :cascade do |t|
+    t.string "code", null: false
+    t.string "districts", null: false, array: true
+    t.bigint "teaching_school_hub_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_regions_on_code", unique: true
+    t.index ["districts"], name: "index_regions_on_districts", using: :gin
+    t.index ["teaching_school_hub_id"], name: "index_regions_on_teaching_school_hub_id"
+  end
+
   create_table "schedules", force: :cascade do |t|
     t.integer "contract_period_year", null: false
     t.enum "identifier", null: false, enum_type: "schedule_identifiers"
@@ -1124,6 +1135,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
   add_foreign_key "pending_induction_submission_batches", "appropriate_body_periods"
   add_foreign_key "pending_induction_submissions", "appropriate_body_periods"
   add_foreign_key "pending_induction_submissions", "pending_induction_submission_batches"
+  add_foreign_key "regions", "teaching_school_hubs"
   add_foreign_key "schedules", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "school_partnerships", "schools"
   add_foreign_key "schools", "appropriate_body_periods", column: "last_chosen_appropriate_body_id"

--- a/db/scripts/create_regions.rb
+++ b/db/scripts/create_regions.rb
@@ -1,0 +1,111 @@
+# Populate all Teaching School Hub regions
+#
+regions = [
+  # East of England
+  ["EE1", "Chelmsford, Braintree, Uttlesford, Epping Forest, Harlow"],
+  ["EE2", "Colchester, Tendring, Ipswich, Babergh"],
+  ["EE3", "Cambridge, South Cambridgeshire, Huntingdonshire, Peterborough, Fenland, East Cambridgeshire"],
+  ["EE4", "North Norfolk, King's Lynn and West Norfolk, Norwich, Broadland"],
+  ["EE5", "Southend-on-Sea, Basildon, Maldon, Castle Point, Rochford, Brentwood, Thurrock"],
+  ["EE6", "East Suffolk S., Mid Suffolk, West Suffolk"],
+  ["EE7", "St Albans, Welwyn Hatfield, Dacorum, Watford, Three Rivers, Hertsmere"],
+  ["EE8", "Luton, North Hertfordshire, Broxbourne, Stevenage, East Hertfordshire"],
+  ["EE9", "Bedford, Central Bedfordshire, Milton Keynes"],
+  ["EE10", "Breckland, East Suffolk N, Great Yarmouth, South Norfolk"],
+  # East Midlands
+  ["EM1", "Charnwood, North West Leicestershire, Melton, Hinckley and Bosworth, Rutland"],
+  ["EM2", "Gedling, Bassetlaw, Newark and Sherwood"],
+  ["EM3", "High Peak, Amber Valley, Derbyshire Dales, Bolsover, North East Derbyshire, Chesterfield"],
+  ["EM4", "Ashfield, Nottingham, Mansfield, Broxtowe, Rushcliffe"],
+  ["EM5", "Harborough, Blaby, Oadby and Wigston, Leicester"],
+  ["EM6", "South Kesteven, Lincoln, North Kesteven, South Holland, Boston, East Lindsey, West Lindsey"],
+  ["EM7", "Derby, South Derbyshire, Erewash"],
+  ["EM8", "North Northamptonshire, West Northamptonshire"],
+  # London
+  ["L1", "Hackney, Tower Hamlets"],
+  ["L2", "Newham, Barking and Dagenham, Havering"],
+  ["L3", "Haringey, Redbridge, Waltham Forest"],
+  ["L4", "Barnet, Enfield, Brent"],
+  ["L5", "Ealing, Harrow, Hillingdon, Hounslow"],
+  ["L6", "City of London, Camden, Hammersmith and Fulham, Islington, Kensington and Chelsea, Westminster"],
+  ["L7", "Wandsworth, Kingston upon Thames, Merton, Richmond upon Thames"],
+  ["L8", "Croydon, Sutton, Epsom and Ewell"],
+  ["L9", "Lambeth, Southwark, Lewisham"],
+  ["L10", "Greenwich, Bexley, Bromley"],
+  # North East
+  ["NE1", "Northumberland, Newcastle upon Tyne, North Tyneside"],
+  ["NE2", "Stockton-on-Tees, Redcar and Cleveland, Middlesbrough, Hartlepool, Darlington"],
+  ["NE3", "Gateshead, South Tyneside, Sunderland"],
+  ["NE4", "County Durham"],
+  # North West
+  ["NW1", "Wirral, Liverpool"],
+  ["NW2", "Wigan, Halton, Warrington"],
+  ["NW3", "Bolton, Bury, Rochdale"],
+  ["NW4", "Blackpool, Preston, Lancaster, Wyre"],
+  ["NW5", "Hyndburn, Burnley, Pendle, Blackburn with Darwen, Ribble Valley, Rossendale"],
+  ["NW6", "Chorley, West Lancashire, South Ribble, Fylde"],
+  ["NW7", "Manchester, Stockport"],
+  ["NW8", "Knowsley, St. Helens, Sefton"],
+  ["NW9", "Salford, Trafford"],
+  ["NW10", "Oldham, Tameside"],
+  ["NW11", "Cumberland, Westmorland and Furness"],
+  ["NW12", "Cheshire East, Cheshire West and Chester"],
+  # South East
+  ["SE1", "Wealden, Lewes, Brighton and Hove, Rother, Hastings, Eastbourne"],
+  ["SE2", "Ashford, Canterbury, Dover, Folkestone and Hythe, Swale, Thanet"],
+  ["SE3", "Havant, Gosport, Eastleigh, Fareham, Portsmouth, Isle of Wight"],
+  ["SE4", "Arun, Chichester, Horsham, Adur, Crawley, Worthing, Mid Sussex"],
+  ["SE5", "Runnymede, Mole Valley, Reigate and Banstead, Elmbridge, Tandridge, Surrey Heath, Woking, Spelthorne"],
+  ["SE6", "Buckinghamshire"],
+  ["SE7", "Southampton, Test Valley, New Forest, Winchester"],
+  ["SE8", "Sevenoaks, Tunbridge Wells, Tonbridge and Malling, Maidstone"],
+  ["SE9", "Oxford, South Oxfordshire, West Oxfordshire, Cherwell, Vale of White Horse"],
+  ["SE10", "Wokingham, Reading, Windsor and Maidenhead, West Berkshire, Slough, Bracknell Forest"],
+  ["SE11", "Rushmoor, East Hampshire, Basingstoke and Deane, Hart, Waverley, Guildford"],
+  ["SE12", "Gravesham, Dartford, Medway"],
+  # South West
+  ["SW1", "Bournemouth, Christchurch and Poole, Dorset"],
+  ["SW2", "Gloucester, Tewkesbury, Forest of Dean"],
+  ["SW3", "Exeter, Plymouth, South Hams, Teignbridge, Torbay, West Devon"],
+  ["SW4", "Mid Devon, East Devon, Torridge, North Devon"],
+  ["SW5", "Somerset"],
+  ["SW6", "Bath and North East Somerset, South Gloucestershire"],
+  ["SW7", "Swindon, Wiltshire"],
+  ["SW8", "Cornwall, Isles of Scilly"],
+  ["SW9", "Bristol, North Somerset"],
+  ["SW10", "Stroud, Cotswold, Cheltenham"],
+  ["SW11", "Cornwall"],
+  # West Midlands
+  ["WM1", "Herefordshire, Wychavon, Malvern Hills, Worcester, Wyre Forest"],
+  ["WM2", "Telford and Wrekin, Shropshire"],
+  ["WM3", "Cannock Chase, East Staffordshire, Lichfield, Tamworth, North Warwickshire, Nuneaton and Bedworth"],
+  ["WM4", "Solihull, Bromsgrove, Redditch, Stratford-on-Avon"],
+  ["WM5", "Newcastle-under-Lyme, Stoke-on-Trent, Staffordshire Moorlands, Stafford"],
+  ["WM6", "Coventry, Warwick, Rugby"],
+  ["WM7", "Sandwell, Dudley"],
+  ["WM8", "Walsall, Wolverhampton, South Staffordshire"],
+  ["WM9", "Birmingham North"],
+  ["WM10", "Birmingham South"],
+  # Yorkshire & Humber
+  ["YH1", "Barnsley, Doncaster"],
+  ["YH2", "Rotherham, Sheffield"],
+  ["YH3", "North Yorkshire E., York"],
+  ["YH4", "North East Lincolnshire, North Lincolnshire"],
+  ["YH5", "Kingston upon Hull, East Riding of Yorkshire"],
+  ["YH6", "Bradford"],
+  ["YH7", "Calderdale, Kirklees"],
+  ["YH8", "North Yorkshire S., Wakefield"],
+  ["YH9", "Leeds"],
+  ["YH10", "North Yorkshire W."],
+
+]
+
+ActiveRecord::Base.transaction do
+  Region.delete_all
+
+  regions.each do |code, districts|
+    districts = districts.split(", ")
+
+    Region.create!(code:, districts:)
+  end
+end

--- a/db/seeds/regions.rb
+++ b/db/seeds/regions.rb
@@ -1,0 +1,7 @@
+def describe_region(region)
+  print_seed_info("#{region.code}: #{region.districts}", indent: 2)
+end
+
+FactoryBot.create_list(:region, 13).map do |region|
+  describe_region(region)
+end

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -151,6 +151,15 @@ erDiagram
     datetime updated_at
   }
   Schedule }o--|| ContractPeriod : belongs_to
+  Region {
+    integer id
+    string code
+    array[string] districts
+    integer teaching_school_hub_id
+    datetime created_at
+    datetime updated_at
+  }
+  Region }o--|| TeachingSchoolHub : belongs_to
   PendingInductionSubmissionBatch {
     integer id
     integer appropriate_body_period_id

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory(:appropriate_body, class: "AppropriateBodyPeriod") do
+    initialize_with do
+      AppropriateBodyPeriod.find_or_initialize_by(name:)
+    end
+
     sequence(:name) { |n| "Appropriate Body Period #{n}" }
     dfe_sign_in_organisation_id { Faker::Internet.uuid }
 
@@ -10,10 +14,6 @@ FactoryBot.define do
     # Once data migration has started
     trait :active do
       association :dfe_sign_in_organisation
-    end
-
-    initialize_with do
-      AppropriateBodyPeriod.find_or_initialize_by(name:)
     end
 
     trait :national do

--- a/spec/factories/dfe_sign_in_organisation_factory.rb
+++ b/spec/factories/dfe_sign_in_organisation_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory(:dfe_sign_in_organisation) do
+    initialize_with do
+      DfESignInOrganisation.find_or_initialize_by(uuid:)
+    end
+
     sequence(:name) { |n| "Organisation #{n}" }
     uuid { Faker::Internet.uuid }
     urn { Faker::Number.unique.number(digits: 6) }

--- a/spec/factories/legacy_appropriate_body_factory.rb
+++ b/spec/factories/legacy_appropriate_body_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory(:legacy_appropriate_body) do
+    initialize_with do
+      LegacyAppropriateBody.find_or_initialize_by(name:)
+    end
+
     name { Faker::Company.name }
     dqt_id { Faker::Internet.uuid }
     appropriate_body_period { association :appropriate_body }

--- a/spec/factories/national_body_factory.rb
+++ b/spec/factories/national_body_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory(:national_body) do
+    initialize_with do
+      NationalBody.find_or_initialize_by(name:)
+    end
+
     sequence(:name) { |n| "National Body #{n}" }
 
     trait :istip do

--- a/spec/factories/region_factory.rb
+++ b/spec/factories/region_factory.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory(:region) do
+    initialize_with do
+      Region.find_or_initialize_by(code:)
+    end
+
+    sequence(:code) { |n| "XYZ#{n}" }
+
+    districts do
+      Array.new(rand(1..8)) { Faker::Address.city }
+    end
+  end
+end

--- a/spec/factories/teaching_school_hub_factory.rb
+++ b/spec/factories/teaching_school_hub_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory(:teaching_school_hub) do
+    initialize_with do
+      TeachingSchoolHub.find_or_initialize_by(name:)
+    end
+
     name { Faker::Company.name }
     association :dfe_sign_in_organisation
     lead_school { association :school }

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Region, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:teaching_school_hub) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.build(:region) }
+
+    it { is_expected.to validate_presence_of(:code) }
+    it { is_expected.to validate_uniqueness_of(:code) }
+    it { is_expected.to validate_presence_of(:districts) }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe School do
     it { is_expected.to have_many(:contract_period_metadata).class_name("Metadata::SchoolContractPeriod") }
     it { is_expected.to have_many(:lead_provider_contract_period_metadata).class_name("Metadata::SchoolLeadProviderContractPeriod") }
     it { is_expected.to have_many(:training_periods).through(:school_partnerships) }
-    it { is_expected.to have_many(:led_teaching_school_hubs).class_name("TeachingSchoolHub") }
+    it { is_expected.to have_one(:led_teaching_school_hub).class_name("TeachingSchoolHub") }
   end
 
   describe "scopes" do
     describe ".lead_schools" do
       before do
-        FactoryBot.create(:school)
+        FactoryBot.create_list(:school, 3)
         FactoryBot.create(:teaching_school_hub)
       end
 

--- a/spec/models/teaching_school_hub_spec.rb
+++ b/spec/models/teaching_school_hub_spec.rb
@@ -13,25 +13,14 @@ RSpec.describe TeachingSchoolHub, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
 
-    describe "#lead_school_limit" do
-      before do
-        FactoryBot.create_list(:teaching_school_hub, 3, lead_school:)
-      end
+    it { is_expected.to validate_presence_of(:lead_school) }
+    it { is_expected.to validate_uniqueness_of(:lead_school) }
 
-      it "allows up to 3 hubs per lead school" do
-        expect(lead_school.led_teaching_school_hubs.count).to eq(3)
-      end
-
-      it "prevents more than 3 hubs per lead school" do
-        fourth_hub = FactoryBot.build(:teaching_school_hub, lead_school:)
-
-        expect(fourth_hub).not_to be_valid
-        expect(fourth_hub.errors[:lead_school]).to include("has reached the maximum of 3 teaching school hubs")
-      end
-    end
+    it { is_expected.to validate_presence_of(:dfe_sign_in_organisation) }
+    it { is_expected.to validate_uniqueness_of(:dfe_sign_in_organisation) }
   end
 
-  describe "appropriate_body_periods" do
+  describe "#appropriate_body_periods" do
     subject(:teaching_school_hub) { FactoryBot.create(:teaching_school_hub, lead_school:) }
 
     # TODO: A TSH can have a multiple periods:
@@ -41,5 +30,15 @@ RSpec.describe TeachingSchoolHub, type: :model do
       FactoryBot.create_list(:appropriate_body, 9, teaching_school_hub:)
       expect(teaching_school_hub.appropriate_body_periods.count).to eq(9)
     end
+  end
+
+  describe "#districts" do
+    subject(:teaching_school_hub) { FactoryBot.create(:teaching_school_hub, lead_school:) }
+
+    before do
+      FactoryBot.create_list(:region, 3, teaching_school_hub:)
+    end
+
+    it { expect(teaching_school_hub.districts).not_to be_empty }
   end
 end

--- a/spec/requests/admin/teaching_school_hubs_spec.rb
+++ b/spec/requests/admin/teaching_school_hubs_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe "Admin::TeachingSchoolHubsController", type: :request do
   let!(:teaching_school_hub) do
-    FactoryBot.create(:teaching_school_hub)
+    FactoryBot.create(:teaching_school_hub, name: "Hub Name")
+  end
+
+  before do
+    FactoryBot.create(:region, districts: %w[West East], teaching_school_hub:)
+    FactoryBot.create(:region, districts: %w[North], teaching_school_hub:)
   end
 
   describe "GET /index" do
@@ -10,7 +15,7 @@ RSpec.describe "Admin::TeachingSchoolHubsController", type: :request do
       it "returns http success" do
         get "/admin/organisations/teaching-school-hubs"
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(teaching_school_hub.name)
+        expect(response.body).to include("Hub Name")
       end
     end
 
@@ -38,7 +43,8 @@ RSpec.describe "Admin::TeachingSchoolHubsController", type: :request do
       it "returns http success" do
         get "/admin/organisations/teaching-school-hubs/#{teaching_school_hub.id}"
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(teaching_school_hub.name)
+        expect(response.body).to include("Hub Name")
+        expect(response.body).to include("West, East, and North")
       end
     end
 


### PR DESCRIPTION
### Context

Discussions have yielded that having the region data for Teaching School Hubs sit in the service is added value for the Data team.

Once in place it can be surfaced in the admin console and user profiles but initially the goal is to accurately map regional bodies for the purpose of reporting.

### Changes proposed in this pull request

Introduce a new table of data which will be linked to TSHs once they have been migrated.

### Guidance to review

<img width="1686" height="729" alt="localhost_3000_admin_organisations_teaching-school-hubs_2" src="https://github.com/user-attachments/assets/39615640-b6ca-4ead-b0fb-34fa41bf1967" />
