### PR TITLE
Close/open training periods on mentor completion

### DIFF
--- a/app/services/declarations/mentor_completion.rb
+++ b/app/services/declarations/mentor_completion.rb
@@ -11,7 +11,7 @@ module Declarations
       return false unless mentor_completion_event?
 
       ActiveRecord::Base.transaction do
-        if latest_completed_declaration.billable_or_changeable?
+        if latest_billable_completed_declaration
           mentor_completed_training!
           finish_training_period!
         else
@@ -74,7 +74,7 @@ module Declarations
 
     def mentor_completed_training!
       teacher.update!(
-        mentor_became_ineligible_for_funding_on: latest_completed_declaration.declaration_date,
+        mentor_became_ineligible_for_funding_on: latest_billable_completed_declaration.declaration_date,
         mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
       )
     end
@@ -86,12 +86,13 @@ module Declarations
       )
     end
 
-    def latest_completed_declaration
-      @latest_completed_declaration ||= teacher
+    def latest_billable_completed_declaration
+      @latest_billable_completed_declaration ||= teacher
         .mentor_declarations
         .declaration_type_completed
+        .billable_or_changeable
         .order(declaration_date: :desc)
-        .first!
+        .first
     end
 
     def record_completion_change_event!

--- a/spec/services/declarations/mentor_completion_spec.rb
+++ b/spec/services/declarations/mentor_completion_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Declarations::MentorCompletion, :with_metadata do
   describe "#perform" do
     context "when declaration is billable or changeable" do
       context "when mentor training is completed" do
+        before do
+          # Voided declaration with a later declaration_date should be ignored.
+          FactoryBot.create(:declaration, :voided, declaration_type: "completed", training_period:, declaration_date: 1.week.ago)
+        end
+
         let(:declaration) { FactoryBot.create(:declaration, :eligible, declaration_type: "completed", training_period:, declaration_date: 2.weeks.ago) }
 
         it "mentor is now ineligible for funding" do


### PR DESCRIPTION
### Context

When a we get a completed, billable declaration submitted for a mentor we want to also close off their latest/ongoing training period for that lead provider.

Where possible we will use the `declaration_date` as the `finished_on`. If, however, that date is before the training period `started_on` we will close it the day after it started.

When a billable, completed declaration is voided we 'uncomplete' the mentor and we also want to resume  their training period with the lead provider (unless it has been resumed through another avenue). 

To do this, we will create a new training period that starts the day their previous period finished and it will mirror the `finished_on` of the school period.

### Changes proposed in this pull request

- Close/open training periods on mentor completion

### Guidance to review
