### PR TITLE
Ensure we make training period `created_at` match the induction record's `created_at`

### DIFF
--- a/app/migration/ecf2_teacher_history/training_period_row.rb
+++ b/app/migration/ecf2_teacher_history/training_period_row.rb
@@ -9,10 +9,12 @@ class ECF2TeacherHistory::TrainingPeriodRow
               :deferred_at,
               :deferral_reason,
               :withdrawn_at,
-              :withdrawal_reason
+              :withdrawal_reason,
+              :created_at
 
   def initialize(started_on:,
                  finished_on:,
+                 created_at:,
                  training_programme:,
                  lead_provider_info: nil,
                  delivery_partner_info: nil,
@@ -24,6 +26,7 @@ class ECF2TeacherHistory::TrainingPeriodRow
                  withdrawal_reason: nil)
     @started_on = started_on
     @finished_on = finished_on
+    @created_at = created_at
     @training_programme = training_programme
     @lead_provider_info = lead_provider_info
     @delivery_partner_info = delivery_partner_info
@@ -44,6 +47,7 @@ class ECF2TeacherHistory::TrainingPeriodRow
       finished_on:,
       training_programme:,
       schedule: ecf2_schedule,
+      created_at:
       # FIXME: soon TPs can be both deferred and withdrawn, so this can be uncommented
       # deferred_at:,
       # deferral_reason:,

--- a/app/migration/teacher_history_converter.rb
+++ b/app/migration/teacher_history_converter.rb
@@ -54,7 +54,8 @@ private
       delivery_partner_info: induction_record.training_provider_info.delivery_partner_info,
       schedule_info: induction_record.schedule_info,
       # FIXME: rename this to contract_period_year
-      contract_period: induction_record.cohort_year
+      contract_period: induction_record.cohort_year,
+      created_at: induction_record.created_at
     }
   end
 

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -12,6 +12,7 @@ describe ECF2TeacherHistory do
   let(:school_a_data) { ECF2TeacherHistory::SchoolData.new(urn: 111_111, name: "School A") }
   let(:school_b_data) { ECF2TeacherHistory::SchoolData.new(urn: 222_222, name: "School B") }
   let(:mentor_data) { ECF2TeacherHistory::MentorData.new(trn: "1234567", urn: "123456", started_on: 1.week.ago, finished_on: 1.day.ago) }
+  let(:created_at) { 1.month.ago.round }
 
   let(:mentorship_period_rows) do
     [
@@ -30,6 +31,7 @@ describe ECF2TeacherHistory do
       ECF2TeacherHistory::TrainingPeriodRow.new(
         started_on: 1.month.ago.to_date,
         finished_on: 1.week.ago.to_date,
+        created_at:,
         training_programme: :provider_led
       ),
     ]
@@ -183,6 +185,7 @@ describe ECF2TeacherHistory do
             ECF2TeacherHistory::TrainingPeriodRow.new(
               started_on: 1.year.ago.to_date,
               finished_on: 1.month.ago.to_date,
+              created_at:,
               training_programme: :provider_led,
               lead_provider_info:,
               delivery_partner_info:,
@@ -212,6 +215,7 @@ describe ECF2TeacherHistory do
             ECF2TeacherHistory::TrainingPeriodRow.new(
               started_on: 1.month.ago.to_date,
               finished_on: 1.week.ago.to_date,
+              created_at:,
               training_programme: :school_led
             )
           end
@@ -260,6 +264,7 @@ describe ECF2TeacherHistory do
                   expect(p1_tp.lead_provider).to eql(lead_provider)
                   expect(p1_tp.contract_period).to eql(contract_period)
                   expect(p1_tp.schedule).to eql(schedule)
+                  expect(p1_tp.created_at).to eql(created_at)
                   # FIXME: soon TPs can be both deferred and withdrawn, so this can be uncommented
                   # expect(p1_tp.withdrawn_at).to eql(1.month.ago.round(2))
                   # expect(p1_tp.withdrawal_reason).to eql("switched_to_school_led")
@@ -282,6 +287,7 @@ describe ECF2TeacherHistory do
                 p2.training_periods.first!.tap do |p2_tp|
                   expect(p2_tp.started_on).to eql(1.month.ago.to_date)
                   expect(p2_tp.finished_on).to eql(1.week.ago.to_date)
+                  expect(p2_tp.created_at).to eql(created_at)
                   expect(p2_tp.training_programme).to eql("school_led")
                   expect(p2_tp.schedule).to be_nil
                 end
@@ -463,6 +469,7 @@ describe ECF2TeacherHistory do
             ECF2TeacherHistory::TrainingPeriodRow.new(
               started_on: 1.year.ago.to_date,
               finished_on: 1.month.ago.to_date,
+              created_at:,
               training_programme: :provider_led,
               lead_provider_info:,
               delivery_partner_info:,

--- a/spec/migration/teacher_history_converter/end_to_end/one_induction_record_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/one_induction_record_spec.rb
@@ -3,7 +3,7 @@ describe "One induction record (end to end)" do
 
   # ECF1 data
   let(:ecf1_induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led) }
-  let(:ecf1_induction_record) { FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme) }
+  let(:ecf1_induction_record) { FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, created_at: 18.hours.ago.round) }
   let(:ecf1_teacher_profile) { ecf1_induction_record.participant_profile.teacher_profile }
   let(:ecf1_urn) { ecf1_induction_programme.school_cohort.school.urn.to_i }
 
@@ -56,6 +56,8 @@ describe "One induction record (end to end)" do
 
       expect(training_period.schedule.identifier).to eql(ecf1_induction_record.schedule.schedule_identifier)
       expect(training_period.schedule.contract_period_year).to eql(ecf1_induction_record.schedule.cohort.start_year)
+
+      expect(training_period.created_at).to eql(ecf1_induction_record.created_at)
     end
   end
 end


### PR DESCRIPTION
In ECF1 the API uses the creation date of a training period to determine the transfer status. To maintain this for v3 we want to set the training period's created_at to be the same as the source induction record's one.
