### PR TITLE
Rename `id` to `ecf1_id` in migration types

### DIFF
--- a/app/migration/ecf1_teacher_history.rb
+++ b/app/migration/ecf1_teacher_history.rb
@@ -129,11 +129,11 @@ class ECF1TeacherHistory
 
     TrainingProviderInfo.new(
       lead_provider_info: Types::LeadProviderInfo.new(
-        id: partnership.lead_provider.id,
+        ecf1_id: partnership.lead_provider.id,
         name: partnership.lead_provider.name
       ),
       delivery_partner_info: Types::DeliveryPartnerInfo.new(
-        id: partnership.delivery_partner.id,
+        ecf1_id: partnership.delivery_partner.id,
         name: partnership.delivery_partner.name
       ),
       cohort_year: partnership.cohort.start_year
@@ -144,7 +144,7 @@ class ECF1TeacherHistory
     appropriate_body = induction_record.appropriate_body
     return if appropriate_body.blank?
 
-    Types::AppropriateBodyData.new(id: appropriate_body.id, name: appropriate_body.name)
+    Types::AppropriateBodyData.new(ecf1_id: appropriate_body.id, name: appropriate_body.name)
   end
 
   def self.build_schedule_info(schedule:)

--- a/app/migration/ecf2_teacher_history/training_period_row.rb
+++ b/app/migration/ecf2_teacher_history/training_period_row.rb
@@ -69,12 +69,12 @@ class ECF2TeacherHistory::TrainingPeriodRow
   def lead_provider
     return if lead_provider_info.blank?
 
-    LeadProvider.find_by!(ecf_id: lead_provider_info.id)
+    LeadProvider.find_by!(ecf_id: lead_provider_info.ecf1_id)
   end
 
   def delivery_partner
     return if delivery_partner_info.blank?
 
-    DeliveryPartner.find_by!(api_id: delivery_partner_info.id)
+    DeliveryPartner.find_by!(api_id: delivery_partner_info.ecf1_id)
   end
 end

--- a/app/migration/types.rb
+++ b/app/migration/types.rb
@@ -1,8 +1,7 @@
 module Types
-  # FIXME: these :id fields are from ECF1, rename them to :ecf1_id so it's clear
-  AppropriateBodyData = Data.define(:id, :name)
-  DeliveryPartnerInfo = Data.define(:id, :name)
-  LeadProviderInfo = Data.define(:id, :name)
+  AppropriateBodyData = Data.define(:ecf1_id, :name)
+  DeliveryPartnerInfo = Data.define(:ecf1_id, :name)
+  LeadProviderInfo = Data.define(:ecf1_id, :name)
   SchoolData = Data.define(:urn, :name)
   ScheduleInfo = Data.define(:schedule_id, :identifier, :name, :cohort_year)
 end

--- a/spec/factories/migration/ecf1_history_factory.rb
+++ b/spec/factories/migration/ecf1_history_factory.rb
@@ -52,8 +52,8 @@ FactoryBot.define do
   end
 
   factory :ecf1_teacher_history_training_provider_info, class: "ECF1TeacherHistory::TrainingProviderInfo" do
-    sequence(:lead_provider_info) { |n| Types::LeadProviderInfo.new(id: SecureRandom.uuid, name: "History Lead Provider #{n}") }
-    sequence(:delivery_partner_info) { |n| Types::DeliveryPartnerInfo.new(id: SecureRandom.uuid, name: "History Delivery Partner #{n}") }
+    sequence(:lead_provider_info) { |n| Types::LeadProviderInfo.new(ecf1_id: SecureRandom.uuid, name: "History Lead Provider #{n}") }
+    sequence(:delivery_partner_info) { |n| Types::DeliveryPartnerInfo.new(ecf1_id: SecureRandom.uuid, name: "History Delivery Partner #{n}") }
     cohort_year { Random.rand(2020..2119) }
 
     initialize_with do
@@ -82,7 +82,7 @@ FactoryBot.define do
     induction_status { "active" }
     training_programme { "full_induction_programme" }
     training_provider_info { FactoryBot.build(:ecf1_teacher_history_training_provider_info, cohort_year:) }
-    sequence(:appropriate_body) { |n| Types::AppropriateBodyData.new(id: SecureRandom.uuid, name: "History Appropriate body #{n}") }
+    sequence(:appropriate_body) { |n| Types::AppropriateBodyData.new(ecf1_id: SecureRandom.uuid, name: "History Appropriate body #{n}") }
 
     initialize_with do
       new(induction_record_id:,

--- a/spec/migration/ecf1_teacher_history_spec.rb
+++ b/spec/migration/ecf1_teacher_history_spec.rb
@@ -72,12 +72,12 @@ describe ECF1TeacherHistory do
               expect(historic_record.training_status).to eq(induction_record.training_status)
               expect(historic_record.induction_status).to eq(induction_record.induction_status)
               expect(historic_record.training_programme).to eq(induction_record.induction_programme.training_programme)
-              expect(historic_record.training_provider_info.lead_provider_info.id).to eq(induction_record.induction_programme.partnership.lead_provider_id)
+              expect(historic_record.training_provider_info.lead_provider_info.ecf1_id).to eq(induction_record.induction_programme.partnership.lead_provider_id)
               expect(historic_record.training_provider_info.lead_provider_info.name).to eq(induction_record.induction_programme.partnership.lead_provider.name)
-              expect(historic_record.training_provider_info.delivery_partner_info.id).to eq(induction_record.induction_programme.partnership.delivery_partner_id)
+              expect(historic_record.training_provider_info.delivery_partner_info.ecf1_id).to eq(induction_record.induction_programme.partnership.delivery_partner_id)
               expect(historic_record.training_provider_info.delivery_partner_info.name).to eq(induction_record.induction_programme.partnership.delivery_partner.name)
               expect(historic_record.training_provider_info.cohort_year).to eq(induction_record.induction_programme.partnership.cohort.start_year)
-              expect(historic_record.appropriate_body.id).to eq(induction_record.appropriate_body.id)
+              expect(historic_record.appropriate_body.ecf1_id).to eq(induction_record.appropriate_body.id)
               expect(historic_record.appropriate_body.name).to eq(induction_record.appropriate_body.name)
             end
           end
@@ -107,9 +107,9 @@ describe ECF1TeacherHistory do
               expect(historic_record.training_status).to eq(induction_record.training_status)
               expect(historic_record.induction_status).to eq(induction_record.induction_status)
               expect(historic_record.training_programme).to eq(induction_record.induction_programme.training_programme)
-              expect(historic_record.training_provider_info.lead_provider_info.id).to eq(induction_record.induction_programme.partnership.lead_provider_id)
+              expect(historic_record.training_provider_info.lead_provider_info.ecf1_id).to eq(induction_record.induction_programme.partnership.lead_provider_id)
               expect(historic_record.training_provider_info.lead_provider_info.name).to eq(induction_record.induction_programme.partnership.lead_provider.name)
-              expect(historic_record.training_provider_info.delivery_partner_info.id).to eq(induction_record.induction_programme.partnership.delivery_partner_id)
+              expect(historic_record.training_provider_info.delivery_partner_info.ecf1_id).to eq(induction_record.induction_programme.partnership.delivery_partner_id)
               expect(historic_record.training_provider_info.delivery_partner_info.name).to eq(induction_record.induction_programme.partnership.delivery_partner.name)
               expect(historic_record.training_provider_info.cohort_year).to eq(induction_record.induction_programme.partnership.cohort.start_year)
             end

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -174,8 +174,8 @@ describe ECF2TeacherHistory do
           let(:schedule) { FactoryBot.create(:schedule, contract_period:) }
           let(:schedule_info) { Types::ScheduleInfo.new(schedule_id: schedule.id, identifier: schedule.identifier, name: schedule.identifier, cohort_year: schedule.contract_period_year) }
 
-          let(:lead_provider_info) { Types::LeadProviderInfo.new(id: lead_provider.ecf_id, name: lead_provider.name) }
-          let(:delivery_partner_info) { Types::DeliveryPartnerInfo.new(id: delivery_partner.api_id, name: delivery_partner.name) }
+          let(:lead_provider_info) { Types::LeadProviderInfo.new(ecf1_id: lead_provider.ecf_id, name: lead_provider.name) }
+          let(:delivery_partner_info) { Types::DeliveryPartnerInfo.new(ecf1_id: delivery_partner.api_id, name: delivery_partner.name) }
 
           let!(:school_partnership) { FactoryBot.create(:school_partnership, school: school_a, lead_provider_delivery_partnership:) }
 
@@ -454,8 +454,8 @@ describe ECF2TeacherHistory do
           let(:schedule) { FactoryBot.create(:schedule, contract_period:) }
           let(:schedule_info) { Types::ScheduleInfo.new(schedule_id: schedule.id, identifier: schedule.identifier, name: schedule.identifier, cohort_year: schedule.contract_period_year) }
 
-          let(:lead_provider_info) { Types::LeadProviderInfo.new(id: lead_provider.ecf_id, name: lead_provider.name) }
-          let(:delivery_partner_info) { Types::DeliveryPartnerInfo.new(id: delivery_partner.api_id, name: delivery_partner.name) }
+          let(:lead_provider_info) { Types::LeadProviderInfo.new(ecf1_id: lead_provider.ecf_id, name: lead_provider.name) }
+          let(:delivery_partner_info) { Types::DeliveryPartnerInfo.new(ecf1_id: delivery_partner.api_id, name: delivery_partner.name) }
 
           let!(:school_partnership) { FactoryBot.create(:school_partnership, school: school_a, lead_provider_delivery_partnership:) }
 

--- a/spec/migration/teacher_history_converter/one_induction_record_spec.rb
+++ b/spec/migration/teacher_history_converter/one_induction_record_spec.rb
@@ -77,11 +77,10 @@ describe "One induction record" do
       end
 
       context "when there is an appropriate body" do
-        let(:appropriate_body) { Types::AppropriateBodyData.new(id: SecureRandom.uuid, name: "Average Appropriate body") }
+        let(:appropriate_body) { Types::AppropriateBodyData.new(ecf1_id: SecureRandom.uuid, name: "Average Appropriate body") }
 
         it "sets the appropriate body to the one on the induction record" do
-          expect(ecf2_ect_at_school_period_row.appropriate_body.id).to eql(ecf1_induction_record_row.appropriate_body.id)
-          expect(ecf2_ect_at_school_period_row.appropriate_body.name).to eql(ecf1_induction_record_row.appropriate_body.name)
+          expect(ecf2_ect_at_school_period_row.appropriate_body).to eql(ecf1_induction_record_row.appropriate_body)
         end
       end
     end


### PR DESCRIPTION
This explicitness should hopefully make it a bit clearer which ID we're referring to, as during the conversion there might be multiple at play.
