### PR TITLE
Rename declarations `voided_at` column

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -41,8 +41,8 @@ class Declaration < ApplicationRecord
   delegate :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
 
   validates :training_period, presence: { message: "Choose a training period" }
-  validates :voided_by_user, presence: { message: "Voided by user must be set as well as the voided date" }, if: :voided_at
-  validates :voided_at, presence: { message: "Voided at must be set as well as the voided by user" }, if: :voided_by_user
+  validates :voided_by_user, presence: { message: "Voided by user must be set as well as the voided date" }, if: :voided_by_user_at
+  validates :voided_by_user_at, presence: { message: "Voided by user at must be set as well as the voided by user" }, if: :voided_by_user
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another declaration" }
   validates :declaration_date, presence: { message: "Declaration date must be specified" }
   validates :declaration_type, inclusion: { in: Declaration.declaration_types.keys, message: "Choose a valid declaration type" }

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -395,7 +395,7 @@
   - clawback_statement_id
   - declaration_type
   - declaration_date
-  - voided_at
+  - voided_by_user_at
   - voided_by_user_id
   - mentorship_period_id
   - api_id

--- a/db/migrate/20251214090653_rename_voided_at_on_declarations.rb
+++ b/db/migrate/20251214090653_rename_voided_at_on_declarations.rb
@@ -1,0 +1,5 @@
+class RenameVoidedAtOnDeclarations < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :declarations, :voided_at, :voided_by_user_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_09_151009) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_14_090653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -169,7 +169,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_09_151009) do
     t.bigint "mentorship_period_id"
     t.bigint "payment_statement_id"
     t.bigint "clawback_statement_id"
-    t.datetime "voided_at"
+    t.datetime "voided_by_user_at"
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "declaration_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.enum "evidence_type", enum_type: "evidence_types"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -96,9 +96,11 @@ erDiagram
     string induction_tutor_name
     citext induction_tutor_email
     uuid api_id
+    integer induction_tutor_last_nominated_in
   }
   School }o--|| AppropriateBody : belongs_to
   School }o--|| LeadProvider : belongs_to
+  School }o--|| ContractPeriod : belongs_to
   Schedule {
     integer id
     integer contract_period_year
@@ -310,7 +312,7 @@ erDiagram
     integer mentorship_period_id
     integer payment_statement_id
     integer clawback_statement_id
-    datetime voided_at
+    datetime voided_by_user_at
     uuid api_id
     datetime declaration_date
     enum evidence_type

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     trait :voided_by_user do
       payment_status { :voided }
       voided_by_user { FactoryBot.create(:user) }
-      voided_at { Time.zone.now }
+      voided_by_user_at { Time.zone.now }
     end
 
     trait :no_payment do

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -25,7 +25,7 @@ describe Declaration do
     it { is_expected.to validate_inclusion_of(:ineligibility_reason).in_array(described_class.ineligibility_reasons.keys).with_message("Choose a valid ineligibility reason").allow_nil }
     it { is_expected.to validate_uniqueness_of(:api_id).with_message("API id already exists for another declaration").case_insensitive }
     it { is_expected.not_to validate_presence_of(:voided_by_user) }
-    it { is_expected.not_to validate_presence_of(:voided_at) }
+    it { is_expected.not_to validate_presence_of(:voided_by_user_at) }
     it { is_expected.not_to validate_presence_of(:ineligibility_reason) }
     it { is_expected.not_to validate_absence_of(:mentorship_period) }
 
@@ -54,7 +54,7 @@ describe Declaration do
       subject { FactoryBot.build(:declaration, :voided_by_user) }
 
       it { is_expected.to validate_presence_of(:voided_by_user).with_message("Voided by user must be set as well as the voided date") }
-      it { is_expected.to validate_presence_of(:voided_at).with_message("Voided at must be set as well as the voided by user") }
+      it { is_expected.to validate_presence_of(:voided_by_user_at).with_message("Voided by user at must be set as well as the voided by user") }
     end
 
     context "when ineligible" do


### PR DESCRIPTION
### Context

Broken out of #1894 

### Changes proposed in this pull request

We only ever want to set `voided_at` when `voided_by_user_id` is set.

This renames the timestamp to `voided_by_user_at`, which conveys the intention more explicitly.

There isn't any declarations data yet, so we can rename the column safely.

### Guidance to review
