### PR TITLE
Fix flaky spec by removing randomness

### DIFF
--- a/spec/factories/school_factory.rb
+++ b/spec/factories/school_factory.rb
@@ -65,8 +65,8 @@ FactoryBot.define do
     end
 
     trait :with_induction_tutor do
-      induction_tutor_name { Faker::Name.name }
-      induction_tutor_email { Faker::Internet.email }
+      induction_tutor_name { "Induction Tutor" }
+      induction_tutor_email { "induction.tutor@a-very-nice-school.sch.uk" }
     end
   end
 end

--- a/spec/requests/schools/induction_tutor_spec.rb
+++ b/spec/requests/schools/induction_tutor_spec.rb
@@ -21,12 +21,16 @@ RSpec.describe "Induction Tutor", :enable_schools_interface do
     end
 
     context "when signed in as a school user" do
-      before { sign_in_as(:school_user, school:) }
+      before do
+        sign_in_as(:school_user, school:)
+        get schools_induction_tutor_path
+      end
 
       it "returns ok" do
-        get schools_induction_tutor_path
-
         expect(response).to have_http_status(:ok)
+      end
+
+      it "shows the induction tutor name and email address" do
         expect(response.body).to include(school.induction_tutor_name)
         expect(response.body).to include(school.induction_tutor_email)
       end


### PR DESCRIPTION
The specs fail when the random SIT name includes an apostrophe.

Also split the status and name/email checks up so if one bit fails in the future it's easier to see what happened.
