### PR TITLE
Fix milestone dates in seed data

### DIFF
--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -17,6 +17,7 @@ class Milestone < ApplicationRecord
 
   validates :schedule_id, presence: { message: "Choose a schedule" }
   validates :start_date, presence: { message: "Enter a start date" }
+  validates :milestone_date, comparison: { greater_than: :start_date, message: "Milestone date must be after the start date" }, allow_nil: true
 
   validates :declaration_type,
             uniqueness: {

--- a/app/services/api_seed_data/schedules_and_milestones.rb
+++ b/app/services/api_seed_data/schedules_and_milestones.rb
@@ -112,36 +112,36 @@ module APISeedData
           identifier: "ecf-standard-september",
           contract_period_year: 2021,
           milestones: [
-            { declaration_type: "started", start_date: "2021-11-30", milestone_date: "2021-11-30" },
-            { declaration_type: "retained-1", start_date: "2022-02-28", milestone_date: "2022-01-31" },
-            { declaration_type: "retained-2", start_date: "2022-05-31", milestone_date: "2022-04-30" },
-            { declaration_type: "retained-3", start_date: "2022-10-31", milestone_date: "2022-09-30" },
-            { declaration_type: "retained-4", start_date: "2023-02-28", milestone_date: "2023-01-31" },
-            { declaration_type: "completed", start_date: "2023-05-31", milestone_date: "2023-04-30" }
+            { declaration_type: "started", start_date: "2021-09-01", milestone_date: "2021-11-30" },
+            { declaration_type: "retained-1", start_date: "2021-09-01", milestone_date: "2022-01-31" },
+            { declaration_type: "retained-2", start_date: "2022-02-01", milestone_date: "2022-04-30" },
+            { declaration_type: "retained-3", start_date: "2022-05-01", milestone_date: "2022-09-30" },
+            { declaration_type: "retained-4", start_date: "2022-10-01", milestone_date: "2023-01-31" },
+            { declaration_type: "completed", start_date: "2023-02-01", milestone_date: "2023-04-30" }
           ]
         },
         {
           identifier: "ecf-standard-january",
           contract_period_year: 2021,
           milestones: [
-            { declaration_type: "started", start_date: "2022-02-28", milestone_date: "2022-01-31" },
-            { declaration_type: "retained-1", start_date: "2022-05-31", milestone_date: "2022-04-30" },
-            { declaration_type: "retained-2", start_date: "2022-10-31", milestone_date: "2022-09-30" },
-            { declaration_type: "retained-3", start_date: "2023-02-28", milestone_date: "2023-01-31" },
-            { declaration_type: "retained-4", start_date: "2023-05-31", milestone_date: "2023-04-30" },
-            { declaration_type: "completed", start_date: "2023-11-30", milestone_date: "2023-09-30" }
+            { declaration_type: "started", start_date: "2021-12-01", milestone_date: "2022-01-31" },
+            { declaration_type: "retained-1", start_date: "2022-02-01", milestone_date: "2022-04-30" },
+            { declaration_type: "retained-2", start_date: "2022-05-01", milestone_date: "2022-09-30" },
+            { declaration_type: "retained-3", start_date: "2022-10-01", milestone_date: "2023-01-31" },
+            { declaration_type: "retained-4", start_date: "2023-02-01", milestone_date: "2023-04-30" },
+            { declaration_type: "completed", start_date: "2023-05-01", milestone_date: "2023-09-30" }
           ]
         },
         {
           identifier: "ecf-standard-april",
           contract_period_year: 2021,
           milestones: [
-            { declaration_type: "started", start_date: "2022-05-31", milestone_date: "2022-05-31" },
-            { declaration_type: "retained-1", start_date: "2022-10-31", milestone_date: "2022-09-30" },
-            { declaration_type: "retained-2", start_date: "2023-02-28", milestone_date: "2023-01-31" },
-            { declaration_type: "retained-3", start_date: "2023-05-31", milestone_date: "2023-04-30" },
-            { declaration_type: "retained-4", start_date: "2023-11-30", milestone_date: "2023-09-30" },
-            { declaration_type: "completed", start_date: "2024-02-28", milestone_date: "2024-01-31" }
+            { declaration_type: "started", start_date: "2022-02-01", milestone_date: "2022-05-31" },
+            { declaration_type: "retained-1", start_date: "2022-05-01", milestone_date: "2022-09-30" },
+            { declaration_type: "retained-2", start_date: "2022-10-01", milestone_date: "2023-01-31" },
+            { declaration_type: "retained-3", start_date: "2023-02-01", milestone_date: "2023-04-30" },
+            { declaration_type: "retained-4", start_date: "2023-05-01", milestone_date: "2023-09-30" },
+            { declaration_type: "completed", start_date: "2023-10-01", milestone_date: "2024-01-31" }
           ]
         },
 
@@ -171,36 +171,36 @@ module APISeedData
           identifier: "ecf-standard-september",
           contract_period_year: 2022,
           milestones: [
-            { declaration_type: "started", start_date: "2022-11-30", milestone_date: "2022-12-31" },
-            { declaration_type: "retained-1", start_date: "2023-04-30", milestone_date: "2023-03-31" },
-            { declaration_type: "retained-2", start_date: "2023-08-31", milestone_date: "2023-07-31" },
-            { declaration_type: "retained-3", start_date: "2024-01-31", milestone_date: "2023-12-31" },
-            { declaration_type: "retained-4", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-            { declaration_type: "completed", start_date: "2024-08-31", milestone_date: "2024-07-31" }
+            { declaration_type: "started", start_date: "2022-06-01", milestone_date: "2022-12-31" },
+            { declaration_type: "retained-1", start_date: "2023-01-01", milestone_date: "2023-03-31" },
+            { declaration_type: "retained-2", start_date: "2023-04-01", milestone_date: "2023-07-31" },
+            { declaration_type: "retained-3", start_date: "2023-08-01", milestone_date: "2023-12-31" },
+            { declaration_type: "retained-4", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+            { declaration_type: "completed", start_date: "2024-04-01", milestone_date: "2024-07-31" }
           ]
         },
         {
           identifier: "ecf-standard-january",
           contract_period_year: 2022,
           milestones: [
-            { declaration_type: "started", start_date: "2023-04-30", milestone_date: "2023-03-31" },
-            { declaration_type: "retained-1", start_date: "2023-08-31", milestone_date: "2023-07-31" },
-            { declaration_type: "retained-2", start_date: "2024-01-31", milestone_date: "2023-12-31" },
-            { declaration_type: "retained-3", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-            { declaration_type: "retained-4", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-            { declaration_type: "completed", start_date: "2025-01-31", milestone_date: "2024-12-31" }
+            { declaration_type: "started", start_date: "2023-01-01", milestone_date: "2023-03-31" },
+            { declaration_type: "retained-1", start_date: "2023-04-01", milestone_date: "2023-07-31" },
+            { declaration_type: "retained-2", start_date: "2023-08-01", milestone_date: "2023-12-31" },
+            { declaration_type: "retained-3", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+            { declaration_type: "retained-4", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+            { declaration_type: "completed", start_date: "2024-08-01", milestone_date: "2024-12-31" }
           ]
         },
         {
           identifier: "ecf-standard-april",
           contract_period_year: 2022,
           milestones: [
-            { declaration_type: "started", start_date: "2023-08-31", milestone_date: "2023-07-31" },
-            { declaration_type: "retained-1", start_date: "2024-01-31", milestone_date: "2023-12-31" },
-            { declaration_type: "retained-2", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-            { declaration_type: "retained-3", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-            { declaration_type: "retained-4", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-            { declaration_type: "completed", start_date: "2025-04-30", milestone_date: "2025-03-31" }
+            { declaration_type: "started", start_date: "2023-04-01", milestone_date: "2023-07-31" },
+            { declaration_type: "retained-1", start_date: "2023-08-01", milestone_date: "2023-12-31" },
+            { declaration_type: "retained-2", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+            { declaration_type: "retained-3", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+            { declaration_type: "retained-4", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+            { declaration_type: "completed", start_date: "2025-01-01", milestone_date: "2025-03-31" }
           ]
         },
 
@@ -228,36 +228,36 @@ module APISeedData
           identifier: "ecf-standard-september",
           contract_period_year: 2023,
           milestones: [
-            { declaration_type: "started", start_date: "2023-11-30", milestone_date: "2023-12-31" },
-            { declaration_type: "retained-1", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-            { declaration_type: "retained-2", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-            { declaration_type: "retained-3", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-            { declaration_type: "retained-4", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-            { declaration_type: "completed", start_date: "2025-08-31", milestone_date: "2025-07-31" }
+            { declaration_type: "started", start_date: "2023-06-01", milestone_date: "2023-12-31" },
+            { declaration_type: "retained-1", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+            { declaration_type: "retained-2", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+            { declaration_type: "retained-3", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+            { declaration_type: "retained-4", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+            { declaration_type: "completed", start_date: "2025-04-01", milestone_date: "2025-07-31" }
           ]
         },
         {
           identifier: "ecf-standard-january",
           contract_period_year: 2023,
           milestones: [
-            { declaration_type: "started", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-            { declaration_type: "retained-1", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-            { declaration_type: "retained-2", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-            { declaration_type: "retained-3", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-            { declaration_type: "retained-4", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-            { declaration_type: "completed", start_date: "2026-01-31", milestone_date: "2025-12-31" }
+            { declaration_type: "started", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+            { declaration_type: "retained-1", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+            { declaration_type: "retained-2", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+            { declaration_type: "retained-3", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+            { declaration_type: "retained-4", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+            { declaration_type: "completed", start_date: "2025-08-01", milestone_date: "2025-12-31" }
           ]
         },
         {
           identifier: "ecf-standard-april",
           contract_period_year: 2023,
           milestones: [
-            { declaration_type: "started", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-            { declaration_type: "retained-1", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-            { declaration_type: "retained-2", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-            { declaration_type: "retained-3", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-            { declaration_type: "retained-4", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-            { declaration_type: "completed", start_date: "2026-04-30", milestone_date: "2026-03-31" }
+            { declaration_type: "started", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+            { declaration_type: "retained-1", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+            { declaration_type: "retained-2", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+            { declaration_type: "retained-3", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+            { declaration_type: "retained-4", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+            { declaration_type: "completed", start_date: "2026-01-01", milestone_date: "2026-03-31" }
           ]
         },
 
@@ -286,36 +286,36 @@ module APISeedData
           identifier: "ecf-standard-september",
           contract_period_year: 2024,
           milestones: [
-            { declaration_type: "started", start_date: "2024-11-30", milestone_date: "2024-12-31" },
-            { declaration_type: "retained-1", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-            { declaration_type: "retained-2", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-            { declaration_type: "retained-3", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-            { declaration_type: "retained-4", start_date: "2026-04-30", milestone_date: "2026-03-31" },
-            { declaration_type: "completed", start_date: "2026-08-31", milestone_date: "2026-07-31" }
+            { declaration_type: "started", start_date: "2024-06-01", milestone_date: "2024-12-31" },
+            { declaration_type: "retained-1", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+            { declaration_type: "retained-2", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+            { declaration_type: "retained-3", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+            { declaration_type: "retained-4", start_date: "2026-01-01", milestone_date: "2026-03-31" },
+            { declaration_type: "completed", start_date: "2026-04-01", milestone_date: "2026-07-31" }
           ]
         },
         {
           identifier: "ecf-standard-january",
           contract_period_year: 2024,
           milestones: [
-            { declaration_type: "started", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-            { declaration_type: "retained-1", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-            { declaration_type: "retained-2", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-            { declaration_type: "retained-3", start_date: "2026-04-30", milestone_date: "2026-03-31" },
-            { declaration_type: "retained-4", start_date: "2026-08-31", milestone_date: "2026-07-31" },
-            { declaration_type: "completed", start_date: "2027-01-31", milestone_date: "2026-12-31" }
+            { declaration_type: "started", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+            { declaration_type: "retained-1", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+            { declaration_type: "retained-2", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+            { declaration_type: "retained-3", start_date: "2026-01-01", milestone_date: "2026-03-31" },
+            { declaration_type: "retained-4", start_date: "2026-04-01", milestone_date: "2026-07-31" },
+            { declaration_type: "completed", start_date: "2026-08-01", milestone_date: "2026-12-31" }
           ]
         },
         {
           identifier: "ecf-standard-april",
           contract_period_year: 2024,
           milestones: [
-            { declaration_type: "started", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-            { declaration_type: "retained-1", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-            { declaration_type: "retained-2", start_date: "2026-04-30", milestone_date: "2026-03-31" },
-            { declaration_type: "retained-3", start_date: "2026-08-31", milestone_date: "2026-07-31" },
-            { declaration_type: "retained-4", start_date: "2027-01-31", milestone_date: "2026-12-31" },
-            { declaration_type: "completed", start_date: "2027-04-30", milestone_date: "2027-03-31" }
+            { declaration_type: "started", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+            { declaration_type: "retained-1", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+            { declaration_type: "retained-2", start_date: "2026-01-01", milestone_date: "2026-03-31" },
+            { declaration_type: "retained-3", start_date: "2026-04-01", milestone_date: "2026-07-31" },
+            { declaration_type: "retained-4", start_date: "2026-08-01", milestone_date: "2026-12-31" },
+            { declaration_type: "completed", start_date: "2027-01-01", milestone_date: "2027-03-31" }
           ]
         },
 

--- a/db/seeds/schedules_and_milestones.rb
+++ b/db/seeds/schedules_and_milestones.rb
@@ -78,36 +78,36 @@ def schedule_and_milestone_data
       identifier: "ecf-standard-september",
       contract_period_year: 2021,
       milestones: [
-        { declaration_type: "started", start_date: "2021-11-30", milestone_date: "2021-11-30" },
-        { declaration_type: "retained-1", start_date: "2022-02-28", milestone_date: "2022-01-31" },
-        { declaration_type: "retained-2", start_date: "2022-05-31", milestone_date: "2022-04-30" },
-        { declaration_type: "retained-3", start_date: "2022-10-31", milestone_date: "2022-09-30" },
-        { declaration_type: "retained-4", start_date: "2023-02-28", milestone_date: "2023-01-31" },
-        { declaration_type: "completed", start_date: "2023-05-31", milestone_date: "2023-04-30" }
+        { declaration_type: "started", start_date: "2021-09-01", milestone_date: "2021-11-30" },
+        { declaration_type: "retained-1", start_date: "2021-09-01", milestone_date: "2022-01-31" },
+        { declaration_type: "retained-2", start_date: "2022-02-01", milestone_date: "2022-04-30" },
+        { declaration_type: "retained-3", start_date: "2022-05-01", milestone_date: "2022-09-30" },
+        { declaration_type: "retained-4", start_date: "2022-10-01", milestone_date: "2023-01-31" },
+        { declaration_type: "completed", start_date: "2023-02-01", milestone_date: "2023-04-30" }
       ]
     },
     {
       identifier: "ecf-standard-january",
       contract_period_year: 2021,
       milestones: [
-        { declaration_type: "started", start_date: "2022-02-28", milestone_date: "2022-01-31" },
-        { declaration_type: "retained-1", start_date: "2022-05-31", milestone_date: "2022-04-30" },
-        { declaration_type: "retained-2", start_date: "2022-10-31", milestone_date: "2022-09-30" },
-        { declaration_type: "retained-3", start_date: "2023-02-28", milestone_date: "2023-01-31" },
-        { declaration_type: "retained-4", start_date: "2023-05-31", milestone_date: "2023-04-30" },
-        { declaration_type: "completed", start_date: "2023-11-30", milestone_date: "2023-09-30" }
+        { declaration_type: "started", start_date: "2021-12-01", milestone_date: "2022-01-31" },
+        { declaration_type: "retained-1", start_date: "2022-02-01", milestone_date: "2022-04-30" },
+        { declaration_type: "retained-2", start_date: "2022-05-01", milestone_date: "2022-09-30" },
+        { declaration_type: "retained-3", start_date: "2022-10-01", milestone_date: "2023-01-31" },
+        { declaration_type: "retained-4", start_date: "2023-02-01", milestone_date: "2023-04-30" },
+        { declaration_type: "completed", start_date: "2023-05-01", milestone_date: "2023-09-30" }
       ]
     },
     {
       identifier: "ecf-standard-april",
       contract_period_year: 2021,
       milestones: [
-        { declaration_type: "started", start_date: "2022-05-31", milestone_date: "2022-05-31" },
-        { declaration_type: "retained-1", start_date: "2022-10-31", milestone_date: "2022-09-30" },
-        { declaration_type: "retained-2", start_date: "2023-02-28", milestone_date: "2023-01-31" },
-        { declaration_type: "retained-3", start_date: "2023-05-31", milestone_date: "2023-04-30" },
-        { declaration_type: "retained-4", start_date: "2023-11-30", milestone_date: "2023-09-30" },
-        { declaration_type: "completed", start_date: "2024-02-28", milestone_date: "2024-01-31" }
+        { declaration_type: "started", start_date: "2022-02-01", milestone_date: "2022-05-31" },
+        { declaration_type: "retained-1", start_date: "2022-05-01", milestone_date: "2022-09-30" },
+        { declaration_type: "retained-2", start_date: "2022-10-01", milestone_date: "2023-01-31" },
+        { declaration_type: "retained-3", start_date: "2023-02-01", milestone_date: "2023-04-30" },
+        { declaration_type: "retained-4", start_date: "2023-05-01", milestone_date: "2023-09-30" },
+        { declaration_type: "completed", start_date: "2023-10-01", milestone_date: "2024-01-31" }
       ]
     },
 
@@ -137,36 +137,36 @@ def schedule_and_milestone_data
       identifier: "ecf-standard-september",
       contract_period_year: 2022,
       milestones: [
-        { declaration_type: "started", start_date: "2022-11-30", milestone_date: "2022-12-31" },
-        { declaration_type: "retained-1", start_date: "2023-04-30", milestone_date: "2023-03-31" },
-        { declaration_type: "retained-2", start_date: "2023-08-31", milestone_date: "2023-07-31" },
-        { declaration_type: "retained-3", start_date: "2024-01-31", milestone_date: "2023-12-31" },
-        { declaration_type: "retained-4", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-        { declaration_type: "completed", start_date: "2024-08-31", milestone_date: "2024-07-31" }
+        { declaration_type: "started", start_date: "2022-06-01", milestone_date: "2022-12-31" },
+        { declaration_type: "retained-1", start_date: "2023-01-01", milestone_date: "2023-03-31" },
+        { declaration_type: "retained-2", start_date: "2023-04-01", milestone_date: "2023-07-31" },
+        { declaration_type: "retained-3", start_date: "2023-08-01", milestone_date: "2023-12-31" },
+        { declaration_type: "retained-4", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+        { declaration_type: "completed", start_date: "2024-04-01", milestone_date: "2024-07-31" }
       ]
     },
     {
       identifier: "ecf-standard-january",
       contract_period_year: 2022,
       milestones: [
-        { declaration_type: "started", start_date: "2023-04-30", milestone_date: "2023-03-31" },
-        { declaration_type: "retained-1", start_date: "2023-08-31", milestone_date: "2023-07-31" },
-        { declaration_type: "retained-2", start_date: "2024-01-31", milestone_date: "2023-12-31" },
-        { declaration_type: "retained-3", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-        { declaration_type: "retained-4", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-        { declaration_type: "completed", start_date: "2025-01-31", milestone_date: "2024-12-31" }
+        { declaration_type: "started", start_date: "2023-01-01", milestone_date: "2023-03-31" },
+        { declaration_type: "retained-1", start_date: "2023-04-01", milestone_date: "2023-07-31" },
+        { declaration_type: "retained-2", start_date: "2023-08-01", milestone_date: "2023-12-31" },
+        { declaration_type: "retained-3", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+        { declaration_type: "retained-4", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+        { declaration_type: "completed", start_date: "2024-08-01", milestone_date: "2024-12-31" }
       ]
     },
     {
       identifier: "ecf-standard-april",
       contract_period_year: 2022,
       milestones: [
-        { declaration_type: "started", start_date: "2023-08-31", milestone_date: "2023-07-31" },
-        { declaration_type: "retained-1", start_date: "2024-01-31", milestone_date: "2023-12-31" },
-        { declaration_type: "retained-2", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-        { declaration_type: "retained-3", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-        { declaration_type: "retained-4", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-        { declaration_type: "completed", start_date: "2025-04-30", milestone_date: "2025-03-31" }
+        { declaration_type: "started", start_date: "2023-04-01", milestone_date: "2023-07-31" },
+        { declaration_type: "retained-1", start_date: "2023-08-01", milestone_date: "2023-12-31" },
+        { declaration_type: "retained-2", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+        { declaration_type: "retained-3", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+        { declaration_type: "retained-4", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+        { declaration_type: "completed", start_date: "2025-01-01", milestone_date: "2025-03-31" }
       ]
     },
 
@@ -194,36 +194,36 @@ def schedule_and_milestone_data
       identifier: "ecf-standard-september",
       contract_period_year: 2023,
       milestones: [
-        { declaration_type: "started", start_date: "2023-11-30", milestone_date: "2023-12-31" },
-        { declaration_type: "retained-1", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-        { declaration_type: "retained-2", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-        { declaration_type: "retained-3", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-        { declaration_type: "retained-4", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-        { declaration_type: "completed", start_date: "2025-08-31", milestone_date: "2025-07-31" }
+        { declaration_type: "started", start_date: "2023-06-01", milestone_date: "2023-12-31" },
+        { declaration_type: "retained-1", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+        { declaration_type: "retained-2", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+        { declaration_type: "retained-3", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+        { declaration_type: "retained-4", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+        { declaration_type: "completed", start_date: "2025-04-01", milestone_date: "2025-07-31" }
       ]
     },
     {
       identifier: "ecf-standard-january",
       contract_period_year: 2023,
       milestones: [
-        { declaration_type: "started", start_date: "2024-04-30", milestone_date: "2024-03-31" },
-        { declaration_type: "retained-1", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-        { declaration_type: "retained-2", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-        { declaration_type: "retained-3", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-        { declaration_type: "retained-4", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-        { declaration_type: "completed", start_date: "2026-01-31", milestone_date: "2025-12-31" }
+        { declaration_type: "started", start_date: "2024-01-01", milestone_date: "2024-03-31" },
+        { declaration_type: "retained-1", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+        { declaration_type: "retained-2", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+        { declaration_type: "retained-3", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+        { declaration_type: "retained-4", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+        { declaration_type: "completed", start_date: "2025-08-01", milestone_date: "2025-12-31" }
       ]
     },
     {
       identifier: "ecf-standard-april",
       contract_period_year: 2023,
       milestones: [
-        { declaration_type: "started", start_date: "2024-08-31", milestone_date: "2024-07-31" },
-        { declaration_type: "retained-1", start_date: "2025-01-31", milestone_date: "2024-12-31" },
-        { declaration_type: "retained-2", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-        { declaration_type: "retained-3", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-        { declaration_type: "retained-4", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-        { declaration_type: "completed", start_date: "2026-04-30", milestone_date: "2026-03-31" }
+        { declaration_type: "started", start_date: "2024-04-01", milestone_date: "2024-07-31" },
+        { declaration_type: "retained-1", start_date: "2024-08-01", milestone_date: "2024-12-31" },
+        { declaration_type: "retained-2", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+        { declaration_type: "retained-3", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+        { declaration_type: "retained-4", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+        { declaration_type: "completed", start_date: "2026-01-01", milestone_date: "2026-03-31" }
       ]
     },
 
@@ -252,36 +252,36 @@ def schedule_and_milestone_data
       identifier: "ecf-standard-september",
       contract_period_year: 2024,
       milestones: [
-        { declaration_type: "started", start_date: "2024-11-30", milestone_date: "2024-12-31" },
-        { declaration_type: "retained-1", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-        { declaration_type: "retained-2", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-        { declaration_type: "retained-3", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-        { declaration_type: "retained-4", start_date: "2026-04-30", milestone_date: "2026-03-31" },
-        { declaration_type: "completed", start_date: "2026-08-31", milestone_date: "2026-07-31" }
+        { declaration_type: "started", start_date: "2024-06-01", milestone_date: "2024-12-31" },
+        { declaration_type: "retained-1", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+        { declaration_type: "retained-2", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+        { declaration_type: "retained-3", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+        { declaration_type: "retained-4", start_date: "2026-01-01", milestone_date: "2026-03-31" },
+        { declaration_type: "completed", start_date: "2026-04-01", milestone_date: "2026-07-31" }
       ]
     },
     {
       identifier: "ecf-standard-january",
       contract_period_year: 2024,
       milestones: [
-        { declaration_type: "started", start_date: "2025-04-30", milestone_date: "2025-03-31" },
-        { declaration_type: "retained-1", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-        { declaration_type: "retained-2", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-        { declaration_type: "retained-3", start_date: "2026-04-30", milestone_date: "2026-03-31" },
-        { declaration_type: "retained-4", start_date: "2026-08-31", milestone_date: "2026-07-31" },
-        { declaration_type: "completed", start_date: "2027-01-31", milestone_date: "2026-12-31" }
+        { declaration_type: "started", start_date: "2025-01-01", milestone_date: "2025-03-31" },
+        { declaration_type: "retained-1", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+        { declaration_type: "retained-2", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+        { declaration_type: "retained-3", start_date: "2026-01-01", milestone_date: "2026-03-31" },
+        { declaration_type: "retained-4", start_date: "2026-04-01", milestone_date: "2026-07-31" },
+        { declaration_type: "completed", start_date: "2026-08-01", milestone_date: "2026-12-31" }
       ]
     },
     {
       identifier: "ecf-standard-april",
       contract_period_year: 2024,
       milestones: [
-        { declaration_type: "started", start_date: "2025-08-31", milestone_date: "2025-07-31" },
-        { declaration_type: "retained-1", start_date: "2026-01-31", milestone_date: "2025-12-31" },
-        { declaration_type: "retained-2", start_date: "2026-04-30", milestone_date: "2026-03-31" },
-        { declaration_type: "retained-3", start_date: "2026-08-31", milestone_date: "2026-07-31" },
-        { declaration_type: "retained-4", start_date: "2027-01-31", milestone_date: "2026-12-31" },
-        { declaration_type: "completed", start_date: "2027-04-30", milestone_date: "2027-03-31" }
+        { declaration_type: "started", start_date: "2025-04-01", milestone_date: "2025-07-31" },
+        { declaration_type: "retained-1", start_date: "2025-08-01", milestone_date: "2025-12-31" },
+        { declaration_type: "retained-2", start_date: "2026-01-01", milestone_date: "2026-03-31" },
+        { declaration_type: "retained-3", start_date: "2026-04-01", milestone_date: "2026-07-31" },
+        { declaration_type: "retained-4", start_date: "2026-08-01", milestone_date: "2026-12-31" },
+        { declaration_type: "completed", start_date: "2027-01-01", milestone_date: "2027-03-31" }
       ]
     },
 

--- a/spec/factories/migration/milestone_factory.rb
+++ b/spec/factories/migration/milestone_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     name { "Started" }
     start_date { Date.new(2024, 9, 1) }
-    milestone_date { Date.new(2024, 9, 1) }
+    milestone_date { Date.new(2024, 10, 1) }
     payment_date { Date.new(2024, 10, 1) }
     declaration_type { "started" }
   end

--- a/spec/factories/milestone_factory.rb
+++ b/spec/factories/milestone_factory.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     declaration_type { "started" }
 
     start_date { Date.new(2024, 9, 1) }
-    milestone_date { Date.new(2024, 9, 1) }
+    milestone_date { Date.new(2024, 10, 1) }
   end
 end

--- a/spec/models/milestone_spec.rb
+++ b/spec/models/milestone_spec.rb
@@ -6,9 +6,12 @@ describe Milestone do
   end
 
   describe "validation" do
+    subject { FactoryBot.build(:milestone) }
+
     it { is_expected.to validate_presence_of(:schedule_id).with_message("Choose a schedule") }
     it { is_expected.to validate_presence_of(:start_date).with_message("Enter a start date") }
     it { is_expected.to validate_inclusion_of(:declaration_type).in_array(declaration_types).with_message("Choose a valid declaration type") }
+    it { is_expected.to validate_comparison_of(:milestone_date).is_greater_than(:start_date).with_message("Milestone date must be after the start date").allow_nil }
 
     it "ensures uniqueness of declaration_types and schedule_ids" do
       original = FactoryBot.create(:milestone)


### PR DESCRIPTION
> ⚠️ We'll need to manually fix sandbox and staging milestone dates before this is merged down.

The seed files have incorrect milestone dates whereby the `milestone_date` is earlier than the `start_date`.

Update to match the milestone dates from ECF in production.

Add validation to the `Milestone` to enforce correct dates.
