### PR TITLE
Add declarations seed data

### DIFF
--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -2,6 +2,7 @@ class ActiveLeadProvider < ApplicationRecord
   belongs_to :contract_period, inverse_of: :active_lead_providers, foreign_key: :contract_period_year
   belongs_to :lead_provider, inverse_of: :active_lead_providers
   has_many :lead_provider_delivery_partnerships
+  has_many :school_partnerships, through: :lead_provider_delivery_partnerships
   has_many :delivery_partners, through: :lead_provider_delivery_partnerships
   has_many :statements
   has_many :expressions_of_interest, class_name: "TrainingPeriod", foreign_key: "expression_of_interest_id", inverse_of: :expression_of_interest

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -23,6 +23,7 @@ class Teacher < ApplicationRecord
   has_many :appropriate_bodies, through: :induction_periods
   has_many :events
   has_many :mentor_declarations, through: :mentor_training_periods, source: :declarations
+  has_many :ect_declarations, through: :ect_training_periods, source: :declarations
 
   has_one :first_induction_period, -> { order(started_on: :asc) }, class_name: "InductionPeriod"
   has_one :last_induction_period, -> { order(started_on: :desc) }, class_name: "InductionPeriod"

--- a/app/services/api_seed_data/declarations.rb
+++ b/app/services/api_seed_data/declarations.rb
@@ -1,0 +1,175 @@
+module APISeedData
+  class Declarations < Base
+    MAX_TEACHERS_WITH_DECLARATIONS = 50
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("declarations")
+
+      active_lead_providers.product(teacher_types).each do |active_lead_provider, teacher_type|
+        log_seed_info("#{active_lead_provider.lead_provider.name} - #{teacher_type}", indent: 4)
+
+        MAX_TEACHERS_WITH_DECLARATIONS.times do
+          school_partnership = find_random_school_partnership(active_lead_provider)
+          next unless school_partnership
+
+          training_periods = find_random_training_periods_without_declarations(school_partnership, teacher_type)
+          next if training_periods.blank?
+
+          create_declarations!(active_lead_provider, training_periods)
+        end
+      end
+    end
+
+  protected
+
+    def plantable?
+      super && Declaration.none?
+    end
+
+    def teacher_types
+      %i[ect mentor]
+    end
+
+    def active_lead_providers
+      ActiveLeadProvider.all.to_a
+    end
+
+    def create_declarations!(active_lead_provider, training_periods)
+      teacher = training_periods.first.trainee.teacher
+      log_seed_info(::Teachers::Name.new(teacher).full_name, indent: 4)
+
+      training_period = training_periods.sample
+
+      declaration_types(training_period, active_lead_provider).each do |declaration_type|
+        schedule = training_period.schedule
+        declaration_date = declaration_date(schedule, declaration_type)
+
+        next unless declaration_date.past?
+
+        payment_status = Declaration.payment_statuses.keys.sample
+        unless payment_status == :no_payment
+          payment_statement = find_random_statement(active_lead_provider)
+          next unless payment_statement
+        end
+
+        clawback_status = clawback_status(payment_status)
+        unless clawback_status == :no_clawback
+          clawback_statement = find_random_statement(active_lead_provider, (payment_statement.deadline_date + 1.day)..)
+          next unless clawback_statement
+        end
+
+        ineligibility_reason = Declaration.ineligibility_reasons.keys.sample if payment_status == "ineligible"
+        mentorship_period = training_period.trainee.mentorship_periods.sample if training_period.for_ect?
+
+        declaration = FactoryBot.build(
+          :declaration,
+          declaration_type:,
+          declaration_date:,
+          payment_status:,
+          clawback_status:,
+          payment_statement:,
+          clawback_statement:,
+          training_period:,
+          ineligibility_reason:,
+          mentorship_period:,
+          **uplifts
+        )
+
+        next if declaration.duplicate_declaration_exists?
+
+        declaration.save!
+        log_declaration_info(declaration)
+      end
+    end
+
+    def uplifts
+      { sparsity_uplift: Faker::Boolean.boolean, pupil_premium_uplift: Faker::Boolean.boolean }
+    end
+
+    def log_declaration_info(declaration)
+      log_seed_info("#{declaration.declaration_type} - #{declaration.overall_status} - #{declaration.declaration_date.to_date}", indent: 6)
+    end
+
+    def find_random_statement(active_lead_provider, deadline_date = :ignore)
+      ::Statements::Search.new(
+        lead_provider_id: active_lead_provider.lead_provider.id,
+        contract_period_years: active_lead_provider.contract_period_year,
+        fee_type: "output",
+        deadline_date:
+      )
+      .statements
+      .sample
+    end
+
+    def clawback_status(payment_status)
+      return :no_clawback unless payment_status == "paid"
+
+      Declaration.clawback_statuses.keys.sample
+    end
+
+    def declaration_types(training_period, active_lead_provider)
+      if training_period.for_mentor? && active_lead_provider.contract_period.mentor_funding_enabled?
+        return %w[started completed]
+      end
+
+      types = Declaration.declaration_types.keys
+      types.sample(rand(1..types.size))
+    end
+
+    def declaration_date(schedule, declaration_type)
+      milestone = schedule.milestones.find_by(declaration_type:)
+      # Sometimes the milestone start_date is in the future; we will omit
+      # these declarations in the calling method.
+      end_date = [milestone&.start_date, 1.day.ago].compact.max
+
+      return Faker::Date.between(from: Date.new(schedule.contract_period.year), to: end_date) unless milestone
+
+      Faker::Date.between(from: milestone.start_date, to: milestone.milestone_date || end_date)
+    end
+
+    def find_random_school_partnership(active_lead_provider)
+      active_lead_provider.school_partnerships.sample
+    end
+
+    def find_random_training_periods_without_declarations(school_partnership, teacher_type)
+      teacher_ids = teacher_ids_without_declarations(school_partnership, teacher_type)
+      teacher = Teacher.where(id: teacher_ids).order("RANDOM()").first
+
+      return [] unless teacher
+
+      if teacher_type == :ect
+        teacher.ect_training_periods.where(school_partnership:)
+      else
+        teacher.mentor_training_periods.where(school_partnership:)
+      end
+    end
+
+    def teacher_ids_with_declarations
+      Declaration
+        .joins(training_period: %i[ect_at_school_period mentor_at_school_period])
+        .pluck("ect_at_school_periods.teacher_id", "mentor_at_school_periods.teacher_id")
+        .flatten
+        .uniq
+    end
+
+    def teacher_ids_without_declarations(school_partnership, teacher_type)
+      training_periods = school_partnership.training_periods
+
+      teacher_ids = if teacher_type == :ect
+                      training_periods
+                        .joins(:ect_at_school_period)
+                        .where.not(ect_at_school_periods: { teacher_id: teacher_ids_with_declarations })
+                        .pluck(ect_at_school_periods: :teacher_id)
+                    else
+                      training_periods
+                        .joins(:mentor_at_school_period)
+                        .where.not(mentor_at_school_periods: { teacher_id: teacher_ids_with_declarations })
+                        .pluck(mentor_at_school_periods: :teacher_id)
+                    end
+
+      teacher_ids.uniq
+    end
+  end
+end

--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -13,7 +13,8 @@ namespace :api_seed_data do
       APISeedData::TeachersWithHistories,
       APISeedData::UnfundedMentors,
       APISeedData::TeachersWithChangeSchedule,
-      APISeedData::Teachers::SchoolTransfers
+      APISeedData::Teachers::SchoolTransfers,
+      APISeedData::Declarations,
     ]
 
     if Rails.env.development? || Rails.env.review?

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -5,7 +5,30 @@ FactoryBot.define do
     clawback_status { :no_clawback }
     api_id { SecureRandom.uuid }
     declaration_date { Faker::Date.between(from: Time.zone.now, to: 1.year.from_now) }
-    evidence_type { Declaration.evidence_types.keys.sample }
+    evidence_type do
+      detailed_evidence_types_enabled = training_period&.contract_period&.detailed_evidence_types_enabled
+      if declaration_type != "started" || detailed_evidence_types_enabled
+        if detailed_evidence_types_enabled
+          case declaration_type
+          when "completed", "retained-2"
+            "75-percent-engagement-met"
+          else
+            %w[
+              training-event-attended
+              self-study-material-completed
+              materials-engaged-with-offline
+              other
+            ].sample
+          end
+        else
+          %w[
+            training-event-attended
+            self-study-material-completed
+            other
+          ].sample
+        end
+      end
+    end
     declaration_type { Declaration.declaration_types.keys.first }
 
     trait :voided_by_user do

--- a/spec/lib/remove_teacher_spec.rb
+++ b/spec/lib/remove_teacher_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RemoveTeacher, :aggregate_failures do
     expect(remove_teacher.has_many_associations).to eq(%i[
       appropriate_bodies
       ect_at_school_periods
+      ect_declarations
       ect_training_periods
       events
       induction_extensions

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -4,6 +4,7 @@ describe ActiveLeadProvider do
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to have_many(:statements) }
     it { is_expected.to have_many(:lead_provider_delivery_partnerships) }
+    it { is_expected.to have_many(:school_partnerships).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:delivery_partners).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:expressions_of_interest).class_name("TrainingPeriod").inverse_of(:expression_of_interest) }
     it { is_expected.to have_many(:events) }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -35,7 +35,8 @@ describe Teacher do
     it { is_expected.to have_many(:appropriate_bodies).through(:induction_periods) }
     it { is_expected.to have_many(:induction_extensions) }
     it { is_expected.to have_many(:events) }
-    it { is_expected.to have_many(:mentor_declarations).through(:mentor_training_periods) }
+    it { is_expected.to have_many(:mentor_declarations).through(:mentor_training_periods).source(:declarations) }
+    it { is_expected.to have_many(:ect_declarations).through(:ect_training_periods).source(:declarations) }
     it { is_expected.to have_many(:teacher_id_changes) }
     it { is_expected.to have_many(:lead_provider_metadata).class_name("Metadata::TeacherLeadProvider") }
     it { is_expected.to have_one(:started_induction_period).class_name("InductionPeriod") }

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Declarations API", type: :request do
+RSpec.describe "Declarations API", :with_metadata, type: :request do
   let(:serializer) { API::DeclarationSerializer }
   let(:serializer_options) { {} }
   let(:query) { API::Declarations::Query }

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe API::Declarations::Query do
             let!(:declaration5) do
               create_declaration(
                 training_period: training_period1,
-                declaration_type: "retained-3",
+                declaration_type: "retained-4",
                 declaration_date: training_period3.started_on.next_day
               )
             end

--- a/spec/services/api_seed_data/declarations_spec.rb
+++ b/spec/services/api_seed_data/declarations_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe APISeedData::Declarations do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  let(:ect_school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: 2023) }
+  let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, school_partnership: ect_school_partnership) }
+  let!(:ect_active_lead_provider) { ect_training_period.school_partnership.active_lead_provider }
+
+  let(:mentor_school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: 2023) }
+  let(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, school_partnership: mentor_school_partnership) }
+  let!(:mentor_active_lead_provider) { mentor_training_period.school_partnership.active_lead_provider }
+
+  before do
+    stub_const("#{described_class}::MAX_TEACHERS_WITH_DECLARATIONS", 1)
+
+    allow(Rails).to receive(:env) { environment.inquiry }
+    ignored_logger = instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil)
+    allow(Logger).to receive(:new).with($stdout) { ignored_logger }
+
+    APISeedData::ContractPeriods.new.plant
+    APISeedData::Statements.new.plant
+    APISeedData::SchedulesAndMilestones.new.plant
+
+    allow(Logger).to receive(:new).with($stdout) { logger }
+  end
+
+  describe "#plant" do
+    subject(:plant) { instance.plant }
+
+    it "does not create data when already present" do
+      expect { instance.plant }.to change(Declaration, :count)
+      expect { instance.plant }.not_to change(Declaration, :count)
+    end
+
+    it "creates declarations for both ECT and mentor teachers" do
+      plant
+
+      expect(Declaration.where(training_period: ect_training_period)).to exist
+      expect(Declaration.where(training_period: mentor_training_period)).to exist
+    end
+
+    it "creates declarations for all lead providers" do
+      plant
+
+      active_lead_providers = Declaration.all.map do |declaration|
+        declaration.training_period.school_partnership.active_lead_provider
+      end
+
+      expect(active_lead_providers.uniq.size).to be > 1
+    end
+
+    it "logs the creation of declaration records" do
+      plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting declarations/).once
+
+      expect(logger).to have_received(:info).with(/#{ect_active_lead_provider.lead_provider.name} - ect/).once
+      expect(logger).to have_received(:info).with(/#{mentor_active_lead_provider.lead_provider.name} - mentor/).once
+
+      types = Declaration.declaration_types.keys
+      statuses = Declaration.payment_statuses.keys + Declaration.clawback_statuses.keys
+
+      expect(logger).to have_received(:info).with(/(#{types.join('|')}) - (#{statuses.join('|')}) - \d+-\d+-\d+/).at_least(:once)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any declarations" do
+        expect { instance.plant }.not_to change(Declaration, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
> ⚠️ We need to run this on sandbox after merging

Add API seed data for declarations.

This will seed a random number of declarations for up to 50 participants per lead provider/contract period combination.

The declarations should have sensible declaration dates and a mixture of states (some paid, clawed back, etc).

The script creates around 5,000 declarations for lead providers.

This PR also adds some additional validation into `Declaration` model for issues I came across while building the seed data out.

I've intentionally kept the testing light; trying to test all the combinations of declaration types created would be more effort than its worth.