### PR TITLE
Fix Gantt chart labels

### DIFF
--- a/app/services/migration/post_migration_gantt.rb
+++ b/app/services/migration/post_migration_gantt.rb
@@ -23,7 +23,7 @@ module Migration
 
         #{ect_at_school_period_bars.join("\n")}
 
-        #{legend(present_lead_provider_names, extras: { 'School led' => 'yellow' })}
+        #{legend(present_lead_provider_names, extras: extra_keys)}
 
         @endgantt
       PLANTUML
@@ -37,6 +37,14 @@ module Migration
       # TODO: get a list of all the lead providers associated with this teacher, either
       #       as an ECT or mentor
       at_school_periods.flat_map(&:training_periods).compact.map { it.lead_provider&.name }
+    end
+
+    def extra_keys
+      if at_school_periods.flat_map(&:training_periods).compact.any?(&:school_led_training_programme?)
+        { "School led" => "yellow" }
+      else
+        {}
+      end
     end
 
     def at_school_periods


### PR DESCRIPTION
This is a small pair of fixes that:

- **Set the at school period label based on class** (i.e., show 'Mentor' for `MentorAtSchoolPeriod` records and ECT for `ECTAtSchoolPeriod` records)
- **Only display school-led key when matching items present**
