### PR TITLE
[2840] Declarations endpoint for index and show

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -1,10 +1,56 @@
 module API
   module V3
     class DeclarationsController < APIController
+      def index
+        conditions = {
+          contract_period_years: extract_conditions(contract_period_years, integers: true),
+          teacher_api_ids: extract_conditions(teacher_api_ids, uuids: true),
+          delivery_partner_api_ids: extract_conditions(delivery_partner_api_ids, uuids: true),
+          updated_since:,
+        }
+        paginated_declarations = declarations_query(conditions:).declarations { paginate(it) }
+
+        render json: to_json(paginated_declarations)
+      end
+
+      def show
+        render json: to_json(declarations_query.declaration_by_api_id(api_id))
+      end
+
       def create = head(:method_not_allowed)
-      def index = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
       def void = head(:method_not_allowed)
+
+    private
+
+      def declarations_query(conditions: {})
+        API::Declarations::Query.new(**(default_query_conditions.merge(conditions).compact))
+      end
+
+      def default_query_conditions
+        @default_query_conditions ||= {
+          lead_provider_id: current_lead_provider.id,
+        }
+      end
+
+      def declarations_params
+        params.permit(:api_id, filter: %i[cohort participant_id delivery_partner_id updated_since])
+      end
+
+      def api_id
+        declarations_params[:api_id]
+      end
+
+      def teacher_api_ids
+        declarations_params.dig(:filter, :participant_id)
+      end
+
+      def delivery_partner_api_ids
+        declarations_params.dig(:filter, :delivery_partner_id)
+      end
+
+      def to_json(obj)
+        API::DeclarationSerializer.render(obj, root: "data")
+      end
     end
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -20,7 +20,7 @@ constraints -> { Rails.application.config.enable_api } do
         end
       end
 
-      resources :declarations, only: %i[create show index] do
+      resources :declarations, only: %i[create show index], param: :api_id do
         put :void, path: "void"
       end
 

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,33 +1,55 @@
-RSpec.describe "Participant declarations API", type: :request do
-  describe "#create" do
-    let(:path) { api_v3_declarations_path }
+RSpec.describe "Declarations API", type: :request do
+  let(:serializer) { API::DeclarationSerializer }
+  let(:serializer_options) { {} }
+  let(:query) { API::Declarations::Query }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:lead_provider) { active_lead_provider.lead_provider }
 
-    it_behaves_like "a token authenticated endpoint", :post
+  def create_resource(active_lead_provider:, teacher: nil)
+    lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+    school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
+    teacher ||= FactoryBot.create(:teacher)
 
-    it "returns method not allowed" do
-      authenticated_api_post path
-      expect(response).to be_method_not_allowed
-    end
+    ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: nil, teacher:, school: school_partnership.school)
+    training_period = FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.year.ago, finished_on: nil, school_partnership:)
+
+    FactoryBot.create(:declaration, training_period:)
   end
 
   describe "#index" do
     let(:path) { api_v3_declarations_path }
 
-    it_behaves_like "a token authenticated endpoint", :get
-
-    it "returns method not allowed" do
-      authenticated_api_get path
-      expect(response).to be_method_not_allowed
+    def apply_expected_order(resources)
+      resources.sort_by(&:created_at)
     end
+
+    it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "an index endpoint"
+    it_behaves_like "a paginated endpoint"
+    it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
+    it_behaves_like "a filter by delivery_partner_id endpoint"
+    it_behaves_like "a filter by participant_id endpoint"
+    it_behaves_like "a filter by updated_since endpoint", updated_at_column: :updated_at
   end
 
   describe "#show" do
-    let(:path) { api_v3_declaration_path(123) }
+    let(:resource) { create_resource(active_lead_provider:) }
+    let(:path_id) { resource.api_id }
+    let(:path) { api_v3_declaration_path(path_id) }
 
     it_behaves_like "a token authenticated endpoint", :get
+    it_behaves_like "a show endpoint"
+    it_behaves_like "a does not filter by cohort endpoint"
+    it_behaves_like "a does not filter by delivery_partner_id endpoint"
+    it_behaves_like "a does not filter by participant_id endpoint"
+    it_behaves_like "a does not filter by updated_since endpoint"
+  end
+
+  describe "#create" do
+    let(:path) { api_v3_declarations_path }
 
     it "returns method not allowed" do
-      authenticated_api_get path
+      authenticated_api_post path
       expect(response).to be_method_not_allowed
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2840
Branched off: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1918

### Changes proposed in this pull request

* GET `/api/v3/participant-declarations`
  * Pagination
  * Filtering on:
    * cohort
    * delivery_partner_id
    * updated_since
    * participant_id
* GET `/api/v3/participant-declarations/:id`

### Guidance to review
