### PR TITLE
Implement void declarations endpoint

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -18,12 +18,21 @@ module API
       end
 
       def create = head(:method_not_allowed)
-      def void = head(:method_not_allowed)
+
+      def void
+        if declaration.payment_status_paid?
+          service = API::Declarations::Clawback.new(**void_declaration_params)
+          respond_with_service(service:, action: :clawback)
+        else
+          service = API::Declarations::Void.new(**void_declaration_params)
+          respond_with_service(service:, action: :void)
+        end
+      end
 
     private
 
       def declarations_query(conditions: {})
-        API::Declarations::Query.new(**(default_query_conditions.merge(conditions).compact))
+        API::Declarations::Query.new(**(default_query_conditions.merge(conditions)).compact)
       end
 
       def default_query_conditions
@@ -32,8 +41,22 @@ module API
         }
       end
 
+      def serializer_options
+        @serializer_options ||= {
+          lead_provider_id: current_lead_provider.id
+        }
+      end
+
       def declarations_params
         params.permit(:api_id, filter: %i[cohort participant_id delivery_partner_id updated_since])
+      end
+
+      def void_declaration_params
+        { lead_provider_id: current_lead_provider.id, declaration_api_id: declaration.api_id }
+      end
+
+      def declaration
+        declarations_query.declaration_by_api_id(api_id)
       end
 
       def api_id
@@ -49,7 +72,7 @@ module API
       end
 
       def to_json(obj)
-        API::DeclarationSerializer.render(obj, root: "data")
+        API::DeclarationSerializer.render(obj, root: "data", **serializer_options)
       end
     end
   end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -21,7 +21,7 @@ constraints -> { Rails.application.config.enable_api } do
       end
 
       resources :declarations, only: %i[create show index], param: :api_id do
-        put :void, path: "void"
+        member { put :void, path: "void" }
       end
 
       resources :statements, only: %i[index show], param: :api_id

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe "Declarations API", type: :request do
   let(:serializer) { API::DeclarationSerializer }
-  let(:serializer_options) { {} }
+  let(:serializer_options) { { lead_provider_id: lead_provider.id } }
   let(:query) { API::Declarations::Query }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let(:lead_provider) { active_lead_provider.lead_provider }
 
-  def create_resource(active_lead_provider:, teacher: nil)
+  def create_resource(active_lead_provider:, teacher: nil, declaration_trait: :no_payment)
     lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
     school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
     teacher ||= FactoryBot.create(:teacher)
@@ -13,7 +13,9 @@ RSpec.describe "Declarations API", type: :request do
     ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: nil, teacher:, school: school_partnership.school)
     training_period = FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.year.ago, finished_on: nil, school_partnership:)
 
-    FactoryBot.create(:declaration, training_period:)
+    declaration = FactoryBot.create(:declaration, declaration_trait, training_period:)
+    declaration.payment_statement&.update!(active_lead_provider:)
+    declaration
   end
 
   describe "#index" do
@@ -55,13 +57,34 @@ RSpec.describe "Declarations API", type: :request do
   end
 
   describe "#void" do
-    let(:path) { api_v3_declaration_void_path(123) }
+    let(:path) { void_api_v3_declaration_path(resource.api_id) }
+    let(:resource_type) { Declaration }
+    let(:service_args) do
+      {
+        lead_provider_id: lead_provider.id,
+        declaration_api_id: resource.api_id
+      }
+    end
+    let(:params) { {} }
 
-    it_behaves_like "a token authenticated endpoint", :put
+    context "when the declaration has been paid" do
+      let(:resource) do
+        create_resource(active_lead_provider:, declaration_trait: :paid)
+      end
+      let(:service) { API::Declarations::Clawback }
 
-    it "returns method not allowed" do
-      authenticated_api_put path
-      expect(response).to be_method_not_allowed
+      it_behaves_like "a token authenticated endpoint", :put
+      it_behaves_like "an API update endpoint", accepts_request_body: false
+    end
+
+    context "when the declaration has not been paid" do
+      let(:resource) do
+        create_resource(active_lead_provider:, declaration_trait: :payable)
+      end
+      let(:service) { API::Declarations::Void }
+
+      it_behaves_like "a token authenticated endpoint", :put
+      it_behaves_like "an API update endpoint", accepts_request_body: false
     end
   end
 end

--- a/spec/support/shared_contexts/update_endpoint.rb
+++ b/spec/support/shared_contexts/update_endpoint.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "an API update endpoint" do
+RSpec.shared_examples "an API update endpoint" do |example_options|
   let(:options) { defined?(serializer_options) ? serializer_options : {} }
 
   it "updates and returns the resource in a serialized format" do
@@ -29,12 +29,14 @@ RSpec.shared_examples "an API update endpoint" do
     expect(response.body).to eq({ errors: [{ title: "attr", detail: "message" }] }.to_json)
   end
 
-  it "returns a 400 response if the request body is malformed" do
-    authenticated_api_put(path, params: { not_a_valid: :body })
+  unless example_options && example_options[:accepts_request_body] == false
+    it "returns a 400 response if the request body is malformed" do
+      authenticated_api_put(path, params: { not_a_valid: :body })
 
-    expect(response).to have_http_status(:bad_request)
-    expect(response.content_type).to eql("application/json; charset=utf-8")
-    expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "Correct json data structure required. See API docs for reference." }] }.to_json)
+      expect(response).to have_http_status(:bad_request)
+      expect(response.content_type).to eql("application/json; charset=utf-8")
+      expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "Correct json data structure required. See API docs for reference." }] }.to_json)
+    end
   end
 
   context "when the resource has a different lead provider" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2849

### Changes proposed in this pull request

Before, the participant declarations `/void` endpoint always returned
`:not_allowed`.

Now that the services exist, along with the declarations query and serializer,
we can build out the endpoint.

This implements the endpoint, with some simple logic to determine whether we
should clawback or void a declaration.

As part of this change, the route has been redefined as a member of
`/declarations` so we can use the same `api_id` param.

### Guidance to review
