### PR TITLE
Transfers endpoint release note 

### DIFF
--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -22,7 +22,7 @@
 #     **bold** and _italic_ text
 
 - title: Transfers endpoint now available in the Register ECTs sandbox with updated leaving and date handling logic
-  date: 2025-12-05
+  date: 2025-12-17
   tags:
     - sandbox-release
   body: |


### PR DESCRIPTION
Re-opening #1849 as the review app got stuck; no changes from that PR.