### PR TITLE
Ensure teacher TRNs are not duplicated

### DIFF
--- a/app/services/api_seed_data/teachers/school_transfers.rb
+++ b/app/services/api_seed_data/teachers/school_transfers.rb
@@ -61,7 +61,7 @@ module APISeedData
     def select_random_teacher(excluding_teachers: [], type: :ect)
       teachers = type == :ect ? ect_teachers : mentor_teachers
       teacher = (teachers - excluding_teachers).sample.presence ||
-        FactoryBot.create(:teacher, :with_realistic_name)
+        FactoryBot.create(:teacher, :with_realistic_name, trn: Helpers::TRNGenerator.next)
       teacher.tap { @transferred_teachers[type] << it }
     end
 


### PR DESCRIPTION
We are seeing an error when running the API seeds whereby the teachers created in the transfer seeds are duplicating existing TRNs.

Update to use the `TRNGenerator` to ensure they are always unique.
