### PR TITLE
Upgrade sentry-ruby and sentry-rails to 6.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ ruby "3.4.7"
 
 gem "rails", "~> 8.0.4"
 
+# temporary, see https://github.com/mperham/connection_pool/issues/212#issuecomment-3637733716
+gem "connection_pool", "< 3"
+
 gem "blazer"
 gem "bootsnap", require: false
 gem "cssbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
     chartkick (5.1.4)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     console (1.33.0)
       fiber-annotation
       fiber-local (~> 1.1)
@@ -844,6 +844,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  connection_pool (< 3)
   cssbundling-rails
   csv
   debug


### PR DESCRIPTION
Some extra attention was needed (see second commit) to ensure this builds cleanly.
