### PR TITLE
Void declaration API documentation

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -72,6 +72,44 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
+  "/api/v3/participant-declarations/{id}/void":
+    put:
+      summary: Void a declaration
+      tags:
+      - Declarations
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The declaration being voided
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/DeclarationResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableContentResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
   "/api/v3/delivery-partners":
     get:
       summary: Retrieve multiple delivery partners

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
       school_partnership:
     )
   end
-  let!(:resource) { FactoryBot.create(:declaration, training_period:) }
+  let(:declaration) { FactoryBot.create(:declaration, training_period:) }
+
+  let(:resource) { declaration }
 
   it_behaves_like "an API index endpoint documentation",
                   {
@@ -40,4 +42,24 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
                     response_description: "A single declaration",
                     response_schema_ref: "#/components/schemas/DeclarationResponse",
                   }
+
+  it_behaves_like "an API update endpoint documentation",
+                  {
+                    url: "/api/v3/participant-declarations/{id}/void",
+                    tag: "Declarations",
+                    resource_description: "Void a declaration",
+                    response_description: "The declaration being voided",
+                    response_schema_ref: "#/components/schemas/DeclarationResponse",
+                    accepts_request_body: false
+                  } do
+    let(:params) { {} }
+    let(:declaration) do
+      FactoryBot.create(:declaration, :payable, training_period:)
+    end
+
+    let(:invalid_params) { {} }
+    let(:invalid_resource) do
+      FactoryBot.create(:declaration, :voided, training_period:)
+    end
+  end
 end

--- a/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
+++ b/spec/support/shared_contexts/api/docs/api_update_endpoint_documentation_support.rb
@@ -13,13 +13,15 @@ RSpec.shared_context "an API update endpoint documentation", :exceptions_app do 
                   "$ref": "#/components/schemas/IDAttribute",
                 }
 
-      parameter name: :params,
-                in: :body,
-                style: :deepObject,
-                required: false,
-                schema: {
-                  "$ref": params[:request_schema_ref],
-                }
+      if params[:request_schema_ref]
+        parameter name: :params,
+                  in: :body,
+                  style: :deepObject,
+                  required: false,
+                  schema: {
+                    "$ref": params[:request_schema_ref],
+                  }
+      end
 
       let(:id) { resource.api_id }
 
@@ -39,16 +41,19 @@ RSpec.shared_context "an API update endpoint documentation", :exceptions_app do 
         run_test!
       end
 
-      response "400", "Bad request" do
-        let(:params) { { data: {} } }
+      unless params[:accepts_request_body] == false
+        response "400", "Bad request" do
+          let(:params) { { data: {} } }
 
-        schema({ "$ref": "#/components/schemas/BadRequestResponse" })
+          schema({ "$ref": "#/components/schemas/BadRequestResponse" })
 
-        run_test!
+          run_test!
+        end
       end
 
       response "422", "Unprocessable entity" do
         let(:params) { invalid_params }
+        let(:id) { (defined?(invalid_resource) ? invalid_resource : resource).api_id }
 
         schema({ "$ref": "#/components/schemas/UnprocessableContentResponse" })
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2850

### Changes proposed in this pull request

This adds swagger documentation for the PUT declarations `/void` endpoint.
    
As part of this change, the shared context has been updated to account for a
request that doesn't have a body.

### Guidance to review
