### PR TITLE
Fix flakey school query spec

### DIFF
--- a/spec/services/api/schools/query_spec.rb
+++ b/spec/services/api/schools/query_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe API::Schools::Query, :with_metadata do
       let(:school2) { travel_to(2.days.ago) { FactoryBot.create(:school, :eligible) } }
       let(:school3) { FactoryBot.create(:school, :eligible) }
 
-      let(:sort) { nil }
+      let(:sort) { { created_at: :asc } }
 
       let(:query_params) do
         {


### PR DESCRIPTION
The ordering is `nil` for the first test and it is expecting the order to be `created_at: :asc` (which is the default for the query service). Passing `nil` into `order()` will clear the ordering, so its undetermined.
