### PR TITLE
Fix flakiness in `TrainingPeriod::Search` spec

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -93,7 +93,10 @@ class TrainingPeriod < ApplicationRecord
   scope :confirmed, -> { where.not(school_partnership_id: nil) }
   scope :at_school, ->(school) {
     left_outer_joins(:ect_at_school_period, :mentor_at_school_period)
-      .merge(ECTAtSchoolPeriod.for_school(school).or(MentorAtSchoolPeriod.for_school(school)))
+      .where(
+        ECTAtSchoolPeriod.arel_table[:school_id].eq(school.id)
+        .or(MentorAtSchoolPeriod.arel_table[:school_id].eq(school.id))
+      )
   }
   scope :including_school_partnership, -> {
     includes(:school_partnership)

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -695,11 +695,11 @@ describe TrainingPeriod do
       end
 
       it "returns training periods for ECTs and Mentors at the school" do
-        expect(TrainingPeriod.at_school(school.id)).to include(ect_training_period, mentor_training_period)
+        expect(TrainingPeriod.at_school(school)).to include(ect_training_period, mentor_training_period)
       end
 
       it "does not return training periods for ECTs and Mentors at other schools" do
-        expect(TrainingPeriod.at_school(school.id)).not_to include(other_training_period)
+        expect(TrainingPeriod.at_school(school)).not_to include(other_training_period)
       end
     end
 


### PR DESCRIPTION
I think that the flakiness is coming from the combination of `left_outer_join` with `merge` and `or` and with how Rails can sometimes interpret this combination.

Switch the syntax out to remove the `merge`, hopefully making it a bit more predictable.

I'm not convinced this will fix it, but it shouldn't hurt to try and I can't see any other part of the logic around the spec that would be a more likely candidate.