### PR TITLE
Clear API seeds when deploying to review

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -112,13 +112,23 @@ runs:
         kubectl exec -n cpd-development deployment/cpd-ec2-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=${{ inputs.environment }} /usr/local/bin/bundle exec rails db:seed:replant"
       env:
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
-
+        
     - name: Run API seed task
       if: (steps.check_label.outputs.has_label == 'true' || steps.check_author.outputs.api_author == 'true') && inputs.pull-request-number != '' && inputs.environment != 'production'
       shell: bash
       run: |
-        echo "Running API seeds..."
-        make ci review get-cluster-credentials
-        kubectl exec -n cpd-development deployment/cpd-ec2-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=${{ inputs.environment }} /usr/local/bin/bundle exec rake api_seed_data:generate"
+          echo "Running API seeds..."
+          make ci review get-cluster-credentials
+          kubectl exec -n cpd-development \
+            deployment/cpd-ec2-review-${{ inputs.pull-request-number }}-web \
+            -- sh -c '
+              cd /app &&
+              DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
+              RAILS_ENV=${{ inputs.environment }} \
+              /usr/local/bin/bundle exec rails db:truncate_all &&
+              DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
+              RAILS_ENV=${{ inputs.environment }} \
+              /usr/local/bin/bundle exec rake api_seed_data:generate
+            '
       env:
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}


### PR DESCRIPTION
I haven't been able to figure out how, but somehow there is the non-api seed data in the review app after deploying via CI. The non-API step doesn't run during deploy and the only other place we call `db:seed` is in `.devcontainer` which is only for Codespaces. As we check for existing data in the API seeds, it causes the majority of them not to run.

Truncate the database before running the API seeds in CI to ensure they are always ran. This also mirror s the dev seeds (which `replant` on each deploy).

Deploying the review app for an API PR now takes about ~10m; we can look at pairing back the amount of seed data if this becomes irritating.
