### PR TITLE
Remove TODO in `API::TeacherSerializer`

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -43,9 +43,7 @@ class API::TeacherSerializer < Blueprinter::Base
         training_period.for_ect? && teacher.ect_sparsity_uplift
       end
       field(:schedule_identifier) do |(training_period, _, _)|
-        # TODO: remove the optional chaining when the provider-led TP
-        # schedules have validation to make mandatory.
-        training_period.schedule&.identifier
+        training_period.schedule.identifier
       end
       field(:delivery_partner_id) do |(training_period, _, _)|
         training_period


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2817

### Changes proposed in this pull request

Since #1767, we ensure provider-led training periods have an associated schedule.

This means we no longer need to account for training periods without schedules in the lead provider API.

This removes the TODO and removes the safe navigation operators from the `API::TeacherSerializer`.

### Guidance to review
