### PR TITLE
[2910] Add `superseded_by` to declarations

### DIFF
--- a/app/services/api_seed_data/declarations.rb
+++ b/app/services/api_seed_data/declarations.rb
@@ -82,11 +82,10 @@ module APISeedData
             payment_statement = find_random_statement(active_lead_provider)
             next unless payment_statement
 
-            declaration.mark_as_ineligible!(
-              ineligibility_reason: :duplicate,
-              payment_statement:,
-              superseded_by: declaration.duplicate_declarations.order(created_at: :asc).first
-            )
+            declaration.ineligibility_reason = :duplicate
+            declaration.payment_statement = payment_statement
+            declaration.superseded_by = declaration.duplicate_declaration
+            declaration.mark_as_ineligible!
           else
             next
           end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -412,6 +412,7 @@
   - created_at
   - updated_at
   - api_updated_at
+  - superseded_by_id
   :data_migrations:
   - id
   - model

--- a/db/migrate/20251219104124_add_superseded_by_to_declarations.rb
+++ b/db/migrate/20251219104124_add_superseded_by_to_declarations.rb
@@ -1,0 +1,5 @@
+class AddSupersededByToDeclarations < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :declarations, :superseded_by, null: true, foreign_key: { to_table: :declarations }, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_18_165603) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_19_104124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -181,10 +181,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_18_165603) do
     t.boolean "sparsity_uplift", default: false, null: false
     t.boolean "pupil_premium_uplift", default: false, null: false
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.bigint "superseded_by_id"
     t.index ["api_id"], name: "index_declarations_on_api_id", unique: true
     t.index ["clawback_statement_id"], name: "index_declarations_on_clawback_statement_id"
     t.index ["mentorship_period_id"], name: "index_declarations_on_mentorship_period_id"
     t.index ["payment_statement_id"], name: "index_declarations_on_payment_statement_id"
+    t.index ["superseded_by_id"], name: "index_declarations_on_superseded_by_id"
     t.index ["training_period_id"], name: "index_declarations_on_training_period_id"
     t.index ["voided_by_user_id"], name: "index_declarations_on_voided_by_user_id"
   end
@@ -891,6 +893,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_18_165603) do
 
   add_foreign_key "active_lead_providers", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "active_lead_providers", "lead_providers"
+  add_foreign_key "declarations", "declarations", column: "superseded_by_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"
   add_foreign_key "declarations", "users", column: "voided_by_user_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -327,12 +327,14 @@ erDiagram
     boolean sparsity_uplift
     boolean pupil_premium_uplift
     datetime api_updated_at
+    integer superseded_by_id
   }
   Declaration }o--|| TrainingPeriod : belongs_to
   Declaration }o--|| User : belongs_to
   Declaration }o--|| MentorshipPeriod : belongs_to
   Declaration }o--|| Statement : belongs_to
   Declaration }o--|| Statement : belongs_to
+  Declaration }o--|| Declaration : belongs_to
   ContractPeriod {
     integer year
     datetime created_at

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe Declarations::Create do
             )
           )
         end
+
+        context "when a duplicate declaration already exists" do
+          let!(:existing_duplicate_declaration) { FactoryBot.create(:declaration, :eligible, training_period:, declaration_type:, declaration_date:) }
+          let!(:existing_superseded_declaration) { FactoryBot.create(:declaration, :ineligible, training_period:, declaration_type:, declaration_date:, superseded_by: existing_duplicate_declaration) }
+
+          it "marks the new declaration ineligible with duplicate `ineligibility_reason`, sets `superseded_by` and assigns a `payment_statement`" do
+            declaration = create_declaration
+
+            expect(declaration).to be_payment_status_ineligible
+            expect(declaration).to be_ineligibility_reason_duplicate
+            expect(declaration.superseded_by).to eq(existing_duplicate_declaration)
+            expect(declaration.payment_statement).to eq(payment_statement)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [2910](https://github.com/DFE-Digital/register-ects-project-board/issues/2910)

We need to handle declarations that are submitted and superseded by another declaration already in the database in RECT.

### Changes proposed in this pull request

- Add `superseded_by` attribute to Declaration;
- Handle superseded declarations as in ECF;
- Added seed data logic for superseded declarations (to be run in sandbox);
- Inform the data migration team of the new attribute (@tonyheadford)

### Guidance to review

Review app