### PR TITLE
Add ECF1 API data extract scripts

### DIFF
--- a/app/migration/ecf1_api_scripts/Makefile
+++ b/app/migration/ecf1_api_scripts/Makefile
@@ -1,0 +1,124 @@
+# extract data from ECF1 API into JSON files
+# You'll need to have a local ECF1 app running connected to a snapshot DB
+# and you'll need to have the provider keys or recreated new ones for this
+# purpose:
+#
+# CpdLeadProvider.joins(:lead_provider).to_h do |cpd_lead_provider|
+#   token = LeadProviderApiToken.create_with_random_token!(
+#     cpd_lead_provider: cpd_lead_provider
+#   )
+#
+#   [cpd_lead_provider.name, token]
+# end
+#
+# store the relevant token under each provider target at the bottom
+# of this file
+
+OUTPUT_DIR := ./api_data
+FETCH_SCRIPT := ./fetch_api_data.zsh
+HOST := "http://localhost:3000"
+PARTICIPANTS_ENDPOINT := "${HOST}/api/v3/participants/ecf"
+DECLARATIONS_ENDPOINT := "${HOST}/api/v3/participant-declarations"
+TRANSFERS_ENDPOINT := "${HOST}/api/v3/participants/ecf/transfers"
+UNFUNDED_MENTORS_ENDPOINT := "${HOST}/api/v3/unfunded-mentors/ecf"
+
+.phony: all
+all: clean_all
+	@$(MAKE) ambition_all
+	@$(MAKE) bpn_all
+	@$(MAKE) capita_all
+	@$(MAKE) edt_all
+	@$(MAKE) tf_all
+	@$(MAKE) ucl_all
+	@$(MAKE) niot_all
+
+.phony: all_endpoints
+all_endpoints: participants declarations transfers unfunded_mentors
+
+.phony: ambition_all
+ambition_all: ambition all_endpoints
+.phony: bpn_all
+bpn_all: bpn all_endpoints
+.phony: capita_all
+capita_all: capita all_endpoints
+.phony: edt_all
+edt_all: edt all_endpoints
+.phony: tf_all
+tf_all: tf all_endpoints
+.phony: ucl_all
+ucl_all: ucl all_endpoints
+.phony: niot_all
+niot_all: niot all_endpoints
+
+.phony: participants
+participants:
+	@echo "🧑‍🎓 Participants"
+	@${FETCH_SCRIPT} -u ${PARTICIPANTS_ENDPOINT} -k ${PROVIDER_KEY} -o "${DIRPATH}/participants"
+
+.phony: declarations
+declarations:
+	@echo "🛃 Declarations"
+	@${FETCH_SCRIPT} -u ${DECLARATIONS_ENDPOINT} -k ${PROVIDER_KEY} -o "${DIRPATH}/declarations"
+
+.phony: transfers
+transfers:
+	@echo "📦 Transfers"
+	@${FETCH_SCRIPT} -u ${TRANSFERS_ENDPOINT} -k ${PROVIDER_KEY} -o "${DIRPATH}/transfers"
+
+.phony: unfunded_mentors
+unfunded_mentors:
+	@echo "💸 Unfunded mentors"
+	@${FETCH_SCRIPT} -u ${UNFUNDED_MENTORS_ENDPOINT} -k ${PROVIDER_KEY} -o "${DIRPATH}/unfunded_mentors"
+
+.phony: clean
+clean:
+	@echo "🧹 cleaning"
+	@rm -rf ${DIRPATH}
+
+.phony: clean_all
+clean_all:
+	@echo "🧹 cleaning all"
+	@rm -rf ${OUTPUT_DIR}
+
+.phony: ambition
+ambition:
+	$(eval PROVIDER_NAME="ambition")
+	$(eval PROVIDER_KEY="senBkNxgPLXrmQqZQeiG")
+	$(eval DIRPATH="${OUTPUT_DIR}/ambition")
+
+.phony: bpn
+bpn:
+	$(eval PROVIDER_NAME="bpn")
+	$(eval PROVIDER_KEY="hENauXegzNYG52ptc98e")
+	$(eval DIRPATH="${OUTPUT_DIR}/bpn")
+
+.phony: capita
+capita:
+	$(eval PROVIDER_NAME="capita")
+	$(eval PROVIDER_KEY="4FTVDrHmx1i3Ur9mxTg2")
+	$(eval DIRPATH="${OUTPUT_DIR}/capita")
+
+.phony: edt
+edt:
+	$(eval PROVIDER_NAME="edt")
+	$(eval PROVIDER_KEY="f1yGRfArhVwog2hy1wNJ")
+	$(eval DIRPATH="${OUTPUT_DIR}/edt")
+
+.phony: tf
+tf:
+	$(eval PROVIDER_NAME="tf")
+	$(eval PROVIDER_KEY="Wnsjee-MDouLjD4wG2tz")
+	$(eval DIRPATH="${OUTPUT_DIR}/tf")
+
+.phony: ucl
+ucl:
+	$(eval PROVIDER_NAME="ucl")
+	$(eval PROVIDER_KEY="H_dAP3X_Xy-F3iPd3e3y")
+	$(eval DIRPATH="${OUTPUT_DIR}/ucl")
+
+.phony: niot
+niot:
+	$(eval PROVIDER_NAME="niot")
+	$(eval PROVIDER_KEY="Dqfmx8PQP4D5Fqky3exn")
+	$(eval DIRPATH="${OUTPUT_DIR}/niot")
+

--- a/app/migration/ecf1_api_scripts/fetch_api_data.zsh
+++ b/app/migration/ecf1_api_scripts/fetch_api_data.zsh
@@ -1,0 +1,58 @@
+#!/bin/zsh
+
+# inputs are:
+# -o outputpath
+# -k apikey
+# -u uri for api end point
+# -p page number
+# -P items per-page number
+#
+
+page=1
+per_page=3000
+
+while [[ "$#" -gt 0 ]]
+do case $1 in
+    -o|--outputpath) output_path="$2"
+    shift;;
+    -k|--key) api_key="$2"
+    shift;;
+    -u|--uri) api_uri="$2"
+    shift;;
+    -p|--page) page="$2"
+    shift;;
+    -P|--per-page) per_page="$2"
+esac
+shift
+done
+
+if [[ -z $output_path ]]; then
+  echo "-o|--outputpath <path> is required"
+  exit 1
+elif [[ -z $api_key ]]; then
+  echo "-k|--key <api-key> is required"
+  exit 1
+elif [[ -z $api_uri ]]; then
+  echo "-u|--uri <api-uri> is required"
+  exit 1
+fi
+
+mkdir -p $output_path
+
+echo "Reading data from: [${api_uri}]"
+
+while true; do
+  file="${output_path}/page${page}.json"
+  echo "Writing ${file}"
+
+  curl -sS "${api_uri}?page\[page\]=${page}&page\[per_page\]=${per_page}" -H "Accept: application/json" -H "Authorization: Bearer ${api_key}" | jq '.' > $file
+
+  len=`jq '.data | length' $file`
+  if [ $len -lt $per_page ]; then
+    break
+  fi
+  ((page++))
+done
+
+echo "📚 Combining and sorting..."
+jq -s '[.[].data[]] | { data: sort_by(.id) }' ${output_path}/page*.json > "${output_path}/combined.json"


### PR DESCRIPTION
### Context

I built these scripts when extracting data from the ECF1 API endpoints so that we could compare the data before and after changes made to ECF1 data.
These rely on `curl` and `jq` being installed locally.

You should have a local ECF1 instance running that is connected to a snapshot DB using `konduit` for example.

You also need the provider API tokens, you can recreate these in a snapshot DB with:
```ruby
 CpdLeadProvider.joins(:lead_provider).to_h do |cpd_lead_provider|
   token = LeadProviderApiToken.create_with_random_token!(
     cpd_lead_provider: cpd_lead_provider
   )

   [cpd_lead_provider.name, token]
 end
```

These tokens need to be added to the appropriate provider target in the `Makefile`. The `PROVIDER_KEY`s used in the `Makefile` are just values I've used locally and won't work anywhere else.

To capture all the data from the `participants`, `declarations`, `transfers` and `unfunded mentors` endpoints for all the providers just run:

```
make
```

Each page of results from an endpoint is stored in it's own file.  Once all the pages have been retrieved a combined file is generated from all the pages and the results are sorted by `id` in that file. This file is named `combined.json`
Having a sorted copy of all the data makes it easier to `diff` across 2 versions of the data:

```
diff -U 10 api_data/ambition/participants/combined.json api_data_previous/ambition/participants/combined.json
```

This removes issues where the same data might be on different pages of different the result sets for example.


You can also target individual providers and endpoints
eg
```
 make ambition participants
```

Each provider and endpoint is in its own directory under `api_data` (by default):
```
api_data
 |
 |-- ambition
 |       |
 |       |-- participants
 |       |-- declarations

etc
```
   
Best to look at the `Makefile` for an idea of the defaults and env vars used.
