### PR TITLE
Optimise `Metadata::Handlers::Teacher` school transfers check

### DIFF
--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -28,8 +28,8 @@ module Metadata::Handlers
         latest_ect_contract_period = latest_ect_training_period&.contract_period
         latest_mentor_contract_period = latest_mentor_training_period&.contract_period
         api_mentor_id = latest_ect_training_period&.trainee&.latest_mentorship_period&.mentor&.teacher&.api_id
-        involved_in_school_transfer = school_transfers_for(teacher.ect_at_school_periods, lead_provider_id).any? ||
-          school_transfers_for(teacher.mentor_at_school_periods, lead_provider_id).any?
+        involved_in_school_transfer = school_transfers_exist_for(teacher.ect_at_school_periods, lead_provider_id) ||
+          school_transfers_exist_for(teacher.mentor_at_school_periods, lead_provider_id)
 
         changes = {
           teacher_id: teacher.id,
@@ -72,8 +72,8 @@ module Metadata::Handlers
       .index_by { it.lead_provider&.id }
     end
 
-    def school_transfers_for(school_periods, lead_provider_id)
-      ::Teachers::SchoolTransfers::History.transfers_for(school_periods:, lead_provider_id:)
+    def school_transfers_exist_for(school_periods, lead_provider_id)
+      ::Teachers::SchoolTransfers::History.exists_for?(school_periods:, lead_provider_id:)
     end
   end
 end

--- a/app/services/teachers/school_transfers/history.rb
+++ b/app/services/teachers/school_transfers/history.rb
@@ -1,6 +1,7 @@
 module Teachers::SchoolTransfers
   class History
     def self.transfers_for(...) = new(...).transfers
+    def self.exists_for?(...) = new(...).exists?
 
     def initialize(school_periods:, lead_provider_id:)
       @school_periods = school_periods.sort_by(&:started_on)
@@ -9,28 +10,39 @@ module Teachers::SchoolTransfers
 
     def transfers
       @school_periods.map.with_index { |school_period, index|
-        next unless school_period.complete?
-
-        leaving_training_period = school_period.latest_training_period
-        next unless leaving_training_period&.complete?
-
         next_school_period = @school_periods[index + 1]
-        next unless different_school?(school_period, next_school_period)
-        next if teacher_completed_induction?(school_period.teacher, next_school_period)
-
-        joining_training_period = next_school_period&.earliest_training_period
-        next unless relevant_to_lead_provider?(leaving_training_period, joining_training_period)
-
-        Transfer.new(
-          leaving_training_period:,
-          leaving_school: school_period.school,
-          joining_training_period:,
-          joining_school: next_school_period&.school
-        )
+        transfer_for(school_period, next_school_period)
       }.compact
     end
 
+    def exists?
+      @school_periods.map.with_index.any? do |school_period, index|
+        next_school_period = @school_periods[index + 1]
+        transfer_for(school_period, next_school_period)
+      end
+    end
+
   private
+
+    def transfer_for(school_period, next_school_period)
+      return unless school_period.complete?
+
+      leaving_training_period = school_period.latest_training_period
+      return unless leaving_training_period&.complete?
+
+      return unless different_school?(school_period, next_school_period)
+      return if teacher_completed_induction?(school_period.teacher, next_school_period)
+
+      joining_training_period = next_school_period&.earliest_training_period
+      return unless relevant_to_lead_provider?(leaving_training_period, joining_training_period)
+
+      Transfer.new(
+        leaving_training_period:,
+        leaving_school: school_period.school,
+        joining_training_period:,
+        joining_school: next_school_period&.school
+      )
+    end
 
     def different_school?(school_period, next_school_period)
       school_period.school != next_school_period&.school

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -338,8 +338,8 @@ RSpec.describe Metadata::Handlers::Teacher do
         context "when Teacher has some school transfers" do
           before do
             allow(Teachers::SchoolTransfers::History)
-              .to receive(:transfers_for)
-              .and_return(double(any?: true))
+              .to receive(:exists_for?)
+              .and_return(true)
 
             refresh_metadata
           end
@@ -350,8 +350,8 @@ RSpec.describe Metadata::Handlers::Teacher do
         context "when Teacher has no school transfers" do
           before do
             allow(Teachers::SchoolTransfers::History)
-              .to receive(:transfers_for)
-              .and_return(double(any?: false))
+              .to receive(:exists_for?)
+              .and_return(false)
 
             refresh_metadata
           end

--- a/spec/services/teachers/school_transfers/history_spec.rb
+++ b/spec/services/teachers/school_transfers/history_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Teachers::SchoolTransfers::History do
   include SchoolTransferHelpers
 
-  describe "#transfers" do
+  describe "transfers" do
     let(:teacher) { FactoryBot.create(:teacher) }
 
     context "when there are no transfers" do
@@ -20,6 +20,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
 
@@ -33,6 +34,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
 
@@ -54,6 +56,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
 
@@ -76,6 +79,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
 
       it "returns an unknown transfer for lead provider #2" do
@@ -93,6 +97,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period3)
         expect(transfer.joining_training_period).to be_nil
+        expect(history).to be_exists
       end
     end
 
@@ -116,6 +121,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
 
       it "returns no transfers for lead provider #2" do
@@ -125,6 +131,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
 
@@ -157,6 +164,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period1)
         expect(transfer.joining_training_period).to eq(@training_period2)
+        expect(history).to be_exists
       end
 
       it "returns no transfers for lead provider #2" do
@@ -166,6 +174,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
 
@@ -199,6 +208,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period1)
         expect(transfer.joining_training_period).to eq(@training_period2)
+        expect(history).to be_exists
       end
 
       it "returns a new_provider transfer for lead provider #2" do
@@ -216,6 +226,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period1)
         expect(transfer.joining_training_period).to eq(@training_period2)
+        expect(history).to be_exists
       end
 
       it "returns no transfers for lead provider #3" do
@@ -225,6 +236,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
 
@@ -254,6 +266,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period1)
         expect(transfer.joining_training_period).to eq(@training_period2)
+        expect(history).to be_exists
       end
     end
 
@@ -283,6 +296,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         expect(transfer).not_to be_for_mentor
         expect(transfer.leaving_training_period).to eq(@training_period1)
         expect(transfer.joining_training_period).to eq(@training_period2)
+        expect(history).to be_exists
       end
     end
 
@@ -305,6 +319,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
         )
 
         expect(history.transfers).to be_empty
+        expect(history).not_to be_exists
       end
     end
   end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2926

### Changes proposed in this pull request

Before, we built the full school transfer history to determine whether or not a given teacher had school transfers in the metadata handler.

We don't need the full history, though, since we only care if there is at least one transfer.

This refactors the history class so we can return early if a school transfer exists.

### Guidance to review
