### PR TITLE
[2987] Fix bug in Schedules::Find

### DIFF
--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -18,19 +18,15 @@ module Schedules
 
   private
 
+    delegate :teacher, to: :period
+
     def schedule_for_target_period
       return most_recent_schedule if most_recent_schedule&.contract_period_year == contract_period_year
 
       Schedule.find_by(contract_period_year:, identifier: most_recent_schedule&.identifier) || Schedule.find_by(contract_period_year:, identifier:)
     end
 
-    def provider_led?
-      training_programme == "provider_led"
-    end
-
-    def teacher
-      period.teacher
-    end
+    def provider_led? = training_programme == "provider_led"
 
     def training_periods
       return teacher.ect_training_periods if teacher.ect_at_school_periods.exists? && period_type_key == :ect_at_school_period
@@ -46,14 +42,10 @@ module Schedules
       @most_recent_schedule ||= most_recent_provider_led_period&.schedule
     end
 
-    def latest_start_date
-      [started_on, Time.zone.today].max
-    end
+    def latest_start_date = [started_on, Time.zone.today].max
 
     def schedule_month
-      month = latest_start_date.month
-
-      case month
+      case latest_start_date.month
       when 6..10
         "september"
       when 11, 12, 1, 2
@@ -64,7 +56,7 @@ module Schedules
     end
 
     def contract_period_year
-      if schedule_month == "april"
+      if latest_start_date.month <= 5
         latest_start_date.year - 1
       else
         latest_start_date.year


### PR DESCRIPTION
### Context

[Ticket / bug report](https://github.com/DFE-Digital/register-ects-project-board/issues/2987)

The reported bug is caused by a newly-assigned provider-led schedule belonging to a different `ContractPeriod` than the `*AtSchoolPeriod`'s `TrainingPeriod`, which makes that `TrainingPeriod` invalid. (It's not actually specific to moving from School-led to Provider-led, but easily manifests in this scenario because School-led training periods don't have schedules, so when moving to Provider-led, a new one is always assigned.)

This happens because contract period years run June through May, so dates in January through May should resolve to the `ContractPeriod` that commences in the preceding calendar year, but the existing implementation of `Schedules::Find` had only hard-coded April to do so.

### Changes proposed in this pull request

- Rewrite tests to check boundaries of each schedule range, rather than a single arbitrary date in the middle
- Fix implementation of `Schedules::Find#contract_period_year`
- Very minor tidy of `Schedules::Find`

The use of `shared_examples` with the hash argument is a bit unusual, but I wanted a more cohesive/structured approach to covering an entire year than individual specs, so hopefully logically & visually grouping the entire year together (and sharing examples across pre-/post-registration) is a step in that direction.