### PR TITLE
Remove defunct Schedules::Find#fallback_contract_period_year

### DIFF
--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -64,7 +64,7 @@ module Schedules
     end
 
     def contract_period_year
-      ContractPeriod.containing_date(latest_start_date).year
+      ContractPeriod.containing_date(latest_start_date)&.year || raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
     end
 
     def identifier


### PR DESCRIPTION
If there's no matching `ContractPeriod`, there's no point calculating the year since there will be no matching schedule anyway, so we can delete this fallback method and blow up right away.

This will raise `undefined method 'year' for nil (NoMethodError)` with the backtrace pointing to :67 — I erred on the side of not defining a specific exception class, since this is already very easy to understand, and I don't anticipate we'd want to rescue it.