### PR TITLE
[3038] Update API seeds to also include dev seeds

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -103,16 +103,6 @@ runs:
 
         echo "api_author=$api_author" >> $GITHUB_OUTPUT
 
-    - name: Run default seed task
-      if: steps.check_label.outputs.has_label == 'false' && steps.check_author.outputs.api_author == 'false' && inputs.pull-request-number != '' && inputs.environment != 'production'
-      shell: bash
-      run: |
-        echo "Running default seeds..."
-        make ci review get-cluster-credentials
-        kubectl exec -n cpd-development deployment/cpd-ec2-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=${{ inputs.environment }} /usr/local/bin/bundle exec rails db:seed:replant"
-      env:
-        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
-        
     - name: Run API seed task
       if: (steps.check_label.outputs.has_label == 'true' || steps.check_author.outputs.api_author == 'true') && inputs.pull-request-number != '' && inputs.environment != 'production'
       shell: bash
@@ -130,5 +120,15 @@ runs:
               RAILS_ENV=${{ inputs.environment }} \
               /usr/local/bin/bundle exec rake api_seed_data:generate
             '
+      env:
+        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
+
+    - name: Run default seed task
+      if: inputs.pull-request-number != '' && inputs.environment != 'production'
+      shell: bash
+      run: |
+        echo "Running default seeds..."
+        make ci review get-cluster-credentials
+        kubectl exec -n cpd-development deployment/cpd-ec2-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 RAILS_ENV=${{ inputs.environment }} /usr/local/bin/bundle exec rails db:seed"
       env:
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}

--- a/spec/factories/api_token_factory.rb
+++ b/spec/factories/api_token_factory.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     association :lead_provider
     description { "A token used for test purposes" }
     last_used_at { Faker::Time.between(from: 1.month.ago, to: 1.day.ago) }
+    token { SecureRandom.base58(32) }
+
+    initialize_with do
+      API::Token.find_or_initialize_by(lead_provider:, token:)
+    end
   end
 end

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     dfe_sign_in_organisation_id { SecureRandom.uuid }
     teaching_school_hub
 
+    initialize_with do
+      AppropriateBody.find_or_initialize_by(name:)
+    end
+
     trait :istip do
       body_type { "national" }
       name { AppropriateBodies::Search::ISTIP }

--- a/spec/factories/delivery_partner_factory.rb
+++ b/spec/factories/delivery_partner_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory(:delivery_partner) do
     sequence(:name) { |n| "#{Faker::University.name} Delivery Partner #{n}" }
+
+    initialize_with do
+      DeliveryPartner.find_or_initialize_by(name:)
+    end
   end
 end

--- a/spec/factories/gias/school_factory.rb
+++ b/spec/factories/gias/school_factory.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
     urn { Faker::Number.unique.within(range: 10_000..9_999_999) }
     ukprn { Faker::Number.unique.within(range: 1_000_000..99_999_999).to_s }
 
+    initialize_with do
+      GIAS::School.find_or_initialize_by(urn:)
+    end
+
     # eligibility to be registered in the service
     trait(:eligible) do
       open
@@ -76,7 +80,7 @@ FactoryBot.define do
     end
 
     trait(:with_school) do
-      school { build_school }
+      school { build(:school, urn:) }
     end
   end
 end

--- a/spec/factories/lead_provider_delivery_partnership_factory.rb
+++ b/spec/factories/lead_provider_delivery_partnership_factory.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     association :active_lead_provider
     association :delivery_partner
 
+    initialize_with do
+      LeadProviderDeliveryPartnership.find_or_initialize_by(active_lead_provider:, delivery_partner:)
+    end
+
     trait :for_year do
       transient do
         year { 2025 }

--- a/spec/factories/lead_provider_factory.rb
+++ b/spec/factories/lead_provider_factory.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory(:lead_provider) do
     sequence(:name) { |n| "Lead Provider #{n}" }
     ecf_id { SecureRandom.uuid }
+
+    initialize_with do
+      LeadProvider.find_or_initialize_by(name:)
+    end
   end
 end

--- a/spec/factories/school_factory.rb
+++ b/spec/factories/school_factory.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     urn { Faker::Number.unique.number(digits: 6) }
     independent
 
+    initialize_with do
+      School.find_or_initialize_by(urn:)
+    end
+
     trait :independent do
       gias_school { association :gias_school, :independent_school_type, :section_41, urn: }
     end

--- a/spec/factories/school_partnership_factory.rb
+++ b/spec/factories/school_partnership_factory.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     association :lead_provider_delivery_partnership
     association :school
 
+    initialize_with do
+      SchoolPartnership.find_or_initialize_by(lead_provider_delivery_partnership:, school:)
+    end
+
     trait :for_year do
       transient do
         year { 2024 }

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
     payment_date { Faker::Date.forward(days: 30) }
     output_fee
 
+    initialize_with do
+      Statement.find_or_initialize_by(active_lead_provider:, month:, year:)
+    end
+
     trait :open do
       status { :open }
     end

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
     sequence(:trs_first_name) { |n| "First name #{n}" }
     sequence(:trs_last_name) { |n| "Last name #{n}" }
 
+    initialize_with do
+      Teacher.find_or_initialize_by(trn:)
+    end
+
     trait :with_realistic_name do
       trs_first_name { Faker::Name.first_name }
       trs_last_name { Faker::Name.last_name }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
 
     admin
 
+    initialize_with do
+      User.find_or_initialize_by(email:)
+    end
+
     trait(:admin) { role { "admin" } }
     trait(:super_admin) { role { "super_admin" } }
     trait(:finance) { role { "finance" } }


### PR DESCRIPTION
### Context

Ticket: [3038](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3038)

Now that we no longer run dev seeds on API PRs, however, we are missing the users the dev seeds create so that reviewers can sign in to the backend.

### Changes proposed in this pull request

- Run dev seeds after API seeds in CI
- Do not run API seeds for non-API PRs

### Guidance to review

[Review app](https://cpd-ec2-review-1989-web.test.teacherservices.cloud/)
