### PR TITLE
Fix review app deploy failures by replanting seeds

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -130,7 +130,7 @@ runs:
         echo "Running default seeds..."
         make ci review get-cluster-credentials
 
-        if [[ "${{ steps.check_author.outputs.api_author }}" == "true" ]]; then
+        if [[ "${{ steps.check_label.outputs.has_label }}" == "true" || "${{ steps.check_author.outputs.api_author }}" == "true" ]]; then
           COMMAND="rails db:seed"
         else
           COMMAND="rails db:seed:replant"


### PR DESCRIPTION
### Context
Review apps seed during [db:prepare](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/config/terraform/application/variables.tf#L143-L147) and [then again during deploy](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/.github/actions/deploy-environment-to-aks/action.yml#L132), the second `db:seed` now fails due to overlap validations.

### Changes proposed in this pull request
Switch review app seed step to `db:seed:replant` to ensure clean, repeatable seeding.