### PR TITLE
Prevent a lead provider voiding another lead provider's declarations

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -73,7 +73,10 @@ module API
       end
 
       def declaration
-        declarations_query.declaration_by_api_id(api_id)
+        # We don't use the declarations query here as that will also return previous
+        # declarations for other lead providers and we only want to let the lead
+        # provider void on their own declarations.
+        current_lead_provider.declarations.find_by!(api_id:)
       end
 
       def api_id

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -6,6 +6,7 @@ class LeadProvider < ApplicationRecord
   has_many :lead_provider_delivery_partnerships, through: :active_lead_providers
   has_many :school_partnerships, through: :lead_provider_delivery_partnerships
   has_many :training_periods, through: :school_partnerships
+  has_many :declarations, through: :training_periods
   has_many :events
   has_many :api_tokens, class_name: "API::Token"
 

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -20,6 +20,7 @@ describe LeadProvider do
     it { is_expected.to have_many(:lead_provider_delivery_partnerships).through(:active_lead_providers) }
     it { is_expected.to have_many(:school_partnerships).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:training_periods).through(:school_partnerships) }
+    it { is_expected.to have_many(:declarations).through(:training_periods) }
     it { is_expected.to have_many(:api_tokens).class_name("API::Token") }
   end
 


### PR DESCRIPTION
### Context

When testing the void declarations endpoint it was found that a lead provider could void a declaration for another lead provider, due to having access to previous declarations for participants associated with past lead providers.

### Changes proposed in this pull request

- Prevent a LP voiding another LPs declarations

We have a pattern of using the query service to ensure that a lead provider has access to a resource they are attempting to update via the API. This is usually fine, however declarations is a special case, as we return 'previous declarations' in the query that are linked to other lead providers, submitted before training with the current lead provider.

Update the void action to query the declaration directly from the `LeadProvider` associations to ensure its a declaration that was actually submitted by that lead provider.

### Guidance to review

I thought about updating the query service to have a flag so we could opt out of including previous declarations, but I think that would overcomplicate an already fairly complex query service and instead opted to re-query the declaration directly in the controller, which I think is the best approach here.