### PR TITLE
[3040] Fallback induction start/end dates in teacher api serializer

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -79,8 +79,24 @@ class API::TeacherSerializer < Blueprinter::Base
 
         earliest_school_period.created_at.utc.rfc3339
       end
-      field(:induction_end_date) { |(_, teacher, _)| teacher.finished_induction_period&.finished_on&.rfc3339 }
-      field(:overall_induction_start_date) { |(_, teacher, _)| teacher.started_induction_period&.started_on&.rfc3339 }
+      field(:induction_end_date) do |(training_period, teacher, _)|
+        if training_period.for_ect?
+          if teacher.finished_induction_period.present?
+            teacher.finished_induction_period.finished_on.rfc3339
+          else
+            teacher.trs_induction_completed_date&.rfc3339
+          end
+        end
+      end
+      field(:overall_induction_start_date) do |(training_period, teacher, _)|
+        if training_period.for_ect?
+          if teacher.started_induction_period.present?
+            teacher.started_induction_period.started_on.rfc3339
+          else
+            teacher.trs_induction_start_date&.rfc3339
+          end
+        end
+      end
       field(:mentor_funding_end_date) { |(training_period, teacher, _)| teacher.mentor_became_ineligible_for_funding_on&.rfc3339 if training_period.for_mentor? }
       field(:cohort_changed_after_payments_frozen) do |(training_period, teacher, _)|
         if training_period.for_ect?

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -190,19 +190,39 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             end
           end
 
-          context "when there is finished induction period" do
-            let!(:finished_induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
+          describe "`induction_end_date`" do
+            context "when a finished induction period is present" do
+              let!(:finished_induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
 
-            it "serializes `induction_end_date`" do
-              expect(ect_enrolment["induction_end_date"]).to eq(finished_induction_period.finished_on.rfc3339)
+              it "serializes `induction_end_date` from finished induction period" do
+                expect(ect_enrolment["induction_end_date"]).to eq(finished_induction_period.finished_on.rfc3339)
+              end
+            end
+
+            context "when a finished induction period is not present" do
+              before { teacher.update!(trs_induction_completed_date: Date.new(2024, 9, 18)) }
+
+              it "serializes `induction_end_date` from TRS induction completed date" do
+                expect(ect_enrolment["induction_end_date"]).to eq(teacher.trs_induction_completed_date.rfc3339)
+              end
             end
           end
 
-          context "when there is started induction period" do
-            let!(:started_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
+          describe "`overall_induction_start_date`" do
+            context "when a started induction period is present" do
+              let!(:started_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
 
-            it "serializes `overall_induction_start_date`" do
-              expect(ect_enrolment["overall_induction_start_date"]).to eq(started_induction_period.started_on.rfc3339)
+              it "serializes `overall_induction_start_date` from started induction period" do
+                expect(ect_enrolment["overall_induction_start_date"]).to eq(started_induction_period.started_on.rfc3339)
+              end
+            end
+
+            context "when a started induction period is not present" do
+              before { teacher.update!(trs_induction_start_date: Date.new(2024, 9, 18)) }
+
+              it "serializes `overall_induction_start_date` from TRS induction start date" do
+                expect(ect_enrolment["overall_induction_start_date"]).to eq(teacher.trs_induction_start_date.rfc3339)
+              end
             end
           end
 
@@ -289,22 +309,6 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
             it "serializes `eligible_for_funding`" do
               expect(mentor_enrolment["eligible_for_funding"]).to be(false)
-            end
-          end
-
-          context "when there is finished induction period" do
-            let!(:finished_induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
-
-            it "serializes `induction_end_date`" do
-              expect(mentor_enrolment["induction_end_date"]).to eq(finished_induction_period.finished_on.rfc3339)
-            end
-          end
-
-          context "when there is no started induction period" do
-            let!(:started_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
-
-            it "serializes `overall_induction_start_date`" do
-              expect(mentor_enrolment["overall_induction_start_date"]).to eq(started_induction_period.started_on.rfc3339)
             end
           end
 


### PR DESCRIPTION
### Context

Ticket: [3040](https://github.com/DFE-Digital/register-ects-project-board/issues/3040)

In an effort to provide accurate start/end dates for induction periods to lead providers we want to fallback to the values we get from TRS.

### Changes proposed in this pull request

- `induction_end_date` falls back to `teacher.trs_induction_completed_date` if `teacher.finished_induction_period` is `nil`
- `overall_induction_start_date` falls back to `teacher.trs_induction_start_date` if `teacher.started_induction_period` is `nil`
- `overall_induction_start_date` is only returned for ECTs
- `induction_end_date` is only returned for ECTs
 
### Guidance to review

Calls to participants end point on the review app