### PR TITLE
[3039] Switch to using corrected name in API responses

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -94,7 +94,7 @@ class API::TeacherSerializer < Blueprinter::Base
 
     exclude :id
 
-    field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name_in_trs }
+    field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name }
     field(:trn, name: :teacher_reference_number)
     field(:api_updated_at, name: :updated_at)
 

--- a/app/serializers/api/teachers/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/teachers/unfunded_mentor_serializer.rb
@@ -2,7 +2,7 @@ class API::Teachers::UnfundedMentorSerializer < Blueprinter::Base
   class AttributesSerializer < Blueprinter::Base
     exclude :id
 
-    field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name_in_trs }
+    field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name }
     field(:email) do |teacher, _options|
       teacher.latest_mentor_at_school_period.email
     end

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -35,12 +35,29 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
     subject(:attributes) { response["attributes"] }
 
     it "serializes correctly" do
-      expect(attributes["full_name"]).to be_present
-      expect(attributes["full_name"]).to eq(Teachers::Name.new(teacher).full_name_in_trs)
       expect(attributes["updated_at"]).to be_present
       expect(attributes["updated_at"]).to eq(api_updated_at.utc.rfc3339)
       expect(attributes["teacher_reference_number"]).to be_present
       expect(attributes["teacher_reference_number"]).to eq(teacher.trn)
+    end
+
+    describe "`full_name`" do
+      subject(:full_name) { attributes["full_name"] }
+
+      it { is_expected.to be_present }
+      it { is_expected.to eq(Teachers::Name.new(teacher).full_name) }
+
+      context "when teacher has a `corrected_name`" do
+        let(:teacher) { FactoryBot.create(:teacher, :with_corrected_name) }
+
+        it { is_expected.to eq(teacher.corrected_name) }
+      end
+
+      context "when teacher has a `full_name_in_trs`" do
+        let(:teacher) { FactoryBot.create(:teacher, :with_realistic_name) }
+
+        it { is_expected.to eq([teacher.trs_first_name, teacher.trs_last_name].join(" ")) }
+      end
     end
 
     describe "participant_id_changes" do

--- a/spec/serializers/api/teachers/unfunded_mentor_serializer_spec.rb
+++ b/spec/serializers/api/teachers/unfunded_mentor_serializer_spec.rb
@@ -32,8 +32,6 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
     subject(:attributes) { response["attributes"] }
 
     it "serializes correctly" do
-      expect(attributes["full_name"]).to be_present
-      expect(attributes["full_name"]).to eq(Teachers::Name.new(unfunded_mentor_teacher).full_name_in_trs)
       expect(attributes["email"]).to be_present
       expect(attributes["email"]).to eq(unfunded_mentor_teacher.latest_mentor_at_school_period.email)
       expect(attributes["email"]).to eq("test1@test.com")
@@ -43,6 +41,25 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
       expect(attributes["created_at"]).to eq(created_at.utc.rfc3339)
       expect(attributes["updated_at"]).to be_present
       expect(attributes["updated_at"]).to eq(api_unfunded_mentor_updated_at.utc.rfc3339)
+    end
+
+    describe "`full_name`" do
+      subject(:full_name) { attributes["full_name"] }
+
+      it { is_expected.to be_present }
+      it { is_expected.to eq(Teachers::Name.new(unfunded_mentor_teacher).full_name) }
+
+      context "when unfunded mentor teacher has a `corrected_name`" do
+        let(:unfunded_mentor_teacher) { FactoryBot.create(:teacher, :with_corrected_name) }
+
+        it { is_expected.to eq(unfunded_mentor_teacher.corrected_name) }
+      end
+
+      context "when unfunded mentor teacher has a `full_name_in_trs`" do
+        let(:unfunded_mentor_teacher) { FactoryBot.create(:teacher, :with_realistic_name) }
+
+        it { is_expected.to eq([unfunded_mentor_teacher.trs_first_name, unfunded_mentor_teacher.trs_last_name].join(" ")) }
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [3039](https://github.com/DFE-Digital/register-ects-project-board/issues/3039)

We currently use `full_name_in_trs` in all places in the API where we return the teacher's name. We want to instead switch to `full_name` which will prioritise the corrected name.

### Changes proposed in this pull request

- Use `full_name` in teachers serializer;
- Use `full_name` in unfunded mentors serializer;

### Guidance to review

Calls to participants and unfunded mentors end points on the review app