### PR TITLE
Seed API data when refreshing staging

### DIFF
--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -29,7 +29,25 @@ jobs:
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 
-    - name: Reseed Staging
+    - name: Seed API data
       run: |
+        echo "Running API seeds..."
         make ci staging get-cluster-credentials
-        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed:replant"
+        kubectl exec -n cpd-development \
+          deployment/cpd-ec2-staging-web \
+          -- sh -c '
+            cd /app &&
+            DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
+            RAILS_ENV=staging \
+            /usr/local/bin/bundle exec rails db:truncate_all &&
+            DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
+            RAILS_ENV=staging \
+            /usr/local/bin/bundle exec rake api_seed_data:generate
+          '
+
+    - name: Seed default data
+      shell: bash
+      run: |
+        echo "Running default seeds..."
+        make ci staging get-cluster-credentials
+        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed"

--- a/app/services/api_seed_data/base.rb
+++ b/app/services/api_seed_data/base.rb
@@ -17,7 +17,7 @@ module APISeedData
     end
 
     def plantable?
-      %w[development review sandbox].include?(Rails.env)
+      %w[development review sandbox staging].include?(Rails.env)
     end
 
   private

--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -17,7 +17,7 @@ namespace :api_seed_data do
       APISeedData::Declarations,
     ]
 
-    if Rails.env.development? || Rails.env.review?
+    if Rails.env.development? || Rails.env.review? || Rails.env.staging?
       seeds += [
         APISeedData::APITokens,
         APISeedData::ParityChecks,


### PR DESCRIPTION
We currently only seed the normal dev/review seeds; to be able to test API endpoints we also want to include the API seeds in the staging data set.

I ran the workflow and its successful but it won't run fully until the code is in staging as it calls out to staging to run the API seeds (and they won't run without this code change).

Example run: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/20818245955/job/59799407656