### PR TITLE
[3051] Add shared spec to ensure we ignore extra parameters sent to POST/PUT api endpoints

### DIFF
--- a/spec/support/shared_contexts/api/create_endpoint.rb
+++ b/spec/support/shared_contexts/api/create_endpoint.rb
@@ -36,4 +36,14 @@ RSpec.shared_examples "an API create endpoint" do
     expect(response.content_type).to eql("application/json; charset=utf-8")
     expect(response.body).to eq({ errors: [{ title: "Bad request", detail: "Correct json data structure required. See API docs for reference." }] }.to_json)
   end
+
+  context "when extra params are sent" do
+    it "calls the service with the correct arguments" do
+      allow(service).to receive(:new).and_call_original
+
+      authenticated_api_post(path, params: params.deep_merge(data: { attributes: { any_param1: "test", any_param2: "test" } }))
+
+      expect(service).to have_received(:new).with(service_args)
+    end
+  end
 end

--- a/spec/support/shared_contexts/api/update_endpoint.rb
+++ b/spec/support/shared_contexts/api/update_endpoint.rb
@@ -50,4 +50,14 @@ RSpec.shared_examples "an API update endpoint" do |example_options|
       expect(response.body).to eq({ errors: [{ title: "Resource not found", detail: "Nothing could be found for the provided details" }] }.to_json)
     end
   end
+
+  context "when extra params are sent" do
+    it "calls the service with the correct arguments" do
+      allow(service).to receive(:new).and_call_original
+
+      authenticated_api_put(path, params: params.deep_merge(data: { attributes: { any_param1: "test", any_param2: "test" } }))
+
+      expect(service).to have_received(:new).with(service_args)
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [3051](https://github.com/DFE-Digital/register-ects-project-board/issues/3051)

In ECF some providers send extra data with their API requests to POST/PUT endpoints and we ignore it. We should ensure we will also ignore extra fields in the RECT API.

### Changes proposed in this pull request

- Improve test coverage to make sure we're ignoring extra parameters sent to POST/PUT api endpoints; 

### Guidance to review
