### PR TITLE
[3054] Increase sandbox database tier

### DIFF
--- a/config/terraform/application/config/sandbox.tfvars.json
+++ b/config/terraform/application/config/sandbox.tfvars.json
@@ -9,5 +9,6 @@
     "webapp_replicas": 2,
     "worker_replicas": 2,
     "worker_memory_max": "2Gi",
-    "webapp_memory_max": "2Gi"
+    "webapp_memory_max": "2Gi",
+    "postgres_flexible_server_sku": "GP_Standard_D2ds_v4"
 }


### PR DESCRIPTION
### Context

Ticket: [3054](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3054)

We had a load of status cake notifications for sandbox having issues over the Christmas break.

### Changes proposed in this pull request

- [ ] Get an idea from infra team how long the DB update is likely to take/how much downtime there will be
- [ ] Raise a PR for updating the DB tier from `Standard_B1ms` to `Standard_D2ds_v4`
- [ ] Wait for the go-ahead before executing the update


### Guidance to review
