### PR TITLE
[3083] Prevent duplicate declarations from being created

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -65,7 +65,13 @@ class Declaration < ApplicationRecord
   delegate :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
 
   # Validations
-  validates :training_period, presence: { message: "Choose a training period" }
+  validates :training_period,
+            presence: { message: "Choose a training period" },
+            uniqueness: {
+              scope: %i[declaration_type payment_status],
+              conditions: -> { billable_or_changeable },
+              message: "A billable declaration with the same type already exists for this training period"
+            }
   validates :voided_by_user, presence: { message: "Voided by user must be set as well as the voided date" }, if: :voided_by_user_at
   validates :voided_by_user_at, presence: { message: "Voided by user at must be set as well as the voided by user" }, if: :voided_by_user
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another declaration" }

--- a/app/services/api_seed_data/declarations.rb
+++ b/app/services/api_seed_data/declarations.rb
@@ -42,6 +42,12 @@ module APISeedData
 
       training_period = training_periods.sample
 
+      existing_declarations = if training_period.for_ect?
+                                teacher.ect_declarations
+                              else
+                                teacher.mentor_declarations
+                              end
+
       declaration_types(training_period, active_lead_provider).each do |declaration_type|
         schedule = training_period.schedule
         declaration_date = declaration_date(schedule, declaration_type)
@@ -77,7 +83,7 @@ module APISeedData
           **uplifts(training_period:)
         )
 
-        next if declaration.duplicate_declaration_exists?
+        next if existing_declarations.billable_or_changeable.where(declaration_type:).exists?
 
         declaration.save!
         log_declaration_info(declaration)

--- a/db/migrate/20260113150052_add_unique_index_to_declarations.rb
+++ b/db/migrate/20260113150052_add_unique_index_to_declarations.rb
@@ -6,6 +6,7 @@ class AddUniqueIndexToDeclarations < ActiveRecord::Migration[8.0]
               %i[training_period_id declaration_type payment_status],
               where: "(payment_status IN ('no_payment','eligible','payable','paid') AND clawback_status = 'no_clawback')",
               unique: true,
+              name: "idx_unique_declarations",
               algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -185,7 +185,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_150052) do
     t.index ["clawback_statement_id"], name: "index_declarations_on_clawback_statement_id"
     t.index ["mentorship_period_id"], name: "index_declarations_on_mentorship_period_id"
     t.index ["payment_statement_id"], name: "index_declarations_on_payment_statement_id"
-    t.index ["training_period_id", "declaration_type", "payment_status"], name: "idx_on_training_period_id_declaration_type_payment__56d5a31273", unique: true, where: "((payment_status = ANY (ARRAY['no_payment'::declaration_payment_statuses, 'eligible'::declaration_payment_statuses, 'payable'::declaration_payment_statuses, 'paid'::declaration_payment_statuses])) AND (clawback_status = 'no_clawback'::declaration_clawback_statuses))"
+    t.index ["training_period_id", "declaration_type", "payment_status"], name: "idx_unique_declarations", unique: true, where: "((payment_status = ANY (ARRAY['no_payment'::declaration_payment_statuses, 'eligible'::declaration_payment_statuses, 'payable'::declaration_payment_statuses, 'paid'::declaration_payment_statuses])) AND (clawback_status = 'no_clawback'::declaration_clawback_statuses))"
     t.index ["training_period_id"], name: "index_declarations_on_training_period_id"
     t.index ["voided_by_user_id"], name: "index_declarations_on_voided_by_user_id"
   end

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -134,6 +134,29 @@ RSpec.describe Declarations::Create do
             )
           )
         end
+
+        context "when a duplicate declaration exists" do
+          let!(:existing_declaration) { service.create }
+
+          it "returns the existing declaration with correct attributes" do
+            declaration = nil
+            expect { declaration = create_declaration }.not_to change(Declaration, :count)
+
+            expect(declaration).to eq(existing_declaration)
+            expect(declaration.payment_statement).to be_nil
+            if trainee_type == :ect
+              expect(declaration.mentorship_period).to eq(mentorship_period)
+            end
+            expect(declaration.evidence_type).to eq(evidence_type)
+            expect(declaration).not_to be_payment_status_eligible
+          end
+
+          it "acquires a lock on the run" do
+            expect(Declaration).to receive(:with_advisory_lock).with("lock_#{training_period.id}_#{declaration_type}").and_call_original
+
+            create_declaration
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [3083](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3083)

In RECT we want to solve duplicated declarations issue using database indexes to prevent these duplicates from being created. When we detect a duplicate would be created we instead want to return the existing declaration.

### Changes proposed in this pull request

- Should we drop the duplicate model validation `declaration_does_not_already_exist`? @ethax-ross 
- Add unique index to declarations (billable declarations of the same type);
- Instead of creating a duplicate we return the existing declaration again;

### Guidance to review

Review app, but it requires multiple quick api calls to POST /declarations using same params to bypass the model validation.
