### PR TITLE
Rename "trainee" to "at_school_period" on TrainingPeriod

### DIFF
--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -149,7 +149,7 @@ module Admin
       end
 
       def move_partnership_path
-        teacher_id = training_period.trainee&.teacher_id
+        teacher_id = training_period.teacher_id
         return if teacher_id.blank?
 
         new_admin_teacher_training_period_partnership_path(teacher_id, training_period)

--- a/app/controllers/admin/teachers/training_partnerships_controller.rb
+++ b/app/controllers/admin/teachers/training_partnerships_controller.rb
@@ -38,12 +38,12 @@ module Admin
       def set_training_period
         @training_period = TrainingPeriod.find(params[:training_period_id])
 
-        raise ActiveRecord::RecordNotFound unless @training_period.trainee.teacher_id == @teacher.id
+        raise ActiveRecord::RecordNotFound unless @training_period.teacher_id == @teacher.id
         raise ActionController::BadRequest, "Training period is not eligible for partnership change" unless @training_period.partnership_change_eligible?
       end
 
       def set_school
-        @school = @training_period.trainee.school
+        @school = @training_period.school
       end
 
       def set_available_partnerships

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -169,7 +169,7 @@ class Declaration < ApplicationRecord
   def voidable_payment? = payment_status.in?(VOIDABLE_PAYMENT_STATUSES)
 
   def teacher
-    training_period&.trainee&.teacher
+    training_period&.teacher
   end
 
   def duplicate_declaration_exists?
@@ -201,7 +201,7 @@ private
   def mentorship_period_belongs_to_teacher
     return unless mentorship_period && training_period
 
-    unless mentorship_period.in?(training_period.trainee.mentorship_periods)
+    unless mentorship_period.in?(training_period.mentorship_periods)
       errors.add(:mentorship_period, "Mentorship period must belong to the trainee")
     end
   end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -45,7 +45,7 @@ class TrainingPeriod < ApplicationRecord
   has_many :events
 
   touch -> { self }, when_changing: %i[started_on finished_on], timestamp_attribute: :api_transfer_updated_at
-  touch -> { trainee&.teacher },
+  touch -> { teacher },
         on_event: %i[create destroy update],
         timestamp_attribute: :api_updated_at,
         when_changing: %i[
@@ -62,13 +62,13 @@ class TrainingPeriod < ApplicationRecord
         ]
 
   refresh_metadata -> { school_partnership&.school }, on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id]
-  refresh_metadata -> { trainee&.teacher }, on_event: %i[create destroy update], when_changing: %i[started_on finished_on withdrawn_at deferred_at school_partnership_id]
+  refresh_metadata -> { teacher }, on_event: %i[create destroy update], when_changing: %i[started_on finished_on withdrawn_at deferred_at school_partnership_id]
 
   # Validations
   validates :started_on,
             presence: true
 
-  validate :one_id_of_trainee_present
+  validate :only_one_at_school_period_present
   validate :at_least_expression_of_interest_or_school_partnership_present, if: :provider_led_training_programme?
   validate :expression_of_interest_absent_for_school_led, if: :school_led_training_programme?
   validate :school_partnership_absent_for_school_led, if: :school_led_training_programme?
@@ -105,6 +105,8 @@ class TrainingPeriod < ApplicationRecord
   # Delegations
   delegate :name, to: :delivery_partner, prefix: true, allow_nil: true
   delegate :name, to: :lead_provider, prefix: true, allow_nil: true
+  delegate :teacher, :teacher_id, :school, :school_id, :mentorship_periods, :email, to: :at_school_period, allow_nil: true
+  delegate :started_on, :finished_on, to: :at_school_period, prefix: true, allow_nil: true
 
   def for_ect?
     ect_at_school_period_id.present?
@@ -122,14 +124,14 @@ class TrainingPeriod < ApplicationRecord
     provider_led_training_programme? && finished_on.blank?
   end
 
-  def trainee
+  def at_school_period
     ect_at_school_period || mentor_at_school_period
   end
 
   def siblings
-    return TrainingPeriod.none unless trainee
+    return TrainingPeriod.none unless at_school_period
 
-    trainee.training_periods.excluding(self)
+    at_school_period.training_periods.excluding(self)
   end
 
   def only_expression_of_interest?
@@ -152,26 +154,27 @@ class TrainingPeriod < ApplicationRecord
 
   def teacher_completed_training?
     if for_ect?
-      trainee.teacher.finished_induction_period&.complete?
+      teacher.finished_induction_period&.complete?
     else
-      trainee.teacher.mentor_became_ineligible_for_funding_on.present?
+      teacher.mentor_became_ineligible_for_funding_on.present?
     end
   end
 
   def eligible_for_funding?
     if for_ect?
-      trainee.teacher.ect_first_became_eligible_for_training_at.present?
+      teacher.ect_first_became_eligible_for_training_at.present?
     else
-      trainee.teacher.mentor_first_became_eligible_for_training_at.present?
+      teacher.mentor_first_became_eligible_for_training_at.present?
     end
   end
 
 private
 
-  def one_id_of_trainee_present
+  def only_one_at_school_period_present
     ids = [ect_at_school_period_id, mentor_at_school_period_id]
-    errors.add(:base, "Id of trainee missing") if ids.none?
-    errors.add(:base, "Only one id of trainee required. Two given") if ids.all?
+
+    errors.add(:base, "Either an ECT at school period or mentor at school period is required") if ids.none?
+    errors.add(:base, "Can belong to either an ECT at school period or a mentor at school period, not both") if ids.all?
   end
 
   def trainee_distinct_period
@@ -180,17 +183,9 @@ private
 
   def enveloped_by_trainee_at_school_period
     return if finished_on.blank?
-    return if (trainee_started_on_at_school..trainee_finished_on_at_school).cover?(started_on..finished_on)
+    return if (at_school_period_started_on..at_school_period_finished_on).cover?(started_on..finished_on)
 
     errors.add(:base, "Date range is not contained by the period the trainee is at the school")
-  end
-
-  def trainee_started_on_at_school
-    ect_at_school_period&.started_on || mentor_at_school_period&.started_on
-  end
-
-  def trainee_finished_on_at_school
-    ect_at_school_period&.finished_on || mentor_at_school_period&.finished_on
   end
 
   def at_least_expression_of_interest_or_school_partnership_present
@@ -240,11 +235,11 @@ private
   end
 
   def school_consistency
-    return if trainee.blank?
+    return if at_school_period.blank?
     return if school_partnership.blank?
-    return if school_partnership.school == trainee.school
+    return if school_partnership.school == school
 
-    extra = { teacher_id: trainee.teacher.id, school_partnership_id: school_partnership.id, trainee_school_id: trainee.school_id }
+    extra = { teacher_id:, school_partnership_id: school_partnership.id, trainee_school_id: school_id }
     Sentry.capture_message("[Data integrity] Attempt to assign school partnership to a different school from the school period", level: :error, extra:)
     errors.add(:school_partnership, "School partnership's school must match the trainee's school")
   end

--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -2,7 +2,7 @@ class API::DeclarationSerializer < Blueprinter::Base
   class AttributesSerializer < Blueprinter::Base
     exclude :id
 
-    field(:participant_id) { |declaration| declaration.training_period.trainee.teacher.api_id }
+    field(:participant_id) { |declaration| declaration.training_period.teacher.api_id }
     field(:declaration_type)
     field(:declaration_date) { |declaration| declaration.declaration_date.rfc3339 }
 

--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -14,7 +14,7 @@ class API::TeacherSerializer < Blueprinter::Base
           teacher.api_mentor_training_record_id
         end
       end
-      field(:email) { |(training_period, _, _)| training_period.trainee.email }
+      field(:email) { |(training_period, _, _)| training_period.email }
       field(:mentor_id) do |(training_period, _, metadata)|
         metadata.api_mentor_id if training_period.for_ect?
       end

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -88,7 +88,7 @@ module API::Declarations
     def mentorship_period
       return unless training_period.for_ect?
 
-      @mentorship_period ||= training_period.trainee.mentorship_periods.closest_to(declaration_date).first
+      @mentorship_period ||= training_period.mentorship_periods.closest_to(declaration_date).first
     end
 
     def delivery_partner

--- a/app/services/api/teachers/resume.rb
+++ b/app/services/api/teachers/resume.rb
@@ -28,7 +28,7 @@ module API::Teachers
     def no_ongoing_today_training_period
       return if errors[:teacher_api_id].any?
 
-      school_period = training_period.trainee
+      school_period = training_period.at_school_period
 
       if school_period.training_periods
         .ongoing_today
@@ -41,7 +41,7 @@ module API::Teachers
     def school_period_ongoing_today
       return if errors[:teacher_api_id].any?
 
-      school_period = training_period.trainee
+      school_period = training_period.at_school_period
       errors.add(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") unless school_period.ongoing_today?
     end
   end

--- a/app/services/api_seed_data/declarations.rb
+++ b/app/services/api_seed_data/declarations.rb
@@ -37,7 +37,7 @@ module APISeedData
     end
 
     def create_declarations!(active_lead_provider, training_periods)
-      teacher = training_periods.first.trainee.teacher
+      teacher = training_periods.first.teacher
       log_seed_info(::Teachers::Name.new(teacher).full_name, indent: 4)
 
       training_period = training_periods.sample
@@ -61,7 +61,7 @@ module APISeedData
         end
 
         ineligibility_reason = Declaration.ineligibility_reasons.keys.sample if payment_status == "ineligible"
-        mentorship_period = training_period.trainee.mentorship_periods.sample if training_period.for_ect?
+        mentorship_period = training_period.mentorship_periods.sample if training_period.for_ect?
 
         declaration = FactoryBot.build(
           :declaration,

--- a/app/services/declarations/clawback.rb
+++ b/app/services/declarations/clawback.rb
@@ -38,7 +38,7 @@ module Declarations
     def record_clawback_event!
       Events::Record.record_teacher_declaration_clawed_back!(
         author:,
-        teacher: declaration.training_period.trainee.teacher,
+        teacher: declaration.training_period.teacher,
         training_period: declaration.training_period,
         declaration:
       )

--- a/app/services/declarations/mentor_completion.rb
+++ b/app/services/declarations/mentor_completion.rb
@@ -26,8 +26,7 @@ module Declarations
   private
 
     delegate :training_period, to: :declaration
-    delegate :trainee, to: :training_period
-    delegate :teacher, to: :trainee
+    delegate :teacher, to: :training_period
 
     def mentor_completion_event?
       training_period.for_mentor? && declaration.declaration_type_completed?

--- a/app/services/declarations/void.rb
+++ b/app/services/declarations/void.rb
@@ -32,7 +32,7 @@ module Declarations
     def record_void_event!
       Events::Record.record_teacher_declaration_voided!(
         author:,
-        teacher: declaration.training_period.trainee.teacher,
+        teacher: declaration.training_period.teacher,
         training_period: declaration.training_period,
         declaration:
       )

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -27,7 +27,7 @@ module Metadata::Handlers
         latest_mentor_training_period = latest_mentor_training_period_by_lead_provider(teacher:)[lead_provider_id]
         latest_ect_contract_period = latest_ect_training_period&.contract_period
         latest_mentor_contract_period = latest_mentor_training_period&.contract_period
-        api_mentor_id = latest_ect_training_period&.trainee&.latest_mentorship_period&.mentor&.teacher&.api_id
+        api_mentor_id = latest_ect_training_period&.at_school_period&.latest_mentorship_period&.mentor&.teacher&.api_id
         involved_in_school_transfer = school_transfers_exist_for(teacher.ect_at_school_periods, lead_provider_id) ||
           school_transfers_exist_for(teacher.mentor_at_school_periods, lead_provider_id)
 

--- a/app/services/teachers/change_schedule.rb
+++ b/app/services/teachers/change_schedule.rb
@@ -56,7 +56,7 @@ module Teachers
     def determine_finished_on
       [
         training_period.finished_on,
-        training_period.trainee.finished_on
+        training_period.at_school_period_finished_on
       ].compact.reject(&:past?).min
     end
 
@@ -67,14 +67,14 @@ module Teachers
         TrainingPeriods::Finish.ect_training(
           author:,
           training_period:,
-          ect_at_school_period: training_period.trainee,
+          ect_at_school_period: training_period.at_school_period,
           finished_on:
         ).finish!
       elsif training_period.for_mentor?
         TrainingPeriods::Finish.mentor_training(
           author:,
           training_period:,
-          mentor_at_school_period: training_period.trainee,
+          mentor_at_school_period: training_period.at_school_period,
           finished_on:
         ).finish!
       end
@@ -82,7 +82,7 @@ module Teachers
 
     def create_new_training_period_with!(finished_on:)
       TrainingPeriods::Create.provider_led(
-        period: training_period.trainee,
+        period: training_period.at_school_period,
         started_on: Time.zone.today,
         finished_on:,
         school_partnership:,

--- a/app/services/teachers/resume.rb
+++ b/app/services/teachers/resume.rb
@@ -12,9 +12,9 @@ module Teachers
     def resume
       ActiveRecord::Base.transaction do
         new_training_period = TrainingPeriods::Create.provider_led(
-          period: training_period.trainee,
+          period: training_period.at_school_period,
           started_on: Time.zone.today,
-          finished_on: training_period.trainee.finished_on,
+          finished_on: training_period.at_school_period_finished_on,
           school_partnership: training_period.school_partnership,
           expression_of_interest: nil,
           schedule: training_period.schedule,

--- a/app/services/training_periods/change_partnership.rb
+++ b/app/services/training_periods/change_partnership.rb
@@ -57,7 +57,7 @@ module TrainingPeriods
 
     def create_replacement_training_period!
       TrainingPeriods::Create.provider_led(
-        period: training_period.trainee,
+        period: training_period.at_school_period,
         started_on: Date.current,
         school_partnership:,
         expression_of_interest: nil,
@@ -72,7 +72,7 @@ module TrainingPeriods
         training_period: period,
         ect_at_school_period: period.ect_at_school_period,
         mentor_at_school_period: period.mentor_at_school_period,
-        teacher: period.trainee.teacher,
+        teacher: period.teacher,
         school_partnership:,
         lead_provider: school_partnership.lead_provider,
         delivery_partner: school_partnership.delivery_partner,

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Participants for different lead providers should not be used.
@@ -163,7 +163,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
       let(:from_teacher) { FactoryBot.create(:teacher) }
 
       before do
@@ -171,9 +171,9 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         FactoryBot.create(:teacher_id_change, teacher:, api_from_teacher_id: from_teacher.api_id)
 
         # Participants with teacher_id_change for different lead providers should not be used.
-        unused_teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher
+        unused_teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).teacher
         FactoryBot.create(:teacher_id_change, teacher: unused_teacher1)
-        unused_teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher
+        unused_teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher
         FactoryBot.create(:teacher_id_change, teacher: unused_teacher2)
       end
 
@@ -185,7 +185,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :active, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Deferred participant for current lead provider
@@ -204,7 +204,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -223,7 +223,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -344,7 +344,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -377,7 +377,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -410,7 +410,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :active, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Deferred participant for current lead provider
@@ -441,7 +441,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :deferred, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -472,7 +472,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :withdrawn, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -505,7 +505,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :deferred, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Active participant for current lead provider
@@ -538,7 +538,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       before do
         # Deferred participant for current lead provider
@@ -607,7 +607,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
         let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
         let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-        let(:teacher) { training_period.trainee.teacher }
+        let(:teacher) { training_period.teacher }
 
         let(:change_to_year) { active_lead_provider.contract_period_year + 1 }
         let(:change_to_contract_period) { FactoryBot.create(:contract_period, year: change_to_year) }
@@ -653,7 +653,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
         let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
         let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-        let(:teacher) { training_period.trainee.teacher }
+        let(:teacher) { training_period.teacher }
 
         let(:change_to_year) { active_lead_provider.contract_period_year + 1 }
         let(:change_to_contract_period) { FactoryBot.create(:contract_period, year: change_to_year) }
@@ -688,7 +688,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
         let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
         let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-        let(:teacher) { training_period.trainee.teacher }
+        let(:teacher) { training_period.teacher }
 
         before do
           allow(Schedule).to receive(:identifiers).and_return({ "ecf-extended-january" => "ecf-extended-january", "ecf-replacement-september" => "ecf-replacement-september" })
@@ -718,7 +718,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
         let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
         let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
         let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-        let(:teacher) { training_period.trainee.teacher }
+        let(:teacher) { training_period.teacher }
 
         it "returns a participant change schedule body with wrong course identifier" do
           expect(Teacher)
@@ -799,7 +799,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
       let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
       let(:school_partnership) { FactoryBot.create(:school_partnership, active_lead_provider:) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:) }
-      let(:teacher) { training_period.trainee.teacher }
+      let(:teacher) { training_period.teacher }
 
       context "when fetching `pre2025_declaration_create_body`" do
         let(:identifier) { :pre2025_declaration_create_body }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -195,7 +195,7 @@ describe Declaration do
       end
 
       context "when the mentorship_period does belong to the trainee" do
-        let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: training_period.trainee, finished_on: nil) }
+        let(:mentorship_period) { FactoryBot.create(:mentorship_period, mentor:, mentee: training_period.at_school_period, finished_on: nil) }
 
         it { is_expected.to be_valid }
       end
@@ -530,7 +530,7 @@ describe Declaration do
 
     let(:declaration) { FactoryBot.create(:declaration) }
 
-    it { is_expected.to eq(declaration.training_period.trainee.teacher) }
+    it { is_expected.to eq(declaration.training_period.teacher) }
 
     context "when training_period is nil" do
       before { declaration.training_period = nil }
@@ -574,7 +574,7 @@ describe Declaration do
       context "when an existing, billable/changeable declaration of the same type exists for the other teacher type" do
         before { FactoryBot.create(:declaration, :eligible, training_period: other_type_training_period, declaration_type: :started) }
 
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: training_period.trainee.teacher, started_on: 1.month.ago, finished_on: nil) }
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: training_period.teacher, started_on: 1.month.ago, finished_on: nil) }
         let(:other_type_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 1.month.ago) }
 
         it { is_expected.not_to be_duplicate_declaration_exists }

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -9,7 +9,7 @@ describe TrainingPeriod do
       when :school_partnership_id
         active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: instance.schedule.contract_period)
         lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
-        school = instance.trainee.school
+        school = instance.school
         FactoryBot.create(:school_partnership, id: new_value, school:, lead_provider_delivery_partnership:)
       when :expression_of_interest_id
         FactoryBot.create(:active_lead_provider, contract_period: instance.schedule.contract_period, id: new_value)
@@ -53,21 +53,21 @@ describe TrainingPeriod do
     let(:instance) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
 
     context "target teacher" do
-      let(:target) { instance.trainee.teacher }
+      let(:target) { instance.teacher }
 
       def will_change_attribute(attribute_to_change:, new_value:)
         case attribute_to_change
         when :school_partnership_id
           active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: instance.schedule.contract_period)
           lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
-          school = instance.trainee.school
+          school = instance.school
           FactoryBot.create(:school_partnership, id: new_value, lead_provider_delivery_partnership:, school:)
         when :schedule_id
           FactoryBot.create(:schedule, id: new_value)
         when :ect_at_school_period_id
-          FactoryBot.create(:ect_at_school_period, id: new_value, teacher: instance.trainee.teacher)
+          FactoryBot.create(:ect_at_school_period, id: new_value, teacher: instance.teacher)
         when :mentor_at_school_period_id
-          FactoryBot.create(:mentor_at_school_period, id: new_value, teacher: instance.trainee.teacher)
+          FactoryBot.create(:mentor_at_school_period, id: new_value, teacher: instance.teacher)
         end
       end
 
@@ -185,7 +185,7 @@ describe TrainingPeriod do
 
         it "add an error" do
           subject.valid?
-          expect(subject.errors.messages[:base]).to include("Id of trainee missing")
+          expect(subject.errors.messages[:base]).to include("Either an ECT at school period or mentor at school period is required")
         end
       end
 
@@ -194,9 +194,11 @@ describe TrainingPeriod do
           FactoryBot.build(:training_period, ect_at_school_period_id: 200, mentor_at_school_period_id: 300)
         end
 
-        it "add an error" do
+        it "adds an error" do
           subject.valid?
-          expect(subject.errors.messages).to include(base: ["Only one id of trainee required. Two given"])
+          expect(subject.errors.messages).to include(base: [
+            "Can belong to either an ECT at school period or a mentor at school period, not both"
+          ])
         end
       end
     end
@@ -619,9 +621,9 @@ describe TrainingPeriod do
             "[Data integrity] Attempt to assign school partnership to a different school from the school period",
             level: :error,
             extra: {
-              teacher_id: training_period.trainee.teacher.id,
+              teacher_id: training_period.teacher_id,
               school_partnership_id: school_partnership.id,
-              trainee_school_id: training_period.trainee.school_id
+              trainee_school_id: training_period.school_id
             }
           )
           training_period.valid?
@@ -942,7 +944,7 @@ describe TrainingPeriod do
   describe "#teacher_completed_training?" do
     subject { training_period.teacher_completed_training? }
 
-    let(:teacher) { training_period.trainee.teacher }
+    let(:teacher) { training_period.teacher }
 
     context "when ECT" do
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect) }
@@ -986,7 +988,7 @@ describe TrainingPeriod do
   describe "#eligible_for_funding?" do
     subject { training_period.eligible_for_funding? }
 
-    let(:teacher) { training_period.trainee.teacher }
+    let(:teacher) { training_period.teacher }
 
     context "when ECT" do
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect) }

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
                   } do
     let(:schedule) { training_period.schedule }
     let(:milestone) { FactoryBot.create(:milestone, declaration_type: :started, schedule:) }
-    let(:teacher) { training_period.trainee.teacher }
+    let(:teacher) { training_period.teacher }
 
     let(:params) do
       {

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -6,7 +6,7 @@ describe API::DeclarationSerializer, type: :serializer do
   end
 
   let(:declaration) { FactoryBot.create(:declaration) }
-  let(:teacher) { declaration.training_period.trainee.teacher }
+  let(:teacher) { declaration.training_period.teacher }
   let(:delivery_partner) { declaration.training_period.delivery_partner }
   let(:lead_provider) { declaration.training_period.lead_provider }
   let(:payment_statement) { declaration.payment_statement }

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe API::Declarations::Create, type: :model do
 
   let(:lead_provider) { training_period.lead_provider }
   let(:lead_provider_id) { lead_provider.id }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
   let(:teacher_api_id) { teacher.api_id }
   let(:school_partnership) { training_period.school_partnership }
   let(:contract_period) { training_period.contract_period }

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
     if following_on_from_training_period
       previous_finished_on = following_on_from_training_period.started_on + rand(10..100).days
       following_on_from_training_period.update!(finished_on: previous_finished_on)
-      school_period = following_on_from_training_period.trainee
+      school_period = following_on_from_training_period.at_school_period
 
       FactoryBot.create(:training_period, trait, :ongoing, school_partnership:, started_on: previous_finished_on, "#{trainee}_at_school_period": school_period)
     else
@@ -182,7 +182,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
 
           context "when teacher has previous ECT declarations, however the lead provider is only associated with their mentor training" do
             # ECT teacher for `training_period1` will be a mentor with a new lead provider `lead_provider4`
-            let(:teacher) { training_period1.trainee.teacher }
+            let(:teacher) { training_period1.teacher }
             let(:mentor_training_period) { create_training_period(contract_period:, trainee: :mentor, teacher:) }
             let(:lead_provider4) { mentor_training_period.lead_provider }
             let!(:mentor_declaration) { create_declaration(training_period: mentor_training_period, declaration_type: "started") }

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
   end
 
   let(:lead_provider) { training_period.lead_provider }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
   let(:school_partnership) { training_period.school_partnership }
   let(:contract_period) { training_period.contract_period }
   let(:contract_period_year) { contract_period.year }

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     describe "filtering" do
       describe "by `lead_provider`" do
         let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
-        let!(:teacher1) { training_period.trainee.teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+        let!(:teacher1) { training_period.teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
 
         context "when `lead_provider` param is omitted" do
           it "returns all teachers" do
@@ -125,9 +125,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
         let(:school_partnership1) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period1)) }
         let(:school_partnership2) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period2)) }
         let(:school_partnership3) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period3)) }
-        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership1).trainee.teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, school_partnership: school_partnership2).trainee.teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership3).trainee.teacher }
+        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership1).teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, school_partnership: school_partnership2).teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership3).teacher }
 
         context "when `contract_period_years` param is omitted" do
           it "returns all teachers" do
@@ -175,9 +175,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `api_from_teacher_id`" do
-        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
-        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher }
-        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
+        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
+        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher }
+        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
         let!(:teacher_id_change1) { FactoryBot.create(:teacher_id_change, teacher: teacher1, api_from_teacher_id: teacher2.api_id) }
         let!(:teacher_id_change2) { FactoryBot.create(:teacher_id_change, teacher: teacher2, api_from_teacher_id: teacher3.api_id) }
         let!(:teacher_id_change3) { FactoryBot.create(:teacher_id_change, teacher: teacher3, api_from_teacher_id: teacher1.api_id) }
@@ -210,9 +210,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
 
       describe "by `training_status`" do
         let(:school_partnership) { FactoryBot.create(:school_partnership) }
-        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:).trainee.teacher }
-        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:).trainee.teacher }
-        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:).trainee.teacher }
+        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:).teacher }
+        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:).teacher }
+        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:).teacher }
 
         context "when `training_status` param is omitted" do
           it "returns all teachers" do
@@ -307,8 +307,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     describe "ordering" do
-      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher }
-      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher } }
+      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
+      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher } }
 
       describe "default order" do
         it "returns teachers ordered by created_at, in ascending order" do
@@ -357,8 +357,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     it "raises an error if the teacher is not in the filtered query" do
-      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher
-      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher
       lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
 
       query = described_class.new(lead_provider_id:)
@@ -386,8 +386,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     it "raises an error if the teacher is not in the filtered query" do
-      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).trainee.teacher
-      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).trainee.teacher
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher
       lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
 
       query = described_class.new(lead_provider_id:)

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe API::TrainingPeriods::TeacherStatus do
   let(:service) { described_class.new(latest_training_period: training_period, teacher:) }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
 
   describe "#status" do
     subject { service.status }

--- a/spec/services/declarations/clawback_spec.rb
+++ b/spec/services/declarations/clawback_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Declarations::Clawback do
         .to receive(:record_teacher_declaration_clawed_back!)
         .with(
           author:,
-          teacher: declaration.training_period.trainee.teacher,
+          teacher: declaration.training_period.teacher,
           training_period: declaration.training_period,
           declaration:
         )

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Declarations::Create do
   let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
   let(:lead_provider) { training_period.lead_provider }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
   let(:declaration_type) { "started" }
   let(:evidence_type) { "training-event-attended" }
   let(:schedule) { training_period.schedule }

--- a/spec/services/declarations/void_spec.rb
+++ b/spec/services/declarations/void_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Declarations::Void do
         .to receive(:record_teacher_declaration_voided!)
         .with(
           author:,
-          teacher: declaration.training_period.trainee.teacher,
+          teacher: declaration.training_period.teacher,
           training_period: declaration.training_period,
           declaration:
         )

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1108,7 +1108,7 @@ RSpec.describe Events::Record do
   end
 
   describe ".record_teacher_training_period_withdrawn_event" do
-    let(:teacher) { training_period.trainee.teacher }
+    let(:teacher) { training_period.teacher }
     let(:lead_provider) { training_period.lead_provider }
     let(:reason) { "left_teaching_profession" }
     let(:teacher_name) { Teachers::Name.new(teacher).full_name }

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Teachers::ChangeSchedule do
   let(:lead_provider) { training_period.lead_provider }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: new_contract_period) }
   let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
   let(:new_contract_period) { FactoryBot.create(:contract_period) }
@@ -38,7 +38,7 @@ RSpec.describe Teachers::ChangeSchedule do
           expect(training_period.school_partnership).not_to eq(new_training_period.school_partnership)
           expect(training_period.contract_period.year).not_to eq(new_training_period.contract_period.year)
 
-          expect(new_training_period.trainee).to eq(at_school_period)
+          expect(new_training_period.at_school_period).to eq(at_school_period)
           expect(new_training_period.started_on).to eq(Time.zone.today)
           expect(new_training_period.finished_on).to be_nil
           expect(new_training_period.schedule).to eq(new_schedule)
@@ -138,7 +138,7 @@ RSpec.describe Teachers::ChangeSchedule do
           it "updates the existing training period with the new schedule/partnership/contract period" do
             expect { service.change_schedule }.not_to change(TrainingPeriod, :count)
 
-            expect(training_period.trainee).to eq(at_school_period)
+            expect(training_period.at_school_period).to eq(at_school_period)
             expect(training_period.started_on).to eq(school_period_started_on)
             expect(training_period.finished_on).to be_nil
             expect(training_period.schedule).to eq(new_schedule)

--- a/spec/services/teachers/defer_spec.rb
+++ b/spec/services/teachers/defer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Teachers::Defer do
   let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
   let(:lead_provider) { training_period.lead_provider }
   let(:reason) { TrainingPeriod.deferral_reasons.values.map(&:dasherize).freeze.sample }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
 
   let(:service) do
     described_class.new(

--- a/spec/services/teachers/resume_spec.rb
+++ b/spec/services/teachers/resume_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Teachers::Resume do
   let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
   let(:lead_provider) { training_period.lead_provider }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
 
   let(:service) do
     described_class.new(
@@ -55,9 +55,9 @@ RSpec.describe Teachers::Resume do
             created_training_period = TrainingPeriod.last
             expect(created_training_period).to be_ongoing
             expect(created_training_period.deferred_at).to be_nil
-            expect(created_training_period.trainee).to eq(training_period.trainee)
+            expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
-            expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
+            expect(created_training_period.finished_on).to eq(training_period.at_school_period_finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
@@ -77,9 +77,9 @@ RSpec.describe Teachers::Resume do
             created_training_period = TrainingPeriod.last
             expect(created_training_period.finished_on).to eq(at_school_period.finished_on)
             expect(created_training_period.deferred_at).to be_nil
-            expect(created_training_period.trainee).to eq(training_period.trainee)
+            expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
-            expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
+            expect(created_training_period.finished_on).to eq(training_period.at_school_period_finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
@@ -98,9 +98,9 @@ RSpec.describe Teachers::Resume do
             created_training_period = TrainingPeriod.last
             expect(created_training_period).to be_ongoing
             expect(created_training_period.withdrawn_at).to be_nil
-            expect(created_training_period.trainee).to eq(training_period.trainee)
+            expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
-            expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
+            expect(created_training_period.finished_on).to eq(training_period.at_school_period_finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
@@ -120,9 +120,9 @@ RSpec.describe Teachers::Resume do
             created_training_period = TrainingPeriod.last
             expect(created_training_period.finished_on).to eq(at_school_period.finished_on)
             expect(created_training_period.withdrawn_at).to be_nil
-            expect(created_training_period.trainee).to eq(training_period.trainee)
+            expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
-            expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
+            expect(created_training_period.finished_on).to eq(training_period.at_school_period_finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end
@@ -145,9 +145,9 @@ RSpec.describe Teachers::Resume do
             created_training_period = TrainingPeriod.last
             expect(created_training_period.finished_on).to eq(training_period_new.started_on)
             expect(created_training_period.withdrawn_at).to be_nil
-            expect(created_training_period.trainee).to eq(training_period.trainee)
+            expect(created_training_period.at_school_period).to eq(training_period.at_school_period)
             expect(created_training_period.started_on).to eq(Time.zone.today)
-            expect(created_training_period.finished_on).to eq(training_period.trainee.finished_on)
+            expect(created_training_period.finished_on).to eq(training_period.at_school_period_finished_on)
             expect(created_training_period.school_partnership).to eq(training_period.school_partnership)
             expect(created_training_period.schedule).to eq(training_period.schedule)
           end

--- a/spec/services/teachers/withdraw_spec.rb
+++ b/spec/services/teachers/withdraw_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Teachers::Withdraw do
   let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
   let(:lead_provider) { training_period.lead_provider }
   let(:reason) { TrainingPeriod.withdrawal_reasons.values.map(&:dasherize).freeze.sample }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
 
   let(:service) do
     described_class.new(

--- a/spec/support/shared_examples/api_teacher_shared_action_support.rb
+++ b/spec/support/shared_examples/api_teacher_shared_action_support.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples "an API teacher shared action", :with_metadata do
   let(:lead_provider) { training_period.lead_provider }
   let(:lead_provider_id) { lead_provider.id }
-  let(:teacher) { training_period.trainee.teacher }
+  let(:teacher) { training_period.teacher }
   let(:teacher_api_id) { teacher.api_id }
 
   describe "validations" do


### PR DESCRIPTION
resolves https://github.com.mcas.ms/DFE-Digital/register-early-career-teachers-public/issues/1762

### Context

The `TrainingPeriond#trainee` method is not ideally named as the word "trainee" is normally used to refer to a teacher, however the `trainee` method returns either an `ect_at_school_period` or a `mentor_at_school_period`. 

### Changes proposed in this pull request

This PR renames `trainee` to `at_school_period`.

Additionally, we since most of the references to `trainee` within the codebase are only calling `trainee` to get to `teacher` or `school` we provide additional delegate convenience methods. While [Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) is out of fashion, the cost/benefit is strongly in favour of encapsulation in this case. 

### Guidance to review

The most interesting stuff here is in the TrainingPeriod class.
Most of the rest of changes here are replacing things like `training_period.trainee.teacher` with `training_period.teacher`.