### PR TITLE
[3090] Course identifier validation error matching ecf1

### DIFF
--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -143,6 +143,7 @@ module API::Declarations
     def validate_milestone_exists
       return if errors[:declaration_type].any?
       return if errors[:teacher_api_id].any?
+      return if errors[:teacher_type].any?
 
       if milestone.blank?
         errors.add(:declaration_type, "The property '#/declaration_type' does not exist for this schedule.")

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           let(:teacher_type) { trainee_type == :ect ? :mentor : :ect }
 
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
+          it { is_expected.to have_no_error(:declaration_type) }
         end
 
         context "when a non existing teacher type is used" do

--- a/spec/support/matchers/have_error_matcher.rb
+++ b/spec/support/matchers/have_error_matcher.rb
@@ -13,3 +13,23 @@ RSpec::Matchers.define :have_error do |attribute, message, context|
     }.join(" and ")
   end
 end
+
+RSpec::Matchers.define :have_no_error do |attribute, message, context|
+  match do |actual|
+    actual.valid?(context) || actual.errors.none? do |error|
+      error_message_match = message.nil? || error.message == message
+
+      error.attribute == attribute && error_message_match
+    end
+  end
+
+  failure_message do |actual|
+    matching_errors = actual.errors.select { |error| error.attribute == attribute }
+    if message
+      matching_errors = matching_errors.select { |error| error.message == message }
+    end
+
+    error_descriptions = matching_errors.map { |error| %("#{error.message}") }.join(", ")
+    %(expected no error on :#{attribute}#{message ? %( with message "#{message}") : ''}, but found: #{error_descriptions})
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3090

### Changes proposed in this pull request

* Updated validation for create declaration service to show `The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.` when incorrect teacher type is provided.

### Guidance to review
