### PR TITLE
Don't create output fee statements for frozen contract periods

### DIFF
--- a/spec/services/api_seed_data/statements_spec.rb
+++ b/spec/services/api_seed_data/statements_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe APISeedData::Statements do
       expect { instance.plant }.not_to change(Statement, :count)
     end
 
+    context "when payments are frozen for the contract period" do
+      let(:contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          year: Time.zone.now.year - 1,
+          payments_frozen_at: 1.month.ago
+        )
+      end
+
+      it "does not create any output fee statements" do
+        instance.plant
+        expect(active_lead_provider.statements.output_fee).not_to exist
+      end
+    end
+
     context "when in the production environment" do
       let(:environment) { "production" }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3089
https://github.com/DFE-Digital/register-ects-project-board/issues/2906

### Changes proposed in this pull request

Before, we created statements for all contract periods.

When a contract period has payments frozen, lead providers shouldn't be able to submit declarations for participants for that contract period.

However the seed data meant statements existed for frozen contract periods, so the `payment_statement_available` validation when creating a declaration passed instead of returning an error message.

This tweaks the seed data, so we don't create output fee statements for contract periods that have payments frozen.

### Guidance to review
