### PR TITLE
[3137] Fix typo in pagination description in swagger docs

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -1220,9 +1220,9 @@ components:
           example: 1
         per_page:
           type: integer
-          description: The number items to display on a page. Defaults to 100. Maximum
-            is 3000, if the value is greater that the maximum allowed it will fallback
-            to 3000.
+          description: The number of items to display on a page. Defaults to 100.
+            Maximum is 3000, if the value is greater that the maximum allowed it will
+            fallback to 3000.
           example: 10
     SortingTimestamps:
       description: Sort records being returned.

--- a/spec/swagger_schemas/filters/pagination.rb
+++ b/spec/swagger_schemas/filters/pagination.rb
@@ -9,7 +9,7 @@ PAGINATION_FILTER = {
     },
     per_page: {
       type: :integer,
-      description: "The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.",
+      description: "The number of items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.",
       example: 10,
     },
   },


### PR DESCRIPTION
### Context

Ticket: https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3137

For pagination filter, an 'of' is missing in:

`The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.`

### Changes proposed in this pull request

- Fix the typo everywhere we have it;

### Guidance to review

Review app
