### PR TITLE
Fix flakey API Seeds Spec

### DIFF
--- a/app/services/api_seed_data/teachers_with_change_schedule.rb
+++ b/app/services/api_seed_data/teachers_with_change_schedule.rb
@@ -78,6 +78,7 @@ module APISeedData
 
       # With new contract_period
       if variation[:change_contract_period]
+        original_year = school_partnership.contract_period.year
         school_partnership = SchoolPartnership
           .includes(:lead_provider, :contract_period)
           .joins(:lead_provider)
@@ -85,6 +86,7 @@ module APISeedData
             school: school_partnership.school,
             lead_providers: { id: active_lead_provider.lead_provider.id }
           )
+          .excluding_contract_period_year(original_year)
           .order("RANDOM()")
           .first!
         schedule = Schedule.find_by!(contract_period: school_partnership.contract_period, identifier: schedule.identifier)


### PR DESCRIPTION
### Context

fixes #2037 

We currently have a flakey spec:

```
Failures:

  1) APISeedData::TeachersWithChangeSchedule#plant creates teachers with all variations
     Failure/Error: expect(change).to be_present
       expected `nil.present?` to be truthy, got false
     # ./spec/services/api_seed_data/teachers_with_change_schedule_spec.rb:71:in 'block (3 levels) in <main>'
     # ./spec/rails_helper.rb:55:in 'block (3 levels) in <top (required)>'
     # ./app/models/concerns/declarative_updates.rb:59:in 'DeclarativeUpdates.skip'
     # ./spec/rails_helper.rb:55:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rack_attack.rb:15:in 'block (2 levels) in <main>'
```

### Changes proposed in this pull request

This happens because when `variation[:change_contract_period]` is true, the query uses `order("RANDOM()")` to select a school partnership for the same school and lead provider. However, it doesn't exclude the original contract period, so it can randomly select the same school partnership (same contract period) again.

So we exclude the contract period from the query to ensure a different one is selected. 

### Guidance to review

**Note: The primary key for contract periods is `year`.**

If you want to ascertain the fix. You can normally confirm the presence of the flake in main with (normally enough occurrences to trigger the flake):
```
for i in {1..50}; do echo "Run $i"; bundle exec rspec spec/services/api_seed_data/teachers_with_change_schedule_spec.rb:66 --fail-fast || break; done
```

and it's absence in this branch.