### PR TITLE
Update release date for RECT API declaration endpoints

### DIFF
--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -22,7 +22,7 @@
 #     **bold** and _italic_ text
 
 - title: Declaration endpoints added, completing the RECT API in sandbox
-  date: 2025-01-19
+  date: 2026-01-19
   tags:
     - sandbox-release
   body: |


### PR DESCRIPTION
Hey Ross - Just fixing the release note date from 2025 to 2026.