### PR TITLE
Fix flaky parity_checks_spec regex for performance gain ratio

### DIFF
--- a/spec/services/api_seed_data/parity_checks_spec.rb
+++ b/spec/services/api_seed_data/parity_checks_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe APISeedData::ParityChecks do
         expect(logger).to have_received(:info).with(/#{Regexp.escape(endpoint.description)}/).at_least(:once)
       end
 
-      expect(logger).to have_received(:info).with(/Concurrent, *\d+ requests, -?\d.\dx performance gain, \d+% match rate/).at_least(:once)
-      expect(logger).to have_received(:info).with(/Sequential, *\d+ requests, -?\d.\dx performance gain, \d+% match rate/).at_least(:once)
+      expect(logger).to have_received(:info).with(/Concurrent, *\d+ requests, -?\d+\.?\d*x performance gain, \d+% match rate/).at_least(:once)
+      expect(logger).to have_received(:info).with(/Sequential, *\d+ requests, -?\d+\.?\d*x performance gain, \d+% match rate/).at_least(:once)
     end
 
     context "when in the production environment" do


### PR DESCRIPTION
### Context

fixes #1875 

There is a flakey spec:
```
Failures:

  1) APISeedData::ParityChecks#plant logs the creation of parity check runs
     Failure/Error: expect(logger).to have_received(:info).with(/Sequential, *\d+ requests, \d.\dx performance gain, \d+% match rate/).at_least(:once)

       #<InstanceDouble(Logger) (anonymous)> received :info with unexpected arguments
         expected: (/Sequential, *\d+ requests, \d.\dx performance gain, \d+% match rate/)
              got: ("\r\n🪴  Planting parity_checks...\r\n") (1 time)
    
...

    # ./spec/services/api_seed_data/parity_checks_spec.rb:55:in 'block (3 levels) in <main>'
     # ./spec/rails_helper.rb:49:in 'block (3 levels) in <top (required)>'
     # ./app/models/concerns/declarative_updates.rb:49:in 'DeclarativeUpdates.skip'
     # ./spec/rails_helper.rb:49:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rack_attack.rb:15:in 'block (2 levels) in <main>'

Finished in 8 minutes 34 seconds (files took 12.34 seconds to load)
8375 examples, 1 failure, 5 pending

Failed examples:

rspec ./spec/services/api_seed_data/parity_checks_spec.rb:43 # APISeedData::ParityChecks#plant logs the creation of parity check runs

Randomized with seed 14755
```

The spec uses regex `-?\d.\dx` which only matched single-digit ratios like "2.3x". Since rect_performance_gain_ratio divides random times (100-2000ms), it can produce values like "10.5x" or "-15.0x" which failed to match. 

### Changes proposed in this pull request

Changed to `-?\d+\.?\d*x` to handle multi-digit values.

### Guidance to review

This flake is very hard to trigger - running for hundreds of times fails to trigger the flake.
