### PR TITLE
Update solid_queue to (hopefully) prevent local seg faults

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -741,7 +741,7 @@ GEM
       jwt (>= 1.5, < 4.0)
       multi_json (~> 1.10)
     slow_enumerator_tools (1.1.0)
-    solid_queue (1.2.4)
+    solid_queue (1.3.1)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)
@@ -768,7 +768,7 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     thor (1.5.0)
-    timeout (0.4.4)
+    timeout (0.6.0)
     traces (0.16.2)
     trailblazer-option (0.1.2)
     tsort (0.2.0)


### PR DESCRIPTION
### Context

I've been having seg faults running background jobs locally. Recompiling all my gems seemed to fix it but then started seeing seg faults again. Always with solid queue trying to connect to the database. Bumping locally seems to have fixed again for now.

### Changes proposed in this pull request

Update solid_queue gem from 1.2.4 to 1.3.1

### Guidance to review
