### PR TITLE
[3167] Prevent participants in a frozen cohort from receiving new declarations

### DIFF
--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -187,10 +187,10 @@ module API::Declarations
       return if errors[:contract_period_year].any?
       return unless teacher
 
-      latest_ongoing_training_period_for_teacher = training_periods.ongoing_today.first
-      return unless latest_ongoing_training_period_for_teacher&.eligible_for_funding?
+      training_period_ongoing_today = training_periods.ongoing_today.first
+      return unless training_period_ongoing_today&.eligible_for_funding?
 
-      current_contract_period = latest_ongoing_training_period_for_teacher.contract_period
+      current_contract_period = training_period_ongoing_today.contract_period
       return unless current_contract_period&.payments_frozen?
 
       errors.add(:contract_period_year, "You cannot submit declarations for the #{current_contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.")

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -242,6 +242,8 @@ RSpec.describe API::Declarations::Create, type: :model do
           end
 
           context "when teacher's latest ongoing training period is in a frozen contract period but declaration targets non-frozen" do
+            let(:declaration_date) { Faker::Date.between(from: training_period.started_on, to: training_period.finished_on).rfc3339 }
+
             let!(:training_period) do
               FactoryBot.create(
                 :training_period,


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3167

### Changes proposed in this pull request

* Added new validation `not_eligible_in_frozen_contract_period` to `API::Declarations::Create` service
* Show validation error if the teacher's latest ongoing training period, ignoring lead provider, is eligible for funding and latest contract period is frozen.

### Guidance to review
