### PR TITLE
[3118] Spike - Statement contracts for RECT

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -10,6 +10,9 @@ class Statement < ApplicationRecord
   has_one :lead_provider, through: :active_lead_provider
   has_one :contract_period, through: :active_lead_provider
 
+  has_one :call_off_contract, class_name: "Statement::CallOffContract"
+  has_one :mentor_call_off_contract, class_name: "Statement::MentorCallOffContract"
+
   touch -> { self }, timestamp_attribute: :api_updated_at
 
   def self.maximum_year = Date.current.year + 5

--- a/app/models/statement/call_off_contract.rb
+++ b/app/models/statement/call_off_contract.rb
@@ -1,0 +1,19 @@
+class Statement::CallOffContract < ApplicationRecord
+  belongs_to :statement
+
+  def bands
+    klass = Struct.new(:letter, :max, :per_participant, :output_payment_percentage, :service_fee_percentage)
+
+    %i[a b c d].filter_map do |letter|
+      next if self[:"band_#{letter}_max"].zero?
+
+      klass.new(
+        letter,
+        self[:"band_#{letter}_max"],
+        self[:"band_#{letter}_per_participant"],
+        self[:"band_#{letter}_output_payment_percentage"],
+        self[:"band_#{letter}_service_fee_percentage"]
+      )
+    end
+  end
+end

--- a/app/models/statement/mentor_call_off_contract.rb
+++ b/app/models/statement/mentor_call_off_contract.rb
@@ -1,0 +1,3 @@
+class Statement::MentorCallOffContract < ApplicationRecord
+  belongs_to :statement
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -577,3 +577,36 @@
   - message
   - created_at
   - updated_at
+  :statement_call_off_contracts:
+  - id
+  - statement_id
+  - recruitment_target
+  - set_up_fee
+  - monthly_service_fee
+  - uplift_target
+  - uplift_amount
+  - band_a_max
+  - band_a_per_participant
+  - band_a_output_payment_percentage
+  - band_a_service_fee_percentage
+  - band_b_max
+  - band_b_per_participant
+  - band_b_output_payment_percentage
+  - band_b_service_fee_percentage
+  - band_c_max
+  - band_c_per_participant
+  - band_c_output_payment_percentage
+  - band_c_service_fee_percentage
+  - band_d_max
+  - band_d_per_participant
+  - band_d_output_payment_percentage
+  - band_d_service_fee_percentage
+  - created_at
+  - updated_at
+  :statement_mentor_call_off_contracts:
+  - id
+  - statement_id
+  - recruitment_target
+  - payment_per_participant
+  - created_at
+  - updated_at

--- a/db/migrate/20260126154824_create_statement_call_off_contracts.rb
+++ b/db/migrate/20260126154824_create_statement_call_off_contracts.rb
@@ -1,0 +1,23 @@
+class CreateStatementCallOffContracts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :statement_call_off_contracts do |t|
+      t.references :statement, foreign_key: { to_table: :statements }
+
+      t.integer :recruitment_target
+      t.decimal :set_up_fee
+      t.decimal :monthly_service_fee
+
+      t.decimal :uplift_target
+      t.decimal :uplift_amount
+
+      %i[a b c d].each do |letter|
+        t.integer :"band_#{letter}_max", default: 0
+        t.decimal :"band_#{letter}_per_participant", default: 0.0
+        t.integer :"band_#{letter}_output_payment_percentage", default: 0
+        t.integer :"band_#{letter}_service_fee_percentage", default: 0
+      end
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260126160027_create_statement_mentor_call_off_contracts.rb
+++ b/db/migrate/20260126160027_create_statement_mentor_call_off_contracts.rb
@@ -1,0 +1,12 @@
+class CreateStatementMentorCallOffContracts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :statement_mentor_call_off_contracts do |t|
+      t.references :statement, foreign_key: { to_table: :statements }
+
+      t.integer :recruitment_target
+      t.decimal :payment_per_participant
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_13_150052) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_26_160027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -763,6 +763,43 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_150052) do
     t.index ["statement_id"], name: "index_statement_adjustments_on_statement_id"
   end
 
+  create_table "statement_call_off_contracts", force: :cascade do |t|
+    t.bigint "statement_id"
+    t.integer "recruitment_target"
+    t.decimal "set_up_fee"
+    t.decimal "monthly_service_fee"
+    t.decimal "uplift_target"
+    t.decimal "uplift_amount"
+    t.integer "band_a_max", default: 0
+    t.decimal "band_a_per_participant", default: "0.0"
+    t.integer "band_a_output_payment_percentage", default: 0
+    t.integer "band_a_service_fee_percentage", default: 0
+    t.integer "band_b_max", default: 0
+    t.decimal "band_b_per_participant", default: "0.0"
+    t.integer "band_b_output_payment_percentage", default: 0
+    t.integer "band_b_service_fee_percentage", default: 0
+    t.integer "band_c_max", default: 0
+    t.decimal "band_c_per_participant", default: "0.0"
+    t.integer "band_c_output_payment_percentage", default: 0
+    t.integer "band_c_service_fee_percentage", default: 0
+    t.integer "band_d_max", default: 0
+    t.decimal "band_d_per_participant", default: "0.0"
+    t.integer "band_d_output_payment_percentage", default: 0
+    t.integer "band_d_service_fee_percentage", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["statement_id"], name: "index_statement_call_off_contracts_on_statement_id"
+  end
+
+  create_table "statement_mentor_call_off_contracts", force: :cascade do |t|
+    t.bigint "statement_id"
+    t.integer "recruitment_target"
+    t.decimal "payment_per_participant"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["statement_id"], name: "index_statement_mentor_call_off_contracts_on_statement_id"
+  end
+
   create_table "statements", force: :cascade do |t|
     t.bigint "active_lead_provider_id", null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
@@ -976,6 +1013,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_150052) do
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "statement_adjustments", "statements"
+  add_foreign_key "statement_call_off_contracts", "statements"
+  add_foreign_key "statement_mentor_call_off_contracts", "statements"
   add_foreign_key "statements", "active_lead_providers"
   add_foreign_key "teacher_id_changes", "teachers"
   add_foreign_key "teacher_id_changes", "teachers", column: "api_from_teacher_id", primary_key: "api_id"


### PR DESCRIPTION
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3118

## Overview

As we're building the same financial statements as ECF1, I wanted to keep the data schema similar. However, the goals for this implementation are:

- **Simplify as much as possible** - Reduce complexity from the ECF1 implementation
- **Allow easier changes** - Make the schema flexible enough to accommodate future contract changes
- **Enable simple CRUD admin UIs** - Allow contract managers to make changes themselves without developer intervention

## Models

### Statement

Statement has one call off contract, that only belongs to it.

### Statement::CallOffContract

Call off contract has the same columns as ECF1, but also includes the Bands as columns, not separate table.
- `band_a_max`
- `band_a_per_participant`
- `band_a_output_payment_percentage`
- `band_a_service_fee_percentage`
- `band_b_max`
- `band_b_per_participant`
- `band_b_output_payment_percentage`
- `band_b_service_fee_percentage`

I've removed `min` column as it can be derived from the previous band max.

### Statement::MentorCallOffContract

Mentor call off contract has the same columns as ECF1.

## Diagram

```mermaid
erDiagram
    Statement ||--o| CallOffContract : "has_one"
    Statement ||--o| MentorCallOffContract : "has_one"

    Statement {
        string fee_type
        string status
        integer year
        integer month
        uuid api_id
    }

    CallOffContract {
        integer recruitment_target
        decimal set_up_fee
        decimal monthly_service_fee
        decimal uplift_target
        decimal uplift_amount
        integer band_a_max
        decimal band_a_per_participant
        integer band_a_output_payment_percentage
        integer band_a_service_fee_percentage
        integer band_b_max
        decimal band_b_per_participant
        integer band_b_output_payment_percentage
        integer band_b_service_fee_percentage
        integer band_c_max
        decimal band_c_per_participant
        integer band_c_output_payment_percentage
        integer band_c_service_fee_percentage
        integer band_d_max
        decimal band_d_per_participant
        integer band_d_output_payment_percentage
        integer band_d_service_fee_percentage
    }

    MentorCallOffContract {
        integer recruitment_target
        decimal payment_per_participant
    }
```

## Admin UI

| Lead provider      | Contract period | Action |
|--------------------|-----------------|--------|
| Ambition Institute | 2025            | [View](#)   |

| Month    | Recruitment target | Setup fee  | Monthly service fee | Uplift target | Uplift amount | Action |
|----------|--------------------|------------|---------------------|---------------|---------------|--------|
| Jan 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)   |
| Feb 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Mar 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Apr 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| May 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Jun 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Jul 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Aug 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Sep 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Oct 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Nov 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |
| Dec 2025 | 4500               | 0          | 100.0               | 0.33          | 100           | [Edit](#)  |


We can do bulk updates with UI by running queries like this:

```ruby
Statement::CallOffContract
  .includes(:statement)
  .where(statement: {month: 1..5, year: 2025})
  .update!(recruitment_target: 1000, set_up_fee: 100)
```

## Benefit of this

- We no longer have to worry about `versions`.
- Update each statement contract values as needed
- No unintended changes to other statements
- No orphaned contracts
- No duplicate contracts
- If we want to, we could track changes to the contract values with something like paper_trail
