### PR TITLE
Remove untrained mentor from seeds

### DIFF
--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -715,16 +715,6 @@ john_withers_training_period = FactoryBot.create(:training_period,
 john_withers_declaration_date = john_withers_training_period.schedule.milestones.find_by(declaration_type: :started).start_date
 FactoryBot.create(:declaration, declaration_type: :started, declaration_date: john_withers_declaration_date, training_period: john_withers_training_period)
 
-print_seed_info("Ichigo Kurosaki (Mentor)", indent: 2, colour: MENTOR_COLOUR)
-
-ichigo_kurosaki = Teacher.find_by!(trs_first_name: "Ichigo", trs_last_name: "Kurosaki")
-FactoryBot.create(:mentor_at_school_period,
-                  teacher: ichigo_kurosaki,
-                  school: brookfield_school,
-                  email: "ichigo.kurosaki@brookfield.com",
-                  started_on: 1.year.ago,
-                  finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
-
 print_seed_info("Dominic West (ECT)", indent: 2, colour: ECT_COLOUR)
 
 dominic_west_ect_at_brookfield_school = FactoryBot.create(:ect_at_school_period,

--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -68,7 +68,6 @@ teachers = [
   { trn: "0000020", trs_first_name: "Helen", trs_last_name: "Mirren", corrected_name: "Dame Helen Mirren", trs_induction_status: "Passed" },
   { trn: "0000021", trs_first_name: "Peter", trs_last_name: "Davison", trs_induction_status: "RequiredToComplete", ect_payments_frozen_year: 2022, mentor_payments_frozen_year: 2022 },
   { trn: "0000022", trs_first_name: "Roy", trs_last_name: "Dotrice", **early_roll_out_mentor_attrs },
-  { trn: "0000023", trs_first_name: "Ichigo", trs_last_name: "Kurosaki", trs_induction_status: "InProgress" },
   { trn: "0000024", trs_first_name: "Alastair", trs_last_name: "Sim", trs_induction_status: "InProgress" },
   { trn: "0000025", trs_first_name: "Margaret", trs_last_name: "Rutherford", trs_induction_status: "InProgress" },
   { trn: "0000026", trs_first_name: "Terry", trs_last_name: "Thomas", trs_induction_status: "InProgress" },


### PR DESCRIPTION
### Context
Ichigo was seeded as a mentor-at-school but without any mentor training period, so he appeared as a mentor but couldn’t actually be assigned. That was confusing, so I’ve removed him from the seeds - requested by @mason-emily 

### Changes proposed in this pull request
Removing Ichigo from db/seeds/teacher_histories.rb and db/seeds/teachers.rb

### Guidance to review

N.B The references to "Ichigo Kurosaki" in specs are just local FactoryBot test data
