### PR TITLE
[2884] Add details component to Change Lead Provider pages for ECT and mentor

### DIFF
--- a/app/views/schools/ects/change_lead_provider_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_lead_provider_wizard/edit.html.erb
@@ -44,6 +44,8 @@
         legend: { text: "Select the new lead provider for #{@wizard.teacher_full_name}" }
       ) %>
 
+  <%= render "schools/shared/roles_details" %>
+
   <%= form.govuk_submit "Continue" %>
 
   <p class="govuk-body">

--- a/app/views/schools/mentors/change_lead_provider_wizard/edit.html.erb
+++ b/app/views/schools/mentors/change_lead_provider_wizard/edit.html.erb
@@ -31,6 +31,8 @@
         legend: {text: "Select lead provider", hidden: true},
       ) %>
 
+  <%= render "schools/shared/roles_details" %>
+
   <%= form.govuk_submit 'Continue' %>
 <% end %>
 

--- a/app/views/schools/shared/_roles_details.html.erb
+++ b/app/views/schools/shared/_roles_details.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_details(summary_text: "What are the roles of an appropriate body, lead provider and delivery partner?") do %>
+  <p class="govuk-body">An appropriate body is responsible for assuring the quality of the statutory induction of ECTs. A lead provider provides the online learning platform used for training ECTs and mentors, while the delivery partner delivers training events.</p>
+  <p class="govuk-body">These roles are sometimes undertaken by the same organisation, for example an appropriate body might be the same organisation as the delivery partner.</p>
+<% end %>


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/2884

### Changes proposed in this pull request

- Add a partial with the content (it's the same for both ECTs and mentors)

No existing view specs, which seems fine to me, so I didn't add any.