### PR TITLE
[3171] Bug: Registering the same ECT at two different schools with the same start date raises an uncaught validation error

### DIFF
--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -29,7 +29,7 @@ module Schools
         previous_period = ect.previous_ect_at_school_period
         return unless previous_start_date_invalid?(previous_period)
 
-        if start_date_as_date < previous_period.started_on
+        if start_date_as_date <= previous_period.started_on
           add_start_date_too_early_error(previous_period)
         end
       end

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -114,55 +114,30 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
         end
       end
 
-      let(:start_date) { { 1 => "2024", 2 => "10", 3 => "01" } }
+      let(:start_date_too_early_message) { "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a later start date." }
 
       context "when the start_date is before the previous ECTAtSchoolPeriod started_on date" do
-        let(:start_date) { { 1 => "2024", 2 => "08", 3 => "01" } }
+        let(:start_date) { previous_period.started_on - 1.day }
 
-        it "is not valid" do
-          expect(subject).not_to be_valid
-          expect(subject.errors[:start_date]).to include(
-            "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a later start date."
-          )
-        end
+        it { is_expected.to have_error(:start_date, start_date_too_early_message) }
       end
 
       context "when the start_date is on the previous ECTAtSchoolPeriod started_on date" do
-        let(:start_date) { { 1 => "2024", 2 => "09", 3 => "01" } }
+        let(:start_date) { previous_period.started_on }
 
-        it "is valid" do
-          expect(subject).to be_valid
-          expect(subject.errors[:start_date]).to be_blank
-        end
+        it { is_expected.to have_error(:start_date, start_date_too_early_message) }
       end
 
       context "when the start_date is after the previous ECTAtSchoolPeriod started_on date" do
-        let(:start_date) { { 1 => "2024", 2 => "10", 3 => "01" } }
+        let(:start_date) { previous_period.started_on + 1.day }
 
-        it "is valid" do
-          expect(subject).to be_valid
-          expect(subject.errors[:start_date]).to be_blank
-        end
+        it { is_expected.not_to have_error(:start_date) }
       end
 
       context "when the start_date is blank" do
         let(:start_date) { nil }
 
-        it "is not valid" do
-          expect(subject).not_to be_valid
-          expect(subject.errors[:start_date]).not_to include(
-            "This ECT was previously registered at Springfield Primary (1 September 2024). Enter a later date."
-          )
-        end
-      end
-
-      context "when there is no previous period" do
-        let(:previous_period) { nil }
-
-        it "is valid" do
-          expect(subject).to be_valid
-          expect(subject.errors[:start_date]).to be_blank
-        end
+        it { is_expected.to have_error(:start_date, "Enter the date the ECT started or will start teaching at your school") }
       end
     end
   end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3171

### Changes proposed in this pull request

- Treat duplicate `started_on` the same as an earlier `started_on`
- Simplify specs very slightly
- Remove a couple of nested cases already covered elsewhere in the spec