### PR TITLE
[3049] Fix the highlighting of current nav elements

### DIFF
--- a/app/components/navigation/primary_navigation_component.rb
+++ b/app/components/navigation/primary_navigation_component.rb
@@ -61,9 +61,9 @@ module Navigation
           { text: "Users", href: admin_users_path, active_when: "/admin/users" }
         ],
         school_user: [
-          { text: "ECTs", href: schools_ects_home_path },
-          { text: "Mentors", href: schools_mentors_home_path },
-          { text: "Induction tutor", href: schools_induction_tutor_path }
+          { text: "ECTs", href: schools_ects_home_path, active_when: schools_ects_path },
+          { text: "Mentors", href: schools_mentors_home_path, active_when: schools_mentors_path },
+          { text: "Induction tutor", href: schools_induction_tutor_path, active_when: "/school/induction-tutor" }
         ],
         api_guidance: [
           { text: "Home", href: "/api/guidance" },


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3049

### Changes proposed in this pull request

Set appropriate `active_when` to enable [automatic active page matching](https://govuk-components.netlify.app/components/service-navigation/#automatic-active-page-matching) in the navigation component.