### PR TITLE
Migration - school_led training fixes

### DIFF
--- a/app/migration/teacher_history_converter/ect/latest_induction_records.rb
+++ b/app/migration/teacher_history_converter/ect/latest_induction_records.rb
@@ -89,6 +89,8 @@ private
   end
 
   def build_training_period(induction_record:, **overrides)
+    training_programme = convert_training_programme_name(induction_record.training_programme)
+
     training_attrs = {
       started_on: induction_record.start_date.to_date,
       finished_on: induction_record.end_date&.to_date,
@@ -102,6 +104,8 @@ private
       ecf_start_induction_record_id: induction_record.induction_record_id,
       schedule_info: induction_record.schedule_info
     }.merge(overrides)
+
+    training_attrs.except!(:lead_provider_info, :delivery_partner_info, :schedule_info) if training_programme == "school_led"
 
     ECF2TeacherHistory::TrainingPeriod.new(**training_attrs)
   end

--- a/spec/migration/teacher_history_converter/ect/latest_induction_records_spec.rb
+++ b/spec/migration/teacher_history_converter/ect/latest_induction_records_spec.rb
@@ -467,4 +467,92 @@ describe "Latest induction records mode conversion" do
       end
     end
   end
+
+  context "training period details" do
+    let(:schedule_a) do
+      {
+        schedule_id: 1,
+        identifier: "ect-schedule-a",
+        name: "Schedule A",
+        cohort_year: 2021,
+      }
+    end
+
+    let(:schedule_b) do
+      {
+        schedule_id: 2,
+        identifier: "ect-schedule-b",
+        name: "Schedule B",
+        cohort_year: 2024,
+      }
+    end
+
+    let(:induction_records) do
+      [
+        {
+          start_date: Time.zone.parse("2022-1-1"),
+          end_date: Time.zone.parse("2022-8-5"),
+          school: school_a,
+          training_programme:,
+          training_provider_info: {
+            lead_provider: lead_provider_a,
+            delivery_partner: delivery_partner_a,
+            cohort_year: 2021
+          },
+          schedule_info: schedule_a
+        },
+        {
+          start_date: Time.zone.parse("2024-3-3"),
+          end_date: Time.zone.parse("2025-6-6"),
+          school: school_b,
+          training_programme:,
+          training_provider_info: {
+            lead_provider: lead_provider_b,
+            delivery_partner: delivery_partner_b,
+            cohort_year: 2024
+          },
+          schedule_info: schedule_b
+        }
+      ]
+    end
+
+    context "provider_led training" do
+      let(:training_programme) { "full_induction_programme" }
+
+      it "adds the correct providers to the training period" do
+        expect(subject.ect_at_school_periods.first.training_periods.first.lead_provider_info.name).to eq lead_provider_a[:name]
+        expect(subject.ect_at_school_periods.first.training_periods.first.delivery_partner_info.name).to eq delivery_partner_a[:name]
+
+        expect(subject.ect_at_school_periods.second.training_periods.first.lead_provider_info.name).to eq lead_provider_b[:name]
+        expect(subject.ect_at_school_periods.second.training_periods.first.delivery_partner_info.name).to eq delivery_partner_b[:name]
+      end
+
+      it "adds the correct schedule to the training period" do
+        schedule_2021 = subject.ect_at_school_periods.first.training_periods.first.schedule_info
+        expect(schedule_2021.name).to eq schedule_a[:name]
+        expect(schedule_2021.cohort_year).to eq schedule_a[:cohort_year]
+
+        schedule_2024 = subject.ect_at_school_periods.second.training_periods.first.schedule_info
+        expect(schedule_2024.name).to eq schedule_b[:name]
+        expect(schedule_2024.cohort_year).to eq schedule_b[:cohort_year]
+      end
+    end
+
+    context "school_led training" do
+      let(:training_programme) { "core_induction_programme" }
+
+      it "does not add providers to the training period" do
+        expect(subject.ect_at_school_periods.first.training_periods.first.lead_provider_info).to be_blank
+        expect(subject.ect_at_school_periods.first.training_periods.first.delivery_partner_info).to be_blank
+
+        expect(subject.ect_at_school_periods.second.training_periods.first.lead_provider_info).to be_blank
+        expect(subject.ect_at_school_periods.second.training_periods.first.delivery_partner_info).to be_blank
+      end
+
+      it "does not add a schedule to the training period" do
+        expect(subject.ect_at_school_periods.first.training_periods.first.schedule_info).to be_blank
+        expect(subject.ect_at_school_periods.second.training_periods.first.schedule_info).to be_blank
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Schedule is not allowed on `TrainingPeriod` if the training is `school_led`. Similarly there is no need to try and resolve provider partnership details for `school_led` so this PR prevents both things from being added to `TrainingPeriod` records during migration unless the training period represents `provider_led` training.
