### PR TITLE
Stop using Faker for delivery partner names

### DIFF
--- a/spec/factories/delivery_partner_factory.rb
+++ b/spec/factories/delivery_partner_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:delivery_partner) do
-    sequence(:name) { |n| "#{Faker::University.name} Delivery Partner #{n}" }
+    sequence(:name) { |n| "Delivery Partner #{n}" }
 
     initialize_with do
       DeliveryPartner.find_or_initialize_by(name:)


### PR DESCRIPTION
### Context

Faker occasionally generates names with apostrophes, which get HTML escaped in the view and broke the response assertion.

[See failure in CI here](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/21483774497/job/61887049650?pr=2104).

### Changes proposed in this pull request

Switch the factory to deterministic names to avoid the escaping mismatch.

### Guidance to review

Run the test as many times as you can bare to: `rspec spec/requests/admin/delivery_partners_spec.rb:187`
