### PR TITLE
Align voidable declaration states with implementation

### DIFF
--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
 
       context "when fetching `voidable_declaration_for_voiding_id`" do
         let(:identifier) { :voidable_declaration_for_voiding_id }
-        let(:possible_states) { %i[submitted eligible payable ineligible] }
+        let(:possible_states) { %i[submitted eligible payable] }
         let(:state) { possible_states.sample }
 
         it { is_expected.to eq(ecf_participant_declaration.id) }


### PR DESCRIPTION
### Context

`ParityCheck::DynamicRequestContent#voidable_declaration_for_voiding_id` only returns declarations in `submitted`, `eligible`, or `payable` states. The spec included `:ineligible`, causing intermittent failures when selected.

This was causing [failed runs](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/21483774497/job/61887049575?pr=2104).

### Changes proposed

- Update voidable declaration spec to only sample from supported states

### Guidance to review

Is the implementation correct to treat only `submitted`, `eligible`, and `payable` as voidable (excluding `ineligible`)?


