### PR TITLE
Add rubocop-rspec plugins for HTTP status consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_from: .rubocop_todo.yml
 plugins:
   - rubocop-performance
   - rubocop-factory_bot
+  - rubocop-rspec
+  - rubocop-rspec_rails
 
 inherit_gem:
   rubocop-govuk:
@@ -28,6 +30,9 @@ RSpec/RequireRailsHelper:
   Exclude:
     - "spec/spec_helper.rb"
     - "spec/rails_helper.rb"
+
+RSpecRails/HttpStatusNameConsistency:
+  Enabled: true
 
 # Otherwise it suggests the namespace "ec_ts"
 RSpec/SpecFilePathFormat:

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,8 @@ group :development, :test do
   gem "rubocop-factory_bot", require: false
   gem "rubocop-govuk", require: false
   gem "rubocop-performance", require: false
+  gem "rubocop-rspec", require: false
+  gem "rubocop-rspec_rails", require: false
 end
 
 group :development, :test, :review, :staging, :sandbox, :paritycheck do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -717,6 +717,10 @@ GEM
     rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
+    rubocop-rspec_rails (2.32.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     rubypants (0.7.1)
     rubyzip (3.2.2)
@@ -899,6 +903,8 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-govuk
   rubocop-performance
+  rubocop-rspec
+  rubocop-rspec_rails
   rubypants
   rubyzip
   savon


### PR DESCRIPTION
## Summary

Add `rubocop-rspec` and `rubocop-rspec_rails` so the `HttpStatusNameConsistency` cop flags `:unprocessable_entity` in specs. 

This is to prevent repeats of the recent slip in #2104 where `:unprocessable_entity` was used and triggered the Rack deprecation warning.
