### PR TITLE
[3143] Fix error messaging on POST partnerships for closed contract periods

### DIFF
--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -59,7 +59,7 @@ module API::SchoolPartnerships
     def contract_period_enabled
       return if errors[:contract_period_year].any?
 
-      errors.add(:contract_period_year, "You cannot create this partnership until the contract period has started.") unless contract_period&.enabled?
+      errors.add(:contract_period_year, "You cannot create this partnership as the contract period is closed.") unless contract_period&.enabled?
     end
 
     def lead_provider_exists

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
 
       it "is invalid" do
         expect(service).to be_invalid
-        expect(service.errors[:contract_period_year]).to eq(["You cannot create this partnership until the contract period has started."])
+        expect(service.errors[:contract_period_year]).to eq(["You cannot create this partnership as the contract period is closed."])
       end
     end
 


### PR DESCRIPTION
### Context

Ticket: [3143](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3143)

When trying to submit a partnership using POST partnerships for closed contract periods, the error message 'You cannot create this partnership until the cohort has started' isn't reflective of the truth.

### Changes proposed in this pull request

- Fix error messaging on POST partnerships for closed contract periods

### Guidance to review

Review app