### PR TITLE
[3213] Refresh metadata when training programme changes to school-led

### DIFF
--- a/app/models/concerns/declarative_updates.rb
+++ b/app/models/concerns/declarative_updates.rb
@@ -11,7 +11,7 @@ module DeclarativeUpdates
       after_commit(on: on_event) do
         next if DeclarativeUpdates.skip?(:metadata)
 
-        should_touch = when_changing.blank? || when_changing.any? do |attr|
+        should_touch = destroyed? || when_changing.blank? || when_changing.any? do |attr|
           saved_change_to_attribute?(attr)
         end
 
@@ -25,7 +25,7 @@ module DeclarativeUpdates
       after_commit(on: on_event) do
         next if DeclarativeUpdates.skip?(:touch)
 
-        should_touch_based_on_changes = when_changing.blank? || when_changing.any? do |attr|
+        should_touch_based_on_changes = destroyed? || when_changing.blank? || when_changing.any? do |attr|
           saved_change_to_attribute?(attr)
         end
 

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -61,7 +61,7 @@ class TrainingPeriod < ApplicationRecord
           school_partnership_id
         ]
 
-  refresh_metadata -> { school_partnership&.school }, on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id]
+  refresh_metadata -> { at_school_period.school }, on_event: %i[create destroy update], when_changing: %i[school_partnership_id expression_of_interest_id]
   refresh_metadata -> { teacher }, on_event: %i[create destroy update], when_changing: %i[started_on finished_on withdrawn_at deferred_at school_partnership_id]
 
   # Validations


### PR DESCRIPTION
### Context

Ticket: [3213](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3213)

When an ECT's `training_period` is removed, the `expression_of_interest` for the school does not turn `FALSE` on GET schools.

### Changes proposed in this pull request

- When the training programme changes to `school-led`, a training period is deleted.. so we need to refresh the school metadata;

### Guidance to review

Review app
