### PR TITLE
[3246] Make datetime fields format consistent in the api responses

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -4,7 +4,7 @@ class API::DeclarationSerializer < Blueprinter::Base
 
     field(:participant_id) { |declaration| declaration.training_period.teacher.api_id }
     field(:declaration_type)
-    field(:declaration_date) { |declaration| declaration.declaration_date.rfc3339 }
+    field(:declaration_date)
 
     field(:course_identifier) do |declaration|
       if declaration.training_period.for_ect?
@@ -20,8 +20,8 @@ class API::DeclarationSerializer < Blueprinter::Base
       status == "no_payment" ? "submitted" : status
     end
 
-    field(:updated_at) { |declaration| declaration.updated_at.rfc3339 }
-    field(:created_at) { |declaration| declaration.created_at.rfc3339 }
+    field(:updated_at)
+    field(:created_at)
     field(:delivery_partner_id) { |declaration| declaration.training_period.delivery_partner.api_id }
     field(:statement_id) { |declaration| declaration.payment_statement&.api_id }
     field(:clawback_statement_id) { |declaration| declaration.clawback_statement&.api_id }

--- a/app/serializers/api/statement_serializer.rb
+++ b/app/serializers/api/statement_serializer.rb
@@ -5,8 +5,8 @@ class API::StatementSerializer < Blueprinter::Base
     field(:month) { |s, _| Date::MONTHNAMES[s.month] }
     field(:year) { |s, _| s.year.to_s }
     field(:cohort) { |s, _| s.active_lead_provider.contract_period_year.to_s }
-    field :deadline_date, name: :cut_off_date, datetime_format: "%Y-%m-%d"
-    field :payment_date, datetime_format: "%Y-%m-%d"
+    field :deadline_date, name: :cut_off_date
+    field :payment_date
     field(:paid?, name: :paid)
     field :created_at
     field(:api_updated_at, name: :updated_at)

--- a/app/serializers/api/teachers/school_transfer_serializer.rb
+++ b/app/serializers/api/teachers/school_transfer_serializer.rb
@@ -7,7 +7,7 @@ class API::Teachers::SchoolTransferSerializer < Blueprinter::Base
       data[:lead_provider]&.name
     end
     field(:date) do |data|
-      data[:date].to_fs(:api)
+      data[:date]
     end
   end
 
@@ -27,7 +27,7 @@ class API::Teachers::SchoolTransferSerializer < Blueprinter::Base
       transfer.status
     end
     field(:created_at) do |(transfer, _teacher, _options)|
-      transfer.leaving_training_period.created_at.utc.rfc3339
+      transfer.leaving_training_period.created_at
     end
     association :leaving, blueprint: TrainingPeriodSerializer do |(transfer, _teacher, _options)|
       training_period = transfer.leaving_training_period

--- a/config/initializers/blueprinter.rb
+++ b/config/initializers/blueprinter.rb
@@ -1,5 +1,5 @@
 Blueprinter.configure do |config|
   config.generator = Oj
-  config.datetime_format = ->(datetime) { datetime&.utc&.rfc3339 }
+  config.datetime_format = ->(date_or_time) { date_or_time.is_a?(Date) ? date_or_time.to_fs(:api) : date_or_time&.utc&.rfc3339 }
   config.sort_fields_by = :definition
 end

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -27,10 +27,10 @@ describe API::DeclarationSerializer, type: :serializer do
     it "serializes correctly" do
       expect(attributes["participant_id"]).to eq(teacher.api_id)
       expect(attributes["declaration_type"]).to eq(declaration.declaration_type)
-      expect(attributes["declaration_date"]).to eq(declaration.declaration_date.rfc3339)
+      expect(attributes["declaration_date"]).to eq(declaration.declaration_date.utc.rfc3339)
 
-      expect(attributes["updated_at"]).to eq(declaration.updated_at.rfc3339)
-      expect(attributes["created_at"]).to eq(declaration.created_at.rfc3339)
+      expect(attributes["updated_at"]).to eq(declaration.updated_at.utc.rfc3339)
+      expect(attributes["created_at"]).to eq(declaration.created_at.utc.rfc3339)
       expect(attributes["delivery_partner_id"]).to eq(delivery_partner.api_id)
       expect(attributes["ineligible_for_funding_reason"]).to be_nil
       expect(attributes["statement_id"]).to be_nil

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -216,7 +216,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
               let!(:finished_induction_period) { FactoryBot.create(:induction_period, :pass, teacher:) }
 
               it "serializes `induction_end_date` from finished induction period" do
-                expect(ect_enrolment["induction_end_date"]).to eq(finished_induction_period.finished_on.rfc3339)
+                expect(ect_enrolment["induction_end_date"]).to eq(finished_induction_period.finished_on.to_fs(:api))
               end
             end
 
@@ -224,7 +224,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
               before { teacher.update!(trs_induction_completed_date: Date.new(2024, 9, 18)) }
 
               it "serializes `induction_end_date` from TRS induction completed date" do
-                expect(ect_enrolment["induction_end_date"]).to eq(teacher.trs_induction_completed_date.rfc3339)
+                expect(ect_enrolment["induction_end_date"]).to eq(teacher.trs_induction_completed_date.to_fs(:api))
               end
             end
           end
@@ -234,7 +234,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
               let!(:started_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:) }
 
               it "serializes `overall_induction_start_date` from started induction period" do
-                expect(ect_enrolment["overall_induction_start_date"]).to eq(started_induction_period.started_on.rfc3339)
+                expect(ect_enrolment["overall_induction_start_date"]).to eq(started_induction_period.started_on.to_fs(:api))
               end
             end
 
@@ -242,7 +242,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
               before { teacher.update!(trs_induction_start_date: Date.new(2024, 9, 18)) }
 
               it "serializes `overall_induction_start_date` from TRS induction start date" do
-                expect(ect_enrolment["overall_induction_start_date"]).to eq(teacher.trs_induction_start_date.rfc3339)
+                expect(ect_enrolment["overall_induction_start_date"]).to eq(teacher.trs_induction_start_date.to_fs(:api))
               end
             end
           end
@@ -309,7 +309,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
             expect(mentor_enrolment["overall_induction_start_date"]).to be_nil
 
-            expect(mentor_enrolment["mentor_funding_end_date"]).to eq(teacher.mentor_became_ineligible_for_funding_on.rfc3339)
+            expect(mentor_enrolment["mentor_funding_end_date"]).to eq(teacher.mentor_became_ineligible_for_funding_on.to_fs(:api))
 
             expect(mentor_enrolment["mentor_ineligible_for_funding_reason"]).to be_present
             expect(mentor_enrolment["mentor_ineligible_for_funding_reason"]).to eq(teacher.mentor_became_ineligible_for_funding_reason)


### PR DESCRIPTION
### Context

Ticket: [3246](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3246)

A LP has reported that time formats vary in the RECT API. They shouldn't, and we should confirm if they're correct, and if so, fix it.

### Changes proposed in this pull request

- Make datetime fields format consistent in the api responses;

### Guidance to review

Review app
