### PR TITLE
Update devcontainer Ruby to `3.4.8`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/ruby:1": {
-      "version": "3.4.7"
+      "version": "3.4.8"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22.5"


### PR DESCRIPTION
### Summary

Follow up to the Ruby `3.4.8` upgrade: devcontainer was still pinned to `3.4.7`.