### PR TITLE
[2130] Fix flaky `ActiveLeadProvider` spec

### DIFF
--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -43,7 +43,7 @@ describe ActiveLeadProvider do
     describe ".available_for_delivery_partner" do
       let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
       let(:other_delivery_partner) { FactoryBot.create(:delivery_partner) }
-      let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+      let(:contract_period) { FactoryBot.create(:contract_period) }
       let!(:available_alp_1) { FactoryBot.create(:active_lead_provider, contract_period:) }
       let!(:available_alp_2) { FactoryBot.create(:active_lead_provider, contract_period:) }
       let!(:assigned_alp) { FactoryBot.create(:active_lead_provider, contract_period:) }
@@ -103,7 +103,7 @@ describe ActiveLeadProvider do
 
     describe ".without_existing_partnership_for" do
       let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-      let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+      let(:contract_period) { FactoryBot.create(:contract_period) }
       let!(:available_alp) { FactoryBot.create(:active_lead_provider, contract_period:) }
       let!(:partnered_alp) { FactoryBot.create(:active_lead_provider, contract_period:) }
       let!(:different_period_alp) { FactoryBot.create(:active_lead_provider) }


### PR DESCRIPTION
### Summary

`ContractPeriod` is created via a factory that persists with `find_or_create_by(year:)`.

Hardcoding the year `2025` in the `.available_for_delivery_partner` spec could reuse an already existing `2025` contract period (and its associated `ActiveLeadProvider`'s), causing unexpected records to appear in the result and breaking the assertion.

Fixed by creating a `contract_period` not fixed to a year in the example so it always uses a fresh year from the factory sequence, avoiding collisions.