### PR TITLE
Enable challenged partnerships in migrator

### DIFF
--- a/app/migration/migrators/school_partnership.rb
+++ b/app/migration/migrators/school_partnership.rb
@@ -9,7 +9,7 @@ module Migrators
     end
 
     def self.partnerships
-      ::Migration::Partnership.where(challenged_at: nil)
+      ::Migration::Partnership.all
     end
 
     def self.dependencies

--- a/spec/migration/migrators/school_partnership_spec.rb
+++ b/spec/migration/migrators/school_partnership_spec.rb
@@ -49,6 +49,20 @@ describe Migrators::SchoolPartnership do
           expect(school_partnership.api_updated_at).to eq expected_api_updated_at
         end
       end
+
+      context "when the partnership is challenged" do
+        before do
+          migration_resource1.update!(challenged_at: 1.week.ago)
+        end
+
+        it "migrates the partnership" do
+          expect {
+            instance.migrate!
+          }.to change(SchoolPartnership, :count).by(2)
+
+          expect(SchoolPartnership.find_by(api_id: migration_resource1.id)).to be_present
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We are not migrating challenged `Partnership` records from ECF1. This means we cannot build training periods for these and also cannot associate any declarations that have been paid via a challenged partnership.

Currently there are 10.7k errors generated in migration related to missing school partnerships, a large number of which is believed to be related to these missing challenged partnerships.

### Changes proposed in this pull request

Remove restriction that prevents challenged partnerships from being migrated.

