### PR TITLE
Fix flakey teacher history converter spec

### DIFF
--- a/spec/migration/teacher_history_converter/teacher_spec.rb
+++ b/spec/migration/teacher_history_converter/teacher_spec.rb
@@ -37,11 +37,11 @@ describe "Migrating a teacher record" do
     end
 
     it "sets the first and last name from the user" do
-      first_name, last_name = *ecf1_teacher_history.user.full_name.split
+      parsed_name = Teachers::FullNameParser.new(full_name: ecf1_teacher_history.user.full_name)
 
       aggregate_failures do
-        expect(subject.teacher.trs_first_name).to eql(first_name)
-        expect(subject.teacher.trs_last_name).to eql(last_name)
+        expect(subject.teacher.trs_first_name).to eql(parsed_name.first_name)
+        expect(subject.teacher.trs_last_name).to eql(parsed_name.last_name)
       end
     end
 


### PR DESCRIPTION
### Summary

`TeacherHistoryConverter` uses `Teachers::FullNameParser` (which strips titles like Miss/Mr/Dr) when setting `trs_first_name`/`last_name`. 

The spec was splitting the raw `full_name`, so it intermittently failed when Faker generated a titled name.

E.g:

```
Failures:

  1) Migrating a teacher record teacher attributes sets the first and last name from the user
     Failure/Error: expect(subject.teacher.trs_first_name).to eql(first_name)

       expected: "Miss"
            got: "Alanius"

       (compared using eql?)
     # ./spec/migration/teacher_history_converter/teacher_spec.rb:43:in 'block (4 levels) in <main>'
     # ./spec/migration/teacher_history_converter/teacher_spec.rb:42:in 'block (3 levels) in <main>'
     # ./spec/rails_helper.rb:55:in 'block (3 levels) in <top (required)>'
     # ./app/models/concerns/declarative_updates.rb:59:in 'DeclarativeUpdates.skip'
     # ./spec/rails_helper.rb:55:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rack_attack.rb:15:in 'block (2 levels) in <main>'

Finished in 2 minutes 1.8 seconds (files took 9.64 seconds to load)
2082 examples, 1 failure, 2 pending

Failed examples:

rspec ./spec/migration/teacher_history_converter/teacher_spec.rb:39 # Migrating a teacher record teacher attributes sets the first and last name from the user

Randomized with seed 28569

```

We can fix this by asserting against the parsed name.
