### PR TITLE
Add migrated record counts component

### DIFF
--- a/app/components/migration/migrated_record_counts_component.rb
+++ b/app/components/migration/migrated_record_counts_component.rb
@@ -1,0 +1,47 @@
+class Migration::MigratedRecordCountsComponent < ViewComponent::Base
+  def call
+    helpers.govuk_summary_list(actions: false) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "ECTAtSchoolPeriod")
+        row.with_value(text: format(ect_at_school_periods_count))
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "MentorAtSchoolPeriod")
+        row.with_value(text: format(mentor_at_school_periods_count))
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "MentorshipPeriod")
+        row.with_value(text: format(mentorship_periods_count))
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "TrainingPeriod")
+        row.with_value(text: format(training_periods_count))
+      end
+    end
+  end
+
+private
+
+  def ect_at_school_periods_count
+    ECTAtSchoolPeriod.count
+  end
+
+  def mentor_at_school_periods_count
+    MentorAtSchoolPeriod.count
+  end
+
+  def mentorship_periods_count
+    MentorshipPeriod.count
+  end
+
+  def training_periods_count
+    TrainingPeriod.count
+  end
+
+  def format(number)
+    helpers.number_with_delimiter(number)
+  end
+end

--- a/app/views/migration/migrations/_completed_migration.html.erb
+++ b/app/views/migration/migrations/_completed_migration.html.erb
@@ -32,6 +32,10 @@ end %>
 
 <%= render Migration::CombinationsSummaryComponent.new(@combinations) %>
 
+<h2 class="govuk-heading-m">Record counts in ECF2</h2>
+
+<%= render Migration::MigratedRecordCountsComponent.new %>
+
 <div class="govuk-!-margin-top-6">
   <%= govuk_button_link_to "View Cache Performance Statistics", cache_stats_migration_migrations_path, secondary: true %>
 </div>

--- a/spec/components/migration/migrated_record_counts_component_spec.rb
+++ b/spec/components/migration/migrated_record_counts_component_spec.rb
@@ -1,0 +1,23 @@
+describe Migration::MigratedRecordCountsComponent, type: :component do
+  before do
+    allow(ECTAtSchoolPeriod).to receive(:count).and_return(100_000)
+    allow(MentorAtSchoolPeriod).to receive(:count).and_return(200_000)
+    allow(MentorshipPeriod).to receive(:count).and_return(300_000)
+    allow(TrainingPeriod).to receive(:count).and_return(400_000)
+
+    render_inline(Migration::MigratedRecordCountsComponent.new)
+  end
+
+  it "renders a summary list" do
+    expect(page).to have_css(".govuk-summary-list")
+  end
+
+  it "renders a summary list displaying formatted counts" do
+    aggregate_failures do
+      expect(page).to have_css(".govuk-summary-list__row", text: /ECTAtSchoolPeriod.*100,000/)
+      expect(page).to have_css(".govuk-summary-list__row", text: /MentorAtSchoolPeriod.*200,000/)
+      expect(page).to have_css(".govuk-summary-list__row", text: /MentorshipPeriod.*300,000/)
+      expect(page).to have_css(".govuk-summary-list__row", text: /TrainingPeriod.*400,000/)
+    end
+  end
+end


### PR DESCRIPTION
This summary list on the completed migration page shows a list of counts for the 4 period types we care about here, `ECTAtSchoolPeriod`, `MentorAtSchoolPeriod`, `MentorshipPeriod` and `TrainingPeriod`.

<img width="756" height="313" alt="image" src="https://github.com/user-attachments/assets/fe6bfeb8-d103-4a79-929d-7a154df208ba" />


