### PR TITLE
Add class for determining migration strategy

### DIFF
--- a/app/migration/teacher_history_converter.rb
+++ b/app/migration/teacher_history_converter.rb
@@ -20,9 +20,7 @@ class TeacherHistoryConverter
 private
 
   def select_migration_mode
-    # FIXME: make this cleverer
-
-    :latest_induction_records
+    MigrationStrategy.new(ecf1_teacher_history).strategy
   end
 
   def date_corrector

--- a/app/migration/teacher_history_converter/migration_strategy.rb
+++ b/app/migration/teacher_history_converter/migration_strategy.rb
@@ -1,0 +1,12 @@
+class TeacherHistoryConverter::MigrationStrategy
+  attr_accessor :ecf1_teacher_history
+
+  def initialize(ecf1_teacher_history)
+    @ecf1_teacher_history = ecf1_teacher_history
+  end
+
+  # :earliest_induction_records or :latest_induction_records
+  def strategy
+    :latest_induction_records
+  end
+end

--- a/spec/migration/teacher_history_converter/migration_strategy_spec.rb
+++ b/spec/migration/teacher_history_converter/migration_strategy_spec.rb
@@ -1,0 +1,15 @@
+describe TeacherHistoryConverter::MigrationStrategy do
+  subject { TeacherHistoryConverter::MigrationStrategy.new(ecf1_teacher_history) }
+
+  let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history) }
+
+  it "defaults to economy" do
+    expect(subject.strategy).to be(:latest_induction_records)
+  end
+
+  describe "Premium" do
+    context "when condition X is met" do
+      it "returns :all_induction_records"
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter_spec.rb
+++ b/spec/migration/teacher_history_converter_spec.rb
@@ -23,4 +23,20 @@ describe TeacherHistoryConverter do
       end
     end
   end
+
+  describe "Strategy selection" do
+    subject { TeacherHistoryConverter.new(ecf1_teacher_history:).migration_mode }
+
+    context "when the ECF1TeacherHistory meets premium conditions", pending: "Add strategy selection logic" do
+      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, :premium) }
+
+      it { is_expected.to be(:all_induction_records) }
+    end
+
+    context "when the ECF1TeacherHistory doesn't meet premium conditions" do
+      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history) }
+
+      it { is_expected.to be(:latest_induction_records) }
+    end
+  end
 end


### PR DESCRIPTION
This will happen at the teacher level and the decision will be made based on the contents of an ECF1TeacherHistory object.

For now it's still hardcoded to `:latest_induction_records`.
