### PR TITLE
Enable migration to raise an error as well as just log it

### DIFF
--- a/app/migration/ecf2_teacher_history.rb
+++ b/app/migration/ecf2_teacher_history.rb
@@ -88,6 +88,11 @@ private
     yield
   rescue ActiveRecord::ActiveRecordError => e
     record_failure!(teacher:, model:, message: e.message, migration_item_id:)
+    raise if raise_errors?
+  end
+
+  def raise_errors?
+    Rails.application.config.raise_migration_errors
   end
 
   def record_failure!(teacher:, model:, message:, migration_item_id:)

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,6 +68,8 @@ module RegisterEarlyCareerTeachers
       rect_url: ENV["PARITY_CHECK_RECT_URL"],
     }
 
+    config.raise_migration_errors = ActiveModel::Type::Boolean.new.cast(ENV.fetch("RAISE_MIGRATION_ERRORS", false))
+
     config.gias_supplemental_schools_path = Rails.root.join("config/gias/schools.csv")
     config.gias_supplemental_links_path = Rails.root.join("config/gias/links.csv")
 


### PR DESCRIPTION
### Context

Enable the migration code to raise errors as well as log errors when migrating teacher data.  This is only useful locally when trying to navigate complicated data issues so that you can see exactly what the issue is and the context around it.

Set the env var RAISE_MIGRATION_ERRORS to enable. By default it will only log errors.
