### PR TITLE
Assign trs_qts_awarded_on in Teacher seeds

### DIFF
--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -72,7 +72,8 @@ teachers = [
   { trn: "0000020", trs_first_name: "Helen", trs_last_name: "Mirren", corrected_name: "Dame Helen Mirren", trs_induction_status: "Passed" },
   { trn: "0000021", trs_first_name: "Peter", trs_last_name: "Davison", trs_induction_status: "RequiredToComplete", ect_payments_frozen_year: 2022, mentor_payments_frozen_year: 2022 },
   { trn: "0000022", trs_first_name: "Roy", trs_last_name: "Dotrice", **early_roll_out_mentor_attrs },
-  { trn: "0000024", trs_first_name: "Alastair", trs_last_name: "Sim", trs_induction_status: "InProgress" },
+  # no QTS needed for AB check-data scenarios
+  { trn: "0000024", trs_first_name: "Alastair", trs_last_name: "Sim", trs_induction_status: "InProgress", trs_qts_awarded_on: nil },
   { trn: "0000025", trs_first_name: "Margaret", trs_last_name: "Rutherford", trs_induction_status: "InProgress" },
   { trn: "0000026", trs_first_name: "Terry", trs_last_name: "Thomas", trs_induction_status: "InProgress" },
   { trn: "0000027", trs_first_name: "Sid", trs_last_name: "James", trs_induction_status: "InProgress" },
@@ -90,10 +91,14 @@ teachers.each do |attrs|
 
   teacher = Teacher.find_or_initialize_by(trn:)
 
-  teacher.assign_attributes(
-    attrs.excluding(:traits, :id_changed_from_trn).except(:trn)
-  )
+  teacher_attributes = attrs.excluding(:traits, :id_changed_from_trn).except(:trn)
 
+  # Set default QTS date (must be before start dates in teacher_histories.rb) unless explicitly defined
+  unless attrs.key?(:trs_qts_awarded_on)
+    teacher_attributes[:trs_qts_awarded_on] = Date.new(2021, 1, 1)
+  end
+
+  teacher.assign_attributes(teacher_attributes)
   teacher.save!
 
   if attrs[:traits]&.include?(:with_teacher_id_change)


### PR DESCRIPTION
### Context

Currently **Teachers** seed data leaves `trs_qts_awarded_on` as null,
this creates an anomaly where teachers without QTS have **InductionPeriods**, 
whereas only **Teachers** _with_ a QTS can have **InductionPeriods**

### Changes proposed in this pull request

Adds a default `trs_qts_awarded_on` to the **Teachers** seed data.
We need to leave at least one as null to support the **AppropriateBody** `check-data` flow.

### Guidance to review

We use `TRN: 0000024` for the missing QTS,  as this teacher is in the `Golden Leaf Teaching School Hub` which has an AppropriateBody persona, and currently does not have an **InductionPeriod** seed.