### PR TITLE
Add `vat_registered` to `LeadProvider`

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -13,6 +13,7 @@ class LeadProvider < ApplicationRecord
   # Validations
   validates :name, presence: true, uniqueness: true
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
+  validates :vat_registered, inclusion: [true, false]
 
   scope :alphabetical, -> { order(name: :asc) }
 

--- a/app/services/api_seed_data/lead_providers.rb
+++ b/app/services/api_seed_data/lead_providers.rb
@@ -1,13 +1,34 @@
 module APISeedData
   class LeadProviders < Base
     DATA = {
-      "Ambition Institute" => 2021..2025,
-      "Best Practice Network" => 2021..2024,
-      "Capita" => 2021..2022,
-      "Teach First" => 2021..2025,
-      "National Institute of Teaching" => 2021..2025,
-      "Education Development Trust" => 2021..2025,
-      "UCL Institute of Education" => 2021..2025,
+      "Ambition Institute" => {
+        contract_period_years: 2021..2025,
+        vat_registered: true,
+      },
+      "Best Practice Network" => {
+        contract_period_years: 2021..2024,
+        vat_registered: true,
+      },
+      "Capita" => {
+        contract_period_years: 2021..2022,
+        vat_registered: true,
+      },
+      "Teach First" => {
+        contract_period_years: 2021..2025,
+        vat_registered: false,
+      },
+      "National Institute of Teaching" => {
+        contract_period_years: 2021..2025,
+        vat_registered: false,
+      },
+      "Education Development Trust" => {
+        contract_period_years: 2021..2025,
+        vat_registered: true,
+      },
+      "UCL Institute of Education" => {
+        contract_period_years: 2021..2025,
+        vat_registered: true,
+      },
     }.freeze
 
     def plant
@@ -15,15 +36,15 @@ module APISeedData
 
       log_plant_info("lead providers")
 
-      DATA.each.with_index do |(name, active_years), index|
-        lead_provider = FactoryBot.create(:lead_provider, name:)
+      DATA.each.with_index do |(name, attributes), index|
+        lead_provider = FactoryBot.create(:lead_provider, name:, vat_registered: attributes[:vat_registered])
 
-        active_years.each do |year|
+        attributes[:contract_period_years].each do |year|
           contract_period = ContractPeriod.find_by!(year:)
           FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:)
         end
 
-        log_seed_info("#{Colourize.text(name, colour(index))} (#{active_years.to_a.join(', ')})")
+        log_seed_info("#{Colourize.text(name, colour(index))} (#{attributes[:contract_period_years].to_a.join(', ')})")
       end
     end
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -331,6 +331,7 @@
   - id
   - ecf_id
   - name
+  - vat_registered
   - created_at
   - updated_at
   :events:

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -28,6 +28,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "TRN" # Teacher Reference Number
   inflect.acronym "TRS" # Teaching Record System
   inflect.acronym "URN" # Unique Reference Number
+  inflect.acronym "VAT" # Value Added Tax
 
   inflect.irregular "was", "were"
 end

--- a/db/migrate/20260206084155_add_vat_registered_to_lead_providers.rb
+++ b/db/migrate/20260206084155_add_vat_registered_to_lead_providers.rb
@@ -1,0 +1,5 @@
+class AddVATRegisteredToLeadProviders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :lead_providers, :vat_registered, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_05_145833) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_06_084155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -431,6 +431,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_05_145833) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "ecf_id"
+    t.boolean "vat_registered", default: true, null: false
     t.index ["ecf_id"], name: "index_lead_providers_on_ecf_id", unique: true
     t.index ["name"], name: "index_lead_providers_on_name", unique: true
   end

--- a/db/seeds/lead_providers.rb
+++ b/db/seeds/lead_providers.rb
@@ -9,17 +9,17 @@ def describe_lead_provider(lead_provider, years)
 end
 
 lead_providers_data = [
-  { name: "Ambition Institute", years: [2021, 2022, 2023, 2024, 2025, 2026] },
-  { name: "Best Practice Network", years: [2022, 2023, 2024, 2025] },
-  { name: "Capita", years: [2021, 2022, 2023] },
-  { name: "Education Development Trust", years: [2021, 2022, 2023, 2024, 2025] },
-  { name: "National Institute of Teaching", years: [2021] },
-  { name: "Teach First", years: [2021, 2022, 2023, 2024, 2025] },
-  { name: "UCL Institute of Education", years: [2021, 2022, 2023, 2024, 2025] },
+  { name: "Ambition Institute", years: [2021, 2022, 2023, 2024, 2025, 2026], vat_registered: true },
+  { name: "Best Practice Network", years: [2022, 2023, 2024, 2025], vat_registered: true },
+  { name: "Capita", years: [2021, 2022, 2023], vat_registered: true },
+  { name: "Education Development Trust", years: [2021, 2022, 2023, 2024, 2025], vat_registered: true },
+  { name: "National Institute of Teaching", years: [2021], vat_registered: false },
+  { name: "Teach First", years: [2021, 2022, 2023, 2024, 2025], vat_registered: false },
+  { name: "UCL Institute of Education", years: [2021, 2022, 2023, 2024, 2025], vat_registered: true },
 ]
 
 lead_providers_data.each do |data|
-  lead_provider = LeadProvider.find_or_create_by!(name: data[:name])
+  lead_provider = LeadProvider.find_or_create_by!(data.slice(:name, :vat_registered))
 
   data[:years].each do |year|
     contract_period = ContractPeriod.find_by!(year:)

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -283,6 +283,7 @@ erDiagram
     datetime created_at
     datetime updated_at
     uuid ecf_id
+    boolean vat_registered
   }
   InductionPeriod {
     integer id

--- a/spec/factories/lead_provider_factory.rb
+++ b/spec/factories/lead_provider_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory(:lead_provider) do
     sequence(:name) { |n| "Lead Provider #{n}" }
     ecf_id { SecureRandom.uuid }
+    vat_registered { true }
 
     initialize_with do
       LeadProvider.find_or_initialize_by(name:)

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -30,6 +30,8 @@ describe LeadProvider do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.allow_nil }
+    it { is_expected.to allow_values(true, false).for(:vat_registered) }
+    it { is_expected.not_to allow_values(nil, "").for(:vat_registered) }
 
     describe ".alphabetical" do
       let(:lead_provider1) { FactoryBot.create(:lead_provider, name: "C") }

--- a/spec/services/api_seed_data/lead_providers_spec.rb
+++ b/spec/services/api_seed_data/lead_providers_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe APISeedData::LeadProviders do
   let(:instance) { described_class.new }
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
-  let(:all_registration_years) { described_class::DATA.values.map(&:to_a).flatten }
+  let(:all_registration_years) { described_class::DATA.values.map { it[:contract_period_years] }.map(&:to_a).flatten }
 
   before do
     allow(Logger).to receive(:new).with($stdout) { logger }
@@ -17,11 +17,11 @@ RSpec.describe APISeedData::LeadProviders do
     it "creates lead providers and active lead providers with correct attributes" do
       instance.plant
 
-      described_class::DATA.each do |name, active_years|
+      described_class::DATA.each do |name, attributes|
         lead_provider = LeadProvider.find_by(name:)
         expect(lead_provider).to be_present
 
-        active_years.each do |year|
+        attributes[:contract_period_years].each do |year|
           active_lead_provider = ActiveLeadProvider.find_by(
             lead_provider:,
             contract_period: ContractPeriod.find_by!(year:)


### PR DESCRIPTION
We need to know if each lead provider is VAT registered or not in order to display the correct total amounts on their financial statements.

Add `vat_registered` to `LeadProvider`.

Default to `true` - we set it to `false` where applicable in the seeds and will need to manually update staging/sandbox.
