### PR TITLE
Fix flakey delivery partner seed spec

### DIFF
--- a/spec/services/api_seed_data/delivery_partners_spec.rb
+++ b/spec/services/api_seed_data/delivery_partners_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe APISeedData::DeliveryPartners do
       expect(logger).to have_received(:info).with(/Planting delivery partners/).once
 
       DeliveryPartner.find_each do |delivery_partner|
-        expect(logger).to have_received(:info).with(/#{delivery_partner.name}/).once
+        expect(logger).to have_received(:info).with(/#{delivery_partner.name}$/).once
       end
     end
 


### PR DESCRIPTION
This is failing because we are creating 100 delivery partners and are using a regex to match on the names; some names are subsets of other names, for example:

Delivery partner 1
Delivery partner 10
Delivery partner 100

By adding a `$` to the end of the regex we are matching on the end of the line and avoiding subset matches.
