### PR TITLE
Update `/participants` error message for invalid course identifiers

### DIFF
--- a/app/services/api/concerns/teachers/shared_action.rb
+++ b/app/services/api/concerns/teachers/shared_action.rb
@@ -13,15 +13,19 @@ module API::Concerns::Teachers
       attribute :teacher_type
 
       validates :lead_provider_id, presence: { message: "Enter a '#/lead_provider_id'." }
-      validates :teacher_api_id, presence: { message: "Enter a '#/teacher_api_id'." }
-      validates :teacher_type, presence: { message: "Enter a '#/teacher_type'." }
-
       validate :lead_provider_exists
-      validate :teacher_training_exists
-      validates :teacher_type, inclusion: {
-        in: TEACHER_TYPES,
-        message: "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again."
-      }, allow_blank: true
+
+      validates :teacher_api_id, presence: { message: "Enter a '#/teacher_api_id'." }
+      validate :teacher_exists
+
+      validates :teacher_type, presence: { message: "Enter a '#/teacher_type'." }
+      validates :teacher_type,
+                inclusion: {
+                  in: TEACHER_TYPES,
+                  message: "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again."
+                },
+                allow_blank: true
+      validate :teacher_type_exists
     end
 
   private
@@ -41,11 +45,18 @@ module API::Concerns::Teachers
       errors.add(:lead_provider_id, "The '#/lead_provider_id' you have entered is invalid.")
     end
 
-    def teacher_training_exists
+    def teacher_exists
       return if errors[:teacher_api_id].any?
-      return if training_period
+      return if teacher
 
       errors.add(:teacher_api_id, "Your update cannot be made as the '#/teacher_api_id' is not recognised. Check participant details and try again.")
+    end
+
+    def teacher_type_exists
+      return if errors[:teacher_type].any?
+      return if training_period
+
+      errors.add(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.")
     end
 
     def metadata

--- a/app/services/api/teachers/resume.rb
+++ b/app/services/api/teachers/resume.rb
@@ -27,6 +27,7 @@ module API::Teachers
 
     def no_ongoing_today_training_period
       return if errors[:teacher_api_id].any?
+      return unless training_period
 
       school_period = training_period.at_school_period
 
@@ -40,6 +41,7 @@ module API::Teachers
 
     def school_period_ongoing_today
       return if errors[:teacher_api_id].any?
+      return unless training_period
 
       school_period = training_period.at_school_period
       errors.add(:teacher_api_id, "The participant is no longer at the school. Please contact the induction tutor to resolve.") unless school_period.ongoing_today?

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -83,20 +83,6 @@ RSpec.describe API::Declarations::Create, type: :model do
           it { is_expected.to have_error(:teacher_type, "Enter a '#/teacher_type'.") }
         end
 
-        context "when wrong teacher type is provided for the trainee" do
-          # Set `teacher_type` param to :ect for Mentor or :mentor for ECT
-          let(:teacher_type) { trainee_type == :ect ? :mentor : :ect }
-
-          it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
-          it { is_expected.to have_no_error(:declaration_type) }
-        end
-
-        context "when a non existing teacher type is used" do
-          let(:teacher_type) { :fake }
-
-          it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
-        end
-
         context "when `declaration_date` is nil" do
           let!(:declaration_date) { nil }
 

--- a/spec/support/shared_examples/api_teacher_shared_action_support.rb
+++ b/spec/support/shared_examples/api_teacher_shared_action_support.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples "an API teacher shared action", :with_metadata do
 
         it { is_expected.to validate_presence_of(:lead_provider_id).with_message("Enter a '#/lead_provider_id'.") }
         it { is_expected.to validate_presence_of(:teacher_api_id).with_message("Enter a '#/teacher_api_id'.") }
-        it { is_expected.to validate_inclusion_of(:teacher_type).in_array(API::Concerns::Teachers::SharedAction::TEACHER_TYPES).with_message("The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
+        it { is_expected.to validate_presence_of(:teacher_type).with_message("Enter a '#/teacher_type'.") }
 
         context "when the `lead_provider` does not exist" do
           let(:lead_provider_id) { 9999 }
@@ -28,14 +28,14 @@ RSpec.shared_examples "an API teacher shared action", :with_metadata do
           let(:teacher_type) { trainee_type == :ect ? :mentor : :ect }
 
           it { is_expected.to have_one_error_per_attribute }
-          it { is_expected.to have_error(:teacher_api_id, "Your update cannot be made as the '#/teacher_api_id' is not recognised. Check participant details and try again.") }
+          it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
         context "when a matching training period does not exist (different lead provider)" do
           let(:lead_provider_id) { FactoryBot.create(:lead_provider, name: "Different to #{lead_provider.name}").id }
 
           it { is_expected.to have_one_error_per_attribute }
-          it { is_expected.to have_error(:teacher_api_id, "Your update cannot be made as the '#/teacher_api_id' is not recognised. Check participant details and try again.") }
+          it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
         context "when the teacher does not exist" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3232

### Changes proposed in this pull request

Before, we returned a slightly misleading/confusing error message on the various PUT `/participants` endpoints.

In #2039 we updated the error message for the POST `/declarations` endpoint, and this makes the same change for the `/participants` endpoints.

Now, the error matches what lead providers would see in ECF1.

### Guidance to review
