### PR TITLE
ignore administrative_district_name check for Children's centre school types

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -65,9 +65,15 @@ module Migrators
         gias_value = gias_school.send(gias_field)
         ecf_value = ecf_school.send(ecf_field)
         next true if gias_value.presence == ecf_value.presence
+        next true if skip_missing_field?(gias_school:, field_name: gias_field)
 
         field_mismatch(gias_school, gias_field, gias_value, ecf_value)
       }.all?
+    end
+
+    def skip_missing_field?(gias_school:, field_name:)
+      # administrative_district_name is not in the split out GIAS export for Children's Centres
+      field_name.to_s == "administrative_district_name" && gias_school.type_name.in?(GIAS::Types::CHILDRENS_CENTRE_TYPES)
     end
 
     def field_mismatch(school, field, gias_value, ecf_value)

--- a/app/services/gias/types.rb
+++ b/app/services/gias/types.rb
@@ -78,6 +78,11 @@ module GIAS
       "Other independent school"
     ].freeze
 
+    CHILDRENS_CENTRE_TYPES = [
+      "Children's centre",
+      "Children's centre linked site"
+    ].freeze
+
     STATE_SCHOOL_TYPES = ALL_TYPES - INDEPENDENT_SCHOOLS_TYPES
 
     NOT_IN_ENGLAND_TYPES = [

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -134,6 +134,44 @@ describe Migrators::School do
       end
     end
 
+    context "when school is a Children's Centre type" do
+      let!(:ecf_school) do
+        FactoryBot.create(:ecf_migration_school,
+                          school_status_code: 1,
+                          administrative_district_name: "AD1",
+                          administrative_district_code: "9999",
+                          school_type_code: 1,
+                          name: "School one",
+                          school_phase_name: "Phase one",
+                          section_41_approved: false,
+                          school_status_name: "Open",
+                          school_type_name: "Children's centre",
+                          ukprn: "12345")
+      end
+
+      let!(:gias_school) do
+        FactoryBot.create(:gias_school, :with_school,
+                          urn: ecf_school.urn,
+                          administrative_district_name: nil,
+                          eligible: true,
+                          in_england: true,
+                          name: "School one",
+                          phase_name: "Phase one",
+                          section_41_approved: false,
+                          status: "open",
+                          type_name: "Children's centre",
+                          ukprn: 12_345)
+      end
+
+      before do
+        described_class.new(worker: 0).migrate!
+      end
+
+      it "skips comparing the administrative_district_name field" do
+        expect(data_migration.reload.failure_count).to be_zero
+      end
+    end
+
     context "when schools match" do
       let!(:ecf_school) { create_ecf_school }
       let!(:gias_school) { create_gias_school(ecf_school) }


### PR DESCRIPTION
### Context

The Children's centres are now imported from a separate file as GIAS has split them off.  This export does not contain the `administrative_district_name` but the original combined GIAS file did, so it is populated in ECF.
This means we report a mismatch when checking the schools in the migrator
This PR just skips this field for Children's centres in the comparison check to reduce the amount of noise in the failure logs.

