### PR TITLE
Fix absence tracking working

### DIFF
--- a/app/components/teachers/outcome_form_fields_component.html.erb
+++ b/app/components/teachers/outcome_form_fields_component.html.erb
@@ -16,7 +16,7 @@
 <%=
   govuk_list([
     "the amount of induction time they've completed so far",
-    "their full-time equivalent (FTE) working patterns and any long periods of absence",
+    "their full-time equivalent (FTE) working patterns",
     "if they have sufficient time in their current post which can count towards their induction",
   ], type: :bullet)
 %>


### PR DESCRIPTION
### Context

Issue https://github.com/DFE-Digital/register-ects-project-board/issues/3294#issuecomment-3870746581

Policy have discovered a gap in their logic around absence tracking, and we need to take away the line 'and any long periods of absence' in the following pages:
- Release ECT journey (single ECT).
- Record outcome (single ECT)

### Changes proposed in this pull request

Remove 'and any long periods of absence' from **Teachers::OutcomeFormFieldsComponent**

### Guidance to review

Simple wording change.