### PR TITLE
Withdrawn/Deferred training periods cannot start in the future

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -84,6 +84,12 @@ class TrainingPeriod < ApplicationRecord
   validate :contract_period_consistent_across_associations, if: :provider_led_training_programme?
   validate :schedule_absent_for_school_led, if: :school_led_training_programme?
   validate :schedule_applicable_for_trainee
+  with_options if: -> { started_on&.future? } do
+    validates :withdrawn_at, absence: true
+    validates :withdrawal_reason, absence: true
+    validates :deferred_at, absence: true
+    validates :deferral_reason, absence: true
+  end
 
   # Scopes
   scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }

--- a/app/services/api_seed_data/teachers_with_histories.rb
+++ b/app/services/api_seed_data/teachers_with_histories.rb
@@ -83,7 +83,11 @@ module APISeedData
       teacher = create_teacher(started_on: school_period[:started_on])
 
       training_period_data = random_period_within(**school_period)
-      training_period_traits = generate_training_period_traits
+      training_period_traits = if school_period[:started_on].future?
+                                 []
+                               else
+                                 generate_training_period_traits
+                               end
       ect_mentor_traits = generate_ect_mentor_school_period_traits
       ect_specific_traits = generate_ect_specific_traits
       schedule = find_schedule(school_partnership.contract_period)

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -177,6 +177,15 @@ describe TrainingPeriod do
       it { is_expected.to validate_presence_of(:deferred_at) }
     end
 
+    context "when started_on is in the future" do
+      subject { FactoryBot.build(:training_period, started_on: 1.day.from_now) }
+
+      it { is_expected.to validate_absence_of(:withdrawn_at) }
+      it { is_expected.to validate_absence_of(:withdrawal_reason) }
+      it { is_expected.to validate_absence_of(:deferred_at) }
+      it { is_expected.to validate_absence_of(:deferral_reason) }
+    end
+
     context "exactly one id of trainee present" do
       context "when ect_at_school_period_id and mentor_at_school_period_id are all nil" do
         subject do

--- a/spec/services/api_seed_data/teachers_with_histories_spec.rb
+++ b/spec/services/api_seed_data/teachers_with_histories_spec.rb
@@ -198,6 +198,10 @@ RSpec.describe APISeedData::TeachersWithHistories do
         stub_const("#{described_class}::ECT_MENTOR_RATIO", 1.0)
         stub_const("#{described_class}::OPTIONAL_MENTOR_TRAINING_RATIO", 1.0)
         stub_const("#{described_class}::WITHDRAWN_RATIO", 1.0)
+        # Withdrawn TrainingPeriod records can only be created if the
+        # started_on is not in the future
+        latest_contract_period = ContractPeriod.order(year: :desc).first
+        travel_to Date.new(latest_contract_period.year, 12, 31)
       end
 
       it { expect { plant }.to change(TrainingPeriod.where.not(withdrawn_at: nil), :count).by(20) }
@@ -209,6 +213,10 @@ RSpec.describe APISeedData::TeachersWithHistories do
         stub_const("#{described_class}::OPTIONAL_MENTOR_TRAINING_RATIO", 1.0)
         stub_const("#{described_class}::WITHDRAWN_RATIO", 0.0)
         stub_const("#{described_class}::DEFERRED_RATIO", 1.0)
+        # Deferred TrainingPeriod records can only be created if the
+        # started_on is not in the future
+        latest_contract_period = ContractPeriod.order(year: :desc).first
+        travel_to Date.new(latest_contract_period.year, 12, 31)
       end
 
       it { expect { plant }.to change(TrainingPeriod.where.not(deferred_at: nil), :count).by(20) }


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3274

### Changes proposed in this pull request

Before, it was possible for a training period to be withdrawn or deferred even when it hadn't started yet.

This shape of data doesn't make much sense though, and we prevent lead providers from withdrawing or deferring participants via the API when their training hasn't started yet.

This reworks the `TeacherWithHistories` seed data so participants are only withdrawn/deferred if their training has started. This also adds a validation to the `TrainingPeriod` model to ensure withdrawal/deferral attributes can only be set if the `started_on` date is *not* in the future.

We will run a script on sandbox to update any impacted training periods.

### Guidance to review
