### PR TITLE
Stamp delivery partner ID on declarations

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -10,10 +10,11 @@ class Declaration < ApplicationRecord
   belongs_to :training_period
   belongs_to :voided_by_user, class_name: "User", optional: true
   belongs_to :mentorship_period, optional: true
+  belongs_to :delivery_partner_when_created, class_name: "DeliveryPartner"
+  attr_readonly :delivery_partner_when_created_id
   belongs_to :payment_statement, optional: true, class_name: "Statement"
   belongs_to :clawback_statement, optional: true, class_name: "Statement"
   has_one :lead_provider, through: :training_period
-  has_one :delivery_partner, through: :training_period
   has_one :contract_period, through: :training_period
   has_one :ect_at_school_period, through: :training_period
   has_one :ect_teacher, through: :ect_at_school_period, source: :teacher
@@ -80,6 +81,7 @@ class Declaration < ApplicationRecord
   validates :mentorship_period, absence: { message: "Mentor teacher can only be assigned to declarations for ECTs" }, if: :for_mentor?
   validates :payment_statement, presence: { message: "Payment statement must be associated for declarations with a payment status" }, unless: :payment_status_no_payment?
   validates :clawback_statement, presence: { message: "Clawback statement must be associated for declarations with a clawback status" }, unless: :clawback_status_no_clawback?
+  validates :delivery_partner_when_created, presence: { message: "Delivery partner when the declaration was created must be specified" }
   validate :mentorship_period_belongs_to_teacher
   validate :contract_period_consistent_across_associations
   validate :declaration_does_not_already_exist

--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -22,7 +22,7 @@ class API::DeclarationSerializer < Blueprinter::Base
 
     field(:updated_at)
     field(:created_at)
-    field(:delivery_partner_id) { |declaration| declaration.training_period.delivery_partner.api_id }
+    field(:delivery_partner_id) { |declaration| declaration.delivery_partner_when_created.api_id }
     field(:statement_id) { |declaration| declaration.payment_statement&.api_id }
     field(:clawback_statement_id) { |declaration| declaration.clawback_statement&.api_id }
     # This will be removed at a later date, retaining for now for ECF parity and so

--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -45,11 +45,11 @@ module API::Declarations
         .includes(
           :payment_statement,
           :clawback_statement,
+          :delivery_partner_when_created,
           mentorship_period: { mentor: :teacher },
           training_period: [
             { ect_at_school_period: :teacher },
             { mentor_at_school_period: :teacher },
-            :delivery_partner,
             :lead_provider,
           ]
         )
@@ -148,8 +148,8 @@ module API::Declarations
       return if ignore?(filter: delivery_partner_api_ids, ignore_empty_array: false)
 
       @scope = scope
-        .joins(:delivery_partner)
-        .where(delivery_partners: { api_id: delivery_partner_api_ids })
+        .joins(:delivery_partner_when_created)
+        .where(delivery_partner_when_created: { api_id: delivery_partner_api_ids })
     end
 
     def where_updated_since(updated_since)

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -72,7 +72,8 @@ module Declarations
         declaration_date:,
         declaration_type:,
         evidence_type:,
-        mentorship_period:
+        mentorship_period:,
+        delivery_partner_when_created: training_period.delivery_partner
       )
     end
 

--- a/app/views/admin/teachers/declarations/_declaration.html.erb
+++ b/app/views/admin/teachers/declarations/_declaration.html.erb
@@ -39,7 +39,7 @@
 
       summary_list.with_row do |row|
         row.with_key { "Delivery partner" }
-        row.with_value { declaration.delivery_partner&.name || "No delivery partner recorded" }
+        row.with_value { declaration.delivery_partner_when_created.name }
       end
 
       summary_list.with_row do |row|

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -188,6 +188,7 @@ shared:
     - voided_by_user_at
     - voided_by_user_id
     - mentorship_period_id
+    - delivery_partner_when_created_id
     - api_id
     - evidence_type
     - payment_status

--- a/db/migrate/20260206151911_add_delivery_partner_when_created_to_declarations.rb
+++ b/db/migrate/20260206151911_add_delivery_partner_when_created_to_declarations.rb
@@ -1,0 +1,11 @@
+class AddDeliveryPartnerWhenCreatedToDeclarations < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :declarations, :delivery_partner_when_created, foreign_key: { to_table: :delivery_partners }, null: true
+
+    Declaration.includes(training_period: :delivery_partner).find_each do |declaration|
+      declaration.update_column(:delivery_partner_when_created_id, declaration.training_period.delivery_partner.id)
+    end
+
+    change_column_null :declarations, :delivery_partner_when_created_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -290,8 +290,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
     t.boolean "pupil_premium_uplift", default: false, null: false
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.enum "payment_status", default: "no_payment", null: false, enum_type: "declaration_payment_statuses"
+    t.bigint "delivery_partner_when_created_id", null: false
     t.index ["api_id"], name: "index_declarations_on_api_id", unique: true
     t.index ["clawback_statement_id"], name: "index_declarations_on_clawback_statement_id"
+    t.index ["delivery_partner_when_created_id"], name: "index_declarations_on_delivery_partner_when_created_id"
     t.index ["mentorship_period_id"], name: "index_declarations_on_mentorship_period_id"
     t.index ["payment_statement_id"], name: "index_declarations_on_payment_statement_id"
     t.index ["training_period_id", "declaration_type", "payment_status"], name: "idx_unique_declarations", unique: true, where: "((payment_status = ANY (ARRAY['no_payment'::declaration_payment_statuses, 'eligible'::declaration_payment_statuses, 'payable'::declaration_payment_statuses, 'paid'::declaration_payment_statuses])) AND (clawback_status = 'no_clawback'::declaration_clawback_statuses))"
@@ -1064,6 +1066,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
   add_foreign_key "contract_banded_fee_structure_bands", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
   add_foreign_key "contracts", "active_lead_providers"
+  add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"
   add_foreign_key "declarations", "users", column: "voided_by_user_id"

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -30,6 +30,13 @@ FactoryBot.define do
       end
     end
     declaration_type { Declaration.declaration_types.keys.first }
+    delivery_partner_when_created do
+      if training_period.present?
+        training_period.delivery_partner
+      else
+        association :delivery_partner
+      end
+    end
 
     trait :voided_by_user do
       payment_status { :voided }

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
     it_behaves_like "an index endpoint"
     it_behaves_like "a paginated endpoint"
     it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
-    it_behaves_like "a filter by delivery_partner_id endpoint"
+    it_behaves_like "a filter by delivery_partner_id endpoint", :delivery_partner_when_created
     it_behaves_like "a filter by participant_id endpoint"
     it_behaves_like "a filter by updated_since endpoint", updated_at_column: :updated_at
   end
@@ -42,7 +42,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "a show endpoint"
     it_behaves_like "a does not filter by cohort endpoint"
-    it_behaves_like "a does not filter by delivery_partner_id endpoint"
+    it_behaves_like "a does not filter by delivery_partner_id endpoint", :delivery_partner_when_created
     it_behaves_like "a does not filter by participant_id endpoint"
     it_behaves_like "a does not filter by updated_since endpoint"
   end

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Partnerships API", type: :request do
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
     it_behaves_like "a filter by updated_since endpoint"
-    it_behaves_like "a filter by delivery_partner_id endpoint"
+    it_behaves_like "a filter by delivery_partner_id endpoint", :delivery_partner
     it_behaves_like "an index endpoint"
     it_behaves_like "a sortable endpoint"
   end
@@ -35,7 +35,7 @@ RSpec.describe "Partnerships API", type: :request do
     it_behaves_like "a show endpoint"
     it_behaves_like "a does not filter by cohort endpoint"
     it_behaves_like "a does not filter by updated_since endpoint"
-    it_behaves_like "a does not filter by delivery_partner_id endpoint"
+    it_behaves_like "a does not filter by delivery_partner_id endpoint", :delivery_partner
   end
 
   describe "#create" do

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       declaration1 = FactoryBot.create(:declaration)
       declaration2 = FactoryBot.create(:declaration)
 
-      query = described_class.new(delivery_partner_api_ids: declaration1.delivery_partner.api_id)
+      query = described_class.new(delivery_partner_api_ids: declaration1.delivery_partner_when_created.api_id)
 
       expect { query.declaration_by_api_id(declaration2.api_id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
@@ -441,7 +441,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       declaration1 = FactoryBot.create(:declaration)
       declaration2 = FactoryBot.create(:declaration)
 
-      query = described_class.new(delivery_partner_api_ids: declaration1.delivery_partner.api_id)
+      query = described_class.new(delivery_partner_api_ids: declaration1.delivery_partner_when_created.api_id)
 
       expect { query.declaration_by_id(declaration2.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -289,14 +289,14 @@ RSpec.shared_examples "a does not filter by updated_since endpoint" do
   end
 end
 
-RSpec.shared_examples "a filter by delivery_partner_id endpoint" do
+RSpec.shared_examples "a filter by delivery_partner_id endpoint" do |delivery_partner_association|
   it "returns only resources for the specified delivery_partner_id" do
     resource = create_resource(active_lead_provider:)
 
     # Resource with another delivery_partner_id should not be included.
     create_resource(active_lead_provider:)
 
-    params = { filter: { delivery_partner_id: resource.delivery_partner.api_id } }
+    params = { filter: { delivery_partner_id: resource.public_send(delivery_partner_association).api_id } }
     authenticated_api_get(path, params:)
 
     expect(response).to have_http_status(:ok)
@@ -310,7 +310,7 @@ RSpec.shared_examples "a filter by delivery_partner_id endpoint" do
     # Resource with another delivery_partner_id should not be included.
     create_resource(active_lead_provider:)
 
-    params = { filter: { delivery_partner_id: "#{resource.delivery_partner.api_id},invalid" } }
+    params = { filter: { delivery_partner_id: "#{resource.public_send(delivery_partner_association).api_id},invalid" } }
     authenticated_api_get(path, params:)
 
     expect(response).to have_http_status(:ok)
@@ -319,14 +319,14 @@ RSpec.shared_examples "a filter by delivery_partner_id endpoint" do
   end
 end
 
-RSpec.shared_examples "a does not filter by delivery_partner_id endpoint" do
+RSpec.shared_examples "a does not filter by delivery_partner_id endpoint" do |delivery_partner_association|
   let(:options) { defined?(serializer_options) ? serializer_options : {} }
 
   it "returns the resources, ignoring the `delivery_partner_id`" do
     # Use of a filter with a different delivery_partner_id should not change the resource returned.
     different_resource = create_resource(active_lead_provider:)
 
-    params = { filter: { delivery_partner_id: different_resource.delivery_partner.api_id } }
+    params = { filter: { delivery_partner_id: different_resource.public_send(delivery_partner_association).api_id } }
     authenticated_api_get(path, params:)
 
     expect(response).to have_http_status(:ok)

--- a/spec/views/admin/teachers/declarations/_declaration.html.erb_spec.rb
+++ b/spec/views/admin/teachers/declarations/_declaration.html.erb_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "admin/teachers/declarations/_declaration.html.erb", type: :view 
   subject { Capybara.string(rendered) }
 
   let(:lead_provider) { FactoryBot.build_stubbed(:lead_provider, name: "Test Lead Provider") }
-  let(:delivery_partner) { FactoryBot.build_stubbed(:delivery_partner, name: "Test Delivery Partner") }
+  let(:delivery_partner_when_created) { FactoryBot.build_stubbed(:delivery_partner, name: "Test Delivery Partner") }
   let(:declaration) do
     FactoryBot.build_stubbed(
       :declaration,
@@ -14,7 +14,7 @@ RSpec.describe "admin/teachers/declarations/_declaration.html.erb", type: :view 
       allow(d).to receive_messages(
         api_id: "test-declaration-uuid",
         lead_provider:,
-        delivery_partner:,
+        delivery_partner_when_created:,
         for_ect?: true,
         for_mentor?: false,
         overall_status: "no_payment",
@@ -41,18 +41,7 @@ RSpec.describe "admin/teachers/declarations/_declaration.html.erb", type: :view 
   it { is_expected.to have_summary_list_row("Declaration date and time", value: "15 January 2024, 12:00am", visible: :all) }
   it { is_expected.to have_summary_list_row("Lead provider", value: "Test Lead Provider", visible: :all) }
   it { is_expected.to have_summary_list_row("Evidence held", value: "training-event-attended", visible: :all) }
-
-  describe "delivery partner" do
-    context "when the declaration has no delivery partner" do
-      let(:delivery_partner) { nil }
-
-      it { is_expected.to have_summary_list_row("Delivery partner", value: "No delivery partner recorded", visible: :all) }
-    end
-
-    context "when the declaration has a delivery partner" do
-      it { is_expected.to have_summary_list_row("Delivery partner", value: "Test Delivery Partner", visible: :all) }
-    end
-  end
+  it { is_expected.to have_summary_list_row("Delivery partner", value: "Test Delivery Partner", visible: :all) }
 
   describe "state history" do
     context "when the declaration has no events" do

--- a/spec/views/admin/teachers/declarations/index.html.erb_spec.rb
+++ b/spec/views/admin/teachers/declarations/index.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "admin/teachers/declarations/index.html.erb" do
       allow(d).to receive_messages(
         api_id: "test-declaration-uuid",
         lead_provider: FactoryBot.build_stubbed(:lead_provider),
-        delivery_partner: FactoryBot.build_stubbed(:delivery_partner),
+        delivery_partner_when_created: FactoryBot.build_stubbed(:delivery_partner),
         for_ect?: true,
         for_mentor?: false,
         overall_status: "no_payment",
@@ -87,7 +87,7 @@ RSpec.describe "admin/teachers/declarations/index.html.erb" do
         allow(d).to receive_messages(
           api_id: "test-mentor-declaration-uuid",
           lead_provider: FactoryBot.build_stubbed(:lead_provider),
-          delivery_partner: FactoryBot.build_stubbed(:delivery_partner),
+          delivery_partner_when_created: FactoryBot.build_stubbed(:delivery_partner),
           for_ect?: false,
           for_mentor?: true,
           overall_status: "no_payment",


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3248

### Changes proposed in this pull request

Before, the lead provider API returned the current delivery partner `api_id` associated to the training period via the delivery partnership.

This was potentially confusing for providers since the delivery partner returned via the API could change over time, and might not reflect to who the declaration had been paid out.

This adds a new `delivery_partner_when_created` association to declarations which is immutable and ensures the delivery partner returned via the API is consistent with the delivery partner at the time the declaration was created.

### Guidance to review
