### PR TITLE
Overwrite first `*AtSchoolPeriod#created_at`

### DIFF
--- a/app/migration/ecf2_teacher_history/ect_at_school_period.rb
+++ b/app/migration/ecf2_teacher_history/ect_at_school_period.rb
@@ -7,6 +7,8 @@ class ECF2TeacherHistory::ECTAtSchoolPeriod
               :mentorship_periods,
               :training_periods
 
+  attr_accessor :created_at
+
   def initialize(started_on:,
                  finished_on:,
                  school:, email:,

--- a/app/migration/ecf2_teacher_history/mentor_at_school_period.rb
+++ b/app/migration/ecf2_teacher_history/mentor_at_school_period.rb
@@ -5,6 +5,8 @@ class ECF2TeacherHistory::MentorAtSchoolPeriod
               :email,
               :training_periods
 
+  attr_accessor :created_at
+
   def initialize(started_on:, finished_on:, school:, email:, training_periods: [])
     @started_on = started_on
     @finished_on = finished_on

--- a/spec/migration/teacher_history_converter_spec.rb
+++ b/spec/migration/teacher_history_converter_spec.rb
@@ -39,4 +39,40 @@ describe TeacherHistoryConverter do
       it { is_expected.to be(:latest_induction_records) }
     end
   end
+
+  describe "building ect_at_school_periods" do
+    subject(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+
+    let(:created_at) { 26.months.ago.round }
+
+    let(:induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 2) }
+    let(:ect) { FactoryBot.build(:ecf1_teacher_history_ect, created_at:, induction_records:) }
+    let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, ect:) }
+
+    it "sets the first ect_at_school_period created_at to the one from the participant_profile" do
+      expect(ecf2_teacher_history.ect_at_school_periods[0].created_at).to eql(created_at)
+    end
+
+    it "doesn't adjust the subsequent record's created_at" do
+      expect(ecf2_teacher_history.ect_at_school_periods[1].created_at).not_to eql(created_at)
+    end
+  end
+
+  describe "building mentor_at_school_periods" do
+    subject(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+
+    let(:created_at) { 28.months.ago.round }
+
+    let(:induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 2) }
+    let(:mentor) { FactoryBot.build(:ecf1_teacher_history_mentor, created_at:, induction_records:) }
+    let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, mentor:) }
+
+    it "sets the first ect_at_school_period created_at to the one from the participant_profile" do
+      expect(ecf2_teacher_history.mentor_at_school_periods[0].created_at).to eql(created_at)
+    end
+
+    it "doesn't adjust the subsequent record's created_at" do
+      expect(ecf2_teacher_history.mentor_at_school_periods[1].created_at).not_to eql(created_at)
+    end
+  end
 end


### PR DESCRIPTION
In ECF1 the API returns the `participant_profile`'s `created_at` but we don't have a natural counterpart in ECF2 so instead we use the first `at_school_period`'s `created_at` instead.
