### PR TITLE
Add `vat_rate` to `Contract` model

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -18,6 +18,9 @@ class Contract < ApplicationRecord
             uniqueness: { case_sensitive: false, message: "Contract with the same flat rate fee structure already exists" }
   validates :banded_fee_structure,
             uniqueness: { case_sensitive: false, message: "Contract with the same banded fee structure already exists" }
+  validates :vat_rate,
+            presence: { message: "VAT rate is required" },
+            numericality: { in: 0..1, message: "VAT rate must be between 0 and 1" }
   validate :active_lead_provider_consistency
 
   with_options if: :ittecf_ectp_contract_type? do

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -643,6 +643,7 @@
   :contracts:
   - id
   - contract_type
+  - vat_rate
   - flat_rate_fee_structure_id
   - banded_fee_structure_id
   - created_at

--- a/db/migrate/20260211081959_add_vat_rate_to_contracts.rb
+++ b/db/migrate/20260211081959_add_vat_rate_to_contracts.rb
@@ -1,0 +1,5 @@
+class AddVATRateToContracts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contracts, :vat_rate, :decimal, precision: 3, scale: 2, default: 0.2, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_09_174809) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_11_081959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -182,6 +182,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_09_174809) do
     t.bigint "banded_fee_structure_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
     t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true
     t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true
   end

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -424,6 +424,7 @@ erDiagram
     integer banded_fee_structure_id
     datetime created_at
     datetime updated_at
+    decimal vat_rate
   }
   Contract }o--|| Contract_FlatRateFeeStructure : belongs_to
   Contract }o--|| Contract_BandedFeeStructure : belongs_to

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -23,6 +23,8 @@ describe Contract do
     it { is_expected.to validate_inclusion_of(:contract_type).in_array(Contract.contract_types.keys).with_message("Choose a valid contract type") }
     it { is_expected.to validate_uniqueness_of(:flat_rate_fee_structure).with_message("Contract with the same flat rate fee structure already exists") }
     it { is_expected.to validate_uniqueness_of(:banded_fee_structure).with_message("Contract with the same banded fee structure already exists") }
+    it { is_expected.to validate_presence_of(:vat_rate).with_message("VAT rate is required") }
+    it { is_expected.to validate_numericality_of(:vat_rate).is_in(0..1).with_message("VAT rate must be between 0 and 1") }
 
     context "when contract type is `ITTECF_ECTP`" do
       subject { FactoryBot.create(:contract, :for_ittecf_ectp) }


### PR DESCRIPTION
We need to know the VAT rate when calculating payments. As the VAT rate could change at any point in time, we want to associate it at the contract-level (so that if it changes, historical contracts contain the previous VAT rate).
