### PR TITLE
Remove `school_funded_fip` induction records in pre-wash step

### DIFF
--- a/app/migration/teacher_history_converter/cleaner.rb
+++ b/app/migration/teacher_history_converter/cleaner.rb
@@ -11,6 +11,7 @@ private
 
   def clean!
     remove_british_schools_overseas(@raw_induction_records)
+      .then { |induction_records| remove_school_funded_fip(induction_records) }
       .then { |induction_records| fix_service_start_dates(induction_records) }
       .then { |induction_records| fix_corrupted_dates(induction_records) }
       .then { |induction_records| fix_zero_day_periods(induction_records) }
@@ -18,6 +19,10 @@ private
 
   def remove_british_schools_overseas(induction_records)
     TeacherHistoryConverter::Cleaner::BritishSchoolsOverseas.new(induction_records).induction_records
+  end
+
+  def remove_school_funded_fip(induction_records)
+    TeacherHistoryConverter::Cleaner::SchoolFundedFip.new(induction_records).induction_records
   end
 
   def fix_service_start_dates(induction_records)

--- a/app/migration/teacher_history_converter/cleaner/school_funded_fip.rb
+++ b/app/migration/teacher_history_converter/cleaner/school_funded_fip.rb
@@ -1,0 +1,17 @@
+class TeacherHistoryConverter::Cleaner::SchoolFundedFip
+  def initialize(raw_induction_records)
+    @raw_induction_records = raw_induction_records
+  end
+
+  def induction_records = remove_school_funded_fip!
+
+private
+
+  def remove_school_funded_fip!
+    @raw_induction_records.reject { |induction_record| is_school_funded_fip?(induction_record) }
+  end
+
+  def is_school_funded_fip?(induction_record)
+    induction_record.training_programme == "school_funded_fip"
+  end
+end

--- a/spec/migration/teacher_history_converter/cleaner/school_funded_fip_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/school_funded_fip_spec.rb
@@ -1,0 +1,40 @@
+describe TeacherHistoryConverter::Cleaner::SchoolFundedFip do
+  subject(:cleaner) { described_class.new(raw_induction_records) }
+
+  describe "#induction_records" do
+    let(:programme_1) { "full_induction_programme" }
+    let(:programme_2) { "core_induction_programme" }
+
+    let(:first_induction_record) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2020, 9, 1),
+        end_date: Date.new(2021, 3, 15),
+        created_at: Time.zone.local(2020, 9, 1, 12, 0, 0),
+        training_programme: programme_1
+      )
+    end
+    let(:second_induction_record) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2021, 9, 1),
+        end_date: Date.new(2022, 8, 31),
+        created_at: Time.zone.local(2021, 9, 1, 12, 0, 0),
+        training_programme: programme_2
+      )
+    end
+    let(:raw_induction_records) { [first_induction_record, second_induction_record] }
+
+    it "returns the induction records" do
+      expect(cleaner.induction_records).to match_array(raw_induction_records)
+    end
+
+    context "when an induction record is associated with a school_funded_fip training_programme" do
+      let(:programme_1) { "school_funded_fip" }
+
+      it "does not return that induction record" do
+        expect(cleaner.induction_records).to eq [second_induction_record]
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We do not want to migrate induction records associated with `school_funded_fip` training.  These are not state-funded and are not associated with any provider partnership. We do not need them and cannot set up a training_period without a partnership in the RECT schema.

### Changes proposed in this pull request

Add a pre-wash step to remove induction records associated with a `school_funded_fip` training programme.

