### PR TITLE
[3297] Fix time format on withdrawn participant endpoint error message

### DIFF
--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -156,7 +156,7 @@ module API::Declarations
       return unless training_status&.withdrawn?
       return unless training_period.withdrawn_at <= declaration_date
 
-      errors.add(:teacher_api_id, "This participant withdrew from this course on #{training_period.withdrawn_at.rfc3339}. Enter a '#/declaration_date' that's on or before the withdrawal date.")
+      errors.add(:teacher_api_id, "This participant withdrew from this course on #{training_period.withdrawn_at.utc.rfc3339}. Enter a '#/declaration_date' that's on or before the withdrawal date.")
     end
 
     def validate_only_started_or_completed_if_mentor

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           end
 
           it { is_expected.to have_one_error_per_attribute }
-          it { is_expected.to have_error(:teacher_api_id, "This participant withdrew from this course on #{withdrawn_at.rfc3339}. Enter a '#/declaration_date' that's on or before the withdrawal date.") }
+          it { is_expected.to have_error(:teacher_api_id, "This participant withdrew from this course on #{withdrawn_at.utc.rfc3339}. Enter a '#/declaration_date' that's on or before the withdrawal date.") }
         end
 
         if trainee_type == :mentor


### PR DESCRIPTION
### Context

Ticket: [3297](https://github.com/DFE-Digital/register-ects-project-board/issues/3297)

Time format is wrong on the error message: `"This participant withdrew from this course on 2026-01-08T00:00:00+00:00. Enter a '#/declaration_date' that's on or before the withdrawal date."`

### Changes proposed in this pull request

-  Fix time format on withdrawn participant endpoint error message

### Guidance to review

Review app