### PR TITLE
Remove BSO schools from migrator

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -28,12 +28,12 @@ module Migrators
     end
 
     def self.schools
-      ::Migration::School.with(eligible_or_cip_or_with_irs:
-                                 [
-                                   ::Migration::School.includes(:local_authority).eligible_or_cip_only_except_welsh.distinct,
-                                   ::Migration::School.not_open.with_induction_records.distinct
-                                 ])
-                         .from("eligible_or_cip_or_with_irs AS schools")
+      ::Migration::School.with(
+        eligible_or_cip_or_with_irs: [
+          ::Migration::School.includes(:local_authority).eligible_or_cip_only_except_welsh.not_bso_schools.distinct,
+          ::Migration::School.not_open.with_induction_records.distinct
+        ]
+      ).from("eligible_or_cip_or_with_irs AS schools")
     end
 
     def migrate!

--- a/app/models/migration/school.rb
+++ b/app/models/migration/school.rb
@@ -5,6 +5,7 @@ module Migration
     CIP_ONLY_EXCEPT_WELSH_TYPE_CODES = [10, 11, 37].freeze
     ELIGIBLE_TYPE_CODES = [1, 2, 3, 5, 6, 7, 8, 12, 14, 15, 18, 28, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 57].freeze
     OPEN_STATUS_CODES = [1, 3].freeze
+    BSO_TYPE_CODES = [37].freeze
 
     has_many :school_cohorts
     has_many :induction_programmes, through: :school_cohorts
@@ -30,6 +31,7 @@ module Migration
     scope :eligible_or_cip_only_except_welsh, -> { eligible.or(cip_only_except_welsh) }
     scope :not_cip_only, -> { where.not(id: cip_only) }
     scope :with_induction_records, -> { joins(:induction_records).distinct }
+    scope :not_bso_schools, -> { where.not(school_type_code: BSO_TYPE_CODES) }
 
     def cip_only_type? = GIAS::Types::CIP_ONLY_EXCEPT_WELSH.include?(school_type_name)
 


### PR DESCRIPTION
### Context

We are not including British schools overseas in RECT so there is no needto report they are missing in the `School` migrator.

### Changes proposed in this pull request

Remove BSO schools from `Migrator::School.schools` query

### Guidance to review
