### PR TITLE
Fix unique index on `Contract` references

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -14,10 +14,6 @@ class Contract < ApplicationRecord
   validates :contract_type,
             presence: { message: "Enter a contract type" },
             inclusion: { in: Contract.contract_types.keys, message: "Choose a valid contract type" }
-  validates :flat_rate_fee_structure,
-            uniqueness: { case_sensitive: false, message: "Contract with the same flat rate fee structure already exists" }
-  validates :banded_fee_structure,
-            uniqueness: { case_sensitive: false, message: "Contract with the same banded fee structure already exists" }
   validates :vat_rate,
             presence: { message: "VAT rate is required" },
             numericality: { in: 0..1, message: "VAT rate must be between 0 and 1" }
@@ -25,16 +21,19 @@ class Contract < ApplicationRecord
 
   with_options if: :ittecf_ectp_contract_type? do
     validates :flat_rate_fee_structure,
-              presence: { message: "Flat rate fee structure must be provided for ITTECF_ECTP contracts" }
+              presence: { message: "Flat rate fee structure must be provided for ITTECF_ECTP contracts" },
+              uniqueness: { message: "Contract with the same flat rate fee structure already exists" }
     validates :banded_fee_structure,
-              presence: { message: "Banded fee structure must be provided for ITTECF_ECTP contracts" }
+              presence: { message: "Banded fee structure must be provided for ITTECF_ECTP contracts" },
+              uniqueness: { message: "Contract with the same banded fee structure already exists" }
   end
 
   with_options if: :ecf_contract_type? do
     validates :flat_rate_fee_structure,
               absence: { message: "Flat rate fee structure must be blank for ECF contracts" }
     validates :banded_fee_structure,
-              presence: { message: "Banded fee structure must be provided for ECF contracts" }
+              presence: { message: "Banded fee structure must be provided for ECF contracts" },
+              uniqueness: { message: "Contract with the same banded fee structure already exists" }
   end
 
 private

--- a/db/migrate/20260212080631_fix_contract_reference_indexes.rb
+++ b/db/migrate/20260212080631_fix_contract_reference_indexes.rb
@@ -1,0 +1,10 @@
+class FixContractReferenceIndexes < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :contracts, :flat_rate_fee_structure_id
+    remove_index :contracts, :banded_fee_structure_id
+
+    # Allow multiple contracts with NULL references, but enforce uniqueness when the reference is present.
+    add_index :contracts, :flat_rate_fee_structure_id, unique: true, where: "flat_rate_fee_structure_id IS NOT NULL"
+    add_index :contracts, :banded_fee_structure_id, unique: true, where: "banded_fee_structure_id IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_11_133827) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_12_080631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -183,8 +183,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_11_133827) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
-    t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true
-    t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true
+    t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true, where: "(banded_fee_structure_id IS NOT NULL)"
+    t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true, where: "(flat_rate_fee_structure_id IS NOT NULL)"
   end
 
   create_table "data_migration_failed_combinations", force: :cascade do |t|

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -21,8 +21,6 @@ describe Contract do
 
     it { is_expected.to validate_presence_of(:contract_type).with_message("Enter a contract type") }
     it { is_expected.to validate_inclusion_of(:contract_type).in_array(Contract.contract_types.keys).with_message("Choose a valid contract type") }
-    it { is_expected.to validate_uniqueness_of(:flat_rate_fee_structure).with_message("Contract with the same flat rate fee structure already exists") }
-    it { is_expected.to validate_uniqueness_of(:banded_fee_structure).with_message("Contract with the same banded fee structure already exists") }
     it { is_expected.to validate_presence_of(:vat_rate).with_message("VAT rate is required") }
     it { is_expected.to validate_numericality_of(:vat_rate).is_in(0..1).with_message("VAT rate must be between 0 and 1") }
 
@@ -31,6 +29,8 @@ describe Contract do
 
       it { is_expected.to validate_presence_of(:flat_rate_fee_structure).with_message("Flat rate fee structure must be provided for ITTECF_ECTP contracts") }
       it { is_expected.to validate_presence_of(:banded_fee_structure).with_message("Banded fee structure must be provided for ITTECF_ECTP contracts") }
+      it { is_expected.to validate_uniqueness_of(:flat_rate_fee_structure).with_message("Contract with the same flat rate fee structure already exists") }
+      it { is_expected.to validate_uniqueness_of(:banded_fee_structure).with_message("Contract with the same banded fee structure already exists") }
     end
 
     context "when contract type is `ECF`" do
@@ -38,6 +38,12 @@ describe Contract do
 
       it { is_expected.to validate_presence_of(:banded_fee_structure).with_message("Banded fee structure must be provided for ECF contracts") }
       it { is_expected.to validate_absence_of(:flat_rate_fee_structure).with_message("Flat rate fee structure must be blank for ECF contracts") }
+      it { is_expected.to validate_uniqueness_of(:banded_fee_structure).with_message("Contract with the same banded fee structure already exists") }
+
+      it "allows multiple ECF contracts to have a NULL flat_rate_fee_structure" do
+        FactoryBot.create(:contract, :for_ecf, flat_rate_fee_structure: nil)
+        expect { FactoryBot.create(:contract, :for_ecf, flat_rate_fee_structure: nil) }.not_to raise_error
+      end
     end
 
     describe "active lead provider consistency" do


### PR DESCRIPTION
We want fee structures to only be referenced by a single `Contract`, however the unique index was also preventing multiple `Contract` records from having `nil` fee structures.

Conditionally apply uniqeness constraints and indexes to allow multiple `nil`.
