### PR TITLE
Fix flakey training period seed data

### DIFF
--- a/app/services/api_seed_data/teachers_with_histories.rb
+++ b/app/services/api_seed_data/teachers_with_histories.rb
@@ -83,7 +83,7 @@ module APISeedData
       teacher = create_teacher(started_on: school_period[:started_on])
 
       training_period_data = random_period_within(**school_period)
-      training_period_traits = if school_period[:started_on].future?
+      training_period_traits = if training_period_data[:started_on].future?
                                  []
                                else
                                  generate_training_period_traits


### PR DESCRIPTION
The seed data fails occasionally because we are looking to see if the school period `started_on` is in the future, however it's the training period `started_on` the validation cares about when checking if a TP can be deferred/withdrawn.

On occasion we are generating a school period that starts in the past and a training period within it that starts in the future, causing the trait to be applied incorrectly.

Switch to checking the training period started on should fix this.
