### PR TITLE
Fix flakey `SchoolURNGenerator` spec

### DIFF
--- a/app/services/api_seed_data/helpers/school_urn_generator.rb
+++ b/app/services/api_seed_data/helpers/school_urn_generator.rb
@@ -10,6 +10,11 @@ module APISeedData
           sprintf("%06d", next_urn)
         end
 
+        def reset!
+          @available = nil
+          @taken = nil
+        end
+
       private
 
         def add_to_taken_stack(next_urn)

--- a/spec/services/api_seed_data/helpers/school_urn_generator_spec.rb
+++ b/spec/services/api_seed_data/helpers/school_urn_generator_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe APISeedData::Helpers::SchoolURNGenerator, type: :helper do
-  before { FactoryBot.create_list(:school, 5) }
+  before do
+    described_class.reset!
+    FactoryBot.create_list(:school, 5)
+  end
 
   describe ".next" do
     it "produces a new unassigned value" do


### PR DESCRIPTION
The `SchoolURNGenerator` holds class instance variables that leak state between tests.

We need to clear them between tests to avoid this. We should rework this service at some point.
