### PR TITLE
Validate completed training before no training when changing schedule

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -12,10 +12,10 @@ module API::Teachers
     validate :change_to_different_schedule
     validate :schedule_applicable_for_trainee
     validate :school_partnership_exists_if_changing_contract_period
+    validate :trainee_not_completed
     validate :lead_provider_is_currently_training_teacher
     validate :no_future_training_periods_exist
     validate :can_move_to_frozen_cohort
-    validate :trainee_not_completed
     validate :schedule_does_not_invalidate_declarations
 
     def change_schedule
@@ -138,7 +138,7 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period&.teacher_completed_training?
 
-      errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training.")
+      errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training or induction.")
     end
 
     def schedule_does_not_invalidate_declarations

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
           context "when participant has completed training" do
             before do
+              training_period.update!(finished_on: 1.day.ago)
               if trainee_type == :ect
                 FactoryBot.create(:induction_period, :pass, teacher:)
               else
@@ -120,7 +121,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
             it "returns error" do
               expect(subject).to have_one_error_per_attribute
-              expect(subject).to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training.")
+              expect(subject).to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training or induction.")
             end
           end
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3261

### Changes proposed in this pull request

Before, if a participant had completed their training or induction the error message would say:

"You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule."

This was because there was no "ongoing today" training period for the authenticated lead provider. However that was misleading.

This refactors the validations so the validation against completed training/induction is raised first.

As part of this change we have also tweaked the error message to highlight the fact a teacher might have completed their "training **or** induction".

### Guidance to review
