### PR TITLE
[3319] script to fix invalid inductions with duplicate outcomes

### DIFF
--- a/db/scripts/fix_duplicate_induction_outcomes.rb
+++ b/db/scripts/fix_duplicate_induction_outcomes.rb
@@ -1,0 +1,19 @@
+# @see https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2153
+#
+# Before adding validation to ensure:
+# - an induction period only has an outcome if it has finished
+# - a teacher only ever has one induction period with an outcome
+#
+# We need to correct 2 records removing passing outcomes where this is not the case,
+# and their corresponding events from the timeline.
+#
+InductionPeriod.transaction do
+  [
+    58_001, # teacher's later IP has an outcome. Manual admin West lakes/One Cumbria
+    28_791, # teacher's current IP is ongoing
+  ].each do |id|
+    induction_period = InductionPeriod.find(id)
+    induction_period.update!(outcome: nil)
+    Event.find_by(event_type: :teacher_passes_induction, induction_period:).delete
+  end
+end


### PR DESCRIPTION
### Context

#2153 requires data to be valid and uncovered a pair of inductions that need to be amended.

### Changes proposed in this pull request

Add a one-off script to remove outcomes (and events) that should not be present

### Guidance to review

Tested against snapshot provided primary keys are set

```ruby
Teacher.primary_key = "id"
InductionPeriod.primary_key = "id"
Event.primary_key = "id"
```