### PR TITLE
Add front matter titles to docs

### DIFF
--- a/documentation/changes-for-schools/index.md
+++ b/documentation/changes-for-schools/index.md
@@ -1,4 +1,6 @@
-# Register early career teacher service: changes for schools
+---
+title: "Register early career teacher service: changes for schools"
+---
 
 The launch of the register early career teacher service means a number of changes for schools. 
 

--- a/documentation/changes-for-schools/supporting-videos.md
+++ b/documentation/changes-for-schools/supporting-videos.md
@@ -1,4 +1,6 @@
-# Register early career teacher service: supporting videos
+---
+title: "Register early career teacher service: supporting videos"
+---
 
 ## Register a school's first early career teacher
 

--- a/documentation/communication-emails-to-schools/index.md
+++ b/documentation/communication-emails-to-schools/index.md
@@ -1,4 +1,6 @@
-# Communication emails to schools
+---
+title: Communication emails to schools
+---
 
 Emails to schools in relation to the register early career teacher service.
 

--- a/documentation/communication-emails-to-schools/new-ect-provider-led.md
+++ b/documentation/communication-emails-to-schools/new-ect-provider-led.md
@@ -1,4 +1,6 @@
-# New ECT registered (provider-led)
+---
+title: New ECT registered (provider-led)
+---
 
 ---
 

--- a/documentation/communication-emails-to-schools/new-ect-school-led.md
+++ b/documentation/communication-emails-to-schools/new-ect-school-led.md
@@ -1,4 +1,6 @@
-# New ECT registered (school-led)
+---
+title: New ECT registered (school-led)
+---
 
 ---
 

--- a/documentation/communication-emails-to-schools/new-mentor.md
+++ b/documentation/communication-emails-to-schools/new-mentor.md
@@ -1,4 +1,6 @@
-# New mentor registered
+---
+title: New mentor registered
+---
 
 ---
 

--- a/documentation/communication-emails-to-schools/new-sit.md
+++ b/documentation/communication-emails-to-schools/new-sit.md
@@ -1,4 +1,6 @@
-# New school induction tutor
+---
+title: New school induction tutor
+---
 
 ---
 

--- a/documentation/communication-emails-to-schools/notice-to-sit-launched-reg-not-open.md
+++ b/documentation/communication-emails-to-schools/notice-to-sit-launched-reg-not-open.md
@@ -1,4 +1,6 @@
-# Notice of new service (service launched, registration 2026-2027 not yet open)
+---
+title: Notice of new service (service launched, registration 2026-2027 not yet open)
+---
 
 ---
 

--- a/documentation/communication-emails-to-schools/reg-open-to-sit.md
+++ b/documentation/communication-emails-to-schools/reg-open-to-sit.md
@@ -1,4 +1,6 @@
-# Registration open for academic year 2026-2027
+---
+title: Registration open for academic year 2026-2027
+---
 
 ---
 

--- a/documentation/communication-emails-to-schools/sit-termly-reminder.md
+++ b/documentation/communication-emails-to-schools/sit-termly-reminder.md
@@ -1,4 +1,6 @@
-# Termly reminder to induction tutor
+---
+title: Termly reminder to induction tutor
+---
 
 ---
 

--- a/documentation/resources-for-release/index.md
+++ b/documentation/resources-for-release/index.md
@@ -1,4 +1,6 @@
-# Register early career teachers service documentation
+---
+title: Register early career teachers service documentation
+---
 
 Resources to help the support schools using the register early career teachers service.
 


### PR DESCRIPTION
### Summary

Use front matter titles instead of `#` so the browser tab title renders correctly.