### PR TITLE
Make `monthly_service_fee` optional on `BandedFeeStructure`

### DIFF
--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -24,10 +24,10 @@ class Contract::BandedFeeStructure < ApplicationRecord
               message: "Uplift fee per declaration must be greater than or equal to zero"
             }
   validates :monthly_service_fee,
-            presence: { message: "Monthly service fee is required" },
             numericality: {
               greater_than_or_equal_to: 0,
-              message: "Monthly service fee must be greater than or equal to zero"
+              message: "Monthly service fee must be greater than or equal to zero",
+              allow_nil: true
             }
   validates :setup_fee,
             presence: { message: "Setup fee is required" },

--- a/db/migrate/20260212124833_make_monthly_service_fee_optional_on_banded_fee_structures.rb
+++ b/db/migrate/20260212124833_make_monthly_service_fee_optional_on_banded_fee_structures.rb
@@ -1,0 +1,5 @@
+class MakeMonthlyServiceFeeOptionalOnBandedFeeStructures < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :contract_banded_fee_structures, :monthly_service_fee, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_12_080631) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -149,7 +149,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_080631) do
   create_table "contract_banded_fee_structures", force: :cascade do |t|
     t.integer "recruitment_target", null: false
     t.decimal "uplift_fee_per_declaration", precision: 12, scale: 2, null: false
-    t.decimal "monthly_service_fee", precision: 12, scale: 2, null: false
+    t.decimal "monthly_service_fee", precision: 12, scale: 2
     t.decimal "setup_fee", precision: 12, scale: 2, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -184,10 +184,10 @@ erDiagram
     integer mentor_payments_frozen_year
     boolean ect_pupil_premium_uplift
     boolean ect_sparsity_uplift
-    datetime ect_first_became_eligible_for_training_at
-    datetime mentor_first_became_eligible_for_training_at
     date trs_induction_start_date
     date trs_induction_completed_date
+    datetime ect_first_became_eligible_for_training_at
+    datetime mentor_first_became_eligible_for_training_at
     boolean trnless
     datetime api_updated_at
     datetime api_unfunded_mentor_updated_at
@@ -378,7 +378,23 @@ erDiagram
     integer ecf2_mentor_combinations_count
     datetime created_at
     datetime updated_at
+    jsonb ecf1_mentorships
+    jsonb ecf2_mentorships
+    integer ecf1_mentorships_count
+    integer ecf2_mentorships_count
     uuid api_id
+  }
+  DataMigrationFailedMentorship {
+    integer id
+    uuid ect_participant_profile_id
+    uuid mentor_participant_profile_id
+    date started_on
+    date finished_on
+    uuid ecf_start_induction_record_id
+    uuid ecf_end_induction_record_id
+    text failure_message
+    datetime created_at
+    datetime updated_at
   }
   DataMigrationFailedCombination {
     integer id

--- a/spec/models/contract/banded_fee_structure_spec.rb
+++ b/spec/models/contract/banded_fee_structure_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Contract::BandedFeeStructure, type: :model do
     it { is_expected.to validate_presence_of(:uplift_fee_per_declaration).with_message("Uplift fee per declaration is required") }
     it { is_expected.to validate_numericality_of(:uplift_fee_per_declaration).is_greater_than_or_equal_to(0).with_message("Uplift fee per declaration must be greater than or equal to zero") }
 
-    it { is_expected.to validate_presence_of(:monthly_service_fee).with_message("Monthly service fee is required") }
-    it { is_expected.to validate_numericality_of(:monthly_service_fee).is_greater_than_or_equal_to(0).with_message("Monthly service fee must be greater than or equal to zero") }
+    it { is_expected.to validate_numericality_of(:monthly_service_fee).is_greater_than_or_equal_to(0).with_message("Monthly service fee must be greater than or equal to zero").allow_nil }
 
     it { is_expected.to validate_presence_of(:setup_fee).with_message("Setup fee is required") }
     it { is_expected.to validate_numericality_of(:setup_fee).is_greater_than_or_equal_to(0).with_message("Setup fee must be greater than or equal to zero") }


### PR DESCRIPTION
In ECF we allow `nil` and fallback to a calculated/default monthly service fee based on the bandings; I missed this on my initial spec, see here: https://github.com/DFE-Digital/early-careers-framework/blob/main/app/services/finance/ecf/statement_calculator.rb#L217