### PR TITLE
Validate declaration types when creating declarations

### DIFF
--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -18,13 +18,17 @@ module API::Declarations
       message: "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again."
     }, allow_blank: true
     validate :teacher_type_exists
+    validates :declaration_type, presence: { message: "Enter a '#/declaration_type'." }
+    validates :declaration_type, inclusion: {
+      in: Declaration.declaration_types.keys,
+      message: "Enter a valid declaration type."
+    }, allow_blank: true
     validates :declaration_date, presence: { message: "Enter a '#/declaration_date'." }
     validate :declaration_date_in_the_past
     validates :declaration_date,
               declaration_date_within_milestone: true,
               api_date_time_format: true,
               allow_blank: true
-    validates :declaration_type, presence: { message: "Enter a '#/declaration_type'." }
     validates :evidence_type, evidence_type: true
     validate :validate_only_started_or_completed_if_mentor
     validate :teacher_not_withdrawn_before_declaration_date
@@ -169,6 +173,7 @@ module API::Declarations
     end
 
     def validates_billable_slot_available
+      return if errors[:declaration_type].any?
       return unless training_period
       return unless existing_declarations.billable_or_changeable_for_declaration_type(declaration_type).exists?
 

--- a/app/validators/declaration_date_within_milestone_validator.rb
+++ b/app/validators/declaration_date_within_milestone_validator.rb
@@ -7,6 +7,7 @@ private
 
   def declaration_within_milestone(record)
     return if record.errors[:declaration_date].any?
+    return if record.errors[:declaration_type].any?
 
     return unless record.milestone && record.declaration_date.present?
 

--- a/app/validators/evidence_type_validator.rb
+++ b/app/validators/evidence_type_validator.rb
@@ -53,6 +53,7 @@ private
 
   def evidence_type_is_valid_detailed_evidence_type(record)
     return if record.errors[:evidence_type].any?
+    return if record.errors[:declaration_type].any?
     return if record.evidence_type.blank?
 
     evidences = if record.training_period.for_ect?

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
           type: "participant-declaration",
           attributes: {
             participant_id: teacher.api_id,
-            declaration_type: "started",
+            declaration_type:,
             declaration_date: declaration_date.rfc3339,
             course_identifier:,
             evidence_held: "other"
@@ -83,6 +83,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
         }
       }
     end
+    let(:declaration_type) { "started" }
 
     %i[ect mentor].each do |teacher_type|
       context "for #{teacher_type}" do
@@ -93,6 +94,20 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
 
         it_behaves_like "a token authenticated endpoint", :post
         it_behaves_like "an API create endpoint"
+
+        context "when the `declaration_type` is invalid" do
+          let(:declaration_type) { "invalid" }
+
+          it "returns `unprocessable_content`" do
+            authenticated_api_post(path, params:)
+
+            expect(response).to have_http_status(:unprocessable_content)
+            expect(parsed_response[:errors]).to contain_exactly(
+              title: "declaration_type",
+              detail: "Enter a valid declaration type."
+            )
+          end
+        end
       end
     end
   end

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe API::Declarations::Create, type: :model do
         it { is_expected.to validate_presence_of(:lead_provider_id).with_message("Enter a '#/lead_provider_id'.") }
         it { is_expected.to validate_presence_of(:teacher_api_id).with_message("Enter a '#/teacher_api_id'.") }
         it { is_expected.to validate_presence_of(:teacher_type).with_message("Enter a '#/teacher_type'.") }
+        it { is_expected.to validate_inclusion_of(:declaration_type).in_array(Declaration.declaration_types.keys).with_message("Enter a valid declaration type.") }
 
         context "when the `lead_provider` does not exist" do
           let(:lead_provider_id) { 9999 }


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3279

### Changes proposed in this pull request

Before, we didn't validate `declaration_type` when creating Declarations via the
API.

This meant we ran in to postgres errors and returned `500` errors from the API.

Now, we validate `declaration_type` is included in the enum and return early
from the `validates_billable_slot_available` validation to ensure no errors are
thrown by postgres.

We also return early from the `EvidenceHeldValidator` when there is an invalid
`declaration_type` to avoid returning a misleading error message related to
evidence types (and also to maintain consistency with [ECF1]).

[ECF1]: https://github.com/DFE-Digital/early-careers-framework/blob/cebeeead1418db03b4b3a8469551288cd8f054d6/app/validators/evidence_held_validator.rb#L49

### Guidance to review
