### PR TITLE
Add `ActiveLeadProvider` to `Contract`

### DIFF
--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -7,6 +7,7 @@ class ActiveLeadProvider < ApplicationRecord
   has_many :statements
   has_many :expressions_of_interest, class_name: "TrainingPeriod", foreign_key: "expression_of_interest_id", inverse_of: :expression_of_interest
   has_many :events
+  has_many :contracts
 
   validates :contract_period_year,
             presence: { message: "Choose a contract period" },

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -67,8 +67,8 @@ class Statement < ApplicationRecord
   end
 
   def contract_active_lead_provider_consistency
-    return unless contract&.statements&.any? { it.active_lead_provider != active_lead_provider }
+    return unless contract && contract.active_lead_provider != active_lead_provider
 
-    errors.add(:contract, "This contract is associated with other statements linked to different lead providers/contract periods.")
+    errors.add(:contract, "This contract must have the same active lead provider as the statement.")
   end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -494,6 +494,7 @@
   - id
   - contract_type
   - vat_rate
+  - active_lead_provider_id
   - flat_rate_fee_structure_id
   - banded_fee_structure_id
   - created_at

--- a/db/migrate/20260212185120_add_active_lead_provider_to_contracts.rb
+++ b/db/migrate/20260212185120_add_active_lead_provider_to_contracts.rb
@@ -1,0 +1,5 @@
+class AddActiveLeadProviderToContracts < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :contracts, :active_lead_provider, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_12_185120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -193,6 +193,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
+    t.bigint "active_lead_provider_id"
+    t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"
     t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true, where: "(banded_fee_structure_id IS NOT NULL)"
     t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true, where: "(flat_rate_fee_structure_id IS NOT NULL)"
   end
@@ -1058,6 +1060,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_124833) do
   add_foreign_key "appropriate_bodies", "dfe_sign_in_organisations"
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
   add_foreign_key "contract_banded_fee_structure_bands", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
+  add_foreign_key "contracts", "active_lead_providers"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"
   add_foreign_key "declarations", "users", column: "voided_by_user_id"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -476,7 +476,9 @@ erDiagram
     datetime created_at
     datetime updated_at
     decimal vat_rate
+    integer active_lead_provider_id
   }
+  Contract }o--|| ActiveLeadProvider : belongs_to
   Contract }o--|| Contract_FlatRateFeeStructure : belongs_to
   Contract }o--|| Contract_BandedFeeStructure : belongs_to
   AppropriateBodyPeriod {
@@ -491,7 +493,6 @@ erDiagram
   }
   AppropriateBodyPeriod }o--|| DfESignInOrganisation : belongs_to
   AppropriateBodyPeriod }o--|| AppropriateBody : belongs_to
-  AppropriateBodyPeriod }o--|| School : belongs_to
   AppropriateBody {
     integer id
     string name

--- a/spec/factories/contract_factory.rb
+++ b/spec/factories/contract_factory.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory(:contract) do
+    association :active_lead_provider
+
     for_ittecf_ectp
 
     trait(:for_ecf) do

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -8,6 +8,7 @@ describe ActiveLeadProvider do
     it { is_expected.to have_many(:delivery_partners).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:expressions_of_interest).class_name("TrainingPeriod").inverse_of(:expression_of_interest) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_many(:contracts) }
   end
 
   describe "validations" do


### PR DESCRIPTION
We restrict contracts with validation so that they don't span different lead providers or contract periods, however the validation rules are a bit awkward.

Contract managers associate contracts with a particular lead provider/cohort combination and - given we will likely have a UI to create contracts in the future - it makes sense for them to be able to exist in an organised way, independently of the statements. I expect we'll want to create a contract and then assign it to a set of statements with a UI.

When migrating contracts from ECF it also became tricky as we need the statement information in place in order to be able to allocate contracts to specific lead provider and contract period (so that we don't create contracts that would otherwise span different LPs/contract periods). This also means we couldn't enforce `contract_id` on `Statement` until after we migrate/go-live.

By adding a direct connection to `ActiveLeadProvider` we can more easily migrate and manage contracts in RECT. We can also make `contract_id` on `Statement` mandatory ahead of the migration.

After this is established we will remove the connection from `ActiveLeadProvider` to `Statement` in a future PR (as it will exist via `Contract` already).

<img width="894" height="821" alt="Screenshot 2026-02-13 at 11 15 55" src="https://github.com/user-attachments/assets/75e22481-0782-4e98-944d-4d03ee63c4c6" />


