### PR TITLE
Introduce `PaymentCalculator::Banded::Uplifts` service

### DIFF
--- a/app/services/payment_calculator/banded/uplifts.rb
+++ b/app/services/payment_calculator/banded/uplifts.rb
@@ -1,0 +1,26 @@
+module PaymentCalculator
+  module Banded
+    class Uplifts
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :declarations
+      attribute :uplift_fee_per_declaration
+
+      def billable_count = @billable_count ||= filtered_declarations.billable.size
+      def refundable_count = @refundable_count ||= filtered_declarations.refundable.size
+      def net_count = billable_count - refundable_count
+
+      def total_billable_amount = billable_count * uplift_fee_per_declaration
+      def total_refundable_amount = refundable_count * uplift_fee_per_declaration
+      def total_net_amount = total_billable_amount - total_refundable_amount
+
+    private
+
+      def filtered_declarations = declarations
+        .where(pupil_premium_uplift: true)
+        .or(declarations.where(sparsity_uplift: true))
+        .declaration_type_started
+    end
+  end
+end

--- a/spec/services/payment_calculator/banded/uplifts_spec.rb
+++ b/spec/services/payment_calculator/banded/uplifts_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe PaymentCalculator::Banded::Uplifts do
+  let(:instance) do
+    described_class.new(declarations:, uplift_fee_per_declaration:)
+  end
+
+  # Billable declarations
+  let!(:billable_eligible_declaration) do
+    FactoryBot.create(:declaration, :eligible, :started, sparsity_uplift: true)
+  end
+  let!(:billable_payable_declaration) do
+    FactoryBot.create(:declaration, :payable, :started, pupil_premium_uplift: true)
+  end
+  let!(:billable_paid_declaration) do
+    FactoryBot.create(:declaration, :paid, :started, sparsity_uplift: true)
+  end
+
+  # Refundable declarations
+  let!(:refundable_awaiting_clawback_declaration) do
+    FactoryBot.create(:declaration, :awaiting_clawback, :started, sparsity_uplift: true)
+  end
+
+  # Out-of-scope declarations
+  let!(:eligible_declaration_without_uplift) do
+    FactoryBot.create(
+      :declaration,
+      :eligible,
+      :started,
+      sparsity_uplift: false,
+      pupil_premium_uplift: false
+    )
+  end
+  let!(:completed_paid_declaration) do
+    FactoryBot.create(:declaration, :paid, :completed, sparsity_uplift: true)
+  end
+  let!(:completed_awaiting_clawback_declaration) do
+    FactoryBot.create(:declaration, :awaiting_clawback, :completed, sparsity_uplift: true)
+  end
+  let(:clawed_back_declaration_without_uplift) do
+    FactoryBot.create(
+      :declaration,
+      :clawed_back,
+      :started,
+      sparsity_uplift: false,
+      pupil_premium_uplift: false
+    )
+  end
+  let!(:no_payment_declaration) do
+    FactoryBot.create(:declaration, :no_payment, :started, sparsity_uplift: true)
+  end
+
+  let(:declarations) { Declaration.all }
+  let(:uplift_fee_per_declaration) { 125 }
+
+  describe "#billable_count" do
+    subject(:billable_count) { instance.billable_count }
+
+    it { is_expected.to eq(3) }
+  end
+
+  describe "#refundable_count" do
+    subject(:refundable_count) { instance.refundable_count }
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe "#net_count" do
+    subject(:net_count) { instance.net_count }
+
+    it { is_expected.to eq(2) }
+  end
+
+  describe "#total_billable_amount" do
+    subject(:total_billable_amount) { instance.total_billable_amount }
+
+    it { is_expected.to eq(375) }
+  end
+
+  describe "#total_refundable_amount" do
+    subject(:total_refundable_amount) { instance.total_refundable_amount }
+
+    it { is_expected.to eq(125) }
+  end
+
+  describe "total_net_amount" do
+    subject(:total_net_amount) { instance.total_net_amount }
+
+    it { is_expected.to eq(250) }
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3276

### Changes proposed in this pull request

This introduces a simple model that calculates uplift for collections of declarations that belong to banded fee structure contracts.

The service expects to receive a filtered collection of relevant declarations and exposes billable, refundable and net count/amount methods.

Declarations are filtered to include only those with a declaration type of
"started" and with either `sparsity_uplift` or `pupil_premium_uplift` flags set
to true.

### Guidance to review
