### PR TITLE
Add contracts to seed data

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -9,6 +9,7 @@ class Contract < ApplicationRecord
 
   # Associations
   belongs_to :active_lead_provider
+  has_one :contract_period, through: :active_lead_provider
   belongs_to :flat_rate_fee_structure, class_name: "Contract::FlatRateFeeStructure", optional: true
   belongs_to :banded_fee_structure, class_name: "Contract::BandedFeeStructure", optional: true
   has_many :statements, inverse_of: :contract

--- a/app/services/api_seed_data/contracts.rb
+++ b/app/services/api_seed_data/contracts.rb
@@ -1,0 +1,46 @@
+module APISeedData
+  class Contracts < Base
+    def plant
+      return unless plantable?
+
+      log_plant_info("contracts")
+
+      ActiveLeadProvider
+        .includes(:lead_provider, :contract_period)
+        .order("lead_providers.name ASC", contract_period_year: :asc)
+        .group_by(&:lead_provider)
+        .each do |lead_provider, active_lead_providers|
+          log_seed_info("#{lead_provider.name} contracts", indent: 0)
+
+          active_lead_providers.map do |active_lead_provider|
+            number_of_contracts = Faker::Number.between(from: 1, to: 3)
+            contracts = if active_lead_provider.contract_period.mentor_funding_enabled?
+                          FactoryBot.create_list(:contract, number_of_contracts, :for_ittecf_ectp, active_lead_provider:)
+                        else
+                          FactoryBot.create_list(:contract, number_of_contracts, :for_ecf, active_lead_provider:)
+                        end
+
+            describe_contracts(active_lead_provider, contracts)
+          end
+      end
+    end
+
+  protected
+
+    def plantable?
+      super && Contract.none?
+    end
+
+  private
+
+    def describe_contracts(active_lead_provider, contracts)
+      colour = active_lead_provider.contract_period.mentor_funding_enabled? ? :magenta : :cyan
+      contracts_summary = contracts
+        .group_by(&:contract_type)
+        .map { |type, contracts| "#{contracts.size} #{type.to_s.humanize.upcase}" }
+        .join(", ")
+
+      log_seed_info("Contracts for #{active_lead_provider.contract_period.year}: #{contracts_summary}", indent: 2, colour:)
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,7 @@ priority_seeds = %w[
   school_partnerships
   schedules_and_milestones
   teachers
+  contracts
 ]
 
 seed_files = Dir["db/seeds/*.rb"].sort_by do |path|

--- a/db/seeds/contracts.rb
+++ b/db/seeds/contracts.rb
@@ -1,0 +1,27 @@
+def describe_contracts(active_lead_provider, contracts)
+  colour = active_lead_provider.contract_period.mentor_funding_enabled? ? :magenta : :cyan
+  contracts_summary = contracts
+    .group_by(&:contract_type)
+    .map { |type, contracts| "#{contracts.size} #{type.to_s.humanize.upcase}" }
+    .join(", ")
+  print_seed_info("Contracts for #{active_lead_provider.contract_period.year}: #{contracts_summary}", indent: 2, colour:)
+end
+
+ActiveLeadProvider
+  .includes(:lead_provider, :contract_period)
+  .order("lead_providers.name ASC", contract_period_year: :asc)
+  .group_by(&:lead_provider)
+  .each do |lead_provider, active_lead_providers|
+    print_seed_info("#{lead_provider.name} contracts", indent: 0)
+
+    active_lead_providers.map do |active_lead_provider|
+      number_of_contracts = Faker::Number.between(from: 1, to: 3)
+      contracts = if active_lead_provider.contract_period.mentor_funding_enabled?
+                    FactoryBot.create_list(:contract, number_of_contracts, :for_ittecf_ectp, active_lead_provider:)
+                  else
+                    FactoryBot.create_list(:contract, number_of_contracts, :for_ecf, active_lead_provider:)
+                  end
+
+      describe_contracts(active_lead_provider, contracts)
+    end
+end

--- a/db/seeds/statements.rb
+++ b/db/seeds/statements.rb
@@ -46,7 +46,12 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
     months = (1..12).to_a
     years = [registration_year, registration_year + 1]
 
-    years.product(months).map do |year, month|
+    years.product(months).each_with_index.map do |(year, month), index|
+      # Distribute contracts across statements evenly and in order, so if there are
+      # 3 contracts, the first 1/3rd of statements get the first, the next 1/3rd get the
+      # second, and the final 1/3rd get the third.
+      contract_index = (index * alp.contracts.size) / (years.size * months.size)
+      contract = alp.contracts[contract_index]
       deadline_date = Date.new(year, month, 1).prev_day
       payment_date = Date.new(year, month, 25)
       fee_type = month.in?(OUTPUT_FEE_MONTHS) ? "output" : "service"
@@ -60,6 +65,7 @@ grouped_active_lead_providers.each do |lead_provider, active_lead_providers|
 
       FactoryBot.create(
         :statement,
+        contract:,
         active_lead_provider: alp,
         month:,
         year:,

--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -5,6 +5,7 @@ namespace :api_seed_data do
       APISeedData::ContractPeriods,
       APISeedData::LeadProviders,
       APISeedData::SchedulesAndMilestones,
+      APISeedData::Contracts,
       APISeedData::Statements,
       APISeedData::Schools,
       APISeedData::DeliveryPartners,

--- a/spec/factories/contract/banded_fee_structure/band_factory.rb
+++ b/spec/factories/contract/banded_fee_structure/band_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :banded_fee_structure, factory: :contract_banded_fee_structure
     min_declarations { 1 }
     max_declarations { 100 }
-    fee_per_declaration { 50 }
+    fee_per_declaration { Faker::Number.between(from: 20, to: 200) }
     output_fee_ratio { 0.75 }
     service_fee_ratio { 0.25 }
   end

--- a/spec/factories/contract/banded_fee_structure_factory.rb
+++ b/spec/factories/contract/banded_fee_structure_factory.rb
@@ -1,18 +1,19 @@
 FactoryBot.define do
   factory :contract_banded_fee_structure, class: "Contract::BandedFeeStructure" do
-    recruitment_target { 6000 }
-    uplift_fee_per_declaration { 100 }
-    monthly_service_fee { 123.45 }
-    setup_fee { 149_651 }
+    recruitment_target { Faker::Number.between(from: 1_000, to: 10_000) }
+    uplift_fee_per_declaration { Faker::Number.between(from: 50, to: 100) }
+    monthly_service_fee { Faker::Number.between(from: 0, to: 20_000) }
+    setup_fee { Faker::Number.between(from: 1_000, to: 50_000) }
 
     trait :with_bands do
       transient do
         declaration_boundaries do
-          [
-            { min: 0, max: 100 },
-            { min: 101, max: 200 },
-            { min: 201, max: 300 }
-          ]
+          min = 0
+
+          Array.new(Faker::Number.between(from: 3, to: 4)) do
+            max = min + Faker::Number.between(from: 20, to: 200)
+            { min:, max: }.tap { min = max + 1 }
+          end
         end
       end
 

--- a/spec/factories/contract/flat_rate_fee_structure_factory.rb
+++ b/spec/factories/contract/flat_rate_fee_structure_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:contract_flat_rate_fee_structure, class: "Contract::FlatRateFeeStructure") do
-    recruitment_target { 4500 }
-    fee_per_declaration { 1000.00 }
+    recruitment_target { Faker::Number.between(from: 1_000, to: 10_000) }
+    fee_per_declaration { Faker::Number.between(from: 500, to: 2_000) }
   end
 end

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
       contract_period { FactoryBot.create(:contract_period) }
     end
 
-    active_lead_provider { FactoryBot.create(:active_lead_provider, contract_period:) }
-    contract { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:) }
+    active_lead_provider { association(:active_lead_provider, contract_period:) }
+    contract { association(:contract, :for_ittecf_ectp, active_lead_provider:) }
     api_id { SecureRandom.uuid }
     sequence(:month) { |n| ((n - 1) % 12) + 1 }
     sequence(:year) do |n|

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -14,6 +14,7 @@ describe Contract do
     it { is_expected.to belong_to(:active_lead_provider) }
     it { is_expected.to belong_to(:banded_fee_structure).class_name("Contract::BandedFeeStructure").optional }
     it { is_expected.to belong_to(:flat_rate_fee_structure).class_name("Contract::FlatRateFeeStructure").optional }
+    it { is_expected.to have_one(:contract_period).through(:active_lead_provider) }
     it { is_expected.to have_many(:statements).inverse_of(:contract) }
   end
 

--- a/spec/services/api_seed_data/contracts_spec.rb
+++ b/spec/services/api_seed_data/contracts_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe APISeedData::Contracts do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+  end
+
+  describe "#plant" do
+    let(:mentor_funding_contract_period) { FactoryBot.create(:contract_period, year: 2025, mentor_funding_enabled: true) }
+    let!(:mentor_funding_active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: mentor_funding_contract_period) }
+
+    let(:contract_period) { FactoryBot.create(:contract_period, year: 2024, mentor_funding_enabled: false) }
+    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+
+    it "creates contracts for active lead providers with the correct attributes" do
+      expect { instance.plant }.to change(active_lead_provider.contracts, :count).by_at_least(1)
+        .and change(mentor_funding_active_lead_provider.contracts, :count).by_at_least(1)
+
+      expect(active_lead_provider.contracts).to all have_attributes(contract_type: "ecf")
+      expect(mentor_funding_active_lead_provider.contracts).to all have_attributes(contract_type: "ittecf_ectp")
+    end
+
+    it "logs the creation of contracts" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting contracts/).once
+
+      expect(logger).to have_received(:info).with(/#{active_lead_provider.lead_provider.name} contracts/).once
+      expect(logger).to have_received(:info).with(/Contracts for #{active_lead_provider.contract_period.year}: \d+ ECF/).once
+
+      expect(logger).to have_received(:info).with(/#{mentor_funding_active_lead_provider.lead_provider.name} contracts/).once
+      expect(logger).to have_received(:info).with(/Contracts for #{mentor_funding_active_lead_provider.contract_period.year}: \d+ ITTECF ECTP/).once
+    end
+
+    it "does not create data when already present" do
+      expect { instance.plant }.to change(Contract, :count)
+      expect { instance.plant }.not_to change(Contract, :count)
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any contracts" do
+        expect { instance.plant }.not_to change(Contract, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to ensure all statements created in the seed data have a suitable contract associated with them (this is currently optional, but will be required in the future).

### Changes proposed in this pull request

- Add contracts to seed data

Update dev and API seeds to create contracts and assign them to statements. If there are multiple contracts for an `ActiveLeadProvider` then the statements will be distributed across the contracts evenly.

Update contract factories with more realistic/random values.

### Guidance to review

<img width="325" height="524" alt="Screenshot 2026-02-16 at 09 49 28" src="https://github.com/user-attachments/assets/38453931-c0c4-4ec0-8c73-a69cac71c152" />

Script to run on sandbox:

```
APISeedData::Contracts.new.plant

ActiveLeadProvider.find_each do |active_lead_provider|
  statements = active_lead_provider.statements.order(:deadline_date)

  statements.each_with_index do |statement, index|
    contract_index = (index * active_lead_provider.contracts.size) / statements.size
    contract = active_lead_provider.contracts[contract_index]
    statement.update!(contract:)
  end
end
```