### PR TITLE
RECT DSI logins on staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,4 +45,4 @@ PARITY_CHECK_RECT_URL=https://cpd-ec2-migration-web.teacherservices.cloud
 ENABLE_TIME_TRAVEL=true
 # 2 hours is 7200 seconds
 MAX_SESSION_IDLE_TIME=7200
-# SEED_NEW_APPROPRIATE_BODY_MODELS=
+# SEED_DFE_SIGN_IN_ORG=true


### PR DESCRIPTION
### Context

Authentication on `staging` and locally using DfE Sign-In works for appropriate bodies because we are now seeding with accurate details and dynamically populating the matching UUID.

School users cannot authenticate until a matching school record is present. In prodcution we are now running the GIAS import script to populate all schools, but this is not necessary for product review.

### Changes proposed in this pull request

- Always seed the `GIAS::School` and `School` records for the lead schools used for testing.
- Optionally seed the AB and DSI org for an ABP with an env var. When testing with personas we will want all our new models populated `/admin/organisations/teaching-school-hubs`. 
- Add `SEED_DFE_SIGN_IN_ORG` to the example replacing `SEED_NEW_APPROPRIATE_BODY_MODELS`
- Simplify role switching.

### Guidance to review

Developers need to test this, assuming you have been approved by the test organisations used to seed [appropriate_body_periods](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/db/seeds/appropriate_body_periods.rb#L49-L165):

1. Check out and run locally with env vars for the DfE Sign-In test environment applied.
2. Replant seeds with `SEED_DFE_SIGN_IN_ORG=true` set
3. Authenticate using DSI and select an org with the following role:
    - RECT only: should successfully access RECT
    - RIAB only (for example ISTIP): should successfully access RIAB
    - both roles: should successfully access RECT by default with option to switch to RIAB 