### PR TITLE
Add X-With-Server-Date guidance for testing API with future dates

### DIFF
--- a/app/views/api/guidance/guidance_for_lead_providers/how_to_test_the_api_effectively.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/how_to_test_the_api_effectively.md
@@ -81,13 +81,6 @@ To test declaration submission functionality, include:
 
 Make a declaration submission using this header: `X-With-Server-Date: 2027-01-10T10:42:00Z`
 
-### Response
-
-Successful requests will return a response body including updates to the declaration state, which will become:
-
-- `voided` if it had been `submitted`, `ineligible`, `eligible`, or `payable`
-- `awaiting_clawback` if it had been `paid`
-
 [View more information on declaration states](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/ecf/definitions-and-states/#declaration-states).
 
 ## Check seed data is adequate or request seed data that’s more tailored to your needs 


### PR DESCRIPTION
### Context
The 'Submit, view and void declarations' guidance is being revised for RECT. Out of the review, it was identified that the "test declaration ability with X-With-Server-Date header" guidance should now live here.


### Changes proposed in this pull request
Added instructions for testing declaration submissions using the X-With-Server-Date header in the sandbox environment, taken from: https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/ecf/guidance.html#submit-view-and-void-declarations


### Guidance to review
I reviewed it with Claire and Andy, but it hasn't been reviewed by an SME to ensure it fits the context of its new home.