### PR TITLE
Fix flaky test

### DIFF
--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "Create mentorship of an ECT to a mentor", :enable_schools_interf
         subject
 
         expect(response).to be_successful
-        expect(sanitize(response.body)).to include("You've assigned #{Teachers::Name.new(mentor.teacher).full_name} as a mentor")
+        expect(sanitize(response.body)).to include("You’ve assigned #{Teachers::Name.new(mentor.teacher).full_name} as a mentor")
       end
     end
   end


### PR DESCRIPTION
Before, this [flaky test] asserted that a confirmation message including the teacher's full name was included in the sanitized response body.

This broke down, though, when the teacher's name included an apostrophe.

Since we were asserting against the sanitized response body,

```
You've assigned Teacher Mc'Teacher as a mentor
```

would neither match against

```
You’ve assigned Teacher Mc'Teacher as a mentor
```

in the sanitized response body (note the smart-quote in "You‘ve", nor would it match against

```
You've assigned Serita O&amp;amp;#39;Reilly as a mentor
```

in the page title (this would match for names without apostrophes).

This fixes the flaky test by ensuring we assert against the sanitized response body with "You’ve".

Now, the test passes every time.

[flaky test]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/22076449239/job/63792478373