### PR TITLE
Restore contract foreign keys deleted from schema by mistake

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1063,6 +1063,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
   add_foreign_key "appropriate_bodies", "dfe_sign_in_organisations"
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
   add_foreign_key "contract_banded_fee_structure_bands", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
+  add_foreign_key "contracts", "contract_banded_fee_structures", column: "banded_fee_structure_id"
+  add_foreign_key "contracts", "contract_flat_rate_fee_structures", column: "flat_rate_fee_structure_id"  
   add_foreign_key "contracts", "active_lead_providers"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"


### PR DESCRIPTION
### Context

@cpjmcquillan spotted `2d523aa6c276f408e17a9a57ff0b6121142d29f4` unintentionally removed foreign keys from the schema

### Changes proposed in this pull request

Restore the lines

### Guidance to review
