### PR TITLE
Fix broken migration

### DIFF
--- a/db/migrate/20260206151911_add_delivery_partner_when_created_to_declarations.rb
+++ b/db/migrate/20260206151911_add_delivery_partner_when_created_to_declarations.rb
@@ -2,8 +2,24 @@ class AddDeliveryPartnerWhenCreatedToDeclarations < ActiveRecord::Migration[8.0]
   def change
     add_reference :declarations, :delivery_partner_when_created, foreign_key: { to_table: :delivery_partners }, null: true
 
-    Declaration.includes(training_period: :delivery_partner).find_each do |declaration|
-      declaration.update_column(:delivery_partner_when_created_id, declaration.training_period.delivery_partner.id)
+    reversible do |direction|
+      direction.up do
+        execute <<-SQL
+          UPDATE declarations
+          SET delivery_partner_when_created_id = lead_provider_delivery_partnerships.delivery_partner_id
+          FROM training_periods
+          JOIN school_partnerships ON training_periods.school_partnership_id = school_partnerships.id
+          JOIN lead_provider_delivery_partnerships ON school_partnerships.lead_provider_delivery_partnership_id = lead_provider_delivery_partnerships.id
+          WHERE declarations.training_period_id = training_periods.id
+        SQL
+      end
+
+      direction.down do
+        execute <<-SQL
+          UPDATE declarations
+          SET delivery_partner_when_created_id = NULL
+        SQL
+      end
     end
 
     change_column_null :declarations, :delivery_partner_when_created_id, false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1066,7 +1066,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
   add_foreign_key "contract_banded_fee_structure_bands", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
   add_foreign_key "contracts", "contract_banded_fee_structures", column: "banded_fee_structure_id"
-  add_foreign_key "contracts", "contract_flat_rate_fee_structures", column: "flat_rate_fee_structure_id"  
+  add_foreign_key "contracts", "contract_flat_rate_fee_structures", column: "flat_rate_fee_structure_id"
   add_foreign_key "contracts", "active_lead_providers"
   add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"


### PR DESCRIPTION
I incorrectly assumed `update_column` would bypass any application logic, but we ran into [errors] running the migration.

I must have run the migration locally before adding the `attr_readonly` attribute.

This refactors the migration to execute the SQL directly.

Now, the migration runs successfully.

[errors]: https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/22078959821/job/63805392864