### PR TITLE
Update fake TRS API blue box with 308 response

### DIFF
--- a/app/components/test_guidance_component.rb
+++ b/app/components/test_guidance_component.rb
@@ -20,6 +20,7 @@ class TestGuidanceComponent < ApplicationComponent
         "7000008 (teacher has failed their induction)",
         "7000009 (teacher is exempt from training)",
         "7000010 (teacher has failed their induction in Wales)",
+        "7000011 (teacher has been merged in TRS)",
       ]
     end
   end


### PR DESCRIPTION
### Context

Following the API version upgrade to support new reponses #2068.

### Changes proposed in this pull request

Add the TRN which returns `308` from the fake API to the blue box.

### Guidance to review

This teacher will currently behave like a `404` but the intention is to provide better feedback. 

<img width="1296" height="1809" alt="localhost_3000_appropriate-body_claim-an-ect_find-ect" src="https://github.com/user-attachments/assets/63bc1bd0-e77d-46c6-9782-d5f1dbd344a0" />
