### PR TITLE
Raise an error when mentor training provider info missing

### DIFF
--- a/app/migration/teacher_history_converter/mentor/latest_induction_records.rb
+++ b/app/migration/teacher_history_converter/mentor/latest_induction_records.rb
@@ -59,6 +59,8 @@ private
 
     training_provider_info = induction_record.training_provider_info
 
+    raise(StandardError, "No training provider info for #{induction_record.induction_record_id}") if training_provider_info.nil?
+
     training_attrs = {
       started_on: induction_record.start_date,
       finished_on: induction_record.end_date,

--- a/spec/migration/teacher_history_converter/real_examples/62025249_8b6f_4fa3_9113_076b329aafde_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/62025249_8b6f_4fa3_9113_076b329aafde_spec.rb
@@ -577,58 +577,62 @@ describe "Real data check for user 62025249-8b6f-4fa3-9113-076b329aafde (mentor 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }
 
-    let(:expected_output) do
-      {
-        teacher: hash_including(
-          trn: "1111111",
-          mentor_at_school_periods: array_including(
-            hash_including(
-              started_on: Date.new(2023, 11, 6),
-              finished_on: Date.new(2023, 11, 7),
-              training_periods: array_including(
-                hash_including(
-                  training_programme: "provider_led",
-                  lead_provider_info: {},
-                  delivery_partner_info: {},
-                  contract_period_year: 2021
-                )
-              )
-            ),
-            hash_including(
-              started_on: Date.new(2023, 11, 8),
-              finished_on: Date.new(2023, 11, 9),
-              training_periods: array_including(
-                hash_including(
-                  training_programme: "provider_led",
-                  started_on: Date.new(2023, 11, 8),
-                  finished_on: Date.new(2023, 11, 9),
-                  lead_provider_info: hash_including(name: "Ambition Institute"),
-                  delivery_partner_info: hash_including(name: "Delivery partner 1"),
-                  contract_period_year: 2021
-                )
-              )
-            ),
-            hash_including(
-              started_on: Date.new(2024, 11, 8),
-              finished_on: nil,
-              training_periods: array_including(
-                hash_including(
-                  training_programme: "provider_led",
-                  started_on: Date.new(2024, 11, 8),
-                  finished_on: nil,
-                  lead_provider_info: hash_including(name: "Ambition Institute"),
-                  delivery_partner_info: hash_including(name: "Delivery partner 1"),
-                  contract_period_year: 2024
-                )
-              )
-            )
-          )
-        )
-      }
-    end
+    # let(:expected_output) do
+    #   {
+    #     teacher: hash_including(
+    #       trn: "1111111",
+    #       mentor_at_school_periods: array_including(
+    #         hash_including(
+    #           started_on: Date.new(2023, 11, 6),
+    #           finished_on: Date.new(2023, 11, 7),
+    #           training_periods: array_including(
+    #             hash_including(
+    #               training_programme: "provider_led",
+    #               lead_provider_info: {},
+    #               delivery_partner_info: {},
+    #               contract_period_year: 2021
+    #             )
+    #           )
+    #         ),
+    #         hash_including(
+    #           started_on: Date.new(2023, 11, 8),
+    #           finished_on: Date.new(2023, 11, 9),
+    #           training_periods: array_including(
+    #             hash_including(
+    #               training_programme: "provider_led",
+    #               started_on: Date.new(2023, 11, 8),
+    #               finished_on: Date.new(2023, 11, 9),
+    #               lead_provider_info: hash_including(name: "Ambition Institute"),
+    #               delivery_partner_info: hash_including(name: "Delivery partner 1"),
+    #               contract_period_year: 2021
+    #             )
+    #           )
+    #         ),
+    #         hash_including(
+    #           started_on: Date.new(2024, 11, 8),
+    #           finished_on: nil,
+    #           training_periods: array_including(
+    #             hash_including(
+    #               training_programme: "provider_led",
+    #               started_on: Date.new(2024, 11, 8),
+    #               finished_on: nil,
+    #               lead_provider_info: hash_including(name: "Ambition Institute"),
+    #               delivery_partner_info: hash_including(name: "Delivery partner 1"),
+    #               contract_period_year: 2024
+    #             )
+    #           )
+    #         )
+    #       )
+    #     )
+    #   }
+    # end
 
-    it "matches the expected output" do
-      expect(actual_output).to include(expected_output)
+    # it "matches the expected output" do
+    #   expect(actual_output).to include(expected_output)
+    # end
+
+    it "raises a missing training provider info error" do
+      expect { ecf2_teacher_history }.to raise_error(/No training provider info/)
     end
   end
 


### PR DESCRIPTION
I changed this in #2248 and it's now allowing records through which just crash at the next step.

This reverts to the old behaviour where induction records with no `training_provider_info` will crash, except now it raises with a sensible error message.