### PR TITLE
Fix typos in resources for release of Register ECTs

### DIFF
--- a/documentation/resources-for-release/index.md
+++ b/documentation/resources-for-release/index.md
@@ -1,8 +1,8 @@
 ---
-title: Register early career teachers service documentation
+title: Resources for release of Register ECTs
 ---
 
-Resources to help the support schools using the register early career teachers service.
+Resources to help support schools using the register early career teachers service.
 
 These resources:
 


### PR DESCRIPTION
@StephenC-V1 I've suggested changing the H1 to match the name of the link to it from the main service manual page. I also think just 'documentation' might be too ambiguous?

Also removed the extra 'the'