### PR TITLE
Move ECT history mentor period building to a separate class

### DIFF
--- a/app/migration/school_mentors_for_ect.rb
+++ b/app/migration/school_mentors_for_ect.rb
@@ -1,0 +1,42 @@
+class SchoolMentorsForECT
+  def initialize(induction_records:)
+    @induction_records = induction_records
+  end
+
+  def mentor_at_school_periods
+    find_mentor_at_school_periods_for_ect
+  end
+
+private
+
+  attr_reader :induction_records
+
+  def find_mentor_at_school_periods_for_ect
+    schools = induction_records.map(&:school).uniq
+    mentor_profile_ids = induction_records.map(&:mentor_profile_id).compact.uniq
+
+    mentor_at_school_periods = ::MentorAtSchoolPeriod.joins(:school, :teacher)
+      .where(schools: { urn: schools.map(&:urn) },
+             teachers: { api_mentor_training_record_id: mentor_profile_ids })
+
+    mentor_at_school_periods.map do |mentor_at_school_period|
+      build_mentor_at_school_period(mentor_at_school_period:, schools:)
+    end
+  end
+
+  def build_mentor_at_school_period(mentor_at_school_period:, schools:)
+    ECF1TeacherHistory::MentorAtSchoolPeriod.new(
+      mentor_at_school_period_id: mentor_at_school_period.id,
+      started_on: mentor_at_school_period.started_on,
+      finished_on: mentor_at_school_period.finished_on,
+      created_at: mentor_at_school_period.created_at,
+      updated_at: mentor_at_school_period.updated_at,
+      school: schools.find { |s| s.urn == mentor_at_school_period.school.urn.to_s },
+      teacher: build_teacher_data(mentor_at_school_period.teacher)
+    )
+  end
+
+  def build_teacher_data(teacher)
+    Types::TeacherData.new(trn: teacher.trn, api_mentor_training_record_id: teacher.api_mentor_training_record_id)
+  end
+end

--- a/spec/migration/ecf1_teacher_history_spec.rb
+++ b/spec/migration/ecf1_teacher_history_spec.rb
@@ -128,7 +128,7 @@ describe ECF1TeacherHistory do
               expect(historic_period.finished_on).to eq(mentor_at_school_period&.finished_on)
               expect(historic_period.created_at).to be_within(1.second).of(mentor_at_school_period.created_at)
               expect(historic_period.updated_at).to be_within(1.second).of(mentor_at_school_period.updated_at)
-              expect(historic_period.school.urn).to eq(mentor_at_school_period.school.urn)
+              expect(historic_period.school.urn).to eq(mentor_at_school_period.school.urn.to_s)
               expect(historic_period.teacher.trn).to eq(mentor_at_school_period.teacher.trn)
               expect(historic_period.teacher.api_mentor_training_record_id).to eq(mentor_at_school_period.teacher.api_mentor_training_record_id)
             end

--- a/spec/migration/school_mentors_for_ect_spec.rb
+++ b/spec/migration/school_mentors_for_ect_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe SchoolMentorsForECT do
+  subject(:service) { described_class.new(induction_records:) }
+
+  let(:ect_profile) { FactoryBot.create(:migration_participant_profile, :ect) }
+  let(:school_cohort) { ect_profile.school_cohort }
+  let(:induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led, school_cohort:) }
+
+  let!(:induction_records) do
+    FactoryBot.create_list(:migration_induction_record, 2, :with_mentor, participant_profile: ect_profile)
+  end
+
+  let!(:mentor_at_school_periods) do
+    school = FactoryBot.create(:school, urn: school_cohort.school.urn.to_i)
+    period_1 = FactoryBot.create(:mentor_at_school_period,
+                                 api_mentor_training_record_id: induction_records.first.mentor_profile_id,
+                                 school:)
+    period_2 = FactoryBot.create(:mentor_at_school_period,
+                                 api_mentor_training_record_id: induction_records.last.mentor_profile_id,
+                                 school:)
+    [period_1, period_2]
+  end
+
+  describe "#mentor_at_school_periods" do
+    it "builds the right number" do
+      expect(service.mentor_at_school_periods.count).to eq mentor_at_school_periods.count
+    end
+
+    it "populates the right attributes" do
+      aggregate_failures "ECT mentor at school periods results" do
+        mentor_at_school_periods.each do |mentor_at_school_period|
+          historic_period = service.mentor_at_school_periods.find { |hp| hp.mentor_at_school_period_id == mentor_at_school_period.id }
+          expect(historic_period.started_on).to eq(mentor_at_school_period.started_on)
+          expect(historic_period.finished_on).to eq(mentor_at_school_period&.finished_on)
+          expect(historic_period.created_at).to be_within(1.second).of(mentor_at_school_period.created_at)
+          expect(historic_period.updated_at).to be_within(1.second).of(mentor_at_school_period.updated_at)
+          expect(historic_period.school.urn).to eq(mentor_at_school_period.school.urn.to_s)
+          expect(historic_period.teacher.trn).to eq(mentor_at_school_period.teacher.trn)
+          expect(historic_period.teacher.api_mentor_training_record_id).to eq(mentor_at_school_period.teacher.api_mentor_training_record_id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

To avoid confusion, move the methods that build `ECF1TeacherHistory::MentorAtSchoolPeriod` for an ECT's history out of the `ECF1TeacherHistory` class.

### Changes proposed in this pull request

Move the functionality that adds the mentor school periods to an ECTs history to a new class

### Guidance to review
