### PR TITLE
Make `Statement#contract_id` mandatory

### DIFF
--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -36,7 +36,6 @@ module Migrators
       active_lead_provider_id = find_active_lead_provider_id!(lead_provider_id:, contract_period_year:)
 
       statement.update!(
-        active_lead_provider_id:,
         contract_id: find_contract_id!(active_lead_provider_id, ecf_statement.contract_version, ecf_statement.sanitized_mentor_contract_version),
         month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]),
         year: ecf_statement.name.split[1],

--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -4,10 +4,10 @@ class ActiveLeadProvider < ApplicationRecord
   has_many :lead_provider_delivery_partnerships
   has_many :school_partnerships, through: :lead_provider_delivery_partnerships
   has_many :delivery_partners, through: :lead_provider_delivery_partnerships
-  has_many :statements
   has_many :expressions_of_interest, class_name: "TrainingPeriod", foreign_key: "expression_of_interest_id", inverse_of: :expression_of_interest
   has_many :events
   has_many :contracts
+  has_many :statements, through: :contracts
 
   validates :contract_period_year,
             presence: { message: "Choose a contract period" },

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -3,11 +3,11 @@ class Statement < ApplicationRecord
 
   VALID_FEE_TYPES = %w[output service].freeze
 
-  belongs_to :active_lead_provider
-  belongs_to :contract, optional: true
+  belongs_to :contract
   has_many :adjustments
   has_many :payment_declarations, inverse_of: :payment_statement, class_name: "Declaration"
   has_many :clawback_declarations, inverse_of: :clawback_statement, class_name: "Declaration"
+  has_one :active_lead_provider, through: :contract
   has_one :lead_provider, through: :active_lead_provider
   has_one :contract_period, through: :active_lead_provider
 
@@ -15,14 +15,14 @@ class Statement < ApplicationRecord
 
   def self.maximum_year = Date.current.year + 5
 
+  validates :contract, presence: { message: "Contract is required" }
   validates :fee_type,
             presence: { message: "Enter a fee type" },
             inclusion: { in: VALID_FEE_TYPES, message: "Fee type must be output or service" }
   validates :month, numericality: { in: 1..12, only_integer: true, message: "Month must be a number between 1 and 12" }
   validates :year, numericality: { greater_than_or_equal_to: 2020, is_less_than_or_equal_to: :maximum_year, only_integer: true, message: "Year must be on or after 2020 and on or before #{maximum_year}" }
-  validates :active_lead_provider_id, uniqueness: { scope: %i[year month], message: "Statement with the same month and year already exists for the lead provider" }
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement" }
-  validate :contract_active_lead_provider_consistency
+  validate :unique_lead_provider_month_year
 
   scope :with_fee_type, ->(fee_type) { where(fee_type:) }
   scope :with_status, ->(*status) { where(status:) }
@@ -66,9 +66,19 @@ class Statement < ApplicationRecord
     output_fee? && payable? && !marked_as_paid_at? && deadline_date < Date.current
   end
 
-  def contract_active_lead_provider_consistency
-    return unless contract && contract.active_lead_provider != active_lead_provider
+private
 
-    errors.add(:contract, "This contract must have the same active lead provider as the statement.")
+  def unique_lead_provider_month_year
+    return unless active_lead_provider
+
+    existing = Statement.joins(:contract)
+                        .where(contracts: { active_lead_provider_id: active_lead_provider.id })
+                        .where(month:, year:)
+                        .where.not(id:)
+                        .exists?
+
+    return unless existing
+
+    errors.add(:base, "Statement with the same month and year already exists for this active lead provider")
   end
 end

--- a/app/services/api_seed_data/statements.rb
+++ b/app/services/api_seed_data/statements.rb
@@ -19,6 +19,9 @@ module APISeedData
 
       active_lead_providers_by_lead_provider.each do |lead_provider, active_lead_providers|
         statements = []
+        existing_statements = Statement
+          .joins(contract: :active_lead_provider)
+          .where(contract: { active_lead_provider: active_lead_providers })
 
         active_lead_providers.each do |active_lead_provider|
           years = years(active_lead_provider.contract_period.year)
@@ -36,7 +39,7 @@ module APISeedData
             contract_index = (index * active_lead_provider.contracts.size) / (years.size * MONTHS.size)
             contract = active_lead_provider.contracts[contract_index]
 
-            Statement.find_by(active_lead_provider:, month:, year:, deadline_date:) ||
+            existing_statements.find { |s| s.month == month && s.year == year && s.deadline_date == deadline_date } ||
               FactoryBot.create(:statement,
                                 active_lead_provider:,
                                 contract:,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -225,7 +225,6 @@ shared:
     - updated_at
   :statements:
     - id
-    - active_lead_provider_id
     - api_id
     - month
     - year

--- a/db/migrate/20260217082651_switch_statement_active_lead_provider_via_contract.rb
+++ b/db/migrate/20260217082651_switch_statement_active_lead_provider_via_contract.rb
@@ -1,0 +1,10 @@
+class SwitchStatementActiveLeadProviderViaContract < ActiveRecord::Migration[8.0]
+  def change
+    # Require contract on statement.
+    change_column_null :statements, :contract_id, false
+    # Require active_lead_provider on contract.
+    change_column_null :contracts, :active_lead_provider_id, false
+    # Remove active_lead_provider from statement.
+    remove_reference :statements, :active_lead_provider, index: true, foreign_key: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_17_082651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -193,7 +193,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
-    t.bigint "active_lead_provider_id"
+    t.bigint "active_lead_provider_id", null: false
     t.string "ecf_contract_version", default: "1.0.0", null: false
     t.string "ecf_mentor_contract_version"
     t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"
@@ -918,7 +918,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
   end
 
   create_table "statements", force: :cascade do |t|
-    t.bigint "active_lead_provider_id", null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
     t.integer "month", null: false
     t.integer "year", null: false
@@ -930,8 +929,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
     t.datetime "updated_at", null: false
     t.enum "fee_type", default: "output", null: false, enum_type: "fee_types"
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
-    t.bigint "contract_id"
-    t.index ["active_lead_provider_id"], name: "index_statements_on_active_lead_provider_id"
+    t.bigint "contract_id", null: false
     t.index ["contract_id"], name: "index_statements_on_contract_id"
   end
 
@@ -1141,7 +1139,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_12_230241) do
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "statement_adjustments", "statements"
-  add_foreign_key "statements", "active_lead_providers"
   add_foreign_key "statements", "contracts"
   add_foreign_key "teacher_id_changes", "teachers"
   add_foreign_key "teacher_id_changes", "teachers", column: "api_from_teacher_id", primary_key: "api_id"

--- a/spec/migration/migrators/reconcile_adjustment_spec.rb
+++ b/spec/migration/migrators/reconcile_adjustment_spec.rb
@@ -13,7 +13,7 @@ describe Migrators::ReconcileAdjustment do
       lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
       contract_period = FactoryBot.create(:contract_period, year: ecf_cohort.start_year)
       active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
-      FactoryBot.create(:statement, api_id: migration_resource.id, lead_provider:, contract_period:, active_lead_provider:)
+      FactoryBot.create(:statement, api_id: migration_resource.id, active_lead_provider:)
     end
 
     def setup_failure_state

--- a/spec/migration/migrators/statement_adjustment_spec.rb
+++ b/spec/migration/migrators/statement_adjustment_spec.rb
@@ -13,7 +13,7 @@ describe Migrators::StatementAdjustment do
       lead_provider = FactoryBot.create(:lead_provider, name: ecf_lp.name, ecf_id: ecf_lp.id)
       contract_period = FactoryBot.create(:contract_period, year: ecf_cohort.start_year)
       active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
-      FactoryBot.create(:statement, api_id: migration_resource.statement_id, lead_provider:, contract_period:, active_lead_provider:)
+      FactoryBot.create(:statement, api_id: migration_resource.statement_id, active_lead_provider:)
     end
 
     def setup_failure_state

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
 
     context "when fetching statement_id" do
       let(:identifier) { :statement_id }
-      let!(:statement) { FactoryBot.create(:statement, :output_fee, lead_provider:) }
+      let!(:statement) { FactoryBot.create(:statement, :output_fee, active_lead_provider:) }
 
       before do
         # Statement for different lead provider should not be used.
         FactoryBot.create(:statement)
         # Statement for service fee should not be used
-        FactoryBot.create(:statement, :service_fee, lead_provider:)
+        FactoryBot.create(:statement, :service_fee, active_lead_provider:)
       end
 
       it { is_expected.to eq(statement.api_id) }
@@ -239,7 +239,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
 
     context "when fetching the same identifier more than once" do
       let(:identifier) { :statement_id }
-      let!(:statement) { FactoryBot.create(:statement, :output_fee, lead_provider:) }
+      let!(:statement) { FactoryBot.create(:statement, :output_fee, active_lead_provider:) }
 
       it "memoises the returned value for the same identifier in subsequent calls" do
         expect(API::Statements::Query).to receive(:new).once.and_call_original

--- a/spec/models/active_lead_provider_spec.rb
+++ b/spec/models/active_lead_provider_spec.rb
@@ -2,7 +2,7 @@ describe ActiveLeadProvider do
   describe "associations" do
     it { is_expected.to belong_to(:contract_period).with_foreign_key(:contract_period_year) }
     it { is_expected.to belong_to(:lead_provider) }
-    it { is_expected.to have_many(:statements) }
+    it { is_expected.to have_many(:statements).through(:contracts) }
     it { is_expected.to have_many(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:school_partnerships).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:delivery_partners).through(:lead_provider_delivery_partnerships) }

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -62,9 +62,10 @@ describe Admin::StatementPresenter do
   end
 
   describe "#page_title" do
-    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
-    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
-    let(:statement) { FactoryBot.build(:statement, active_lead_provider:, month: 5, year: 2023) }
+    let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+    let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
+    let(:statement) { FactoryBot.build(:statement, contract:, month: 5, year: 2023) }
 
     it "returns the lead provider, month and year in a string" do
       expect(subject.page_title).to eql("Some LP - May 2023")
@@ -72,9 +73,10 @@ describe Admin::StatementPresenter do
   end
 
   describe "#lead_provider_name" do
-    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some LP") }
-    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, lead_provider:) }
-    let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+    let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+    let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
+    let(:statement) { FactoryBot.build(:statement, contract:) }
 
     it "returns the lead provider name" do
       expect(subject.lead_provider_name).to eql("Some LP")
@@ -82,9 +84,10 @@ describe Admin::StatementPresenter do
   end
 
   describe "#contract_period_year" do
-    let(:contract_period) { FactoryBot.build(:contract_period, year: 2022) }
-    let(:active_lead_provider) { FactoryBot.build(:active_lead_provider, contract_period:) }
-    let(:statement) { FactoryBot.build(:statement, active_lead_provider:) }
+    let(:contract_period) { FactoryBot.create(:contract_period, year: 2022) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+    let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
+    let(:statement) { FactoryBot.build(:statement, contract:) }
 
     it "returns the lead provider name" do
       expect(subject.contract_period_year).to eql("2022")

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
     ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: nil, teacher:, school: school_partnership.school)
     training_period = FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: 1.year.ago, finished_on: nil, school_partnership:)
 
-    declaration = FactoryBot.create(:declaration, declaration_trait, training_period:)
-    declaration.payment_statement&.update!(active_lead_provider:)
-    declaration
+    FactoryBot.create(:declaration, declaration_trait, training_period:).tap do |declaration|
+      # Using update_all bypasses the readonly check on that attribute.
+      active_lead_provider_id = active_lead_provider.id
+      Contract.where(id: declaration.payment_statement&.contract).update_all(active_lead_provider_id:)
+    end
   end
 
   describe "#index" do

--- a/spec/services/api/declarations/clawback_spec.rb
+++ b/spec/services/api/declarations/clawback_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe API::Declarations::Clawback, type: :model do
 private
 
   def ensure_active_lead_providers_are_consistent
-    active_lead_provider = declaration.training_period.active_lead_provider
-    declaration.payment_statement.update!(active_lead_provider:)
+    # Using update_all bypasses the readonly check on that attribute.
+    active_lead_provider_id = declaration.training_period.active_lead_provider.id
+    Contract.where(id: declaration.payment_statement.contract).update_all(active_lead_provider_id:)
   end
 end

--- a/spec/services/api/statements/query_spec.rb
+++ b/spec/services/api/statements/query_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe API::Statements::Query do
   end
 
   describe "#statements" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+    let(:lead_provider) { active_lead_provider.lead_provider }
 
     it "returns all statements" do
       statement = FactoryBot.create(:statement)
@@ -53,7 +54,7 @@ RSpec.describe API::Statements::Query do
 
     describe "filtering" do
       describe "by `lead_provider`" do
-        let!(:statement1) { FactoryBot.create(:statement, lead_provider:) }
+        let!(:statement1) { FactoryBot.create(:statement, active_lead_provider:) }
         let!(:statement2) { FactoryBot.create(:statement) }
         let!(:statement3) { FactoryBot.create(:statement) }
 
@@ -147,8 +148,8 @@ RSpec.describe API::Statements::Query do
         let(:updated_since) { 1.day.ago }
 
         it "filters by `updated_since`" do
-          FactoryBot.create(:statement, lead_provider:, api_updated_at: 2.days.ago)
-          statement2 = FactoryBot.create(:statement, lead_provider:, api_updated_at: Time.zone.now)
+          FactoryBot.create(:statement, active_lead_provider:, api_updated_at: 2.days.ago)
+          statement2 = FactoryBot.create(:statement, active_lead_provider:, api_updated_at: Time.zone.now)
 
           query = described_class.new(lead_provider_id: lead_provider.id, updated_since:)
 
@@ -246,10 +247,11 @@ RSpec.describe API::Statements::Query do
   end
 
   describe "#statement_by_api_id" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+    let(:lead_provider) { active_lead_provider.lead_provider }
 
     it "returns the statement for a Lead Provider" do
-      statement = FactoryBot.create(:statement, lead_provider:)
+      statement = FactoryBot.create(:statement, active_lead_provider:)
       query = described_class.new
 
       expect(query.statement_by_api_id(statement.api_id)).to eq(statement)
@@ -262,8 +264,8 @@ RSpec.describe API::Statements::Query do
     end
 
     it "raises an error if the statement is not in the filtered query" do
-      other_lead_provider = FactoryBot.create(:lead_provider)
-      other_statement = FactoryBot.create(:statement, lead_provider: other_lead_provider)
+      other_active_lead_provider = FactoryBot.create(:active_lead_provider)
+      other_statement = FactoryBot.create(:statement, active_lead_provider: other_active_lead_provider)
 
       query = described_class.new(lead_provider_id: lead_provider.id)
 
@@ -276,10 +278,11 @@ RSpec.describe API::Statements::Query do
   end
 
   describe "#statement_by_id" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+    let(:lead_provider) { active_lead_provider.lead_provider }
 
     it "returns the statement for a Lead Provider" do
-      statement = FactoryBot.create(:statement, lead_provider:)
+      statement = FactoryBot.create(:statement, active_lead_provider:)
       query = described_class.new
 
       expect(query.statement_by_id(statement.id)).to eq(statement)
@@ -292,8 +295,8 @@ RSpec.describe API::Statements::Query do
     end
 
     it "raises an error if the statement is not in the filtered query" do
-      other_lead_provider = FactoryBot.create(:lead_provider)
-      other_statement = FactoryBot.create(:statement, lead_provider: other_lead_provider)
+      other_active_lead_provider = FactoryBot.create(:active_lead_provider)
+      other_statement = FactoryBot.create(:statement, active_lead_provider: other_active_lead_provider)
 
       query = described_class.new(lead_provider_id: lead_provider.id)
 

--- a/spec/services/api_seed_data/declarations_spec.rb
+++ b/spec/services/api_seed_data/declarations_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe APISeedData::Declarations do
     allow(Logger).to receive(:new).with($stdout) { ignored_logger }
 
     APISeedData::ContractPeriods.new.plant
+    APISeedData::Contracts.new.plant
     APISeedData::Statements.new.plant
     APISeedData::SchedulesAndMilestones.new.plant
 

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
       FactoryBot.create_list(:lead_provider_delivery_partnership, 5, :for_year, lead_provider:, year: contract_period_2025.year)
     end
     FactoryBot.create_list(:appropriate_body, 5)
+    APISeedData::Contracts.new.plant
     APISeedData::Statements.new.plant
     APISeedData::Schools.new.plant
     APISeedData::SchoolPartnerships.new.plant

--- a/spec/services/statements/search_spec.rb
+++ b/spec/services/statements/search_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Statements::Search do
   describe "#statements" do
-    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+    let(:lead_provider) { active_lead_provider.lead_provider }
 
     it "returns all statements" do
       statement = FactoryBot.create(:statement)
@@ -21,7 +22,7 @@ RSpec.describe Statements::Search do
 
     describe "filtering" do
       describe "by `lead_provider`" do
-        let!(:statement1) { FactoryBot.create(:statement, lead_provider:) }
+        let!(:statement1) { FactoryBot.create(:statement, active_lead_provider:) }
         let!(:statement2) { FactoryBot.create(:statement) }
         let!(:statement3) { FactoryBot.create(:statement) }
 


### PR DESCRIPTION
### Context

We are now migrating contracts and populate the contract on all statements (in both seed data and the data migration), so we want to make `contract` mandatory with validation and non-nullable foreign key.

As we can reach `ActiveLeadProvider` via `Statement#contract` we no longer need to reference `Statement#active_lead-provider` directly and can remove it.

### Changes proposed in this pull request

Update the `contract_id` to be not-nullable and add required validation.

Remove `Statement#active_lead_provider_id` as this is now redundant (we can get the `active_lead_provider` via the `contract`).

Change `Statement` uniqueness validation to work through `contract.active_lead_provider`.

Update all references in specs.

### Guidance to review

Now that `Statement` doesn't have a direct association to `ActiveLeadProvider` we can't enforce uniqueness (of month/year/active lead provider) at the database level. We weren't doing this previously anyway, but it is something we _could_ have done and no longer can without the direct reference in place (there can be multiple contracts for an `ActiveLeadProvider`).