### PR TITLE
Fix range based change matcher

### DIFF
--- a/spec/services/api_seed_data/lead_provider_delivery_partnerships_spec.rb
+++ b/spec/services/api_seed_data/lead_provider_delivery_partnerships_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe APISeedData::LeadProviderDeliveryPartnerships do
     it "creates the correct number of lead provider delivery partnerships" do
       minimum_records = described_class::DELIVERY_PARTNERS_PER_LEAD_PROVIDER
       maximum_records = minimum_records + described_class::SHARED_DELIVERY_PARTNERS_PER_LEAD_PROVIDER
-      expect { instance.plant }.to(change(LeadProviderDeliveryPartnership, :count).by(minimum_records..maximum_records))
+      expect { instance.plant }.to(change(LeadProviderDeliveryPartnership, :count).by(be_between(minimum_records, maximum_records)))
     end
 
     it "does not create data when already present" do


### PR DESCRIPTION
### Summary

RSpec now compares ranges with `==` (equality) instead of `===` (inclusion). So `by(30..35)` won't match a number like 31 any more.

Switch to `be_between` to preserve the original inclusive range intent.

See: https://github.com/rspec/rspec/pull/298/changes/a8f86b755f92b22b4f888518b105b590a9f12351

Fixes the [failing test ](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/22116393808/job/63926068682?pr=2272)in #2272 