### PR TITLE
Add cleaner step to adjust dates from induction record introduction

### DIFF
--- a/app/migration/teacher_history_converter/cleaner.rb
+++ b/app/migration/teacher_history_converter/cleaner.rb
@@ -11,14 +11,13 @@ private
 
   def clean!
     remove_british_schools_overseas(@raw_induction_records)
-      .then { |induction_records| remove_school_funded_fip(induction_records) }
-      .then { |induction_records| remove_independent_non_section_41(induction_records) }
-      .then { |induction_records| fix_service_start_dates(induction_records) }
-      .then { |induction_records| fix_corrupted_dates(induction_records) }
-      .then { |induction_records| fix_zero_day_periods(induction_records) }
-      .then { |induction_records| fix_first_start_date(induction_records) }
-      .then { |induction_records| fix_first_start_date(induction_records) }
-      .then { |induction_records| adjust_initial_induction_record_start_date(induction_records) }
+      .then { remove_school_funded_fip(it) }
+      .then { remove_independent_non_section_41(it) }
+      .then { fix_service_start_dates(it) }
+      .then { fix_corrupted_dates(it) }
+      .then { fix_zero_day_periods(it) }
+      .then { override_first_start_date_with_creation_date_if_earlier(it) }
+      .then { override_first_start_date_for_induction_record_introduction(it) }
   end
 
   def remove_british_schools_overseas(induction_records)
@@ -45,11 +44,11 @@ private
     TeacherHistoryConverter::Cleaner::ZeroDay.new(induction_records).induction_records
   end
 
-  def fix_first_start_date(induction_records)
-    TeacherHistoryConverter::Cleaner::FixFirstStartDate.new(induction_records).induction_records
+  def override_first_start_date_with_creation_date_if_earlier(induction_records)
+    TeacherHistoryConverter::Cleaner::OverrideFirstStartDateWithCreationDateIfEarlier.new(induction_records).induction_records
   end
 
-  def adjust_initial_induction_record_start_date(induction_records)
-    TeacherHistoryConverter::Cleaner::AdjustInitialInductionRecordStartDates.new(induction_records).induction_records
+  def override_first_start_date_for_induction_record_introduction(induction_records)
+    TeacherHistoryConverter::Cleaner::OverrideFirstStartDateForInductionRecordIntroduction.new(induction_records).induction_records
   end
 end

--- a/app/migration/teacher_history_converter/cleaner/override_first_start_date_for_induction_record_introduction.rb
+++ b/app/migration/teacher_history_converter/cleaner/override_first_start_date_for_induction_record_introduction.rb
@@ -1,4 +1,4 @@
-class TeacherHistoryConverter::Cleaner::AdjustInitialInductionRecordStartDates
+class TeacherHistoryConverter::Cleaner::OverrideFirstStartDateForInductionRecordIntroduction
   INDUCTION_RECORD_INTRODUCTION_DATE = Date.new(2022, 2, 9).freeze
   REPLACEMENT_START_DATE = Date.new(2021, 9, 1).freeze
 

--- a/app/migration/teacher_history_converter/cleaner/override_first_start_date_with_creation_date_if_earlier.rb
+++ b/app/migration/teacher_history_converter/cleaner/override_first_start_date_with_creation_date_if_earlier.rb
@@ -1,4 +1,4 @@
-class TeacherHistoryConverter::Cleaner::FixFirstStartDate
+class TeacherHistoryConverter::Cleaner::OverrideFirstStartDateWithCreationDateIfEarlier
   def initialize(raw_induction_records)
     @raw_induction_records = raw_induction_records
   end

--- a/spec/migration/teacher_history_converter/cleaner/override_first_start_date_for_induction_record_introduction_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/override_first_start_date_for_induction_record_introduction_spec.rb
@@ -1,6 +1,6 @@
-describe TeacherHistoryConverter::Cleaner::AdjustInitialInductionRecordStartDates do
+describe TeacherHistoryConverter::Cleaner::OverrideFirstStartDateForInductionRecordIntroduction do
   subject do
-    TeacherHistoryConverter::Cleaner::AdjustInitialInductionRecordStartDates.new(induction_records).induction_records
+    TeacherHistoryConverter::Cleaner::OverrideFirstStartDateForInductionRecordIntroduction.new(induction_records).induction_records
   end
 
   let(:second_induction_record) { FactoryBot.build(:ecf1_teacher_history_induction_record_row) }

--- a/spec/migration/teacher_history_converter/cleaner/override_first_start_date_with_creation_date_if_earlier_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/override_first_start_date_with_creation_date_if_earlier_spec.rb
@@ -1,6 +1,6 @@
-describe TeacherHistoryConverter::Cleaner::FixFirstStartDate do
+describe TeacherHistoryConverter::Cleaner::OverrideFirstStartDateWithCreationDateIfEarlier do
   subject do
-    TeacherHistoryConverter::Cleaner::FixFirstStartDate.new(induction_records).induction_records
+    TeacherHistoryConverter::Cleaner::OverrideFirstStartDateWithCreationDateIfEarlier.new(induction_records).induction_records
   end
 
   let(:induction_records) { [first_induction_record, second_induction_record] }

--- a/spec/migration/teacher_history_converter/cleaner_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner_spec.rb
@@ -8,8 +8,8 @@ describe TeacherHistoryConverter::Cleaner do
       TeacherHistoryConverter::Cleaner::ServiceStartDate,
       TeacherHistoryConverter::Cleaner::CorruptedDates,
       TeacherHistoryConverter::Cleaner::ZeroDay,
-      TeacherHistoryConverter::Cleaner::FixFirstStartDate,
-      TeacherHistoryConverter::Cleaner::AdjustInitialInductionRecordStartDates
+      TeacherHistoryConverter::Cleaner::OverrideFirstStartDateWithCreationDateIfEarlier,
+      TeacherHistoryConverter::Cleaner::OverrideFirstStartDateForInductionRecordIntroduction
     ]
   end
 


### PR DESCRIPTION
### Context

Induction records were introduced to ECF1 on 2022-02-09 which makes it a common start_date, but the training of these participants is more likely to have started on 2021-09-01.

This step makes that adjustment; any first induction record that has a `start_date` of `2022-02-09` will be changed to `2021-09-01`.

### Changes proposed in this pull request

- **Add cleaner step that overrides first IR dates**
- **Add the new adjustment step to the cleaner**
- **Make the cleaner class names a bit clearer**

Fixes DFE-Digital/register-ects-project-board#3212
