### PR TITLE
Handle migrating ERO mentor training

### DIFF
--- a/app/migration/ecf1_teacher_history.rb
+++ b/app/migration/ecf1_teacher_history.rb
@@ -133,6 +133,8 @@ class ECF1TeacherHistory
   end
 
   def self.build_mentor_data(participant_profile:)
+    ero_check = EROMentorChecker.new(participant_profile:)
+
     Mentor.new(
       participant_profile_id: participant_profile.id,
       created_at: participant_profile.created_at,
@@ -141,7 +143,9 @@ class ECF1TeacherHistory
       mentor_completion_reason: participant_profile.mentor_completion_reason,
       payments_frozen_cohort_start_year: participant_profile.previous_payments_frozen_cohort_start_year,
       states: build_profile_states(participant_profile:),
-      induction_records: build_induction_records(participant_profile:)
+      induction_records: build_induction_records(participant_profile:),
+      ero_mentor: ero_check.ero_mentor?,
+      ero_declarations: ero_check.ero_mentor_with_declarations?
     )
   end
 

--- a/app/migration/ecf1_teacher_history/mentor.rb
+++ b/app/migration/ecf1_teacher_history/mentor.rb
@@ -7,11 +7,13 @@ class ECF1TeacherHistory::Mentor
               :mentor_completion_date,
               :mentor_completion_reason,
               :payments_frozen_cohort_start_year,
-              :states
+              :states,
+              :ero_mentor,
+              :ero_declarations
 
   attr_accessor :induction_records
 
-  def initialize(participant_profile_id:, created_at:, updated_at:, mentor_completion_date:, mentor_completion_reason:, payments_frozen_cohort_start_year:, states:, induction_records:)
+  def initialize(participant_profile_id:, created_at:, updated_at:, mentor_completion_date:, mentor_completion_reason:, payments_frozen_cohort_start_year:, states:, induction_records:, ero_mentor:, ero_declarations:)
     @participant_profile_id = participant_profile_id
     @created_at = created_at
     @updated_at = updated_at
@@ -20,6 +22,8 @@ class ECF1TeacherHistory::Mentor
     @payments_frozen_cohort_start_year = payments_frozen_cohort_start_year
     @states = states
     @induction_records = induction_records
+    @ero_mentor = ero_mentor
+    @ero_declarations = ero_declarations
   end
 
   def self.from_hash(hash)

--- a/app/migration/ero_mentor_checker.rb
+++ b/app/migration/ero_mentor_checker.rb
@@ -1,0 +1,29 @@
+class EROMentorChecker
+  attr_reader :participant_profile
+
+  def initialize(participant_profile:)
+    @participant_profile = participant_profile
+  end
+
+  def ero_mentor?
+    participant_profile.mentor? && Migration::ECFIneligibleParticipant.exists?(trn:)
+  end
+
+  def relevant_declarations
+    @relevant_declarations ||= participant_profile.participant_declarations.where(state: %w[paid clawed_back])
+  end
+
+  def ero_mentor_with_declarations?
+    ero_mentor? && relevant_declarations.any?
+  end
+
+  def ero_mentor_without_declarations?
+    ero_mentor? && relevant_declarations.none?
+  end
+
+private
+
+  def trn
+    participant_profile.teacher_profile.trn
+  end
+end

--- a/app/migration/teacher_history_converter.rb
+++ b/app/migration/teacher_history_converter.rb
@@ -83,15 +83,20 @@ private
     raw_induction_records = ecf1_teacher_history.mentor.induction_records
     induction_records = TeacherHistoryConverter::Cleaner.new(raw_induction_records).induction_records
     states = ecf1_teacher_history.mentor.states
+    exclude_training_periods = exclude_ero_training_periods?
 
     case migration_mode
     when :latest_induction_records
-      TeacherHistoryConverter::Mentor::LatestInductionRecords.new(trn:, profile_id:, induction_records:, states:)
+      TeacherHistoryConverter::Mentor::LatestInductionRecords.new(trn:, profile_id:, induction_records:, states:, exclude_training_periods:)
         .mentor_at_school_periods
         .then { |at_school_periods| override_first_at_school_period_created_at(at_school_periods, ecf1_teacher_history.mentor.created_at) }
     when :all_induction_records
       TeacherHistoryConverter::Mentor::AllInductionRecords.new(induction_records).mentor_at_school_periods
     end
+  end
+
+  def exclude_ero_training_periods?
+    ecf1_teacher_history.mentor.ero_mentor && !ecf1_teacher_history.mentor.ero_declarations
   end
 
   # in ECF1 we use the participant profile `created_at`, but as

--- a/app/models/migration/ecf_ineligible_participant.rb
+++ b/app/models/migration/ecf_ineligible_participant.rb
@@ -1,0 +1,4 @@
+module Migration
+  class ECFIneligibleParticipant < Migration::Base
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,6 +19,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "ECF2" # Early Career Framework 2 (the new service, Register ECTs)
   inflect.acronym "ECT" # Early Career Teacher
   inflect.acronym "ECTs" # Early Career Teachers
+  inflect.acronym "ERO" # Early Roll Out (ECF1 pre-launch mentor participants)
   inflect.acronym "GIAS" # Get Information About Schools
   inflect.acronym "ITT" # Initial teacher training
   inflect.acronym "OmniAuth"

--- a/spec/factories/migration/ecf1_history_factory.rb
+++ b/spec/factories/migration/ecf1_history_factory.rb
@@ -229,6 +229,8 @@ FactoryBot.define do
     updated_at { 6.months.ago }
     states { [FactoryBot.build(:ecf1_teacher_history_profile_state_row)] }
     induction_records { [] }
+    ero_mentor { false }
+    ero_declarations { false }
 
     payments_frozen_cohort_start_year { nil }
 
@@ -240,6 +242,8 @@ FactoryBot.define do
           updated_at:,
           states:,
           induction_records:,
+          ero_mentor:,
+          ero_declarations:,
           payments_frozen_cohort_start_year:)
     end
   end

--- a/spec/factories/migration/ecf_ineligible_participant_factory.rb
+++ b/spec/factories/migration/ecf_ineligible_participant_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :migration_ecf_ineligible_participant, class: "Migration::ECFIneligibleParticipant" do
+    trn { Faker::Number.unique.number(digits: 7) }
+    reason { "previous_participation" }
+  end
+end

--- a/spec/migration/ecf1_teacher_history_spec.rb
+++ b/spec/migration/ecf1_teacher_history_spec.rb
@@ -78,6 +78,53 @@ describe ECF1TeacherHistory do
       expect(history.mentor.participant_profile_id).to eq(mentor_profile.id)
     end
 
+    describe "ERO mentor attributes" do
+      let(:state) { :payable }
+      let!(:declaration) { FactoryBot.create(:migration_participant_declaration, participant_profile: mentor_profile, state:) }
+
+      context "when the mentor did not participate in the ECF1 ERO phase" do
+        it "the ero_mentor flag is not set" do
+          expect(history.mentor.ero_mentor).to be_falsey
+        end
+
+        it "does not set the ero_declarations flag" do
+          expect(history.mentor.ero_declarations).to be_falsey
+        end
+      end
+
+      context "when the mentor participated in ECF1 ERO phase" do
+        before do
+          FactoryBot.create(:migration_ecf_ineligible_participant, trn: teacher_profile.trn)
+        end
+
+        it "sets the ero_mentor flag" do
+          expect(history.mentor.ero_mentor).to be_truthy
+        end
+
+        context "when the mentor does not have any 'paid' or 'clawed_back' declarations" do
+          it "does not set the ero_declarations flag" do
+            expect(history.mentor.ero_declarations).to be_falsey
+          end
+        end
+
+        context "when the mentor does have 'paid' declarations" do
+          let(:state) { :paid }
+
+          it "sets the ero_declarations flag" do
+            expect(history.mentor.ero_declarations).to be_truthy
+          end
+        end
+
+        context "when the mentor does have 'clawed_back' declarations" do
+          let(:state) { :clawed_back }
+
+          it "sets the ero_declarations flag" do
+            expect(history.mentor.ero_declarations).to be_truthy
+          end
+        end
+      end
+    end
+
     describe "setting up induction records correctly" do
       describe "ECT induction records" do
         it "creates the right number" do

--- a/spec/migration/ero_mentor_checker_spec.rb
+++ b/spec/migration/ero_mentor_checker_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe EROMentorChecker do
+  subject(:checker) { described_class.new(participant_profile: profile) }
+
+  let(:profile) { FactoryBot.create(:migration_participant_profile, :mentor) }
+
+  describe "#ero_mentor?" do
+    context "when the participant is a mentor" do
+      context "when they were not part of ERO" do
+        it "returns false" do
+          expect(checker).not_to be_ero_mentor
+        end
+      end
+
+      context "when they were part of ERO" do
+        before do
+          FactoryBot.create(:migration_ecf_ineligible_participant, trn: profile.teacher_profile.trn)
+        end
+
+        it "returns true" do
+          expect(checker).to be_ero_mentor
+        end
+      end
+    end
+
+    context "when the participant is not a mentor" do
+      let(:profile) { FactoryBot.create(:migration_participant_profile, :ect) }
+
+      it "returns false" do
+        expect(checker).not_to be_ero_mentor
+      end
+    end
+  end
+
+  describe "#relevant_declarations" do
+    context "when they had a paid declaration" do
+      let!(:declaration) { FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state: :paid) }
+
+      it "returns the declaration" do
+        expect(checker.relevant_declarations).to eq [declaration]
+      end
+    end
+
+    context "when they had a clawed_back declaration" do
+      let!(:declaration) { FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state: :clawed_back) }
+
+      it "returns the declaration" do
+        expect(checker.relevant_declarations).to eq [declaration]
+      end
+    end
+
+    context "when they had a declaration that wasn't paid or clawed_back" do
+      let!(:declaration) { FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state: :clawed_back) }
+
+      %i[submitted eligible payable voided ineligible awaiting_clawback].each do |state|
+        it "does not return those declarations" do
+          FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state:)
+          expect(checker.relevant_declarations).to eq [declaration]
+        end
+      end
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter/end_to_end/ero_mentor_with_declarations_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/ero_mentor_with_declarations_spec.rb
@@ -1,0 +1,112 @@
+describe "ERO mentor with a relevant declaration" do
+  subject(:teacher) { Teacher.find_by(trn:) }
+
+  # ECF1 data
+  let(:ecf1_participant_profile) { FactoryBot.create(:migration_participant_profile, :mentor) }
+  let!(:ecf1_declaration) do
+    FactoryBot.create(:migration_participant_declaration, participant_profile: ecf1_participant_profile, state: :paid)
+  end
+
+  let(:ecf1_induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led) }
+  let(:ecf1_induction_record) do
+    FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, participant_profile: ecf1_participant_profile)
+  end
+  let(:ecf1_teacher_profile) { ecf1_participant_profile.teacher_profile }
+  let(:trn) { ecf1_teacher_profile.trn }
+  let(:ecf1_urn) { ecf1_induction_programme.school_cohort.school.urn.to_i }
+  let!(:ineligible_participant) { FactoryBot.create(:migration_ecf_ineligible_participant, trn:) }
+
+  # ECF2 data
+  let(:ecf2_school) { ecf2_gias_school.school }
+  let(:ecf2_contract_period) { FactoryBot.create(:contract_period, year: ecf1_induction_record.induction_programme.school_cohort.cohort.start_year) }
+  let(:ecf2_lead_provider) { FactoryBot.create(:lead_provider, name: ecf1_induction_programme.partnership.lead_provider.name, ecf_id: ecf1_induction_programme.partnership.lead_provider_id) }
+  let(:ecf2_delivery_partner) { FactoryBot.create(:delivery_partner, name: ecf1_induction_programme.partnership.delivery_partner.name, api_id: ecf1_induction_programme.partnership.delivery_partner_id) }
+  let(:ecf2_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: ecf2_lead_provider, contract_period: ecf2_contract_period) }
+  let(:ecf2_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: ecf2_active_lead_provider, delivery_partner: ecf2_delivery_partner) }
+
+  let!(:ecf2_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: ecf1_urn) }
+  let!(:ecf2_schedule) { FactoryBot.create(:schedule, contract_period: ecf2_contract_period, identifier: ecf1_induction_record.schedule.schedule_identifier) }
+  let!(:ecf2_school_partnership) { FactoryBot.create(:school_partnership, school: ecf2_school, lead_provider_delivery_partnership: ecf2_lead_provider_delivery_partnership) }
+
+  # Conversion objects
+  let(:ecf1_teacher_history) { ECF1TeacherHistory.build(teacher_profile: ecf1_teacher_profile) }
+  let(:teacher_history_converter) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:) }
+
+  before do
+    ecf2_teacher_history = teacher_history_converter.convert_to_ecf2!
+    ecf2_teacher_history.save_all_mentor_data!
+  end
+
+  context "when in latest_induction_records mode (economy)" do
+    let(:migration_mode) { :latest_induction_records }
+
+    it "creates the teacher record" do
+      expect(teacher).to be_persisted
+    end
+
+    it "creates a single mentor_at_school_period linked to the teacher at the right school" do
+      mentor_at_school_periods = teacher.mentor_at_school_periods
+      mentor_at_school_period = mentor_at_school_periods.first
+
+      aggregate_failures do
+        expect(mentor_at_school_periods.count).to be(1)
+        expect(mentor_at_school_period.school.urn).to eql(ecf1_urn)
+      end
+    end
+
+    it "creates a single training_period for the teacher linked to the right schedule and school partnership" do
+      training_periods = teacher.mentor_at_school_periods.first.training_periods
+      training_period = training_periods.first
+
+      aggregate_failures do
+        expect(training_periods.count).to be(1)
+
+        expect(training_period.school_partnership.contract_period.year).to eql(ecf1_induction_programme.partnership.cohort.start_year)
+        expect(training_period.school_partnership.lead_provider.name).to eql(ecf1_induction_programme.partnership.lead_provider.name)
+        expect(training_period.school_partnership.delivery_partner.name).to eql(ecf1_induction_programme.partnership.delivery_partner.name)
+
+        expect(training_period.schedule.identifier).to eql(ecf1_induction_record.schedule.schedule_identifier)
+        expect(training_period.schedule.contract_period_year).to eql(ecf1_induction_record.schedule.cohort.start_year)
+
+        expect(training_period.created_at).to eql(ecf1_induction_record.created_at)
+      end
+    end
+  end
+
+  context "when in all_induction_records mode (premium)", skip: "re-enable once we've implemented premium mode" do
+    let(:migration_mode) { :all_induction_records }
+
+    it "creates the teacher record" do
+      expect(teacher).to be_persisted
+    end
+
+    it "creates a single mentor_at_school_period linked to the teacher at the right school" do
+      mentor_at_school_periods = teacher.mentor_at_school_periods
+      mentor_at_school_period = mentor_at_school_periods.first
+
+      aggregate_failures do
+        expect(mentor_at_school_periods.count).to be(1)
+
+        expect(mentor_at_school_period.school.urn).to eql(ecf1_urn)
+      end
+    end
+
+    it "creates a single training_period for the teacher linked to the right schedule and school partnership" do
+      training_periods = teacher.mentor_at_school_periods.first.training_periods
+      training_period = training_periods.first
+
+      aggregate_failures do
+        expect(training_periods.count).to be(1)
+
+        expect(training_period.school_partnership.contract_period.year).to eql(ecf1_induction_programme.partnership.cohort.start_year)
+        expect(training_period.school_partnership.lead_provider.name).to eql(ecf1_induction_programme.partnership.lead_provider.name)
+        expect(training_period.school_partnership.delivery_partner.name).to eql(ecf1_induction_programme.partnership.delivery_partner.name)
+
+        expect(training_period.schedule.identifier).to eql(ecf1_induction_record.schedule.schedule_identifier)
+        expect(training_period.schedule.contract_period_year).to eql(ecf1_induction_record.schedule.cohort.start_year)
+
+        expect(training_period.created_at).to eql(ecf1_induction_record.created_at)
+      end
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter/end_to_end/ero_mentor_without_declarations_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/ero_mentor_without_declarations_spec.rb
@@ -1,0 +1,84 @@
+describe "ERO mentor without a relevant declaration" do
+  subject(:teacher) { Teacher.find_by(trn:) }
+
+  # ECF1 data
+  let(:ecf1_participant_profile) { FactoryBot.create(:migration_participant_profile, :mentor) }
+
+  let(:ecf1_induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led) }
+  let(:ecf1_induction_record) do
+    FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, participant_profile: ecf1_participant_profile)
+  end
+  let(:ecf1_teacher_profile) { ecf1_participant_profile.teacher_profile }
+  let(:trn) { ecf1_teacher_profile.trn }
+  let(:ecf1_urn) { ecf1_induction_programme.school_cohort.school.urn.to_i }
+  let!(:ineligible_participant) { FactoryBot.create(:migration_ecf_ineligible_participant, trn:) }
+
+  # ECF2 data
+  let(:ecf2_school) { ecf2_gias_school.school }
+  let(:ecf2_contract_period) { FactoryBot.create(:contract_period, year: ecf1_induction_record.induction_programme.school_cohort.cohort.start_year) }
+  let(:ecf2_lead_provider) { FactoryBot.create(:lead_provider, name: ecf1_induction_programme.partnership.lead_provider.name, ecf_id: ecf1_induction_programme.partnership.lead_provider_id) }
+  let(:ecf2_delivery_partner) { FactoryBot.create(:delivery_partner, name: ecf1_induction_programme.partnership.delivery_partner.name, api_id: ecf1_induction_programme.partnership.delivery_partner_id) }
+  let(:ecf2_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: ecf2_lead_provider, contract_period: ecf2_contract_period) }
+  let(:ecf2_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: ecf2_active_lead_provider, delivery_partner: ecf2_delivery_partner) }
+
+  let!(:ecf2_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: ecf1_urn) }
+  let!(:ecf2_schedule) { FactoryBot.create(:schedule, contract_period: ecf2_contract_period, identifier: ecf1_induction_record.schedule.schedule_identifier) }
+  let!(:ecf2_school_partnership) { FactoryBot.create(:school_partnership, school: ecf2_school, lead_provider_delivery_partnership: ecf2_lead_provider_delivery_partnership) }
+
+  # Conversion objects
+  let(:ecf1_teacher_history) { ECF1TeacherHistory.build(teacher_profile: ecf1_teacher_profile) }
+  let(:teacher_history_converter) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:) }
+
+  before do
+    ecf2_teacher_history = teacher_history_converter.convert_to_ecf2!
+    ecf2_teacher_history.save_all_mentor_data!
+  end
+
+  context "when in latest_induction_records mode (economy)" do
+    let(:migration_mode) { :latest_induction_records }
+
+    it "creates the teacher record" do
+      expect(teacher).to be_persisted
+    end
+
+    it "creates a single mentor_at_school_period linked to the teacher at the right school" do
+      mentor_at_school_periods = teacher.mentor_at_school_periods
+      mentor_at_school_period = mentor_at_school_periods.first
+
+      aggregate_failures do
+        expect(mentor_at_school_periods.count).to be(1)
+
+        expect(mentor_at_school_period.school.urn).to eql(ecf1_urn)
+      end
+    end
+
+    it "does not create a training_period for the teacher" do
+      training_periods = teacher.mentor_at_school_periods.first.training_periods
+      expect(training_periods.count).to be_zero
+    end
+  end
+
+  context "when in all_induction_records mode (premium)", skip: "re-enable once we've implemented premium mode" do
+    let(:migration_mode) { :all_induction_records }
+
+    it "creates the teacher record" do
+      expect(teacher).to be_persisted
+    end
+
+    it "creates a single mentor_at_school_period linked to the teacher at the right school" do
+      mentor_at_school_periods = teacher.mentor_at_school_periods
+      mentor_at_school_period = mentor_at_school_periods.first
+
+      aggregate_failures do
+        expect(mentor_at_school_periods.count).to be(1)
+
+        expect(mentor_at_school_period.school.urn).to eql(ecf1_urn)
+      end
+    end
+
+    it "does not create a training_period for the teacher" do
+      training_periods = teacher.mentor_at_school_periods.first.training_periods
+      expect(training_periods.count).to be_zero
+    end
+  end
+end


### PR DESCRIPTION
### Context

There are a few ERO mentors in ECF1 that have had declarations that have been recorded in statements i.e. `paid` and `clawed_back`. In those cases we should add `training_periods` as normal
**In all other cases** we should not create training period records for ERO mentors.

### Changes proposed in this pull request

- Adds service to check mentor's ERO details
- Adds ERO flags into ECF1TeacherHistory::Mentor to aid with decision making
- Prevents adding training periods for ERO mentors that do not have relevant declarations

### Guidance to review
