### PR TITLE
Conversion logic for uplift flags when migrating declarations

### DIFF
--- a/app/migration/migrators/declaration.rb
+++ b/app/migration/migrators/declaration.rb
@@ -46,8 +46,8 @@ module Migrators
                                     evidence_type: participant_declaration.evidence_held,
                                     payment_statement_id: payment_statement(participant_declaration:)&.id,
                                     payment_status: participant_declaration.payment_status,
-                                    pupil_premium_uplift: participant_declaration.pupil_premium_uplift,
-                                    sparsity_uplift: participant_declaration.sparsity_uplift,
+                                    pupil_premium_uplift: participant_declaration.migrated_pupil_premium_uplift,
+                                    sparsity_uplift: participant_declaration.migrated_sparsity_uplift,
                                     training_period_id: training_period&.id,
                                     updated_at: participant_declaration.updated_at,
                                     voided_by_user_at: participant_declaration.voided_at)

--- a/app/models/migration/participant_declaration.rb
+++ b/app/models/migration/participant_declaration.rb
@@ -19,6 +19,8 @@ module Migration
 
     def refundable? = REFUNDABLE_STATES.include?(state)
 
+    def started? = declaration_type == "started"
+
     def submitted? = state == "submitted"
 
     # status
@@ -31,12 +33,17 @@ module Migration
 
     def payment_statement = billable_line_item&.statement
 
-    # type predicates
+    # others
     def ect? = type == "ParticipantDeclaration::ECT"
+
+    def migrated_pupil_premium_uplift = migrated_uplift_flag(pupil_premium_uplift)
+    def migrated_sparsity_uplift = migrated_uplift_flag(sparsity_uplift)
 
   private
 
     def billable_line_item = @billable_line_item ||= statement_line_items.detect(&:billable?)
+
+    def migrated_uplift_flag(flag) = flag && started? && cohort.start_year < 2025
 
     def refundable_line_item = @refundable_line_item ||= statement_line_items.detect(&:refundable?)
   end

--- a/spec/models/migration/participant_declaration_spec.rb
+++ b/spec/models/migration/participant_declaration_spec.rb
@@ -153,4 +153,72 @@ describe Migration::ParticipantDeclaration, type: :model do
       end
     end
   end
+
+  describe "#migrated_pupil_premium_uplift" do
+    subject { participant_declaration.migrated_pupil_premium_uplift }
+
+    let(:start_year) { 2022 }
+    let(:cohort) { FactoryBot.create(:migration_cohort, start_year:) }
+    let(:participant_declaration) { FactoryBot.build(:migration_participant_declaration, declaration_type:, cohort:) }
+
+    %w[started].each do |checked_declaration_type|
+      context "when the declaration is '#{checked_declaration_type}'" do
+        let(:declaration_type) { checked_declaration_type }
+
+        context "when the cohort is earlier than 2025/2026" do
+          let(:start_year) { 2024 }
+
+          it { is_expected.to eq(participant_declaration.pupil_premium_uplift) }
+        end
+
+        context "when the cohort is not earlier than 2025/2026" do
+          let(:start_year) { 2025 }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    %w[retained-1 retained-2 retained-3 retained-4 completed extended-1 extended-2 extended-3].each do |checked_declaration_type|
+      context "when the declaration is '#{checked_declaration_type}'" do
+        let(:declaration_type) { checked_declaration_type }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+
+  describe "#migrated_sparsity_uplift" do
+    subject { participant_declaration.migrated_sparsity_uplift }
+
+    let(:start_year) { 2022 }
+    let(:cohort) { FactoryBot.create(:migration_cohort, start_year:) }
+    let(:participant_declaration) { FactoryBot.build(:migration_participant_declaration, declaration_type:, cohort:) }
+
+    %w[started].each do |checked_declaration_type|
+      context "when the declaration is '#{checked_declaration_type}'" do
+        let(:declaration_type) { checked_declaration_type }
+
+        context "when the cohort is earlier than 2025/2026" do
+          let(:start_year) { 2024 }
+
+          it { is_expected.to eq(participant_declaration.sparsity_uplift) }
+        end
+
+        context "when the cohort is not earlier than 2025/2026" do
+          let(:start_year) { 2025 }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    %w[retained-1 retained-2 retained-3 retained-4 completed extended-1 extended-2 extended-3].each do |checked_declaration_type|
+      context "when the declaration is '#{checked_declaration_type}'" do
+        let(:declaration_type) { checked_declaration_type }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

To migrate `pupil_premium_uplift` and `sparsity_uplift` fields from a ECF1 participant_declaration we need to set them to false in case either:
- the cohort of the declaration is >= 2025/2026, or
- the declaration is not `started` 

### Changes proposed in this pull request

Logic applied to `Migrators::Declaration`

### Guidance to review
