### PR TITLE
Add wizard session data to Sentry context

### DIFF
--- a/app/controllers/concerns/schools/wizardable.rb
+++ b/app/controllers/concerns/schools/wizardable.rb
@@ -28,6 +28,10 @@ module Schools
                     unless: -> { wizard_class.step?(@previous_step) },
                     only: :new
 
+      before_action :set_sentry_context,
+                    if: -> { Rails.application.config.enable_sentry },
+                    unless: -> { Rails.env.production? }
+
     private
 
       def set_steps
@@ -56,6 +60,12 @@ module Schools
           store: @store,
           wizard_record_name => instance_variable_get("@#{wizard_record_name}")
         )
+      end
+
+      def set_sentry_context
+        Sentry.configure_scope do |scope|
+          scope.set_context("wizard_session_#{FORM_KEY}", store.data)
+        end
       end
 
       def wizard_class

--- a/app/controllers/schools/register_ect_wizard_controller.rb
+++ b/app/controllers/schools/register_ect_wizard_controller.rb
@@ -6,6 +6,9 @@ module Schools
     before_action :initialize_wizard, only: %i[new create]
     before_action :reset_wizard, only: :new
     before_action :check_allowed_step, except: %i[start]
+    before_action :set_sentry_context,
+                  if: -> { Rails.application.config.enable_sentry },
+                  unless: -> { Rails.env.production? }
 
     FORM_KEY = :register_ect_wizard
     WIZARD_CLASS = Schools::RegisterECTWizard::Wizard.freeze
@@ -26,6 +29,12 @@ module Schools
     end
 
   private
+
+    def set_sentry_context
+      Sentry.configure_scope do |scope|
+        scope.set_context("wizard_session_#{FORM_KEY}", store.data)
+      end
+    end
 
     def initialize_wizard
       @wizard = WIZARD_CLASS.new(

--- a/lib/session_repository.rb
+++ b/lib/session_repository.rb
@@ -22,6 +22,8 @@ class SessionRepository
   end
   alias_method :update!, :update
 
+  def data = store.dup
+
 private
 
   def method_missing(name, *args)


### PR DESCRIPTION
Recently there have been some [bugs reported] that have so far proved difficult to reproduce.

This provides Sentry with session store data as extra context, which should help us find out more about these errors in non-Production environments if/when they happen.

This is disabled in Production to avoid any PII exposure.

For now this has only been added to the "Register ECT" and "Change" wizards, since this is where we have seen errors.

[bugs reported]: https://github.com/DFE-Digital/register-ects-project-board/issues/3370