### PR TITLE
Transform ECF1 evidence_held values into ECF2 evidence_types

### DIFF
--- a/app/migration/migrators/declaration.rb
+++ b/app/migration/migrators/declaration.rb
@@ -43,7 +43,7 @@ module Migrators
                                     clawback_status: participant_declaration.clawback_status,
                                     declaration_date: participant_declaration.declaration_date,
                                     declaration_type: participant_declaration.declaration_type,
-                                    evidence_type: participant_declaration.evidence_held,
+                                    evidence_type: participant_declaration.migrated_evidence_held,
                                     payment_statement_id: payment_statement(participant_declaration:)&.id,
                                     payment_status: participant_declaration.payment_status,
                                     pupil_premium_uplift: participant_declaration.migrated_pupil_premium_uplift,

--- a/app/models/migration/participant_declaration.rb
+++ b/app/models/migration/participant_declaration.rb
@@ -2,6 +2,19 @@ module Migration
   class ParticipantDeclaration < Migration::Base
     BILLABLE_STATES = %w[eligible payable paid].freeze
     REFUNDABLE_STATES = %w[awaiting_clawback clawed_back].freeze
+    MIGRATED_EVIDENCE_HELD = {
+      "75-percent-engagement-met" => "75-percent-engagement-met",
+      "75-percent-engagement-met-reduced-induction" => "75-percent-engagement-met-reduced-induction",
+      "materials-engaged-with-offline" => "materials-engaged-with-offline",
+      "one-term-induction" => "one-term-induction",
+      "other" => "other",
+      "self-study-material completed" => "self-study-material-completed",
+      "self-study-material-completed" => "self-study-material-completed",
+      "training_event_attendance" => "training-event-attended",
+      "training-event-attended" => "training-event-attended",
+      "" => nil
+    }.tap { |mapping| mapping.default_proc = ->(_h, k) { k } }
+     .freeze
 
     self.inheritance_column = :ignore
 
@@ -36,6 +49,7 @@ module Migration
     # others
     def ect? = type == "ParticipantDeclaration::ECT"
 
+    def migrated_evidence_held = MIGRATED_EVIDENCE_HELD[evidence_held]
     def migrated_pupil_premium_uplift = migrated_uplift_flag(pupil_premium_uplift)
     def migrated_sparsity_uplift = migrated_uplift_flag(sparsity_uplift)
 

--- a/spec/models/migration/participant_declaration_spec.rb
+++ b/spec/models/migration/participant_declaration_spec.rb
@@ -154,6 +154,37 @@ describe Migration::ParticipantDeclaration, type: :model do
     end
   end
 
+  describe "#migrated_evidende_held" do
+    subject { participant_declaration.migrated_evidence_held }
+
+    let(:participant_declaration) { FactoryBot.build(:migration_participant_declaration, evidence_held:) }
+
+    {
+      "75-percent-engagement-met" => "75-percent-engagement-met",
+      "75-percent-engagement-met-reduced-induction" => "75-percent-engagement-met-reduced-induction",
+      "materials-engaged-with-offline" => "materials-engaged-with-offline",
+      "one-term-induction" => "one-term-induction",
+      "other" => "other",
+      "self-study-material completed" => "self-study-material-completed",
+      "self-study-material-completed" => "self-study-material-completed",
+      "training_event_attendance" => "training-event-attended",
+      "training-event-attended" => "training-event-attended",
+      "" => nil
+    }.each do |ecf_value, rect_value|
+      context "when the value is '#{ecf_value}'" do
+        let(:evidence_held) { ecf_value }
+
+        it { is_expected.to eq(rect_value) }
+      end
+
+      context "any other value" do
+        let(:evidence_held) { "other_value" }
+
+        it { is_expected.to eq(evidence_held) }
+      end
+    end
+  end
+
   describe "#migrated_pupil_premium_uplift" do
     subject { participant_declaration.migrated_pupil_premium_uplift }
 


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/3388)

We need to map `Declaration#evidence_held` values from ECF1 into `Declaration#evidence_type` on ECF2 according to the mapping in the ticket.

### Changes proposed in this pull request

### Guidance to review
