### PR TITLE
Add migration strategy choosing logic

### DIFF
--- a/app/migration/teacher_history_converter/migration_strategy.rb
+++ b/app/migration/teacher_history_converter/migration_strategy.rb
@@ -5,8 +5,21 @@ class TeacherHistoryConverter::MigrationStrategy
     @ecf1_teacher_history = ecf1_teacher_history
   end
 
-  # :earliest_induction_records or :latest_induction_records
   def strategy
-    :latest_induction_records
+    if mentor_induction_records_count <= 1 && ect_induction_records_count <= 1
+      :all_induction_records
+    else
+      :latest_induction_records
+    end
+  end
+
+private
+
+  def ect_induction_records_count
+    ecf1_teacher_history.ect&.induction_records&.count || 0
+  end
+
+  def mentor_induction_records_count
+    ecf1_teacher_history.mentor&.induction_records&.count || 0
   end
 end

--- a/spec/migration/teacher_history_converter/migration_strategy_spec.rb
+++ b/spec/migration/teacher_history_converter/migration_strategy_spec.rb
@@ -1,15 +1,29 @@
 describe TeacherHistoryConverter::MigrationStrategy do
   subject { TeacherHistoryConverter::MigrationStrategy.new(ecf1_teacher_history) }
 
-  let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history) }
+  let(:mentor) { FactoryBot.build(:ecf1_teacher_history_mentor, induction_records: mentor_induction_records) }
+  let(:ect) { FactoryBot.build(:ecf1_teacher_history_ect, induction_records: ect_induction_records) }
 
-  it "defaults to economy" do
-    expect(subject.strategy).to be(:latest_induction_records)
-  end
+  let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, number_of_ect_induction_records) }
+  let(:mentor_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, number_of_mentor_induction_records) }
 
-  describe "Premium" do
-    context "when condition X is met" do
-      it "returns :all_induction_records"
+  let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, ect:, mentor:) }
+
+  [
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 0, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 1, number_of_mentor_induction_records: 0, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 1, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 2, expected_outcome: :latest_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 2, number_of_mentor_induction_records: 0, expected_outcome: :latest_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 2, number_of_mentor_induction_records: 2, expected_outcome: :latest_induction_records),
+  ].each do |test_case|
+    context "when there are #{test_case.number_of_mentor_induction_records} mentor induction records and #{test_case.number_of_ect_induction_records} ECT induction records" do
+      let(:number_of_ect_induction_records) { test_case.number_of_ect_induction_records }
+      let(:number_of_mentor_induction_records) { test_case.number_of_mentor_induction_records }
+
+      it "returns #{test_case.expected_outcome}" do
+        expect(subject.strategy).to be(test_case.expected_outcome)
+      end
     end
   end
 end

--- a/spec/migration/teacher_history_converter_spec.rb
+++ b/spec/migration/teacher_history_converter_spec.rb
@@ -27,14 +27,14 @@ describe TeacherHistoryConverter do
   describe "Strategy selection" do
     subject { TeacherHistoryConverter.new(ecf1_teacher_history:).migration_mode }
 
-    context "when the ECF1TeacherHistory meets premium conditions", pending: "Add strategy selection logic" do
-      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, :premium) }
+    context "when the ECF1TeacherHistory meets premium conditions" do
+      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history) }
 
       it { is_expected.to be(:all_induction_records) }
     end
 
     context "when the ECF1TeacherHistory doesn't meet premium conditions" do
-      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history) }
+      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, :ect_with_two_induction_record) }
 
       it { is_expected.to be(:latest_induction_records) }
     end


### PR DESCRIPTION
### Context

Until now this has been hardcoded to 'economy' mode.

Now, it will be economy if the teacher has more than one ECT induction record or more than one mentor induction record.

All the rest will be premium.

This is calculated at the **teacher level**. We might separate it so it's done twice; once per a teacher's mentor history and once per their ECT history.
