### PR TITLE
Remove redundant links from school overview page

### DIFF
--- a/app/components/admin/schools/overview_component.html.erb
+++ b/app/components/admin/schools/overview_component.html.erb
@@ -17,13 +17,11 @@
   sl.with_row do |row|
     row.with_key(text: "Induction tutor")
     row.with_value(text: induction_tutor_name)
-    row.with_action(text: "Change", href: "#", visually_hidden_text: "induction tutor name")
   end
 
   sl.with_row do |row|
     row.with_key(text: "Induction tutor email")
     row.with_value(text: induction_tutor_email)
-    row.with_action(text: "Change", href: "#", visually_hidden_text: "induction tutor email")
   end
 
   sl.with_row do |row|

--- a/spec/components/admin/schools/overview_component_spec.rb
+++ b/spec/components/admin/schools/overview_component_spec.rb
@@ -199,13 +199,5 @@ RSpec.describe Admin::Schools::OverviewComponent, type: :component do
       expect(rendered_content).to have_css("dt", text: "Administratrive district")
       expect(rendered_content).to have_css("dd", text: "South Northamptonshire")
     end
-
-    it "includes change links for editable fields" do
-      render_inline(component)
-
-      expect(rendered_content).to have_css("a", text: "Change")
-      expect(rendered_content).to have_css(".govuk-visually-hidden", text: "induction tutor name")
-      expect(rendered_content).to have_css(".govuk-visually-hidden", text: "induction tutor email")
-    end
   end
 end

--- a/spec/views/admin/schools/overviews/show.html.erb_spec.rb
+++ b/spec/views/admin/schools/overviews/show.html.erb_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe "admin/schools/overviews/show.html.erb", type: :view do
     expect(rendered).to have_css("dt", text: "Induction tutor email")
     expect(rendered).to have_css("dt", text: "Local authority")
     expect(rendered).to have_css("dt", text: "Address")
-    expect(rendered).to have_css("a", text: "Change")
   end
 
   it "marks overview as current in navigation" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3132

### Changes proposed in this pull request

These are links to nowhere, and the intended functionality can be actioned by impersonating a School, so we can remove the links!

### Guidance to review
