### PR TITLE
Add counts for teachers with their `migration_mode`

### DIFF
--- a/app/controllers/migration/migrations_controller.rb
+++ b/app/controllers/migration/migrations_controller.rb
@@ -14,6 +14,11 @@ class Migration::MigrationsController < ::AdminController
       "SUM(ecf1_mentorships_count) AS total_ecf1_mentorships,
        SUM(ecf2_mentorships_count) AS total_ecf2_mentorships"
     ).take
+
+    @teachers_via_latest_induction_records = Teacher.where(migration_mode: "latest_induction_records").count
+    @teachers_via_all_induction_records = Teacher.where(migration_mode: "all_induction_records").count
+    @not_migrated_teachers = Teacher.where(migration_mode: "not_migrated").count
+    @all_teachers = Teacher.count
   end
 
   def create

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -116,4 +116,8 @@ module MigrationHelper
     combined[:caches_loaded] = combined[:caches_loaded].to_a.sort
     combined
   end
+
+  def number_and_percentage(number, total)
+    "#{number_with_delimiter(number)} (#{((number / total.to_f) * 100).round(2)}%)"
+  end
 end

--- a/app/views/migration/migrations/_completed_migration.html.erb
+++ b/app/views/migration/migrations/_completed_migration.html.erb
@@ -30,6 +30,29 @@
   end
 end %>
 
+<h2 class="govuk-heading-m">Migration strategy (by teacher)</h2>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Economy")
+      row.with_value(text: number_and_percentage(@teachers_via_latest_induction_records, @all_teachers))
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Premium")
+      row.with_value(text: number_and_percentage(@teachers_via_all_induction_records, @all_teachers))
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Not migrated")
+      row.with_value(text: number_and_percentage(@not_migrated_teachers, @all_teachers))
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Total")
+      row.with_value(text: tag.strong(number_with_delimiter(@all_teachers)))
+    end
+  end
+%>
+
 <%= render Migration::CombinationsSummaryComponent.new(@combinations) %>
 <%= render Migration::MentorshipSummaryComponent.new(@mentorships) %>
 


### PR DESCRIPTION
This shows the total and percentage for economy, premium and not migrated (existing in RIAB already) teachers

<img width="1014" height="371" alt="image" src="https://github.com/user-attachments/assets/93780dd9-0f36-40d1-9c3d-114a7f38d054" />