### PR TITLE
Remove redundant method

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -238,16 +238,4 @@ private
       errors.add(:declaration_type, "Only 'started' or 'completed' declaration types are allowed for mentor funding enabled contract periods.")
     end
   end
-
-  def uplifts_absent_for_mentor
-    return unless for_mentor?
-
-    if sparsity_uplift.present?
-      errors.add(:sparsity_uplift, "must be absent for mentor declarations.")
-    end
-
-    if pupil_premium_uplift.present?
-      errors.add(:pupil_premium_uplift, "must be absent for mentor declarations.")
-    end
-  end
 end


### PR DESCRIPTION
This stopped being used in 1062378a4c159dbba81453fc89853a005d1d3e54, but it looks like we forgot to clear it up.

This removes the method.