### PR TITLE
Expose `vat_amount` from payment calculators

### DIFF
--- a/app/services/payment_calculator/banded.rb
+++ b/app/services/payment_calculator/banded.rb
@@ -40,6 +40,8 @@ module PaymentCalculator
       end
     end
 
+    def vat_amount = subtotal * vat_rate
+
   private
 
     def subtotal
@@ -48,10 +50,6 @@ module PaymentCalculator
         monthly_service_fee +
         setup_fee +
         total_manual_adjustments_amount
-    end
-
-    def vat_amount
-      subtotal * vat_rate
     end
 
     def declarations

--- a/app/services/payment_calculator/flat_rate.rb
+++ b/app/services/payment_calculator/flat_rate.rb
@@ -16,13 +16,14 @@ module PaymentCalculator
       end
     end
 
+    def vat_amount = outputs.total_net_amount * vat_rate
+
     def outputs
       @outputs ||= Outputs.new(declarations: filtered_declarations, fee_per_declaration:, fee_proportions:)
     end
 
   private
 
-    def vat_amount = outputs.total_net_amount * vat_rate
     def fee_per_declaration = flat_rate_fee_structure.fee_per_declaration
     def vat_rate = flat_rate_fee_structure.contract.vat_rate
 

--- a/spec/services/payment_calculator/banded_spec.rb
+++ b/spec/services/payment_calculator/banded_spec.rb
@@ -201,4 +201,22 @@ RSpec.describe PaymentCalculator::Banded do
       end
     end
   end
+
+  describe "#vat_amount" do
+    subject { banded.vat_amount }
+
+    let(:outputs_double) { double(total_net_amount: 200) }
+    let(:uplifts_double) { double(total_net_amount: 50) }
+
+    before do
+      allow(PaymentCalculator::Banded::Outputs)
+        .to receive(:new)
+        .and_return(outputs_double)
+      allow(PaymentCalculator::Banded::Uplifts)
+        .to receive(:new)
+        .and_return(uplifts_double)
+    end
+
+    it { is_expected.to eq(350) }
+  end
 end

--- a/spec/services/payment_calculator/flat_rate_spec.rb
+++ b/spec/services/payment_calculator/flat_rate_spec.rb
@@ -90,6 +90,18 @@ RSpec.describe PaymentCalculator::FlatRate do
     end
   end
 
+  describe "#vat_amount" do
+    subject { flat_rate.vat_amount }
+
+    before do
+      allow(PaymentCalculator::FlatRate::Outputs)
+        .to receive(:new)
+        .and_return(double(total_net_amount: 200))
+    end
+
+    it { is_expected.to eq(40) }
+  end
+
   describe "#outputs" do
     it "calls the `FlatRate::Outputs` service with filtered declarations" do
       expect(PaymentCalculator::FlatRate::Outputs)


### PR DESCRIPTION
We display this in the payment breakdown for financial statements, so we need to expose it as a public method.