### PR TITLE
[3128] Force titles that exceed the width of a govuk_panel to wrap

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -188,6 +188,10 @@ $_current-link-border-width: govuk-spacing(1);
   }
 }
 
+.govuk-panel__title {
+  word-wrap: break-word;
+}
+
 .app-mono {
   padding: 2px 5px;
   font-family: monospace;


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3128

### Changes proposed in this pull request

Email addresses can render wider than a GOV.UK panel, and don't have natural breaks since they're one long "word". The CSS rule here makes the content wrap so the observed bug no longer occurs:

<img width="661" height="748" alt="Screenshot 2026-02-24 at 15 09 41" src="https://github.com/user-attachments/assets/238e3e8e-665a-43b7-917b-95e3252f9178" />