### PR TITLE
[3347] Add 2025 ECTs with previous contract periods mentors to api seeds scenarios

### DIFF
--- a/app/services/api_seed_data/ect_scenarios.rb
+++ b/app/services/api_seed_data/ect_scenarios.rb
@@ -1,0 +1,79 @@
+require Rails.root.join("db/seeds/support/mentorship_period_helpers")
+
+module APISeedData
+  class ECTScenarios < Base
+    include MentorshipPeriodHelpers
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("api ect seed scenarios")
+
+      ect_2025_with_2024_mentor
+      ect_2025_with_2023_mentor
+    end
+
+    def ect_2025_with_2024_mentor
+      ect_2025_with_previous_mentor(2024)
+    end
+
+    def ect_2025_with_2023_mentor
+      ect_2025_with_previous_mentor(2023)
+    end
+
+  private
+
+    def ect_2025_with_previous_mentor(mentor_year)
+      contract_period_2025 = find_contract_period(2025)
+      contract_period_mentor = find_contract_period(mentor_year)
+      return unless contract_period_2025 && contract_period_mentor
+
+      ActiveLeadProvider.for_contract_period(contract_period_2025.year).each do |ect_active_lead_provider|
+        mentor_active_lead_provider = ActiveLeadProvider.for_contract_period(contract_period_mentor.year).for_lead_provider(ect_active_lead_provider.lead_provider_id).first
+        school = find_school_with_partnerships_in_both_periods(mentor_active_lead_provider, ect_active_lead_provider)
+        next unless school
+
+        mentee_school_partnership = find_school_partnership_for(school, ect_active_lead_provider)
+        mentor_school_partnership = find_school_partnership_for(school, mentor_active_lead_provider)
+        next unless mentee_school_partnership && mentor_school_partnership
+
+        mentorship_period = create_mentorship_period_for(
+          mentee_school_partnership:,
+          mentor_school_partnership:
+        )
+
+        log_seed_info("Created ECT (TRN: #{mentorship_period.mentee.teacher.trn}) from #{mentee_school_partnership.contract_period.year} with mentor from #{mentor_school_partnership.contract_period.year} with #{ect_active_lead_provider.lead_provider.name}", colour: Colourize::COLOURS.keys.sample)
+      end
+    end
+
+    def find_contract_period(year)
+      ContractPeriod.find_by(year:)
+    end
+
+    def find_school_with_partnerships_in_both_periods(mentor_active_lead_provider, ect_active_lead_provider)
+      mentor_schools = School
+        .joins(school_partnerships: { lead_provider_delivery_partnership: :active_lead_provider })
+        .where(school_partnerships: { lead_provider_delivery_partnerships: { active_lead_provider: mentor_active_lead_provider } })
+        .pluck(:id)
+
+      ect_schools = School
+        .joins(school_partnerships: { lead_provider_delivery_partnership: :active_lead_provider })
+        .where(school_partnerships: { lead_provider_delivery_partnerships: { active_lead_provider: ect_active_lead_provider } })
+        .pluck(:id)
+
+      School
+        .where(id: mentor_schools & ect_schools)
+        .order("RANDOM()")
+        .first
+    end
+
+    def find_school_partnership_for(school, active_lead_provider)
+      school
+      .school_partnerships
+      .includes(lead_provider_delivery_partnership: :active_lead_provider)
+      .where(lead_provider_delivery_partnerships: { active_lead_provider: })
+      .order("RANDOM()")
+      .first
+    end
+  end
+end

--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -21,7 +21,8 @@ namespace :api_seed_data do
     # These need to run last to avoid earlier seeds messing up the specific scenarios.
     seeds += [
       APISeedData::SchoolScenarios,
-      APISeedData::ParticipantScenarios
+      APISeedData::ParticipantScenarios,
+      APISeedData::ECTScenarios
     ]
 
     if Rails.env.development? || Rails.env.review? || Rails.env.staging?

--- a/spec/services/api_seed_data/ect_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_scenarios_spec.rb
@@ -1,0 +1,150 @@
+RSpec.describe APISeedData::ECTScenarios do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+
+  let(:contract_period_2023) { FactoryBot.create(:contract_period, year: 2023) }
+  let(:contract_period_2024) { FactoryBot.create(:contract_period, year: 2024) }
+  let(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025) }
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+
+    # Create support data
+    FactoryBot.create_list(:lead_provider, 2).each do |lead_provider|
+      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: contract_period_2023.year)
+      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: contract_period_2024.year)
+      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, :for_year, lead_provider:, year: contract_period_2025.year)
+    end
+    APISeedData::Schools.new.plant
+    APISeedData::SchoolPartnerships.new.plant
+    APISeedData::SchedulesAndMilestones.new.plant
+  end
+
+  describe "#plant" do
+    it "logs the creation of scenarios" do
+      instance.plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO).at_least(:once)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter).at_least(:once)
+      expect(logger).to have_received(:info).with(/Planting api ect seed scenarios/).once
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any teachers" do
+        expect { instance.plant }.not_to change(Teacher, :count)
+      end
+    end
+  end
+
+  describe "#ect_2025_with_2024_mentor" do
+    it "creates an ECT with a mentor" do
+      expect {
+        instance.ect_2025_with_2024_mentor
+      }.to change(Teacher, :count).by_at_least(2) # 1 mentor + 1 ECT per active lead provider
+    end
+
+    it "creates ECTs for contract period 2025" do
+      instance.ect_2025_with_2024_mentor
+
+      ects_count = Teacher
+        .joins(ect_at_school_periods: { training_periods: :active_lead_provider })
+        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .distinct
+        .count
+
+      expect(ects_count).to be >= 1
+    end
+
+    it "creates mentors for contract period 2024" do
+      instance.ect_2025_with_2024_mentor
+
+      mentors_count = Teacher
+        .joins(mentor_at_school_periods: { training_periods: :active_lead_provider })
+        .where(active_lead_providers: { contract_period_year: contract_period_2024.year })
+        .distinct
+        .count
+
+      expect(mentors_count).to be >= 1
+    end
+
+    it "makes sure the created mentors and mentees are both linked" do
+      instance.ect_2025_with_2024_mentor
+
+      mentorships = MentorshipPeriod
+        .joins(:mentor, :mentee)
+        .where(mentee: ECTAtSchoolPeriod.joins(training_periods: :active_lead_provider).where(active_lead_providers: { contract_period_year: contract_period_2025.year }))
+        .where(mentor: MentorAtSchoolPeriod.joins(training_periods: :active_lead_provider).where(active_lead_providers: { contract_period_year: contract_period_2024.year }))
+
+      expect(mentorships.count).to be >= 1
+
+      mentorships.each do |mentorship|
+        expect(mentorship.mentee.mentorship_periods.first.mentor).to eq(mentorship.mentor)
+        expect(mentorship.mentor.mentorship_periods.first.mentee).to eq(mentorship.mentee)
+      end
+    end
+
+    it "logs the creation of ECT scenarios" do
+      instance.ect_2025_with_2024_mentor
+
+      expect(logger).to have_received(:info).with(/Created ECT \(TRN: .*?\) from 2025 with mentor from 2024/).at_least(:once)
+    end
+  end
+
+  describe "#ect_2025_with_2023_mentor" do
+    it "creates an ECT with a mentor" do
+      expect {
+        instance.ect_2025_with_2023_mentor
+      }.to change(Teacher, :count).by_at_least(2) # 1 mentor + 1 ECT per active lead provider
+    end
+
+    it "creates ECTs for contract period 2025" do
+      instance.ect_2025_with_2023_mentor
+
+      ects_count = Teacher
+        .joins(ect_at_school_periods: { training_periods: :active_lead_provider })
+        .where(active_lead_providers: { contract_period_year: contract_period_2025.year })
+        .distinct
+        .count
+
+      expect(ects_count).to be >= 1
+    end
+
+    it "creates mentors for contract period 2023" do
+      instance.ect_2025_with_2023_mentor
+
+      mentors_count = Teacher
+        .joins(mentor_at_school_periods: { training_periods: :active_lead_provider })
+        .where(active_lead_providers: { contract_period_year: contract_period_2023.year })
+        .distinct
+        .count
+
+      expect(mentors_count).to be >= 1
+    end
+
+    it "makes sure the created mentors and mentees are both linked" do
+      instance.ect_2025_with_2023_mentor
+
+      mentorships = MentorshipPeriod
+        .joins(:mentor, :mentee)
+        .where(mentee: ECTAtSchoolPeriod.joins(training_periods: :active_lead_provider).where(active_lead_providers: { contract_period_year: contract_period_2025.year }))
+        .where(mentor: MentorAtSchoolPeriod.joins(training_periods: :active_lead_provider).where(active_lead_providers: { contract_period_year: contract_period_2023.year }))
+
+      expect(mentorships.count).to be >= 1
+
+      mentorships.each do |mentorship|
+        expect(mentorship.mentee.mentorship_periods.first.mentor).to eq(mentorship.mentor)
+        expect(mentorship.mentor.mentorship_periods.first.mentee).to eq(mentorship.mentee)
+      end
+    end
+
+    it "logs the creation of ECT scenarios" do
+      instance.ect_2025_with_2023_mentor
+
+      expect(logger).to have_received(:info).with(/Created ECT \(TRN: .*?\) from 2025 with mentor from 2023/).at_least(:once)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3347

LPs have requested some extra api seed data to be added.

### Changes proposed in this pull request

Scenarios to be added:

- 1 2025 ECT with a 2024 mentor
- 1 2025 ECT with a 2023 mentor

### Guidance to review

I'll run the script created for sandbox in the review app for testing. After reviewed, we can run the same in sandbox.

```
Rails.logger.silence do
  ActiveRecord::Base.transaction do
    DeclarativeUpdates.skip do
      APISeedData::ECTScenarios.new.plant
    end
  end
  Metadata::Manager.refresh_all_metadata!(async: true)
end
```