### PR TITLE
Fix HTML escaping of ampersands in page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
 
   def page_data(title:, header: :use_title, header_size: "l", error: false, backlink_href: nil, breadcrumbs: nil, caption: nil, caption_size: "m", header_classes: [], test_guidance: false)
     page_title = title_with_error_prefix(title, error:)
-    content_for(:page_title) { page_title }
+    content_for(:page_title, page_title.to_s.html_safe)
 
     backlink_or_breadcrumb = if breadcrumbs
                                govuk_breadcrumbs(breadcrumbs:)

--- a/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
+++ b/spec/views/admin/appropriate_bodies/show.html.erb_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "admin/appropriate_bodies/show.html.erb" do
-  let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
+  let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name:) }
+  let(:name) { "Ancient County Council" }
 
   before do
     assign(:appropriate_body, appropriate_body_period)
@@ -9,6 +10,14 @@ RSpec.describe "admin/appropriate_bodies/show.html.erb" do
   it "sets the main heading and page title to the appropriate body name" do
     expect(view.content_for(:page_title)).to start_with(appropriate_body_period.name)
     expect(view.content_for(:page_header)).to have_css("h1", text: appropriate_body_period.name)
+  end
+
+  context "when the appropriate body name contains ampersands" do
+    let(:name) { "Bright Futures Teaching School Hub (Salford & Trafford)" }
+
+    it "does not add the &amp; escape code in the title" do
+      expect(view.content_for(:page_title)).to eq name
+    end
   end
 
   it "displays the DfE Sign In organisation ID" do


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-early-career-teachers-public/issues/2264

Encoded characters are appearing in the page head. E.g.    
**expected:** `<title>Bright Futures Teaching School Hub (Salford & Trafford)..`
**actual:** "<title>Bright Futures Teaching School Hub (Salford &amp; Trafford)..`

### Changes proposed in this pull request

The changes fix an issue where content_for(:page_title) was unnecessarily escaping HTML entities (e.g. & becoming &amp;), and add a spec to cover the case of AppropriateBody names containing ampersands.

This change apply's to all titles, as this is a common `application_helper` method and a common `_head` partial.

### Guidance to review

* The records are stored in the DB as standard text, i.e. `Bright Futures Teaching School Hub (Salford & Trafford)` 
* Added rSpec example to cover this expectation.
* If you want to check in the review app admin -> appropriate bodies -> click on "Bright Futures Teaching School Hub (Salford & Trafford)"