### PR TITLE
Spike into uplifts fees

### DIFF
--- a/app/migration/migrators/pupil_premium.rb
+++ b/app/migration/migrators/pupil_premium.rb
@@ -1,0 +1,36 @@
+module Migrators
+  class PupilPremium < Migrators::Base
+    def self.record_count
+      pupil_premiums.size
+    end
+
+    def self.model
+      :pupil_premium
+    end
+
+    def self.pupil_premiums
+      Migration::PupilPremium.includes(:school).all
+    end
+
+    def self.dependencies
+      %i[school contract_period]
+    end
+
+    def self.reset!
+      if Rails.application.config.enable_migration_testing
+        ::Teacher.connection.execute("TRUNCATE #{::PupilPremium.table_name} RESTART IDENTITY CASCADE")
+      end
+    end
+
+    def migrate!
+      migrate(self.class.pupil_premiums) do |pupil_premium|
+        ::PupilPremium.find_or_create_by!(
+          school_urn: pupil_premium.school.urn,
+          contract_period_year: pupil_premium.start_year,
+          pupil_premium_uplift: pupil_premium.pupil_premium_incentive,
+          sparsity_uplift: pupil_premium.sparsity_incentive
+        )
+      end
+    end
+  end
+end

--- a/app/models/migration/pupil_premium.rb
+++ b/app/models/migration/pupil_premium.rb
@@ -1,0 +1,7 @@
+module Migration
+  class PupilPremium < Migration::Base
+    self.table_name = :pupil_premiums
+
+    belongs_to :school
+  end
+end

--- a/app/models/pupil_premium.rb
+++ b/app/models/pupil_premium.rb
@@ -1,0 +1,16 @@
+class PupilPremium < ApplicationRecord
+  self.table_name = "pupil_premiums"
+
+  belongs_to :school,
+             foreign_key: :school_urn,
+             primary_key: :urn
+
+  belongs_to :contract_period,
+             foreign_key: :contract_period_year,
+             primary_key: :year
+
+  validates :school, presence: true
+  validates :contract_period, presence: true
+  validates :pupil_premium_uplift, inclusion: { in: [true, false] }
+  validates :sparsity_uplift, inclusion: { in: [true, false] }
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -26,6 +26,10 @@ class School < ApplicationRecord
   has_many :lead_provider_contract_period_metadata, class_name: "Metadata::SchoolLeadProviderContractPeriod"
   has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod"
   has_many :training_periods, through: :school_partnerships
+  has_many :pupil_premiums,
+           foreign_key: :school_urn,
+           primary_key: :urn,
+           inverse_of: :school
 
   touch -> { self }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
   touch -> { school_partnerships }, when_changing: %i[urn induction_tutor_name induction_tutor_email], timestamp_attribute: :api_updated_at

--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -45,18 +45,22 @@ class API::TeacherSerializer < Blueprinter::Base
           teacher.mentor_first_became_eligible_for_training_at.present?
         end
       end
-      field(:pupil_premium_uplift) do |(training_period, teacher, metadata)|
+      field(:pupil_premium_uplift) do |(training_period, _, metadata)|
         if training_period.for_ect?
-          metadata.latest_ect_contract_period.uplift_fees_enabled? && teacher.pupil_premium_uplift
+          year = metadata.latest_ect_contract_period_year
+          metadata.latest_ect_contract_period.uplift_fees_enabled? && (training_period.school_partnership.school.pupil_premiums.find { |pp| pp.contract_period_year == year }&.pupil_premium_uplift || false)
         else
-          metadata.latest_mentor_contract_period.uplift_fees_enabled? && teacher.pupil_premium_uplift
+          year = metadata.latest_mentor_contract_period_year
+          metadata.latest_mentor_contract_period.uplift_fees_enabled? && (training_period.school_partnership.school.pupil_premiums.find { |pp| pp.contract_period_year == year }&.pupil_premium_uplift || false)
         end
       end
-      field(:sparsity_uplift) do |(training_period, teacher, metadata)|
+      field(:sparsity_uplift) do |(training_period, _, metadata)|
         if training_period.for_ect?
-          metadata.latest_ect_contract_period.uplift_fees_enabled? && teacher.sparsity_uplift
+          year = metadata.latest_ect_contract_period_year
+          metadata.latest_ect_contract_period.uplift_fees_enabled? && (training_period.school_partnership.school.pupil_premiums.find { |pp| pp.contract_period_year == year }&.sparsity_uplift || false)
         else
-          metadata.latest_mentor_contract_period.uplift_fees_enabled? && teacher.sparsity_uplift
+          year = metadata.latest_mentor_contract_period_year
+          metadata.latest_mentor_contract_period.uplift_fees_enabled? && (training_period.school_partnership.school.pupil_premiums.find { |pp| pp.contract_period_year == year }&.sparsity_uplift || false)
         end
       end
       field(:schedule_identifier) do |(training_period, _, _)|

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -53,7 +53,7 @@ module API::Teachers
           lead_provider_metadata: {
             latest_ect_training_period: {
               school_partnership: [
-                :school,
+                { school: :pupil_premiums },
                 { lead_provider_delivery_partnership: :delivery_partner }
               ],
               ect_at_school_period: [],
@@ -62,7 +62,7 @@ module API::Teachers
             latest_ect_contract_period: [],
             latest_mentor_training_period: {
               school_partnership: [
-                :school,
+                { school: :pupil_premiums },
                 { lead_provider_delivery_partnership: :delivery_partner }
               ],
               mentor_at_school_period: [],

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -79,12 +79,22 @@ module Declarations
 
     def update_uplifts!(declaration)
       return unless declaration.declaration_type_started?
-      return unless training_period.contract_period.uplift_fees_enabled?
+      return unless contract_period.uplift_fees_enabled?
+
+      pupil_premium = school.pupil_premiums.find_by(contract_period:)
 
       declaration.update!(
-        pupil_premium_uplift: teacher.pupil_premium_uplift,
-        sparsity_uplift: teacher.sparsity_uplift
+        pupil_premium_uplift: pupil_premium&.pupil_premium_uplift || false,
+        sparsity_uplift: pupil_premium&.sparsity_uplift || false
       )
+    end
+
+    def contract_period
+      @contract_period ||= training_period.contract_period
+    end
+
+    def school
+      @school ||= training_period.school
     end
 
     def set_eligibility!(declaration)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -502,3 +502,11 @@
   - ecf_mentor_contract_version
   - created_at
   - updated_at
+  :pupil_premiums:
+  - id
+  - school_urn
+  - contract_period_year
+  - pupil_premium_uplift
+  - sparsity_uplift
+  - created_at
+  - updated_at

--- a/db/migrate/20260224142242_add_pupil_premiums.rb
+++ b/db/migrate/20260224142242_add_pupil_premiums.rb
@@ -1,0 +1,24 @@
+class AddPupilPremiums < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pupil_premiums do |t|
+      t.bigint :school_urn, null: false
+      t.integer :contract_period_year, null: false
+
+      t.boolean :pupil_premium_uplift, null: false, default: false
+      t.boolean :sparsity_uplift, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :pupil_premiums, :schools,
+                    column: :school_urn,
+                    primary_key: :urn
+
+    add_foreign_key :pupil_premiums, :contract_periods,
+                    column: :contract_period_year,
+                    primary_key: :year
+
+    add_index :pupil_premiums, :school_urn
+    add_index :pupil_premiums, :contract_period_year
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_23_131036) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_24_142242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -735,6 +735,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_131036) do
     t.index ["trn"], name: "index_pending_induction_submissions_on_trn"
   end
 
+  create_table "pupil_premiums", force: :cascade do |t|
+    t.bigint "school_urn", null: false
+    t.integer "contract_period_year", null: false
+    t.boolean "pupil_premium_uplift", default: false, null: false
+    t.boolean "sparsity_uplift", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contract_period_year"], name: "index_pupil_premiums_on_contract_period_year"
+    t.index ["school_urn"], name: "index_pupil_premiums_on_school_urn"
+  end
+
   create_table "regions", force: :cascade do |t|
     t.string "code", null: false
     t.string "districts", null: false, array: true
@@ -1127,6 +1138,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_131036) do
   add_foreign_key "pending_induction_submission_batches", "appropriate_body_periods"
   add_foreign_key "pending_induction_submissions", "appropriate_body_periods"
   add_foreign_key "pending_induction_submissions", "pending_induction_submission_batches"
+  add_foreign_key "pupil_premiums", "contract_periods", column: "contract_period_year", primary_key: "year"
+  add_foreign_key "pupil_premiums", "schools", column: "school_urn", primary_key: "urn"
   add_foreign_key "regions", "appropriate_bodies"
   add_foreign_key "schedules", "contract_periods", column: "contract_period_year", primary_key: "year"
   add_foreign_key "school_partnerships", "schools"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -149,6 +149,17 @@ erDiagram
     integer appropriate_body_id
   }
   Region }o--|| AppropriateBody : belongs_to
+  PupilPremium {
+    integer id
+    integer school_urn
+    integer contract_period_year
+    boolean pupil_premium_uplift
+    boolean sparsity_uplift
+    datetime created_at
+    datetime updated_at
+  }
+  PupilPremium }o--|| School : belongs_to
+  PupilPremium }o--|| ContractPeriod : belongs_to
   PendingInductionSubmissionBatch {
     integer id
     integer appropriate_body_period_id

--- a/spec/factories/migration/pupil_premium_factory.rb
+++ b/spec/factories/migration/pupil_premium_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :migration_pupil_premium, class: "Migration::PupilPremium" do
+    association :school, factory: :ecf_migration_school
+    start_year { 2024 }
+    pupil_premium_incentive { true }
+    sparsity_incentive { true }
+  end
+end

--- a/spec/factories/pupil_premium_factory.rb
+++ b/spec/factories/pupil_premium_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory(:pupil_premium) do
+    association :school
+    association :contract_period
+
+    pupil_premium_uplift { true }
+    sparsity_uplift { true }
+  end
+end

--- a/spec/migration/migrators/pupil_premium_spec.rb
+++ b/spec/migration/migrators/pupil_premium_spec.rb
@@ -1,0 +1,43 @@
+describe Migrators::PupilPremium do
+  it_behaves_like "a migrator", :pupil_premium, %i[school contract_period] do
+    let(:pupil_premium) { FactoryBot.create(:migration_pupil_premium) }
+
+    def create_migration_resource
+      FactoryBot.create(:migration_pupil_premium, pupil_premium_incentive: [true, false].sample, sparsity_incentive: [true, false].sample)
+    end
+
+    def create_resource(migration_resource)
+      FactoryBot.create(:school, urn: migration_resource.school.urn, api_id: migration_resource.school.id)
+      FactoryBot.create(:contract_period, year: migration_resource.start_year)
+    end
+
+    def setup_failure_state
+      # Pupil premium where school does not exist
+      create_migration_resource
+    end
+
+    describe "#migrate!" do
+      it "creates the correct number of pupil premiums" do
+        expect { instance.migrate! }.to change(PupilPremium, :count).by(2)
+      end
+
+      it "does not create duplicate pupil premiums" do
+        instance.migrate!
+        expect { instance.migrate! }.not_to change(PupilPremium, :count)
+      end
+
+      it "sets the pupil premium attributes correctly" do
+        instance.migrate!
+
+        pupil_premium = PupilPremium.find_by(school_urn: migration_resource1.school.urn.to_i, contract_period_year: migration_resource1.start_year)
+
+        expect(pupil_premium).to have_attributes(
+          school_urn: migration_resource1.school.urn.to_i,
+          contract_period_year: migration_resource1.start_year,
+          pupil_premium_uplift: migration_resource1.pupil_premium_incentive,
+          sparsity_uplift: migration_resource1.sparsity_incentive
+        )
+      end
+    end
+  end
+end

--- a/spec/models/pupil_premium_spec.rb
+++ b/spec/models/pupil_premium_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe PupilPremium do
+  describe "associations" do
+    it { is_expected.to belong_to(:school).with_foreign_key(:school_urn).with_primary_key(:urn) }
+    it { is_expected.to belong_to(:contract_period).with_foreign_key(:contract_period_year).with_primary_key(:year) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:school) }
+    it { is_expected.to validate_presence_of(:contract_period) }
+    it { is_expected.to allow_values(true, false).for(:pupil_premium_uplift) }
+    it { is_expected.not_to allow_values(nil, "").for(:pupil_premium_uplift) }
+    it { is_expected.to allow_values(true, false).for(:sparsity_uplift) }
+    it { is_expected.not_to allow_values(nil, "").for(:sparsity_uplift) }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe School do
     it { is_expected.to have_many(:contract_period_metadata).class_name("Metadata::SchoolContractPeriod") }
     it { is_expected.to have_many(:lead_provider_contract_period_metadata).class_name("Metadata::SchoolLeadProviderContractPeriod") }
     it { is_expected.to have_many(:training_periods).through(:school_partnerships) }
+    it { is_expected.to have_many(:pupil_premiums).with_foreign_key(:school_urn).inverse_of(:school).with_primary_key(:urn) }
   end
 
   describe "delegation" do

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -112,6 +112,7 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
         end
         let(:school) { school_partnership.school }
+        let!(:pupil_premium) { FactoryBot.create(:pupil_premium, school:, contract_period: school_partnership.contract_period) }
 
         let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 2.months.ago, finished_on: nil) }
         let!(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, started_on: 1.month.ago, ect_at_school_period:, school_partnership:) }
@@ -186,6 +187,15 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           context "when `uplift_fees_enabled` is `false` for the contract period" do
             before { ect_training_period.school_partnership.contract_period.update!(uplift_fees_enabled: false) }
+
+            it "serializes `pupil_premium_uplift` and `sparsity_uplift` as false" do
+              expect(ect_enrolment["pupil_premium_uplift"]).to be(false)
+              expect(ect_enrolment["sparsity_uplift"]).to be(false)
+            end
+          end
+
+          context "when there are no pupil premiums for the school and contract period" do
+            let!(:pupil_premium) { nil }
 
             it "serializes `pupil_premium_uplift` and `sparsity_uplift` as false" do
               expect(ect_enrolment["pupil_premium_uplift"]).to be(false)
@@ -324,6 +334,15 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
           context "when `uplift_fees_enabled` is `false` for the contract period" do
             before { mentor_training_period.school_partnership.contract_period.update!(uplift_fees_enabled: false) }
+
+            it "serializes `pupil_premium_uplift` and `sparsity_uplift` as false" do
+              expect(mentor_enrolment["pupil_premium_uplift"]).to be(false)
+              expect(mentor_enrolment["sparsity_uplift"]).to be(false)
+            end
+          end
+
+          context "when there are no pupil premiums for the school and contract period" do
+            let!(:pupil_premium) { nil }
 
             it "serializes `pupil_premium_uplift` and `sparsity_uplift` as false" do
               expect(mentor_enrolment["pupil_premium_uplift"]).to be(false)

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
           expect(training_period.school_partnership.association(:school)).to be_loaded
           expect(training_period.school_partnership.association(:lead_provider_delivery_partnership)).to be_loaded
 
+          expect(training_period.school_partnership.school.association(:pupil_premiums)).to be_loaded
+
           expect(training_period.school_partnership.lead_provider_delivery_partnership.association(:delivery_partner)).to be_loaded
 
           if training_period.for_ect?

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -67,8 +67,11 @@ RSpec.describe Declarations::Create do
           expect(declaration).not_to be_payment_status_eligible
         end
 
-        context "when pupil premium and sparsity uplifts are set on the teacher" do
-          before { teacher.update!(pupil_premium_uplift: true, sparsity_uplift: true) }
+        context "when pupil premium and sparsity uplifts are set on the school" do
+          before do
+            school = at_school_period.school
+            FactoryBot.create(:pupil_premium, contract_period:, school:, pupil_premium_uplift: true, sparsity_uplift: true)
+          end
 
           it "sets pupil premium and sparsity uplifts on the declaration" do
             declaration = create_declaration


### PR DESCRIPTION
> [!WARNING]
>  Spike, not to be merged!

A spike into implementing uplifts in a more sensible way.

In ECF we stamp the participant profiles with uplifts when the participant is first registered at a school and it doesn't look like the uplift status of the participant ever changes even when they move school.

In RECT we currently stamp the `Teacher` with uplifts; originally we thought only ECTs had uplifts so we prefixed the fields with `ect_` and prevented them for mentors. We since learned any pre-2025 cohort participant can have uplifts, so we adjusted the validation to allow for this and removed the `ect_` prefix from the fields on `Teacher`. We're now in the state where we're using the ECT uplift status from ECF for both mentors and ECTs in RECT, and we have the same issue in ECF where the uplift state doesn't change as they change school.

This spike looks to fix that by bringing over the `pupil_premiums` table from ECF which links a school + contract period to a particular uplift state. We then read this state via the declaration -> training period -> school partnership -> school, so its accurate relative to the school the declaration is being submitted against. It also updates the serializer to return the participants uplift status relevant to their current training period/school for the LP.

Testing in parity check it seems to work fine and whilst the participants endpoint may be a little slower it doesn't seem awful; we could always cache it in the metadata to improve the performance if we want to.

If we take this forward we should think of a better table name than `pupil_premiums`.