### PR TITLE
Fix uniqueness validation for duplicate declarations

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -65,13 +65,7 @@ class Declaration < ApplicationRecord
   delegate :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
 
   # Validations
-  validates :training_period,
-            presence: { message: "Choose a training period" },
-            uniqueness: {
-              scope: %i[declaration_type payment_status],
-              conditions: -> { billable_or_changeable },
-              message: "A billable declaration with the same type already exists for this training period"
-            }
+  validates :training_period, presence: { message: "Choose a training period" }
   validates :voided_by_user, presence: { message: "Voided by user must be set as well as the voided date" }, if: :voided_by_user_at
   validates :voided_by_user_at, presence: { message: "Voided by user at must be set as well as the voided by user" }, if: :voided_by_user
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another declaration" }
@@ -84,7 +78,7 @@ class Declaration < ApplicationRecord
   validates :delivery_partner_when_created, presence: { message: "Delivery partner when the declaration was created must be specified" }
   validate :mentorship_period_belongs_to_teacher
   validate :contract_period_consistent_across_associations
-  validate :declaration_does_not_already_exist
+  validate :does_not_result_in_duplicate_billable_or_changeable_with_same_type
   validate :declaration_type_started_or_completed_for_mentor_funding_contract_period
   validate :uplifts_are_allowed, if: :uplifts_present?
 
@@ -174,27 +168,27 @@ class Declaration < ApplicationRecord
     training_period&.teacher
   end
 
-  def duplicate_declaration_exists?
-    return unless billable_or_changeable?
+  def milestone
+    training_period&.schedule&.milestones&.find_by(declaration_type:)
+  end
 
-    existing_declarations = if training_period.for_ect?
-                              teacher.ect_declarations
-                            else
-                              teacher.mentor_declarations
-                            end
+private
 
+  def existing_declarations
+    @existing_declarations ||= if training_period.for_ect?
+                                 teacher.ect_declarations
+                               else
+                                 teacher.mentor_declarations
+                               end
+  end
+
+  def billable_or_changeable_of_same_type_exists?
     existing_declarations
       .billable_or_changeable
       .where(declaration_type:)
       .excluding(self)
       .exists?
   end
-
-  def milestone
-    training_period&.schedule&.milestones&.find_by(declaration_type:)
-  end
-
-private
 
   def uplifts_are_allowed
     return unless uplifts_present?
@@ -224,10 +218,11 @@ private
     errors.add(:training_period, "Contract period mismatch: training period, payment_statement and clawback_statement must have the same contract period.")
   end
 
-  def declaration_does_not_already_exist
+  def does_not_result_in_duplicate_billable_or_changeable_with_same_type
     return unless training_period && declaration_type
+    return unless billable_or_changeable? && billable_or_changeable_of_same_type_exists?
 
-    errors.add(:base, "A matching declaration already exists.") if duplicate_declaration_exists?
+    errors.add(:base, "A billable/changeable declaration with the same type and training period already exists.")
   end
 
   def declaration_type_started_or_completed_for_mentor_funding_contract_period

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -79,5 +79,9 @@ FactoryBot.define do
       clawback_status { :clawed_back }
       clawback_statement { FactoryBot.create(:statement, :paid, active_lead_provider: training_period.active_lead_provider) }
     end
+
+    trait :billable_or_changeable do
+      Declaration::BILLABLE_OR_CHANGEABLE_PAYMENT_STATUSES.sample
+    end
   end
 end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -103,30 +103,6 @@ describe Declaration do
       end
     end
 
-    context "training period unique index" do
-      subject { FactoryBot.create(:declaration) }
-
-      it { is_expected.to validate_uniqueness_of(:training_period).scoped_to(:declaration_type, :payment_status).with_message("A billable declaration with the same type already exists for this training period") }
-
-      context "when the declaration payment status is voided" do
-        subject { FactoryBot.create(:declaration, :voided) }
-
-        it { is_expected.not_to validate_uniqueness_of(:training_period).scoped_to(:declaration_type, :payment_status) }
-      end
-
-      context "when the declaration clawback status is `awaiting_clawback`" do
-        subject { FactoryBot.create(:declaration, :awaiting_clawback) }
-
-        it { is_expected.not_to validate_uniqueness_of(:training_period).scoped_to(:declaration_type, :payment_status) }
-      end
-
-      context "when the declaration clawback status is `clawed_back`" do
-        subject { FactoryBot.create(:declaration, :clawed_back) }
-
-        it { is_expected.not_to validate_uniqueness_of(:training_period).scoped_to(:declaration_type, :payment_status) }
-      end
-    end
-
     context "when payment" do
       subject { FactoryBot.build(:declaration, :paid) }
 
@@ -293,23 +269,60 @@ describe Declaration do
     end
 
     describe "existing declarations" do
-      subject { FactoryBot.build(:declaration, :eligible, training_period:, declaration_type: :started) }
+      %i[voided awaiting_clawback clawed_back].each do |status|
+        it "allows a #{status} declaration when a billable/changeable of the same type already exists" do
+          training_period = FactoryBot.create(:training_period)
 
-      let(:training_period) { FactoryBot.create(:training_period, :for_ect) }
+          # Ensure there is a billable/changeable declaration already.
+          FactoryBot.create(
+            :declaration,
+            :billable_or_changeable,
+            training_period:,
+            declaration_type: :started
+          )
 
-      context "when the declaration duplicates an existing declaration" do
-        before { FactoryBot.create(:declaration, :payable, training_period:, declaration_type: :started) }
+          # Add a non-billable/changeable declaration.
+          FactoryBot.create(
+            :declaration,
+            status,
+            training_period:,
+            declaration_type: :started
+          )
 
-        it "is not valid" do
-          expect(subject).not_to be_valid
-          expect(subject.errors[:base]).to include("A matching declaration already exists.")
+          # Add a duplicate non-billable/changeable declaration.
+          expect {
+            FactoryBot.create(
+              :declaration,
+              status,
+              training_period:,
+              declaration_type: :started
+            )
+          }.not_to raise_error
         end
       end
 
-      context "when the declaration does not duplicate an existing declaration" do
-        before { FactoryBot.create(:declaration, :voided, training_period:, declaration_type: :completed) }
+      described_class::BILLABLE_OR_CHANGEABLE_PAYMENT_STATUSES.each do |status|
+        it "does not allow a #{status} declaration when a billable/changeable of the same type already exists" do
+          training_period = FactoryBot.create(:training_period)
 
-        it { is_expected.to be_valid }
+          # Ensure there is a billable/changeable declaration already.
+          FactoryBot.create(
+            :declaration,
+            :billable_or_changeable,
+            training_period:,
+            declaration_type: :started
+          )
+
+          # Add a duplicate, billable/changeable declaration.
+          expect {
+            FactoryBot.create(
+              :declaration,
+              status,
+              training_period:,
+              declaration_type: :started
+            )
+          }.to raise_error(ActiveRecord::RecordInvalid, /A billable\/changeable declaration with the same type and training period already exists./)
+        end
       end
     end
   end
@@ -626,61 +639,6 @@ describe Declaration do
       before { declaration.training_period = nil }
 
       it { is_expected.to be_nil }
-    end
-  end
-
-  describe "#duplicate_declaration_exists?" do
-    let(:training_period) { FactoryBot.create(:training_period, :for_ect) }
-
-    context "when the declaration is not billable/changeable" do
-      subject { FactoryBot.build(:declaration, :voided, training_period:, declaration_type: :started) }
-
-      it { is_expected.not_to be_duplicate_declaration_exists }
-
-      context "when an existing declaration of the same type and state exists" do
-        before { FactoryBot.create(:declaration, :voided, training_period:, declaration_type: :started) }
-
-        it { is_expected.not_to be_duplicate_declaration_exists }
-      end
-    end
-
-    context "when the declaration is billable/changeable" do
-      subject { FactoryBot.build(:declaration, :payable, training_period:, declaration_type: :started) }
-
-      it { is_expected.not_to be_duplicate_declaration_exists }
-
-      context "when an existing, billable/changeable declaration of the same type exists" do
-        before { FactoryBot.create(:declaration, :eligible, training_period:, declaration_type: :started) }
-
-        it { is_expected.to be_duplicate_declaration_exists }
-      end
-
-      context "when an existing, billable/changeable declaration of the same type exists for another teacher" do
-        before { FactoryBot.create(:declaration, :eligible, declaration_type: :started) }
-
-        it { is_expected.not_to be_duplicate_declaration_exists }
-      end
-
-      context "when an existing, billable/changeable declaration of the same type exists for the other teacher type" do
-        before { FactoryBot.create(:declaration, :eligible, training_period: other_type_training_period, declaration_type: :started) }
-
-        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: training_period.teacher, started_on: 1.month.ago, finished_on: nil) }
-        let(:other_type_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 1.month.ago) }
-
-        it { is_expected.not_to be_duplicate_declaration_exists }
-      end
-
-      context "when an existing declaration of a different type exists" do
-        before { FactoryBot.create(:declaration, :eligible, training_period:, declaration_type: :completed) }
-
-        it { is_expected.not_to be_duplicate_declaration_exists }
-      end
-
-      context "when an existing declaration of a non-billable/changeable type exists" do
-        before { FactoryBot.create(:declaration, :clawed_back, training_period:, declaration_type: :started) }
-
-        it { is_expected.not_to be_duplicate_declaration_exists }
-      end
     end
   end
 


### PR DESCRIPTION
The uniqueness `conditions` apply to existing declarations - not the declaration being created - so if there was an existing billable declaration and we went to create a non-billable declaration, the validation rule would fail as the uniqueness constraint is satisfied.

Remove uniqueness constraint as we already cover it `declaration_does_not_already_exist` validation rule.

Tidy up and rename `declaration_does_not_already_exist` validation rule.

Update specs to better cover the scenario, as shoulda matchers can't correctly test uniqueness constraints with conditions.