### PR TITLE
[3360] Alternate contract periods when creating new unfunded mentors in api seeds

### DIFF
--- a/app/services/api_seed_data/unfunded_mentors.rb
+++ b/app/services/api_seed_data/unfunded_mentors.rb
@@ -25,21 +25,6 @@ module APISeedData
       end
     end
 
-  protected
-
-    def plantable?
-      lead_providers = ActiveLeadProvider.all.map(&:lead_provider).uniq
-      existing_unfunded_mentors = lead_providers.any? do
-        API::Teachers::UnfundedMentors::Query.new(
-          lead_provider_id: it.id
-        )
-        .unfunded_mentors
-        .exists?
-      end
-
-      super && !existing_unfunded_mentors
-    end
-
   private
 
     # Interleaves partnerships from different contract years.

--- a/spec/services/api_seed_data/unfunded_mentors_spec.rb
+++ b/spec/services/api_seed_data/unfunded_mentors_spec.rb
@@ -44,11 +44,6 @@ RSpec.describe APISeedData::UnfundedMentors, :with_metadata do
       end
     end
 
-    it "does not create data when already present" do
-      expect { instance.plant }.to change(Teacher, :count)
-      expect { instance.plant }.not_to change(Teacher, :count)
-    end
-
     it "logs the creation of unfunded mentors" do
       plant
 


### PR DESCRIPTION
### Context

Ticket: [3360](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3360
)

When creating unfunded mentors in api seeds we're not specifying the contract period, so the sequence of school partnerships is followed but we might not create unfunded mentors for all contract periods.

### Changes proposed in this pull request

Alternate contract periods in the sequence of school partnerships (ie: school partnership 2024, 2025, 2024, 2025..) so we make sure we create new unfunded mentors in api seeds for all contract periods.

### Guidance to review

I'll run the script created for sandbox in the review app for testing. After reviewed, we can run the same in sandbox.

```
Rails.logger.silence do
  ActiveRecord::Base.transaction do
    DeclarativeUpdates.skip do
      APISeedData::UnfundedMentors.new.plant
    end
  end
  Metadata::Manager.refresh_all_metadata!(async: true)
end
```