### PR TITLE
Redefine Migration::ParticipantDeclaration.payment_status

### DIFF
--- a/app/models/migration/participant_declaration.rb
+++ b/app/models/migration/participant_declaration.rb
@@ -36,13 +36,17 @@ module Migration
 
     def submitted? = state == "submitted"
 
+    def voided? = state == "voided"
+
     # status
     def clawback_status = refundable_line_item&.state || "no_clawback"
 
     def payment_status
       return billable_line_item.state if billable_line_item
+      return "voided" if voided?
+      return "no_payment" if submitted?
 
-      submitted? ? "no_payment" : state
+      raise "ECF1 declaration state doesn't match its statement line items states"
     end
 
     # statements

--- a/spec/models/migration/participant_declaration_spec.rb
+++ b/spec/models/migration/participant_declaration_spec.rb
@@ -148,12 +148,22 @@ describe Migration::ParticipantDeclaration, type: :model do
         FactoryBot.create(:migration_statement_line_item, participant_declaration:, state: "voided")
       end
 
-      before { participant_declaration.state = 'submitted' }
+      before { participant_declaration.state = "submitted" }
 
       it { is_expected.to eq("no_payment") }
     end
 
-    %w[ineligible voided awaiting_clawback clawed_back].each do |checking_state|
+    context "when there is no billable statement line item but the declaration state is 'voided'" do
+      let!(:statement_line_item) do
+        FactoryBot.create(:migration_statement_line_item, participant_declaration:, state: "ineligible")
+      end
+
+      before { participant_declaration.state = "voided" }
+
+      it { is_expected.to eq("voided") }
+    end
+
+    %w[ineligible awaiting_clawback clawed_back].each do |checking_state|
       context "when there is a no billable statement line item but the declaration state is #{checking_state}" do
         let!(:statement_line_item) do
           FactoryBot.create(:migration_statement_line_item, participant_declaration:, state: "voided")
@@ -161,7 +171,9 @@ describe Migration::ParticipantDeclaration, type: :model do
 
         before { participant_declaration.state = checking_state }
 
-        it { is_expected.to eq(participant_declaration.state) }
+        it "raises an error" do
+          expect { subject }.to raise_error("ECF1 declaration state doesn't match its statement line items states")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

On ECF2 declarations `state` field has been replaced with 2 new fields `payment_status` and `clawback_status`.
This PR aims to redefine the mapping between ECF1 `state` and ECF2 `payment_status` for a migrated declaration.
