### PR TITLE
Add ECF data source to Blazer

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -26,6 +26,10 @@ data_sources:
       induction_period_id: "/admin/teachers/N/induction-periods/{value}/edit"
       zendesk_ticket_id: "https://becomingateacher.zendesk.com/agent/tickets/{value}"
 
+  # http://localhost:3000/admin/blazer/queries/docs?data_source=ecf
+  ecf:
+    url: <%= ENV.fetch("ECF_DATABASE_URL", "postgres://localhost:5432") %>
+
 
 # statement timeout, in seconds
 # none by default


### PR DESCRIPTION
### Context

We need to be able to run Blazer queries against the ECF database in addition to the existing `main` data source.

### Changes proposed in this pull request

- Add an `ecf` Blazer data source in `config/blazer.yml`
- Configure it to use `ECF_DATABASE_URL`
- Keep the existing `main` Blazer data source unchanged

### Guidance to review

- Confirm `config/blazer.yml` now exposes `data_sources.ecf`
- Confirm the environment running Blazer has `ECF_DATABASE_URL` set
- In Blazer UI, verify `ecf` appears as a selectable data source
