### PR TITLE
Add `awaiting_clawback` to ERO mentor checker

### DIFF
--- a/app/migration/ero_mentor_checker.rb
+++ b/app/migration/ero_mentor_checker.rb
@@ -10,7 +10,7 @@ class EROMentorChecker
   end
 
   def relevant_declarations
-    @relevant_declarations ||= participant_profile.participant_declarations.where(state: %w[paid clawed_back])
+    @relevant_declarations ||= participant_profile.participant_declarations.where(state: %w[paid awaiting_clawback clawed_back])
   end
 
   def ero_mentor_with_declarations?

--- a/spec/migration/ero_mentor_checker_spec.rb
+++ b/spec/migration/ero_mentor_checker_spec.rb
@@ -48,10 +48,18 @@ RSpec.describe EROMentorChecker do
       end
     end
 
-    context "when they had a declaration that wasn't paid or clawed_back" do
+    context "when they had an awaiting_clawback declaration" do
+      let!(:declaration) { FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state: :awaiting_clawback) }
+
+      it "returns the declaration" do
+        expect(checker.relevant_declarations).to eq [declaration]
+      end
+    end
+
+    context "when they had a declaration that wasn't paid, awaiting_clawback or clawed_back" do
       let!(:declaration) { FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state: :clawed_back) }
 
-      %i[submitted eligible payable voided ineligible awaiting_clawback].each do |state|
+      %i[submitted eligible payable voided ineligible].each do |state|
         it "does not return those declarations" do
           FactoryBot.create(:migration_participant_declaration, participant_profile: profile, state:)
           expect(checker.relevant_declarations).to eq [declaration]


### PR DESCRIPTION
### Context

In the original ERO checker, we only included `paid` and `clawed_back` states in relevant declarations query.  However if a declaration is `awaiting_clawback` it should also be included because it will have appeared on statements.

### Changes proposed in this pull request

Adds `awaiting_clawback` states matched in the relevant declarations query
