### PR TITLE
Give the migration workers more ram

### DIFF
--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -6,6 +6,6 @@
     "worker_memory_max": "6Gi",
     "webapp_memory_max": "2Gi",
     "worker_replicas": 10,
-    "webapp_replicas": 6,
+    "webapp_replicas": 1,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }


### PR DESCRIPTION
We're hitting the limit when running migrations, as we're going live in <2 months this won't be a long standing setup.

Just testing it out for now, manually deployed to the `migration` env.
