### PR TITLE
Add retry logic for terraform apply in deploy action

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -56,7 +56,26 @@ runs:
       id: apply-terraform
       shell: bash
       run: |
-        make ci ${{ inputs.environment }} terraform-apply
+        max_attempts=3
+        attempt=1
+        while [ "$attempt" -le "$max_attempts" ]; do
+          echo "Running terraform apply (attempt ${attempt}/${max_attempts})"
+          if make ci ${{ inputs.environment }} terraform-apply; then
+            break
+          fi
+
+          exit_code=$?
+          if [ "$attempt" -eq "$max_attempts" ]; then
+            echo "Terraform apply failed after ${max_attempts} attempts"
+            exit "$exit_code"
+          fi
+
+          sleep_seconds=$((attempt * 30))
+          echo "Terraform apply failed with exit code ${exit_code}. Retrying in ${sleep_seconds}s..."
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done
+
         cd config/terraform/application && echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
       env:
         TF_VAR_statuscake_api_token: ${{ inputs.statuscake-api-token }}


### PR DESCRIPTION
### Context
Deployments are intermittently failing during Terraform apply with Azure API `context deadline exceeded` errors when reading existing PostgreSQL snapshot resources. These failures are transient and unrelated to application code changes, but currently fail the whole deployment on first occurrence.

### Changes proposed in this pull request
- Add retry logic around `make ci ${{ inputs.environment }} terraform-apply` in the deploy GitHub Action
- Retry up to 3 attempts total
- Add incremental backoff between attempts (30s, then 60s)
- Preserve existing behavior after successful apply
- Exit with failure if all retry attempts fail

### Guidance to review
- Confirm retry loop behavior and failure handling in `.github/actions/deploy-environment-to-aks/action.yml`
- Confirm no changes to Terraform configuration or infrastructure resources themselves, only deployment robustness
