### PR TITLE
Reapply "Add ECF data source to Blazer"

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -26,6 +26,10 @@ data_sources:
       induction_period_id: "/admin/teachers/N/induction-periods/{value}/edit"
       zendesk_ticket_id: "https://becomingateacher.zendesk.com/agent/tickets/{value}"
 
+  # http://localhost:3000/admin/blazer/queries/docs?data_source=ecf
+  ecf:
+    url: <%= ENV.fetch("ECF_DATABASE_URL", "postgres://localhost:5432") %>
+
 
 # statement timeout, in seconds
 # none by default


### PR DESCRIPTION
### Context

This PR reapplies the "Add ECF data source to Blazer" changes from #2339.

They were reverted in #2344, but after confirming the code was not responsible for the deployment issues, we want to reapply the updates to the Blazer configuration.

