### PR TITLE
Add ECT participant declaration seed scenarios

### DIFF
--- a/app/services/api_seed_data/ect_declaration_scenarios.rb
+++ b/app/services/api_seed_data/ect_declaration_scenarios.rb
@@ -1,0 +1,124 @@
+module APISeedData
+  class ECTDeclarationScenarios < Base
+    NUMBER_OF_RECORDS_PER_SCENARIO = 3
+
+    def plant
+      return unless plantable?
+
+      log_plant_info("api testing 2025 ECT declaration seed scenarios")
+
+      NUMBER_OF_RECORDS_PER_SCENARIO.times do
+        # ECT with a retained-1 declaration but no started declaration
+        seed_retained_1_declaration_without_started_declaration
+
+        # ECT with a paid started declaration and a submitted retained 2 declaration
+        seed_paid_started_declaration_and_submitted_retained_2_declaration
+      end
+    end
+
+  private
+
+    def seed_retained_1_declaration_without_started_declaration
+      active_lead_providers.find_each do |active_lead_provider|
+        school_partnership = school_partnerships(active_lead_provider:).sample
+        school = school_partnership.school
+        school_time_period = { started_on: Date.new(contract_period.year, 9, 2), finished_on: nil }
+        teacher = create_teacher(school_time_period:)
+        ect_at_school_period = create_at_school_period(school_time_period:, teacher:, school:)
+        training_time_period = { started_on: school_time_period[:started_on], finished_on: nil }
+        training_period = create_training_period(ect_at_school_period:, school_partnership:, training_time_period:)
+        create_ongoing_induction_period(teacher:, school_time_period:)
+        create_declaration(state: :paid, declaration_type: :"retained-1", training_period:, declaration_date: Date.new(2026, 1, 1))
+
+        log_plant_info("Created participant for #{school_partnership.active_lead_provider.lead_provider.name} with retained-1 declaration and no started declaration")
+      end
+    end
+
+    def seed_paid_started_declaration_and_submitted_retained_2_declaration
+      active_lead_providers.find_each do |active_lead_provider|
+        school_partnership = school_partnerships(active_lead_provider:).sample
+        school = school_partnership.school
+        school_time_period = { started_on: Date.new(contract_period.year, 9, 1), finished_on: nil }
+        teacher = create_teacher(school_time_period:)
+        ect_at_school_period = create_at_school_period(school_time_period:, teacher:, school:)
+        training_time_period = { started_on: school_time_period[:started_on], finished_on: nil }
+        training_period = create_training_period(ect_at_school_period:, school_partnership:, training_time_period:)
+        create_ongoing_induction_period(teacher:, school_time_period:)
+        create_declaration(state: :paid, declaration_type: :started, training_period:, declaration_date: Date.new(2025, 9, 1))
+        create_declaration(state: :no_payment, declaration_type: :"retained-2", training_period:, declaration_date: Date.new(2025, 9, 2))
+
+        log_plant_info("Created participant for #{school_partnership.active_lead_provider.lead_provider.name} with paid started declaration and submitted retained-2 declaration")
+      end
+    end
+
+    def contract_period
+      @contract_period ||= ContractPeriod.find_by(year: 2025)
+    end
+
+    def active_lead_providers
+      @active_lead_providers ||= ActiveLeadProvider.where(contract_period:)
+    end
+
+    def schedule
+      Schedule.find_by(contract_period:, identifier: "ecf-standard-september")
+    end
+
+    def school_partnerships(active_lead_provider:)
+      SchoolPartnership
+        .joins(:school, :lead_provider_delivery_partnership, :contract_period)
+        .where(lead_provider_delivery_partnership: { active_lead_provider: })
+    end
+
+    def create_declaration(state:, declaration_type:, training_period:, declaration_date:)
+      FactoryBot.create(:declaration, state, declaration_type:, training_period:, declaration_date:)
+    end
+
+    def create_ongoing_induction_period(teacher:, school_time_period:)
+      started_on = school_time_period[:started_on]
+      FactoryBot.create(:induction_period, outcome: nil, teacher:, started_on:, finished_on: nil, number_of_terms: nil)
+    end
+
+    def create_teacher(school_time_period:)
+      created_at = school_time_period[:started_on].to_time + rand(60 * 23).minutes
+      FactoryBot.create(
+        :teacher,
+        :with_realistic_name,
+        trn: APISeedData::Helpers::TRNGenerator.next,
+        ect_first_became_eligible_for_training_at: created_at
+      ).tap do |t|
+        t.update!(
+          created_at:,
+          updated_at: created_at,
+          api_updated_at: created_at
+        )
+      end
+    end
+
+    def create_at_school_period(school_time_period:, teacher:, school:)
+      email = Faker::Internet.email(name: ::Teachers::Name.new(teacher).full_name)
+      school_reported_appropriate_body = AppropriateBodyPeriod.order(Arel.sql("RANDOM()")).first
+      FactoryBot.create(
+        :ect_at_school_period,
+        teacher:,
+        school:,
+        email:,
+        school_reported_appropriate_body:,
+        created_at: teacher.created_at,
+        **school_time_period
+      )
+    end
+
+    def create_training_period(ect_at_school_period:, school_partnership:, training_time_period:, traits: [])
+      FactoryBot.create(
+        :training_period,
+        *traits,
+        :with_schedule,
+        :for_ect,
+        schedule:,
+        ect_at_school_period:,
+        school_partnership:,
+        **training_time_period
+      )
+    end
+  end
+end

--- a/lib/tasks/api_seed_data.rake
+++ b/lib/tasks/api_seed_data.rake
@@ -27,6 +27,7 @@ namespace :api_seed_data do
       APISeedData::MentorScenarios,
       APISeedData::SITBecomeMentorScenarios,
       APISeedData::ECTParticipantActionScenarios,
+      APISeedData::ECTDeclarationScenarios,
     ]
 
     if Rails.env.development? || Rails.env.review? || Rails.env.staging?

--- a/spec/services/api_seed_data/ect_declaration_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_declaration_scenarios_spec.rb
@@ -1,0 +1,154 @@
+RSpec.describe APISeedData::ECTDeclarationScenarios do
+  let(:instance) { described_class.new }
+  let(:environment) { "sandbox" }
+  let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
+  let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+
+  def setup_test_data(lead_provider:)
+    FactoryBot.create(:school_partnership, :for_year, year: contract_period.year, lead_provider:)
+    FactoryBot.create(:schedule, contract_period:, identifier: "ecf-standard-september").tap do |schedule|
+      Declaration.declaration_types.each_key do |declaration_type|
+        schedule.milestones.create!(declaration_type:, start_date: Date.new(2025, 6, 1))
+      end
+    end
+  end
+
+  before do
+    allow(Logger).to receive(:new).with($stdout) { logger }
+    allow(Rails).to receive(:env) { environment.inquiry }
+
+    stub_const("#{described_class}::NUMBER_OF_RECORDS_PER_SCENARIO", 1)
+
+    # Ensure there is test data
+    setup_test_data(lead_provider:)
+  end
+
+  describe "#plant" do
+    subject(:plant) { instance.plant }
+
+    it "creates participants relative to the NUMBER_OF_RECORDS_PER_SCENARIO constant for each scenario" do
+      stub_const("#{described_class}::NUMBER_OF_RECORDS_PER_SCENARIO", 0)
+
+      expect { plant }.not_to change(TrainingPeriod, :count)
+    end
+
+    it "creates a 2025 participant with a retrained-1 declaration but no started declaration" do
+      plant
+
+      # The first training period/teacher created is for the first scenario.
+      training_period = TrainingPeriod.first
+      teacher = training_period.teacher
+
+      Metadata::Manager.new.refresh_metadata!(teacher)
+
+      expect(training_period.contract_period.year).to eq(2025)
+
+      expect(training_period.schedule.identifier).to eq("ecf-standard-september")
+
+      expect(training_period.started_on).to eq(Date.new(2025, 9, 2))
+      expect(training_period).to be_ongoing
+
+      expect(training_period.at_school_period.started_on).to eq(Date.new(2025, 9, 2))
+      expect(training_period.at_school_period).to be_ongoing
+
+      expect(teacher.induction_periods).to be_present
+      expect(teacher.finished_induction_period).to be_nil
+
+      expect(teacher.ect_declarations.count).to eq(1)
+      expect(teacher.ect_declarations.first).to have_attributes(
+        declaration_type: "retained-1",
+        declaration_date: Date.new(2026, 1, 1).in_time_zone,
+        overall_status: "paid"
+      )
+
+      service = API::Declarations::Create.new(
+        lead_provider_id: lead_provider.id,
+        teacher_api_id: teacher.api_id,
+        teacher_type: :ect,
+        evidence_type: "other",
+        declaration_date: "2025-11-21T08:46:29Z",
+        declaration_type: "started"
+      )
+
+      expect(service).to be_valid
+      expect { service.create }.not_to raise_error
+    end
+
+    it "creates a 2025 participant with a paid started and submitted retained-2 declaration" do
+      plant
+
+      # The last training period/teacher created is for the second scenario.
+      training_period = TrainingPeriod.last
+      teacher = training_period.teacher
+
+      Metadata::Manager.new.refresh_metadata!(teacher)
+
+      expect(training_period.contract_period.year).to eq(2025)
+
+      expect(training_period.schedule.identifier).to eq("ecf-standard-september")
+
+      expect(training_period.started_on).to eq(Date.new(2025, 9, 1))
+      expect(training_period).to be_ongoing
+
+      expect(training_period.at_school_period.started_on).to eq(Date.new(2025, 9, 1))
+      expect(training_period.at_school_period).to be_ongoing
+
+      expect(teacher.induction_periods).to be_present
+      expect(teacher.finished_induction_period).to be_nil
+
+      expect(teacher.ect_declarations.count).to eq(2)
+      started_declaration = teacher.ect_declarations.find_by(declaration_type: "started")
+      expect(started_declaration).to have_attributes(
+        declaration_type: "started",
+        declaration_date: Date.new(2025, 9, 1).in_time_zone,
+        overall_status: "paid"
+      )
+      retained_2_declaration = teacher.ect_declarations.find_by(declaration_type: "retained-2")
+      expect(retained_2_declaration).to have_attributes(
+        declaration_type: "retained-2",
+        declaration_date: Date.new(2025, 9, 2).in_time_zone,
+        overall_status: "no_payment"
+      )
+
+      void_service = API::Declarations::Void.new(
+        lead_provider_id: lead_provider.id,
+        declaration_api_id: retained_2_declaration.api_id
+      )
+
+      expect(void_service).to be_valid
+      expect { void_service.void }.not_to raise_error
+
+      service = API::Declarations::Create.new(
+        lead_provider_id: lead_provider.id,
+        teacher_api_id: teacher.api_id,
+        teacher_type: :ect,
+        evidence_type: "other",
+        declaration_date: "2025-09-02T08:46:29Z",
+        declaration_type: "retained-1"
+      )
+
+      expect(service).to be_valid
+      expect { service.create }.not_to raise_error
+    end
+
+    it "logs the creation of records" do
+      plant
+
+      expect(logger).to have_received("level=").with(Logger::INFO)
+      expect(logger).to have_received("formatter=").with(Rails.logger.formatter)
+
+      expect(logger).to have_received(:info).with(/Planting api testing 2025 ECT declaration seed scenarios/).once
+      expect(logger).to have_received(:info).with(/Created participant for #{lead_provider.name} with retained-1 declaration and no started declaration/).once
+      expect(logger).to have_received(:info).with(/Created participant for #{lead_provider.name} with paid started declaration and submitted retained-2 declaration/).once
+    end
+
+    context "when in the production environment" do
+      let(:environment) { "production" }
+
+      it "does not create any data" do
+        expect { instance.plant }.not_to change(TrainingPeriod, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add seed data to support the user testing scenarios; this one covers declarations in different states for particular participants. The tests call the services that the lead provider will be tasked with calling (so we can verify they will accept the participant details).

Will be ran manually on sandbox:

```
Rails.logger.silence do
  ActiveRecord::Base.transaction do
      APISeedData::ECTDeclarationScenarios.new.plant
  end
  Metadata::Manager.refresh_all_metadata!(async: true)
end
```