### PR TITLE
[3375] Fix broken evidence held validation rule for 2025 started declarations

### DIFF
--- a/app/validators/evidence_type_validator.rb
+++ b/app/validators/evidence_type_validator.rb
@@ -11,7 +11,7 @@ class EvidenceTypeValidator < ActiveModel::Validator
 
     evidence_type_is_present(record) if self.class.evidence_type_required?(record)
 
-    if validate_detailed_evidence_types?(record)
+    if self.class.validate_detailed_evidence_types?(record)
       evidence_type_is_valid_detailed_evidence_type(record)
     elsif validate_simple_evidence_types?(record)
       evidence_type_is_valid_simple_evidence_type(record)
@@ -19,18 +19,21 @@ class EvidenceTypeValidator < ActiveModel::Validator
   end
 
   def self.evidence_type_required?(record)
-    record.declaration_type.present? && record.declaration_type != "started"
+    record.declaration_type.present? && (
+      record.declaration_type != "started" ||
+      validate_detailed_evidence_types?(record)
+    )
   end
 
   def self.evidence_type_allowed?(record)
-    record.training_period.contract_period.detailed_evidence_types_enabled || evidence_type_required?(record)
+    validate_detailed_evidence_types?(record) || evidence_type_required?(record)
+  end
+
+  def self.validate_detailed_evidence_types?(record)
+    record.training_period.contract_period.detailed_evidence_types_enabled
   end
 
 private
-
-  def validate_detailed_evidence_types?(record)
-    record.training_period.contract_period.detailed_evidence_types_enabled
-  end
 
   def validate_simple_evidence_types?(record)
     record.declaration_type.present?

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -2014,6 +2014,7 @@ components:
       - declaration_type
       - declaration_date
       - course_identifier
+      - evidence_held
       additionalProperties: false
       properties:
         participant_id:

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
             declaration_type: "started",
             declaration_date: milestone.start_date.beginning_of_day.rfc3339,
             course_identifier: "ecf-induction",
+            evidence_held: "other",
           },
         },
       }
@@ -60,6 +61,7 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
             declaration_type: "started",
             declaration_date: Time.zone.now.rfc3339,
             course_identifier: "ecf-induction",
+            evidence_held: "invalid",
           },
         },
       }

--- a/spec/swagger_schemas/requests/declaration_post2024_ect.rb
+++ b/spec/swagger_schemas/requests/declaration_post2024_ect.rb
@@ -1,7 +1,7 @@
 DECLARATION_POST2024_ECT_STARTED_ATTRIBUTES = {
   description: "An ECT started declaration",
   type: :object,
-  required: %i[participant_id declaration_type declaration_date course_identifier],
+  required: %i[participant_id declaration_type declaration_date course_identifier evidence_held],
   additionalProperties: false,
   properties: {
     participant_id: {

--- a/spec/validators/evidence_type_validator_spec.rb
+++ b/spec/validators/evidence_type_validator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
         context "when `declaration_type` is `started`" do
           let(:declaration_type) { "started" }
 
-          context "when `evidence_type` is nil" do
+          context "when `evidence_type` is not present" do
             let(:evidence_type) { nil }
 
             it "does not show validation error" do
@@ -64,7 +64,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
         context "when `declaration_type` is other than started" do
           let(:declaration_type) { "retained-1" }
 
-          context "when `evidence_type` is nil" do
+          context "when `evidence_type` is not present" do
             let(:evidence_type) { nil }
 
             it "has a meaningful error", :aggregate_failures do
@@ -102,11 +102,13 @@ RSpec.describe EvidenceTypeValidator, type: :model do
         context "when `declaration_type` is `started`" do
           let(:declaration_type) { "started" }
 
-          context "when `evidence_type` is nil" do
+          context "when `evidence_type` is not present" do
             let(:evidence_type) { nil }
 
-            it "does not show validation error" do
-              expect(subject).to be_valid
+            it "has a meaningful error", :aggregate_failures do
+              expect(subject).to be_invalid
+              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
 
@@ -172,7 +174,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
         context "when `declaration_type` is `started`" do
           let(:declaration_type) { "started" }
 
-          context "when `evidence_type` is nil" do
+          context "when `evidence_type` is not present" do
             let(:evidence_type) { nil }
 
             it "does not show validation error" do
@@ -202,7 +204,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
         context "when `declaration_type` is other than started" do
           let(:declaration_type) { "retained-1" }
 
-          context "when `evidence_type` is nil" do
+          context "when `evidence_type` is not present" do
             let(:evidence_type) { nil }
 
             it "has a meaningful error", :aggregate_failures do
@@ -240,11 +242,13 @@ RSpec.describe EvidenceTypeValidator, type: :model do
         context "when `declaration_type` is `started`" do
           let(:declaration_type) { "started" }
 
-          context "when `evidence_type` is nil" do
+          context "when `evidence_type` is not present" do
             let(:evidence_type) { nil }
 
-            it "does not show validation error" do
-              expect(subject).to be_valid
+            it "has a meaningful error", :aggregate_failures do
+              expect(subject).to be_invalid
+              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
 
@@ -305,30 +309,36 @@ RSpec.describe EvidenceTypeValidator, type: :model do
   describe ".evidence_type_required?" do
     subject { described_class.evidence_type_required?(record) }
 
-    let(:record) { Struct.new(:declaration_type).new(declaration_type) }
+    let(:detailed_evidence_types_enabled) { false }
+    let(:record) { Struct.new(:declaration_type, :training_period).new(declaration_type, training_period) }
+    let(:training_period) { Struct.new(:contract_period).new(contract_period) }
 
-    context "when `declaration_type` is nil" do
+    context "when `declaration_type` is not present" do
       let(:declaration_type) { nil }
 
-      it "evidence_type is not required" do
-        expect(subject).to be(false)
-      end
+      it { is_expected.to be(false) }
     end
 
     context "when `declaration_type` is `started`" do
       let(:declaration_type) { "started" }
 
-      it "evidence_type is not required" do
-        expect(subject).to be(false)
+      context "when detailed evidence types are not enabled" do
+        let(:detailed_evidence_types_enabled) { false }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when detailed evidence types are enabled" do
+        let(:detailed_evidence_types_enabled) { true }
+
+        it { is_expected.to be(true) }
       end
     end
 
     context "when `declaration_type` is other than started" do
       let(:declaration_type) { "retained-1" }
 
-      it "evidence_type is required" do
-        expect(subject).to be(true)
-      end
+      it { is_expected.to be(true) }
     end
   end
 
@@ -341,56 +351,44 @@ RSpec.describe EvidenceTypeValidator, type: :model do
     context "when contract period has simple evidence types" do
       let(:detailed_evidence_types_enabled) { false }
 
-      context "when `declaration_type` is nil" do
+      context "when `declaration_type` is not present" do
         let(:declaration_type) { nil }
 
-        it "evidence_type is not allowed" do
-          expect(subject).to be(false)
-        end
+        it { is_expected.to be(false) }
       end
 
       context "when `declaration_type` is `started`" do
         let(:declaration_type) { "started" }
 
-        it "evidence_type is not allowed" do
-          expect(subject).to be(false)
-        end
+        it { is_expected.to be(false) }
       end
 
       context "when `declaration_type` is other than started" do
         let(:declaration_type) { "retained-1" }
 
-        it "evidence_type is allowed" do
-          expect(subject).to be(true)
-        end
+        it { is_expected.to be(true) }
       end
     end
 
     context "when contract period has detailed evidence types" do
       let(:detailed_evidence_types_enabled) { true }
 
-      context "when `declaration_type` is nil" do
+      context "when `declaration_type` is not present" do
         let(:declaration_type) { nil }
 
-        it "evidence_type is allowed" do
-          expect(subject).to be(true)
-        end
+        it { is_expected.to be(true) }
       end
 
       context "when `declaration_type` is `started`" do
         let(:declaration_type) { "started" }
 
-        it "evidence_type is allowed" do
-          expect(subject).to be(true)
-        end
+        it { is_expected.to be(true) }
       end
 
       context "when `declaration_type` is other than started" do
         let(:declaration_type) { "retained-1" }
 
-        it "evidence_type is allowed" do
-          expect(subject).to be(true)
-        end
+        it { is_expected.to be(true) }
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [3375](https://github.com/DFE-Digital/register-ects-project-board/issues/3375)
Resurrecting [3053](https://github.com/DFE-Digital/register-ects-project-board/issues/3053) as changes were lost due a rebase.

### Changes proposed in this pull request

- Prevent submitting a started declaration for the post-2024 cohorts without evidence held;
- Correct the Swagger docs so evidence_held has a mandatory red star for post-2024 started declarations;

### Guidance to review

Review app
