### PR TITLE
Remove unmigrated teachers from output summary

### DIFF
--- a/app/controllers/migration/migrations_controller.rb
+++ b/app/controllers/migration/migrations_controller.rb
@@ -17,8 +17,7 @@ class Migration::MigrationsController < ::AdminController
 
     @teachers_via_latest_induction_records = Teacher.where(migration_mode: "latest_induction_records").count
     @teachers_via_all_induction_records = Teacher.where(migration_mode: "all_induction_records").count
-    @not_migrated_teachers = Teacher.where(migration_mode: "not_migrated").count
-    @all_teachers = Teacher.count
+    @all_migrated_teachers = Teacher.count.where.not(migration_mode: "not_migrated")
   end
 
   def create

--- a/app/views/migration/migrations/_completed_migration.html.erb
+++ b/app/views/migration/migrations/_completed_migration.html.erb
@@ -36,19 +36,15 @@ end %>
   govuk_summary_list do |sl|
     sl.with_row do |row|
       row.with_key(text: "Economy")
-      row.with_value(text: number_and_percentage(@teachers_via_latest_induction_records, @all_teachers))
+      row.with_value(text: number_and_percentage(@teachers_via_latest_induction_records, @all_migrated_teachers))
     end
     sl.with_row do |row|
       row.with_key(text: "Premium")
-      row.with_value(text: number_and_percentage(@teachers_via_all_induction_records, @all_teachers))
-    end
-    sl.with_row do |row|
-      row.with_key(text: "Not migrated")
-      row.with_value(text: number_and_percentage(@not_migrated_teachers, @all_teachers))
+      row.with_value(text: number_and_percentage(@teachers_via_all_induction_records, @all_migrated_teachers))
     end
     sl.with_row do |row|
       row.with_key(text: "Total")
-      row.with_value(text: tag.strong(number_with_delimiter(@all_teachers)))
+      row.with_value(text: tag.strong(number_with_delimiter(@all_migrated_teachers)))
     end
   end
 %>


### PR DESCRIPTION
We don't need to display RIAB-only teachers in the migration summary.
