### PR TITLE
Ensure bands are consistent across active lead providers

### DIFF
--- a/app/models/contract/banded_fee_structure/band.rb
+++ b/app/models/contract/banded_fee_structure/band.rb
@@ -41,6 +41,8 @@ class Contract::BandedFeeStructure::Band < ApplicationRecord
            if: -> { output_fee_ratio? && service_fee_ratio? }
   validate :declaration_boundaries_sequential_without_gaps,
            if: -> { min_declarations? && max_declarations? }
+  validate :first_band_min_declarations_is_one
+  validate :band_consistency_across_active_lead_provider
 
   def capacity
     max_declarations - min_declarations + 1
@@ -53,17 +55,51 @@ private
       (output_fee_ratio + service_fee_ratio).to_d == 1.0.to_d
   end
 
+  def first_band_min_declarations_is_one
+    first_band = banded_fee_structure&.bands&.first || self
+
+    return if first_band.min_declarations == 1
+
+    errors.add(:min_declarations, "The first band's min declarations must be 1")
+  end
+
   def declaration_boundaries_sequential_without_gaps
     return unless banded_fee_structure
 
-    ordered_bands = banded_fee_structure.bands.sort_by(&:min_declarations)
-    previous_band_max_declarations = if ordered_bands.empty?
-                                       0
-                                     else
-                                       ordered_bands.last.max_declarations
-                                     end
+    ordered_bands = banded_fee_structure
+      .bands
+      .where.not(id:)
+      .to_a
+      .push(self)
+      .sort_by(&:min_declarations)
 
-    errors.add(:base, "Declaration boundaries must be sequential without gaps") unless
-      min_declarations == previous_band_max_declarations + 1
+    return if ordered_bands.each_cons(2).all? { |a, b| a.max_declarations + 1 == b.min_declarations }
+
+    errors.add(:base, "Declaration boundaries must be sequential without gaps")
+  end
+
+  # As the banded calculations take into account previous statements for
+  # the same active lead provider, we need to ensure that the bands remain
+  # consistent across all contracts associated with the same active lead provider.
+  def band_consistency_across_active_lead_provider
+    active_lead_provider = banded_fee_structure&.contract&.active_lead_provider
+    return unless active_lead_provider
+
+    bands_for_active_lead_provider = self.class
+        .joins(banded_fee_structure: { contract: :active_lead_provider })
+        .where(contracts: { active_lead_provider: })
+        .where.not(id:)
+        .to_a
+        .push(self)
+
+    attributes_to_ignore = %w[id banded_fee_structure_id created_at updated_at].freeze
+    unique_bands_by_index = bands_for_active_lead_provider
+      .group_by { it.banded_fee_structure.reload.bands.index(it) || it.banded_fee_structure.bands.count }
+      .transform_values { |bands| bands.map { it.attributes.except(*attributes_to_ignore) }.uniq }
+
+    inconsistent_bands = unique_bands_by_index.select { |_, bands| bands.size > 1 }
+    inconsistent_bands.each_key do |index|
+      errors.add(:base, "Band at index #{index} is inconsistent across statements for the same active lead provider")
+    end
   end
 end

--- a/spec/models/contract/banded_fee_structure/band_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
 
     describe "sequential band declaration boundaries" do
       subject(:band) do
-        FactoryBot.build_stubbed(
+        FactoryBot.build(
           :contract_banded_fee_structure_band,
           banded_fee_structure:,
           min_declarations:,
@@ -61,13 +61,13 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
       end
 
       let(:banded_fee_structure) do
-        FactoryBot.build_stubbed(
+        FactoryBot.create(
           :contract_banded_fee_structure,
           :with_bands,
           declaration_boundaries: [
             { min: 1, max: 100 },
-            { min: 201, max: 300 },
             { min: 101, max: 200 },
+            { min: 201, max: 300 },
           ]
         )
       end
@@ -77,7 +77,10 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
         let(:min_declarations) { 250 }
         let(:max_declarations) { 400 }
 
-        it { is_expected.to be_invalid }
+        it "is expected to be invalid" do
+          expect(band).to be_invalid
+          expect(band.errors[:base]).to include("Declaration boundaries must be sequential without gaps")
+        end
       end
 
       context "when the band's min declarations is greater than the " \
@@ -85,7 +88,10 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
         let(:min_declarations) { 350 }
         let(:max_declarations) { 450 }
 
-        it { is_expected.to be_invalid }
+        it "is expected to be invalid" do
+          expect(band).to be_invalid
+          expect(band.errors[:base]).to include("Declaration boundaries must be sequential without gaps")
+        end
       end
 
       context "when the band's min declarations is greater than the " \
@@ -104,7 +110,10 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
         let(:min_declarations) { 2 }
         let(:max_declarations) { 400 }
 
-        it { is_expected.to be_invalid }
+        it "is expected to be invalid" do
+          expect(band).to be_invalid
+          expect(band.errors[:min_declarations]).to include("The first band's min declarations must be 1")
+        end
       end
 
       context "when the banded fee structure has no bands yet " \
@@ -116,6 +125,91 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
         let(:max_declarations) { 400 }
 
         it { is_expected.to be_valid }
+      end
+
+      context "when updating an existing band" do
+        let(:banded_fee_structure) { FactoryBot.create(:contract_banded_fee_structure, :with_bands) }
+
+        it "is valid if the updated band still has sequential declaration boundaries" do
+          band = banded_fee_structure.bands.last
+          band.max_declarations += 50
+
+          expect(band).to be_valid
+        end
+
+        it "is invalid if the updated band no longer has sequential declaration boundaries" do
+          band = banded_fee_structure.bands.last
+          band.min_declarations = 1
+
+          expect(band).to be_invalid
+          expect(band.errors[:base]).to include("Declaration boundaries must be sequential without gaps")
+        end
+      end
+    end
+
+    describe "band consistency across active lead providers" do
+      let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+
+      it "is valid when creating the first band for the active lead provider" do
+        contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract:)
+        band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure:)
+        expect(band).to be_valid
+      end
+
+      it "is valid when creating bands for another contract for the same active lead provider when the bands are consistent" do
+        original_contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract: original_contract)
+        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100)
+
+        new_contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        new_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract: new_contract)
+        new_band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 100)
+
+        expect(new_band).to be_valid
+      end
+
+      it "is invalid when creating bands for another contract for the same active lead provider when the bands are not consistent" do
+        original_contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract: original_contract)
+        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100, min_declarations: 1, max_declarations: 2)
+        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 150, min_declarations: 3, max_declarations: 4)
+
+        new_contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        new_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract: new_contract)
+        new_band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 150, min_declarations: 1, max_declarations: 2)
+
+        expect(new_band).to be_invalid
+        expect(new_band.errors[:base]).to include(/Band at index 0 is inconsistent across statements for the same active lead provider/)
+
+        new_band.fee_per_declaration = 100
+        expect(new_band).to be_valid
+        new_band.save!
+
+        new_band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 150, min_declarations: 3, max_declarations: 5)
+        expect(new_band).to be_invalid
+        expect(new_band.errors[:base]).to include(/Band at index 1 is inconsistent across statements for the same active lead provider/)
+
+        new_band.max_declarations = 4
+        expect(new_band).to be_valid
+      end
+
+      it "is invalid when updating a band such that it becomes inconsistent with bands for the same active lead provider" do
+        original_contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract: original_contract)
+        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100)
+
+        new_contract = FactoryBot.create(:contract, :for_ecf, active_lead_provider:)
+        new_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, contract: new_contract)
+        new_band = FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 100)
+
+        new_band.fee_per_declaration = 150
+
+        expect(new_band).to be_invalid
+        expect(new_band.errors[:base]).to include(/Band at index 0 is inconsistent across statements for the same active lead provider/)
+
+        new_band.fee_per_declaration = 100
+        expect(new_band).to be_valid
       end
     end
   end

--- a/spec/services/payment_calculator/banded/outputs_spec.rb
+++ b/spec/services/payment_calculator/banded/outputs_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe PaymentCalculator::Banded::Outputs do
 
   describe "#total_billable_amount" do
     it "sums billable amounts across all declaration types" do
-      # 3x eligible/started declarations (0.20 fee proportion)
+      # 5x eligible/started declarations (0.20 fee proportion)
       # 0.75 output fee ratio
       # 100.0 fee per declaration
-      expect(outputs.total_billable_amount).to eq(3 * 0.75 * 100.0 * 0.20)
+      expect(outputs.total_billable_amount).to eq(5 * 0.75 * 100.0 * 0.20)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe PaymentCalculator::Banded::Outputs do
 
   describe "#total_net_amount" do
     it "returns total_billable_amount minus total_refundable_amount" do
-      expect(outputs.total_net_amount).to eq(15.0)
+      expect(outputs.total_net_amount).to eq(45.0)
     end
   end
 


### PR DESCRIPTION
The bands should remain consistent for all the statements for a given active lead provider. This is due to the way the banded calculator works; the bands are filled with declarations from previous statements, so must remain consistent to avoid accounting errors.

Add validation to ensure bands remain consistent for all contracts associated to the active lead provider.

Improve validation around min/max boundaries as it was falling over when updating existing bands.

We may look at refactoring `Band` so that it lives outwith contracts post-launch.

Re-ran in parity check environment, didn't need to fix any data in ECF thankfully: 

<img width="661" height="58" alt="Screenshot 2026-03-04 at 11 13 22" src="https://github.com/user-attachments/assets/51a13f95-97fe-4e9c-a578-e915433eed87" />
