### PR TITLE
[3382] Completed declaration submission is giving 500 error

### DIFF
--- a/app/services/declarations/mentor_completion.rb
+++ b/app/services/declarations/mentor_completion.rb
@@ -13,7 +13,7 @@ module Declarations
       ActiveRecord::Base.transaction do
         if latest_billable_completed_declaration
           mentor_completed_training!
-          finish_training_period! if latest_training_period.finished_on.blank?
+          finish_training_period! if training_period_ongoing_or_finishing_in_the_future?
         else
           mentor_not_completed_training!
           create_training_period! unless latest_training_period.ongoing_today?
@@ -61,6 +61,10 @@ module Declarations
       else
         latest_training_period.started_on + 1.day
       end
+    end
+
+    def training_period_ongoing_or_finishing_in_the_future?
+      latest_training_period.finished_on.blank? || latest_training_period.finished_on.future?
     end
 
     def latest_training_period

--- a/spec/services/declarations/mentor_completion_spec.rb
+++ b/spec/services/declarations/mentor_completion_spec.rb
@@ -46,9 +46,12 @@ RSpec.describe Declarations::MentorCompletion, :with_metadata do
         end
 
         context "when the training period is already finished" do
-          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 2.months.ago, finished_on: 1.week.ago) }
-          let(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on: 1.week.ago) }
-          let(:declaration) { FactoryBot.create(:declaration, :eligible, declaration_type: "completed", training_period:, declaration_date: 2.weeks.ago) }
+          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 2.months.ago, finished_on:) }
+          let(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on:) }
+          let(:declaration) { FactoryBot.create(:declaration, :eligible, declaration_type: "completed", training_period:, declaration_date:) }
+
+          let(:declaration_date) { 2.weeks.ago }
+          let(:finished_on) { 1.week.ago }
 
           it "does not change the training period finished_on" do
             expect { service.perform }.not_to(change { training_period.reload.finished_on })
@@ -61,19 +64,33 @@ RSpec.describe Declarations::MentorCompletion, :with_metadata do
             expect(teacher.mentor_became_ineligible_for_funding_on).to eq(declaration.declaration_date.to_date)
             expect(teacher.mentor_became_ineligible_for_funding_reason).to eq("completed_declaration_received")
           end
-        end
 
-        context "when the training period is already finished and the declaration date is outside the school period" do
-          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 2.months.ago, finished_on: 3.weeks.ago) }
-          let(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: 2.months.ago, finished_on: 3.weeks.ago) }
-          let(:declaration) { FactoryBot.create(:declaration, :eligible, declaration_type: "completed", training_period:, declaration_date: 2.weeks.ago) }
+          context "when the declaration date is outside the school period" do
+            let(:declaration_date) { mentor_at_school_period.finished_on + 2.days }
 
-          it "does not raise an error" do
-            expect { service.perform }.not_to raise_error
+            it "does not raise an error" do
+              expect { service.perform }.not_to raise_error
+            end
+
+            it "does not change the training period finished_on" do
+              expect { service.perform }.not_to(change { training_period.reload.finished_on })
+            end
           end
 
-          it "does not change the training period finished_on" do
-            expect { service.perform }.not_to(change { training_period.reload.finished_on })
+          context "when the training period has a future finished_on" do
+            let(:finished_on) { 2.months.from_now }
+
+            it "brings forward the training period finished_on to the declaration date" do
+              expect { service.perform }.to change { training_period.reload.finished_on }.from(finished_on.to_date).to(declaration.declaration_date.to_date)
+            end
+
+            it "marks the teacher as ineligible for funding" do
+              service.perform
+
+              teacher.reload
+              expect(teacher.mentor_became_ineligible_for_funding_on).to eq(declaration.declaration_date.to_date)
+              expect(teacher.mentor_became_ineligible_for_funding_reason).to eq("completed_declaration_received")
+            end
           end
         end
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3382

### Changes proposed in this pull request

* Error is raised because the training period already has `finished_on` and we're trying to run `TrainingPeriods::Finish.mentor_training`
* On `Declarations::MentorCompletion`, run `finish_training_period!` if `finished_on` is not set

### Guidance to review
