### PR TITLE
Display clawbacks in financial statements

### DIFF
--- a/app/components/admin/statements/clawbacks_component.html.erb
+++ b/app/components/admin/statements/clawbacks_component.html.erb
@@ -1,0 +1,35 @@
+<% calculators.each do |calculator| %>
+  <div class="finance-panel govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+    <%=
+      govuk_table do |table|
+        table.with_caption(text: caption_text(calculator), size: "m")
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(header: true) { "Payment type" }
+            row.with_cell(header: true) { "Number of participants" }
+            row.with_cell(header: true, numeric: true) { "Fee per participant" }
+            row.with_cell(header: true, numeric: true) { "Payments" }
+          end
+        end
+
+        table.with_body do |body|
+          calculator.outputs.declaration_type_outputs.each do |declaration_type_output|
+            body.with_row do |row|
+              row.with_cell { payment_type(calculator, declaration_type_output) }
+              row.with_cell { declaration_type_output.refundable_count.to_s }
+              row.with_cell(numeric: true) { number_to_pounds(-declaration_type_output.type_adjusted_fee_per_declaration) }
+              row.with_cell(numeric: true) { number_to_pounds(-declaration_type_output.total_refundable_amount) }
+            end
+          end
+        end
+      end
+    %>
+
+    <div class="govuk-!-text-align-right govuk-heading-s govuk-!-margin-bottom-0">
+      Total
+    </div>
+    <div class="govuk-!-text-align-right govuk-heading-s">
+      <%= number_to_pounds(-calculator.outputs.total_refundable_amount) %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/admin/statements/clawbacks_component.rb
+++ b/app/components/admin/statements/clawbacks_component.rb
@@ -1,0 +1,47 @@
+module Admin
+  module Statements
+    class ClawbacksComponent < ApplicationComponent
+      attr_reader :statement
+
+      def initialize(statement:)
+        @statement = statement
+      end
+
+    private
+
+      delegate :number_to_pounds, to: :helpers
+
+      def caption_text(calculator)
+        return "Clawbacks" if contract.ecf_contract_type?
+
+        case calculator
+        when PaymentCalculator::Banded
+          "ECT clawbacks"
+        when PaymentCalculator::FlatRate
+          "Mentor clawbacks"
+        end
+      end
+
+      def payment_type(calculator, declaration_type_output)
+        declaration_type_label = declaration_type_output.declaration_type.humanize
+
+        case calculator
+        when PaymentCalculator::Banded
+          <<~TXT.squish
+            #{declaration_type_label} (Band
+            #{declaration_type_output.band.min_declarations} to
+            #{declaration_type_output.band.max_declarations})
+          TXT
+        when PaymentCalculator::FlatRate
+          declaration_type_label
+        end
+      end
+
+      delegate :contract, to: :statement, private: true
+
+      def calculators
+        @calculators ||= PaymentCalculator::Resolver.new(statement:, contract:).calculators
+      end
+    end
+  end
+end

--- a/app/services/payment_calculator/banded/declaration_type_output.rb
+++ b/app/services/payment_calculator/banded/declaration_type_output.rb
@@ -19,14 +19,14 @@ module PaymentCalculator
 
     attribute :band_allocation
 
-    delegate :declaration_type, to: :band_allocation
+    delegate :declaration_type, :band, :billable_count, :refundable_count, to: :band_allocation
 
-    def output_fee_per_declaration
+    def type_adjusted_fee_per_declaration
       fee_proportion * band.output_fee_ratio * band.fee_per_declaration
     end
 
-    def total_billable_amount = billable_count * output_fee_per_declaration
-    def total_refundable_amount = refundable_count * output_fee_per_declaration
+    def total_billable_amount = billable_count * type_adjusted_fee_per_declaration
+    def total_refundable_amount = refundable_count * type_adjusted_fee_per_declaration
     def total_net_amount = total_billable_amount - total_refundable_amount
 
   private
@@ -37,9 +37,5 @@ module PaymentCalculator
               "No fee proportion defined for declaration type: #{declaration_type}"
       end
     end
-
-    delegate :billable_count, :refundable_count, :band,
-             to: :band_allocation,
-             private: true
   end
 end

--- a/app/services/payment_calculator/flat_rate/declaration_type_output.rb
+++ b/app/services/payment_calculator/flat_rate/declaration_type_output.rb
@@ -25,17 +25,13 @@ module PaymentCalculator
       @refundable_count ||= declarations_of_matching_type.refundable.count
     end
 
-    def total_billable_amount
-      billable_count * type_adjusted_fee_per_declaration
+    def type_adjusted_fee_per_declaration
+      fee_proportion * fee_per_declaration
     end
 
-    def total_refundable_amount
-      refundable_count * type_adjusted_fee_per_declaration
-    end
-
-    def total_net_amount
-      total_billable_amount - total_refundable_amount
-    end
+    def total_billable_amount = billable_count * type_adjusted_fee_per_declaration
+    def total_refundable_amount = refundable_count * type_adjusted_fee_per_declaration
+    def total_net_amount = total_billable_amount - total_refundable_amount
 
   private
 
@@ -43,11 +39,11 @@ module PaymentCalculator
       declarations.where(declaration_type:)
     end
 
-    def type_adjusted_fee_per_declaration
-      output_ratio = fee_proportions.fetch(declaration_type.to_sym) do
-        raise DeclarationTypeNotSupportedError, "No fee proportion defined for declaration type: #{declaration_type}"
+    def fee_proportion
+      fee_proportions.fetch(declaration_type.to_sym) do
+        raise DeclarationTypeNotSupportedError,
+              "No fee proportion defined for declaration type: #{declaration_type}"
       end
-      output_ratio * fee_per_declaration
     end
   end
 end

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -48,4 +48,5 @@
 
 <%= render Admin::Statements::PaymentAuthorisationComponent.new(statement: @statement) %>
 <%= render Admin::Statements::UpliftFeesComponent.new(statement: @statement) %>
+<%= render Admin::Statements::ClawbacksComponent.new(statement: @statement) %>
 <%= render Admin::Statements::AdjustmentsComponent.new(statement: @statement) %>

--- a/spec/components/admin/statements/clawbacks_component_spec.rb
+++ b/spec/components/admin/statements/clawbacks_component_spec.rb
@@ -1,0 +1,152 @@
+RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
+  subject(:component) { described_class.new(statement:) }
+
+  let(:statement) { FactoryBot.create(:statement, contract:) }
+
+  let(:bands) do
+    [band(from: 1, to: 10), band(from: 11, to: 20), band(from: 21, to: 30)]
+  end
+  let(:banded_declaration_type_outputs) do
+    [
+      double(
+        declaration_type: "started",
+        band: bands.first,
+        refundable_count: 10,
+        type_adjusted_fee_per_declaration: 15,
+        total_refundable_amount: 150
+      ),
+      double(
+        declaration_type: "started",
+        band: bands.second,
+        refundable_count: 10,
+        type_adjusted_fee_per_declaration: 15,
+        total_refundable_amount: 150
+      ),
+      double(
+        declaration_type: "completed",
+        band: bands.third,
+        refundable_count: 5,
+        type_adjusted_fee_per_declaration: 20,
+        total_refundable_amount: 100
+      )
+    ]
+  end
+  let(:banded_outputs) do
+    instance_double(
+      PaymentCalculator::Banded::Outputs,
+      declaration_type_outputs: banded_declaration_type_outputs,
+      total_refundable_amount: 400
+    )
+  end
+
+  let(:flat_rate_declaration_type_outputs) do
+    [
+      instance_double(
+        PaymentCalculator::FlatRate::DeclarationTypeOutput,
+        declaration_type: "started",
+        refundable_count: 15,
+        type_adjusted_fee_per_declaration: 10,
+        total_refundable_amount: 150
+      ),
+      instance_double(
+        PaymentCalculator::FlatRate::DeclarationTypeOutput,
+        declaration_type: "completed",
+        refundable_count: 5,
+        type_adjusted_fee_per_declaration: 16,
+        total_refundable_amount: 80
+      ),
+    ]
+  end
+  let(:flat_rate_outputs) do
+    instance_double(
+      PaymentCalculator::FlatRate::Outputs,
+      declaration_type_outputs: flat_rate_declaration_type_outputs,
+      total_refundable_amount: 230
+    )
+  end
+
+  before do
+    allow(PaymentCalculator::Banded::Outputs).to receive(:new).and_return(banded_outputs)
+    allow(PaymentCalculator::FlatRate::Outputs).to receive(:new).and_return(flat_rate_outputs)
+    render_inline(component)
+  end
+
+  context "for `ecf` contracts" do
+    let(:contract) { FactoryBot.create(:contract, :for_ecf) }
+
+    it "renders one table of clawbacks" do
+      expect(page).to have_css("table", count: 1)
+    end
+
+    it "renders the clawbacks table" do
+      expect(page).to have_statement_table(
+        caption: "Clawbacks",
+        headings: [
+          "Payment type",
+          "Number of participants",
+          "Fee per participant",
+          "Payments"
+        ],
+        rows: [
+          ["Started (Band 1 to 10)", "10", "-£15.00", "-£150.00"],
+          ["Started (Band 11 to 20)", "10", "-£15.00", "-£150.00"],
+          ["Completed (Band 21 to 30)", "5", "-£20.00", "-£100.00"]
+        ],
+        total: "-£400.00"
+      )
+    end
+  end
+
+  context "for `ittecf_ectp` contracts" do
+    let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp) }
+
+    it "renders two tables of clawbacks" do
+      expect(page).to have_css("table", count: 2)
+    end
+
+    it "renders ECT clawbacks" do
+      expect(page).to have_statement_table(
+        caption: "ECT clawbacks",
+        headings: [
+          "Payment type",
+          "Number of participants",
+          "Fee per participant",
+          "Payments"
+        ],
+        rows: [
+          ["Started (Band 1 to 10)", "10", "-£15.00", "-£150.00"],
+          ["Started (Band 11 to 20)", "10", "-£15.00", "-£150.00"],
+          ["Completed (Band 21 to 30)", "5", "-£20.00", "-£100.00"]
+        ],
+        total: "-£400.00"
+      )
+    end
+
+    it "renders Mentor clawbacks" do
+      expect(page).to have_statement_table(
+        caption: "Mentor clawbacks",
+        headings: [
+          "Payment type",
+          "Number of participants",
+          "Fee per participant",
+          "Payments"
+        ],
+        rows: [
+          ["Started", "15", "-£10.00", "-£150.00"],
+          ["Completed", "5", "-£16.00", "-£80.00"]
+        ],
+        total: "-£230.00"
+      )
+    end
+  end
+
+private
+
+  def band(from:, to:)
+    FactoryBot.build_stubbed(
+      :contract_banded_fee_structure_band,
+      min_declarations: from,
+      max_declarations: to
+    )
+  end
+end

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory(:declaration) do
-    training_period { FactoryBot.create(:training_period) }
+    transient do
+      active_lead_provider { FactoryBot.create(:active_lead_provider) }
+    end
+
+    training_period { FactoryBot.create(:training_period, :with_active_lead_provider, active_lead_provider:) }
     payment_status { :no_payment }
     clawback_status { :no_clawback }
     api_id { SecureRandom.uuid }

--- a/spec/factories/school_partnership_factory.rb
+++ b/spec/factories/school_partnership_factory.rb
@@ -22,5 +22,16 @@ FactoryBot.define do
                     delivery_partner:
       end
     end
+
+    trait :with_active_lead_provider do
+      transient do
+        active_lead_provider { association :active_lead_provider }
+      end
+
+      lead_provider_delivery_partnership do
+        association :lead_provider_delivery_partnership,
+                    active_lead_provider:
+      end
+    end
   end
 end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -61,6 +61,19 @@ FactoryBot.define do
       school_partnership { association :school_partnership, school: teacher_period&.school || FactoryBot.create(:school) }
     end
 
+    trait :with_active_lead_provider do
+      transient do
+        active_lead_provider { association :active_lead_provider }
+      end
+
+      school_partnership do
+        association :school_partnership,
+                    :with_active_lead_provider,
+                    active_lead_provider:,
+                    school: teacher_period&.school || FactoryBot.create(:school)
+      end
+    end
+
     trait :with_schedule do
       transient do
         schedule do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
   config.include APIHelper, type: :request
   config.include HaveSummaryListRow, type: :component
   config.include HaveSummaryListRow, type: :view
+  config.include HaveStatementTable, type: :component
+  config.include HaveStatementTable, type: :view
   config.include SwaggerExampleParser, type: :request
 
   config.use_transactional_fixtures = true

--- a/spec/services/payment_calculator/banded/declaration_type_output_spec.rb
+++ b/spec/services/payment_calculator/banded/declaration_type_output_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe PaymentCalculator::Banded::DeclarationTypeOutput do
 
   it { is_expected.to delegate_method(:declaration_type).to(:band_allocation) }
 
-  describe "#output_fee_per_declaration" do
-    subject(:output_fee_per_declaration) { instance.output_fee_per_declaration }
+  describe "#type_adjusted_fee_per_declaration" do
+    subject(:type_adjusted_fee_per_declaration) { instance.type_adjusted_fee_per_declaration }
 
     it { is_expected.to eq(15) }
 
@@ -24,7 +24,7 @@ RSpec.describe PaymentCalculator::Banded::DeclarationTypeOutput do
       let(:declaration_type) { "unsupported" }
 
       it "raises an error" do
-        expect { output_fee_per_declaration }
+        expect { type_adjusted_fee_per_declaration }
           .to raise_error(PaymentCalculator::Banded::DeclarationTypeOutput::DeclarationTypeNotSupportedError)
           .with_message("No fee proportion defined for declaration type: unsupported")
       end

--- a/spec/support/matchers/have_statement_table.rb
+++ b/spec/support/matchers/have_statement_table.rb
@@ -1,0 +1,52 @@
+module HaveStatementTable
+  class Matcher
+    def initialize(caption:, headings:, rows:, total:)
+      @caption = caption
+      @headings = headings
+      @rows = rows
+      @total = total
+    end
+
+    def matches?(page)
+      @page = page
+      # Assert table exists with the expected caption
+      return false unless page.has_css?("table caption", text: @caption)
+
+      table = page.find("table", text: @caption)
+      # Assert table has the expected headings
+      return false unless @headings.each_with_index.all? do |heading, index|
+        table.has_css?(th_selector(index: index + 1), text: heading)
+      end
+
+      # Assert table has the expected number of rows
+      return false unless table.has_css?("tbody tr", count: @rows.count)
+
+      # Assert table has the expected cells
+      return false unless @rows.each_with_index.all? do |row, index|
+        row.each_with_index.all? do |cell, cell_index|
+          table.has_css?(td_selector(row: index + 1, cell: cell_index + 1), text: cell)
+        end
+      end
+
+      # Assert the expected total is displayed as a heading
+      total = table.sibling(".govuk-heading-s", text: "Total")
+      return false unless total.sibling(".govuk-heading-s").has_text?(@total)
+
+      true
+    end
+
+    def failure_message
+      <<~TXT
+        Expected "#{@caption}" table with rows: #{@rows} and total: #{@total}, but
+        it could not be found: #{@page.native.inner_html}
+      TXT
+    end
+
+  private
+
+    def td_selector(row:, cell:) = "tbody tr:nth-child(#{row}) td:nth-child(#{cell})"
+    def th_selector(index:) = "thead tr th:nth-child(#{index})"
+  end
+
+  def have_statement_table(...) = Matcher.new(...)
+end

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -1,17 +1,108 @@
 RSpec.describe "admin/finance/statements/show.html.erb" do
-  let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-  let(:statement_rec) { FactoryBot.create(:statement, active_lead_provider:, month: 5, year: 2023) }
-  let(:statement) { Admin::StatementPresenter.new(statement_rec) }
+  let!(:contract_period) { FactoryBot.create(:contract_period) }
+  let!(:active_lead_provider) do
+    FactoryBot.create(
+      :active_lead_provider,
+      lead_provider: FactoryBot.create(:lead_provider, name: "Some LP"),
+      contract_period:
+    )
+  end
+
+  let(:banded_fee_structure) do
+    FactoryBot.create(:contract_banded_fee_structure, :with_bands)
+  end
+  let(:contract) do
+    FactoryBot.create(
+      :contract,
+      contract_trait,
+      active_lead_provider:,
+      banded_fee_structure:
+    )
+  end
+  let(:contract_trait) { :for_ecf }
+
+  let!(:jan_statement) do
+    deadline_date = Date.new(contract_period.year, 1, 1).prev_day
+    payment_date = Date.new(contract_period.year, 1, 31)
+    FactoryBot.create(
+      :statement,
+      contract:,
+      contract_period:,
+      active_lead_provider:,
+      deadline_date:,
+      payment_date:,
+      year: payment_date.year,
+      month: payment_date.month
+    )
+  end
+  let!(:feb_statement) do
+    deadline_date = Date.new(contract_period.year, 2, 1).prev_day
+    payment_date = Date.new(contract_period.year, 2, 28)
+    FactoryBot.create(
+      :statement,
+      contract:,
+      contract_period:,
+      active_lead_provider:,
+      deadline_date:,
+      payment_date:,
+      year: payment_date.year,
+      month: payment_date.month
+    )
+  end
+
+  let(:ect_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      :with_active_lead_provider,
+      active_lead_provider:
+    )
+  end
+  let(:mentor_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :for_mentor,
+      :with_active_lead_provider,
+      active_lead_provider:
+    )
+  end
+
+  let(:statement) { Admin::StatementPresenter.new(feb_statement) }
 
   before do
+    create_clawback(
+      ect_training_period,
+      payment_statement: jan_statement,
+      clawback_statement: feb_statement
+    )
+    create_clawback(
+      mentor_training_period,
+      payment_statement: jan_statement,
+      clawback_statement: feb_statement
+    )
     assign(:statement, statement)
+  end
+
+  def create_clawback(training_period, payment_statement:, clawback_statement:)
+    FactoryBot.create(
+      :declaration,
+      :paid,
+      payment_statement:,
+      training_period:
+    )
+    FactoryBot.create(
+      :declaration,
+      :clawed_back,
+      clawback_statement:,
+      training_period:
+    )
   end
 
   it "has title with lead provider name and statement month and year" do
     render
 
-    expect(view.content_for(:page_title)).to eq("Some LP - May 2023")
+    expect(view.content_for(:page_title))
+      .to eq("Some LP - February #{contract_period.year}")
   end
 
   it "displays the statement information in a summary list" do
@@ -20,5 +111,24 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
     expect(rendered).to have_css(".govuk-summary-list")
   end
 
-  it "contains values relevant to the statement"
+  context "for `ecf` contracts" do
+    let(:contract_trait) { :for_ecf }
+
+    it "displays clawbacks in a single table" do
+      render
+
+      expect(rendered).to have_css("table caption", text: "Clawbacks")
+    end
+  end
+
+  context "for `ittecf_ectp` contracts" do
+    let(:contract_trait) { :for_ittecf_ectp }
+
+    it "displays clawbacks in separate tables" do
+      render
+
+      expect(rendered).to have_css("table caption", text: "ECT clawbacks")
+      expect(rendered).to have_css("table caption", text: "Mentor clawbacks")
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3400

### Changes proposed in this pull request

This introduces a component for rendering clawbacks for a given statement, and
renders the component on the statements page.

Depending on the contract, it renders either a "Clawbacks" table (for `:ecf`
contract types) or an "ECT clawbacks" and a "Mentor clawbacks" table (for
`:ittecf_ectp` contract_types).

As part of this change, the declaration type output models have been refactored
for both the `Banded` and `FlatRate` calculators so they have a consistent API.
This means we can iterate each calculator and render the clawbacks.

I've also added a `HaveStatementTable` matcher to make asserting against tables
in finance statements a little more ergonomic.

Some `:with_active_lead_provider` traits have been added to both the
`SchoolPartnership` and `TrainingPeriod` factories to make it easier to create
declarations with consistent contract periods.

### Guidance to review

> [!NOTE]
> We plan to work on refining the seeds based on @thenapking's work, and we can review the statements from a product perspective once that is done. For now it's a real pain to get things set up!

<img width="974" height="392" alt="Screenshot 2026-03-04 at 16 47 29" src="https://github.com/user-attachments/assets/6d015ced-9c84-46a4-857d-c7afdc308edc" />

<img width="985" height="508" alt="Screenshot 2026-03-04 at 16 47 01" src="https://github.com/user-attachments/assets/4a0c0e8d-484c-44ce-addf-1918f3925196" />

