### PR TITLE
Implement automated email in induction Fail Journey

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,18 @@
 class ApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "c437a1cb-9e1c-49ff-83ee-967c92f95637"
   PRIVACY_NOTICE_URL = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers"
+
+private
+
+  # Bypass GOV.UK Notify in development when the API key is not configured,
+  # allowing mailer previews to render locally without a Notify account.
+  def view_mail(template_id, options)
+    return mail(options) if development_without_notify_api_key?
+
+    super
+  end
+
+  def development_without_notify_api_key?
+    Rails.env.development? && !ENV.key?("GOVUK_NOTIFY_API_KEY")
+  end
 end

--- a/app/mailers/failed_induction_mailer.rb
+++ b/app/mailers/failed_induction_mailer.rb
@@ -1,0 +1,13 @@
+class FailedInductionMailer < ApplicationMailer
+  TRA_EMAIL = "TRA.SE@education.gov.uk"
+
+  def tra_notification(induction_period:)
+    teacher = induction_period.teacher
+    @teacher_name = Teachers::Name.new(teacher).full_name
+    @trn = teacher.trn
+    @appropriate_body_name = induction_period.appropriate_body_name
+    @fail_confirmation_sent_on = induction_period.fail_confirmation_sent_on.to_fs(:govuk)
+
+    view_mail(NOTIFY_TEMPLATE_ID, to: TRA_EMAIL, subject: "Fail notification from RIAB")
+  end
+end

--- a/app/services/appropriate_bodies/record_fail.rb
+++ b/app/services/appropriate_bodies/record_fail.rb
@@ -25,6 +25,7 @@ module AppropriateBodies
         delete_submission
         sync_with_trs
         update_event_history
+        send_tra_failed_notification_email
       end
     end
 
@@ -57,6 +58,10 @@ module AppropriateBodies
         start_date: first_induction_period.started_on,
         completed_date: last_induction_period.finished_on
       )
+    end
+
+    def send_tra_failed_notification_email
+      FailedInductionMailer.tra_notification(induction_period: ongoing_induction_period).deliver_later
     end
   end
 end

--- a/app/views/failed_induction_mailer/tra_notification.text.erb
+++ b/app/views/failed_induction_mailer/tra_notification.text.erb
@@ -1,0 +1,21 @@
+Hi TRA colleagues,
+
+<%= @appropriate_body_name %> has submitted a fail induction outcome for the following ECT:
+
+Name: <%= @teacher_name %>
+TRN: <%= @trn %>
+
+The AB confirmed they notified the ECT of their decision in writing on <%= @fail_confirmation_sent_on %>.
+
+The ECT has been told:
+
+- They have failed their induction
+- They have a right to appeal
+- About the appeal process
+
+Please ensure that the 20‑working‑day appeal window is monitored and that the ECT's record is updated accordingly:
+
+- Add a note if an appeal has been submitted or not
+- Add a FAIL alert if no appeal is received after the 20‑day period
+
+Thank you.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,14 +41,18 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # GOVUK Notify
-  config.action_mailer.delivery_method = :notify
-
   if ENV.key?("GOVUK_NOTIFY_API_KEY")
+    config.action_mailer.delivery_method = :notify
     config.action_mailer.notify_settings = {
       api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
     }
   else
-    Logger.new($stdout).warn("GOVUK_NOTIFY_API_KEY is not set")
+    config.action_mailer.delivery_method = :test
+    Logger.new($stdout).warn("GOVUK_NOTIFY_API_KEY is not set, using test delivery method")
+
+    config.after_initialize do
+      ActionMailer::Base.preview_interceptors.delete(MailNotifyPreviewInterceptor)
+    end
   end
   config.action_mailer.default_url_options = { host: "localhost", port: "3000" }
 

--- a/spec/mailers/previews/failed_induction_mailer_preview.rb
+++ b/spec/mailers/previews/failed_induction_mailer_preview.rb
@@ -1,0 +1,16 @@
+class FailedInductionMailerPreview < ActionMailer::Preview
+  def tra_notification
+    FailedInductionMailer.tra_notification(induction_period: example_failed_induction_period)
+  end
+
+private
+
+  def example_failed_induction_period
+    teacher = FactoryBot.build(:teacher, trn: "0000016", trs_first_name: "Imogen", trs_last_name: "Stubbs")
+    appropriate_body_period = FactoryBot.build(:appropriate_body_period, name: "Golden Leaf Teaching School Hub")
+
+    FactoryBot.build(:induction_period,
+                     teacher:, appropriate_body_period:,
+                     outcome: :fail, fail_confirmation_sent_on: 2.days.ago)
+  end
+end

--- a/spec/services/admin/record_fail_spec.rb
+++ b/spec/services/admin/record_fail_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe Admin::RecordFail do
       service_call
     end
 
+    it "sends tra failed notification email" do
+      expect { service_call }.to have_enqueued_mail(FailedInductionMailer, :tra_notification)
+    end
+
     context "when the ect at school period has already finished" do
       let(:finished_on) { 2.days.ago }
 

--- a/spec/services/appropriate_bodies/record_fail_spec.rb
+++ b/spec/services/appropriate_bodies/record_fail_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe AppropriateBodies::RecordFail do
       service_call
     end
 
+    it "sends tra failed notification email" do
+      expect { service_call }.to have_enqueued_mail(FailedInductionMailer, :tra_notification)
+    end
+
     context "when the ect at school period has already finished" do
       let(:finished_on) { 2.days.ago }
 


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3293

As part of the improvements we have made to the induction fail journey we wanted to automate an email so that whenever an AB records a fail on RIAB and gives us the relevant dates it sends an email to the TRA team. This is currently done manually by the engagement team (Komal) so that is rationale for streamlining this is that it removes the need for them to monitor this closely.

Whenever someone clicks the below button on appropriate-body/teachers/xxxx/record-failed-outcome/new we want an email to be sent to [TRA.SE@EDUCATION.GOV.UK](mailto:TRA.SE@EDUCATION.GOV.UK)

### Changes proposed in this pull request

* Modifies **ApplicationMailer** to bypass Gov UK Notifier, to allow standard _ActionMailer_ behaviour for previews, etc.
* Sends a `InductionMailerFailure#tra_notification` email when **RecordFail** is triggered by an **AppropriateBody** or an _Admin_.
* Avoids inclusion of the ECT teachers Date of Birth in the email, as we don't have it in our database, and we don't really need to provide it in the email.
* **TODO: CC's the DfE group who would have normally sent the email**

### Guidance to review

When we have no `GOVUK_NOTIFY_API_KEY` we modify the configuration to bypass `:notify`, but because our **ApplicationMailer** inherits from a non-standard superclass (**Mail::Notify::Mailer**) we also add a bypass in the **ApplicationMailer**.

Other than that this is a small PR.
