### PR TITLE
Add guidance for financial statements

### DIFF
--- a/app/components/admin/statements/guidance_component.rb
+++ b/app/components/admin/statements/guidance_component.rb
@@ -1,0 +1,39 @@
+module Admin::Statements
+  class GuidanceComponent < ApplicationComponent
+    erb_template <<~ERB
+      <%=
+        govuk_details(
+          summary_text: "Calculation rounding errors",
+          text: rounding_errors_text
+        )
+      %>
+
+      <%=
+        govuk_details(
+          summary_text: "Updated financial statement design",
+          text: updated_financial_statement_text
+        )
+      %>
+    ERB
+
+  private
+
+    def rounding_errors_text
+      <<~TXT.squish
+        Due to the way payments per participant are made, there may be rounding
+        errors in some of the individual sub-calculations. The total output fees
+        displayed are correct. Contact your contract manager if you have any
+        queries.
+      TXT
+    end
+
+    def updated_financial_statement_text
+      <<~TXT.squish
+        We’ve updated the financial statements from June 2025 onwards to reflect
+        changes to the payment schedules. We’ve split out ECT and mentor output
+        payments, removed uplift fees, and deleted Band D from the ECT payment
+        bands.
+      TXT
+    end
+  end
+end

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -50,3 +50,4 @@
 <%= render Admin::Statements::UpliftFeesComponent.new(statement: @statement) %>
 <%= render Admin::Statements::ClawbacksComponent.new(statement: @statement) %>
 <%= render Admin::Statements::AdjustmentsComponent.new(statement: @statement) %>
+<%= render Admin::Statements::GuidanceComponent.new %>

--- a/spec/components/admin/statements/guidance_component_spec.rb
+++ b/spec/components/admin/statements/guidance_component_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe Admin::Statements::GuidanceComponent, type: :component do
+  subject(:component) { render_inline(described_class.new) }
+
+  it { is_expected.to have_css("details", text: "Calculation rounding errors") }
+  it { is_expected.to have_css("details", text: "Updated financial statement design") }
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3446

### Changes proposed in this pull request

This adds some basic details to the financial statements page, highlighting potential rounding errors and the updated designs.

### Guidance to review

- [ ] Look at a statement and check content in the two details is as expected!
