### PR TITLE
Increase Teacher TRS sync throughput

### DIFF
--- a/app/jobs/teachers/schedule_trs_sync_job.rb
+++ b/app/jobs/teachers/schedule_trs_sync_job.rb
@@ -2,13 +2,13 @@ module Teachers
   class ScheduleTRSSyncJob < ApplicationJob
     queue_as :default
 
-    BATCH_SIZE = 1200
+    BATCH_SIZE = 50
 
     def perform
       teachers = Teacher.found_in_trs.active_in_trs.ordered_by_trs_data_last_refreshed_at_nulls_first.limit(BATCH_SIZE)
 
       teachers.each_with_index do |teacher, i|
-        Teachers::SyncTeacherWithTRSJob.set(wait: (i * 3).seconds).perform_later(teacher:)
+        Teachers::SyncTeacherWithTRSJob.set(wait: i.seconds).perform_later(teacher:)
       end
     end
   end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -12,7 +12,7 @@ production:
   schedule_trs_sync:
     class: Teachers::ScheduleTRSSyncJob
     queue: default
-    schedule: Every hour
+    schedule: Every minute
 
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"

--- a/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
+++ b/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Teachers::ScheduleTRSSyncJob, type: :job do
     it "schedules sync jobs for teachers ordered by trs_data_last_refreshed_at" do
       [
         [teacher0, 0],
-        [teacher1, 3],
-        [teacher2, 6],
-        [teacher3, 9],
-        [teacher4, 12],
-        [teacher5, 15],
+        [teacher1, 1],
+        [teacher2, 2],
+        [teacher3, 3],
+        [teacher4, 4],
+        [teacher5, 5],
       ].each do |teacher, wait_time|
         allow(Teachers::SyncTeacherWithTRSJob).to receive(:set).with(wait: wait_time.seconds).and_return(Teachers::SyncTeacherWithTRSJob)
 


### PR DESCRIPTION
### Context

Resolves: https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3203
We want a faster refresh of Teachers from TRS.

### Changes proposed in this pull request

* Increases the job frequency from every hour to every minute, 
* but decreases the batch size from 1200 to 50.
* increases the frequency of the individual refreshes from i.seconds * 3, to i.seconds (i.e. 1 per second) 

This means we do one refresh per second for 50 seconds then take an approximate 10 seconds rest.
We can expect to increase the overall throughput from 1200 to 3000 per hour, 
while having a greater protection against hitting the rate limits (500 per minute).

### Guidance to review

* There are currently around 60,000 Teachers to be refreshed.