### PR TITLE
Do not migrate `voided` and `submitted` declarations for ERO mentors

### DIFF
--- a/app/migration/migrators/declaration.rb
+++ b/app/migration/migrators/declaration.rb
@@ -19,6 +19,15 @@ module Migrators
         .includes(:participant_profile, :statement_line_items, :cohort, cpd_lead_provider: :lead_provider)
         .not_superseded
         .not_ineligible
+        .where.not(id: ero_mentor_declarations_to_exclude)
+    end
+
+    def self.ero_mentor_declarations_to_exclude
+      ::Migration::ParticipantDeclaration
+        .joins(participant_profile: :teacher_profile)
+        .joins("inner join ecf_ineligible_participants eip on eip.trn = teacher_profiles.trn")
+        .where(state: %w[voided submitted])
+        .where(participant_profile: { type: "ParticipantProfile::Mentor" })
     end
 
     def self.dependencies

--- a/spec/factories/migration/participant_declaration_factory.rb
+++ b/spec/factories/migration/participant_declaration_factory.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     trait :mentor do
       type { "ParticipantDeclaration::Mentor" }
       participant_profile { FactoryBot.create(:migration_participant_profile, :mentor, cohort:) }
+      course_identifier { "ecf-mentor" }
     end
 
     trait :billable do

--- a/spec/migration/migrators/declaration_spec.rb
+++ b/spec/migration/migrators/declaration_spec.rb
@@ -8,6 +8,18 @@ describe Migrators::Declaration do
   end
 
   def create_training_period_and_statements_for(participant_declaration)
+    training_period = create_training_period_for(participant_declaration)
+    active_lead_provider = training_period.school_partnership.lead_provider_delivery_partnership.active_lead_provider
+    contract_period = active_lead_provider.contract_period
+
+    {
+      training_period:,
+      payment_statement: FactoryBot.create(:statement, status: "paid", contract_period:, active_lead_provider:, api_id: participant_declaration.payment_statement.id),
+      clawback_statement: FactoryBot.create(:statement, status: "paid", contract_period:, active_lead_provider:, api_id: participant_declaration.clawback_statement.id)
+    }
+  end
+
+  def create_training_period_for(participant_declaration)
     ecf_lead_provider = participant_declaration.cpd_lead_provider.lead_provider
     lead_provider = FactoryBot.create(:lead_provider, ecf_id: ecf_lead_provider.id, name: ecf_lead_provider.name)
     delivery_partner = FactoryBot.create(:delivery_partner)
@@ -15,14 +27,16 @@ describe Migrators::Declaration do
     active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
     lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
     school_partnership = FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:)
-    teacher = FactoryBot.create(:teacher, api_ect_training_record_id: participant_declaration.participant_profile_id)
-    ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher:, school: school_partnership.school)
 
-    {
-      training_period: FactoryBot.create(:training_period, school_partnership:, ect_at_school_period:),
-      payment_statement: FactoryBot.create(:statement, status: "paid", contract_period:, active_lead_provider:, api_id: participant_declaration.payment_statement.id),
-      clawback_statement: FactoryBot.create(:statement, status: "paid", contract_period:, active_lead_provider:, api_id: participant_declaration.clawback_statement.id)
-    }
+    if participant_declaration.participant_profile.ect?
+      teacher = FactoryBot.create(:teacher, api_ect_training_record_id: participant_declaration.participant_profile_id)
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, teacher:, school: school_partnership.school)
+      FactoryBot.create(:training_period, :for_ect, school_partnership:, ect_at_school_period:)
+    else
+      teacher = FactoryBot.create(:teacher, api_mentor_training_record_id: participant_declaration.participant_profile_id)
+      mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, teacher:, school: school_partnership.school)
+      FactoryBot.create(:training_period, :for_mentor, school_partnership:, mentor_at_school_period:)
+    end
   end
 
   it_behaves_like "a migrator", :declaration, %i[statement mentor ect] do
@@ -39,28 +53,75 @@ describe Migrators::Declaration do
 
   describe "#migrate!" do
     let(:instance) { described_class.new(worker: 0) }
-    let(:clawback_statement) { Statement.find_by_api_id(participant_declaration.clawback_statement.id) }
-    let(:payment_statement) { Statement.find_by_api_id(participant_declaration.payment_statement.id) }
-    let(:ecf_lead_provider_id) { participant_declaration.cpd_lead_provider.lead_provider.id }
-
     let!(:data_migration) { FactoryBot.create(:data_migration, model: :declaration, worker: 0) }
-    let!(:participant_declaration) { create_participant_declaration }
-    let!(:training_period) { create_training_period_and_statements_for(participant_declaration)[:training_period] }
 
-    it "sets the created declaration attributes correctly" do
-      instance.migrate!
+    context "when the declaration is not related to an ERO mentor" do
+      let(:clawback_statement) { Statement.find_by_api_id(participant_declaration.clawback_statement.id) }
+      let(:payment_statement) { Statement.find_by_api_id(participant_declaration.payment_statement.id) }
+      let(:ecf_lead_provider_id) { participant_declaration.cpd_lead_provider.lead_provider.id }
+      let!(:participant_declaration) { create_participant_declaration }
+      let!(:training_period) { create_training_period_and_statements_for(participant_declaration)[:training_period] }
 
-      Declaration.find_by(api_id: participant_declaration.id) do |declaration|
-        aggregate_failures do
-          expect(declaration).to have_attributes(participant_declaration.attributes.slice("created_at", "declaration_date", "declaration_type", "evidence_type", "pupil_premium_uplift", "sparsity_uplift", "updated_at"))
-          expect(declaration.clawback_statement_id).to eq(clawback_statement.id)
-          expect(declaration.clawback_status).to eq(participant_declaration.clawback_status)
-          expect(declaration.delivery_partner_when_created.id).to eq(training_period.delivery_partner.id)
-          expect(declaration.lead_provider.ecf_id).to eq(ecf_lead_provider_id)
-          expect(declaration.payment_statement_id).to eq(payment_statement.id)
-          expect(declaration.payment_status).to eq(participant_declaration.payment_status)
-          expect(declaration.training_period_id).to eq(training_period.id)
-          expect(declaration.voided_by_user_at).to eq(participant_declaration.voided_at)
+      it "sets the created declaration attributes correctly" do
+        instance.migrate!
+
+        Declaration.find_by(api_id: participant_declaration.id) do |declaration|
+          aggregate_failures do
+            expect(declaration).to have_attributes(participant_declaration.attributes.slice("created_at", "declaration_date", "declaration_type", "evidence_type", "pupil_premium_uplift", "sparsity_uplift", "updated_at"))
+            expect(declaration.clawback_statement_id).to eq(clawback_statement.id)
+            expect(declaration.clawback_status).to eq(participant_declaration.clawback_status)
+            expect(declaration.delivery_partner_when_created.id).to eq(training_period.delivery_partner.id)
+            expect(declaration.lead_provider.ecf_id).to eq(ecf_lead_provider_id)
+            expect(declaration.payment_statement_id).to eq(payment_statement.id)
+            expect(declaration.payment_status).to eq(participant_declaration.payment_status)
+            expect(declaration.training_period_id).to eq(training_period.id)
+            expect(declaration.voided_by_user_at).to eq(participant_declaration.voided_at)
+          end
+        end
+      end
+    end
+
+    context "when the declaration belongs to an ERO mentor" do
+      let(:mentor_profile) { mentor_declaration.participant_profile }
+      let!(:ineligible_entry) { FactoryBot.create(:migration_ecf_ineligible_participant, trn: mentor_profile.teacher_profile.trn) }
+
+      context "when the declaration is not in an excluded state" do
+        let!(:mentor_declaration) { FactoryBot.create(:migration_participant_declaration, :mentor, :billable) }
+        let!(:training_period) { create_training_period_for(mentor_declaration) }
+
+        let!(:statement) do
+          FactoryBot.create(:statement, status: "payable", contract_period: training_period.contract_period,
+                                        active_lead_provider: training_period.school_partnership.active_lead_provider,
+                                        api_id: mentor_declaration.payment_statement.id)
+        end
+
+        it "migrates the declaration" do
+          expect {
+            instance.migrate!
+          }.to change { training_period.declarations.count }.by(1)
+        end
+      end
+
+      context "when the declaration has voided state" do
+        let!(:mentor_declaration) { FactoryBot.create(:migration_participant_declaration, :mentor, state: "voided") }
+        let!(:training_period) { create_training_period_for(mentor_declaration) }
+
+        it "does not migrate the declaration" do
+          expect {
+            instance.migrate!
+          }.not_to(change { training_period.declarations.count })
+        end
+      end
+
+      context "when the declaration has submitted state" do
+        let!(:mentor_declaration) { FactoryBot.create(:migration_participant_declaration, :mentor, state: "submitted") }
+        let!(:training_period) { create_training_period_for(mentor_declaration) }
+        let(:state) { "submitted" }
+
+        it "does not migrate the declaration" do
+          expect {
+            instance.migrate!
+          }.not_to(change { training_period.declarations.count })
         end
       end
     end


### PR DESCRIPTION
### Context

We do not create `TrainingPeriod` records for ERO mentors unless they have a valid declaration. This means that there is nowhere for "invalid" declarations for these mentors to be stored and as we are not interested in these we should not migrate them.

This PR removes these from the declarations migrator

### Changes proposed in this pull request

Change declarations migrator so that it does not migrate `voided` or `submitted` declarations for ERO mentors

### Guidance to review
