### PR TITLE
Drop the public schema before restoring parity check/migration envs

### DIFF
--- a/.github/actions/refresh-database/action.yml
+++ b/.github/actions/refresh-database/action.yml
@@ -87,4 +87,7 @@ runs:
 
     - name: Restore to ${{ inputs.target_environment }} DB
       shell: bash
-      run: bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-${{ env.DB_INSTANCE }}-pg -k s189p01-cpdec2-${{ env.DB_INSTANCE }}-app-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ec2-${{ inputs.target_environment }}-web -- psql
+      run: |
+        bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-${{ env.DB_INSTANCE }}-pg -k s189p01-cpdec2-${{ env.DB_INSTANCE }}-app-kv -t 60 cpd-ec2-${{ inputs.target_environment }}-web -- psql -c "drop schema public cascade; create schema public;"
+
+        bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-${{ env.DB_INSTANCE }}-pg -k s189p01-cpdec2-${{ env.DB_INSTANCE }}-app-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ec2-${{ inputs.target_environment }}-web -- psql


### PR DESCRIPTION
We ran into problems where the database wasn't being restored correctly
because of object interdependencies. This should give us a clean slate
to restore into.