### PR TITLE
Upgrade zlib to 1.3.2-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apk add --update --no-cache tzdata && \
 
 # build-base: dependencies for bundle
 # postgresql-dev: postgres driver and libraries
-RUN apk add --no-cache build-base yaml-dev nodejs npm postgresql16-dev
+# zlib-dev: required for some gems with native extensions
+RUN apk add --no-cache build-base yaml-dev nodejs npm postgresql18-dev zlib-dev && \
+    apk upgrade --no-cache zlib zlib-dev
 
 # Install gems defined in Gemfile
 COPY .ruby-version Gemfile Gemfile.lock ./
@@ -76,7 +78,9 @@ RUN apk add --update --no-cache tzdata && \
 RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
 
 # libpq: required to run postgres
-RUN apk add --no-cache libpq
+# zlib: required for runtime compression support
+RUN apk add --no-cache libpq zlib && \
+    apk upgrade --no-cache zlib
 
 RUN apk add --no-cache plantuml # FIXME can be removed once the migration is done
 


### PR DESCRIPTION
### Context

Security vulnerability found on zlib <1.3.2-r0 which is in Alpine <= 3.23

https://security.snyk.io/vuln/SNYK-ALPINE323-ZLIB-15435528

```
✗ Critical severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE323-ZLIB-15435528
  Introduced through: zlib/zlib@1.3.1-r2
  From: zlib/zlib@1.3.1-r2
  Image layer: Introduced by your base image (ruby:3.4.8-alpine)
  Fixed in: 1.3.2-r0
```

### Changes proposed in this pull request

- upgrade zlib version to 1.3.2-r0 or higher;

### Guidance to review
