### PR TITLE
Revert "Scale down webapps"

### DIFF
--- a/config/terraform/application/config/paritycheck.tfvars.json
+++ b/config/terraform/application/config/paritycheck.tfvars.json
@@ -6,6 +6,6 @@
     "worker_memory_max": "4Gi",
     "webapp_memory_max": "2Gi",
     "worker_replicas": 10,
-    "webapp_replicas": 1,
+    "webapp_replicas": 6,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }


### PR DESCRIPTION
This reverts commit 1b05cf65b6497aa16508cd0243614eb730686bde.

Now that we're running parity checks again its timing out as we only have 1 web app; the workers end up hitting the same web app. Ramping back up to 6 so that it can better deal with the load.