### PR TITLE
Populate `api_updated_at` when migrating statements

### DIFF
--- a/app/migration/migrators/statement.rb
+++ b/app/migration/migrators/statement.rb
@@ -45,7 +45,8 @@ module Migrators
         fee_type: fee_type(ecf_statement),
         status: status(ecf_statement),
         created_at: ecf_statement.created_at,
-        updated_at: ecf_statement.updated_at
+        updated_at: ecf_statement.updated_at,
+        api_updated_at: ecf_statement.updated_at
       )
 
       statement

--- a/spec/migration/migrators/statement_spec.rb
+++ b/spec/migration/migrators/statement_spec.rb
@@ -43,6 +43,8 @@ describe Migrators::Statement do
           expect(statement.status).to eq("open")
           expect(statement.fee_type).to eq("output")
           expect(statement.contract).to eq(contract)
+          expect(statement.updated_at).to eq(migration_resource1.updated_at)
+          expect(statement.api_updated_at).to eq(statement.updated_at)
         end
       end
 


### PR DESCRIPTION
We are not populating the `api_updated_at`, so the parity check highlighted that the `updated_at` in the API response is defaulting to the time the migration was ran.

Set `api_updated_at` to `updated_at` during `Statement` migration.
