### PR TITLE
Add provider targets to statements page

### DIFF
--- a/app/components/admin/statements/provider_targets_component.rb
+++ b/app/components/admin/statements/provider_targets_component.rb
@@ -1,0 +1,27 @@
+module Admin::Statements
+  class ProviderTargetsComponent < ApplicationComponent
+    def initialize(statement:)
+      @statement = statement
+    end
+
+    erb_template <<~ERB
+      <%= govuk_details(summary_text: "Provider targets (per academic year)") do %>
+          <%= govuk_summary_list do |summary_list|
+            summary_list.with_row do |row|
+              row.with_key { "Provider" }
+              row.with_value { lead_provider.name }
+            end
+          end %>
+
+          <%= render BandedFeeComponent.new(contract:) %>
+          <%= render FlatRateFeeComponent.new(contract:) %>
+      <% end %>
+    ERB
+
+  private
+
+    attr_reader :statement
+
+    delegate :contract, :lead_provider, to: :statement, private: true
+  end
+end

--- a/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
+++ b/app/components/admin/statements/provider_targets_component/banded_fee_component.rb
@@ -1,0 +1,102 @@
+module Admin::Statements
+  class ProviderTargetsComponent::BandedFeeComponent < ApplicationComponent
+    REVISED_RECRUITMENT_TARGET_MULTIPLIER = 1.5
+    UPLIFT_TARGET_PERCENTAGE = 33
+
+    def initialize(contract:)
+      @contract = contract
+    end
+
+    def render? = banded_fee_structure.present?
+
+    erb_template <<~ERB
+      <%=
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key(text: recruitment_target_label)
+            row.with_value(text: recruitment_target)
+          end
+
+          summary_list.with_row do |row|
+            row.with_key(text: revisted_recruitment_target_label)
+            row.with_value(text: (recruitment_target * REVISED_RECRUITMENT_TARGET_MULTIPLIER).to_i)
+          end
+
+          if display_uplifts?
+            summary_list.with_row do |row|
+              row.with_key(text: "Uplift target")
+              row.with_value(text: number_to_percentage(UPLIFT_TARGET_PERCENTAGE, precision: 0))
+            end
+
+            summary_list.with_row do |row|
+              row.with_key(text: "Uplift amount")
+              row.with_value(text: number_to_pounds(uplift_amount))
+            end
+          end
+
+          summary_list.with_row do |row|
+            row.with_key(text: "Setup fee")
+            row.with_value(text: number_to_pounds(setup_fee))
+          end
+        end
+      %>
+
+      <%=
+        govuk_table do |table|
+          table.with_caption(text: "Contract bands", classes: "govuk-visually-hidden")
+
+          table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(header: true) { "Band" }
+              row.with_cell(header: true, numeric: true, text: "Min")
+              row.with_cell(header: true, numeric: true, text: "Max")
+              row.with_cell(header: true, numeric: true, text: "Payment amount per participant")
+            end
+          end
+
+          table.with_body do |body|
+            bands.each_with_index do |band, index|
+              body.with_row do |row|
+                row.with_cell { band_label(index) }
+                row.with_cell(numeric: true, text: band.min_declarations)
+                row.with_cell(numeric: true, text: band.max_declarations)
+                row.with_cell(numeric: true, text: number_to_pounds(band.fee_per_declaration))
+              end
+            end
+          end
+        end
+      %>
+    ERB
+
+  private
+
+    attr_reader :contract
+
+    delegate :banded_fee_structure, to: :contract, private: true
+    delegate :number_to_pounds, :number_to_percentage, to: :helpers
+
+    def recruitment_target_label
+      if contract.ecf_contract_type?
+        "Recruitment target"
+      else
+        "ECTs recruitment target"
+      end
+    end
+
+    def revisted_recruitment_target_label
+      "Revised recruitment target " \
+      "(#{number_to_percentage(REVISED_RECRUITMENT_TARGET_MULTIPLIER * 100, precision: 0)})"
+    end
+
+    def recruitment_target = banded_fee_structure.recruitment_target
+    def display_uplifts? = contract.ecf_contract_type?
+    def uplift_amount = banded_fee_structure.uplift_fee_per_declaration
+    def setup_fee = banded_fee_structure.setup_fee
+    def bands = banded_fee_structure.bands
+
+    def band_label(index)
+      letter = ("A"..."Z").to_a[index]
+      "Band #{letter}"
+    end
+  end
+end

--- a/app/components/admin/statements/provider_targets_component/flat_rate_fee_component.rb
+++ b/app/components/admin/statements/provider_targets_component/flat_rate_fee_component.rb
@@ -1,0 +1,35 @@
+module Admin::Statements
+  class ProviderTargetsComponent::FlatRateFeeComponent < ApplicationComponent
+    def initialize(contract:)
+      @contract = contract
+    end
+
+    def render? = flat_rate_fee_structure.present?
+
+    erb_template <<~ERB
+      <%=
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key(text: "Mentors recruitment target")
+            row.with_value(text: recruitment_target)
+          end
+
+          summary_list.with_row do |row|
+            row.with_key(text: "Payment per participant")
+            row.with_value(text: number_to_pounds(payment_per_participant))
+          end
+        end
+      %>
+    ERB
+
+  private
+
+    attr_reader :contract
+
+    delegate :flat_rate_fee_structure, to: :contract, private: true
+    delegate :number_to_pounds, :number_to_percentage, to: :helpers
+
+    def recruitment_target = flat_rate_fee_structure.recruitment_target
+    def payment_per_participant = flat_rate_fee_structure.fee_per_declaration
+  end
+end

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -50,4 +50,5 @@
 <%= render Admin::Statements::UpliftFeesComponent.new(statement: @statement) %>
 <%= render Admin::Statements::ClawbacksComponent.new(statement: @statement) %>
 <%= render Admin::Statements::AdjustmentsComponent.new(statement: @statement) %>
+<%= render Admin::Statements::ProviderTargetsComponent.new(statement: @statement) %>
 <%= render Admin::Statements::GuidanceComponent.new %>

--- a/spec/components/admin/statements/provider_targets_component/banded_fee_component_spec.rb
+++ b/spec/components/admin/statements/provider_targets_component/banded_fee_component_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe Admin::Statements::ProviderTargetsComponent::BandedFeeComponent, type: :component do
+  subject(:component) { described_class.new(contract:) }
+
+  let(:banded_fee_structure) do
+    FactoryBot.build_stubbed(
+      :contract_banded_fee_structure,
+      :with_bands,
+      recruitment_target: 2500,
+      uplift_fee_per_declaration: 50,
+      setup_fee: 5000,
+      declaration_boundaries: [
+        { min: 1, max: 50 },
+        { min: 51, max: 100 },
+        { min: 101, max: 150 }
+      ]
+    )
+  end
+
+  before { render_inline(component) }
+
+  context "when there is no banded fee structure" do
+    let(:contract) { FactoryBot.build_stubbed(:contract, banded_fee_structure: nil) }
+
+    it "does not render anything" do
+      expect(page).to have_no_selector("body")
+    end
+  end
+
+  context "for `ecf` contracts" do
+    let(:contract) do
+      FactoryBot.build_stubbed(:contract, :for_ecf, banded_fee_structure:)
+    end
+
+    it "renders the recruitment target" do
+      expect(page).to have_summary_list_row("Recruitment target", value: "2500")
+    end
+
+    it "renders the revised recruitment target" do
+      expect(page).to have_summary_list_row("Revised recruitment target (150%)", value: "3750")
+    end
+
+    it "renders the uplift target" do
+      expect(page).to have_summary_list_row("Uplift target", value: "33%")
+    end
+
+    it "renders the uplift amount" do
+      expect(page).to have_summary_list_row("Uplift amount", value: "£50.00")
+    end
+
+    it "renders the setup fee" do
+      expect(page).to have_summary_list_row("Setup fee", value: "£5,000.00")
+    end
+
+    it "renders a table of the bands" do
+      expect(page).to have_statement_table(
+        caption: "Contract bands",
+        headings: ["Band", "Min", "Max", "Payment amount per participant"],
+        rows: [
+          ["Band A", 1, 50, /£\d+\.\d{2}/],
+          ["Band B", 51, 100, /£\d+\.\d{2}/],
+          ["Band C", 101, 150, /£\d+\.\d{2}/]
+        ]
+      )
+    end
+  end
+
+  context "for `ittecf_ectp` contracts" do
+    let(:contract) do
+      FactoryBot.build_stubbed(:contract, :for_ittecf_ectp, banded_fee_structure:)
+    end
+
+    it "renders the recruitment target" do
+      expect(page).to have_summary_list_row("ECTs recruitment target", value: "2500")
+    end
+
+    it "renders the revised recruitment target" do
+      expect(page).to have_summary_list_row("Revised recruitment target (150%)", value: "3750")
+    end
+
+    it "does not render the uplift target" do
+      expect(page).not_to have_summary_list_row("Uplift target")
+    end
+
+    it "does not render the uplift amount" do
+      expect(page).not_to have_summary_list_row("Uplift amount")
+    end
+
+    it "renders the setup fee" do
+      expect(page).to have_summary_list_row("Setup fee", value: "£5,000.00")
+    end
+
+    it "renders a table of the bands" do
+      expect(page).to have_statement_table(
+        caption: "Contract bands",
+        headings: ["Band", "Min", "Max", "Payment amount per participant"],
+        rows: [
+          ["Band A", 1, 50, /£\d+\.\d{2}/],
+          ["Band B", 51, 100, /£\d+\.\d{2}/],
+          ["Band C", 101, 150, /£\d+\.\d{2}/]
+        ]
+      )
+    end
+  end
+end

--- a/spec/components/admin/statements/provider_targets_component/flat_rate_fee_component_spec.rb
+++ b/spec/components/admin/statements/provider_targets_component/flat_rate_fee_component_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Admin::Statements::ProviderTargetsComponent::FlatRateFeeComponent, type: :component do
+  subject(:component) { described_class.new(contract:) }
+
+  let(:contract) { FactoryBot.build_stubbed(:contract, flat_rate_fee_structure:) }
+  let(:flat_rate_fee_structure) do
+    FactoryBot.create(
+      :contract_flat_rate_fee_structure,
+      recruitment_target: 3000,
+      fee_per_declaration: 750
+    )
+  end
+
+  before { render_inline(component) }
+
+  context "when there is no flat rate fee structure" do
+    let(:flat_rate_fee_structure) { nil }
+
+    it "does not render anything" do
+      expect(page).to have_no_selector("body")
+    end
+  end
+
+  it "renders the recruitment target" do
+    expect(page).to have_summary_list_row("Mentors recruitment target", value: "3000")
+  end
+
+  it "renders the payment per participant" do
+    expect(page).to have_summary_list_row("Payment per participant", value: "£750.00")
+  end
+end

--- a/spec/components/admin/statements/provider_targets_component_spec.rb
+++ b/spec/components/admin/statements/provider_targets_component_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Admin::Statements::ProviderTargetsComponent, type: :component do
+  subject(:component) { described_class.new(statement:) }
+
+  let(:statement) { FactoryBot.create(:statement) }
+
+  before do
+    allow(Admin::Statements::ProviderTargetsComponent::BandedFeeComponent)
+      .to receive(:new)
+      .with(contract: statement.contract)
+      .and_call_original
+    allow(Admin::Statements::ProviderTargetsComponent::FlatRateFeeComponent)
+      .to receive(:new)
+      .with(contract: statement.contract)
+      .and_call_original
+
+    render_inline(component)
+  end
+
+  it "renders the provider targets" do
+    expect(page).to have_css("details", text: "Provider targets (per academic year)")
+  end
+
+  it "renders the lead provider name" do
+    expect(page).to have_summary_list_row(
+      "Provider",
+      value: statement.lead_provider.name,
+      visible: :hidden
+    )
+  end
+
+  it "renders the banded fee contract targets" do
+    expect(Admin::Statements::ProviderTargetsComponent::BandedFeeComponent)
+      .to have_received(:new)
+      .with(contract: statement.contract)
+  end
+
+  it "renders the flat rate fee contract targets" do
+    expect(Admin::Statements::ProviderTargetsComponent::FlatRateFeeComponent)
+      .to have_received(:new)
+      .with(contract: statement.contract)
+  end
+end

--- a/spec/factories/contract_factory.rb
+++ b/spec/factories/contract_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     trait(:for_ecf) do
       contract_type { "ecf" }
       ecf_contract_version { "1" }
-      association :banded_fee_structure, factory: :contract_banded_fee_structure
+      association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure
       flat_rate_fee_structure_id { nil }
     end
 
@@ -15,7 +15,7 @@ FactoryBot.define do
       contract_type { "ittecf_ectp" }
       ecf_contract_version { "1" }
       ecf_mentor_contract_version { "2" }
-      association :banded_fee_structure, factory: :contract_banded_fee_structure
+      association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure
       association :flat_rate_fee_structure, factory: :contract_flat_rate_fee_structure
     end
   end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -65,7 +65,13 @@ describe Contract do
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
 
     context "when creating a new contract" do
-      let(:contract) { FactoryBot.build(:contract, active_lead_provider:) }
+      let(:contract) do
+        FactoryBot.build(
+          :contract,
+          active_lead_provider:,
+          banded_fee_structure: FactoryBot.create(:contract_banded_fee_structure)
+        )
+      end
 
       it "assigns the active lead provider" do
         expect { contract.save! }.not_to raise_error

--- a/spec/support/matchers/have_statement_table.rb
+++ b/spec/support/matchers/have_statement_table.rb
@@ -1,6 +1,6 @@
 module HaveStatementTable
   class Matcher
-    def initialize(caption:, headings:, rows:, total:)
+    def initialize(caption:, headings:, rows:, total: nil)
       @caption = caption
       @headings = headings
       @rows = rows
@@ -29,8 +29,10 @@ module HaveStatementTable
       end
 
       # Assert the expected total is displayed as a heading
-      total = table.sibling(".govuk-heading-s", text: "Total")
-      return false unless total.sibling(".govuk-heading-s").has_text?(@total)
+      if @total
+        total = table.sibling(".govuk-heading-s", text: "Total")
+        return false unless total.sibling(".govuk-heading-s").has_text?(@total)
+      end
 
       true
     end

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
     expect(rendered).to have_css(".govuk-summary-list")
   end
 
+  it "displays provider targets" do
+    render
+
+    expect(rendered).to have_css("details", text: "Provider targets (per academic year)")
+  end
+
   context "for `ecf` contracts" do
     let(:contract_trait) { :for_ecf }
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3445

### Changes proposed in this pull request

This adds a `<details>` element outlining the provider targets for a given contract on the statements page.

Since all contracts have a `banded_fee_structure`, we always render the table of bands. When a contract has a `flat_rate_fee_structure` too, we render a breakdown of those targets as well.

In ECF, the revised recruitment target multiplier and uplift target percentage are the same for all contracts, so we have hardcoded these values rather than adding them to the schema.

### Guidance to review

<details>
<summary>ecf contracts (pre-2025)</summary>
<img width="1040" height="675" alt="image" src="https://github.com/user-attachments/assets/a21a3bac-6aa2-4e93-85ac-2fc30554c605" />
</details>

<details>
<summary>ittecf_ectp contracts (post-2024)</summary>
<img width="1015" height="644" alt="image" src="https://github.com/user-attachments/assets/d18cf3ae-a940-4df8-bebb-169d240f1d21" />
</details>
