### PR TITLE
Hide school start date and working pattern for migrated data

### DIFF
--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -56,6 +56,10 @@ module Schools
         !withdrawn_training_period?
       end
 
+      def show_school_start_date_row?
+        ect_at_school_period.migrated_data_accurate?
+      end
+
       def withdrawn_message_text
         training_period_withdrawn_message_text(
           teacher_name: teacher_full_name(teacher),
@@ -105,6 +109,8 @@ module Schools
       end
 
       def start_date_row
+        return unless show_school_start_date_row?
+
         {
           key: { text: "School start date" },
           value: { text: ect_at_school_period.started_on.to_fs(:govuk) }

--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -50,19 +50,23 @@
     <% end %>
   <% end %>
 
-  <% list.with_row do |row| %>
-    <% row.with_key { "School start date" } %>
-    <% row.with_value { ect_start_date(@ect) } %>
+  <% if show_school_start_date? %>
+    <% list.with_row do |row| %>
+      <% row.with_key { "School start date" } %>
+      <% row.with_value { ect_start_date(@ect) } %>
+    <% end %>
   <% end %>
 
-  <% list.with_row do |row| %>
-    <% row.with_key { "Working pattern" } %>
-    <% row.with_value { @ect.working_pattern&.humanize } %>
-    <% row.with_action(
-      text: "Change",
-      visually_hidden_text: "working pattern",
-      href: schools_ects_change_working_pattern_wizard_edit_path(@ect),
-      classes: "govuk-link--no-visited-state"
-    ) %>
+  <% if show_working_pattern? %>
+    <% list.with_row do |row| %>
+      <% row.with_key { "Working pattern" } %>
+      <% row.with_value { @ect.working_pattern&.humanize } %>
+      <% row.with_action(
+        text: "Change",
+        visually_hidden_text: "working pattern",
+        href: schools_ects_change_working_pattern_wizard_edit_path(@ect),
+        classes: "govuk-link--no-visited-state"
+      ) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/schools/teacher_profile_summary_list_component.rb
+++ b/app/components/schools/teacher_profile_summary_list_component.rb
@@ -10,6 +10,9 @@ module Schools
 
   private
 
+    def show_school_start_date? = @ect.migrated_data_accurate?
+    def show_working_pattern? = @ect.migrated_data_accurate?
+
     def show_withdrawn_or_deferred_status?
       return false if leaving_school?
       return false if exempt?

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -1,4 +1,6 @@
 class ECTAtSchoolPeriod < ApplicationRecord
+  RECT_GO_LIVE_DATE = Date.new(2026, 4, 28).freeze
+
   include Interval
   include DeclarativeUpdates
 
@@ -145,6 +147,10 @@ class ECTAtSchoolPeriod < ApplicationRecord
     mentors = Schools::EligibleMentors.new(school).for_ect(self)
 
     mentors.excluding(current_mentor).exists?
+  end
+
+  def migrated_data_accurate?
+    teacher.not_migrated_migration_mode? || created_at.after?(RECT_GO_LIVE_DATE.beginning_of_day)
   end
 
   delegate :trn, :trs_initial_teacher_training_provider_name, to: :teacher

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -336,4 +336,30 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
       expect(rendered_content).not_to have_css("strong.govuk-tag.govuk-tag--yellow", text: "Leaving school")
     end
   end
+
+  context "when the ECT's migrated data is not accurate" do
+    before do
+      allow(ect_at_school_period).to receive(:migrated_data_accurate?).and_return(false)
+    end
+
+    it "does not show the start date" do
+      component = described_class.new(teacher:, ect_at_school_period:, training_period:)
+      render_inline(component)
+
+      expect(page).not_to have_summary_list_row("School start date")
+    end
+  end
+
+  context "when the ECT's migrated data is accurate" do
+    before do
+      allow(ect_at_school_period).to receive(:migrated_data_accurate?).and_return(true)
+    end
+
+    it "shows the start date" do
+      component = described_class.new(teacher:, ect_at_school_period:, training_period:)
+      render_inline(component)
+
+      expect(page).to have_summary_list_row("School start date")
+    end
+  end
 end

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -247,4 +247,34 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
       expect(page).not_to have_text("Mentor required")
     end
   end
+
+  context "when the ECT's migrated data is not accurate" do
+    before do
+      allow(mentee).to receive(:migrated_data_accurate?).and_return(false)
+      render_inline(described_class.new(mentee))
+    end
+
+    it "does not show the school start date" do
+      expect(page).not_to have_summary_list_row("School start date")
+    end
+
+    it "does not show the working pattern" do
+      expect(page).not_to have_summary_list_row("Working pattern")
+    end
+  end
+
+  context "when the ECT's migrated data is accurate" do
+    before do
+      allow(mentee).to receive(:migrated_data_accurate?).and_return(true)
+      render_inline(described_class.new(mentee))
+    end
+
+    it "shows the school start date" do
+      expect(page).to have_summary_list_row("School start date")
+    end
+
+    it "shows the working pattern" do
+      expect(page).to have_summary_list_row("Working pattern")
+    end
+  end
 end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -619,4 +619,73 @@ describe ECTAtSchoolPeriod do
       end
     end
   end
+
+  describe "#migrated_data_accurate?" do
+    subject(:migrated_data_accurate?) { ect_at_school_period.migrated_data_accurate? }
+
+    before do
+      stub_const(
+        "ECTAtSchoolPeriod::RECT_GO_LIVE_DATE",
+        Date.yesterday
+      )
+    end
+
+    let(:ect_at_school_period) do
+      FactoryBot.build_stubbed(:ect_at_school_period, teacher:, created_at:)
+    end
+
+    context "when the teacher has not been migrated" do
+      let(:teacher) do
+        FactoryBot.build_stubbed(:teacher, :not_migrated)
+      end
+
+      context "when the record was created after `RECT_GO_LIVE_DATE`" do
+        let(:created_at) { Time.current }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the record was created before `RECT_GO_LIVE_DATE`" do
+        let(:created_at) { 2.days.ago }
+
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    context "when the teacher has been partially migrated" do
+      let(:teacher) do
+        FactoryBot.build_stubbed(:teacher, :latest_induction_records)
+      end
+
+      context "when the record was created after `RECT_GO_LIVE_DATE`" do
+        let(:created_at) { Time.current }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the record was created before `RECT_GO_LIVE_DATE`" do
+        let(:created_at) { 2.days.ago }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context "when the teacher has been fully migrated" do
+      let(:teacher) do
+        FactoryBot.build_stubbed(:teacher, :all_induction_records)
+      end
+
+      context "when the record was created after `RECT_GO_LIVE_DATE`" do
+        let(:created_at) { Time.current }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the record was created before `RECT_GO_LIVE_DATE`" do
+        let(:created_at) { 2.days.ago }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3390

### Changes proposed in this pull request

Before, we always displayed school start date and working pattern for ECTs.

For migrated data, it is likely the data is inaccurate. In that case, we don't want to show it to users!

This tweaks the `Schools::ECTs::ListingCardComponent` and the `Schools::TeacherProfileSummaryListComponent` to only show school start dates and working patterns when the following criteria are met:

- Teacher migration mode is `not_migrated`, **or**
- ECT record was created **after** the go live date (i.e after we have migrated data across from ECF1)

### Guidance to review


