### PR TITLE
Fix parity check bad gateway errors

### DIFF
--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -50,7 +50,7 @@ private
   end
 
   def load_completed_runs
-    completed_runs = ParityCheck::Run.includes(requests: %i[endpoint responses]).completed
+    completed_runs = ParityCheck::Run.completed
     @pagy, @completed_runs = pagy(completed_runs)
   end
 

--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -76,11 +76,13 @@ module ParityCheck
     end
 
     def match_rate
-      rates = responses.map(&:match_rate).compact
+      @match_rate ||= begin
+        rates = responses.where.not(match_rate: nil).pluck(:match_rate)
 
-      return if rates.empty?
+        return if rates.empty?
 
-      rates.sum.fdiv(rates.size).round
+        rates.sum.fdiv(rates.size).round
+      end
     end
 
     def ecf_response_bodies_array

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -107,19 +107,17 @@ module ParityCheck
   private
 
     def calculate_match_rate
-      Rails.cache.fetch(["response", id, created_at, "match_rate"]) do
-        return self.match_rate = 0 if ecf_status_code != rect_status_code
-        return self.match_rate = 100 if matching?
+      return self.match_rate = 0 if ecf_status_code != rect_status_code
+      return self.match_rate = 100 if matching?
 
-        ecf_lines  = ecf_body.to_s.lines.to_set
-        rect_lines = rect_body.to_s.lines.to_set
+      ecf_lines  = ecf_body.to_s.lines.to_set
+      rect_lines = rect_body.to_s.lines.to_set
 
-        diff_lines = (ecf_lines ^ rect_lines).size
-        total_lines = ecf_lines.size + rect_lines.size
+      diff_lines = (ecf_lines ^ rect_lines).size
+      total_lines = ecf_lines.size + rect_lines.size
 
-        self.match_rate =
-          (100 * (1 - diff_lines.to_f / total_lines)).floor
-      end
+      self.match_rate =
+        (100 * (1 - diff_lines.to_f / total_lines)).floor
     end
 
     def format_body(body)

--- a/app/models/parity_check/run.rb
+++ b/app/models/parity_check/run.rb
@@ -63,11 +63,13 @@ module ParityCheck
     end
 
     def match_rate
-      rates = requests.map(&:match_rate).compact
+      @match_rate ||= begin
+        rates = Response.where(request: requests).where.not(match_rate: nil).pluck(:match_rate)
 
-      return if rates.empty?
+        return if rates.empty?
 
-      rates.sum.fdiv(rates.size).round
+        rates.sum.fdiv(rates.size).round
+      end
     end
 
     def progress

--- a/app/views/migration/parity_checks/completed.html.erb
+++ b/app/views/migration/parity_checks/completed.html.erb
@@ -22,7 +22,6 @@
         row.with_cell(text: "Runtime")
         row.with_cell(text: "Mode")
         row.with_cell(text: "Match rate")
-        row.with_cell(text: "Performance")
         row.with_cell
       end
     end
@@ -35,7 +34,6 @@
           row.with_cell(text: distance_of_time_in_words(run.started_at, run.completed_at))
           row.with_cell(text: run.mode.capitalize)
           row.with_cell(text: match_rate_tag(run.match_rate))
-          row.with_cell(text: performance_gain(run.rect_performance_gain_ratio))
           row.with_cell(text: govuk_link_to("Run details", migration_parity_check_path(run)))
         end
       end

--- a/spec/features/migration/view_completed_parity_checks_spec.rb
+++ b/spec/features/migration/view_completed_parity_checks_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "View completed parity checks" do
     expect(tbody.get_by_text("3 minutes")).to be_visible
     expect(tbody.get_by_text("Concurrent")).to be_visible
     expect(tbody.get_by_text("75%")).to be_visible
-    expect(tbody.get_by_text(/faster|slower|equal/)).to be_visible
     expect(tbody.get_by_role("link", name: "Run details")).to be_visible
 
     expect(page.locator(".govuk-pagination")).not_to be_visible

--- a/spec/models/parity_check/run_spec.rb
+++ b/spec/models/parity_check/run_spec.rb
@@ -203,7 +203,7 @@ describe ParityCheck::Run do
     end
     let(:run) { FactoryBot.create(:parity_check_run, :completed, requests:) }
 
-    it { is_expected.to eq(83) }
+    it { is_expected.to eq(75) }
 
     context "when there are no requests" do
       let(:requests) { [] }


### PR DESCRIPTION
Fix bad gateway errors in parity check completed runs The completed runs `includes` all responses for all runs; when the runs contain a lot of responses this is a very expensive query and it causes the web app to fall over.

Instead of `includes` switch to separate, efficient queries to calculate the match rates.

Remove run-level performance metrics as these are also expensive and are computed rather than stored (unlike `match_rate` which we persist on `Response`).

Removes redundant `cache` write (as we store `match_rate` in the model now the caching doesn't really add anything).