### PR TITLE
Wrap ECF2 teacher history-writing in a transaction

### DIFF
--- a/app/migration/migrators/ect.rb
+++ b/app/migration/migrators/ect.rb
@@ -40,7 +40,7 @@ module Migrators
 
       begin
         ecf2_teacher_history = history_converter.convert_to_ecf2!
-        ecf2_teacher_history.save_all_ect_data!
+        Teacher.transaction { ecf2_teacher_history.save_all_ect_data! }
         success = ecf2_teacher_history.success?
       rescue StandardError => e
         failure_manager.record_failure(teacher_profile, e.message, migration_mode)
@@ -54,7 +54,7 @@ module Migrators
           history_converter.set_migration_mode_to_latest_induction_records!
 
           ecf2_teacher_history = history_converter.convert_to_ecf2!
-          ecf2_teacher_history.save_all_ect_data!
+          Teacher.transaction { ecf2_teacher_history.save_all_ect_data! }
           success = ecf2_teacher_history.success?
         rescue StandardError => e
           failure_manager.record_failure(teacher_profile, e.message, migration_mode)

--- a/app/migration/migrators/mentor.rb
+++ b/app/migration/migrators/mentor.rb
@@ -36,7 +36,7 @@ module Migrators
 
       begin
         ecf2_teacher_history = history_converter.convert_to_ecf2!
-        ecf2_teacher_history.save_all_mentor_data!
+        Teacher.transaction { ecf2_teacher_history.save_all_mentor_data! }
         success = ecf2_teacher_history.success?
       rescue StandardError => e
         failure_manager.record_failure(teacher_profile, e.message, migration_mode)
@@ -50,7 +50,7 @@ module Migrators
           history_converter.set_migration_mode_to_latest_induction_records!
 
           ecf2_teacher_history = history_converter.convert_to_ecf2!
-          ecf2_teacher_history.save_all_mentor_data!
+          Teacher.transaction { ecf2_teacher_history.save_all_mentor_data! }
           success = ecf2_teacher_history.success?
         rescue StandardError => e
           failure_manager.record_failure(teacher_profile, e.message, migration_mode)


### PR DESCRIPTION
### Context

This change wraps the writing of complete ECF2 histories into a transaction, which means if any one of the records fails nothing persists in the database.

It's now necessary becuase we're retrying a teacher in the economy migrator if a premium migration fails (#2410).
