### PR TITLE
Fix parity check show timeouts

### DIFF
--- a/app/controllers/migration/parity_checks_controller.rb
+++ b/app/controllers/migration/parity_checks_controller.rb
@@ -27,7 +27,7 @@ class Migration::ParityChecksController < ::AdminController
   end
 
   def show
-    @run = ParityCheck::Run.includes(requests: %i[lead_provider responses endpoint]).completed.find(params[:run_id])
+    @run = ParityCheck::Run.includes(requests: %i[lead_provider endpoint]).completed.find(params[:run_id])
     @breadcrumbs = {
       "Run a parity check" => new_migration_parity_check_path,
       "Completed parity checks" => completed_migration_parity_checks_path,

--- a/app/views/migration/parity_checks/show.html.erb
+++ b/app/views/migration/parity_checks/show.html.erb
@@ -29,10 +29,9 @@
 
       table.with_head do |head|
         head.with_row do |row|
-          row.with_cell(text: "Endpoint", width: "one-quarter")
-          row.with_cell(text: "Description", width: "one-quarter")
-          row.with_cell(text: "Match rate", width: "one-quarter")
-          row.with_cell(text: "Performance", width: "one-quarter")
+          row.with_cell(text: "Endpoint", width: "one-third")
+          row.with_cell(text: "Description", width: "one-third")
+          row.with_cell(text: "Match rate", width: "one-third")
           row.with_cell
         end
       end
@@ -44,7 +43,6 @@
               row.with_cell(text: request.human_readable_url)
               row.with_cell(text: request.description)
               row.with_cell(text: match_rate_tag(request.match_rate))
-              row.with_cell(text: performance_gain(request.rect_performance_gain_ratio))
               row.with_cell(text: govuk_link_to("Request details", migration_parity_check_request_path(@run, request)))
             end
           end

--- a/spec/features/migration/view_parity_check_spec.rb
+++ b/spec/features/migration/view_parity_check_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "View parity check" do
       requests.each do |request|
         expect(table.get_by_text(request.human_readable_url)).to be_visible
         expect(table.get_by_text("#{request.match_rate}%")).to be_visible
-        expect(table.get_by_text(/faster|slower|equal/)).to be_visible
         expect(table.get_by_role("link", name: "Request details")).to be_visible
       end
     end


### PR DESCRIPTION
- Fix timeout on show parity check run page

When the run has a lot of responses we get a timeout due to the large `includes` and from calculating the per-request performance gains.