### PR TITLE
[3428] Increase worker max memory for review apps to prevent `SolidQueue::Processes::ProcessPrunedError` from being raised

### DIFF
--- a/config/terraform/application/config/review.tfvars.json
+++ b/config/terraform/application/config/review.tfvars.json
@@ -5,5 +5,6 @@
     "enable_postgres_ssl": false,
     "enable_logit": true,
     "gcp_table_deletion_protection": false,
-    "create_bigquery_dataset": false
+    "create_bigquery_dataset": false,
+    "worker_memory_max": "2Gi"
 }


### PR DESCRIPTION
### Context

API seeds job is failing and raising `SolidQueue::Processes::ProcessPrunedError` due memory consumption in the review apps;

### Changes proposed in this pull request

- Increasing review app workers memory from 1Gb to 2Gb seems to have fixed it;

### Guidance to review
