### PR TITLE
Add confirmation when accessing production console

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,7 +128,13 @@ Rails/Output:
     - db/seeds*
     # Excluded because this file intentionally writes a dev-only message to stdout after migrations, which does not
     # impact application behavior and is not intended for production environments.
+    - config/initializers/confirm_production_console.rb
+
+Rails/Exit:
+  Enabled: true
+  Exclude:
     - config/initializers/post_migration_erd_prompt.rb
+    - config/initializers/confirm_production_console.rb
 
 Rails/SaveBang:
   Exclude:

--- a/config/initializers/confirm_production_console.rb
+++ b/config/initializers/confirm_production_console.rb
@@ -1,0 +1,10 @@
+if defined?(Rails::Console) && Rails.env.production?
+  puts "\n⚠️  You are opening a Rails console in PRODUCTION."
+  print "Type 'production' to continue: "
+
+  input = $stdin.gets.strip
+  unless input == "production"
+    puts "Aborting console startup."
+    exit(1)
+  end
+end


### PR DESCRIPTION
As we often do a lot of console work in the production space for production-like environments, we want to add an extra layer of safety when accessing the production rails console.

Put rails console behind confirmation prompt.
