### PR TITLE
[3396] Add service to make declarations eligible

### DIFF
--- a/app/helpers/declaration_helper.rb
+++ b/app/helpers/declaration_helper.rb
@@ -24,7 +24,7 @@ module DeclarationHelper
     "teacher_declaration_voided" => "Voided",
     "teacher_declaration_awaiting_clawback" => "Awaiting clawback",
     "teacher_declaration_payable" => "Payable",
-    "teacher_declaration_marked_eligible" => "Eligible",
+    "teacher_declaration_eligible" => "Eligible",
   }.freeze
 
   def declaration_state_tag(declaration)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -60,7 +60,7 @@ class Event < ApplicationRecord
     teacher_declaration_voided
     teacher_declaration_awaiting_clawback
     teacher_declaration_created
-    teacher_declaration_marked_eligible
+    teacher_declaration_eligible
     mentor_completion_status_change
     training_period_assigned_to_school_partnership
     dfe_user_created

--- a/app/services/declarations/actions/mark_declarations_eligible.rb
+++ b/app/services/declarations/actions/mark_declarations_eligible.rb
@@ -1,6 +1,8 @@
 module Declarations
   module Actions
     class MarkDeclarationsEligible
+      class MissingPaymentStatementError < StandardError; end
+
       attr_reader :declarations, :author
 
       def initialize(declarations:, author:)
@@ -10,9 +12,10 @@ module Declarations
 
       def mark
         ApplicationRecord.transaction do
-          declarations.payment_status_no_payment.each do |declaration|
-            declaration.update!(payment_status: :eligible, payment_statement: payment_statement(declaration:))
-            record_eligible_event!(declaration:, author:)
+          declarations.each do |declaration|
+            declaration.payment_statement = payment_statement(declaration:)
+            declaration.mark_as_eligible!
+            record_eligible_event!(declaration:)
           end
         end
       end
@@ -26,11 +29,13 @@ module Declarations
           fee_type: "output",
           deadline_date: Time.zone.today..,
           order: :deadline_date
-        ).statements.first
+        ).statements.first.tap do |statement|
+          raise MissingPaymentStatementError, "Payment statement not found for declaration #{declaration.id}" if statement.nil?
+        end
       end
 
-      def record_eligible_event!(declaration:, author:)
-        Events::Record.record_teacher_declaration_marked_eligible!(
+      def record_eligible_event!(declaration:)
+        Events::Record.record_teacher_declaration_eligible!(
           author:,
           teacher: declaration.training_period.teacher,
           training_period: declaration.training_period,

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -571,10 +571,10 @@ module Events
       new(event_type:, author:, heading:, teacher:, training_period:, declaration:, happened_at:).record_event!
     end
 
-    def self.record_teacher_declaration_marked_eligible!(author:, teacher:, training_period:, declaration:, happened_at: Time.current)
-      event_type = :teacher_declaration_marked_eligible
+    def self.record_teacher_declaration_eligible!(author:, teacher:, training_period:, declaration:, happened_at: Time.current)
+      event_type = :teacher_declaration_eligible
       teacher_name = Teachers::Name.new(teacher).full_name
-      heading = "#{teacher_name}’s declaration was marked as eligible"
+      heading = "#{teacher_name}’s #{declaration.declaration_type} declaration was marked as eligible"
 
       new(event_type:, author:, heading:, teacher:, training_period:, declaration:, happened_at:).record_event!
     end

--- a/app/services/teachers/set_funding_eligibility.rb
+++ b/app/services/teachers/set_funding_eligibility.rb
@@ -8,7 +8,6 @@ class Teachers::SetFundingEligibility
 
   def set!
     ActiveRecord::Base.transaction do
-      grab_current_eligibility
       set_eligibility!
       make_declarations_eligible!
       record_teacher_set_funding_eligibility_event!
@@ -16,11 +15,6 @@ class Teachers::SetFundingEligibility
   end
 
 private
-
-  def grab_current_eligibility
-    @previous_ect_first_became_eligible_for_training_at = teacher.ect_first_became_eligible_for_training_at
-    @previous_mentor_first_became_eligible_for_training_at = teacher.mentor_first_became_eligible_for_training_at
-  end
 
   def set_eligibility!
     if eligible_for_ect_training?
@@ -35,20 +29,14 @@ private
   end
 
   def make_declarations_eligible!
-    declaration_ids_to_make_eligible = []
+    declarations_to_mark_eligible = []
+    declarations_to_mark_eligible += teacher.ect_declarations.payment_status_no_payment if teacher.ect_first_became_eligible_for_training_at
+    declarations_to_mark_eligible += teacher.mentor_declarations.payment_status_no_payment if teacher.mentor_first_became_eligible_for_training_at
 
-    if @previous_ect_first_became_eligible_for_training_at.nil? && teacher.ect_first_became_eligible_for_training_at.present?
-      declaration_ids_to_make_eligible.concat(teacher.ect_declarations.ids)
-    end
-
-    if @previous_mentor_first_became_eligible_for_training_at.nil? && teacher.mentor_first_became_eligible_for_training_at.present?
-      declaration_ids_to_make_eligible.concat(teacher.mentor_declarations.ids)
-    end
-
-    return unless declaration_ids_to_make_eligible.any?
+    return unless declarations_to_mark_eligible.any?
 
     Declarations::Actions::MarkDeclarationsEligible.new(
-      declarations: Declaration.where(id: declaration_ids_to_make_eligible.uniq),
+      declarations: declarations_to_mark_eligible,
       author:
     ).mark
   end

--- a/spec/helpers/declaration_helper_spec.rb
+++ b/spec/helpers/declaration_helper_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe DeclarationHelper, type: :helper do
       it { is_expected.to eq("Payable") }
     end
 
-    context "when the event type is 'teacher_declaration_marked_eligible'" do
-      let(:event_type) { "teacher_declaration_marked_eligible" }
+    context "when the event type is 'teacher_declaration_eligible'" do
+      let(:event_type) { "teacher_declaration_eligible" }
 
       it { is_expected.to eq("Eligible") }
     end

--- a/spec/services/api/declarations/actions/mark_declarations_eligible_spec.rb
+++ b/spec/services/api/declarations/actions/mark_declarations_eligible_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Declarations::Actions::MarkDeclarationsEligible do
     let(:author) { Events::SystemAuthor.new }
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
     let(:training_period) { FactoryBot.create(:training_period, :with_active_lead_provider, active_lead_provider:) }
-    let(:declarations) { Declaration.where(id: [no_payment_declaration.id, already_eligible_declaration.id]) }
-    let!(:no_payment_declaration) { FactoryBot.create(:declaration, :no_payment, training_period:) }
-    let!(:already_eligible_declaration) { FactoryBot.create(:declaration, :eligible, declaration_type: :completed, training_period:) }
+    let!(:no_payment_declaration) { FactoryBot.create(:declaration, :no_payment, declaration_type: :"retained-1", training_period:) }
+    let!(:another_no_payment_declaration) { FactoryBot.create(:declaration, :no_payment, declaration_type: :"extended-1", training_period:) }
+    let(:declarations) { [no_payment_declaration, another_no_payment_declaration] }
 
     let!(:next_output_fee_statement) do
       FactoryBot.create(
@@ -46,45 +46,70 @@ RSpec.describe Declarations::Actions::MarkDeclarationsEligible do
       )
     end
 
-    it "marks only `no_payment` declarations eligible" do
+    it "marks declarations as eligible" do
       expect { mark }
         .to change { no_payment_declaration.reload.payment_status }
         .from("no_payment")
         .to("eligible")
-        .and(not_change { already_eligible_declaration.reload.payment_status })
+        .and change { another_no_payment_declaration.reload.payment_status }
+        .from("no_payment")
+        .to("eligible")
     end
 
     it "assigns the next output fee statement correctly" do
       mark
 
       expect(no_payment_declaration.reload.payment_statement).to eq(next_output_fee_statement)
+      expect(another_no_payment_declaration.reload.payment_statement).to eq(next_output_fee_statement)
     end
 
-    it "records an event" do
-      expect(Events::Record)
-        .to receive(:record_teacher_declaration_marked_eligible!)
-        .with(
-          author:,
-          teacher: no_payment_declaration.training_period.teacher,
-          training_period: no_payment_declaration.training_period,
-          declaration: no_payment_declaration
-        )
+    it "records an event for each successful declaration" do
+      declarations.each do |declaration|
+        expect(Events::Record)
+        .to receive(:record_teacher_declaration_eligible!)
+          .with(
+            author:,
+            teacher: declaration.training_period.teacher,
+            training_period: declaration.training_period,
+            declaration:
+          )
+      end
 
       mark
     end
 
-    context "when one of the declarations cannot be updated" do
-      let!(:first_no_payment_declaration) { FactoryBot.create(:declaration, :no_payment, declaration_type: :"retained-1", training_period:) }
-      let!(:second_no_payment_declaration) { FactoryBot.create(:declaration, :no_payment, declaration_type: :"extended-1") }
-      let(:declarations) { Declaration.where(id: [first_no_payment_declaration.id, second_no_payment_declaration.id]) }
+    context "when there's a missing payment statement" do
+      let!(:another_no_payment_declaration) { FactoryBot.create(:declaration, :no_payment, declaration_type: :"extended-1") }
+
+      it "raises a `MissingPaymentStatementError`" do
+        expect { mark }
+        .to raise_error(Declarations::Actions::MarkDeclarationsEligible::MissingPaymentStatementError)
+        .with_message(/Payment statement not found for declaration #{another_no_payment_declaration.id}/)
+      end
 
       it "rolls back all updates" do
-        expect { mark }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { mark }
+        .to raise_error(Declarations::Actions::MarkDeclarationsEligible::MissingPaymentStatementError)
+        .and(not_change { no_payment_declaration.reload.payment_status })
+        .and(not_change { no_payment_declaration.payment_statement })
+        .and(not_change { another_no_payment_declaration.reload.payment_status })
+        .and(not_change { another_no_payment_declaration.payment_statement })
+      end
+    end
 
-        expect(first_no_payment_declaration.reload.payment_status).to eq("no_payment")
-        expect(first_no_payment_declaration.payment_statement).to be_nil
-        expect(second_no_payment_declaration.reload.payment_status).to eq("no_payment")
-        expect(second_no_payment_declaration.payment_statement).to be_nil
+    context "when a declaration is in a payment status that cannot transition to eligible" do
+      let!(:already_eligible_declaration) { FactoryBot.create(:declaration, :eligible, declaration_type: :completed, training_period:) }
+
+      let(:declarations) { [already_eligible_declaration] }
+
+      it "raises `StateMachines::InvalidTransition` error" do
+        expect { mark }.to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "does not record an event for it" do
+        expect(Events::Record).not_to receive(:record_teacher_declaration_eligible!)
+
+        expect { mark }.to raise_error(StateMachines::InvalidTransition)
       end
     end
   end

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -2125,7 +2125,7 @@ RSpec.describe Events::Record do
     end
   end
 
-  describe ".record_teacher_declaration_marked_eligible!" do
+  describe ".record_teacher_declaration_eligible!" do
     let(:ect_at_school_period) do
       FactoryBot.create(:ect_at_school_period, teacher:)
     end
@@ -2133,13 +2133,13 @@ RSpec.describe Events::Record do
       FactoryBot.create(:training_period, :for_ect, ect_at_school_period:)
     end
     let(:declaration) do
-      FactoryBot.create(:declaration, :voided, training_period:)
+      FactoryBot.create(:declaration, training_period:)
     end
 
     it "queues a RecordEventJob with the correct values" do
       freeze_time
 
-      Events::Record.record_teacher_declaration_marked_eligible!(
+      Events::Record.record_teacher_declaration_eligible!(
         author:,
         teacher:,
         training_period:,
@@ -2147,8 +2147,8 @@ RSpec.describe Events::Record do
       )
 
       expect(RecordEventJob).to have_received(:perform_later).with(
-        event_type: :teacher_declaration_marked_eligible,
-        heading: "Rhys Ifans’s declaration was marked as eligible",
+        event_type: :teacher_declaration_eligible,
+        heading: "Rhys Ifans’s started declaration was marked as eligible",
         teacher:,
         training_period:,
         declaration:,

--- a/spec/services/teachers/set_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_funding_eligibility_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe Teachers::SetFundingEligibility do
             expect { service.set! }.to change(teacher, :ect_first_became_eligible_for_training_at).from(nil).to(Time.zone.now)
           end
         end
-
-        it "calls `Declarations::Actions::MarkDeclarationsEligible` service" do
-          expect(Declarations::Actions::MarkDeclarationsEligible).to receive(:new).with(declarations: teacher.ect_declarations, author:).and_call_original
-
-          service.set!
-        end
       end
 
       context "when `ect_first_became_eligible_for_training_at` is already set" do
@@ -41,12 +35,12 @@ RSpec.describe Teachers::SetFundingEligibility do
         it "does not change `ect_first_became_eligible_for_training_at`" do
           expect { service.set! }.not_to change(teacher, :ect_first_became_eligible_for_training_at)
         end
+      end
 
-        it "does not call `Declarations::Actions::MarkDeclarationsEligible` service" do
-          expect(Declarations::Actions::MarkDeclarationsEligible).not_to receive(:new)
+      it "calls `Declarations::Actions::MarkDeclarationsEligible` service" do
+        expect(Declarations::Actions::MarkDeclarationsEligible).to receive(:new).with(declarations: teacher.ect_declarations, author:).and_call_original
 
-          service.set!
-        end
+        service.set!
       end
     end
 
@@ -82,12 +76,6 @@ RSpec.describe Teachers::SetFundingEligibility do
             expect { service.set! }.to change(teacher, :mentor_first_became_eligible_for_training_at).from(nil).to(Time.zone.now)
           end
         end
-
-        it "calls `Declarations::Actions::MarkDeclarationsEligible` service" do
-          expect(Declarations::Actions::MarkDeclarationsEligible).to receive(:new).with(declarations: teacher.mentor_declarations, author:).and_call_original
-
-          service.set!
-        end
       end
 
       context "when `mentor_first_became_eligible_for_training_at` is already set" do
@@ -98,12 +86,12 @@ RSpec.describe Teachers::SetFundingEligibility do
         it "does not change `mentor_first_became_eligible_for_training_at`" do
           expect { service.set! }.not_to change(teacher, :mentor_first_became_eligible_for_training_at)
         end
+      end
 
-        it "does not call `Declarations::Actions::MarkDeclarationsEligible` service" do
-          expect(Declarations::Actions::MarkDeclarationsEligible).not_to receive(:new)
+      it "calls `Declarations::Actions::MarkDeclarationsEligible` service" do
+        expect(Declarations::Actions::MarkDeclarationsEligible).to receive(:new).with(declarations: teacher.mentor_declarations, author:).and_call_original
 
-          service.set!
-        end
+        service.set!
       end
     end
 
@@ -164,6 +152,65 @@ RSpec.describe Teachers::SetFundingEligibility do
         expect { service.set! }.to raise_error(ActiveRecord::RecordInvalid)
         expect(teacher.reload.ect_first_became_eligible_for_training_at).to eq(original_ect_eligible_at)
         expect(teacher.reload.mentor_first_became_eligible_for_training_at).to eq(original_mentor_eligible_at)
+      end
+    end
+
+    context "when teacher is eligible for ECT training and also for mentor training" do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period,
+                                                 teacher:,
+                                                 started_on: 2.months.ago,
+                                                 finished_on: nil)
+        training_period = FactoryBot.create(:training_period,
+                                            :for_ect,
+                                            :ongoing,
+                                            ect_at_school_period:)
+        FactoryBot.create(:declaration, training_period:)
+        FactoryBot.create(:statement, :open, active_lead_provider: training_period.active_lead_provider)
+
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period,
+                                                    teacher:,
+                                                    started_on: 2.months.ago,
+                                                    finished_on: nil)
+        training_period = FactoryBot.create(:training_period,
+                                            :for_mentor,
+                                            :ongoing,
+                                            mentor_at_school_period:)
+        FactoryBot.create(:declaration, training_period:)
+        FactoryBot.create(:statement, :open, active_lead_provider: training_period.active_lead_provider)
+      end
+
+      it "calls `Declarations::Actions::MarkDeclarationsEligible` service" do
+        expect(Declarations::Actions::MarkDeclarationsEligible).to receive(:new).with(declarations: teacher.ect_declarations + teacher.mentor_declarations, author:).and_call_original
+
+        service.set!
+      end
+
+      context "when `ect/mentor_first_became_eligible_for_training_at` is not already set" do
+        it "sets `ect/mentor_first_became_eligible_for_training_at`" do
+          freeze_time do
+            expect { service.set! }
+            .to change(teacher, :ect_first_became_eligible_for_training_at).from(nil).to(Time.zone.now)
+            .and change(teacher, :mentor_first_became_eligible_for_training_at).from(nil).to(Time.zone.now)
+          end
+        end
+      end
+
+      context "when `ect/mentor_first_became_eligible_for_training_at` is already set" do
+        it "does not change `ect/mentor_first_became_eligible_for_training_at`" do
+          freeze_time do
+            teacher.update!(
+              ect_first_became_eligible_for_training_at: 1.day.ago,
+              mentor_first_became_eligible_for_training_at: 1.day.ago
+            )
+
+            service.set!
+
+            expect(teacher.reload.ect_first_became_eligible_for_training_at).to eq(1.day.ago)
+            expect(teacher.reload.mentor_first_became_eligible_for_training_at).to eq(1.day.ago)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [3396](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3396)

When a participant becomes eligible for funding, we need to make sure any declarations attached to them transition between 'submitted' to 'eligible.

### Changes proposed in this pull request

- Add service to make declarations eligible;
- Call it from the right places;

### Guidance to review

Review app