### PR TITLE
Handle invalid dates cleanly

### DIFF
--- a/app/controllers/admin/induction_periods_controller.rb
+++ b/app/controllers/admin/induction_periods_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class InductionPeriodsController < AdminController
+    include MultiparameterDateErrorHandling
+
     before_action :set_teacher
     before_action :set_induction_period, except: %i[new create]
 
@@ -8,16 +10,20 @@ module Admin
     end
 
     def create
-      service = create_induction_period_service
+      @service = create_induction_period_service
 
-      if service.create_induction_period!
+      if @service.create_induction_period!
         redirect_to admin_teacher_induction_path(@teacher), alert: "Induction period created successfully"
       else
-        @induction_period = service.induction_period
+        @induction_period = @service.induction_period
         render :new, status: :unprocessable_content
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback
-      @induction_period = service.induction_period
+      @induction_period = @service.induction_period
+      render :new, status: :unprocessable_content
+    rescue ActiveRecord::MultiparameterAssignmentErrors => e
+      @induction_period = @service.induction_period
+      add_multiparameter_date_errors(@induction_period, e, param_key: :induction_period)
       render :new, status: :unprocessable_content
     end
 
@@ -30,6 +36,9 @@ module Admin
       render :edit, status: :unprocessable_content
     rescue ActiveRecord::RecordInvalid
       @induction_period = service.induction_period
+      render :edit, status: :unprocessable_content
+    rescue ActiveRecord::MultiparameterAssignmentErrors => e
+      add_multiparameter_date_errors(@induction_period, e, param_key: :induction_period)
       render :edit, status: :unprocessable_content
     end
 

--- a/app/controllers/admin/teachers/record_failed_induction_controller.rb
+++ b/app/controllers/admin/teachers/record_failed_induction_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   module Teachers
     class RecordFailedInductionController < CloseInductionController
+      include MultiparameterDateErrorHandling
       def new
         @record_fail = RecordFail.new(
           teacher: @teacher,
@@ -31,6 +32,9 @@ module Admin
         end
       rescue ActiveRecord::RecordInvalid,
              ActiveModel::ValidationError
+        render :new, status: :unprocessable_content
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        add_multiparameter_date_errors(@record_fail, e, param_key: RecordFail.model_name.param_key)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/admin/teachers/record_passed_induction_controller.rb
+++ b/app/controllers/admin/teachers/record_passed_induction_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   module Teachers
     class RecordPassedInductionController < CloseInductionController
+      include MultiparameterDateErrorHandling
       def new
         @record_pass = RecordPass.new(
           teacher: @teacher,
@@ -31,6 +32,9 @@ module Admin
         end
       rescue ActiveRecord::RecordInvalid,
              ActiveModel::ValidationError
+        render :new, status: :unprocessable_content
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        add_multiparameter_date_errors(@record_pass, e, param_key: RecordPass.model_name.param_key)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
@@ -1,6 +1,7 @@
 module AppropriateBodies
   module ClaimAnECT
     class FindECTController < AppropriateBodiesController
+      include MultiparameterDateErrorHandling
       def new
         @pending_induction_submission = PendingInductionSubmission.new trn: params[:trn]
       end
@@ -29,6 +30,13 @@ module AppropriateBodies
         teacher = Teacher.find_by(trn: @pending_induction_submission.trn)
         full_name = ::Teachers::Name.new(teacher).full_name
         redirect_to ab_teacher_path(teacher), notice: "Teacher #{full_name} already has an ongoing induction period with this appropriate body"
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        @pending_induction_submission = PendingInductionSubmission.new(
+          trn: params.dig(:pending_induction_submission, :trn),
+          appropriate_body_period_id: @appropriate_body.id
+        )
+        add_multiparameter_date_errors(@pending_induction_submission, e, param_key: :pending_induction_submission)
+        render :new
       end
 
     private

--- a/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
@@ -1,11 +1,13 @@
 module AppropriateBodies
   module ClaimAnECT
     class RegisterECTController < AppropriateBodiesController
+      include MultiparameterDateErrorHandling
       def edit
         @pending_induction_submission = find_pending_induction_submission
       end
 
       def update
+        register_ect = nil
         register_ect = AppropriateBodies::ClaimAnECT::RegisterECT
           .new(
             appropriate_body_period: @appropriate_body,
@@ -20,6 +22,10 @@ module AppropriateBodies
 
           render(:edit)
         end
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        @pending_induction_submission = register_ect.pending_induction_submission
+        add_multiparameter_date_errors(@pending_induction_submission, e, param_key: :pending_induction_submission)
+        render :edit
       end
 
       def show

--- a/app/controllers/appropriate_bodies/induction_periods_controller.rb
+++ b/app/controllers/appropriate_bodies/induction_periods_controller.rb
@@ -1,10 +1,13 @@
 module AppropriateBodies
   class InductionPeriodsController < AppropriateBodiesController
+    include MultiparameterDateErrorHandling
+
     def edit
       @induction_period = induction_period
     end
 
     def update
+      service = nil
       service = update_induction_period_service
       service.update_induction_period!
       redirect_to ab_teacher_path(@induction_period.teacher), alert: "Induction period updated successfully"
@@ -12,7 +15,11 @@ module AppropriateBodies
       @induction_period.errors.add(:base, e.message)
       render :edit, status: :unprocessable_content
     rescue ActiveRecord::RecordInvalid
-      @induction_period = service.induction_period
+      @induction_period = service&.induction_period
+      render :edit, status: :unprocessable_content
+    rescue ActiveRecord::MultiparameterAssignmentErrors => e
+      @induction_period = service&.induction_period
+      add_multiparameter_date_errors(induction_period, e, param_key: :induction_period)
       render :edit, status: :unprocessable_content
     end
 

--- a/app/controllers/appropriate_bodies/teachers/close_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/close_induction_controller.rb
@@ -1,6 +1,7 @@
 module AppropriateBodies
   module Teachers
     class CloseInductionController < AppropriateBodiesController
+      include MultiparameterDateErrorHandling
       before_action :find_former_teacher, only: [:show]
       before_action :find_current_teacher, except: [:show]
 

--- a/app/controllers/appropriate_bodies/teachers/record_failed_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_failed_induction_controller.rb
@@ -35,6 +35,9 @@ module AppropriateBodies
       rescue ActiveRecord::RecordInvalid,
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        add_multiparameter_date_errors(@record_fail, e, param_key: RecordFail.model_name.param_key)
+        render :new, status: :unprocessable_content
       end
 
     private

--- a/app/controllers/appropriate_bodies/teachers/record_passed_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_passed_induction_controller.rb
@@ -23,6 +23,9 @@ module AppropriateBodies
       rescue ActiveRecord::RecordInvalid,
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        add_multiparameter_date_errors(@record_pass, e, param_key: RecordPass.model_name.param_key)
+        render :new, status: :unprocessable_content
       end
 
     private

--- a/app/controllers/appropriate_bodies/teachers/record_released_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_released_induction_controller.rb
@@ -23,6 +23,9 @@ module AppropriateBodies
       rescue ActiveRecord::RecordInvalid,
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
+      rescue ActiveRecord::MultiparameterAssignmentErrors => e
+        add_multiparameter_date_errors(@record_release, e, param_key: RecordRelease.model_name.param_key)
+        render :new, status: :unprocessable_content
       end
 
     private

--- a/app/controllers/concerns/multiparameter_date_error_handling.rb
+++ b/app/controllers/concerns/multiparameter_date_error_handling.rb
@@ -1,0 +1,19 @@
+module MultiparameterDateErrorHandling
+  extend ActiveSupport::Concern
+
+private
+
+  def add_multiparameter_date_errors(record, exception, param_key:)
+    raw_params = params[param_key]
+
+    exception.errors.each do |error|
+      attribute = error.attribute
+      day = raw_params["#{attribute}(3i)"]
+      month = raw_params["#{attribute}(2i)"]
+      year = raw_params["#{attribute}(1i)"]
+      entered = "#{day}/#{month}/#{year}"
+
+      record.errors.add(attribute, "#{entered} is not a valid date")
+    end
+  end
+end

--- a/spec/requests/admin/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_induction_spec.rb
@@ -74,6 +74,26 @@ RSpec.describe "Admin recording a failed outcome for a teacher" do
         end
       end
 
+      context "when date is not valid" do
+        let(:params) do
+          {
+            admin_record_fail: {
+              "finished_on(3i)" => "aa",
+              "finished_on(2i)" => "bb",
+              "finished_on(1i)" => "cccc",
+              number_of_terms: 3,
+              note: "Note from Admin",
+              zendesk_ticket_id: "#123456"
+            }
+          }
+        end
+
+        it "returns error with the entered value" do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "with missing params" do
         let(:params) do
           {

--- a/spec/requests/admin/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_induction_spec.rb
@@ -74,6 +74,26 @@ RSpec.describe "Admin recording a passed outcome for a teacher" do
         end
       end
 
+      context "when date is not valid" do
+        let(:params) do
+          {
+            admin_record_pass: {
+              "finished_on(3i)" => "aa",
+              "finished_on(2i)" => "bb",
+              "finished_on(1i)" => "cccc",
+              number_of_terms: 3,
+              note: "Note from Admin",
+              zendesk_ticket_id: "#123456"
+            }
+          }
+        end
+
+        it "returns error with the entered value" do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "with missing params" do
         let(:params) do
           {

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -130,6 +130,24 @@ RSpec.describe "Appropriate body claiming an ECT: finding the ECT" do
         end
       end
 
+      context "when date of birth is not valid" do
+        let(:search_params) do
+          {
+            trn: "1234567",
+            "date_of_birth(3i)" => "aa",
+            "date_of_birth(2i)" => "bb",
+            "date_of_birth(1i)" => "cccc",
+          }
+        end
+
+        it "returns error with the entered value" do
+          post("/appropriate-body/claim-an-ect/find-ect", params: { pending_induction_submission: search_params })
+
+          expect(response.body).to include(page_heading)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "when the submission is invalid" do
         let(:birth_year_param) { (Date.current.year - 2).to_s }
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -140,6 +140,28 @@ RSpec.describe "Appropriate body claiming an ECT: registering the ECT" do
         end
       end
 
+      context "when the start date is not valid" do
+        let(:registration_params) do
+          {
+            trs_induction_status: "None",
+            training_programme: "provider_led",
+            "started_on(3i)" => "aa",
+            "started_on(2i)" => "bb",
+            "started_on(1i)" => "cccc",
+          }
+        end
+
+        it "returns error with the entered value" do
+          patch(
+            "/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}",
+            params: { pending_induction_submission: registration_params }
+          )
+
+          expect(response.body).to include(page_heading)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "when the submission is invalid" do
         context "with new induction programme types (post-2025)" do
           let(:registration_params) { { training_programme: "xyz", } }

--- a/spec/requests/appropriate_bodies/induction_periods_spec.rb
+++ b/spec/requests/appropriate_bodies/induction_periods_spec.rb
@@ -110,6 +110,27 @@ RSpec.describe "AppropriateBodies::InductionPeriodsController", type: :request d
         end
       end
 
+      context "when date is not valid" do
+        let(:params) do
+          {
+            induction_period: {
+              "started_on(3i)" => "aa",
+              "started_on(2i)" => "bb",
+              "started_on(1i)" => "cccc",
+              training_programme: "provider_led",
+              appropriate_body_period_id: appropriate_body_period.id
+            }
+          }
+        end
+
+        it "returns error with the entered value" do
+          patch(ab_teacher_induction_period_path(induction_period.teacher, induction_period), params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "when dates would cause overlap" do
         before do
           FactoryBot.create(:induction_period, teacher:, started_on: 1.year.ago, finished_on: 9.months.ago)

--- a/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe "Appropriate body recording a failed induction outcome for a teac
         end
       end
 
+      context "when date is not valid" do
+        let(:params) do
+          {
+            appropriate_bodies_record_fail: {
+              "finished_on(3i)" => "aa",
+              "finished_on(2i)" => "bb",
+              "finished_on(1i)" => "cccc",
+              number_of_terms: 3,
+            }
+          }
+        end
+
+        it "returns error with the entered value" do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "with missing params" do
         let(:params) do
           {

--- a/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe "Appropriate body recording a passed induction outcome for a teac
         end
       end
 
+      context "when date is not valid" do
+        let(:params) do
+          {
+            appropriate_bodies_record_pass: {
+              "finished_on(3i)" => "aa",
+              "finished_on(2i)" => "bb",
+              "finished_on(1i)" => "cccc",
+              number_of_terms: 3,
+            }
+          }
+        end
+
+        it "returns error with the entered value" do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("aa/bb/cccc is not a valid date")
+        end
+      end
+
       context "with missing params" do
         let(:params) do
           {

--- a/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe "Appropriate body releasing an ECT" do
           expect(response).to redirect_to("/appropriate-body/teachers/#{teacher.id}/release")
         end
 
+        context "when date is not valid" do
+          let(:params) do
+            {
+              appropriate_bodies_record_release: {
+                "finished_on(3i)" => "aa",
+                "finished_on(2i)" => "bb",
+                "finished_on(1i)" => "cccc",
+                number_of_terms: 3,
+              }
+            }
+          end
+
+          it "returns error with the entered value" do
+            expect(response).to have_http_status(:unprocessable_content)
+            expect(response.body).to include("aa/bb/cccc is not a valid date")
+          end
+        end
+
         context "with missing params" do
           let(:params) do
             {


### PR DESCRIPTION
### Context

By default we use a Day/Month/Year combination text entry for dates. This allows alpha characters to be entered. Currently when this happens Rails throws an **ActiveRecord::MultiparameterAssignmentErrors** and the user gets a 500 error.

**What we get right now:**
<img width="1295" height="998" alt="Screenshot 2026-03-13 at 11 36 16" src="https://github.com/user-attachments/assets/49bb715d-b6a2-488e-b6af-9d946bc506f3" />


### Changes proposed in this pull request

Instead we catch this and make it look like a date validation error.

**What we get with this change**
<img width="1301" height="1146" alt="Screenshot 2026-03-13 at 11 35 14" src="https://github.com/user-attachments/assets/7ab7b676-fd74-4ae1-8d80-d466fb71eaf2" />


### Guidance to review

This PR covers all RIAB date entry, specifically:
- admin/induction_periods_controller.rb
- admin/teachers/record_failed_induction_controller.rb
- admin/teachers/record_released_induction_controller.rb
- appropriate_bodies/induction_periods_controller.rb
- appropriate_bodies/claim_an_ect/find_ect_controller.rb
- appropriate_bodies/claim_an_ect/register_ect_controller.rb
- appropriate_bodies/teachers/record_passed_induction_controller.rb
- appropriate_bodies/teachers/record_failed_induction_controller.rb
- appropriate_bodies/teachers/record_released_induction_controller.rb

Out of scope: Wizards
