### PR TITLE
drop snapshot schema before restoring from backup

### DIFF
--- a/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
@@ -110,6 +110,8 @@ runs:
           COMPRESS_ARG=-c
         fi
 
+        ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 60 -x ${{ inputs.app-name }} -- psql -c "drop schema public cascade; create schema public;"
+
         ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i ${{ inputs.backup-file }} ${COMPRESS_ARG} -t 7200 -x ${{ inputs.app-name }} -- psql
 
     - name: Restore Summary

--- a/.github/workflows/restore-snapshot-db-from-azure-storage.yml
+++ b/.github/workflows/restore-snapshot-db-from-azure-storage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: Environment to restore
+        description: Environment to restore from
         required: true
         default: production
         type: choice
@@ -32,7 +32,7 @@ on:
         required: true
     inputs:
       environment:
-        description: Environment to restore
+        description: Environment to restore from
         required: true
         default: production
         type: string


### PR DESCRIPTION
### Context

The snapshot is failing to restore from the production backup, presumably due to the same issues we saw in the migration environment.  This adds the same "fix" to the Github action that restores the snapshot from the backup which is to drop and recreate the public schema of the snapshot database before restoring from a backup.

Please give this careful eyes to ensure I haven't made a mistake that will drop the schema on production 🙀 

### Changes proposed in this pull request

### Guidance to review
