### PR TITLE
[3409] Move link for CSV download to correct position

### DIFF
--- a/app/components/admin/statements/declaration_component.html.erb
+++ b/app/components/admin/statements/declaration_component.html.erb
@@ -37,4 +37,10 @@
       end
     end
   end %>
+
+  <% if statement.output_fee? %>
+    <p class="govuk-body-s govuk-!-text-align-right">
+      <%= govuk_link_to "Download declarations (CSV)", declarations_export_admin_finance_statement_path(statement, format: :csv) %>
+    </p>
+  <% end %>
 </div>

--- a/app/views/admin/finance/statements/show.html.erb
+++ b/app/views/admin/finance/statements/show.html.erb
@@ -6,20 +6,10 @@
 
 <%= render Admin::Statements::SelectorComponent.new(statement: @statement) %>
 <%= render Admin::Statements::PaymentOverviewComponent.for(statement: @statement) %>
-
-<% if @statement.output_fee? %>
-  <p class="govuk-body">
-    <%# TODO: Move this link into the declarations summary section once that section is built. %>
-    <%= govuk_link_to "Download declarations (CSV)", declarations_export_admin_finance_statement_path(@statement, format: :csv) %>
-  </p>
-<% end %>
-
 <%= render Admin::Statements::PaymentAuthorisationComponent.new(statement: @statement) %>
 <%= render Admin::Statements::DeclarationComponent.new(statement: @statement)%>
 <%= render Admin::Statements::UpliftFeesComponent.new(statement: @statement) %>
 <%= render Admin::Statements::ClawbacksComponent.new(statement: @statement) %>
-
-<br />
 <%= render Admin::Statements::AdjustmentsComponent.new(statement: @statement) %>
 <%= render Admin::Statements::ProviderTargetsComponent.new(statement: @statement) %>
 <%= render Admin::Statements::GuidanceComponent.new %>

--- a/spec/components/admin/statements/declaration_component_spec.rb
+++ b/spec/components/admin/statements/declaration_component_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   subject { render_inline(component) }
 
   let(:component) { described_class.new statement: }
@@ -7,7 +9,8 @@ RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
   let!(:contract_period) { active_lead_provider.contract_period }
   let(:contract) { FactoryBot.create(:contract, contract_trait, active_lead_provider:, contract_period:) }
   let(:contract_trait) { :for_ecf }
-  let(:statement) { FactoryBot.create(:statement, :payable, :output_fee, active_lead_provider:, contract:) }
+  let(:statement_trait) { :output_fee }
+  let(:statement) { FactoryBot.create(:statement, :payable, statement_trait, active_lead_provider:, contract:) }
 
   let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :with_active_lead_provider, active_lead_provider:) }
   let!(:ect_declaration) { FactoryBot.create(:declaration, :voided, training_period: ect_training_period, payment_statement: statement) }
@@ -163,6 +166,27 @@ RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
     it "renders the correct headers" do
       expect(subject).to have_table(text: "ECTs")
       expect(subject).to have_table(text: "Mentors")
+    end
+  end
+
+  describe "download CSV link" do
+    context "when the statement is for output fees" do
+      let(:statement_trait) { :output_fee }
+
+      it "shows the CSV download link for output fee statements" do
+        expect(subject).to have_link(
+          "Download declarations (CSV)",
+          href: declarations_export_admin_finance_statement_path(statement, format: :csv)
+        )
+      end
+    end
+
+    context "when the statement is for service fees" do
+      let(:statement_trait) { :service_fee }
+
+      it "does not show the CSV download link" do
+        expect(subject).not_to have_link("Download declarations (CSV)")
+      end
     end
   end
 end

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -144,25 +144,6 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
     expect(rendered).to have_css("details", text: "Provider targets (per academic year)")
   end
 
-  it "shows the CSV download link for output fee statements" do
-    render
-
-    expect(rendered).to have_link(
-      "Download declarations (CSV)",
-      href: declarations_export_admin_finance_statement_path(feb_statement, format: :csv)
-    )
-  end
-
-  context "when the statement is for service fees" do
-    let(:feb_statement_fee_type) { :service_fee }
-
-    it "does not show the CSV download link" do
-      render
-
-      expect(rendered).not_to have_link("Download declarations (CSV)")
-    end
-  end
-
   context "when the statement is for an ECF contract" do
     let(:contract_trait) { :for_ecf }
 


### PR DESCRIPTION
### Context
Now both the declarations panel and the declarations CSV download have been merged we can move the download link to the position indicated in the designs.

### Changes proposed in this pull request

### Guidance to review
