### PR TITLE
Update link for declaration states information

### DIFF
--- a/app/views/api/guidance/guidance_for_lead_providers/how_to_test_the_api_effectively.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/how_to_test_the_api_effectively.md
@@ -82,7 +82,7 @@ To test declaration submission functionality, include:
 
 Make a declaration submission using this header: `X-With-Server-Date: 2027-01-10T10:42:00Z`
 
-[View more information on declaration states](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/ecf/definitions-and-states/#declaration-states).
+[View more information on declaration states](/api/guidance/guidance-for-lead-providers/understanding-declarations).
 
 ## Check seed data is adequate or request seed data that’s more tailored to your needs 
 


### PR DESCRIPTION
### Context
On the [How to test the API effectively](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively), there's a link in the 'Test declaration submissions using X-With-Server-Date" section to some declarations guidance.

It needed to be updated to point to the new declarations guidance once it was ready. It's now ready, so I've updated it.