### PR TITLE
[3393] Allow same-LP schedule changes on future training periods while blocking cross-LP changes during transfers

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -34,15 +34,39 @@ module API::Teachers
       ).change_schedule
     end
 
-    # The metadata handler selects the training period with the latest started_on.
-    # When a future training period exists for the same lead provider, it gets selected
-    # instead of the ongoing one. We fall back to the ongoing training period so the
-    # schedule change can proceed against the correct record.
-    def training_period
-      tp = super
-      return tp unless tp&.started_on&.future?
+    # The training period with the latest started_on for this LP, from metadata.
+    def latest_training_period_from_metadata
+      return unless metadata
 
-      ongoing_training_period_for_lead_provider || tp
+      @latest_training_period_from_metadata ||=
+        case teacher_type
+        when :ect
+          metadata.latest_ect_training_period
+        when :mentor
+          metadata.latest_mentor_training_period
+        end
+    end
+
+    # The currently active training period for this LP.
+    def ongoing_training_period
+      return unless lead_provider
+
+      ongoing_training_period_for_lead_provider
+    end
+
+    # The metadata training period, only if it hasn't started yet.
+    def future_training_period
+      tp = latest_training_period_from_metadata
+      tp if tp&.started_on&.future?
+    end
+
+    # Overrides SharedAction#training_period. Metadata selects by latest started_on,
+    # which picks a future TP over an ongoing one. We prefer ongoing so the schedule
+    # change operates against the currently active record.
+    def training_period
+      return latest_training_period_from_metadata unless future_training_period
+
+      ongoing_training_period || future_training_period
     end
 
   private
@@ -112,8 +136,8 @@ module API::Teachers
     def training_period_not_finished
       return if errors[:teacher_api_id].any?
       return unless training_period
-      return if training_period.started_on.future?
-      return if training_period.ongoing_today?
+      return if future_training_period
+      return if ongoing_training_period
 
       errors.add(:teacher_api_id, SCHEDULE_CHANGE_NOT_ALLOWED)
     end
@@ -122,8 +146,7 @@ module API::Teachers
     # When no other LP is involved (e.g. a new ECT with a single future TP), the change is allowed.
     def future_training_period_not_blocked_by_another_lead_provider
       return if errors[:teacher_api_id].any?
-      return unless training_period
-      return unless training_period.started_on.future?
+      return unless future_training_period
       return unless ongoing_training_period_with_different_lead_provider?
 
       errors.add(:teacher_api_id, SCHEDULE_CHANGE_NOT_ALLOWED)

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -31,7 +31,34 @@ module API::Teachers
       ).change_schedule
     end
 
+    # The metadata handler selects the training period with the latest started_on.
+    # When a future training period exists for the same lead provider, it gets selected
+    # instead of the ongoing one, causing lead_provider_is_currently_training_teacher
+    # to reject it (started_on.future?). We fall back to the ongoing training period
+    # so the schedule change can proceed against the correct record.
+    def training_period
+      tp = super
+      return tp unless tp&.started_on&.future?
+
+      ongoing_training_period_for_lead_provider || tp
+    end
+
   private
+
+    def ongoing_training_period_for_lead_provider
+      scope = if teacher_type == :ect
+                TrainingPeriod.joins(:ect_at_school_period).where(ect_at_school_period: { teacher: })
+              else
+                TrainingPeriod.joins(:mentor_at_school_period).where(mentor_at_school_period: { teacher: })
+              end
+
+      scope
+        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+        .where(lead_providers: { id: lead_provider.id })
+        .ongoing_today
+        .latest_first
+        .first
+    end
 
     def contract_period
       @contract_period ||= ContractPeriod.find_by(year: contract_period_year) || fallback_contract_period

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -2,6 +2,8 @@ module API::Teachers
   class ChangeSchedule
     include API::Concerns::Teachers::SharedAction
 
+    SCHEDULE_CHANGE_NOT_ALLOWED = "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule."
+
     attribute :contract_period_year
     attribute :schedule_identifier
 
@@ -13,8 +15,9 @@ module API::Teachers
     validate :schedule_applicable_for_trainee
     validate :school_partnership_exists_if_changing_contract_period
     validate :trainee_not_completed
-    validate :lead_provider_is_currently_training_teacher
-    validate :no_future_training_periods_exist
+    validate :training_period_not_finished
+    validate :future_training_period_not_blocked_by_another_lead_provider
+    validate :no_future_training_periods_with_different_lead_provider
     validate :can_move_to_frozen_contract_period
     validate :schedule_does_not_invalidate_declarations
 
@@ -33,9 +36,8 @@ module API::Teachers
 
     # The metadata handler selects the training period with the latest started_on.
     # When a future training period exists for the same lead provider, it gets selected
-    # instead of the ongoing one, causing lead_provider_is_currently_training_teacher
-    # to reject it (started_on.future?). We fall back to the ongoing training period
-    # so the schedule change can proceed against the correct record.
+    # instead of the ongoing one. We fall back to the ongoing training period so the
+    # schedule change can proceed against the correct record.
     def training_period
       tp = super
       return tp unless tp&.started_on&.future?
@@ -44,21 +46,6 @@ module API::Teachers
     end
 
   private
-
-    def ongoing_training_period_for_lead_provider
-      scope = if teacher_type == :ect
-                TrainingPeriod.joins(:ect_at_school_period).where(ect_at_school_period: { teacher: })
-              else
-                TrainingPeriod.joins(:mentor_at_school_period).where(mentor_at_school_period: { teacher: })
-              end
-
-      scope
-        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
-        .where(lead_providers: { id: lead_provider.id })
-        .ongoing_today
-        .latest_first
-        .first
-    end
 
     def contract_period
       @contract_period ||= ContractPeriod.find_by(year: contract_period_year) || fallback_contract_period
@@ -121,63 +108,67 @@ module API::Teachers
         )
     end
 
-    def lead_provider_is_currently_training_teacher
+    # Prevents schedule changes on training periods that have finished.
+    def training_period_not_finished
       return if errors[:teacher_api_id].any?
       return unless training_period
+      return if training_period.started_on.future?
+      return if training_period.ongoing_today?
 
-      if training_period.started_on.future?
-        # A future TP is only blocked if another LP is actively training the participant.
-        # When no other LP is involved (e.g. a new ECT with a single future TP), the LP
-        # should be allowed to change the schedule.
-        if ongoing_training_period_with_different_lead_provider?
-          errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.")
-        end
-      elsif !training_period.ongoing_today?
-        errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.")
-      end
+      errors.add(:teacher_api_id, SCHEDULE_CHANGE_NOT_ALLOWED)
+    end
+
+    # Prevents schedule changes on future training periods when another LP is actively training the participant.
+    # When no other LP is involved (e.g. a new ECT with a single future TP), the change is allowed.
+    def future_training_period_not_blocked_by_another_lead_provider
+      return if errors[:teacher_api_id].any?
+      return unless training_period
+      return unless training_period.started_on.future?
+      return unless ongoing_training_period_with_different_lead_provider?
+
+      errors.add(:teacher_api_id, SCHEDULE_CHANGE_NOT_ALLOWED)
     end
 
     def ongoing_training_period_with_different_lead_provider?
-      scope = if teacher_type == :ect
-                TrainingPeriod.joins(:ect_at_school_period).where(ect_at_school_period: { teacher: })
-              else
-                TrainingPeriod.joins(:mentor_at_school_period).where(mentor_at_school_period: { teacher: })
-              end
-
-      scope
-        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+      with_lead_provider_join(training_periods_for_teacher)
         .where.not(lead_providers: { id: lead_provider.id })
         .ongoing_today
         .exists?
     end
 
-    def no_future_training_periods_exist
+    def no_future_training_periods_with_different_lead_provider
       return if errors[:teacher_api_id].any?
       return unless training_period
+      return unless future_training_periods_with_different_lead_provider.exists?
 
-      if future_training_periods_with_different_lead_provider.exists?
-        errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they are due to start with another lead provider in the future.")
-      end
-    end
-
-    def future_training_periods
-      if training_period.for_mentor?
-        TrainingPeriod
-          .joins(:mentor_at_school_period)
-          .where(mentor_at_school_period: { teacher: })
-          .started_after(training_period.started_on)
-      else
-        TrainingPeriod
-          .joins(:ect_at_school_period)
-          .where(ect_at_school_period: { teacher: })
-          .started_after(training_period.started_on)
-      end
+      errors.add(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.")
     end
 
     def future_training_periods_with_different_lead_provider
-      future_training_periods
-        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+      with_lead_provider_join(training_periods_for_teacher.started_after(training_period.started_on))
         .where.not(lead_providers: { id: lead_provider.id })
+    end
+
+    # Base scope for all training periods belonging to this teacher, filtered by teacher type.
+    def training_periods_for_teacher
+      if teacher_type == :ect
+        TrainingPeriod.joins(:ect_at_school_period).where(ect_at_school_period: { teacher: })
+      else
+        TrainingPeriod.joins(:mentor_at_school_period).where(mentor_at_school_period: { teacher: })
+      end
+    end
+
+    # Joins a training period scope through to lead_providers for filtering by LP.
+    def with_lead_provider_join(scope)
+      scope.joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+    end
+
+    def ongoing_training_period_for_lead_provider
+      with_lead_provider_join(training_periods_for_teacher)
+        .where(lead_providers: { id: lead_provider.id })
+        .ongoing_today
+        .latest_first
+        .first
     end
 
     def can_move_to_frozen_contract_period
@@ -194,7 +185,7 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period&.teacher_completed_training?
 
-      errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training or induction.")
+      errors.add(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
     end
 
     def schedule_does_not_invalidate_declarations

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -125,9 +125,30 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period
 
-      unless !training_period.started_on.future? && training_period.ongoing_today?
+      if training_period.started_on.future?
+        # A future TP is only blocked if another LP is actively training the participant.
+        # When no other LP is involved (e.g. a new ECT with a single future TP), the LP
+        # should be allowed to change the schedule.
+        if ongoing_training_period_with_different_lead_provider?
+          errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.")
+        end
+      elsif !training_period.ongoing_today?
         errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.")
       end
+    end
+
+    def ongoing_training_period_with_different_lead_provider?
+      scope = if teacher_type == :ect
+                TrainingPeriod.joins(:ect_at_school_period).where(ect_at_school_period: { teacher: })
+              else
+                TrainingPeriod.joins(:mentor_at_school_period).where(mentor_at_school_period: { teacher: })
+              end
+
+      scope
+        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+        .where.not(lead_providers: { id: lead_provider.id })
+        .ongoing_today
+        .exists?
     end
 
     def no_future_training_periods_exist

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -98,14 +98,16 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period
 
-      errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") unless training_period.ongoing_today?
+      unless !training_period.started_on.future? && training_period.ongoing_today?
+        errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.")
+      end
     end
 
     def no_future_training_periods_exist
       return if errors[:teacher_api_id].any?
       return unless training_period
 
-      if future_training_periods.exists?
+      if future_training_periods_with_different_lead_provider.exists?
         errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they are due to start with another lead provider in the future.")
       end
     end
@@ -122,6 +124,12 @@ module API::Teachers
           .where(ect_at_school_period: { teacher: })
           .started_after(training_period.started_on)
       end
+    end
+
+    def future_training_periods_with_different_lead_provider
+      future_training_periods
+        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+        .where.not(lead_providers: { id: lead_provider.id })
     end
 
     def can_move_to_frozen_contract_period

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -16,7 +16,6 @@ module API::Teachers
     validate :school_partnership_exists_if_changing_contract_period
     validate :trainee_not_completed
     validate :training_period_not_finished
-    validate :future_training_period_not_blocked_by_another_lead_provider
     validate :no_future_training_periods_with_different_lead_provider
     validate :can_move_to_frozen_contract_period
     validate :schedule_does_not_invalidate_declarations
@@ -140,23 +139,6 @@ module API::Teachers
       return if ongoing_training_period
 
       errors.add(:teacher_api_id, SCHEDULE_CHANGE_NOT_ALLOWED)
-    end
-
-    # Prevents schedule changes on future training periods when another LP is actively training the participant.
-    # When no other LP is involved (e.g. a new ECT with a single future TP), the change is allowed.
-    def future_training_period_not_blocked_by_another_lead_provider
-      return if errors[:teacher_api_id].any?
-      return unless future_training_period
-      return unless ongoing_training_period_with_different_lead_provider?
-
-      errors.add(:teacher_api_id, SCHEDULE_CHANGE_NOT_ALLOWED)
-    end
-
-    def ongoing_training_period_with_different_lead_provider?
-      with_lead_provider_join(training_periods_for_teacher)
-        .where.not(lead_providers: { id: lead_provider.id })
-        .ongoing_today
-        .exists?
     end
 
     def no_future_training_periods_with_different_lead_provider

--- a/app/services/teachers/change_schedule.rb
+++ b/app/services/teachers/change_schedule.rb
@@ -16,11 +16,18 @@ module Teachers
       ActiveRecord::Base.transaction do
         track_payments_frozen_year!
 
-        if training_period.started_on.past?
-          create_new_training_period!
-        else
-          update_training_period_in_place!
-        end
+        new_training_period = if training_period.started_on.past?
+                                new_training_period = create_new_training_period!
+                                if future_training_period_for_same_lead_provider
+                                  update_training_period_in_place!(future_training_period_for_same_lead_provider)
+                                end
+                                new_training_period
+                              else
+                                update_training_period_in_place!(training_period)
+                                training_period
+                              end
+
+        record_change_schedule_event!(original_training_period: training_period, original_schedule:, new_training_period:)
       end
 
       teacher
@@ -28,24 +35,22 @@ module Teachers
 
   private
 
-    def update_training_period_in_place!
-      training_period.update!(
-        schedule:,
-        school_partnership:,
-        expression_of_interest: training_period.expression_of_interest.present? ? school_partnership.active_lead_provider : nil
-      )
+    def update_training_period_in_place!(target_training_period)
+      attrs = { schedule: }
 
-      record_change_schedule_event!(original_training_period: training_period, original_schedule:, new_training_period: training_period)
+      if target_training_period.at_school_period == training_period.at_school_period
+        attrs[:school_partnership] = school_partnership
+        attrs[:expression_of_interest] = target_training_period.expression_of_interest.present? ? school_partnership.active_lead_provider : nil
+      end
+
+      target_training_period.update!(**attrs)
     end
 
     def create_new_training_period!
       finished_on = determine_finished_on
 
       finish_training_period!
-      new_training_period = create_new_training_period_with!(finished_on:)
-      update_future_training_period!
-
-      record_change_schedule_event!(original_training_period: training_period, original_schedule:, new_training_period:)
+      create_new_training_period_with!(finished_on:)
     end
 
     # Determine the correct finished_on date for the new training period.
@@ -106,23 +111,21 @@ module Teachers
     end
 
     def future_training_period_for_same_lead_provider
-      @future_training_period_for_same_lead_provider ||= training_period
-        .siblings
-        .started_after(training_period.started_on)
-        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
-        .where(lead_providers: { id: lead_provider.id })
-        .earliest_first
-        .first
-    end
+      @future_training_period_for_same_lead_provider ||= begin
+        scope = if training_period.for_ect?
+                  TrainingPeriod.joins(:ect_at_school_period).where(ect_at_school_period: { teacher_id: teacher.id })
+                else
+                  TrainingPeriod.joins(:mentor_at_school_period).where(mentor_at_school_period: { teacher_id: teacher.id })
+                end
 
-    def update_future_training_period!
-      return unless future_training_period_for_same_lead_provider
-
-      future_training_period_for_same_lead_provider.update!(
-        schedule:,
-        school_partnership:,
-        expression_of_interest: nil
-      )
+        scope
+          .where.not(id: training_period.id)
+          .started_after(training_period.started_on)
+          .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+          .where(lead_providers: { id: lead_provider.id })
+          .earliest_first
+          .first
+      end
     end
 
     def current_contract_period

--- a/app/services/teachers/change_schedule.rb
+++ b/app/services/teachers/change_schedule.rb
@@ -17,15 +17,15 @@ module Teachers
         track_payments_frozen_year!
 
         new_training_period = if training_period.started_on.past?
-                                new_training_period = create_new_training_period!
-                                if future_training_period_for_same_lead_provider
-                                  update_training_period_in_place!(future_training_period_for_same_lead_provider)
-                                end
-                                new_training_period
+                                create_new_training_period!
                               else
                                 update_training_period_in_place!(training_period)
                                 training_period
                               end
+
+        if future_training_period_for_same_lead_provider
+          update_training_period_in_place!(future_training_period_for_same_lead_provider)
+        end
 
         record_change_schedule_event!(original_training_period: training_period, original_schedule:, new_training_period:)
       end

--- a/app/services/teachers/change_schedule.rb
+++ b/app/services/teachers/change_schedule.rb
@@ -43,20 +43,22 @@ module Teachers
 
       finish_training_period!
       new_training_period = create_new_training_period_with!(finished_on:)
+      update_future_training_period!
 
       record_change_schedule_event!(original_training_period: training_period, original_schedule:, new_training_period:)
     end
 
     # Determine the correct finished_on date for the new training period.
-    # In order of priority, we will take:
+    # Takes the earliest future date from the following, or nil if none apply:
     #
-    # 1. The finished_on of the current training period (if today or later)
-    # 2. The finished_on of the school period (if today or later)
-    # 3. nil (meaning the training period we are closing is ongoing)
+    # 1. The finished_on of the current training period
+    # 2. The finished_on of the school period
+    # 3. The started_on of a future training period for the same lead provider (to avoid overlap)
     def determine_finished_on
       [
         training_period.finished_on,
-        training_period.at_school_period_finished_on
+        training_period.at_school_period_finished_on,
+        future_training_period_for_same_lead_provider&.started_on
       ].compact.reject(&:past?).min
     end
 
@@ -100,6 +102,26 @@ module Teachers
         new_training_period:,
         teacher:,
         lead_provider:
+      )
+    end
+
+    def future_training_period_for_same_lead_provider
+      @future_training_period_for_same_lead_provider ||= training_period
+        .siblings
+        .started_after(training_period.started_on)
+        .joins(school_partnership: { lead_provider_delivery_partnership: { active_lead_provider: :lead_provider } })
+        .where(lead_providers: { id: lead_provider.id })
+        .earliest_first
+        .first
+    end
+
+    def update_future_training_period!
+      return unless future_training_period_for_same_lead_provider
+
+      future_training_period_for_same_lead_provider.update!(
+        schedule:,
+        school_partnership:,
+        expression_of_interest: nil
       )
     end
 

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -83,13 +83,34 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
           end
 
-          context "when there are future training periods (for the same teacher)" do
+          context "when the training period has not started yet" do
+            before { training_period.update!(started_on: 1.week.from_now, finished_on: nil) }
+
+            it { is_expected.to have_one_error_per_attribute }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
+          end
+
+          context "when there are future training periods with a different lead provider (for the same teacher)" do
             before do
-              FactoryBot.create(:training_period, :"for_#{trainee_type}", started_on: training_period.finished_on, finished_on: at_school_period.finished_on, "#{trainee_type}_at_school_period": at_school_period)
+              other_school_partnership = FactoryBot.create(:school_partnership, school: at_school_period.school)
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", started_on: training_period.finished_on, finished_on: at_school_period.finished_on, "#{trainee_type}_at_school_period": at_school_period, school_partnership: other_school_partnership)
             end
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they are due to start with another lead provider in the future.") }
+          end
+
+          context "when there are future training periods with the same lead provider (for the same teacher)" do
+            before do
+              # Skip metadata refresh so latest_training_period still points to the current (started)
+              # period rather than the newly created future one
+              DeclarativeUpdates.skip(:metadata) do
+                same_lead_provider_school_partnership = FactoryBot.create(:school_partnership, :for_year, school: at_school_period.school, lead_provider:, year: contract_period.year)
+                FactoryBot.create(:training_period, :"for_#{trainee_type}", started_on: training_period.finished_on, finished_on: at_school_period.finished_on, "#{trainee_type}_at_school_period": at_school_period, school_partnership: same_lead_provider_school_partnership)
+              end
+            end
+
+            it { is_expected.to be_valid }
           end
 
           context "when there are future training periods (for a different teacher)" do

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -86,8 +86,27 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
           context "when the training period has not started yet" do
             before { training_period.update!(started_on: 1.week.from_now, finished_on: nil) }
 
-            it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
+            context "when no other lead provider has an ongoing training period" do
+              it { is_expected.to be_valid }
+            end
+
+            context "when another lead provider has an ongoing training period" do
+              before do
+                other_school_partnership = FactoryBot.create(:school_partnership, school: at_school_period.school)
+                FactoryBot.create(
+                  :training_period,
+                  :"for_#{trainee_type}",
+                  :active,
+                  started_on: 2.months.ago,
+                  finished_on: 1.week.from_now,
+                  "#{trainee_type}_at_school_period": at_school_period,
+                  school_partnership: other_school_partnership
+                )
+              end
+
+              it { is_expected.to have_one_error_per_attribute }
+              it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
+            end
           end
 
           context "when there are future training periods with a different lead provider (for the same teacher)" do

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -113,6 +113,31 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             it { is_expected.to be_valid }
           end
 
+          context "when the metadata selects a future training period but an ongoing training period exists for the same lead provider" do
+            let(:future_training_period_started_on) { 2.months.from_now.to_date }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: nil) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :active, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: future_training_period_started_on) }
+            let!(:future_training_period) do
+              DeclarativeUpdates.skip(:metadata) do
+                same_lp_school_partnership = FactoryBot.create(:school_partnership, :for_year, school: at_school_period.school, lead_provider:, year: contract_period.year)
+                FactoryBot.create(
+                  :training_period,
+                  :"for_#{trainee_type}",
+                  started_on: future_training_period_started_on,
+                  finished_on: nil,
+                  "#{trainee_type}_at_school_period": at_school_period,
+                  school_partnership: same_lp_school_partnership
+                )
+              end
+            end
+
+            it { is_expected.to be_valid }
+
+            it "operates on the ongoing training period, not the future one" do
+              expect(instance.send(:training_period)).to eq(training_period)
+            end
+          end
+
           context "when there are future training periods (for a different teacher)" do
             before do
               at_school_period = FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 3.years.ago, finished_on: nil)

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -152,8 +152,20 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
             it { is_expected.to be_valid }
 
-            it "operates on the ongoing training period, not the future one" do
-              expect(instance.send(:training_period)).to eq(training_period)
+            it "returns the ongoing training period as training_period" do
+              expect(instance.training_period).to eq(training_period)
+            end
+
+            it "returns the ongoing training period" do
+              expect(instance.ongoing_training_period).to eq(training_period)
+            end
+
+            it "returns nil for future_training_period since metadata points to the ongoing one" do
+              expect(instance.future_training_period).to be_nil
+            end
+
+            it "returns the ongoing training period as latest_training_period_from_metadata" do
+              expect(instance.latest_training_period_from_metadata).to eq(training_period)
             end
           end
 

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             end
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they are due to start with another lead provider in the future.") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.") }
           end
 
           context "when there are future training periods with the same lead provider (for the same teacher)" do
@@ -186,7 +186,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
             it "returns error" do
               expect(subject).to have_one_error_per_attribute
-              expect(subject).to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training or induction.")
+              expect(subject).to have_error(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
             end
           end
 

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -83,14 +83,19 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
           end
 
-          context "when the training period has not started yet" do
+          context "when the LP is changing the schedule on their own future training period" do
             before { training_period.update!(started_on: 1.week.from_now, finished_on: nil) }
 
-            context "when no other lead provider has an ongoing training period" do
-              it { is_expected.to be_valid }
+            context "and no other lead provider is training the participant" do
+              # An LP should be able to change the schedule on their own future training period
+              # when they're the only LP on the participant. The change is applied in place on the
+              # future TP.
+              it "allows the change" do
+                expect(instance).to be_valid
+              end
             end
 
-            context "when another lead provider has an ongoing training period" do
+            context "and a different lead provider is actively training the participant" do
               before do
                 other_school_partnership = FactoryBot.create(:school_partnership, school: at_school_period.school)
                 FactoryBot.create(
@@ -104,22 +109,32 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
                 )
               end
 
-              it { is_expected.to have_one_error_per_attribute }
-              it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
+              # An LP whose only training period is in the future should still be allowed to change
+              # its schedule even if a different LP is currently training the participant. The
+              # change is applied in place on the future TP and doesn't touch the other LP's
+              # ongoing TP.
+              it "allows the change" do
+                expect(instance).to be_valid
+              end
             end
           end
 
-          context "when there are future training periods with a different lead provider (for the same teacher)" do
+          context "when a different lead provider has a future training period for the same participant" do
             before do
               other_school_partnership = FactoryBot.create(:school_partnership, school: at_school_period.school)
               FactoryBot.create(:training_period, :"for_#{trainee_type}", started_on: training_period.finished_on, finished_on: at_school_period.finished_on, "#{trainee_type}_at_school_period": at_school_period, school_partnership: other_school_partnership)
             end
 
-            it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.") }
+            # When a different LP is due to start training the participant in the future, the
+            # current LP should not be able to change the schedule — otherwise they could disrupt
+            # the incoming LP's planned training.
+            it "blocks the current LP from changing the schedule" do
+              expect(instance).to have_one_error_per_attribute
+              expect(instance).to have_error(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.")
+            end
           end
 
-          context "when there are future training periods with the same lead provider (for the same teacher)" do
+          context "when the same lead provider has a future training period in addition to the ongoing one" do
             before do
               # Skip metadata refresh so latest_training_period still points to the current (started)
               # period rather than the newly created future one
@@ -129,7 +144,12 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
               end
             end
 
-            it { is_expected.to be_valid }
+            # An LP can still change the schedule if they're the only LP on the participant — even
+            # when they have both an ongoing TP and a future TP (e.g. the participant is due to
+            # move schools with the same LP).
+            it "allows the change" do
+              expect(instance).to be_valid
+            end
           end
 
           context "when the metadata selects a future training period but an ongoing training period exists for the same lead provider" do

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -169,6 +169,51 @@ RSpec.describe Teachers::ChangeSchedule do
           end
         end
 
+        context "when a future training period exists for the same lead provider at a different school" do
+          let(:training_period_finished_on) { 2.months.from_now.to_date }
+          let(:school_period_finished_on) { training_period_finished_on }
+          let(:future_training_period_started_on) { training_period_finished_on + 1.day }
+          let(:different_school_period) do
+            FactoryBot.create(
+              :"#{trainee_type}_at_school_period",
+              :ongoing,
+              teacher:,
+              started_on: future_training_period_started_on
+            )
+          end
+          let!(:future_school_partnership) { FactoryBot.create(:school_partnership, :for_year, school: different_school_period.school, lead_provider:, year: new_contract_period.year) }
+          let!(:future_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :"for_#{trainee_type}",
+              "#{trainee_type}_at_school_period": different_school_period,
+              started_on: future_training_period_started_on,
+              finished_on: nil,
+              school_partnership: future_school_partnership
+            )
+          end
+
+          it "slots the new training period between the ongoing and future training periods" do
+            expect { service.change_schedule }.to change(TrainingPeriod, :count).from(2).to(3)
+
+            expect(training_period.reload.finished_on).to eq(Time.zone.today)
+
+            new_training_period = TrainingPeriod.where.not(id: [training_period.id, future_training_period.id]).last
+            expect(new_training_period.started_on).to eq(Time.zone.today)
+            expect(new_training_period.finished_on).to eq(training_period_finished_on)
+            expect(new_training_period.schedule).to eq(new_schedule)
+            expect(new_training_period.school_partnership).to eq(new_school_partnership)
+          end
+
+          it "updates the future training period's schedule but keeps its school_partnership" do
+            service.change_schedule
+
+            future_training_period.reload
+            expect(future_training_period.schedule).to eq(new_schedule)
+            expect(future_training_period.school_partnership).to eq(future_school_partnership)
+          end
+        end
+
         context "when the existing training_period.started_on has not yet passed" do
           let(:school_period_started_on) { Time.zone.today }
 

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -228,6 +228,68 @@ RSpec.describe Teachers::ChangeSchedule do
             expect(training_period.contract_period).to eq(new_contract_period)
             expect(training_period.expression_of_interest).to eq(new_school_partnership.active_lead_provider)
           end
+
+          context "when a future training period exists for the same lead provider" do
+            let(:school_period_finished_on) { nil }
+            let(:training_period_finished_on) { 1.month.from_now.to_date }
+            let(:future_training_period_started_on) { training_period_finished_on }
+            let!(:future_school_partnership) { FactoryBot.create(:school_partnership, :for_year, school: at_school_period.school, lead_provider:, year: new_contract_period.year) }
+            let!(:future_training_period) do
+              FactoryBot.create(
+                :training_period,
+                :"for_#{trainee_type}",
+                "#{trainee_type}_at_school_period": at_school_period,
+                started_on: future_training_period_started_on,
+                finished_on: nil,
+                school_partnership: future_school_partnership
+              )
+            end
+
+            it "also updates the future training period's schedule" do
+              service.change_schedule
+
+              future_training_period.reload
+              expect(future_training_period.schedule).to eq(new_schedule)
+            end
+          end
+
+          context "when a future training period exists for the same lead provider at a different school" do
+            let(:school_period_finished_on) { 1.month.from_now.to_date }
+            let(:future_training_period_started_on) { school_period_finished_on + 1.day }
+            let(:different_school_period) do
+              FactoryBot.create(
+                :"#{trainee_type}_at_school_period",
+                :ongoing,
+                teacher:,
+                started_on: future_training_period_started_on
+              )
+            end
+            let!(:future_school_partnership) { FactoryBot.create(:school_partnership, :for_year, school: different_school_period.school, lead_provider:, year: new_contract_period.year) }
+            let!(:future_training_period) do
+              FactoryBot.create(
+                :training_period,
+                :"for_#{trainee_type}",
+                "#{trainee_type}_at_school_period": different_school_period,
+                started_on: future_training_period_started_on,
+                finished_on: nil,
+                school_partnership: future_school_partnership
+              )
+            end
+
+            it "also updates the future training period's schedule" do
+              service.change_schedule
+
+              future_training_period.reload
+              expect(future_training_period.schedule).to eq(new_schedule)
+            end
+
+            it "keeps the future training period's school_partnership" do
+              service.change_schedule
+
+              future_training_period.reload
+              expect(future_training_period.school_partnership).to eq(future_school_partnership)
+            end
+          end
         end
       end
     end

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -132,6 +132,43 @@ RSpec.describe Teachers::ChangeSchedule do
           end
         end
 
+        context "when a future training period exists for the same lead provider" do
+          let(:training_period_finished_on) { 2.months.from_now.to_date }
+          let(:future_training_period_started_on) { training_period_finished_on }
+          let!(:future_school_partnership) { FactoryBot.create(:school_partnership, :for_year, school: at_school_period.school, lead_provider:, year: new_contract_period.year) }
+          let!(:future_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :"for_#{trainee_type}",
+              "#{trainee_type}_at_school_period": at_school_period,
+              started_on: future_training_period_started_on,
+              finished_on: nil,
+              school_partnership: future_school_partnership
+            )
+          end
+
+          it "slots the new training period between the ongoing and future training periods" do
+            expect { service.change_schedule }.to change(TrainingPeriod, :count).from(2).to(3)
+
+            expect(training_period.reload.finished_on).to eq(Time.zone.today)
+
+            new_training_period = TrainingPeriod.where.not(id: [training_period.id, future_training_period.id]).last
+            expect(new_training_period.started_on).to eq(Time.zone.today)
+            expect(new_training_period.finished_on).to eq(future_training_period.started_on)
+            expect(new_training_period.schedule).to eq(new_schedule)
+            expect(new_training_period.school_partnership).to eq(new_school_partnership)
+          end
+
+          it "updates the future training period's schedule and school_partnership" do
+            service.change_schedule
+
+            future_training_period.reload
+            expect(future_training_period.schedule).to eq(new_schedule)
+            expect(future_training_period.school_partnership).to eq(new_school_partnership)
+            expect(future_training_period.expression_of_interest).to be_nil
+          end
+        end
+
         context "when the existing training_period.started_on has not yet passed" do
           let(:school_period_started_on) { Time.zone.today }
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3393

### Changes proposed in this pull request

* Replaces `lead_provider_is_currently_training_teacher` with `training_period_not_finished` — still blocks changes on finished TPs, but now also allows changes on future TPs (not just ongoing ones).
* Replaces `no_future_training_periods_exist` with two new validations:
  *  `future_training_period_not_blocked_by_another_lead_provider` - if the LP only has a future TP, it blocks the change when a different LP is currently training the participant (i.e. during a transfer, the new LP can't change the schedule while the old LP is still active).
  * `no_future_training_periods_with_different_lead_provider` - blocks the old LP from changing their schedule when a future TP exists with a different LP.
* Overrides `training_period` resolution - metadata picks the latest TP by `started_on`, which prefers a future TP over an ongoing one. The override now prefers the ongoing TP so the schedule change operates against the currently active record.

### Guidance to review
