### PR TITLE
Ensure service action response is reloaded

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -20,7 +20,9 @@ protected
 
   def respond_with_service(service:, action:)
     if service.valid?
-      render json: to_json(service.send(action))
+      response = service.send(action)
+      response.reload if response.respond_to?(:reload)
+      render json: to_json(response)
     else
       render json: API::Errors::Response.from(service), status: :unprocessable_content
     end

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Declarations API", :with_metadata, type: :request do
+RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request do
   let(:serializer) { API::DeclarationSerializer }
   let(:serializer_options) { { lead_provider_id: lead_provider.id } }
   let(:query) { API::Declarations::Query }
@@ -127,9 +127,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
 
     Declaration::VOIDABLE_PAYMENT_STATUSES.each do |status|
       context "when the declaration is in a `voidable` status: #{status}" do
-        let(:resource) do
-          create_resource(active_lead_provider:, declaration_trait: status.to_sym)
-        end
+        let(:resource) { travel_to(3.days.ago) { create_resource(active_lead_provider:, declaration_trait: status.to_sym) } }
         let(:service) { API::Declarations::Void }
 
         it_behaves_like "a token authenticated endpoint", :put
@@ -138,9 +136,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
     end
 
     context "when the declaration is in `paid` status" do
-      let(:resource) do
-        create_resource(active_lead_provider:, declaration_trait: :paid)
-      end
+      let(:resource) { travel_to(3.days.ago) { create_resource(active_lead_provider:, declaration_trait: :paid) } }
       let(:service) { API::Declarations::Clawback }
 
       it_behaves_like "a token authenticated endpoint", :put
@@ -148,9 +144,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
     end
 
     context "when the declaration is in `voided` status" do
-      let(:resource) do
-        create_resource(active_lead_provider:, declaration_trait: :voided)
-      end
+      let(:resource) { travel_to(3.days.ago) {  create_resource(active_lead_provider:, declaration_trait: :voided) } }
 
       it "returns a 422 response" do
         authenticated_api_put(path, params:)
@@ -162,7 +156,7 @@ RSpec.describe "Declarations API", :with_metadata, type: :request do
     end
 
     context "when the declaration is a previous declaration for a different lead provider" do
-      let(:resource) { create_resource(active_lead_provider: FactoryBot.create(:active_lead_provider)) }
+      let(:resource) { travel_to(3.days.ago) {  create_resource(active_lead_provider: FactoryBot.create(:active_lead_provider)) } }
 
       before do
         # Close training periods for other lead providers.

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Participants API", :with_metadata, type: :request do
+RSpec.describe "Participants API", :with_metadata, :with_touches, type: :request do
   let(:serializer) { API::TeacherSerializer }
   let(:serializer_options) { { lead_provider_id: lead_provider.id } }
   let(:query) { API::Teachers::Query }
@@ -58,7 +58,7 @@ RSpec.describe "Participants API", :with_metadata, type: :request do
     let(:path) { change_schedule_api_v3_participant_path(resource.api_id) }
     let(:service) { API::Teachers::ChangeSchedule }
     let(:resource_type) { Teacher }
-    let(:resource) { create_resource(active_lead_provider:) }
+    let(:resource) { travel_to(3.days.ago) { create_resource(active_lead_provider:) } }
     let(:schedule_identifier) { FactoryBot.create(:schedule, contract_period:).identifier }
     let(:contract_period) { FactoryBot.create(:contract_period) }
     let(:contract_period_year) { contract_period.year.to_s }
@@ -100,7 +100,7 @@ RSpec.describe "Participants API", :with_metadata, type: :request do
     let(:path) { defer_api_v3_participant_path(resource.api_id) }
     let(:service) { API::Teachers::Defer }
     let(:resource_type) { Teacher }
-    let(:resource) { create_resource(active_lead_provider:) }
+    let(:resource) { travel_to(3.days.ago) { create_resource(active_lead_provider:) } }
     let(:reason) { service::DEFERRAL_REASONS.sample }
     let(:course_identifier) { "ecf-induction" }
     let(:service_args) do
@@ -131,7 +131,7 @@ RSpec.describe "Participants API", :with_metadata, type: :request do
     let(:path) { resume_api_v3_participant_path(resource.api_id) }
     let(:service) { API::Teachers::Resume }
     let(:resource_type) { Teacher }
-    let(:resource) { create_resource(active_lead_provider:, training_status: :withdrawn) }
+    let(:resource) { travel_to(3.days.ago) {  create_resource(active_lead_provider:, training_status: :withdrawn) } }
     let(:course_identifier) { "ecf-induction" }
     let(:service_args) do
       {
@@ -159,7 +159,7 @@ RSpec.describe "Participants API", :with_metadata, type: :request do
     let(:path) { withdraw_api_v3_participant_path(resource.api_id) }
     let(:service) { API::Teachers::Withdraw }
     let(:resource_type) { Teacher }
-    let(:resource) { create_resource(active_lead_provider:) }
+    let(:resource) { travel_to(3.days.ago) { create_resource(active_lead_provider:) } }
     let(:reason) { service::WITHDRAWAL_REASONS.sample }
     let(:course_identifier) { "ecf-mentor" }
     let(:service_args) do

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Partnerships API", type: :request do
+RSpec.describe "Partnerships API", :with_touches, type: :request do
   let(:serializer) { API::SchoolPartnershipSerializer }
   let(:serializer_options) { { lead_provider: } }
   let(:query) { API::SchoolPartnerships::Query }
@@ -73,7 +73,7 @@ RSpec.describe "Partnerships API", type: :request do
     let(:path) { api_v3_partnership_path(resource.api_id) }
     let(:service) { API::SchoolPartnerships::Update }
     let(:resource_type) { SchoolPartnership }
-    let(:resource) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) }
+    let(:resource) { travel_to(3.days.ago) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:) } }
     let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
     let(:other_delivery_partner) do
       other_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)


### PR DESCRIPTION
When the API calls a service that peforms an action on an object we often respond with that object. Often these services will mutated the object indirectly (via touch callbacks, for example) -- if we don't `reload` the object before responding the values may not be up to date.

We had a request spec to catch this already, however it was missing when the object is touched via `DeclarativeUpdates` as by default we disable the touch model in tests.

Enable `with_touches` on request specs that perform an action.

Travel to a previous date when creating resources in these tests (to ensure the `api_updated_at` will change).

Add a catch-all `reload` in `respond_with_service` to ensure we always return the latest version of the object.
