### PR TITLE
Fix `created_at` of first `AtSchoolPeriod` migrated

### DIFF
--- a/app/migration/ecf2_teacher_history/ect_at_school_period.rb
+++ b/app/migration/ecf2_teacher_history/ect_at_school_period.rb
@@ -26,6 +26,7 @@ class ECF2TeacherHistory::ECTAtSchoolPeriod
 
   def to_hash
     {
+      created_at:,
       started_on:,
       finished_on:,
       school: real_school,
@@ -36,6 +37,7 @@ class ECF2TeacherHistory::ECTAtSchoolPeriod
 
   def to_h
     {
+      created_at:,
       started_on:,
       finished_on:,
       school: school.to_h,

--- a/app/migration/ecf2_teacher_history/mentor_at_school_period.rb
+++ b/app/migration/ecf2_teacher_history/mentor_at_school_period.rb
@@ -17,6 +17,7 @@ class ECF2TeacherHistory::MentorAtSchoolPeriod
 
   def to_hash
     {
+      created_at:,
       started_on:,
       finished_on:,
       school: real_school,
@@ -26,6 +27,7 @@ class ECF2TeacherHistory::MentorAtSchoolPeriod
 
   def to_h
     {
+      created_at:,
       started_on:,
       finished_on:,
       school: school.to_h,

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -268,7 +268,7 @@ describe ECF2TeacherHistory do
               appropriate_body: appropriate_body_a_data,
               training_periods: [first_training_period],
               mentorship_periods: []
-            )
+            ).tap { it.created_at = 2.months.ago }
           end
 
           let(:second_training_period) do
@@ -320,6 +320,7 @@ describe ECF2TeacherHistory do
                 expect(p1.finished_on).to eql(30.days.ago.to_date)
                 expect(p1.school.urn).to eql(school_a_data.urn)
                 expect(p1.email).to eql("a@example.org")
+                expect(p1.created_at).to be_within(5.seconds).of(first_ect_at_school_period.created_at)
                 # expect(p1.school_reported_appropriate_body.id).to eql(appropriate_body_a_data.id)
 
                 p1.training_periods.first!.tap do |p1_tp|
@@ -675,7 +676,7 @@ describe ECF2TeacherHistory do
               school: school_a_data,
               email: "a@example.org",
               training_periods: [first_training_period]
-            )
+            ).tap { it.created_at = 2.months.ago }
           end
 
           let(:mentor_at_school_periods) do
@@ -697,6 +698,7 @@ describe ECF2TeacherHistory do
                 expect(p1.finished_on).to eql(1.month.ago.to_date)
                 expect(p1.school.urn).to eql(school_a_data.urn)
                 expect(p1.email).to eql("a@example.org")
+                expect(p1.created_at).to be_within(5.seconds).of(first_mentor_at_school_period.created_at)
 
                 p1.training_periods.first!.tap do |p1_tp|
                   expect(p1_tp.started_on).to eql(1.year.ago.to_date)


### PR DESCRIPTION
We should be setting the first school period's `created_at` to the `ParticipantProfile#created_at` (for both ECTs and mentors).

We override the `created_at` in `TeacherHistoryConverter` already:

https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/app/migration/teacher_history_converter.rb#L58

However, when we later pass it into a`MentorAtSchoolPeriod.create!` in `ECF2TeacherHistory` we double-splat the object, which internally will call `to_hash` and we were not adding `created_at` to the list of keys returned.

Add `created_at` to school period `to_hash/to_h` methods and cover with a test to ensure we populate `created_at` of the first school periods during migration.
