### PR TITLE
Exclude fields form change schedule parity check response

### DIFF
--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -555,18 +555,30 @@ put:
       ecf_path: "/api/v3/participants/ecf/:id/change-schedule"
       id: ":teacher_api_id_for_change_schedule_action"
       body: change_schedule_different_schedule_and_cohort_participant_body
+      exclude:
+        - teacher_reference_number_validated
+        - overall_induction_start_date
   - "/api/v3/participants/:id/change-schedule":
       description: "Change schedule to a different cohort"
       ecf_path: "/api/v3/participants/ecf/:id/change-schedule"
       id: ":teacher_api_id_for_change_schedule_action"
       body: change_schedule_different_cohort_participant_body
+      exclude:
+        - teacher_reference_number_validated
+        - overall_induction_start_date
   - "/api/v3/participants/:id/change-schedule":
       description: "Change schedule to a different schedule"
       ecf_path: "/api/v3/participants/ecf/:id/change-schedule"
       id: ":teacher_api_id_for_change_schedule_action"
       body: change_schedule_different_schedule_participant_body
+      exclude:
+        - teacher_reference_number_validated
+        - overall_induction_start_date
   - "/api/v3/participants/:id/change-schedule":
       description: "Change schedule with incorrect course identifier"
       ecf_path: "/api/v3/participants/ecf/:id/change-schedule"
       id: ":teacher_api_id_for_change_schedule_action"
       body: change_schedule_error_state_participant_body
+      exclude:
+        - teacher_reference_number_validated
+        - overall_induction_start_date


### PR DESCRIPTION
The `teacher_reference_number_validated` is only returned by ECF and `overall_induction_start_date` is only returned by RECT.
