### PR TITLE
Update ordering of fields in `DeclarationSerializer`

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -4,7 +4,6 @@ class API::DeclarationSerializer < Blueprinter::Base
 
     field(:participant_id) { |declaration| declaration.training_period.teacher.api_id }
     field(:declaration_type)
-    field(:declaration_date)
 
     field(:course_identifier) do |declaration|
       if declaration.training_period.for_ect?
@@ -13,6 +12,9 @@ class API::DeclarationSerializer < Blueprinter::Base
         "ecf-mentor"
       end
     end
+
+    field(:declaration_date)
+    field(:mentor_id) { |declaration| declaration.mentorship_period&.mentor&.teacher&.api_id }
 
     field(:state) do |declaration|
       status = declaration.overall_status
@@ -28,7 +30,6 @@ class API::DeclarationSerializer < Blueprinter::Base
     # This will be removed at a later date, retaining for now for ECF parity and so
     # we don't have to communicate another change to LPs just yet.
     field(:ineligible_for_funding_reason) { nil }
-    field(:mentor_id) { |declaration| declaration.mentorship_period&.mentor&.teacher&.api_id }
     field(:uplift_paid?, name: :uplift_paid)
     field(:evidence_type, name: :evidence_held)
     field(:lead_provider_name) { |declaration| declaration.training_period.lead_provider.name }


### PR DESCRIPTION
The `course_identifier` and `mentor_id` are out of order when compared to ECF.

Updating so they match in the parity check.
