### PR TITLE
Name correctly Teacher#trs_induction_completed_date in the migrators

### DIFF
--- a/app/migration/ecf2_teacher_history/teacher.rb
+++ b/app/migration/ecf2_teacher_history/teacher.rb
@@ -18,7 +18,7 @@ class ECF2TeacherHistory::Teacher
               :mentor_first_became_eligible_for_training_at,
               :mentor_payments_frozen_year,
               :trs_induction_start_date,
-              :trs_induction_completion_date,
+              :trs_induction_completed_date,
               :created_at,
               :updated_at
 
@@ -41,7 +41,7 @@ class ECF2TeacherHistory::Teacher
                  mentor_first_became_eligible_for_training_at: nil,
                  mentor_payments_frozen_year: nil,
                  trs_induction_start_date: nil,
-                 trs_induction_completion_date: nil,
+                 trs_induction_completed_date: nil,
                  created_at: nil,
                  updated_at: nil)
     @trn = trn
@@ -63,7 +63,7 @@ class ECF2TeacherHistory::Teacher
     @mentor_first_became_eligible_for_training_at = mentor_first_became_eligible_for_training_at
     @mentor_payments_frozen_year = mentor_payments_frozen_year
     @trs_induction_start_date = trs_induction_start_date
-    @trs_induction_completion_date = trs_induction_completion_date
+    @trs_induction_completed_date = trs_induction_completed_date
     @created_at = created_at
     @updated_at = updated_at
   end
@@ -77,7 +77,7 @@ class ECF2TeacherHistory::Teacher
       corrected_name:,
 
       trs_induction_start_date:,
-      trs_induction_completion_date:,
+      trs_induction_completed_date:,
 
       api_id:,
       api_ect_training_record_id:,

--- a/app/migration/teacher_history_converter.rb
+++ b/app/migration/teacher_history_converter.rb
@@ -133,7 +133,7 @@ private
       mentor_became_ineligible_for_funding_on: ecf1_teacher_history.mentor&.mentor_completion_date,
       mentor_became_ineligible_for_funding_reason: ecf1_teacher_history.mentor&.mentor_completion_reason,
       trs_induction_start_date: ecf1_teacher_history.ect&.induction_start_date,
-      trs_induction_completion_date: ecf1_teacher_history.ect&.induction_completion_date,
+      trs_induction_completed_date: ecf1_teacher_history.ect&.induction_completion_date,
       created_at: ecf1_teacher_history.user.created_at,
       updated_at: ecf1_teacher_history.user.updated_at
     )

--- a/spec/migration/teacher_history_converter/real_examples/006ed3de_112f_4e78_bdda_b738a3490cfa_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/006ed3de_112f_4e78_bdda_b738a3490cfa_spec.rb
@@ -138,7 +138,7 @@ describe "Real data check for user 006ed3de-112f-4e78-bdda-b738a3490cfa" do
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2022, 9, 1),
-          trs_induction_completion_date: Date.new(2024, 7, 22),
+          trs_induction_completed_date: Date.new(2024, 7, 22),
           ect_at_school_periods: array_including(
             hash_including(
               school: hash_including(urn: "100001", name: "School 1"),

--- a/spec/migration/teacher_history_converter/real_examples/1ed6d4d4_fc15_4536_bcbc_bc6250f859da_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/1ed6d4d4_fc15_4536_bcbc_bc6250f859da_spec.rb
@@ -155,7 +155,7 @@ describe "Real data check for user 1ed6d4d4-fc15-4536-bcbc-bc6250f859da (with a 
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2023, 9, 1),
-          trs_induction_completion_date: Date.new(2025, 7, 22),
+          trs_induction_completed_date: Date.new(2025, 7, 22),
           ect_at_school_periods: array_including(
             hash_including(
               # NOTE: here, the final induction record above has been converted to a stub because

--- a/spec/migration/teacher_history_converter/real_examples/3dfb8ce4_2df6_4aff_a69a_107244d04615_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/3dfb8ce4_2df6_4aff_a69a_107244d04615_spec.rb
@@ -131,7 +131,7 @@ describe "Real data check for user 3dfb8ce4-2df6-4aff-a69a-107244d04615", skip: 
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2021, 11, 29),
-          trs_induction_completion_date: :ignore,
+          trs_induction_completed_date: :ignore,
           ect_at_school_periods: array_including(
             hash_including(
               started_on: Date.new(2021, 12, 1),

--- a/spec/migration/teacher_history_converter/real_examples/653c0693_e8ad_4487_8a4a_0d48f678ba70_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/653c0693_e8ad_4487_8a4a_0d48f678ba70_spec.rb
@@ -256,7 +256,7 @@ describe "Real data check for user 653c0693-e8ad-4487-8a4a-0d48f678ba70" do
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2022, 9, 1),
-          trs_induction_completion_date: Date.new(2024, 7, 23),
+          trs_induction_completed_date: Date.new(2024, 7, 23),
           ect_at_school_periods: array_including(
             hash_including(
               started_on: Date.new(2024, 7, 23),

--- a/spec/migration/teacher_history_converter/real_examples/668787fb_6c01_46ee_83bf_2e5362eba446_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/668787fb_6c01_46ee_83bf_2e5362eba446_spec.rb
@@ -298,7 +298,7 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2025, 1, 10),
-          trs_induction_completion_date: Date.new(2025, 4, 4),
+          trs_induction_completed_date: Date.new(2025, 4, 4),
           ect_at_school_periods: array_including(
             hash_including(
               # NOTE: here, the final induction record above has been converted to a stub because

--- a/spec/migration/teacher_history_converter/real_examples/924dd86e_416d_4d2e_aba3_6e72a8c3c8c5_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/924dd86e_416d_4d2e_aba3_6e72a8c3c8c5_spec.rb
@@ -105,7 +105,7 @@ describe "Real data check for user 924dd86e-416d-4d2e-aba3-6e72a8c3c8c5 (straigh
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2026, 1, 13),
-          trs_induction_completion_date: nil,
+          trs_induction_completed_date: nil,
           ect_at_school_periods: array_including(
             hash_including(
               started_on: Date.new(2025, 6, 1),

--- a/spec/migration/teacher_history_converter/real_examples/a1d38b72_4f11_490c_bee4_5b475f4b224f_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/a1d38b72_4f11_490c_bee4_5b475f4b224f_spec.rb
@@ -178,7 +178,7 @@ describe "Real data check for user a1d38b72-4f11-490c-bee4-5b475f4b224f" do
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2021, 9, 6),
-          trs_induction_completion_date: Date.new(2024, 3, 28),
+          trs_induction_completed_date: Date.new(2024, 3, 28),
           ect_at_school_periods: array_including(
             hash_including(
               started_on: Date.new(2024, 2, 3),

--- a/spec/migration/teacher_history_converter/real_examples/d283a5c2_ab76_465e_b261_cb55cf946f00_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/d283a5c2_ab76_465e_b261_cb55cf946f00_spec.rb
@@ -206,7 +206,7 @@ describe "Real data check for user d283a5c2-ab76-465e-b261-cb55cf946f00" do
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2024, 9, 2),
-          trs_induction_completion_date: nil,
+          trs_induction_completed_date: nil,
           ect_at_school_periods: array_including(
             # stub record
             hash_including(

--- a/spec/migration/teacher_history_converter/real_examples/ebc97a2d_6ecf_42bb_874d_152cf6e324f9_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/ebc97a2d_6ecf_42bb_874d_152cf6e324f9_spec.rb
@@ -163,7 +163,7 @@ describe "Real data check for user ebc97a2d-6ecf-42bb-874d-152cf6e324f9 (setting
         teacher: hash_including(
           trn: "1111111",
           trs_induction_start_date: Date.new(2023, 9, 1),
-          trs_induction_completion_date: nil,
+          trs_induction_completed_date: nil,
           ect_at_school_periods: array_including(
             hash_including(
               started_on: Date.new(2025, 6, 2),


### PR DESCRIPTION
### Context

Rename `trs_induction_completion_date` to `trs_induction_completed_date` in the migrators according to the name of the field in the `Teacher` model.

### Changes proposed in this pull request

### Guidance to review
