### PR TITLE
Dasherize declaration state when serializing

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -17,7 +17,7 @@ class API::DeclarationSerializer < Blueprinter::Base
     field(:state) do |declaration|
       status = declaration.overall_status
       # This is for ecf1 consistency as "submitted" has been renamed to "no_payment" on rect
-      status == "no_payment" ? "submitted" : status
+      status == "no_payment" ? "submitted" : status.dasherize
     end
 
     field(:updated_at)

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -1515,8 +1515,8 @@ components:
               - payable
               - paid
               - voided
-              - awaiting_clawback
-              - clawed_back
+              - awaiting-clawback
+              - clawed-back
               example: submitted
             updated_at:
               description: The date the declaration was last updated.
@@ -1653,8 +1653,8 @@ components:
               - payable
               - paid
               - voided
-              - awaiting_clawback
-              - clawed_back
+              - awaiting-clawback
+              - clawed-back
               example: submitted
             updated_at:
               description: The date the declaration was last updated.

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -72,7 +72,7 @@ describe API::DeclarationSerializer, type: :serializer do
             expected_state = status.to_s
             expected_state = "submitted" if expected_state == "no_payment"
 
-            expect(attributes["state"]).to eq(expected_state)
+            expect(attributes["state"]).to eq(expected_state.dasherize)
           end
         end
       end

--- a/spec/swagger_schemas/models/declaration.rb
+++ b/spec/swagger_schemas/models/declaration.rb
@@ -48,7 +48,7 @@ DECLARATION = {
           description: "Indicates the state of this payment declaration.",
           type: :string,
           nullable: false,
-          enum: %w[submitted] + Declaration.payment_statuses.values.excluding("no_payment") + Declaration.clawback_statuses.values.excluding("no_clawback"),
+          enum: %w[submitted] + (Declaration.payment_statuses.values.excluding("no_payment") + Declaration.clawback_statuses.values.excluding("no_clawback")).map(&:dasherize),
           example: "submitted",
         },
         updated_at: {


### PR DESCRIPTION
To match ECF the declaration states should be dasherized, so `awaiting-clawback` instead of `awaiting_clawback`.
