### PR TITLE
Improve schools migrator

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -41,10 +41,13 @@ module Migrators
 
       migrate(schools_with_associations) do |ecf_school|
         gias_school = find_gias_school_by_urn(ecf_school.urn.to_i) || migrate_school!(ecf_school)
+
         if check_gias_school(gias_school:, ecf_school:)
+          school = ::School.find_by!(urn: ecf_school.urn)
+
           [
             compare_fields(gias_school:, ecf_school:),
-            update_school!(school: gias_school.school, ecf_school:),
+            update_school!(school:, ecf_school:)
           ].all?
         end
       end
@@ -85,11 +88,15 @@ module Migrators
     def find_gias_school_by_urn(urn) = gias_schools_by_urn[urn.to_i]
 
     def gias_schools_by_urn
-      @gias_schools_by_urn ||= ::GIAS::School.where(urn: self.class.schools.pluck(:urn)).index_by(&:urn)
+      @gias_schools_by_urn ||= ::GIAS::School.where(urn: self.class.schools.pluck(:urn)).index_by { |s| s.urn.to_i }
     end
 
     def migrate_school!(ecf_school)
-      Builders::GIAS::School.new(ecf_school).build if migratable_school?(ecf_school)
+      return unless migratable_school?(ecf_school)
+
+      school = Builders::GIAS::School.new(ecf_school).build
+      gias_schools_by_urn[school.urn] = school if school
+      school
     end
 
     def migratable_school?(ecf_school)


### PR DESCRIPTION
### Context

Seeing some schools being migrated but with different `api_id`.

ie:

This school is in ECF1 and it's been migrated to RECT but it has a different `api_id` for the same `URN` in RECT.

ECF1:
```
#<School:0x00007f9650be0288
 id: "4ebc3618-46c6-4313-b354-1b739cb87f01",
 created_at: Thu, 22 Apr 2021 12:35:24.639365000 UTC +00:00,
 updated_at: Mon, 02 Mar 2026 06:00:36.701988000 UTC +00:00,
 urn: "123BLA",
 name: "School Name",
...
```

RECT
```
#<School:0x00007f0920565010
 id: 11329,
 urn: 123BLA,
 name: "School Name",
 created_at: "2026-03-16 20:38:31.171168000 +0000",
 updated_at: "2026-03-16 20:38:31.171168000 +0000",
 api_id: "79d511f0-9b31-4f5a-8416-7e5f7bd7b663",
...
```

### Changes proposed in this pull request

- Improve schools migrator in order to prevent the error from happening.

### Guidance to review
