### PR TITLE
Return `nil` `statement_id` when declaration voided

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -25,7 +25,7 @@ class API::DeclarationSerializer < Blueprinter::Base
     field(:updated_at)
     field(:created_at)
     field(:delivery_partner_id) { |declaration| declaration.delivery_partner_when_created.api_id }
-    field(:statement_id) { |declaration| declaration.payment_statement&.api_id }
+    field(:statement_id) { |declaration| declaration.payment_statement&.api_id unless declaration.payment_status_voided? }
     field(:clawback_statement_id) { |declaration| declaration.clawback_statement&.api_id }
     # This will be removed at a later date, retaining for now for ECF parity and so
     # we don't have to communicate another change to LPs just yet.

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -87,6 +87,15 @@ describe API::DeclarationSerializer, type: :serializer do
           expect(attributes["clawback_statement_id"]).to be_nil
         end
       end
+
+      context "when the declaration has been voided" do
+        let(:declaration) { FactoryBot.create(:declaration, :voided) }
+
+        it "does not return the `statement_id`" do
+          expect(declaration.payment_statement).to be_present
+          expect(attributes["statement_id"]).to be_nil
+        end
+      end
     end
 
     describe "clawback_statement_id" do


### PR DESCRIPTION
In ECF we do not return a `statement_id` when the declaration has been `voided`.

This is due to the `StatementLineItem` in ECF moving from `eligible/payable` to `voided` and the serializer only returns the `statement_id` from `billable` line items (once `voided` the line item is no longer `billable`).

Do not return `statement_id` when `payment_status` is `voided`, even though there is still a `payment_statement` on the `Declaration` if the state was previously `eligible` or `payable`.
