### PR TITLE
[3621] Amend mentor output payments to exclude clawbacks

### DIFF
--- a/app/services/payment_calculator/flat_rate.rb
+++ b/app/services/payment_calculator/flat_rate.rb
@@ -19,7 +19,12 @@ module PaymentCalculator
     def vat_amount = outputs.total_net_amount * vat_rate
 
     def outputs
-      @outputs ||= FlatRate::Outputs.new(declarations: filtered_declarations, fee_per_declaration:, fee_proportions:)
+      @outputs ||= FlatRate::Outputs.new(
+        billable_declarations: filtered_billable_declarations,
+        refundable_declarations: filtered_refundable_declarations,
+        fee_per_declaration:,
+        fee_proportions:
+      )
     end
 
     def voided_declarations_count
@@ -31,10 +36,12 @@ module PaymentCalculator
     def fee_per_declaration = flat_rate_fee_structure.fee_per_declaration
     def vat_rate = flat_rate_fee_structure.contract.applicable_vat_rate
 
-    def filtered_declarations
-      declarations = statement.payment_declarations.billable
-        .or(statement.clawback_declarations.refundable)
-      declaration_selector.call(declarations)
+    def filtered_billable_declarations
+      declaration_selector.call(statement.payment_declarations.billable)
+    end
+
+    def filtered_refundable_declarations
+      declaration_selector.call(statement.clawback_declarations.refundable)
     end
 
     def filtered_voided_declarations

--- a/app/services/payment_calculator/flat_rate/declaration_type_output.rb
+++ b/app/services/payment_calculator/flat_rate/declaration_type_output.rb
@@ -6,7 +6,8 @@ module PaymentCalculator
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    attribute :declarations
+    attribute :billable_declarations
+    attribute :refundable_declarations
     attribute :declaration_type
     attribute :fee_per_declaration
     attribute :fee_proportions
@@ -18,11 +19,11 @@ module PaymentCalculator
     end
 
     def billable_count
-      @billable_count ||= declarations_of_matching_type.billable.count
+      @billable_count ||= billable_declarations.where(declaration_type:).count
     end
 
     def refundable_count
-      @refundable_count ||= declarations_of_matching_type.refundable.count
+      @refundable_count ||= refundable_declarations.where(declaration_type:).count
     end
 
     def type_adjusted_fee_per_declaration
@@ -34,10 +35,6 @@ module PaymentCalculator
     def total_net_amount = total_billable_amount - total_refundable_amount
 
   private
-
-    def declarations_of_matching_type
-      declarations.where(declaration_type:)
-    end
 
     def fee_proportion
       fee_proportions.fetch(declaration_type.to_sym) do

--- a/app/services/payment_calculator/flat_rate/outputs.rb
+++ b/app/services/payment_calculator/flat_rate/outputs.rb
@@ -3,13 +3,14 @@ module PaymentCalculator
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    attribute :declarations
+    attribute :billable_declarations
+    attribute :refundable_declarations
     attribute :fee_per_declaration
     attribute :fee_proportions
 
     def declaration_type_outputs
       @declaration_type_outputs ||= declaration_types.map do |declaration_type|
-        FlatRate::DeclarationTypeOutput.new(declarations:, declaration_type:, fee_per_declaration:, fee_proportions:)
+        FlatRate::DeclarationTypeOutput.new(billable_declarations:, refundable_declarations:, declaration_type:, fee_per_declaration:, fee_proportions:)
       end
     end
 
@@ -32,7 +33,8 @@ module PaymentCalculator
   private
 
     def declaration_types
-      declarations.pluck("DISTINCT declaration_type")
+      (billable_declarations.pluck("DISTINCT declaration_type") +
+        refundable_declarations.pluck("DISTINCT declaration_type")).uniq
     end
   end
 end

--- a/spec/services/payment_calculator/flat_rate/declaration_type_output_spec.rb
+++ b/spec/services/payment_calculator/flat_rate/declaration_type_output_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe PaymentCalculator::FlatRate::DeclarationTypeOutput do
   subject(:output) do
     described_class.new(
-      declarations: Declaration.all,
+      billable_declarations:,
+      refundable_declarations:,
       declaration_type:,
       fee_per_declaration:,
       fee_proportions:
@@ -12,32 +13,45 @@ RSpec.describe PaymentCalculator::FlatRate::DeclarationTypeOutput do
   let(:declaration_type) { "started" }
   let(:fee_proportions) { { started: 0.25, completed: 0.75 } }
 
+  let(:billable_ids) { [] }
+  let(:refundable_ids) { [] }
+  let(:billable_declarations) { Declaration.where(id: billable_ids) }
+  let(:refundable_declarations) { Declaration.where(id: refundable_ids) }
+
   before do
-    traits = %i[no_payment eligible payable paid voided awaiting_clawback clawed_back]
-    traits.each do |trait|
-      # Create a `started` declaration for each trait
+    %i[eligible payable paid].each do |trait|
+      billable_ids << FactoryBot.create(:declaration, trait, declaration_type:).id
+      billable_ids << FactoryBot.create(:declaration, trait, declaration_type: "completed").id
+    end
+
+    %i[awaiting_clawback clawed_back].each do |trait|
+      refundable_ids << FactoryBot.create(:declaration, trait, declaration_type:).id
+      refundable_ids << FactoryBot.create(:declaration, trait, declaration_type: "completed").id
+    end
+
+    %i[no_payment voided].each do |trait|
       FactoryBot.create(:declaration, trait, declaration_type:)
-      # Create a `completed` declaration for each trait, should not be counted
       FactoryBot.create(:declaration, trait, declaration_type: "completed")
     end
   end
 
   describe "#billable_count" do
-    it "counts declarations with billable statuses" do
-      # eligible(1) + payable(1) + paid(1) + awaiting_clawback(1, payment_status: paid) + clawed_back(1, payment_status: paid)
-      expect(output.billable_count).to eq(5)
+    it "counts billable declarations of matching type" do
+      # eligible(1) + payable(1) + paid(1) for "started"
+      expect(output.billable_count).to eq(3)
     end
   end
 
   describe "#refundable_count" do
-    it "counts declarations with refundable statuses" do
+    it "counts refundable declarations of matching type" do
+      # awaiting_clawback(1) + clawed_back(1) for "started"
       expect(output.refundable_count).to eq(2)
     end
   end
 
   describe "#total_billable_amount" do
     it "returns billable_count multiplied by fee_per_declaration and fee proportion" do
-      expect(output.total_billable_amount).to eq(5 * 100.0 * 0.25)
+      expect(output.total_billable_amount).to eq(3 * 100.0 * 0.25)
     end
   end
 
@@ -49,7 +63,7 @@ RSpec.describe PaymentCalculator::FlatRate::DeclarationTypeOutput do
 
   describe "#total_net_amount" do
     it "returns total_billable_amount minus total_refundable_amount" do
-      expect(output.total_net_amount).to eq(75.0)
+      expect(output.total_net_amount).to eq(25.0)
     end
   end
 

--- a/spec/services/payment_calculator/flat_rate/outputs_spec.rb
+++ b/spec/services/payment_calculator/flat_rate/outputs_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe PaymentCalculator::FlatRate::Outputs do
   subject(:outputs) do
     described_class.new(
-      declarations: Declaration.all,
+      billable_declarations:,
+      refundable_declarations:,
       fee_per_declaration:,
       fee_proportions:
     )
@@ -10,9 +11,23 @@ RSpec.describe PaymentCalculator::FlatRate::Outputs do
   let(:fee_per_declaration) { 100.0 }
   let(:fee_proportions) { { started: 0.5, completed: 0.5 } }
 
+  let(:billable_ids) { [] }
+  let(:refundable_ids) { [] }
+  let(:billable_declarations) { Declaration.where(id: billable_ids) }
+  let(:refundable_declarations) { Declaration.where(id: refundable_ids) }
+
   before do
-    traits = %i[no_payment eligible payable paid voided awaiting_clawback clawed_back]
-    traits.each do |trait|
+    %i[eligible payable paid].each do |trait|
+      billable_ids << FactoryBot.create(:declaration, trait, declaration_type: "started").id
+      billable_ids << FactoryBot.create(:declaration, trait, declaration_type: "completed").id
+    end
+
+    %i[awaiting_clawback clawed_back].each do |trait|
+      refundable_ids << FactoryBot.create(:declaration, trait, declaration_type: "started").id
+      refundable_ids << FactoryBot.create(:declaration, trait, declaration_type: "completed").id
+    end
+
+    %i[no_payment voided].each do |trait|
       FactoryBot.create(:declaration, trait, declaration_type: "started")
       FactoryBot.create(:declaration, trait, declaration_type: "completed")
     end
@@ -20,16 +35,21 @@ RSpec.describe PaymentCalculator::FlatRate::Outputs do
 
   describe "#declaration_type_outputs" do
     it "returns an output for each valid declaration type" do
-      expect(outputs.declaration_type_outputs.map(&:declaration_type)).to match_array(Declaration.all.map(&:declaration_type).uniq)
-      expect(outputs.declaration_type_outputs).to all(have_attributes(declarations: Declaration.all, fee_per_declaration:, fee_proportions:))
+      expect(outputs.declaration_type_outputs.map(&:declaration_type)).to match_array(%w[started completed])
+      expect(outputs.declaration_type_outputs).to all(have_attributes(
+                                                        billable_declarations:,
+                                                        refundable_declarations:,
+                                                        fee_per_declaration:,
+                                                        fee_proportions:
+                                                      ))
     end
   end
 
   describe "#total_billable_amount" do
     it "sums billable amounts across all declaration types" do
-      # 2x declaration types, 5x billable statuses (eligible, payable, paid, awaiting_clawback, clawed_back),
+      # 2x declaration types, 3x billable statuses (eligible, payable, paid),
       # 100.0 fee per declaration, 0.5 fee proportion for each declaration type
-      expect(outputs.total_billable_amount).to eq(2 * 5 * 100.0 * 0.5)
+      expect(outputs.total_billable_amount).to eq(2 * 3 * 100.0 * 0.5)
     end
   end
 
@@ -49,8 +69,8 @@ RSpec.describe PaymentCalculator::FlatRate::Outputs do
 
   describe "#total_net_amount" do
     it "returns total_billable_amount minus total_refundable_amount" do
-      # 2x declaration types (started, completed), 5x billable - 2x refundable, 100.0 fee per declaration and fee proportion of 0.5
-      expect(outputs.total_net_amount).to eq((2 * 5 * 100.0 * 0.5) - (2 * 2 * 100.0 * 0.5))
+      # 2x declaration types (started, completed), 3x billable - 2x refundable, 100.0 fee per declaration and fee proportion of 0.5
+      expect(outputs.total_net_amount).to eq((2 * 3 * 100.0 * 0.5) - (2 * 2 * 100.0 * 0.5))
     end
   end
 

--- a/spec/services/payment_calculator/flat_rate_spec.rb
+++ b/spec/services/payment_calculator/flat_rate_spec.rb
@@ -134,8 +134,10 @@ RSpec.describe PaymentCalculator::FlatRate do
       expect(PaymentCalculator::FlatRate::Outputs)
         .to receive(:new)
         .with(
-          declarations: contain_exactly(
-            mentor_billable_declaration,
+          billable_declarations: contain_exactly(
+            mentor_billable_declaration
+          ),
+          refundable_declarations: contain_exactly(
             mentor_refundable_declaration
           ),
           fee_per_declaration: flat_rate_fee_structure.fee_per_declaration,


### PR DESCRIPTION
https://github.com/DFE-Digital/register-ects-project-board/issues/3621

Currently flat rate mentor output calculations incorrectly factor in clawbacks

They should not, as per banded calculators