### PR TITLE
Show fallback delivery partner text for EOI mentors in summary component

### DIFF
--- a/app/components/schools/mentors/summary_component.rb
+++ b/app/components/schools/mentors/summary_component.rb
@@ -41,7 +41,7 @@ module Schools
 
         [
           { key: { text: "Lead provider" }, value: { text: provider_display_with_status } },
-          { key: { text: "Delivery partner" }, value: { text: delivery_partner_name } },
+          { key: { text: "Delivery partner" }, value: { text: delivery_partner_display_text } },
         ]
       end
 
@@ -103,8 +103,12 @@ module Schools
         latest_training_period.only_expression_of_interest?
       end
 
-      def delivery_partner_name
-        latest_training_period&.delivery_partner_name
+      def delivery_partner_display_text
+        if partnership_confirmed? && latest_training_period.delivery_partner_name.present?
+          latest_training_period.delivery_partner_name
+        else
+          "Yet to be reported by the lead provider"
+        end
       end
 
       def mentor_period_for_school

--- a/spec/components/schools/mentors/summary_component_spec.rb
+++ b/spec/components/schools/mentors/summary_component_spec.rb
@@ -47,14 +47,26 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
       end
 
       let(:completed_period) do
-        FactoryBot.create(:ect_at_school_period, teacher: completed_teacher, school:, started_on: finished, finished_on: completed_teacher.trs_induction_completed_date)
+        FactoryBot.create(
+          :ect_at_school_period,
+          teacher: completed_teacher,
+          school:,
+          started_on: finished,
+          finished_on: completed_teacher.trs_induction_completed_date
+        )
       end
 
       before do
         FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: current_period, started_on: current, finished_on: nil)
         FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: upcoming_period, started_on: upcoming, finished_on: nil)
         FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: finished_period, started_on: finished, finished_on: Date.yesterday)
-        FactoryBot.create(:mentorship_period, mentor: mentor_at_school_period, mentee: completed_period, started_on: finished, finished_on: completed_teacher.trs_induction_completed_date)
+        FactoryBot.create(
+          :mentorship_period,
+          mentor: mentor_at_school_period,
+          mentee: completed_period,
+          started_on: finished,
+          finished_on: completed_teacher.trs_induction_completed_date
+        )
       end
 
       it { is_expected.not_to have_text("No ECTs assigned") }
@@ -150,12 +162,59 @@ RSpec.describe Schools::Mentors::SummaryComponent, type: :component do
     end
 
     context "when the mentor has a current training period" do
-      let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, mentor_at_school_period:, started_on: 1.week.ago, finished_on: nil) }
-      let!(:old_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, mentor_at_school_period:, started_on:, finished_on: 2.weeks.ago) }
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :provider_led,
+          :for_mentor,
+          mentor_at_school_period:,
+          started_on: 1.week.ago,
+          finished_on: nil
+        )
+      end
+
+      let!(:old_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :provider_led,
+          :for_mentor,
+          mentor_at_school_period:,
+          started_on:,
+          finished_on: 2.weeks.ago
+        )
+      end
 
       it { is_expected.to have_text(active_text) }
       it { is_expected.to have_summary_list_row("Lead provider", value: "#{training_period.lead_provider_name}Confirmed by #{training_period.lead_provider_name}") }
       it { is_expected.to have_summary_list_row("Delivery partner", value: training_period.delivery_partner_name) }
+    end
+
+    context "when the mentor has a current expression of interest training period" do
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :provider_led,
+          :for_mentor,
+          :with_only_expression_of_interest,
+          mentor_at_school_period:,
+          started_on: 1.week.ago,
+          finished_on: nil
+        )
+      end
+
+      let!(:old_training_period) do
+        FactoryBot.create(
+          :training_period,
+          :provider_led,
+          :for_mentor,
+          mentor_at_school_period:,
+          started_on:,
+          finished_on: 2.weeks.ago
+        )
+      end
+
+      it { is_expected.to have_text(active_text) }
+      it { is_expected.to have_summary_list_row("Delivery partner", value: "Yet to be reported by the lead provider") }
     end
 
     context "when the latest training period is deferred" do


### PR DESCRIPTION
Ticket [here](https://github.com/DFE-Digital/register-ects-project-board/issues/3463)

### Context
When a mentor is registered with an expression of interest (EOI) and the partnership has not yet been confirmed, the delivery partner is not yet known.

On the mentors overview (summary) page, we were rendering latest_training_period.delivery_partner_name directly. In EOI/unconfirmed cases this returns nil, which resulted in a blank "Delivery partner" row.

This differs from other parts of the UI (e.g. mentor/ECT training details), which show a fallback message.

### Changes proposed in this pull request
- Update Schools::Mentors::SummaryComponent to use display logic for the delivery partner instead of rendering the raw value
- When the partnership is not confirmed (or no delivery partner is present), show:
"Yet to be reported by the lead provider"
- Rename method to delivery_partner_display_text to better reflect its purpose
- Add a component spec to cover the EOI/unconfirmed scenario and prevent regression

### Guidance to review
Visit the mentors overview page

For a mentor with an unconfirmed (EOI) training period:
- Confirm the "Delivery partner" row now shows:
"Yet to be reported by the lead provider"
(Previously this appeared blank)
- For a mentor with a confirmed partnership:
- Confirm the actual delivery partner name is still displayed
