### PR TITLE
Add guidance for viewing financial statement payment dates

### DIFF
--- a/app/views/api/guidance/guidance_for_lead_providers/view_financial_statement_payment_dates.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/view_financial_statement_payment_dates.md
@@ -11,14 +11,14 @@ Financial statements are also directly provided to lead providers by DfE and con
 
 `GET /api/v3/statements`
 
-For more information on this endpoint, [view the Swagger documentation](https://sandbox.register-early-career-teachers.education.gov.uk/api/docs/v3#/Statements).
+For more information on this endpoint, [view the Swagger documentation](/api/docs/v3#/Statements).
 
 ## View specific statement payment dates
 
 `GET /api/v3/statements/{id}`
 
-Providers can find statement IDs within [previously submitted declaration](https://sandbox.register-early-career-teachers.education.gov.uk/api/docs/v3#/Declarations) response bodies. This shows which cohort the declaration was made in, which can be helpful to identify when a participant started their training.
+Providers can find statement IDs within [previously submitted declaration](/api/docs/v3#/Declarations) response bodies. This shows which cohort the declaration was made in, which can be helpful to identify when a participant started their training.
 
-This endpoint is also useful when [identifying which cohorts participants have moved between](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/how-cohort-closures-and-changes-work#identifying-ects-who-we-39-ve-moved-to-the-2024-cohort).
+This endpoint is also useful when [identifying which cohorts participants have moved between](/api/guidance/guidance-for-lead-providers/how-cohort-closures-and-changes-work#identifying-ects-who-we-39-ve-moved-to-the-2024-cohort).
 
-For more information on this endpoint, [view the Swagger documentation](https://sandbox.register-early-career-teachers.education.gov.uk/api/docs/v3#/Statements).
+For more information on this endpoint, [view the Swagger documentation](/api/docs/v3#/Statements).


### PR DESCRIPTION
Added guidance for viewing financial statement payment dates, including endpoints for retrieving all and specific payment dates.

See https://github.com/DFE-Digital/register-ects-project-board/issues/3473 for context.