### PR TITLE
set created_at and updated_at on stubbed periods for declarations

### DIFF
--- a/app/migration/migrators/declaration.rb
+++ b/app/migration/migrators/declaration.rb
@@ -85,10 +85,14 @@ module Migrators
     def create_training_period(at_school_period:, school_partnership:, started_on:, finished_on:)
       schedule = ::Schedule.find_by(contract_period_year: school_partnership.contract_period.year,
                                     identifier: "ecf-standard-september")
-
       at_school_period.training_periods
                       .provider_led_training_programme
-                      .create!(school_partnership:, started_on:, finished_on:, schedule:)
+                      .create!(school_partnership:,
+                               started_on:,
+                               finished_on:,
+                               schedule:,
+                               created_at: at_school_period.created_at,
+                               updated_at: at_school_period.updated_at)
     end
 
     # Finds a date to create an at_school_period starting from started_on backwards, so that
@@ -148,11 +152,15 @@ module Migrators
     # Also, a stub school partnership might be created if none matches the declaration combo.
     def make_training_period(teacher:, participant_declaration:, school:, lead_provider:, delivery_partner_id:, contract_period_year:, started_on:)
       at_school_period_class = participant_declaration.ect? ? ECTAtSchoolPeriod : MentorAtSchoolPeriod
-      at_school_periods = (participant_declaration.ect? ? teacher.ect_at_school_periods : teacher.mentor_at_school_periods)
-
+      at_school_periods = (participant_declaration.ect? ? teacher.ect_at_school_periods : teacher.mentor_at_school_periods).to_a
       started_on = date_for_new_training_period(at_school_periods:, started_on:)
       finished_on = started_on + 1.day
-      at_school_period ||= at_school_period_class.create!(teacher:, school:, started_on:, finished_on:)
+      at_school_period = at_school_period_class.create!(teacher:, school:, started_on:, finished_on:).tap do |period|
+        if at_school_periods.none?
+          period.update!(created_at: participant_declaration.participant_profile.created_at,
+                         updated_at: participant_declaration.participant_profile.created_at)
+        end
+      end
       school_partnership = find_or_create_school_partnership(school:, lead_provider:, delivery_partner_id:, contract_period_year:)
 
       create_training_period(at_school_period:, school_partnership:, started_on:, finished_on:)
@@ -246,7 +254,6 @@ module Migrators
                                { active_lead_provider: %i[lead_provider contract_period] }
                              ]
                            }).to_a
-
       training_period = fully_matching_training_period(training_periods:, lead_provider:, delivery_partner_id:, contract_period_year:, school:, declaration_date:)
       training_period ||= matching_closest_earlier_training_period(training_periods:, lead_provider:, delivery_partner_id:, contract_period_year:, school:, declaration_date:)
       return training_period if training_period

--- a/spec/migration/migrators/declaration_spec.rb
+++ b/spec/migration/migrators/declaration_spec.rb
@@ -205,8 +205,6 @@ describe Migrators::Declaration do
           let!(:school_partnership) { FactoryBot.create(:school_partnership, lead_provider_delivery_partnership:, school:) }
           let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: participant_declaration.declaration_date - 2.years) }
           let!(:training_period) { FactoryBot.create(:training_period, :for_ect, school_partnership:, ect_at_school_period:) }
-          # let(:started_on) { Date.new(contract_period.year, 9, 1) }
-          # let(:finished_on) { Date.new(contract_period.year, 9, 2) }
 
           it "associate that training period and creates a declaration with the expected attributes" do
             instance.migrate!
@@ -235,7 +233,7 @@ describe Migrators::Declaration do
           let!(:training_period) { FactoryBot.create(:training_period, :for_ect, school_partnership:, ect_at_school_period:) }
           let(:started_on) { Date.new(contract_period.year, 8, 30) }
 
-          it "build ASP and TP and create a declaration with the expected attributes" do
+          it "build ASP and TP and create a declaration with the expected attributes associated to them" do
             instance.migrate!
 
             declaration = Declaration.find_by(api_id: participant_declaration.id)
@@ -254,6 +252,21 @@ describe Migrators::Declaration do
               expect(declaration.training_period.finished_on).to eq(started_on + 1.day)
               expect(declaration.training_period.school_partnership).not_to eq(school_partnership)
               expect(declaration.voided_by_user_at).to eq(participant_declaration.voided_at)
+            end
+          end
+
+          context "when the at school period created is the teacher's only one" do
+            let!(:ect_at_school_period) {}
+            let!(:training_period) {}
+
+            it "set its creation date to the participant profile's creation date" do
+              instance.migrate!
+
+              declaration = Declaration.find_by(api_id: participant_declaration.id)
+              training_period = declaration.training_period
+
+              expect(training_period.created_at).to eq(participant_profile.created_at)
+              expect(training_period.at_school_period.created_at).to eq(training_period.created_at)
             end
           end
 


### PR DESCRIPTION
### Context

Stubbed period created for declarations must behave exactly like the ones migrated when it comes to setting `created_at. The value must be the `participant_profiles#created_at` if it is the only period of the teacher.

### Changes proposed in this pull request

### Guidance to review
