### PR TITLE
Align MultiparameterDateErrorHandling copy

### DIFF
--- a/app/controllers/admin/induction_periods_controller.rb
+++ b/app/controllers/admin/induction_periods_controller.rb
@@ -23,7 +23,7 @@ module Admin
       render :new, status: :unprocessable_content
     rescue ActiveRecord::MultiparameterAssignmentErrors => e
       @induction_period = @service.induction_period
-      add_multiparameter_date_errors(@induction_period, e, param_key: :induction_period)
+      add_multiparameter_date_errors(@induction_period, e)
       render :new, status: :unprocessable_content
     end
 
@@ -38,7 +38,7 @@ module Admin
       @induction_period = service.induction_period
       render :edit, status: :unprocessable_content
     rescue ActiveRecord::MultiparameterAssignmentErrors => e
-      add_multiparameter_date_errors(@induction_period, e, param_key: :induction_period)
+      add_multiparameter_date_errors(@induction_period, e)
       render :edit, status: :unprocessable_content
     end
 

--- a/app/controllers/admin/teachers/record_failed_induction_controller.rb
+++ b/app/controllers/admin/teachers/record_failed_induction_controller.rb
@@ -34,7 +34,7 @@ module Admin
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
       rescue ActiveRecord::MultiparameterAssignmentErrors => e
-        add_multiparameter_date_errors(@record_fail, e, param_key: RecordFail.model_name.param_key)
+        add_multiparameter_date_errors(@record_fail, e)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/admin/teachers/record_passed_induction_controller.rb
+++ b/app/controllers/admin/teachers/record_passed_induction_controller.rb
@@ -34,7 +34,7 @@ module Admin
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
       rescue ActiveRecord::MultiparameterAssignmentErrors => e
-        add_multiparameter_date_errors(@record_pass, e, param_key: RecordPass.model_name.param_key)
+        add_multiparameter_date_errors(@record_pass, e)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/find_ect_controller.rb
@@ -35,7 +35,7 @@ module AppropriateBodies
           trn: params.dig(:pending_induction_submission, :trn),
           appropriate_body_period_id: @appropriate_body.id
         )
-        add_multiparameter_date_errors(@pending_induction_submission, e, param_key: :pending_induction_submission)
+        add_multiparameter_date_errors(@pending_induction_submission, e)
         render :new
       end
 

--- a/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
+++ b/app/controllers/appropriate_bodies/claim_an_ect/register_ect_controller.rb
@@ -24,7 +24,7 @@ module AppropriateBodies
         end
       rescue ActiveRecord::MultiparameterAssignmentErrors => e
         @pending_induction_submission = register_ect.pending_induction_submission
-        add_multiparameter_date_errors(@pending_induction_submission, e, param_key: :pending_induction_submission)
+        add_multiparameter_date_errors(@pending_induction_submission, e)
         render :edit
       end
 

--- a/app/controllers/appropriate_bodies/induction_periods_controller.rb
+++ b/app/controllers/appropriate_bodies/induction_periods_controller.rb
@@ -19,7 +19,7 @@ module AppropriateBodies
       render :edit, status: :unprocessable_content
     rescue ActiveRecord::MultiparameterAssignmentErrors => e
       @induction_period = service&.induction_period
-      add_multiparameter_date_errors(induction_period, e, param_key: :induction_period)
+      add_multiparameter_date_errors(induction_period, e)
       render :edit, status: :unprocessable_content
     end
 

--- a/app/controllers/appropriate_bodies/teachers/record_failed_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_failed_induction_controller.rb
@@ -36,7 +36,7 @@ module AppropriateBodies
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
       rescue ActiveRecord::MultiparameterAssignmentErrors => e
-        add_multiparameter_date_errors(@record_fail, e, param_key: RecordFail.model_name.param_key)
+        add_multiparameter_date_errors(@record_fail, e)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/appropriate_bodies/teachers/record_passed_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_passed_induction_controller.rb
@@ -24,7 +24,7 @@ module AppropriateBodies
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
       rescue ActiveRecord::MultiparameterAssignmentErrors => e
-        add_multiparameter_date_errors(@record_pass, e, param_key: RecordPass.model_name.param_key)
+        add_multiparameter_date_errors(@record_pass, e)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/appropriate_bodies/teachers/record_released_induction_controller.rb
+++ b/app/controllers/appropriate_bodies/teachers/record_released_induction_controller.rb
@@ -24,7 +24,7 @@ module AppropriateBodies
              ActiveModel::ValidationError
         render :new, status: :unprocessable_content
       rescue ActiveRecord::MultiparameterAssignmentErrors => e
-        add_multiparameter_date_errors(@record_release, e, param_key: RecordRelease.model_name.param_key)
+        add_multiparameter_date_errors(@record_release, e)
         render :new, status: :unprocessable_content
       end
 

--- a/app/controllers/concerns/multiparameter_date_error_handling.rb
+++ b/app/controllers/concerns/multiparameter_date_error_handling.rb
@@ -3,17 +3,10 @@ module MultiparameterDateErrorHandling
 
 private
 
-  def add_multiparameter_date_errors(record, exception, param_key:)
-    raw_params = params[param_key]
-
+  def add_multiparameter_date_errors(record, exception)
     exception.errors.each do |error|
       attribute = error.attribute
-      day = raw_params["#{attribute}(3i)"]
-      month = raw_params["#{attribute}(2i)"]
-      year = raw_params["#{attribute}(1i)"]
-      entered = "#{day}/#{month}/#{year}"
-
-      record.errors.add(attribute, "#{entered} is not a valid date")
+      record.errors.add(attribute, "Enter the #{attribute.humanize.downcase} using the correct format, for example, 17 09 1999")
     end
   end
 end

--- a/spec/requests/admin/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_induction_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe "Admin recording a failed outcome for a teacher" do
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the finished on using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/admin/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_induction_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe "Admin recording a passed outcome for a teacher" do
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the finished on using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe "Appropriate body claiming an ECT: finding the ECT" do
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           post("/appropriate-body/claim-an-ect/find-ect", params: { pending_induction_submission: search_params })
 
           expect(response.body).to include(page_heading)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the date of birth using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -151,14 +151,14 @@ RSpec.describe "Appropriate body claiming an ECT: registering the ECT" do
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           patch(
             "/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}",
             params: { pending_induction_submission: registration_params }
           )
 
           expect(response.body).to include(page_heading)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the started on using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/appropriate_bodies/induction_periods_spec.rb
+++ b/spec/requests/appropriate_bodies/induction_periods_spec.rb
@@ -123,11 +123,11 @@ RSpec.describe "AppropriateBodies::InductionPeriodsController", type: :request d
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           patch(ab_teacher_induction_period_path(induction_period.teacher, induction_period), params:)
 
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the started on using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe "Appropriate body recording a failed induction outcome for a teac
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the finished on using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe "Appropriate body recording a passed induction outcome for a teac
           }
         end
 
-        it "returns error with the entered value" do
+        it "returns error with the correct format hint" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("Enter the finished on using the correct format, for example, 17 09 1999")
         end
       end
 

--- a/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe "Appropriate body releasing an ECT" do
             }
           end
 
-          it "returns error with the entered value" do
+          it "returns error with the correct format hint" do
             expect(response).to have_http_status(:unprocessable_content)
-            expect(response.body).to include("aa/bb/cccc is not a valid date")
+            expect(response.body).to include("Enter the finished on using the correct format, for example, 17 09 1999")
           end
         end
 


### PR DESCRIPTION
### Context

We have been given copy of how date errors are shown elsewhere:

<img width="1590" height="868" alt="image" src="https://github.com/user-attachments/assets/6e8f430a-d783-405e-a4e7-a19ed7613c43" />

### Changes proposed in this pull request

Changes the copy to align with this.
Note: The attribute names do not always align perfectly with the copy, though it is not completely confusing:

<img width="1094" height="1063" alt="Screenshot 2026-03-19 at 15 20 07" src="https://github.com/user-attachments/assets/24207b65-82ba-4e68-b735-68057295cd3f" />



### Guidance to review
