### PR TITLE
Populate `api_unfunded_mentor_updated_at` during migration

### DIFF
--- a/app/migration/ecf2_teacher_history/teacher.rb
+++ b/app/migration/ecf2_teacher_history/teacher.rb
@@ -18,7 +18,8 @@ class ECF2TeacherHistory::Teacher
               :trs_induction_start_date,
               :trs_induction_completed_date,
               :created_at,
-              :updated_at
+              :updated_at,
+              :api_unfunded_mentor_updated_at
 
   def initialize(trn:,
                  trs_first_name:,
@@ -39,7 +40,8 @@ class ECF2TeacherHistory::Teacher
                  trs_induction_start_date: nil,
                  trs_induction_completed_date: nil,
                  created_at: nil,
-                 updated_at: nil)
+                 updated_at: nil,
+                 api_unfunded_mentor_updated_at: nil)
     @trn = trn
     @trnless = trnless
     @trs_first_name = trs_first_name
@@ -60,6 +62,7 @@ class ECF2TeacherHistory::Teacher
     @trs_induction_completed_date = trs_induction_completed_date
     @created_at = created_at
     @updated_at = updated_at
+    @api_unfunded_mentor_updated_at = api_unfunded_mentor_updated_at
   end
 
   def to_h
@@ -83,7 +86,8 @@ class ECF2TeacherHistory::Teacher
       mentor_first_became_eligible_for_training_at:,
       mentor_payments_frozen_year:,
       created_at:,
-      updated_at:
+      updated_at:,
+      api_unfunded_mentor_updated_at:
     }
   end
 

--- a/app/migration/teacher_history_converter.rb
+++ b/app/migration/teacher_history_converter.rb
@@ -133,7 +133,8 @@ private
       trs_induction_start_date: ecf1_teacher_history.ect&.induction_start_date,
       trs_induction_completed_date: ecf1_teacher_history.ect&.induction_completion_date,
       created_at: ecf1_teacher_history.user.created_at,
-      updated_at: ecf1_teacher_history.user.updated_at
+      updated_at: ecf1_teacher_history.user.updated_at,
+      api_unfunded_mentor_updated_at: ecf1_teacher_history.user.updated_at
     )
   end
 

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -109,6 +109,7 @@ describe ECF2TeacherHistory do
       let(:migration_mode) { "latest_induction_records" }
       let(:ect_first_became_eligible_for_training_at) { 3.years.ago.round(2) }
       let(:ect_payments_frozen_year) { contract_period.year }
+      let(:api_unfunded_mentor_updated_at) { 1.month.ago }
 
       let(:teacher_data) do
         ECF2TeacherHistory::Teacher.new(
@@ -121,7 +122,8 @@ describe ECF2TeacherHistory do
           api_mentor_training_record_id:,
           migration_mode:,
           ect_first_became_eligible_for_training_at:,
-          ect_payments_frozen_year:
+          ect_payments_frozen_year:,
+          api_unfunded_mentor_updated_at:
         )
       end
 
@@ -141,6 +143,7 @@ describe ECF2TeacherHistory do
           expect(teacher.migration_mode).to eql(migration_mode)
           expect(teacher.ect_first_became_eligible_for_training_at).to eql(ect_first_became_eligible_for_training_at)
           expect(teacher.ect_payments_frozen_year).to eql(ect_payments_frozen_year)
+          expect(teacher.api_unfunded_mentor_updated_at).to be_within(5.seconds).of(api_unfunded_mentor_updated_at)
         end
       end
 
@@ -506,6 +509,7 @@ describe ECF2TeacherHistory do
       let(:mentor_became_ineligible_for_funding_reason) { "completed_declaration_received" }
       let(:mentor_first_became_eligible_for_training_at) { 2.years.ago.round(2) }
       let(:mentor_payments_frozen_year) { contract_period.year }
+      let(:api_unfunded_mentor_updated_at) { 1.month.ago }
 
       let(:teacher_data) do
         ECF2TeacherHistory::Teacher.new(
@@ -517,6 +521,7 @@ describe ECF2TeacherHistory do
           api_id:,
           api_ect_training_record_id:,
           api_mentor_training_record_id:,
+          api_unfunded_mentor_updated_at:,
 
           migration_mode:,
 
@@ -545,6 +550,7 @@ describe ECF2TeacherHistory do
           expect(teacher.mentor_became_ineligible_for_funding_reason).to eql(mentor_became_ineligible_for_funding_reason)
           expect(teacher.mentor_first_became_eligible_for_training_at).to eql(mentor_first_became_eligible_for_training_at)
           expect(teacher.mentor_payments_frozen_year).to eql(mentor_payments_frozen_year)
+          expect(teacher.api_unfunded_mentor_updated_at).to be_within(5.seconds).of(api_unfunded_mentor_updated_at)
         end
       end
 

--- a/spec/migration/teacher_history_converter_spec.rb
+++ b/spec/migration/teacher_history_converter_spec.rb
@@ -22,6 +22,13 @@ describe TeacherHistoryConverter do
         expect(subject.teacher.corrected_name).to eql("Test User")
       end
     end
+
+    describe "setting api_unfunded_mentor_updated_at" do
+      let(:ecf1_teacher_history_user) { FactoryBot.build(:ecf1_teacher_history_user, updated_at: 1.week.ago) }
+      let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, user: ecf1_teacher_history_user) }
+
+      it { expect(subject.teacher.api_unfunded_mentor_updated_at).to eql(ecf1_teacher_history_user.updated_at) }
+    end
   end
 
   describe "building ect_at_school_periods" do


### PR DESCRIPTION
We want this to match the value we currently serialize in ECF for unfunded mentors, which is the `User#updated_at`.
