### PR TITLE
Improve invalid date error message

### DIFF
--- a/app/controllers/concerns/multiparameter_date_error_handling.rb
+++ b/app/controllers/concerns/multiparameter_date_error_handling.rb
@@ -13,7 +13,7 @@ private
       year = raw_params["#{attribute}(1i)"]
       entered = "#{day}/#{month}/#{year}"
 
-      record.errors.add(attribute, "#{entered} is not a valid date")
+      record.errors.add(attribute, "#{entered} is not a valid date format")
     end
   end
 end

--- a/spec/requests/admin/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_failed_induction_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Admin recording a failed outcome for a teacher" do
 
         it "returns error with the entered value" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/admin/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/admin/teachers/record_passed_induction_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Admin recording a passed outcome for a teacher" do
 
         it "returns error with the entered value" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Appropriate body claiming an ECT: finding the ECT" do
           post("/appropriate-body/claim-an-ect/find-ect", params: { pending_induction_submission: search_params })
 
           expect(response.body).to include(page_heading)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "Appropriate body claiming an ECT: registering the ECT" do
           )
 
           expect(response.body).to include(page_heading)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/appropriate_bodies/induction_periods_spec.rb
+++ b/spec/requests/appropriate_bodies/induction_periods_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "AppropriateBodies::InductionPeriodsController", type: :request d
           patch(ab_teacher_induction_period_path(induction_period.teacher, induction_period), params:)
 
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_failed_induction_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Appropriate body recording a failed induction outcome for a teac
 
         it "returns error with the entered value" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_passed_induction_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Appropriate body recording a passed induction outcome for a teac
 
         it "returns error with the entered value" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("aa/bb/cccc is not a valid date")
+          expect(response.body).to include("aa/bb/cccc is not a valid date format")
         end
       end
 

--- a/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
+++ b/spec/requests/appropriate_bodies/teachers/record_released_induction_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Appropriate body releasing an ECT" do
 
           it "returns error with the entered value" do
             expect(response).to have_http_status(:unprocessable_content)
-            expect(response.body).to include("aa/bb/cccc is not a valid date")
+            expect(response.body).to include("aa/bb/cccc is not a valid date format")
           end
         end
 


### PR DESCRIPTION
### Context

While this is a low priority fix, and what is there is better than the 500 we were previously experiencing, we want a slightly better message that indicates that the issue may be with the format, not just the date.

At the same time, the current approach used by others may not be appropriate for RIAB as many of the attribute names do not match the UI names. See https://github.com.mcas.ms/DFE-Digital/register-early-career-teachers-public/pull/2498

### Changes proposed in this pull request

Was: `"aa/bb/cccc is not a valid date"`
Now: `"aa/bb/cccc is not a valid date format"`

We add the word format to the error message.

### Guidance to review

None