### PR TITLE
Mentorship failures don't block teacher migration

### DIFF
--- a/app/migration/ecf2_teacher_history.rb
+++ b/app/migration/ecf2_teacher_history.rb
@@ -123,8 +123,6 @@ class ECF2TeacherHistory
   end
 
   def record_failure!(teacher:, model:, message:, migration_item_id:)
-    @failed = true
-
     record_failed_combinations(at_school_period: model, message:) if model.respond_to?(:training_periods)
     record_failed_combination(combination: model.combination, message:) if model.respond_to?(:combination)
     record_failed_mentorship(mentorship: model, message:) if model.is_a?(ECF2TeacherHistory::MentorshipPeriod)
@@ -223,7 +221,7 @@ private
         end
 
         ect_at_school_period.mentorship_periods.each do |mentorship_period|
-          with_failure_recording(teacher: found_teacher, model: mentorship_period, migration_item_id: mentorship_period.ecf_start_induction_record_id) do
+          with_failure_recording(teacher: found_teacher, model: mentorship_period, migration_item_id: mentorship_period.ecf_start_induction_record_id, acceptable: true) do
             ::MentorshipPeriod.create!(mentee: created_ect_at_school_period, **mentorship_period.to_h)
             ecf2_mentorship_summaries << mentorship_period.summary
           end
@@ -275,10 +273,11 @@ private
     )
   end
 
-  def with_failure_recording(teacher:, model:, migration_item_id:)
+  def with_failure_recording(teacher:, model:, migration_item_id:, acceptable: false)
     yield
   rescue StandardError => e
-    if raise_errors?
+    @failed = true unless acceptable
+    if !acceptable && raise_errors?
       raise(SaveError.new(teacher:, model:, message: e.message, migration_item_id:))
     end
 

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/AnyInstance
 describe ECF2TeacherHistory do
   subject { ECF2TeacherHistory.new(teacher: teacher_data, **other_arguments) }
 
@@ -493,6 +494,26 @@ describe ECF2TeacherHistory do
                   expect(p1_mp.ecf_end_induction_record_id).to eql(mentorship_period.ecf_end_induction_record_id)
                 end
               end
+            end
+          end
+
+          context "when a mentorship period cannot be persisted" do
+            before do
+              allow_any_instance_of(MentorshipPeriod).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError)
+            end
+
+            it "do not raise an exception" do
+              expect { teacher }.not_to raise_exception
+            end
+
+            it "do not set the teacher save as failed" do
+              expect { teacher }.not_to change(subject, :success?)
+            end
+
+            it "persist the failure but still allow the teacher to continue be saved" do
+              expect { teacher }
+                .to change(DataMigrationFailedMentorship, :count).by(1)
+                .and change(TeacherMigrationFailure, :count).by(1)
             end
           end
         end
@@ -1190,3 +1211,4 @@ describe ECF2TeacherHistory do
     end
   end
 end
+# rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/3616)

Mentorship failures should not fail a teacher migration

### Changes proposed in this pull request

Accept mentorship failures without setting the whole teacher migration as failed.

### Guidance to review
