### PR TITLE
Broken workflows using Slack

### DIFF
--- a/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
@@ -21,9 +21,6 @@ inputs:
   app-name:
     description: Name of the app deployment
     required: true
-  slack-webhook:
-    description: Name of the slack webhook
-    required: true
 
 runs:
   using: composite

--- a/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
@@ -28,9 +28,6 @@ inputs:
   backup-file:
     description: Name of the backup file to restore. Must include the .gz extension if the remote file has it.
     required: true
-  slack-webhook:
-    description: Name of the slack webhook
-    required: true
 
 runs:
   using: composite

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -110,15 +110,6 @@ jobs:
           fi
           echo "BACKUP_FILE=${BACKUP_FILE}" >> $GITHUB_ENV
 
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: key-vault-secrets
-        with:
-          inlineScript: |
-            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name ${KEYVAULT_NAME} --query "value" -o tsv)
-            echo "::add-mask::$SLACK_WEBHOOK"
-            echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
-
       - name: Backup ${{ env.DEPLOY_ENV }} postgres
         uses: DFE-Digital/github-actions/backup-postgres@master
         with:
@@ -132,4 +123,3 @@ jobs:
           azure-tenant-id: ${{ secrets.azure-tenant-id || secrets.AZURE_TENANT_ID }}
           backup-file: ${{ env.BACKUP_FILE }}.sql
           db-server-name: ${{ inputs.db-server }}
-          slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -24,14 +24,3 @@ jobs:
           reuse-cache: false
           snyk-token: ${{ secrets.SNYK_TOKEN }}
           max-cache: true
-
-      - name: Notify slack on failure
-        uses: rtCamp/action-slack-notify@master
-        if: ${{ failure() }}
-        env:
-          SLACK_USERNAME: CI Deployment
-          SLACK_COLOR: failure
-          SLACK_ICON_EMOJI: ":github-logo:"
-          SLACK_TITLE: "Build failure"
-          SLACK_MESSAGE: ":alert: Rebuild docker cache failure :sadparrot:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,6 @@ jobs:
         azure-client-id:  ${{ secrets.AZURE_CLIENT_ID }}
         azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID }}
         azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
         terraform-base: config/terraform/domains/infrastructure
 
   deploy_domains_env:
@@ -204,5 +203,4 @@ jobs:
           azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           environment: ${{ matrix.domain_environment }}
           healthcheck: healthcheck
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
           terraform-base: config/terraform/domains/environment_domains

--- a/.github/workflows/directly-copy-main-db-into-snapshot-db.yml
+++ b/.github/workflows/directly-copy-main-db-into-snapshot-db.yml
@@ -51,15 +51,6 @@ jobs:
           # Set Azure environment variables
           echo "KEYVAULT_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-inf-kv" >> $GITHUB_ENV
 
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: key-vault-secrets
-        with:
-          inlineScript: |
-            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name ${KEYVAULT_NAME} --query "value" -o tsv)
-            echo "::add-mask::$SLACK_WEBHOOK"
-            echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
-
       - name: Backup and restore snapshot
         uses: ./.github/actions/directly-backup-and-restore-snapshot-database
         with:
@@ -68,5 +59,4 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           app-name: ${{ env.SERVICE_NAME }}-${{ inputs.environment || 'production' }}-web
-          slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
           exclude-jobs: ${{ inputs.exclude-jobs }}

--- a/.github/workflows/restore-app-main-db.yml
+++ b/.github/workflows/restore-app-main-db.yml
@@ -105,15 +105,6 @@ jobs:
         echo "BACKUP_FILE=$BACKUP_FILE" >> $GITHUB_ENV
         echo "BACKUP_FILE_IN_STORAGE=${STORAGE_ACCOUNT_NAME} / database-backup / ${BACKUP_FILE}" >> $GITHUB_ENV
 
-    - name: Fetch secrets from key vault
-      uses: azure/CLI@v2
-      id: key-vault-secrets
-      with:
-        inlineScript: |
-          SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name ${KEYVAULT_NAME} --query "value" -o tsv)
-          echo "::add-mask::$SLACK_WEBHOOK"
-          echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
-
     - name: Restore ${{ inputs.environment }} postgres
       uses: DFE-Digital/github-actions/restore-postgres-backup@master
       with:

--- a/.github/workflows/restore-snapshot-db-from-azure-storage.yml
+++ b/.github/workflows/restore-snapshot-db-from-azure-storage.yml
@@ -100,15 +100,6 @@ jobs:
           fi
           echo "BACKUP_FILE=${BACKUP_FILE}" >> $GITHUB_ENV
 
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: key-vault-secrets
-        with:
-          inlineScript: |
-            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name ${KEYVAULT_NAME} --query "value" -o tsv)
-            echo "::add-mask::$SLACK_WEBHOOK"
-            echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
-
       - name: Restore ${{ env.DEPLOY_ENV }} postgres
         uses: ./.github/actions/restore-snapshot-database-from-azure-storage
         with:
@@ -121,4 +112,3 @@ jobs:
           azure-subscription-id: ${{ secrets.azure-subscription-id || secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.azure-tenant-id || secrets.AZURE_TENANT_ID }}
           backup-file: ${{ env.BACKUP_FILE }}.sql.gz
-          slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

Following decommission of Slack the API is not responding and breaking workflow actions.

[This has prevented the nightly snapshot refresh but would also block any action with Slack notification.](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/23229722360)

### Changes proposed in this pull request

Delete all uses of `action-slack-notify` webhook in workflows

### Guidance to review

This is a temporary fix because we should replace it with a Teams notification or similar.
