### PR TITLE
Declaration summary tweaks

### DIFF
--- a/app/components/admin/statements/declaration_component.html.erb
+++ b/app/components/admin/statements/declaration_component.html.erb
@@ -5,7 +5,7 @@
 
     table.with_head do |head|
       head.with_row do |row|
-        row.with_cell(header: true) { "" } 
+        row.with_cell(header: true) { "" }
         ordered_calculators.each do |calculator|
           row.with_cell(header: true, numeric: true) { count_header_text(calculator) }
         end
@@ -17,22 +17,26 @@
         body.with_row do |row|
           row.with_cell { type.capitalize }
           ordered_calculators.each do |calculator|
-            row.with_cell(numeric: true) { declarations_count(calculator, type).to_s }
+            if calculator.is_a?(PaymentCalculator::FlatRate) && type.in?(%w[retained extended])
+              row.with_cell(numeric: true) { "-" }
+            else
+              row.with_cell(numeric: true) { declarations_count(calculator, type).to_s }
+            end
           end
         end
       end
 
       body.with_row do |row|
-        row.with_cell { "Clawed back" }
+        row.with_cell { "Clawbacks" }
         ordered_calculators.each do |calculator|
-          row.with_cell(numeric: true) { refunded(calculator).to_s }
+          row.with_cell(numeric: true) { refunded_count(calculator).to_s }
         end
       end
 
       body.with_row do |row|
         row.with_cell { "Voided" }
         ordered_calculators.each do |calculator|
-          row.with_cell(numeric: true) { voided(calculator).to_s }
+          row.with_cell(numeric: true) { voided_count(calculator).to_s }
         end
       end
     end

--- a/app/components/admin/statements/declaration_component.rb
+++ b/app/components/admin/statements/declaration_component.rb
@@ -59,11 +59,11 @@ module Admin
           .sum(&:billable_count)
       end
 
-      def refunded(calculator)
+      def refunded_count(calculator)
         calculator.outputs.total_refundable_count
       end
 
-      def voided(calculator)
+      def voided_count(calculator)
         calculator.voided_declarations_count
       end
     end

--- a/app/services/payment_calculator/flat_rate.rb
+++ b/app/services/payment_calculator/flat_rate.rb
@@ -39,7 +39,6 @@ module PaymentCalculator
 
     def filtered_voided_declarations
       declarations = statement.payment_declarations.payment_status_voided
-
       declaration_selector.call(declarations)
     end
   end

--- a/spec/components/admin/statements/declaration_component_spec.rb
+++ b/spec/components/admin/statements/declaration_component_spec.rb
@@ -135,12 +135,12 @@ RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
 
     it "renders the declaration types correctly" do
       expect(subject).to have_table rows: [
-        ["Started", "10"],
-        ["Retained", "20"],
-        ["Completed", "7"],
-        ["Extended", "3"],
-        ["Clawed back", "6"],
-        ["Voided", "2"],
+        %w[Started 10],
+        %w[Retained 20],
+        %w[Completed 7],
+        %w[Extended 3],
+        %w[Clawbacks 6],
+        %w[Voided 2],
       ]
     end
 
@@ -155,10 +155,10 @@ RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
     it "displays banded first and flat rate second" do
       expect(subject).to have_table rows: [
         ["Started", "10", "9"],
-        ["Retained", "20", "0"],
+        ["Retained", "20", "-"],
         ["Completed", "7", "2"],
-        ["Extended", "3", "0"],
-        ["Clawed back", "6", "4"],
+        ["Extended", "3", "-"],
+        ["Clawbacks", "6", "4"],
         ["Voided", "1", "1"],
       ]
     end

--- a/spec/services/payment_calculator/banded_spec.rb
+++ b/spec/services/payment_calculator/banded_spec.rb
@@ -3,11 +3,7 @@ RSpec.describe PaymentCalculator::Banded do
     described_class.new(statement: statement_july, banded_fee_structure:, declaration_selector:)
   end
 
-  let(:school_partnership) do
-    FactoryBot.create(:school_partnership, :for_year, year: Date.current.year, lead_provider:)
-  end
-
-  let(:active_lead_provider) { school_partnership.active_lead_provider }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
   let(:lead_provider) { FactoryBot.create(:lead_provider, vat_registered:) }
   let(:vat_registered) { true }
 
@@ -69,15 +65,28 @@ RSpec.describe PaymentCalculator::Banded do
     )
   end
 
-  let(:training_period) do
-    FactoryBot.create(:training_period, :for_ect, school_partnership:)
+  let(:ect_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      :with_active_lead_provider,
+      active_lead_provider:
+    )
+  end
+  let(:mentor_training_period) do
+    FactoryBot.create(
+      :training_period,
+      :for_mentor,
+      :with_active_lead_provider,
+      active_lead_provider:
+    )
   end
   let!(:billable_declaration) do
     FactoryBot.create(
       :declaration,
       :payable,
       declaration_type: :started,
-      training_period:,
+      training_period: ect_training_period,
       payment_statement: statement_july
     )
   end
@@ -87,7 +96,7 @@ RSpec.describe PaymentCalculator::Banded do
       payment_status: :paid,
       clawback_status: :awaiting_clawback,
       declaration_type: :completed,
-      training_period:,
+      training_period: ect_training_period,
       payment_statement: statement_may,
       clawback_statement: statement_july
     )
@@ -97,7 +106,7 @@ RSpec.describe PaymentCalculator::Banded do
       :declaration,
       :no_payment,
       declaration_type: :completed,
-      training_period:,
+      training_period: ect_training_period,
       payment_statement: statement_july
     )
   end
@@ -106,7 +115,12 @@ RSpec.describe PaymentCalculator::Banded do
 
   describe "#outputs" do
     let(:previous_training_period) do
-      FactoryBot.create(:training_period, :for_ect, school_partnership:)
+      FactoryBot.create(
+        :training_period,
+        :for_ect,
+        :with_active_lead_provider,
+        active_lead_provider:
+      )
     end
 
     let!(:previous_billable_declaration) do
@@ -274,7 +288,7 @@ RSpec.describe PaymentCalculator::Banded do
   end
 
   describe "#vat_amount" do
-    subject { banded.vat_amount }
+    subject(:vat_amount) { banded.vat_amount }
 
     let(:outputs_double) { double(total_net_amount: 200) }
     let(:uplifts_double) { double(total_net_amount: 50) }
@@ -302,10 +316,10 @@ RSpec.describe PaymentCalculator::Banded do
   end
 
   describe "#voided_declarations_count" do
+    subject(:voided_declarations_count) { banded.voided_declarations_count }
+
     context "with no voided declarations" do
-      it "returns 0" do
-        expect(banded.voided_declarations_count).to eq(0)
-      end
+      it { is_expected.to eq(0) }
     end
 
     context "with voided ECT declarations" do
@@ -314,15 +328,12 @@ RSpec.describe PaymentCalculator::Banded do
           :declaration,
           4,
           :voided,
-          :with_ect,
-          school_partnership:,
+          training_period: ect_training_period,
           payment_statement: statement_july
         )
       end
 
-      it "returns the count of voided declarations matching the selector" do
-        expect(banded.voided_declarations_count).to eq(4)
-      end
+      it { is_expected.to eq(4) }
     end
 
     context "with voided mentor declarations" do
@@ -331,15 +342,12 @@ RSpec.describe PaymentCalculator::Banded do
           :declaration,
           2,
           :voided,
-          :with_mentor,
-          school_partnership:,
+          training_period: mentor_training_period,
           payment_statement: statement_july
         )
       end
 
-      it "returns the count of voided declarations matching the selector" do
-        expect(banded.voided_declarations_count).to eq(2)
-      end
+      it { is_expected.to eq(2) }
     end
   end
 end

--- a/spec/services/payment_calculator/flat_rate_spec.rb
+++ b/spec/services/payment_calculator/flat_rate_spec.rb
@@ -3,16 +3,17 @@ RSpec.describe PaymentCalculator::FlatRate do
     described_class.new(statement:, flat_rate_fee_structure:, declaration_selector:, fee_proportions:)
   end
 
-  let(:school_partnership) do
-    FactoryBot.create(:school_partnership, :for_year, year: Date.current.year, lead_provider:)
-  end
-
-  let(:active_lead_provider) { school_partnership.active_lead_provider }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
   let(:lead_provider) { FactoryBot.create(:lead_provider, vat_registered:) }
   let(:vat_registered) { true }
 
   let(:mentor_training_period) do
-    FactoryBot.create(:training_period, :for_mentor, school_partnership:)
+    FactoryBot.create(
+      :training_period,
+      :for_mentor,
+      :with_active_lead_provider,
+      active_lead_provider:
+    )
   end
   let!(:mentor_billable_declaration) do
     FactoryBot.create(
@@ -42,7 +43,12 @@ RSpec.describe PaymentCalculator::FlatRate do
     )
   end
   let(:ect_training_period) do
-    FactoryBot.create(:training_period, :for_ect, school_partnership:)
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      :with_active_lead_provider,
+      active_lead_provider:
+    )
   end
   let!(:ect_declaration) do
     FactoryBot.create(
@@ -72,7 +78,7 @@ RSpec.describe PaymentCalculator::FlatRate do
   let(:fee_proportions) { { started: 0.5, completed: 0.5 } }
 
   describe "#total_amount" do
-    subject { flat_rate.total_amount(with_vat:) }
+    subject(:total_amount) { flat_rate.total_amount(with_vat:) }
 
     before do
       allow(PaymentCalculator::FlatRate::Outputs)
@@ -108,7 +114,7 @@ RSpec.describe PaymentCalculator::FlatRate do
   end
 
   describe "#vat_amount" do
-    subject { flat_rate.vat_amount }
+    subject(:vat_amount) { flat_rate.vat_amount }
 
     before do
       allow(PaymentCalculator::FlatRate::Outputs)
@@ -130,6 +136,8 @@ RSpec.describe PaymentCalculator::FlatRate do
   end
 
   describe "#outputs" do
+    subject(:outputs) { flat_rate.outputs }
+
     it "calls the `FlatRate::Outputs` service with filtered declarations" do
       expect(PaymentCalculator::FlatRate::Outputs)
         .to receive(:new)
@@ -142,15 +150,15 @@ RSpec.describe PaymentCalculator::FlatRate do
           fee_proportions:
         )
 
-      flat_rate.outputs
+      outputs
     end
   end
 
   describe "#voided_declarations_count" do
+    subject(:voided_declarations_count) { flat_rate.voided_declarations_count }
+
     context "with no voided declarations" do
-      it "returns 0" do
-        expect(flat_rate.voided_declarations_count).to eq(0)
-      end
+      it { is_expected.to eq(0) }
     end
 
     context "with voided mentor declarations" do
@@ -159,15 +167,12 @@ RSpec.describe PaymentCalculator::FlatRate do
           :declaration,
           4,
           :voided,
-          :with_mentor,
-          school_partnership:,
+          training_period: mentor_training_period,
           payment_statement: statement
         )
       end
 
-      it "returns the count of voided declarations matching the selector" do
-        expect(flat_rate.voided_declarations_count).to eq(4)
-      end
+      it { is_expected.to eq(4) }
     end
 
     context "with voided ECT declarations" do
@@ -176,15 +181,12 @@ RSpec.describe PaymentCalculator::FlatRate do
           :declaration,
           2,
           :voided,
-          :with_ect,
-          school_partnership:,
+          training_period: ect_training_period,
           payment_statement: statement
         )
       end
 
-      it "does not count them" do
-        expect(flat_rate.voided_declarations_count).to eq(0)
-      end
+      it { is_expected.to eq(0) }
     end
   end
 end

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -152,14 +152,12 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
     it "displays the ECF payment overview component" do
       render
 
-      expect(rendered).to have_text("Uplift fees")
-      expect(rendered).to have_text("Output payment")
-      expect(rendered).to have_text("Clawbacks")
-
-      expect(rendered).not_to have_text("ECTs output payment")
-      expect(rendered).not_to have_text("Mentors output payment")
-      expect(rendered).not_to have_text("ECTs clawbacks")
-      expect(rendered).not_to have_text("Mentors clawbacks")
+      expect(rendered).to have_css("table tr:nth-child(1) td:nth-child(1)", text: "Output payment")
+      expect(rendered).to have_css("table tr:nth-child(2) td:nth-child(1)", text: "Service fee")
+      expect(rendered).to have_css("table tr:nth-child(3) td:nth-child(1)", text: "Uplift fees")
+      expect(rendered).to have_css("table tr:nth-child(4) td:nth-child(1)", text: "Clawbacks")
+      expect(rendered).to have_css("table tr:nth-child(5) td:nth-child(1)", text: "Additional adjustments")
+      expect(rendered).to have_css("table tr:nth-child(6) td:nth-child(1)", text: "VAT")
     end
 
     it "displays clawbacks in a single table" do
@@ -175,14 +173,13 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
     it "displays the ITTECF ECTP payment overview component" do
       render
 
-      expect(rendered).to have_text("ECTs output payment")
-      expect(rendered).to have_text("Mentors output payment")
-      expect(rendered).to have_text("ECTs clawbacks")
-      expect(rendered).to have_text("Mentors clawbacks")
-
-      expect(rendered).not_to have_text("Uplift fees")
-      expect(rendered).not_to have_text("Output payment")
-      expect(rendered).not_to have_text("Clawbacks")
+      expect(rendered).to have_css("table tr:nth-child(1) td:nth-child(1)", text: "ECTs output payment")
+      expect(rendered).to have_css("table tr:nth-child(2) td:nth-child(1)", text: "Mentors output payment")
+      expect(rendered).to have_css("table tr:nth-child(3) td:nth-child(1)", text: "Service fee")
+      expect(rendered).to have_css("table tr:nth-child(4) td:nth-child(1)", text: "ECTs clawbacks")
+      expect(rendered).to have_css("table tr:nth-child(5) td:nth-child(1)", text: "Mentors clawbacks")
+      expect(rendered).to have_css("table tr:nth-child(6) td:nth-child(1)", text: "Additional adjustments")
+      expect(rendered).to have_css("table tr:nth-child(7) td:nth-child(1)", text: "VAT")
     end
 
     it "displays clawbacks in separate tables" do


### PR DESCRIPTION
Initially we thought we should change the "Clawed back" count so it only
included declarations that have been clawed back (i.e to be consistent with
ECF).

But after discussing with Product and Contract Managers, we decided we'd
actually prefer to include declarations that are awaiting clawback too.

Since we're already doing that, we can just change the label to "Clawbacks".

We have also tweaked the output for declaration types that don't apply to
mentors. Now, we display a "-" instead of "0" for retained and extended
declaration counts for mentors in statements for `ittecf_ectp` contracts.