### PR TITLE
Clarify "refundable" declarations definition

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -4,7 +4,7 @@ class Declaration < ApplicationRecord
   BILLABLE_OR_CHANGEABLE_PAYMENT_STATUSES = %w[no_payment eligible payable paid].freeze
   VOIDABLE_PAYMENT_STATUSES = %w[no_payment eligible payable].freeze
   BILLABLE_PAYMENT_STATUSES = %w[eligible payable paid].freeze
-  REFUNDABLE_PAYMENT_STATUSES = %w[awaiting_clawback clawed_back].freeze
+  REFUNDABLE_CLAWBACK_STATUSES = %w[awaiting_clawback clawed_back].freeze
 
   # Associations
   belongs_to :training_period
@@ -95,7 +95,7 @@ class Declaration < ApplicationRecord
 
   # Declaration can be both billable and refundable, paid in one month and clawed_back in another
   scope :billable, -> { where(payment_status: BILLABLE_PAYMENT_STATUSES) }
-  scope :refundable, -> { where(clawback_status: REFUNDABLE_PAYMENT_STATUSES) }
+  scope :refundable, -> { where(clawback_status: REFUNDABLE_CLAWBACK_STATUSES) }
 
   touch -> { self },
         timestamp_attribute: :api_updated_at,

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -398,10 +398,10 @@ describe Declaration do
 
       describe ".refundable" do
         let(:declarations) { described_class.clawback_statuses.keys.map { |status| FactoryBot.create(:declaration, :"#{status}") } }
-        let(:refundable_declarations) { declarations.select { |d| described_class::REFUNDABLE_PAYMENT_STATUSES.include?(d.clawback_status) } }
+        let(:refundable_declarations) { declarations.select { |d| described_class::REFUNDABLE_CLAWBACK_STATUSES.include?(d.clawback_status) } }
 
         it "returns declarations with refundable statuses" do
-          expect(described_class.refundable.pluck(:clawback_status)).to all(be_in(described_class::REFUNDABLE_PAYMENT_STATUSES))
+          expect(described_class.refundable.pluck(:clawback_status)).to all(be_in(described_class::REFUNDABLE_CLAWBACK_STATUSES))
         end
       end
     end


### PR DESCRIPTION
We define "refundable" declarations as those with a clawback status of `awaiting_clawback` or `clawed_back`, but the constant described these as `REFUNDABLE_PAYMENT_STATUSES`.

This renames the constant to `REFUNDABLE_CLAWBACK_STATUSES` to avoid any confusion.