### PR TITLE
Refer to "contract period" rather than "cohort"

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -15,7 +15,7 @@ module API::Teachers
     validate :trainee_not_completed
     validate :lead_provider_is_currently_training_teacher
     validate :no_future_training_periods_exist
-    validate :can_move_to_frozen_cohort
+    validate :can_move_to_frozen_contract_period
     validate :schedule_does_not_invalidate_declarations
 
     def change_schedule
@@ -124,13 +124,13 @@ module API::Teachers
       end
     end
 
-    def can_move_to_frozen_cohort
+    def can_move_to_frozen_contract_period
       return unless contract_period&.payments_frozen?
 
       original_frozen_year = training_period.for_ect? ? teacher.ect_payments_frozen_year : teacher.mentor_payments_frozen_year
 
       unless original_frozen_year == contract_period.year
-        errors.add(:contract_period_year, "You cannot move a participant to a payments frozen cohort unless they previously belonged to that cohort.")
+        errors.add(:contract_period_year, "You cannot move a participant to a payments frozen contract period unless they previously belonged to that contract period.")
       end
     end
 

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
             it { is_expected.to have_one_error_per_attribute }
 
-            it { is_expected.to have_error(:contract_period_year, "You cannot move a participant to a payments frozen cohort unless they previously belonged to that cohort.") }
+            it { is_expected.to have_error(:contract_period_year, "You cannot move a participant to a payments frozen contract period unless they previously belonged to that contract period.") }
           end
 
           context "when the training period `started_on` has not yet passed and there are existing declarations" do


### PR DESCRIPTION
We want to refer to "contract periods" rather than "cohorts" in the codebase, since this corresponds to the new domain models.

We map error messages for the API, so we can refer to "contract period" in the `API::Teachers::ChangeSchedule` service.

This keeps terms consistent and hopefully makes things a little clearer.