### PR TITLE
Treat closed/proposed_to_open and open/proposed_to_closed as similar statuses on school migrations

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -64,15 +64,20 @@ module Migrators
         gias_value = gias_school.send(gias_field)
         ecf_value = ecf_school.send(ecf_field)
         next true if gias_value.presence == ecf_value.presence
-        next true if skip_missing_field?(gias_school:, field_name: gias_field)
+        next true if skip_missing_field?(gias_school:, field_name: gias_field, gias_value:, ecf_value:)
 
         field_mismatch(gias_school, gias_field, gias_value, ecf_value)
       }.all?
     end
 
-    def skip_missing_field?(gias_school:, field_name:)
-      # administrative_district_name is not in the split out GIAS export for Children's Centres
-      field_name.to_s == "administrative_district_name" && gias_school.type_name.in?(GIAS::Types::CHILDRENS_CENTRE_TYPES)
+    # administrative_district_name is not in the split out GIAS export for Children's Centres
+    # statuses open and proposed_to_close are considered the same status
+    # statuses closed and proposed_to_open are considered the same status
+    def skip_missing_field?(gias_school:, field_name:, gias_value:, ecf_value:)
+      return true if field_name.to_s == "administrative_district_name" && gias_school.type_name.in?(GIAS::Types::CHILDRENS_CENTRE_TYPES)
+      return true if field_name.to_s == "status" && ([gias_value, ecf_value] - %w[open proposed_to_close]).empty?
+
+      field_name.to_s == "status" && ([gias_value, ecf_value] - %w[closed proposed_to_open]).empty?
     end
 
     def field_mismatch(school, field, gias_value, ecf_value)

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -87,6 +87,10 @@ describe Migrators::School do
     end
 
     context "when fields mismatch" do
+      let(:school_status_name) { "Open" }
+      let(:status) { "closed" }
+      let(:failure_messages) { data_migration.migration_failures.order(:created_at).pluck(:failure_message) }
+
       let!(:ecf_school) do
         FactoryBot.create(:ecf_migration_school,
                           school_status_code: 1,
@@ -95,7 +99,7 @@ describe Migrators::School do
                           school_type_code: 1,
                           school_phase_name: "Phase one",
                           section_41_approved: false,
-                          school_status_name: "Open",
+                          school_status_name:,
                           school_type_name: "Type one",
                           ukprn: "12345")
       end
@@ -108,7 +112,7 @@ describe Migrators::School do
                           in_england: true,
                           phase_name: "Another Phase one",
                           section_41_approved: true,
-                          status: "proposed_to_close",
+                          status:,
                           type_name: "Academy converter",
                           ukprn: 54_321)
       end
@@ -119,15 +123,31 @@ describe Migrators::School do
 
       it "adds mismatch errors" do
         expect(data_migration.reload.failure_count).to eq(1)
-        expect(data_migration.migration_failures.order(:created_at).pluck(:failure_message))
+        expect(failure_messages)
           .to contain_exactly(":administrative_district_name - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'administrative_district_name': 'AD1' on ECF whilst 'AAD1' expected on RECT!",
                               ":eligible - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'eligible': 'false' on ECF whilst 'true' expected on RECT!",
                               ":in_england - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'in_england': 'false' on ECF whilst 'true' expected on RECT!",
                               ":phase_name - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'phase_name': 'Phase one' on ECF whilst 'Another Phase one' expected on RECT!",
                               ":section_41_approved - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'section_41_approved': 'false' on ECF whilst 'true' expected on RECT!",
-                              ":status - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'status': 'open' on ECF whilst 'proposed_to_close' expected on RECT!",
+                              ":status - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'status': 'open' on ECF whilst 'closed' expected on RECT!",
                               ":type_name - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'type_name': 'Type one' on ECF whilst 'Academy converter' expected on RECT!",
                               ":ukprn - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'ukprn': '12345' on ECF whilst '54321' expected on RECT!")
+      end
+
+      {
+        "Open" => "proposed_to_close",
+        "Proposed to Close" => "open",
+        "Closed" => "proposed_to_open",
+        "Proposed to Open" => "closed"
+      }.each do |ecf1_value, ecf2_value|
+        context "when the ECF1 school has status value '#{ecf1_value}' and the ECF2's is '#{ecf2_value}'" do
+          let(:school_status_name) { ecf1_value }
+          let(:status) { ecf2_value }
+
+          it "do not add mismatch errors on :status" do
+            expect(failure_messages.join(" ")).not_to include(":status")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/3652)

### Changes proposed in this pull request
The school migrator should not log migration errors when comparing ECF1 school `Open` status value with `proposed_to_close` on the RECT school or viceverse.

Similarly, it should not log errors for `Closed` and `proposed_to_open` or viceverse.

### Guidance to review
