### PR TITLE
Exclude completed ECTs from transfer history

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -80,20 +80,12 @@ class API::TeacherSerializer < Blueprinter::Base
       end
       field(:induction_end_date) do |(training_period, teacher, _)|
         if training_period.for_ect?
-          if teacher.finished_induction_period.present?
-            teacher.finished_induction_period.finished_on
-          else
-            teacher.trs_induction_completed_date
-          end
+          API::Teachers::InductionStatus.new(teacher:).induction_end_date
         end
       end
       field(:overall_induction_start_date) do |(training_period, teacher, _)|
         if training_period.for_ect?
-          if teacher.started_induction_period.present?
-            teacher.started_induction_period.started_on
-          else
-            teacher.trs_induction_start_date
-          end
+          API::Teachers::InductionStatus.new(teacher:).induction_start_date
         end
       end
       field(:mentor_funding_end_date) { |(training_period, teacher, _)| teacher.mentor_became_ineligible_for_funding_on if training_period.for_mentor? }

--- a/app/serializers/api/teachers/school_transfer_serializer.rb
+++ b/app/serializers/api/teachers/school_transfer_serializer.rb
@@ -58,11 +58,11 @@ class API::Teachers::SchoolTransferSerializer < Blueprinter::Base
   field(:type) { "participant-transfer" }
 
   association :attributes, blueprint: AttributesSerializer do |teacher, options|
-    ect_transfers = ::Teachers::SchoolTransfers::History.transfers_for(
+    ect_transfers = ::API::Teachers::SchoolTransfers::History.transfers_for(
       school_periods: teacher.ect_at_school_periods,
       lead_provider_id: options[:lead_provider_id]
     )
-    mentor_transfers = ::Teachers::SchoolTransfers::History.transfers_for(
+    mentor_transfers = ::API::Teachers::SchoolTransfers::History.transfers_for(
       school_periods: teacher.mentor_at_school_periods,
       lead_provider_id: options[:lead_provider_id]
     )

--- a/app/services/api/teachers/induction_status.rb
+++ b/app/services/api/teachers/induction_status.rb
@@ -1,0 +1,21 @@
+module API::Teachers
+  class InductionStatus
+    attr_reader :teacher
+
+    def initialize(teacher:)
+      @teacher = teacher
+    end
+
+    def induction_end_date
+      teacher.finished_induction_period&.finished_on || teacher.trs_induction_completed_date
+    end
+
+    def induction_start_date
+      teacher.started_induction_period&.started_on || teacher.trs_induction_start_date
+    end
+
+    def completed_induction?
+      induction_end_date.present?
+    end
+  end
+end

--- a/app/services/api/teachers/school_transfers/history.rb
+++ b/app/services/api/teachers/school_transfers/history.rb
@@ -1,4 +1,4 @@
-module Teachers::SchoolTransfers
+module API::Teachers::SchoolTransfers
   class History
     def self.transfers_for(...) = new(...).transfers
     def self.exists_for?(...) = new(...).exists?
@@ -49,8 +49,7 @@ module Teachers::SchoolTransfers
     end
 
     def teacher_completed_induction?(teacher, next_school_period)
-      finished_induction_period = teacher.finished_induction_period
-      next_school_period.nil? && finished_induction_period&.complete?
+      next_school_period.nil? && API::Teachers::InductionStatus.new(teacher:).completed_induction?
     end
 
     def relevant_to_lead_provider?(leaving_training_period, joining_training_period)

--- a/app/services/api/teachers/school_transfers/transfer.rb
+++ b/app/services/api/teachers/school_transfers/transfer.rb
@@ -1,4 +1,4 @@
-module Teachers::SchoolTransfers
+module API::Teachers::SchoolTransfers
   class InvalidTransferError < StandardError; end
 
   class Transfer

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -73,7 +73,7 @@ module Metadata::Handlers
     end
 
     def school_transfers_exist_for(school_periods, lead_provider_id)
-      ::Teachers::SchoolTransfers::History.exists_for?(school_periods:, lead_provider_id:)
+      ::API::Teachers::SchoolTransfers::History.exists_for?(school_periods:, lead_provider_id:)
     end
   end
 end

--- a/spec/services/api/teachers/induction_status_spec.rb
+++ b/spec/services/api/teachers/induction_status_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe API::Teachers::InductionStatus, type: :model do
+  let(:instance) { described_class.new(teacher:) }
+
+  describe "#induction_end_date" do
+    subject { instance.induction_end_date }
+
+    context "when the teacher has a TRS induction completed date" do
+      let(:teacher) { FactoryBot.create(:teacher, trs_induction_completed_date: 1.month.ago) }
+
+      it { is_expected.to eq(teacher.trs_induction_completed_date) }
+    end
+
+    context "when the teacher has a finished induction period" do
+      let(:teacher) { finished_induction_period.teacher }
+      let(:finished_induction_period) { FactoryBot.create(:induction_period, :pass) }
+
+      it { is_expected.to eq(finished_induction_period.finished_on) }
+    end
+
+    context "when the teacher has both a TRS induction completed date and a finished induction period" do
+      let(:teacher) { finished_induction_period.teacher }
+      let(:finished_induction_period) { FactoryBot.create(:induction_period, :pass) }
+
+      before { teacher.update!(trs_induction_completed_date: 1.month.ago) }
+
+      it { is_expected.to eq(finished_induction_period.finished_on) }
+    end
+
+    context "when the teacher does not have a TRS induction completed date or a finished induction period" do
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#induction_start_date" do
+    subject { instance.induction_start_date }
+
+    context "when the teacher has a TRS induction start date" do
+      let(:teacher) { FactoryBot.create(:teacher, trs_induction_start_date: 1.month.ago) }
+
+      it { is_expected.to eq(teacher.trs_induction_start_date) }
+    end
+
+    context "when the teacher has a started induction period" do
+      let(:teacher) { started_induction_period.teacher }
+      let(:started_induction_period) { FactoryBot.create(:induction_period, :pass) }
+
+      it { is_expected.to eq(started_induction_period.started_on) }
+    end
+
+    context "when the teacher has both a TRS induction start date and a started induction period" do
+      let(:teacher) { started_induction_period.teacher }
+      let(:started_induction_period) { FactoryBot.create(:induction_period, :pass) }
+
+      before { teacher.update!(trs_induction_start_date: 1.month.ago) }
+
+      it { is_expected.to eq(started_induction_period.started_on) }
+    end
+
+    context "when the teacher does not have a TRS induction start date or a started induction period" do
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#completed_induction?" do
+    subject { instance }
+
+    context "when the teacher has a TRS induction completed date" do
+      let(:teacher) { FactoryBot.create(:teacher, trs_induction_completed_date: 1.month.ago) }
+
+      it { is_expected.to be_completed_induction }
+    end
+
+    context "when the teacher has a finished induction period" do
+      let(:teacher) { FactoryBot.create(:induction_period, :pass).teacher }
+
+      it { is_expected.to be_completed_induction }
+    end
+
+    context "when the teacher does not have a TRS induction completed date or a finished induction period" do
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      it { is_expected.not_to be_completed_induction }
+    end
+  end
+end

--- a/spec/services/api/teachers/school_transfers/history_spec.rb
+++ b/spec/services/api/teachers/school_transfers/history_spec.rb
@@ -1,5 +1,5 @@
 # rubocop:disable RSpec/InstanceVariable
-RSpec.describe Teachers::SchoolTransfers::History do
+RSpec.describe API::Teachers::SchoolTransfers::History do
   include SchoolTransferHelpers
 
   describe "transfers" do
@@ -90,7 +90,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
 
         expect(history.transfers.size).to eq(1)
         transfer = history.transfers.first
-        expect(transfer).to be_a(Teachers::SchoolTransfers::Transfer)
+        expect(transfer).to be_a(API::Teachers::SchoolTransfers::Transfer)
         expect(transfer.type).to eq(:unknown)
         expect(transfer.status).to eq(:complete)
         expect(transfer).to be_for_ect
@@ -157,7 +157,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
 
         expect(history.transfers.size).to eq(1)
         transfer = history.transfers.first
-        expect(transfer).to be_a(Teachers::SchoolTransfers::Transfer)
+        expect(transfer).to be_a(API::Teachers::SchoolTransfers::Transfer)
         expect(transfer.type).to eq(:new_school)
         expect(transfer.status).to eq(:complete)
         expect(transfer).to be_for_ect
@@ -201,7 +201,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
 
         expect(history.transfers.size).to eq(1)
         transfer = history.transfers.first
-        expect(transfer).to be_a(Teachers::SchoolTransfers::Transfer)
+        expect(transfer).to be_a(API::Teachers::SchoolTransfers::Transfer)
         expect(transfer.type).to eq(:new_provider)
         expect(transfer.status).to eq(:complete)
         expect(transfer).to be_for_ect
@@ -219,7 +219,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
 
         expect(history.transfers.size).to eq(1)
         transfer = history.transfers.first
-        expect(transfer).to be_a(Teachers::SchoolTransfers::Transfer)
+        expect(transfer).to be_a(API::Teachers::SchoolTransfers::Transfer)
         expect(transfer.type).to eq(:new_provider)
         expect(transfer.status).to eq(:complete)
         expect(transfer).to be_for_ect
@@ -259,7 +259,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
 
         expect(history.transfers.size).to eq(1)
         transfer = history.transfers.first
-        expect(transfer).to be_a(Teachers::SchoolTransfers::Transfer)
+        expect(transfer).to be_a(API::Teachers::SchoolTransfers::Transfer)
         expect(transfer.type).to eq(:new_provider)
         expect(transfer.status).to eq(:complete)
         expect(transfer).to be_for_ect
@@ -289,7 +289,7 @@ RSpec.describe Teachers::SchoolTransfers::History do
 
         expect(history.transfers.size).to eq(1)
         transfer = history.transfers.first
-        expect(transfer).to be_a(Teachers::SchoolTransfers::Transfer)
+        expect(transfer).to be_a(API::Teachers::SchoolTransfers::Transfer)
         expect(transfer.type).to eq(:new_provider)
         expect(transfer.status).to eq(:complete)
         expect(transfer).to be_for_ect

--- a/spec/services/api/teachers/school_transfers/transfer_spec.rb
+++ b/spec/services/api/teachers/school_transfers/transfer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Teachers::SchoolTransfers::Transfer do
+RSpec.describe API::Teachers::SchoolTransfers::Transfer do
   subject(:transfer) do
     described_class.new(
       leaving_training_period:,
@@ -95,7 +95,7 @@ RSpec.describe Teachers::SchoolTransfers::Transfer do
 
       it "raises an error" do
         expect { type }.to raise_error(
-          Teachers::SchoolTransfers::InvalidTransferError,
+          API::Teachers::SchoolTransfers::InvalidTransferError,
           "Unexpected transfer"
         )
       end

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe Metadata::Handlers::Teacher do
 
         context "when Teacher has some school transfers" do
           before do
-            allow(Teachers::SchoolTransfers::History)
+            allow(API::Teachers::SchoolTransfers::History)
               .to receive(:exists_for?)
               .and_return(true)
 
@@ -349,7 +349,7 @@ RSpec.describe Metadata::Handlers::Teacher do
 
         context "when Teacher has no school transfers" do
           before do
-            allow(Teachers::SchoolTransfers::History)
+            allow(API::Teachers::SchoolTransfers::History)
               .to receive(:exists_for?)
               .and_return(false)
 


### PR DESCRIPTION
If we are looking at the last school period of a `Teacher` and they have completed induction we should not treat it as a transfer.

We recently updated the serializer to class a teacher as completed if they have a finished induction period or a completion date from TRS.

The transfer service is only checking for a completed induction period, however, so we are incorrectly classifying some completed ETCs as transferring.

Add `InductionStatus` service, scoped to the `API` to avoid conflicting with the existing `InductionStatus` service. As the `History` service now references this, I've also moved this under the `API` namespace (it isn't used anywhere
else yet anyway, we can maybe revisit if that becomes the case).
