### PR TITLE
Limit cookie access as much as possible

### DIFF
--- a/app/services/sessions/manager.rb
+++ b/app/services/sessions/manager.rb
@@ -22,7 +22,7 @@ module Sessions
       check_authorisation!(session_user)
       @current_user = nil
       session["user_session"] = session_user.to_h
-      cookies["id_token"] = encrypt_token(id_token)
+      cookies["id_token"] = { value: encrypt_token(id_token), httponly: true, secure: true, same_site: :strict }
     end
 
     # @see Sessions::User

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -40,9 +40,33 @@ RSpec.describe Sessions::Manager do
       expect(session["user_session"]["dfe_sign_in_user_id"]).to eql("1")
     end
 
-    it "'stores the id_token encrypted in the 'id_token' cookie'" do
-      service.begin_session!(user, id_token: "dfe_token")
-      expect(cookies["id_token"]).to be_present
+    describe "storing the 'id_token' cookie" do
+      let(:secret_key) { Rails.application.secret_key_base.byteslice(0, 32) }
+
+      before do
+        allow(ActiveSupport::MessageEncryptor).to receive(:new).and_call_original
+        service.begin_session!(user, id_token: "dfe_token")
+      end
+
+      it "is set" do
+        expect(cookies["id_token"]).to be_present
+      end
+
+      it "id_token is encrypted" do
+        expect(ActiveSupport::MessageEncryptor).to have_received(:new).once.with(secret_key)
+      end
+
+      it "has 'httponly: true' set" do
+        expect(cookies.dig("id_token", "httponly")).to be(true)
+      end
+
+      it "has 'secure: true' set" do
+        expect(cookies.dig("id_token", "secure")).to be(true)
+      end
+
+      it "has 'same_site: :strict' set" do
+        expect(cookies.dig("id_token", "same_site")).to be(:strict)
+      end
     end
 
     context "when the user signs via DfE Sign In but has no role permissions for their organisation" do


### PR DESCRIPTION
### Context

We were previously setting our `id_token` cookie without any extra arguments, meaning it was set to:

```ruby
{
  secure: false,
  httponly: false,
  same_site: :lax
}
```

This change updates it so:

* `secure: true` (always set the Secure attribute, indicating that the cookie should only be sent over HTTPS)
* `httponly: true` (prevents JavaScript from reading the cookie, helps prevent XSS)
* `same_site: :strict` (to restrict the transmission of cookies in requests that originate from different sites)

https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Cookies


| Before | After |
| ------ | ------- |
|<img width="494" height="120" alt="Screenshot From 2026-03-25 11-32-25" src="https://github.com/user-attachments/assets/a17dc8a0-b5e8-41c6-bf76-51148ac2a9dd" /> | <img width="532" height="121" alt="Screenshot From 2026-03-25 11-32-44" src="https://github.com/user-attachments/assets/cc7a9fe6-bacc-4cf9-a5d4-cfa28e2f9b6a" /> |
