### PR TITLE
Ensure we migrate all schools returned by the API

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -12,7 +12,6 @@ module Migrators
     }.freeze
 
     MISMATCH_FIELD_MESSAGE = ->(school, field, gias_value, ecf_value) { ":#{field} - School #{school.urn} (#{school.name}) mismatch value on field named '#{field}': '#{ecf_value}' on ECF whilst '#{gias_value}' expected on RECT!" }
-    MISSING_SCHOOL_MESSAGE = ->(urn, name) { ":school_missing - School #{urn} (#{name}) missing on RECT!" }
 
     def self.dependencies = %i[gias_import gias_childrens_centres]
 
@@ -27,12 +26,32 @@ module Migrators
     end
 
     def self.schools
-      ::Migration::School.with(
-        eligible_or_cip_or_with_irs: [
-          ::Migration::School.includes(:local_authority).eligible_or_cip_only_except_welsh.not_bso_schools.distinct,
-          ::Migration::School.not_open.with_induction_records.distinct
-        ]
-      ).from("eligible_or_cip_or_with_irs AS schools")
+      # All RECT schools
+      rect_school_urns = ::School.pluck(:urn)
+
+      # All ECF schools that are returned by the API
+      ecf_schools_with_partnerships = ::Migration::School
+          .where.not(partnerships: { id: nil })
+          .where(partnerships: {
+            challenged_at: nil,
+            challenge_reason: nil,
+            relationship: false,
+          })
+      ecf_api_school_urns = ::Migration::School
+        .eligible
+        .not_cip_only
+        .or(ecf_schools_with_partnerships)
+        .includes(:partnerships)
+        .pluck(:urn)
+
+      # All ECF schools that have induction records
+      ecf_induction_record_school_urns = ::Migration::School
+          .with_induction_records
+          .pluck(:urn)
+
+      urns = (rect_school_urns + ecf_api_school_urns + ecf_induction_record_school_urns).uniq
+
+      ::Migration::School.where(urn: urns)
     end
 
     def migrate!
@@ -40,24 +59,16 @@ module Migrators
 
       migrate(schools_with_associations) do |ecf_school|
         gias_school = find_gias_school_by_urn(ecf_school.urn.to_i) || migrate_school!(ecf_school)
-        if check_gias_school(gias_school:, ecf_school:)
-          [
-            compare_fields(gias_school:, ecf_school:),
-            update_school!(school: gias_school.school, ecf_school:),
-          ].all?
-        end
+        next unless gias_school
+
+        [
+          compare_fields(gias_school:, ecf_school:),
+          update_school!(school: gias_school.school, ecf_school:),
+        ].all?
       end
     end
 
   private
-
-    def check_gias_school(gias_school:, ecf_school:)
-      return true if gias_school
-
-      failure_manager.record_failure(ecf_school, MISSING_SCHOOL_MESSAGE.call(ecf_school.urn, ecf_school.name))
-
-      false
-    end
 
     def compare_fields(gias_school:, ecf_school:)
       FIELDS_MAPPING.map { |gias_field, ecf_field|
@@ -66,7 +77,7 @@ module Migrators
         next true if gias_value.presence == ecf_value.presence
         next true if skip_missing_field?(gias_school:, field_name: gias_field, gias_value:, ecf_value:)
 
-        field_mismatch(gias_school, gias_field, gias_value, ecf_value)
+        field_mismatch(ecf_school, gias_field, gias_value, ecf_value)
       }.all?
     end
 
@@ -78,6 +89,10 @@ module Migrators
       return true if field_name.to_s == "status" && ([gias_value, ecf_value] - %w[open proposed_to_close]).empty?
 
       field_name.to_s == "status" && ([gias_value, ecf_value] - %w[closed proposed_to_open]).empty?
+    end
+
+    def failed_to_build_school(ecf_school, error_message)
+      failure_manager.record_failure(ecf_school, "Failed to find or build a GIAS school for school with urn #{ecf_school.urn} (#{ecf_school.name}): #{error_message}")
     end
 
     def field_mismatch(school, field, gias_value, ecf_value)
@@ -93,13 +108,10 @@ module Migrators
     end
 
     def migrate_school!(ecf_school)
-      Builders::GIAS::School.new(ecf_school).build if migratable_school?(ecf_school)
-    end
-
-    def migratable_school?(ecf_school)
-      return ecf_school.partnerships.any? if ecf_school.open?
-
-      ecf_school.induction_records.any?
+      builder = Builders::GIAS::School.new(ecf_school)
+      builder.build.tap do |gias_school|
+        failed_to_build_school(ecf_school, builder.error) unless gias_school
+      end
     end
 
     def update_school!(school:, ecf_school:)

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -34,13 +34,33 @@ describe Migrators::School do
 
     def create_resource(migration_resource) = create_gias_school(migration_resource)
 
-    def setup_failure_state = create_migration_resource
+    def setup_failure_state
+      ecf_school = create_migration_resource
+      gias_school = create_resource(ecf_school)
+
+      gias_school.update!(section_41_approved: !ecf_school.section_41_approved)
+    end
   end
 
   describe "#migrate!" do
     let!(:data_migration) { FactoryBot.create(:data_migration, model: :school, worker: 0) }
 
     context "when the ECF school can't be found in RECT" do
+      context "when the GIAS school can't be created from the ECF school" do
+        let!(:induction_record) { FactoryBot.create(:migration_induction_record) }
+        let!(:ecf_school) { induction_record.school.tap { it.update!(school_status_name: "open") } }
+
+        before do
+          allow(::GIAS::School).to receive(:create!).and_raise(ActiveRecord::ActiveRecordError, "can't create school!")
+        end
+
+        it "logs a failure" do
+          expect { described_class.new(worker: 0).migrate! }.not_to change(GIAS::School, :count)
+          failure_messages = data_migration.migration_failures.pluck(:failure_message)
+          expect(failure_messages).to contain_exactly("Failed to find or build a GIAS school for school with urn #{ecf_school.urn} (#{ecf_school.name}): can't create school!")
+        end
+      end
+
       context "when the school is closed and with induction records" do
         let!(:induction_record) { FactoryBot.create(:migration_induction_record) }
         let!(:ecf_school) { induction_record.school }
@@ -56,13 +76,13 @@ describe Migrators::School do
         end
       end
 
-      context "when the school is open and with partnerships" do
+      context "when the school is closed and with an unchallenged partnerships" do
         let!(:partnership) { FactoryBot.create(:migration_partnership) }
         let!(:ecf_school) { partnership.school }
         let(:rect_school) { School.find_by_urn(ecf_school.urn) }
 
         before do
-          ecf_school.update!(school_status_code: 1, school_type_code: 10, school_status_name: "open", school_type_name: "Community school")
+          ecf_school.update!(school_status_code: 1, school_type_code: 10, school_status_name: "closed", school_type_name: "Community school")
         end
 
         it "migrates it to RECT" do
@@ -71,18 +91,22 @@ describe Migrators::School do
         end
       end
 
-      context "when the school has no partnerships or induction records" do
-        let!(:ecf_school) { FactoryBot.create(:ecf_migration_school, school_status_code: 1, school_status_name: "open", school_type_code: 10) }
+      context "when the school is closed and with an challenged partnerships" do
+        let!(:partnership) { FactoryBot.create(:migration_partnership, challenged_at: 1.month.ago) }
+        let!(:ecf_school) { partnership.school }
+        let(:rect_school) { School.find_by_urn(ecf_school.urn) }
 
         before do
-          described_class.new(worker: 0).migrate!
+          ecf_school.update!(school_status_code: 1, school_type_code: 10, school_status_name: "closed", school_type_name: "Community school")
         end
 
-        it "adds an error" do
-          expect(data_migration.reload.failure_count).to eq(1)
-          expect(data_migration.migration_failures.count).to eq(1)
-          expect(data_migration.migration_failures.first.failure_message).to eq(":school_missing - School #{ecf_school.urn} (#{ecf_school.name}) missing on RECT!")
-        end
+        it { expect { described_class.new(worker: 0).migrate! }.not_to change(School, :count) }
+      end
+
+      context "when the school has no partnerships or induction records and is not returned by the API" do
+        let!(:ecf_school) { FactoryBot.create(:ecf_migration_school, school_status_code: 1, school_status_name: "open", school_type_code: 10) }
+
+        it { expect { described_class.new(worker: 0).migrate! }.not_to change(School, :count) }
       end
     end
 
@@ -124,14 +148,14 @@ describe Migrators::School do
       it "adds mismatch errors" do
         expect(data_migration.reload.failure_count).to eq(1)
         expect(failure_messages)
-          .to contain_exactly(":administrative_district_name - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'administrative_district_name': 'AD1' on ECF whilst 'AAD1' expected on RECT!",
-                              ":eligible - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'eligible': 'false' on ECF whilst 'true' expected on RECT!",
-                              ":in_england - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'in_england': 'false' on ECF whilst 'true' expected on RECT!",
-                              ":phase_name - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'phase_name': 'Phase one' on ECF whilst 'Another Phase one' expected on RECT!",
-                              ":section_41_approved - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'section_41_approved': 'false' on ECF whilst 'true' expected on RECT!",
-                              ":status - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'status': 'open' on ECF whilst 'closed' expected on RECT!",
-                              ":type_name - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'type_name': 'Type one' on ECF whilst 'Academy converter' expected on RECT!",
-                              ":ukprn - School #{gias_school.urn} (#{gias_school.name}) mismatch value on field named 'ukprn': '12345' on ECF whilst '54321' expected on RECT!")
+          .to contain_exactly(":administrative_district_name - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'administrative_district_name': 'AD1' on ECF whilst 'AAD1' expected on RECT!",
+                              ":eligible - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'eligible': 'false' on ECF whilst 'true' expected on RECT!",
+                              ":in_england - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'in_england': 'false' on ECF whilst 'true' expected on RECT!",
+                              ":phase_name - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'phase_name': 'Phase one' on ECF whilst 'Another Phase one' expected on RECT!",
+                              ":section_41_approved - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'section_41_approved': 'false' on ECF whilst 'true' expected on RECT!",
+                              ":status - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'status': 'open' on ECF whilst 'closed' expected on RECT!",
+                              ":type_name - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'type_name': 'Type one' on ECF whilst 'Academy converter' expected on RECT!",
+                              ":ukprn - School #{ecf_school.urn} (#{ecf_school.name}) mismatch value on field named 'ukprn': '12345' on ECF whilst '54321' expected on RECT!")
       end
 
       {


### PR DESCRIPTION
The filtering of schools during migration is currently omitting some ~3.5k schools that are closed yet exist in both RECT and ECF and two schools that are open but are otherwise excluded by the migrator.

This results in schools that exist in both platforms yet are not synced up via the `api_id`. Some of these schools are also returned by the API, so the parity check flagged them as having different `id`s in the response.

Update the `schools` method on the migrator to ensure we include:

- All schools that are in RECT and are also in ECF (so we get the ECF `api_id`)
- All schools that are returned by the API
- All schools that are linked to an induction record

This should cover all scenarios and ensure we bring across the `api_id` from ECF on schools that are exposed over the API.

As part of this change it looks like we will always  create a `GIAS::School` in RECT for any school brought over from ECF, so we can drop the check/error around missing schools.

Pass the ECF resource to the failure manager, as expected by the shared context.

Migration ran on this branch results in just one failure:

<img width="1025" height="299" alt="Screenshot 2026-03-26 at 08 06 47" src="https://github.com/user-attachments/assets/1e20c667-ea5a-49d8-bcad-c2a2d996608f" />

After migration I've verified the `api_id`s all match up:

```
ecf_map  = Migration::School.pluck(:urn, :id).to_h { |urn, id| [urn.to_i, id] }
rect_map = School.where(urn: ecf_map.keys).pluck(:urn, :api_id).to_h

mismatched = ecf_map.each_with_object({}) do |(urn, ecf_id, school_status_code), acc|
  rect_id = rect_map[urn]
  if rect_id && rect_id != ecf_id
    school_status_code = Migration::School.find_by(id: ecf_id).school_status_code
    acc[urn] = { ecf_id:, rect_id:, closed: school_status_code == 2 }
  end
end

=> {}
```
