### PR TITLE
Seed Blazer queries

### DIFF
--- a/db/seeds/blazer_queries.rb
+++ b/db/seeds/blazer_queries.rb
@@ -1,0 +1,53 @@
+# Blazer queries (/admin/blazer) for local, review and staging apps.
+#
+# Handy for:
+# 1. repopulating useful queries
+# 2. live demoing a local WIP
+# 3. product review of backend data
+# 4. saving queries in version control
+#
+user_manager = User.find_by(name: "Daphne Blake")
+
+def create_query(creator:, name:, statement:, description:)
+  Blazer::Query.create(creator:, name:, description:, statement:, data_source: :main, status: :active)
+end
+
+[
+  {
+    name: "Users",
+    statement: "SELECT * FROM users;",
+    description: nil,
+  },
+  {
+    name: "Jobs",
+    statement: "SELECT * FROM solid_queue_jobs;",
+    description: "SolidQueue activity",
+  },
+  {
+    name: "Appropriate bodies",
+    statement: "SELECT * FROM appropriate_bodies;",
+    description: "new data model migrating from appropriate_body_periods",
+  },
+  {
+    name: "Legacy appropriate bodies",
+    statement: "SELECT * FROM legacy_appropriate_bodies;",
+    description: "new data model extracted from appropriate_body_periods",
+  },
+  {
+    name: "DfE Sign-In Organisations",
+    statement: "SELECT * FROM dfe_sign_in_organisations;",
+    description: "new data model persisted during migration",
+  },
+  {
+    name: "Regions",
+    statement: "SELECT * FROM regions;",
+    description: "new data model",
+  },
+  {
+    name: "Appropriate body periods",
+    statement: "SELECT * FROM appropriate_body_periods;",
+    description: "old data model decommisioning and moving fields to other tables",
+  },
+].each do |query|
+  create_query(creator: user_manager, **query)
+end


### PR DESCRIPTION
### Context

We use Blazer dashboards and queries to interrogate `production` data using the day-old snapshot. 

However, we do not leverage this in `staging` or `review` apps where seeding is run.

### Changes proposed in this pull request

Adding commonly used queries to the seeds and populating the queries in Blazer gives us access to use them when testing against staging. This is going to be useful for the RIAB team working on data model changes behind a feature flag which rely upon DfE Sign-In.

DfE Sign-In does not work with review apps.

The queries can be used to inspect and visualise any backend data for development and review purposes.

### Guidance to review

Visit `/admin/blazer`