### PR TITLE
Allow teachers with >2 non-overlapping induction records to go premium 

### DIFF
--- a/app/migration/teacher_history_converter/migration_strategy.rb
+++ b/app/migration/teacher_history_converter/migration_strategy.rb
@@ -16,11 +16,20 @@ class TeacherHistoryConverter::MigrationStrategy
 private
 
   def teacher_history_meets_premium_criteria?
-    below_threshold_for_induction_records &&
-      has_not_been_withdrawn_or_deferred? &&
-      has_not_completed_induction? &&
-      dates_are_in_the_right_order_for?(ecf1_teacher_history.ect&.induction_records) &&
-      dates_are_in_the_right_order_for?(ecf1_teacher_history.mentor&.induction_records)
+    [
+      has_not_been_withdrawn_or_deferred?,
+      has_not_completed_induction?,
+      dates_are_in_the_right_order_for?(ecf1_teacher_history.ect&.induction_records),
+      dates_are_in_the_right_order_for?(ecf1_teacher_history.mentor&.induction_records),
+      (below_threshold_for_induction_records || !any_induction_records_overlap?)
+    ].all?
+  end
+
+  def any_induction_records_overlap?
+    [
+      has_overlaps?(ecf1_teacher_history.mentor&.induction_records),
+      has_overlaps?(ecf1_teacher_history.ect&.induction_records)
+    ].any?
   end
 
   def dates_are_in_the_right_order_for?(induction_records)
@@ -57,5 +66,14 @@ private
 
   def mentor_induction_records_count
     ecf1_teacher_history.mentor&.induction_records&.count || 0
+  end
+
+  def has_overlaps?(induction_records)
+    return false if induction_records.blank?
+
+    induction_records
+      .map { it.start_date..it.end_date }
+      .each_cons(2)
+      .any? { |a, b| a.overlap?(b) }
   end
 end

--- a/spec/factories/migration/ecf1_history_factory.rb
+++ b/spec/factories/migration/ecf1_history_factory.rb
@@ -72,9 +72,19 @@ FactoryBot.define do
       full_name { Faker::FunnyName.two_word_name }
     end
 
+    trait(:consecutive) do
+      sequence(:start_date) { |n| Date.new(cohort_year) + (n * 2).days }
+      sequence(:end_date) { start_date.tomorrow }
+    end
+
+    trait(:concurrent) do
+      start_date { Date.new(cohort_year, 9, 1) }
+      end_date { Date.new(cohort_year + 2, 6, 1) }
+    end
+
+    concurrent
+
     induction_record_id { SecureRandom.uuid }
-    start_date { Date.new(cohort_year, 9, 1) }
-    end_date { Date.new(cohort_year + 2, 6, 1) }
     cohort_year { 2024 }
     created_at { start_date }
     updated_at { 6.months.ago }

--- a/spec/migration/teacher_history_converter/migration_strategy_spec.rb
+++ b/spec/migration/teacher_history_converter/migration_strategy_spec.rb
@@ -4,24 +4,31 @@ describe TeacherHistoryConverter::MigrationStrategy do
   let(:mentor) { FactoryBot.build(:ecf1_teacher_history_mentor, induction_records: mentor_induction_records) }
   let(:ect) { FactoryBot.build(:ecf1_teacher_history_ect, induction_records: ect_induction_records) }
 
-  let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, number_of_ect_induction_records) }
-  let(:mentor_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, number_of_mentor_induction_records) }
+  let(:induction_records_trait) { :concurrent }
+  let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, number_of_ect_induction_records, induction_records_trait) }
+  let(:mentor_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, number_of_mentor_induction_records, induction_records_trait) }
 
   let(:ecf1_teacher_history) { FactoryBot.build(:ecf1_teacher_history, ect:, mentor:) }
 
   [
-    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 0, expected_outcome: :all_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 1, number_of_mentor_induction_records: 0, expected_outcome: :all_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 1, expected_outcome: :all_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 2, expected_outcome: :all_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 2, number_of_mentor_induction_records: 0, expected_outcome: :all_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 2, number_of_mentor_induction_records: 2, expected_outcome: :all_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 3, number_of_mentor_induction_records: 0, expected_outcome: :latest_induction_records),
-    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 3, expected_outcome: :latest_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 0, overlap: true, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 1, number_of_mentor_induction_records: 0, overlap: true, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 1, overlap: true, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 2, overlap: true, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 2, number_of_mentor_induction_records: 0, overlap: true, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 2, number_of_mentor_induction_records: 2, overlap: true, expected_outcome: :all_induction_records),
+    # more than 2, overlapping
+    OpenStruct.new(number_of_ect_induction_records: 3, number_of_mentor_induction_records: 0, overlap: true, expected_outcome: :latest_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 3, overlap: true, expected_outcome: :latest_induction_records),
+    # more than 2 but not overlapping
+    OpenStruct.new(number_of_ect_induction_records: 3, number_of_mentor_induction_records: 0, overlap: false, expected_outcome: :all_induction_records),
+    OpenStruct.new(number_of_ect_induction_records: 0, number_of_mentor_induction_records: 3, overlap: false, expected_outcome: :all_induction_records),
   ].each do |test_case|
     context "when there are #{test_case.number_of_mentor_induction_records} mentor induction records and #{test_case.number_of_ect_induction_records} ECT induction records" do
       let(:number_of_ect_induction_records) { test_case.number_of_ect_induction_records }
       let(:number_of_mentor_induction_records) { test_case.number_of_mentor_induction_records }
+
+      let(:induction_records_trait) { test_case.overlap ? :concurrent : :consecutive }
 
       it "returns #{test_case.expected_outcome}" do
         expect(subject.strategy).to be(test_case.expected_outcome)
@@ -38,10 +45,20 @@ describe TeacherHistoryConverter::MigrationStrategy do
     end
 
     context "when there are more than 2 induction records" do
-      let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 3) }
+      context "when the induction records overlap" do
+        let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 3) }
 
-      it "does not meet the criteria for premium" do
-        expect(subject.strategy).to eq(:latest_induction_records)
+        it "does not meet the criteria for premium" do
+          expect(subject.strategy).to eq(:latest_induction_records)
+        end
+      end
+
+      context "when the induction records don't overlap" do
+        let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 3, :consecutive) }
+
+        it "meets the criteria for premium" do
+          expect(subject.strategy).to eq(:all_induction_records)
+        end
       end
     end
 


### PR DESCRIPTION
### Context

This should boost the premium:economy ratio without introducing too much additional risk.

### Changes proposed in this pull request

- **Remove randomness from ECF1 teacher history factory**
- **Allow >2 non-overlapping IRs to go premium**
