### PR TITLE
Make the DfE Sign-in button more obvious

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,6 +5,6 @@
 <% if Rails.application.config.dfe_sign_in_enabled %>
   <!-- FIXME: delete this! -->
   <%= form_with url: '/auth/dfe_sign_in' do %>
-    <button>Log in</button>
+    <button class="govuk-button">DfE Sign-in</button>
   <% end %>
 <% end %>


### PR DESCRIPTION
Now it's clear that it will take you to DfE Sign-in too.

<img width="300" alt="Screenshot of the admin login page with a green 'DfE Sign-in button' rather than a grey one" src="https://github.com/user-attachments/assets/b2634dcc-2059-4e2a-b638-8cfae309742f" />
