### PR TITLE
Mentors can be registered at a school any time after their old school start date

### DIFF
--- a/app/wizards/schools/register_mentor_wizard/change_started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/change_started_on_step.rb
@@ -2,7 +2,7 @@ module Schools
   module RegisterMentorWizard
     class ChangeStartedOnStep < StartedOnStep
       def next_step
-        if !contract_period_enabled?
+        if registrations_closed_for_contract_period?
           wizard.store.revised_start_date_in_closed_contract_period = true
           :cannot_register_mentor_yet
         else
@@ -17,12 +17,11 @@ module Schools
     private
 
       def persist
-        if contract_period_enabled?
-          super
-        else
+        if registrations_closed_for_contract_period?
           wizard.store.started_on = mentor.started_on&.to_date
-
           true
+        else
+          super
         end
       end
     end

--- a/app/wizards/schools/register_mentor_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_mentor_wizard/registration_store/queries.rb
@@ -49,7 +49,8 @@ module Schools
         end
 
         def previous_school_mentor_at_school_periods
-          finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(registration_store.start_date)
+          finished_on_or_after_date = registration_store.started_on.presence || Date.current
+          finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(finished_on_or_after_date)
           scope = ::MentorAtSchoolPeriod.ongoing.or(finishes_in_the_future_scope)
           mentor_at_school_periods.where.not(school:).merge(scope)
         end

--- a/app/wizards/schools/register_mentor_wizard/registration_store/status.rb
+++ b/app/wizards/schools/register_mentor_wizard/registration_store/status.rb
@@ -52,15 +52,15 @@ module Schools
         end
 
         def previous_school_closed_mentor_at_school_periods?
-          queries.previous_school_mentor_at_school_periods.where.not(finished_on: nil).exists?
+          queries.previous_school_mentor_at_school_periods.finished.exists?
         end
 
         def mentorship_status
           mentor_at_school_periods = queries.mentor_at_school_periods
 
-          if mentor_at_school_periods.any?(&:ongoing?)
+          if mentor_at_school_periods.ongoing_today.exists?
             :currently_a_mentor
-          elsif mentor_at_school_periods.any?
+          elsif mentor_at_school_periods.exists?
             :previously_a_mentor
           else
             raise MentorStatusError, "No mentor_at_school_periods found for a previously registered mentor"

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -4,15 +4,13 @@ module Schools
       attr_accessor :started_on
 
       validates :started_on, mentor_start_date: true
-      validate :started_on_cannot_be_before_previous_started_and_finished_dates, if: :started_on
+      validate :started_on_after_all_previous_period_started_on_dates
       validate :started_on_within_4_months, if: :currently_mentor_at_another_school?
 
-      def self.permitted_params
-        %i[started_on]
-      end
+      def self.permitted_params = %i[started_on]
 
       def next_step
-        if !contract_period_enabled?
+        if registrations_closed_for_contract_period?
           :cannot_register_mentor_yet
         elsif mentor.became_ineligible_for_funding? || !mentor.provider_led_ect?
           :check_answers
@@ -43,21 +41,30 @@ module Schools
         self.started_on = Schools::Validation::MentorStartDate.new(date_as_hash: mentor.started_on).date_as_hash unless started_on
       end
 
-      def started_on_cannot_be_before_previous_started_and_finished_dates
+      def started_on_after_all_previous_period_started_on_dates
         return if errors.any?
 
-        date = mentor.previous_school_mentor_at_school_periods.pluck(:started_on, :finished_on).flatten.compact.max
-        return unless date
+        latest_started_on_at_previous_school = mentor
+          .previous_school_mentor_at_school_periods
+          .maximum(:started_on)
+        return unless latest_started_on_at_previous_school
 
-        if started_on_as_date.before?(date.next_day)
-          errors.add(:started_on, "#{mentor.full_name} was registered as a mentor at their last school starting on the #{date.to_fs(:govuk)}. Enter a later date.")
+        unless started_on_as_date.after?(latest_started_on_at_previous_school)
+          error_message = <<~TXT.squish
+            #{mentor.full_name} was registered as a mentor at their last school
+            starting on the #{latest_started_on_at_previous_school.to_fs(:govuk)}.
+            Enter a later date.
+          TXT
+          errors.add(:started_on, error_message)
         end
       end
 
       def started_on_within_4_months
-        earliest_invalid_started_on = (4.months + 1.day).from_now.to_date
+        return if errors.any?
 
-        if started_on_as_date >= earliest_invalid_started_on
+        earliest_invalid_started_on = 4.months.from_now.to_date.next_day
+
+        unless started_on_as_date.before?(earliest_invalid_started_on)
           errors.add(
             :started_on,
             "Start date must be before #{earliest_invalid_started_on.to_formatted_s(:govuk)}"
@@ -77,10 +84,8 @@ module Schools
         @started_on_as_date ||= started_on_obj.value_as_date
       end
 
-      def contract_period_enabled?
-        return true if started_on_as_date <= Time.zone.today
-
-        contract_period&.enabled?
+      def registrations_closed_for_contract_period?
+        started_on_as_date.future? && !contract_period&.enabled?
       end
 
       def contract_period

--- a/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
@@ -1,0 +1,243 @@
+RSpec.describe "Registering a mentor that is mentoring at the new school only", :enable_schools_interface do
+  include_context "test TRS API returns a teacher"
+  include SchoolPartnershipHelpers
+
+  before { freeze_time }
+
+  scenario "mentor is starting at the new school before the reported leaving date from the old school" do
+    given_there_is_a_school_in_the_service
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_mentor_has_existing_mentorship_at_another_school_finishing_in_future
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_should_be_taken_to_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_find_mentor_form
+    then_i_should_be_taken_to_the_review_mentor_details_page
+    and_i_should_see_the_mentor_details_in_the_review_page
+
+    when_i_select_that_my_mentor_name_is_correct
+    and_i_click_confirm_and_continue
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_the_mentor_email_address
+    and_i_click_continue
+    then_i_should_be_taken_to_mentoring_at_your_school_only_page
+
+    when_i_select_yes_they_will_not_be_mentoring_at_another_school
+    and_i_click_continue
+    then_i_should_be_taken_to_the_start_date_page
+
+    when_i_enter_a_start_date_before_the_previous_reported_leaving_date
+    and_i_click_continue
+    then_i_should_be_taken_to_the_check_answers_page
+    and_i_should_see_all_the_mentor_data_on_the_page
+
+    when_i_click_confirm_details
+    then_i_should_be_taken_to_the_confirmation_page
+    and_mentor_has_mentorship_with_new_school
+    and_all_the_dates_are_correct
+  end
+
+private
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school)
+  end
+
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period = FactoryBot.create(
+      :contract_period,
+      :current,
+      :with_schedules
+    )
+    @school_partnership = make_partnership_for(@school, @contract_period)
+    @lead_provider = @school_partnership
+      .lead_provider_delivery_partnership
+      .lead_provider
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    @training_period = FactoryBot.create(
+      :training_period,
+      :ongoing,
+      :school_led,
+      ect_at_school_period: @ect
+    )
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_mentor_has_existing_mentorship_at_another_school_finishing_in_future
+    another_school = FactoryBot.create(:school)
+    @mentor = FactoryBot.create(
+      :teacher,
+      trs_first_name: "Kirk",
+      trs_last_name: "Van Houten",
+      corrected_name: nil
+    )
+    @mentor_name = Teachers::Name.new(@mentor).full_name
+    @existing_mentor_at_school_period = FactoryBot.create(
+      :mentor_at_school_period,
+      school: another_school,
+      teacher: @mentor,
+      started_on: 1.year.ago,
+      finished_on: 2.weeks.from_now
+    )
+    other_ect = FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      school: another_school
+    )
+    @existing_mentorship = FactoryBot.create(
+      :mentorship_period,
+      mentee: other_ect,
+      mentor: @existing_mentor_at_school_period,
+      started_on: 6.months.ago,
+      finished_on: 2.weeks.from_now
+    )
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = "/school/home/ects"
+    page.goto path
+    expect(page).to have_path(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role("link", name: "Assign a mentor for this ECT").click
+  end
+
+  def then_i_should_be_taken_to_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role("link", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    path = "/school/register-mentor/find-mentor"
+    expect(page).to have_path(path)
+  end
+
+  def when_i_submit_the_find_mentor_form
+    page.get_by_label("trn").fill(@mentor.trn)
+    page.get_by_label("day").fill("3")
+    page.get_by_label("month").fill("2")
+    page.get_by_label("year").fill("1977")
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page).to have_path("/school/register-mentor/review-mentor-details")
+  end
+
+  def and_i_should_see_the_mentor_details_in_the_review_page
+    expect(page.get_by_text(@mentor.trn)).to be_visible
+    expect(page.get_by_text(@mentor_name)).to be_visible
+    expect(page.get_by_text("3 February 1977")).to be_visible
+  end
+
+  def when_i_select_that_my_mentor_name_is_correct
+    change_name_fieldset = page.locator(
+      "fieldset",
+      hasText: "Are these details correct for the mentor?"
+    )
+    change_name_fieldset.get_by_label("Yes").check
+  end
+
+  def and_i_click_confirm_and_continue
+    page.get_by_role("button", name: "Confirm and continue").click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page).to have_path("/school/register-mentor/email-address")
+  end
+
+  def when_i_enter_the_mentor_email_address
+    page.get_by_label("email").fill("example@example.com")
+  end
+
+  def and_i_click_continue
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_mentoring_at_your_school_only_page
+    expect(page).to have_path("/school/register-mentor/mentoring-at-new-school-only")
+  end
+
+  def when_i_select_yes_they_will_not_be_mentoring_at_another_school
+    mentoring_schools_fieldset = page.locator(
+      "fieldset",
+      hasText: "Will #{@mentor_name} be mentoring ECTs at your school only?"
+    )
+    mentoring_schools_fieldset.get_by_label("Yes").check
+  end
+
+  def then_i_should_be_taken_to_the_start_date_page
+    expect(page).to have_path("/school/register-mentor/started-on")
+  end
+
+  def when_i_enter_a_start_date_before_the_previous_reported_leaving_date
+    start_date_fieldset = page.locator("fieldset", hasText: "Mentor start date")
+    reported_leaving_date = @existing_mentor_at_school_period.finished_on
+    @new_mentor_start_date = (reported_leaving_date - 1.month).to_date
+    start_date_fieldset.get_by_label("Day").fill(@new_mentor_start_date.day.to_s)
+    start_date_fieldset.get_by_label("Month").fill(@new_mentor_start_date.month.to_s)
+    start_date_fieldset.get_by_label("Year").fill(@new_mentor_start_date.year.to_s)
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page).to have_path("/school/register-mentor/check-answers")
+  end
+
+  def and_i_should_see_all_the_mentor_data_on_the_page
+    expect(page.locator("dt", hasText: "Teacher reference number (TRN)")).to be_visible
+    expect(page.locator("dd", hasText: @mentor.trn)).to be_visible
+    expect(page.locator("dt", hasText: "Name")).to be_visible
+    expect(page.locator("dd", hasText: @mentor_name)).to be_visible
+    expect(page.locator("dt", hasText: "Email address")).to be_visible
+    expect(page.locator("dd", hasText: "example@example.com")).to be_visible
+    expect(page.locator("dt", hasText: "Mentoring only at your school")).to be_visible
+    expect(page.locator("dd", hasText: "Yes")).to be_visible
+  end
+
+  def when_i_click_confirm_details
+    page.get_by_role("button", name: "Confirm details").click
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page).to have_path("/school/register-mentor/confirmation")
+  end
+
+  def and_mentor_has_mentorship_with_new_school
+    expect(@mentor.mentor_at_school_periods.size).to eq 2
+    @new_mentor_at_school_period = @mentor
+      .mentor_at_school_periods
+      .excluding(@existing_mentor_at_school_period)
+      .take
+    expect(@new_mentor_at_school_period).to be_present
+    expect(@new_mentor_at_school_period.mentorship_periods.size).to eq 1
+    @new_mentorship = @new_mentor_at_school_period.mentorship_periods.take
+    expect(@new_mentorship).to be_present
+    expect(@new_mentor_at_school_period.school).to eq @school
+  end
+
+  def and_all_the_dates_are_correct
+    expect(@existing_mentor_at_school_period.reload.finished_on).to eq @new_mentor_start_date
+    expect(@existing_mentorship.reload.finished_on).to eq @new_mentor_start_date
+    expect(@new_mentor_at_school_period.started_on).to eq @new_mentor_start_date
+    expect(@new_mentorship.started_on).to eq @new_mentor_start_date
+  end
+end

--- a/spec/wizards/schools/register_mentor_wizard/change_started_on_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/change_started_on_step_spec.rb
@@ -1,19 +1,50 @@
 require_relative "./shared_examples/started_on_step"
 
 RSpec.describe Schools::RegisterMentorWizard::ChangeStartedOnStep do
-  subject(:step) { described_class.new(wizard:, started_on:) }
+  subject(:step) { described_class.new(wizard:, started_on: started_on_params) }
 
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :started_on, store:) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     mentoring_at_new_school_only: "no")
+    FactoryBot.build(:session_repository, mentoring_at_new_school_only: "no")
   end
 
-  let(:started_on) { { "day" => "10", "month" => "9", "year" => "2025" } }
+  let(:started_on) { Date.new(2025, 9, 10) }
+  let(:started_on_params) do
+    {
+      "day" => started_on.day.to_s,
+      "month" => started_on.month.to_s,
+      "year" => started_on.year.to_s
+    }
+  end
+
+  let!(:contract_period) do
+    FactoryBot.create(:contract_period, :current, enabled: contract_period_enabled)
+  end
+  let(:contract_period_enabled) { true }
 
   it_behaves_like "a started on step", current_step: :started_on
 
+  describe "#next_step" do
+    subject(:next_step) { step.next_step }
+
+    context "when registrations are closed for the contract period" do
+      let(:started_on) { 1.day.from_now }
+      let(:contract_period_enabled) { false }
+
+      it { is_expected.to eq(:cannot_register_mentor_yet) }
+    end
+
+    context "when registrations are open for the contract period" do
+      let(:started_on) { 1.day.from_now }
+      let(:contract_period_enabled) { true }
+
+      it { is_expected.to eq(:check_answers) }
+    end
+  end
+
   describe "#previous_step" do
-    it { expect(step.previous_step).to eq(:check_answers) }
+    subject(:previous_step) { step.previous_step }
+
+    it { is_expected.to eq(:check_answers) }
   end
 end

--- a/spec/wizards/schools/register_mentor_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store/queries_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Queries do
   let(:school) { FactoryBot.create(:school) }
   let(:store) { {} }
   let(:registration_store) do
-    Struct.new(:trn, :school_urn, :lead_provider_id, :started_on, :start_date, :store)
-          .new(trn, school_urn, lead_provider_id, started_on, start_date, store)
+    Struct.new(:trn, :school_urn, :lead_provider_id, :started_on, :store)
+          .new(trn, school_urn, lead_provider_id, started_on, store)
   end
   let(:school_urn) { school.urn }
   let(:lead_provider_id) { nil }
   let(:started_on) { nil }
-  let(:start_date) { nil }
 
   describe "#active_record_at_school" do
     let!(:ongoing_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school:) }
@@ -125,7 +124,7 @@ RSpec.describe Schools::RegisterMentorWizard::RegistrationStore::Queries do
                         started_on: 2.years.ago,
                         finished_on: 1.month.from_now)
     end
-    let(:start_date) { 1.year.ago }
+    let(:started_on) { 1.year.ago }
 
     it "returns mentor periods from other schools that are ongoing or recently finished" do
       expect(queries.previous_school_mentor_at_school_periods).to contain_exactly(ongoing_other_school, finished_recently)

--- a/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
@@ -429,7 +429,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
     let(:teacher) { FactoryBot.create(:teacher, trn: registration_store.trn) }
     let(:other_school) { FactoryBot.create(:school) }
 
-    before { store.start_date = Date.current }
+    before { store.started_on = Date.current }
 
     context "when there is an ongoing record at another school" do
       before do
@@ -449,10 +449,12 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
   end
 
   describe "#previous_school_closed_mentor_at_school_periods?" do
+    subject { registration_store.previous_school_closed_mentor_at_school_periods? }
+
     let(:teacher) { FactoryBot.create(:teacher, trn: registration_store.trn) }
     let(:other_school) { FactoryBot.create(:school) }
 
-    before { store.start_date = Date.current - 1.year }
+    before { store.started_on = Date.current - 1.year }
 
     context "when a previous school period finished recently" do
       before do
@@ -465,9 +467,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
         )
       end
 
-      it "returns true" do
-        expect(registration_store.previous_school_closed_mentor_at_school_periods?).to be(true)
-      end
+      it { is_expected.to be_truthy }
     end
 
     context "when all previous periods are ongoing" do
@@ -475,9 +475,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
         FactoryBot.create(:mentor_at_school_period, :ongoing, school: other_school, teacher:)
       end
 
-      it "returns false" do
-        expect(registration_store.previous_school_closed_mentor_at_school_periods?).to be(false)
-      end
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
@@ -1,145 +1,103 @@
 RSpec.shared_examples "a started on step" do |current_step:|
-  subject(:step) { described_class.new(wizard:, started_on:) }
+  subject(:step) { described_class.new(wizard:, started_on: started_on_params) }
 
-  let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step:, store:) }
-  let(:store) do
-    FactoryBot.build(:session_repository,
-                     previous_school_mentor_at_school_periods: [])
+  let(:wizard) do
+    FactoryBot.build(:register_mentor_wizard, current_step:, store:)
+  end
+  let(:store) { FactoryBot.build(:session_repository) }
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, year: 2025, enabled: true)
   end
 
-  let(:started_on) { { "day" => "1", "month" => "6", "year" => "2025" } }
-  let(:contract_period) { FactoryBot.create(:contract_period, year: 2025, enabled: true) }
-  let(:currently_mentor_at_another_school) { false }
-  let(:today) { Date.new(2025, 6, 3) }
+  let(:started_on) { Date.new(2025, 6, 1) }
+  let(:started_on_params) do
+    {
+      "day" => started_on.day.to_s,
+      "month" => started_on.month.to_s,
+      "year" => started_on.year.to_s
+    }
+  end
+
+  let(:previous_school_mentor_at_school_periods) { [] }
+
+  describe ".permitted_params" do
+    subject(:permitted_params) { wizard.permitted_params }
+
+    it { is_expected.to contain_exactly(:started_on) }
+  end
 
   describe "validations" do
-    around do |example|
-      travel_to(today) { example.run }
+    before do
+      allow(wizard.mentor).to receive_messages(
+        currently_mentor_at_another_school?: currently_mentor_at_another_school,
+        previous_school_mentor_at_school_periods:
+      )
     end
 
-    context "when the start_date is invalid" do
-      let(:started_on) { { "day" => "30", "month" => "2", "year" => "2025" } }
+    context "when the mentor is not currently mentoring at another school" do
       let(:currently_mentor_at_another_school) { false }
+      let(:previous_school_mentor_at_school_periods) { [] }
 
-      before do
-        allow(wizard.mentor).to receive(:currently_mentor_at_another_school?).and_return(currently_mentor_at_another_school)
+      context "and the start_date is invalid" do
+        let(:started_on_params) { { "day" => "30", "month" => "2", "year" => "2025" } }
+
+        it { is_expected.to have_error(:started_on, "Enter the date in the correct format, for example 12 03 1998") }
       end
 
-      it "is invalid with the correct error message" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:started_on]).to include("Enter the date in the correct format, for example 12 03 1998")
-      end
-    end
-
-    context "when start date is in the future" do
-      let(:started_on) { { "day" => "1", "month" => "11", "year" => "2025" } }
-
-      before do
-        allow(wizard.mentor).to receive(:currently_mentor_at_another_school?).and_return(currently_mentor_at_another_school)
-      end
-
-      context "and the mentor is not currently mentoring at another school" do
-        let(:currently_mentor_at_another_school) { false }
+      context "and the start date is more than 4 months in the future" do
+        let(:started_on) { 4.months.from_now.advance(days: 1) }
 
         it { is_expected.to be_valid }
       end
 
-      context "and the mentor is currently mentoring at another school" do
-        let(:currently_mentor_at_another_school) { true }
-        let(:latest_valid_started_on) { 4.months.from_now.to_date }
-
-        it "is valid up to 4 months from today" do
-          subject.started_on = latest_valid_started_on
-          expect(subject).to be_valid
-        end
-
-        it "is invalid over 4 months from today" do
-          subject.started_on = latest_valid_started_on + 1.day
-          expect(subject).not_to be_valid
-          expect(subject.errors[:started_on]).to include("Start date must be before 4 October 2025")
-        end
-      end
-    end
-
-    context "when start date is today" do
-      let(:started_on) { { "day" => "3", "month" => "6", "year" => "2025" } }
-
-      context "and the mentor is not currently mentoring at another school" do
-        let(:currently_mentor_at_another_school) { false }
+      context "and the start date is 4 months in the future" do
+        let(:started_on) { 4.months.from_now }
 
         it { is_expected.to be_valid }
       end
 
-      context "and the mentor is currently mentoring at another school" do
-        let(:currently_mentor_at_another_school) { true }
-        let(:started_on) { Date.new(2024, 12, 1) }
+      context "and the start date is less than 4 months in the future" do
+        let(:started_on) { 4.months.from_now.advance(days: -1) }
 
         it { is_expected.to be_valid }
       end
     end
 
-    context "when start date is in the past" do
-      let(:started_on) { { "day" => "1", "month" => "6", "year" => "2025" } }
+    context "when the mentor is currently mentoring at another school" do
+      let(:currently_mentor_at_another_school) { true }
+      let(:previous_school_mentor_at_school_periods) do
+        [FactoryBot.build_stubbed(:mentor_at_school_period, started_on: 2.months.ago)]
+      end
 
-      context "and the mentor is not currently mentoring at another school" do
-        let(:currently_mentor_at_another_school) { false }
+      context "and the start_date is invalid" do
+        let(:started_on_params) { { "day" => "30", "month" => "2", "year" => "2025" } }
+
+        it { is_expected.to have_error(:started_on, "Enter the date in the correct format, for example 12 03 1998") }
+      end
+
+      context "and the start date is more than 4 months in the future" do
+        let(:started_on) { 4.months.from_now.advance(days: 1) }
+
+        it { is_expected.to have_error(:started_on, "Start date must be before #{4.months.from_now.to_date.next_day.to_formatted_s(:govuk)}") }
+      end
+
+      context "and the start date is 4 months in the future" do
+        let(:started_on) { 4.months.from_now }
 
         it { is_expected.to be_valid }
       end
 
-      context "and the mentor is currently mentoring at another school" do
-        let(:currently_mentor_at_another_school) { true }
-        let(:started_on) { Date.new(2024, 12, 1) }
+      context "and the start date is less than 4 months in the future" do
+        let(:started_on) { 1.month.from_now }
 
         it { is_expected.to be_valid }
       end
-    end
-  end
 
-  describe "#next_step" do
-    around do |example|
-      travel_to(Date.new(2025, 6, 3)) { example.run }
-    end
+      context "and the start date is before the previous school mentor at school period" do
+        let(:started_on) { 3.months.ago }
 
-    context "when start date is in the future" do
-      let(:started_on) { { "day" => "1", "month" => "7", "year" => "2025" } }
-
-      context "when contract period is enabled" do
-        let!(:contract_period) { FactoryBot.create(:contract_period, year: 2025, enabled: true) }
-
-        it { expect(step.next_step).to eq(:check_answers) }
+        it { is_expected.to have_error(:started_on, "was registered as a mentor at their last school starting on the #{2.months.ago.to_date.to_formatted_s(:govuk)}. Enter a later date.") }
       end
-
-      context "when contract period is disabled" do
-        let!(:contract_period) { FactoryBot.create(:contract_period, year: 2025, enabled: false) }
-
-        it { expect(step.next_step).to eq(:cannot_register_mentor_yet) }
-      end
-
-      context "when there is no matching contract period" do
-        it { expect(step.next_step).to eq(:cannot_register_mentor_yet) }
-      end
-
-      context "when the start date is the last day of the current contract period" do
-        let!(:contract_period) { FactoryBot.create(:contract_period, year: 2025, enabled: true) }
-        let(:started_on) { contract_period.finished_on }
-        let(:today) { contract_period.finished_on - 1.day }
-
-        it { expect(step.next_step).to eq(:check_answers) }
-      end
-    end
-
-    context "when start date is today" do
-      let(:started_on) { { "day" => "3", "month" => "6", "year" => "2025" } }
-
-      it { expect(step.next_step).to eq(:check_answers) }
-    end
-
-    context "when start date is in the past" do
-      let(:started_on) { { "day" => "1", "month" => "6", "year" => "2025" } }
-      let(:contract_period) { nil }
-
-      it { expect(step.next_step).to eq(:check_answers) }
     end
   end
 end

--- a/spec/wizards/schools/register_mentor_wizard/started_on_step_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/started_on_step_spec.rb
@@ -1,65 +1,147 @@
 require_relative "./shared_examples/started_on_step"
 
 RSpec.describe Schools::RegisterMentorWizard::StartedOnStep do
-  subject(:step) { described_class.new(wizard:, started_on:) }
+  subject(:step) { described_class.new(wizard:, started_on: started_on_params) }
 
   let(:wizard) { FactoryBot.build(:register_mentor_wizard, current_step: :started_on, store:) }
   let(:store) do
-    FactoryBot.build(:session_repository,
-                     mentoring_at_new_school_only: mentoring_only)
+    FactoryBot.build(:session_repository, mentoring_at_new_school_only: mentoring_only)
   end
 
   let(:mentoring_only) { "no" }
-  let(:started_on) { { "day" => "10", "month" => "9", "year" => "2025" } }
-  let(:contract_period) { FactoryBot.create(:contract_period, year: 2025, enabled: true) }
+  let(:started_on) { Date.new(2025, 9, 10) }
+  let(:started_on_params) do
+    {
+      "day" => started_on.day.to_s,
+      "month" => started_on.month.to_s,
+      "year" => started_on.year.to_s
+    }
+  end
+
+  let!(:contract_period) do
+    FactoryBot.create(:contract_period, :current, enabled: contract_period_enabled)
+  end
+  let(:contract_period_enabled) { true }
 
   it_behaves_like "a started on step", current_step: :started_on
 
   describe "#next_step" do
-    let(:contract_period_enabled?) { contract_period.enabled }
+    subject(:next_step) { step.next_step }
+
     let(:ineligible) { false }
     let(:provider_led) { true }
     let(:previous_training_period) { FactoryBot.build(:training_period) }
 
     before do
-      allow(wizard.mentor).to receive_messages(provider_led_ect?: provider_led,
-                                               became_ineligible_for_funding?: ineligible,
-                                               previous_training_period:,
-                                               contract_period_enabled?: contract_period_enabled?)
+      allow(wizard.mentor).to receive_messages(
+        provider_led_ect?: provider_led,
+        became_ineligible_for_funding?: ineligible,
+        previous_training_period:
+      )
+    end
+
+    context "when contract period is missing" do
+      let!(:contract_period) { nil }
+
+      context "when started_on is today" do
+        let(:started_on) { Date.current }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
+
+      context "when started_on is in the past" do
+        let(:started_on) { 1.day.ago }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
+
+      context "when started_on is in the future" do
+        let(:started_on) { 1.day.from_now }
+
+        it { is_expected.to eq(:cannot_register_mentor_yet) }
+      end
+    end
+
+    context "when contract period is disabled" do
+      let(:contract_period_enabled) { false }
+
+      context "when started_on is today" do
+        let(:started_on) { Date.current }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
+
+      context "when started_on is in the past" do
+        let(:started_on) { 1.day.ago }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
+
+      context "when started_on is in the future" do
+        let(:started_on) { 1.day.from_now }
+
+        it { is_expected.to eq(:cannot_register_mentor_yet) }
+      end
+    end
+
+    context "when contract period is enabled" do
+      let(:contract_period_enabled) { true }
+
+      context "when started_on is today" do
+        let(:started_on) { Date.current }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
+
+      context "when started_on is in the past" do
+        let(:started_on) { 1.day.ago }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
+
+      context "when started_on is in the future" do
+        let(:started_on) { 1.day.from_now }
+
+        it { is_expected.not_to eq(:cannot_register_mentor_yet) }
+      end
     end
 
     context "when mentor is ineligible for funding" do
       let(:ineligible) { true }
 
-      it { expect(step.next_step).to eq(:check_answers) }
+      it { is_expected.to eq(:check_answers) }
     end
 
     context "when ECT is school-led" do
       let(:provider_led) { false }
 
-      it { expect(step.next_step).to eq(:check_answers) }
-    end
-
-    context "when mentor is eligible, the contract period is open and ECT is provider-led" do
-      it { expect(step.next_step).to eq(:previous_training_period_details) }
+      it { is_expected.to eq(:check_answers) }
     end
 
     context "when there is no previous training period" do
       let(:previous_training_period) { nil }
 
-      it { expect(step.next_step).to eq(:programme_choices) }
+      it { is_expected.to eq(:programme_choices) }
+    end
+
+    context "when mentor is eligible, contract period is enabled, ECT is provider-led, and there is a previous training period" do
+      it { is_expected.to eq(:previous_training_period_details) }
     end
   end
 
   describe "#previous_step" do
+    subject(:previous_step) { step.previous_step }
+
     context "when mentoring_at_new_school_only is 'yes'" do
       let(:mentoring_only) { "yes" }
 
-      it { expect(step.previous_step).to eq(:mentoring_at_new_school_only) }
+      it { is_expected.to eq(:mentoring_at_new_school_only) }
     end
 
     context "when mentoring_at_new_school_only is 'no'" do
-      it { expect(step.previous_step).to eq(:email_address) }
+      let(:mentoring_only) { "no" }
+
+      it { is_expected.to eq(:email_address) }
     end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3599

### Changes proposed in this pull request

Before, users would run into a validation error if they tried to enter a start
date that was after the start date for a previous mentor at school period but
before the reported leaving date.

This wasn't intended, though.

Instead, we want the new school to be able to enter any start date after the
most recent previous school period start date. Any school, training, or
mentorship period end dates should be updated to use the new school's start date
to avoid overlaps.

This amends the `RegisterMentorWizard::StartedOnStep` to account for this.

Making this change (and adding the feature test) uncovered some other small bugs
too. These have been addressed as part of this change.

### Guidance to review

- [x] Register a mentor mentoring only at the new school, starting before the reported leaving date at the other school
- [x] Register a mentor mentoring only at the new school, starting after the reported leaving date at the other school
- [x] Register a mentor mentoring only at the new school, starting on the reported leaving date at the other school
- [x] Register a mentor mentoring not only at the new school
