### PR TITLE
Update dfe-analytics config for teachers

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -42,6 +42,20 @@ shared:
     - trs_not_found
     - trs_induction_start_date
     - trs_induction_completed_date
+    - trs_first_name
+    - trs_last_name
+    - corrected_name
+    - api_id
+    - api_ect_training_record_id
+    - api_mentor_training_record_id
+    - mentor_became_ineligible_for_funding_on
+    - mentor_became_ineligible_for_funding_reason
+    - ect_payments_frozen_year
+    - mentor_payments_frozen_year
+    - ect_first_became_eligible_for_training_at
+    - mentor_first_became_eligible_for_training_at
+    - api_updated_at
+    - api_unfunded_mentor_updated_at
   :users:
     - id
     - name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -187,23 +187,7 @@
   - created_at
   - updated_at
   :teachers:
-  - api_id
-  - api_ect_training_record_id
-  - api_mentor_training_record_id
-  - corrected_name
-  - trs_first_name
-  - trs_last_name
-  - mentor_became_ineligible_for_funding_on
-  - mentor_became_ineligible_for_funding_reason
-  - ect_payments_frozen_year
-  - mentor_payments_frozen_year
   - migration_mode
-  - pupil_premium_uplift
-  - sparsity_uplift
-  - ect_first_became_eligible_for_training_at
-  - mentor_first_became_eligible_for_training_at
-  - api_updated_at
-  - api_unfunded_mentor_updated_at
   :metadata_teachers_lead_providers:
   - id
   - teacher_id


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3675

### Changes proposed in this pull request

Before, most of the fields on the `teachers` table were blocked from analytics.

The Data & Insights team need this data, though!

This moves fields out of the blocklist so they can be sent across.

`trs_first_name`, `trs_last_name` and `corrected_name` are already in the hidden PII list, so no action is needed there.

### Guidance to review

https://github.com/DFE-Digital/register-early-career-teachers-public/blob/c27185b5785c62dbb1897f7d366a872784f0fa51/config/analytics_hidden_pii.yml#L5-L7