### PR TITLE
Fix performance gain calculations

### DIFF
--- a/app/helpers/parity_check_helper.rb
+++ b/app/helpers/parity_check_helper.rb
@@ -62,7 +62,7 @@ module ParityCheckHelper
 
     formatted_ratio = ratio.abs.to_s.chomp(".0")
 
-    return "⚖️ equal" if ratio == 1
+    return "⚖️ equal" if ratio.abs == 1
     return "🚀 #{formatted_ratio}x faster" if ratio.positive?
 
     "🐌 #{formatted_ratio}x slower"

--- a/spec/helpers/parity_check_helper_spec.rb
+++ b/spec/helpers/parity_check_helper_spec.rb
@@ -144,6 +144,12 @@ RSpec.describe ParityCheckHelper, type: :helper do
       it { is_expected.to eq("⚖️ equal") }
     end
 
+    context "when the ratio is -1" do
+      let(:ratio) { -1 }
+
+      it { is_expected.to eq("⚖️ equal") }
+    end
+
     context "when the ratio is greater than 0" do
       let(:ratio) { 2.5 }
 

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -219,6 +219,20 @@ describe ParityCheck::Response do
 
       it { is_expected.to eq(-2.9) }
     end
+
+    context "when the response times are very close together (RECT faster)" do
+      let(:rect_time_ms) { 253 }
+      let(:ecf_time_ms) { 260 }
+
+      it { is_expected.to eq(1.0) }
+    end
+
+    context "when the response times are very close together (RECT slower)" do
+      let(:rect_time_ms) { 260 }
+      let(:ecf_time_ms) { 253 }
+
+      it { is_expected.to eq(-1.0) }
+    end
   end
 
   describe "#description" do


### PR DESCRIPTION
When the response times are very close to each other they get rounded to either `1` or  `-1`. In the view helper we treat `1` as equal, but not `-1`, so we end up with `1x slower` in the UI, which really means 'the same'. Remap `-1.0` to `equal` so this is clearer.
