### PR TITLE
Optimise statements endpoint

### DIFF
--- a/app/services/api/statements/query.rb
+++ b/app/services/api/statements/query.rb
@@ -7,7 +7,7 @@ module API::Statements
     attr_reader :scope
 
     def initialize(lead_provider_id: :ignore, contract_period_years: :ignore, updated_since: :ignore, fee_type: "output", sort: { payment_date: :asc })
-      @scope = Statement.distinct
+      @scope = Statement
 
       where_lead_provider_is(lead_provider_id)
       where_contract_period_year_in(contract_period_years)

--- a/db/migrate/20260327141539_add_index_to_statements_payment_date.rb
+++ b/db/migrate/20260327141539_add_index_to_statements_payment_date.rb
@@ -1,0 +1,5 @@
+class AddIndexToStatementsPaymentDate < ActiveRecord::Migration[8.0]
+  def change
+    add_index :statements, :payment_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_07_121950) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_27_141539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -948,6 +948,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_07_121950) do
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.bigint "contract_id", null: false
     t.index ["contract_id"], name: "index_statements_on_contract_id"
+    t.index ["payment_date"], name: "index_statements_on_payment_date"
   end
 
   create_table "support_queries", force: :cascade do |t|


### PR DESCRIPTION
Remove unnecessary `distinct` call on `Statement` and add an index to `payment_date` as we order by this field by default.

I've tested on the parity check environment and the statements checks still return 100% match rates.