### PR TITLE
Store TRS qualification route summaries on teachers

### DIFF
--- a/app/services/concerns/teachers/manageable.rb
+++ b/app/services/concerns/teachers/manageable.rb
@@ -39,6 +39,7 @@ module Teachers
         trs_qts_awarded_on: trs_data.trs_qts_awarded_on,
         trs_initial_teacher_training_provider_name: trs_data.trs_initial_teacher_training_provider_name,
         trs_initial_teacher_training_end_date: trs_data.trs_initial_teacher_training_end_date,
+        trs_routes_to_professional_status_summaries: trs_data.trs_routes_to_professional_status_summaries,
         trs_data_last_refreshed_at: Time.zone.now
       )
     end

--- a/app/services/teachers/manage.rb
+++ b/app/services/teachers/manage.rb
@@ -69,13 +69,14 @@ class Teachers::Manage
     end
   end
 
-  def update_trs_attributes!(trs_qts_status_description:, trs_qts_awarded_on:, trs_initial_teacher_training_provider_name:, trs_initial_teacher_training_end_date:, trs_data_last_refreshed_at:)
+  def update_trs_attributes!(trs_qts_status_description:, trs_qts_awarded_on:, trs_initial_teacher_training_provider_name:, trs_initial_teacher_training_end_date:, trs_routes_to_professional_status_summaries:, trs_data_last_refreshed_at:)
     Teacher.transaction do
       teacher.assign_attributes(
         trs_qts_status_description:,
         trs_qts_awarded_on:,
         trs_initial_teacher_training_provider_name:,
-        trs_initial_teacher_training_end_date:
+        trs_initial_teacher_training_end_date:,
+        trs_routes_to_professional_status_summaries:
       )
 
       record_teacher_trs_attribute_update(modifications: teacher.changes)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -56,6 +56,7 @@ shared:
     - mentor_first_became_eligible_for_training_at
     - api_updated_at
     - api_unfunded_mentor_updated_at
+    - trs_routes_to_professional_status_summaries
   :users:
     - id
     - name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -233,6 +233,7 @@
   - pending_induction_submission_batch_id
   - error_messages
   - fail_confirmation_sent_on
+  - trs_routes_to_professional_status_summaries
   :pending_induction_submission_batches:
   - data
   - error_message

--- a/db/migrate/20260327150814_add_trs_routes_to_professional_status_to_teachers.rb
+++ b/db/migrate/20260327150814_add_trs_routes_to_professional_status_to_teachers.rb
@@ -1,0 +1,5 @@
+class AddTRSRoutesToProfessionalStatusToTeachers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :teachers, :trs_routes_to_professional_status_summaries, :string, array: true, default: []
+  end
+end

--- a/db/migrate/20260401092632_add_trs_routes_to_professional_status_summaries_to_pending_induction_submissions.rb
+++ b/db/migrate/20260401092632_add_trs_routes_to_professional_status_summaries_to_pending_induction_submissions.rb
@@ -1,0 +1,5 @@
+class AddTRSRoutesToProfessionalStatusSummariesToPendingInductionSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :pending_induction_submissions, :trs_routes_to_professional_status_summaries, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_27_141539) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_01_092632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -735,6 +735,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_141539) do
     t.date "trs_induction_completed_date"
     t.date "trs_date_of_birth"
     t.date "fail_confirmation_sent_on"
+    t.string "trs_routes_to_professional_status_summaries", default: [], array: true
     t.index ["appropriate_body_period_id"], name: "idx_on_appropriate_body_period_id_b868757d9f"
     t.index ["pending_induction_submission_batch_id"], name: "idx_on_pending_induction_submission_batch_id_bb4509358d"
     t.index ["trn"], name: "index_pending_induction_submissions_on_trn"
@@ -1020,6 +1021,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_141539) do
     t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.enum "migration_mode", default: "not_migrated", enum_type: "participant_migration_mode"
     t.boolean "trs_not_found", default: false
+    t.string "trs_routes_to_professional_status_summaries", default: [], array: true
     t.index ["api_ect_training_record_id"], name: "index_teachers_on_api_ect_training_record_id", unique: true
     t.index ["api_id"], name: "index_teachers_on_api_id", unique: true
     t.index ["api_mentor_training_record_id"], name: "index_teachers_on_api_mentor_training_record_id", unique: true

--- a/lib/trs/teacher.rb
+++ b/lib/trs/teacher.rb
@@ -47,7 +47,7 @@ module TRS
       @trs_national_insurance_number = data["nationalInsuranceNumber"]
       @trs_alerts = data.fetch("alerts", []).map { |a| a.dig(*%w[alertType alertCategory alertCategoryId]) }
       @trs_qtls_status = data["qtlsStatus"]
-      @trs_routes_to_professional_status = data["routesToProfessionalStatuses"]
+      @trs_routes_to_professional_status = data.fetch("routesToProfessionalStatuses", [])
       @trs_induction_start_date = data.dig("induction", "startDate")
       @trs_induction_completed_date = data.dig("induction", "completedDate")
       @trs_induction_status = data.dig("induction", "status")
@@ -93,6 +93,10 @@ module TRS
       true
     end
 
+    def trs_routes_to_professional_status_summaries
+      QualificationRoute.to_summary(trs_routes_to_professional_status)
+    end
+
     # @return [Hash] splatted into PendingInductionSubmissions and wizard SessionRepositories
     def to_h
       {
@@ -107,6 +111,7 @@ module TRS
         trs_qts_status_description:,
         trs_initial_teacher_training_provider_name:,
         trs_initial_teacher_training_end_date:,
+        trs_routes_to_professional_status_summaries:,
         trs_alerts:,
         trs_prohibited_from_teaching:,
       }

--- a/lib/trs/teacher/qualification_route.rb
+++ b/lib/trs/teacher/qualification_route.rb
@@ -1,0 +1,65 @@
+class TRS::Teacher::QualificationRoute
+  attr_reader :trs_route_to_professional_status
+
+  QUALIFICATIONS = {
+    "QualifiedTeacherStatus" => "QTS",
+    "EarlyYearsTeacherStatus" => "EYTS",
+    "EarlyYearsProfessionalStatus" => "EYPS",
+    "PartialQualifiedTeacherStatus" => "PQTS"
+  }.freeze
+
+  class << self
+    def to_summary(trs_routes_to_professional_status)
+      trs_routes_to_professional_status.map do |trs_route_to_professional_status|
+        new(trs_route_to_professional_status).to_summary
+      end
+    end
+  end
+
+  def initialize(trs_route_to_professional_status)
+    @trs_route_to_professional_status = trs_route_to_professional_status
+  end
+
+  def to_summary
+    parts.join " "
+  end
+
+private
+
+  def parts
+    result = [status, formatted_qualification]
+    result += ["from", holds_from_as_date] if holds_from.present?
+    result + ["via", route_name]
+  end
+
+  def holds_from
+    trs_route_to_professional_status["holdsFrom"]
+  end
+
+  def holds_from_as_date
+    Date.parse(holds_from).strftime("%d %b %Y")
+  rescue Date::Error
+    holds_from
+  end
+
+  def route_to_professional_status_type
+    trs_route_to_professional_status.fetch("routeToProfessionalStatusType", {})
+  end
+
+  def status
+    trs_route_to_professional_status["status"]
+  end
+
+  def formatted_qualification
+    # Fall back to raw_qualification if qualification is unknown
+    QUALIFICATIONS.fetch raw_qualification, raw_qualification.to_s.titleize
+  end
+
+  def raw_qualification
+    route_to_professional_status_type["professionalStatusType"]
+  end
+
+  def route_name
+    route_to_professional_status_type["name"]
+  end
+end

--- a/lib/trs/teacher/qualification_route.rb
+++ b/lib/trs/teacher/qualification_route.rb
@@ -8,6 +8,83 @@ class TRS::Teacher::QualificationRoute
     "PartialQualifiedTeacherStatus" => "PQTS"
   }.freeze
 
+  # These are the route names returned from TRS (as at April 2026).
+  # Uncomment and modify the values, to have a more human friendly route name.
+  # E.g. "HEI - Historic" => "Higher Education Institution (Historic)",
+  PRETTY_ACTIVE_ROUTE_NAMES = {
+    # "Apply for Qualified Teacher Status in England" => "Apply for Qualified Teacher Status in England",
+    # "Assessment Only" => "Assessment Only",
+    # "Early Years ITT Assessment Only" => "Early Years ITT Assessment Only",
+    # "Early Years ITT Graduate Employment Based" => "Early Years ITT Graduate Employment Based",
+    # "Early Years ITT Graduate Entry" => "Early Years ITT Graduate Entry",
+    # "Early Years ITT School Direct" => "Early Years ITT School Direct",
+    # "Early Years ITT Undergraduate" => "Early Years ITT Undergraduate",
+    # "Early Years Teacher Degree Apprenticeship" => "Early Years Teacher Degree Apprenticeship",
+    # "Flexible ITT" => "Flexible ITT",
+    # "Future Teaching Scholars" => "Future Teaching Scholars",
+    # "HEI" => "HEI",
+    "High Potential ITT" => "High Potential Initial Teacher Training"
+    # "International Qualified Teacher Status" => "International Qualified Teacher Status",
+    # "Northern Irish Recognition" => "Northern Irish Recognition",
+    # "Postgraduate Teaching Apprenticeship" => "Postgraduate Teaching Apprenticeship",
+    # "Primary and secondary postgraduate fee funded" => "Primary and secondary postgraduate fee funded",
+    # "Primary and secondary undergraduate fee funded" => "Primary and secondary undergraduate fee funded",
+    # "Provider led Postgrad" => "Provider led Postgrad",
+    # "Provider led Undergrad" => "Provider led Undergrad",
+    # "QTLS and SET Membership" => "QTLS and SET Membership",
+    # "School Direct Training Programme" => "School Direct Training Programme",
+    # "School Direct Training Programme Salaried" => "School Direct Training Programme Salaried",
+    # "School Direct Training Programme Self Funded" => "School Direct Training Programme Self Funded",
+    # "Scottish Recognition" => "Scottish Recognition",
+    # "Teacher Degree Apprenticeship" => "Teacher Degree Apprenticeship",
+    # "Undergraduate Opt In" => "Undergraduate Opt In",
+    # "Welsh Recognition" => "Welsh Recognition"
+  }.freeze
+
+  PRETTY_INACTIVE_ROUTE_NAMES = {
+    # "Authorised Teacher Programme" => "Authorised Teacher Programme",
+    # "Core" => "Core",
+    # "Core Flexible" => "Core Flexible",
+    # "CTC or CCTA" => "CTC or CCTA",
+    # "EC directive" => "EC directive",
+    # "European Recognition" => "European Recognition",
+    # "European Recognition - PQTS" => "European Recognition - PQTS",
+    # "EYPS" => "EYPS",
+    # "EYPS ITT Migrated" => "EYPS ITT Migrated",
+    # "EYTS ITT Migrated" => "EYTS ITT Migrated",
+    # "FE Recognition 2000-2004" => "FE Recognition 2000-2004",
+    # "Graduate non-trained" => "Graduate non-trained",
+    # "Graduate Teacher Programme" => "Graduate Teacher Programme",
+    "HEI - Historic" => "Higher Education Institution (Historic)",
+    # "Legacy ITT" => "Legacy ITT",
+    # "Legacy Migration" => "Legacy Migration",
+    # "Licensed Teacher Programme" => "Licensed Teacher Programme",
+    # "Licensed Teacher Programme - Armed Forces" => "Licensed Teacher Programme - Armed Forces",
+    # "Licensed Teacher Programme - FE" => "Licensed Teacher Programme - FE",
+    # "Licensed Teacher Programme - Independent School" => "Licensed Teacher Programme - Independent School",
+    # "Licensed Teacher Programme - Maintained School" => "Licensed Teacher Programme - Maintained School",
+    # "Licensed Teacher Programme - OTT" => "Licensed Teacher Programme - OTT",
+    # "Long Service" => "Long Service",
+    # "Other Qualifications non ITT" => "Other Qualifications non ITT",
+    # "Overseas Trained Teacher Programme" => "Overseas Trained Teacher Programme",
+    # "Overseas Trained Teacher Recognition" => "Overseas Trained Teacher Recognition",
+    # "PGATC ITT" => "PGATC ITT",
+    # "PGATD ITT" => "PGATD ITT",
+    "PGCE ITT" => "Postgrad Certificate in Education"
+    # "PGDE ITT" => "PGDE ITT",
+    # "ProfGCE ITT" => "ProfGCE ITT",
+    # "ProfGDE ITT" => "ProfGDE ITT",
+    # "Registered Teacher Programme" => "Registered Teacher Programme",
+    # "School Centered ITT" => "School Centered ITT",
+    # "TC ITT" => "TC ITT",
+    # "TCMH" => "TCMH",
+    # "Teach First Programme" => "Teach First Programme",
+    # "Troops to Teach" => "Troops to Teach",
+    # "UGMT ITT" => "UGMT ITT"
+  }.freeze
+
+  PRETTY_ROUTE_NAMES = PRETTY_ACTIVE_ROUTE_NAMES.merge(PRETTY_INACTIVE_ROUTE_NAMES).freeze
+
   class << self
     def to_summary(trs_routes_to_professional_status)
       trs_routes_to_professional_status.map do |trs_route_to_professional_status|
@@ -60,6 +137,7 @@ private
   end
 
   def route_name
-    route_to_professional_status_type["name"]
+    raw_route_name = route_to_professional_status_type["name"]
+    PRETTY_ROUTE_NAMES.fetch(raw_route_name, raw_route_name)
   end
 end

--- a/spec/lib/trs/teacher/qualification_route_spec.rb
+++ b/spec/lib/trs/teacher/qualification_route_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe TRS::Teacher::QualificationRoute do
 
     it {
       expect(subject).to contain_exactly(
-        "Holds QTS from 11 Nov 2023 via PGCE ITT",
+        "Holds QTS from 11 Nov 2023 via Postgrad Certificate in Education",
         "Holds EYTS from 03 Sep 2021 via Assessment Only"
       )
     }
@@ -80,13 +80,13 @@ RSpec.describe TRS::Teacher::QualificationRoute do
     context "when holding QTS via PCGE ITT" do
       let(:qualification_route) { qts_via_pcge }
 
-      it { is_expected.to eq "Holds QTS from 11 Nov 2023 via PGCE ITT" }
+      it { is_expected.to eq "Holds QTS from 11 Nov 2023 via Postgrad Certificate in Education" }
     end
 
     context "when holding QTS via HEI Historic" do
       let(:qualification_route) { qts_via_hei_historic }
 
-      it { is_expected.to eq "Holds QTS from 03 Nov 2021 via HEI - Historic" }
+      it { is_expected.to eq "Holds QTS from 03 Nov 2021 via Higher Education Institution (Historic)" }
     end
 
     context "when holding EYTS via Assessment Only" do
@@ -98,7 +98,7 @@ RSpec.describe TRS::Teacher::QualificationRoute do
     context "when status is Failed and holdsFrom is absent" do
       let(:qualification_route) { failed_qts_via_high_potential_itt }
 
-      it { is_expected.to eq "Failed QTS via High Potential ITT" }
+      it { is_expected.to eq "Failed QTS via High Potential Initial Teacher Training" }
     end
   end
 end

--- a/spec/lib/trs/teacher/qualification_route_spec.rb
+++ b/spec/lib/trs/teacher/qualification_route_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe TRS::Teacher::QualificationRoute do
+  let(:qts_via_pcge) do
+    {
+      "routeToProfessionalStatusId" => "08ca66bf-7602-452f-8985-712cd93916bc",
+      "routeToProfessionalStatusType" => {
+        "routeToProfessionalStatusTypeId" => "02a2135c-ac34-4481-a293-8a00aab7ee69",
+        "name" => "PGCE ITT",
+        "professionalStatusType" => "QualifiedTeacherStatus"
+      },
+      "status" => "Holds",
+      "holdsFrom" => "2023-11-11",
+      "trainingStartDate" => "2023-10-01",
+      "degreeType" => { "degreeTypeId" => "40a85dd0-8512-438e-8040-649d7d677d07", "name" => "Postgraduate Certificate in Education" },
+      "inductionExemption" => { "isExempt" => false, "exemptionReasons" => [] }
+    }
+  end
+
+  let(:failed_qts_via_high_potential_itt) do
+    {
+      "routeToProfessionalStatusId" => "08ca66bf-7602-452f-8985-712cd93916bc",
+      "routeToProfessionalStatusType" => {
+        "routeToProfessionalStatusTypeId" => "02a2135c-ac34-4481-a293-8a00aab7ee69",
+        "name" => "High Potential ITT",
+        "professionalStatusType" => "QualifiedTeacherStatus"
+      },
+      "status" => "Failed",
+      "inductionExemption" => { "isExempt" => false, "exemptionReasons" => [] }
+    }
+  end
+
+  let(:eyts_via_assessment_only) do
+    {
+      "routeToProfessionalStatusId" => "ae03d1c9-23f5-4d1a-8aa9-83f0053b5cf9",
+      "routeToProfessionalStatusType" => {
+        "routeToProfessionalStatusTypeId" => "32017d68-9da4-43b2-ae91-4f24c68f6f78",
+        "name" => "Assessment Only",
+        "professionalStatusType" => "EarlyYearsTeacherStatus"
+      },
+      "status" => "Holds",
+      "holdsFrom" => "2021-09-03",
+      "trainingStartDate" => "2019-12-09",
+      "inductionExemption" => { "isExempt" => false, "exemptionReasons" => [] }
+    }
+  end
+
+  let(:qts_via_hei_historic) do
+    {
+      "routeToProfessionalStatusId" => "ae03d1c9-23f5-4d1a-8aa9-83f0053b5cf9",
+      "routeToProfessionalStatusType" => {
+        "routeToProfessionalStatusTypeId" => "32017d68-9da4-43b2-ae91-4f24c68f6f78",
+        "name" => "HEI - Historic",
+        "professionalStatusType" => "QualifiedTeacherStatus"
+      },
+      "status" => "Holds",
+      "holdsFrom" => "2021-11-03",
+      "trainingStartDate" => "2019-12-09",
+      "degreeType" => { "degreeTypeId" => "dbb7c27b-8a27-4a94-908d-4b4404acebd5", "name" => "BA (Hons)" },
+      "inductionExemption" => { "isExempt" => false, "exemptionReasons" => [] }
+    }
+  end
+
+  let(:routes) { [qts_via_pcge, eyts_via_assessment_only] }
+
+  describe "class#to_summary" do
+    subject(:summary) { described_class.to_summary(routes) }
+
+    it {
+      expect(subject).to contain_exactly(
+        "Holds QTS from 11 Nov 2023 via PGCE ITT",
+        "Holds EYTS from 03 Sep 2021 via Assessment Only"
+      )
+    }
+  end
+
+  describe "to_summary" do
+    subject(:summary) { summarizer.to_summary }
+
+    let(:summarizer) { described_class.new(qualification_route) }
+
+    context "when holding QTS via PCGE ITT" do
+      let(:qualification_route) { qts_via_pcge }
+
+      it { is_expected.to eq "Holds QTS from 11 Nov 2023 via PGCE ITT" }
+    end
+
+    context "when holding QTS via HEI Historic" do
+      let(:qualification_route) { qts_via_hei_historic }
+
+      it { is_expected.to eq "Holds QTS from 03 Nov 2021 via HEI - Historic" }
+    end
+
+    context "when holding EYTS via Assessment Only" do
+      let(:qualification_route) { eyts_via_assessment_only }
+
+      it { is_expected.to eq "Holds EYTS from 03 Sep 2021 via Assessment Only" }
+    end
+
+    context "when status is Failed and holdsFrom is absent" do
+      let(:qualification_route) { failed_qts_via_high_potential_itt }
+
+      it { is_expected.to eq "Failed QTS via High Potential ITT" }
+    end
+  end
+end

--- a/spec/lib/trs/teacher_spec.rb
+++ b/spec/lib/trs/teacher_spec.rb
@@ -128,6 +128,22 @@ RSpec.describe TRS::Teacher do
     }
   end
 
+  describe "#trs_routes_to_professional_status_summaries" do
+    it "returns formatted summaries from the routes to professional statuses" do
+      expect(service.trs_routes_to_professional_status_summaries).to eq(
+        ["Holds QTS from 19 Sep 2024 via Scottish Recognition"]
+      )
+    end
+
+    context "when routesToProfessionalStatuses is missing from the API response" do
+      let(:data) { {} }
+
+      it "returns an empty array" do
+        expect(service.trs_routes_to_professional_status_summaries).to eq([])
+      end
+    end
+  end
+
   describe "#to_h" do
     it "returns a hash of attributes" do
       expect(service.to_h).to eq({

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -451,6 +451,18 @@ describe Teacher do
     end
   end
 
+  describe "trs_routes_to_professional_status_summaries" do
+    it "defaults to an empty array" do
+      teacher = FactoryBot.create(:teacher)
+      expect(teacher.trs_routes_to_professional_status_summaries).to eq([])
+    end
+
+    it "stores and retrieves summary strings" do
+      teacher = FactoryBot.create(:teacher, trs_routes_to_professional_status_summaries: ["Holds QTS from 19 Sep 2024 via Scottish Recognition"])
+      expect(teacher.trs_routes_to_professional_status_summaries).to eq(["Holds QTS from 19 Sep 2024 via Scottish Recognition"])
+    end
+  end
+
   describe "normalizing" do
     subject { FactoryBot.build(:teacher, corrected_name: " Tobias Menzies ") }
 

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -80,7 +80,8 @@ describe Teachers::RefreshTRSAttributes do
               trs_initial_teacher_training_end_date: "2021-04-05",
               trs_initial_teacher_training_provider_name: "Example Provider Ltd.",
               trs_qts_awarded_on: 3.years.ago.to_date.to_s,
-              trs_qts_status_description: "QualifiedTeacherStatus"
+              trs_qts_status_description: "QualifiedTeacherStatus",
+              trs_routes_to_professional_status_summaries: ["Holds QTS from 01 Jan 2022 via "]
             })
             expect(fake_manage).to have_received(:update_trs_induction_status!).once.with(
               trs_induction_status: "Passed",


### PR DESCRIPTION
### Context

Appropriate Bodies want to see the route an ECT took to get to their qualification to help them evaluate how to treat their induction period.

### Changes proposed in this pull request

Each route to professional status from the TRS API is converted to a human-readable summary string and persisted on the teacher record as part of the regular TRS data refresh. For example:

 `"Holds QTS from 11 Nov 2023 via PGCE ITT"`

### Guidance to review

* This PR adds the data to our database but doesn't surface it in any views. This will be done in a subsequent PR.
* We process the raw data into `trs_routes_to_professional_status_summaries` at import time to reduce any downstream overhead. This is stored as a string array (there can be more than 1 route). If we decide to change the structure of these summaries we can expect this to be rolled across the entire dataset approximately within 3 days (based on current periodic reloading frequencies).
* We add `trs_routes_to_professional_status_summaries` to PendingInductionSubmission. This is due to the fact that we splat `TRS::Teacher#to_h` around - which isn't ideal in my view - but is a bigger architectural question and out of scope of this change. Adding the `trs_routes_to_professional_status_summaries` is the safest way of dealing with this.
* As requested by @peteryates - we optionally "prettify" the raw qualification route name that comes back from TRS, I have added a commented out comprehensive list of qualification routes from TRS, when we want to prettify a route name, we can uncomment the name and replace the raw route name with a pretty alternative.
