### PR TITLE
Fix flakyness around schedule selection

### DIFF
--- a/spec/services/api_seed_data/teachers_with_histories_spec.rb
+++ b/spec/services/api_seed_data/teachers_with_histories_spec.rb
@@ -2,8 +2,10 @@ RSpec.describe APISeedData::TeachersWithHistories do
   let(:instance) { described_class.new }
   let(:environment) { "sandbox" }
   let(:logger) { instance_double(Logger, info: nil, "formatter=" => nil, "level=" => nil) }
-  let!(:school_partnerships) { FactoryBot.create_list(:school_partnership, 5) }
-  let!(:appropriate_bodies) { FactoryBot.create_list(:appropriate_body, 5) }
+  let!(:school_partnerships) { FactoryBot.create_list(:school_partnership, 2) }
+  let!(:appropriate_bodies) { FactoryBot.create_list(:appropriate_body, 2) }
+  let(:expected_teachers_per_iteration) { 2 } # ECT and mentor
+  let(:expected_number_of_teachers) { described_class::NUMBER_OF_RECORDS * school_partnerships.count * expected_teachers_per_iteration }
 
   before do
     allow(Logger).to receive(:new).with($stdout) { logger }
@@ -100,18 +102,25 @@ RSpec.describe APISeedData::TeachersWithHistories do
     end
 
     context "when creating ECTAtSchoolPeriod records" do
-      before { stub_const("#{described_class}::ECT_MENTOR_RATIO", 1.0) }
+      let(:expected_teachers_per_iteration) { 1 } # ECT only
 
-      it { expect { plant }.to change(ECTAtSchoolPeriod, :count).by(10) }
+      before do
+        stub_const("#{described_class}::ECT_MENTOR_RATIO", 1.0)
+        stub_const("#{described_class}::OPTIONAL_ECT_TRAINING_RATIO", 0.0)
+      end
+
+      it { expect { plant }.to change(ECTAtSchoolPeriod, :count).by(expected_number_of_teachers) }
     end
 
     context "when creating MentorAtSchoolPeriod records" do
+      let(:expected_teachers_per_iteration) { 1 } # Mentor only
+
       before do
         stub_const("#{described_class}::ECT_MENTOR_RATIO", 0.0)
         stub_const("#{described_class}::ASSIGN_ECT_TO_MENTOR_RATIO", 1.0)
       end
 
-      it { expect { plant }.to change(MentorAtSchoolPeriod, :count).by(10) }
+      it { expect { plant }.to change(MentorAtSchoolPeriod, :count).by(expected_number_of_teachers) }
     end
 
     context "when assigning ECTs to Mentors" do
@@ -152,7 +161,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
         stub_const("#{described_class}::FINISHED_PERIOD_RATIO", 0.0)
       end
 
-      it { expect { plant }.to change(TrainingPeriod.where(finished_on: nil), :count).by(20) }
+      it { expect { plant }.to change(TrainingPeriod.where(finished_on: nil), :count).by(expected_number_of_teachers) }
     end
 
     context "when creating TrainingPeriod records with a finished_on" do
@@ -162,7 +171,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
         stub_const("#{described_class}::FINISHED_PERIOD_RATIO", 1.0)
       end
 
-      it { expect { plant }.to change(TrainingPeriod.where.not(finished_on: nil), :count).by(20) }
+      it { expect { plant }.to change(TrainingPeriod.where.not(finished_on: nil), :count).by(expected_number_of_teachers) }
     end
 
     context "when creating withdrawn TrainingPeriod records" do
@@ -179,7 +188,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
         travel_to Date.new(latest_contract_period.year, 12, 31)
       end
 
-      it { expect { plant }.to change(TrainingPeriod.where.not(withdrawn_at: nil), :count).by(20) }
+      it { expect { plant }.to change(TrainingPeriod.where.not(withdrawn_at: nil), :count).by(expected_number_of_teachers) }
     end
 
     context "when creating deferred TrainingPeriod records" do
@@ -197,7 +206,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
         travel_to Date.new(latest_contract_period.year, 12, 31)
       end
 
-      it { expect { plant }.to change(TrainingPeriod.where.not(deferred_at: nil), :count).by(20) }
+      it { expect { plant }.to change(TrainingPeriod.where.not(deferred_at: nil), :count).by(expected_number_of_teachers) }
     end
 
     context "when creating active TrainingPeriod records" do
@@ -210,7 +219,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
         stub_const("#{described_class}::DEFERRED_RATIO", 0.0)
       end
 
-      it { expect { plant }.to change(TrainingPeriod.where(deferred_at: nil, withdrawn_at: nil), :count).by(20) }
+      it { expect { plant }.to change(TrainingPeriod.where(deferred_at: nil, withdrawn_at: nil), :count).by(expected_number_of_teachers) }
     end
 
     context "when creating teachers with induction period" do


### PR DESCRIPTION
**Fix flakiness around schedule selection**

We could end up selecting the `ecf-standard-september` for all `Teacher` records created occasionally due to:

- Not ensuring we create a schedule with a different identifier for all contract periods during test setup.
- Creating multiple teachers (by way of ID changes) throwing off the schedule cycling (which cycles on `Teacher.count`).

**Reduce amount of fixture data**

We were unnecessarily creating 5 `SchoolPartnership` records and the associated `ActiveLeadProvider` records, causing the test to take a longer time than
needed to run.

Reduce the amount of test fixture data to speed it up.