### PR TITLE
Fix migration teacher history end to end flakey specs

### DIFF
--- a/spec/migration/teacher_history_converter/end_to_end/two_ect_induction_records_withdrawal_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/two_ect_induction_records_withdrawal_spec.rb
@@ -108,8 +108,8 @@ describe "Two ECT induction records (with the second being a withdrawal)" do
       expect(teacher.ect_at_school_periods[1].training_periods.count).to be(1)
     end
 
-    it "sets the withdrawal time and reason on the second training period" do
-      withdrawal_training_period = teacher.ect_at_school_periods[1].training_periods[0]
+    it "sets the withdrawal time and reason correctly" do
+      withdrawal_training_period = teacher.ect_at_school_periods.flat_map(&:training_periods).find { |tp| tp.status == :withdrawn }
 
       aggregate_failures do
         expect(withdrawal_training_period.withdrawn_at).to eql(ecf1_participant_profile_state.created_at)
@@ -118,7 +118,7 @@ describe "Two ECT induction records (with the second being a withdrawal)" do
     end
 
     it "closes the withdrawn training_period" do
-      withdrawal_training_period = teacher.ect_at_school_periods[1].training_periods[0]
+      withdrawal_training_period = teacher.ect_at_school_periods.flat_map(&:training_periods).find { |tp| tp.status == :withdrawn }
       expected_closing_date = [withdrawal_training_period.started_on + 1.day, withdrawal_training_period.withdrawn_at.to_date].max
 
       expect(withdrawal_training_period.finished_on).to eq(expected_closing_date)

--- a/spec/migration/teacher_history_converter/end_to_end/two_mentor_induction_records_withdrawal_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/two_mentor_induction_records_withdrawal_spec.rb
@@ -108,8 +108,8 @@ describe "Two mentor induction records (with the second being a withdrawal)" do
       expect(teacher.mentor_at_school_periods[1].training_periods.count).to be(1)
     end
 
-    it "sets the withdrawal time and reason on the second training period" do
-      withdrawal_training_period = teacher.mentor_at_school_periods[1].training_periods[0]
+    it "sets the withdrawal time and reason correctly" do
+      withdrawal_training_period = teacher.mentor_at_school_periods.flat_map(&:training_periods).find { it.status == :withdrawn }
 
       aggregate_failures do
         expect(withdrawal_training_period.withdrawn_at).to eql(ecf1_participant_profile_state.created_at)
@@ -118,7 +118,7 @@ describe "Two mentor induction records (with the second being a withdrawal)" do
     end
 
     it "closes the withdrawn training_period" do
-      withdrawal_training_period = teacher.mentor_at_school_periods[1].training_periods[0]
+      withdrawal_training_period = teacher.mentor_at_school_periods.flat_map(&:training_periods).find { |tp| tp.status == :withdrawn }
       expected_closing_date = [withdrawal_training_period.started_on + 1.day, withdrawal_training_period.withdrawn_at.to_date].max
 
       expect(withdrawal_training_period.finished_on).to eq(expected_closing_date)


### PR DESCRIPTION
### Context

Some specs are flakey. [example run](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/23799964817/job/69357305878).

### Changes proposed in this pull request
- Fix flakey specs, selecting the correct withdrawn training period.

### Guidance to review

Review app