### PR TITLE
Retry konduit commands in the CI snapshot restore workflow

### DIFF
--- a/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
@@ -107,9 +107,15 @@ runs:
           COMPRESS_ARG=-c
         fi
 
-        ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 60 -x ${{ inputs.app-name }} -- psql -c "drop schema public cascade; create schema public;"
+        # Drop and create schema with retry
+        ${{ github.action_path }}/retry-konduit.sh \
+          "./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 360 -x ${{ inputs.app-name }} -- psql -c \"drop schema public cascade; create schema public;\"" \
+          "Schema recreate"
 
-        ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i ${{ inputs.backup-file }} ${COMPRESS_ARG} -t 7200 -x ${{ inputs.app-name }} -- psql
+        # Restore backup with retry
+        ${{ github.action_path }}/retry-konduit.sh \
+          "./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i ${{ inputs.backup-file }} ${COMPRESS_ARG} -t 7200 -x ${{ inputs.app-name }} -- psql" \
+          "Database restore"
 
     - name: Restore Summary
       if: success()

--- a/.github/actions/restore-snapshot-database-from-azure-storage/retry-konduit.sh
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/retry-konduit.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Konduit connections occassionally fail outside of our control
+# Retry a command with exponential backoff
+# Usage: ./retry-konduit.sh "command" "description"
+
+COMMAND="$1"
+DESCRIPTION="$2"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+INITIAL_DELAY="${INITIAL_DELAY:-10}"
+
+ATTEMPT=1
+DELAY=$INITIAL_DELAY
+
+while [ $ATTEMPT -le $MAX_RETRIES ]; do
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Attempt $ATTEMPT/$MAX_RETRIES: $DESCRIPTION"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  if eval "$COMMAND"; then
+    echo "✅ $DESCRIPTION completed successfully"
+    exit 0
+  else
+    EXIT_CODE=$?
+
+    if [ $ATTEMPT -lt $MAX_RETRIES ]; then
+      echo "❌ $DESCRIPTION failed with exit code $EXIT_CODE"
+      echo "⏳ Waiting ${DELAY}s before retry (attempt $((ATTEMPT + 1))/$MAX_RETRIES)..."
+      sleep $DELAY
+
+      DELAY=$((DELAY * 2))  # Exponential backoff: 10s, 20s, 40s
+      ATTEMPT=$((ATTEMPT + 1))
+    else
+      echo "❌ $DESCRIPTION failed after $MAX_RETRIES attempts"
+      exit $EXIT_CODE
+    fi
+
+  fi
+done


### PR DESCRIPTION
### Context

We have observed konduit connections breaking despite longer timeouts. This was a pain when connecting locally but we also use konduit for manipulating the databases in our workflows.

Infrastructure issues outside of our control might prevent a step that involves konduit from completing, like the nightly restoration of our snapshot.

For 2 consecutive days the restoration has failed when it had previously run to completion. There have been no relevant code changes in the interim.

- [Partial retry of snapshot restoration ❌](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/23833006782/attempts/6)
  Fails to connect when using the default 1min timeout when trying to drop the db
  ```
  Using app konduit-app-23117 to connect to database for cpd-ec2-production-web
  SSL error: unexpected eof while reading
  connection to server was lost
  ```
- [Full retry of backup and snapshot ❌](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/23833006782/attempts/7)
  Fails because the timestamped backup file already exists
  ```
  Checking if backup cpdec2_production_nightly_copy_2026-04-01.sql.gz already exists in Azure Blob Storage...
  Backup cpdec2_production_nightly_copy_2026-04-01.sql.gz already exists. Skipping backup to avoid overwrite.
  ```
- [Manual direct copy of prod to the snapshot ❌](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/23850337554/job/69528403749)
  Timeout set to 2hrs, connects and runs but breaks midway
  ```sql
  SET
  SET
  SET
  ALTER TABLE
  ALTER TABLE
  ALTER TABLE
  SSL error: unexpected eof while reading
  connection to server was lost
  gzip: stdout: Broken pipe
  Error: Process completed with exit code 2.
  ```
  This demonstrates that at the time of testing connections to `cpd-ec2-production-web` are possible inthe pipeline, but they still get cut short despite the long timeout flag.

### Changes proposed in this pull request

- Increase the timeout of the initial schema drop/create task to 1hr (the restore uses 2)
- Wrap both with a shell script to retry them when they fail.

### Guidance to review
