### PR TITLE
Add and configure redis-session-store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+REDIS_CACHE_URL=redis://localhost:6379
 # GOVUK_NOTIFY_API_KEY=abc123
 ENVIRONMENT_COLOUR=red
 ENVIRONMENT_PHASE_BANNER_CONTENT="Local development environment"

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "propshaft"
 gem "puma", ">= 5.0"
 gem "rack-attack"
 gem "redis"
+gem "redis-session-store"
 gem "tzinfo-data", platforms: %i[windows jruby]
 
 gem "govuk-components", "6.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -651,6 +651,9 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.25.1)
       connection_pool
+    redis-session-store (0.11.6)
+      actionpack (>= 5.2.4.1, < 9)
+      redis (>= 3, < 6)
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -910,6 +913,7 @@ DEPENDENCIES
   rack-attack
   rails (~> 8.1.3)
   redis
+  redis-session-store
   rotp
   rspec
   rspec-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,16 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.session_store(
+    :redis_session_store,
+    serializer: :json,
+    redis: {
+      expire_after: ENV.fetch("MAX_SESSION_IDLE_TIME", 7200.seconds).to_i,
+      key_prefix: "_ecf2_session:",
+      url: ENV.fetch("REDIS_CACHE_URL")
+    }
+  )
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,14 +26,9 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
-
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
   else
     config.action_controller.perform_caching = false
-
+    config.action_controller.enable_fragment_cache_logging = false
     config.cache_store = :null_store
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,15 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL") }
+  config.session_store(
+    :redis_session_store,
+    serializer: :json,
+    redis: {
+      expire_after: ENV.fetch("MAX_SESSION_IDLE_TIME", 7200.seconds).to_i,
+      key_prefix: "_ecf2_session:",
+      url: ENV.fetch("REDIS_CACHE_URL")
+    }
+  )
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,9 @@
+Rails.application.config.session_store(
+  :redis_session_store,
+  serializer: :json,
+  redis: {
+    expire_after: ENV.fetch("MAX_SESSION_IDLE_TIME", 7200.seconds).to_i,
+    key_prefix: "_ecf2_session:",
+    url: ENV.fetch("REDIS_CACHE_URL")
+  }
+)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,9 +1,0 @@
-Rails.application.config.session_store(
-  :redis_session_store,
-  serializer: :json,
-  redis: {
-    expire_after: ENV.fetch("MAX_SESSION_IDLE_TIME", 7200.seconds).to_i,
-    key_prefix: "_ecf2_session:",
-    url: ENV.fetch("REDIS_CACHE_URL")
-  }
-)


### PR DESCRIPTION
This gem moves our sessions from cookies (where there's a chance they'll overflow at 4k) to Redis.

We opted for Redis over PostgreSQL for this because we're able to take advantage of its inbuilt [TTL](https://redis.io/docs/latest/commands/ttl/) functionality to avoid having to write extra functionality to clean up old sessions.
