### PR TITLE
[3514] Add API::Teachers::EligibilityForFunding service

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -39,11 +39,8 @@ class API::TeacherSerializer < Blueprinter::Base
       field(:training_status) { |(training_period, _, _)| API::TrainingPeriods::TrainingStatus.new(training_period:).status }
       field(:participant_status) { |(training_period, teacher, _)| API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status }
       field(:eligible_for_funding) do |(training_period, teacher, _)|
-        if training_period.for_ect?
-          teacher.ect_first_became_eligible_for_training_at.present?
-        else
-          teacher.mentor_first_became_eligible_for_training_at.present?
-        end
+        teacher_type = training_period.for_ect? ? :ect : :mentor
+        API::Teachers::EligibilityForFunding.new(teacher:, teacher_type:).eligible?
       end
       field(:pupil_premium_uplift) do |(training_period, _, metadata)|
         uplift_value(training_period, metadata, :pupil_premium_uplift)

--- a/app/services/api/teachers/eligibility_for_funding.rb
+++ b/app/services/api/teachers/eligibility_for_funding.rb
@@ -1,0 +1,33 @@
+class API::Teachers::EligibilityForFunding
+  attr_reader :teacher, :teacher_type
+
+  def initialize(teacher:, teacher_type:)
+    @teacher = teacher
+    @teacher_type = teacher_type
+  end
+
+  def eligible?
+    return nil if eligible_on.nil? && ineligible_on.nil?
+    return true if eligible_on.present? && (ineligible_on.nil? || eligible_on.before?(ineligible_on))
+
+    false
+  end
+
+private
+
+  def eligible_on
+    @eligible_on ||= if teacher_type == :ect
+                       teacher.ect_first_became_eligible_for_training_at&.to_date
+                     else
+                       teacher.mentor_first_became_eligible_for_training_at&.to_date
+                     end
+  end
+
+  def ineligible_on
+    @ineligible_on ||= if teacher_type == :ect
+                         teacher.ect_became_ineligible_for_funding_on
+                       else
+                         teacher.mentor_became_ineligible_for_funding_on
+                       end
+  end
+end

--- a/app/services/api/teachers/eligibility_for_funding.rb
+++ b/app/services/api/teachers/eligibility_for_funding.rb
@@ -7,10 +7,8 @@ class API::Teachers::EligibilityForFunding
   end
 
   def eligible?
-    return nil if eligible_on.nil? && ineligible_on.nil?
-    return true if eligible_on.present? && (ineligible_on.nil? || eligible_on.before?(ineligible_on))
-
-    false
+    earliest = [eligible_on, ineligible_on].compact.min
+    earliest && earliest == eligible_on
   end
 
 private

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -209,19 +209,57 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             end
           end
 
-          context "when `eligible_for_funding` is true" do
-            let(:teacher) { FactoryBot.create(:teacher, ect_first_became_eligible_for_training_at: Time.zone.now) }
+          describe "`eligible_for_funding`" do
+            context "when `ect_first_became_eligible_for_training_at` is nil and `ect_became_ineligible_for_funding_on` is nil" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  ect_first_became_eligible_for_training_at: nil,
+                                  ect_became_ineligible_for_funding_on: nil)
+              end
 
-            it "serializes `eligible_for_funding`" do
-              expect(ect_enrolment["eligible_for_funding"]).to be(true)
+              it "serializes `eligible_for_funding` as nil" do
+                expect(ect_enrolment["eligible_for_funding"]).to be_nil
+              end
             end
-          end
 
-          context "when `eligible_for_funding` is false" do
-            let(:teacher) { FactoryBot.create(:teacher, ect_first_became_eligible_for_training_at: nil) }
+            context "when only `ect_first_became_eligible_for_training_at` is set" do
+              let(:teacher) { FactoryBot.create(:teacher, ect_first_became_eligible_for_training_at: Time.zone.now) }
 
-            it "serializes `eligible_for_funding`" do
-              expect(ect_enrolment["eligible_for_funding"]).to be(false)
+              it "serializes `eligible_for_funding` as true" do
+                expect(ect_enrolment["eligible_for_funding"]).to be(true)
+              end
+            end
+
+            context "when only `ect_became_ineligible_for_funding_on` is set" do
+              let(:teacher) { FactoryBot.create(:teacher, ect_became_ineligible_for_funding_on: Date.current) }
+
+              it "serializes `eligible_for_funding` as false" do
+                expect(ect_enrolment["eligible_for_funding"]).to be(false)
+              end
+            end
+
+            context "when `ect_first_became_eligible_for_training_at` is before `ect_became_ineligible_for_funding_on`" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  ect_first_became_eligible_for_training_at: 2.days.ago,
+                                  ect_became_ineligible_for_funding_on: Date.current)
+              end
+
+              it "serializes `eligible_for_funding` as true" do
+                expect(ect_enrolment["eligible_for_funding"]).to be(true)
+              end
+            end
+
+            context "when `ect_became_ineligible_for_funding_on` is before `ect_first_became_eligible_for_training_at`" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  ect_became_ineligible_for_funding_on: 2.days.ago.to_date,
+                                  ect_first_became_eligible_for_training_at: Time.current)
+              end
+
+              it "serializes `eligible_for_funding` as false" do
+                expect(ect_enrolment["eligible_for_funding"]).to be(false)
+              end
             end
           end
 
@@ -348,19 +386,69 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             end
           end
 
-          context "when `eligible_for_funding` is true" do
-            let(:teacher) { FactoryBot.create(:teacher, mentor_first_became_eligible_for_training_at: Time.zone.now) }
+          describe "`eligible_for_funding`" do
+            context "when `mentor_first_became_eligible_for_training_at` is nil and `mentor_became_ineligible_for_funding_on` is nil" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  mentor_first_became_eligible_for_training_at: nil,
+                                  mentor_became_ineligible_for_funding_on: nil,
+                                  mentor_became_ineligible_for_funding_reason: nil)
+              end
 
-            it "serializes `eligible_for_funding`" do
-              expect(mentor_enrolment["eligible_for_funding"]).to be(true)
+              it "serializes `eligible_for_funding` as nil" do
+                expect(mentor_enrolment["eligible_for_funding"]).to be_nil
+              end
             end
-          end
 
-          context "when `eligible_for_funding` is false" do
-            let(:teacher) { FactoryBot.create(:teacher, mentor_first_became_eligible_for_training_at: nil) }
+            context "when only `mentor_first_became_eligible_for_training_at` is set" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  mentor_first_became_eligible_for_training_at: Time.zone.now,
+                                  mentor_became_ineligible_for_funding_on: nil,
+                                  mentor_became_ineligible_for_funding_reason: nil)
+              end
 
-            it "serializes `eligible_for_funding`" do
-              expect(mentor_enrolment["eligible_for_funding"]).to be(false)
+              it "serializes `eligible_for_funding` as true" do
+                expect(mentor_enrolment["eligible_for_funding"]).to be(true)
+              end
+            end
+
+            context "when only `mentor_became_ineligible_for_funding_on` is set" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  mentor_became_ineligible_for_funding_on: Date.current,
+                                  mentor_became_ineligible_for_funding_reason: "started_not_completed")
+              end
+
+              it "serializes `eligible_for_funding` as false" do
+                expect(mentor_enrolment["eligible_for_funding"]).to be(false)
+              end
+            end
+
+            context "when `mentor_first_became_eligible_for_training_at` is before `mentor_became_ineligible_for_funding_on`" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  mentor_first_became_eligible_for_training_at: 2.days.ago,
+                                  mentor_became_ineligible_for_funding_on: Date.current,
+                                  mentor_became_ineligible_for_funding_reason: "completed_declaration_received")
+              end
+
+              it "serializes `eligible_for_funding` as true" do
+                expect(mentor_enrolment["eligible_for_funding"]).to be(true)
+              end
+            end
+
+            context "when `mentor_became_ineligible_for_funding_on` is before `mentor_first_became_eligible_for_training_at`" do
+              let(:teacher) do
+                FactoryBot.create(:teacher,
+                                  mentor_became_ineligible_for_funding_on: 2.days.ago.to_date,
+                                  mentor_became_ineligible_for_funding_reason: "completed_during_early_roll_out",
+                                  mentor_first_became_eligible_for_training_at: Time.current)
+              end
+
+              it "serializes `eligible_for_funding` as false" do
+                expect(mentor_enrolment["eligible_for_funding"]).to be(false)
+              end
             end
           end
 

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -210,56 +210,15 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           describe "`eligible_for_funding`" do
-            context "when `ect_first_became_eligible_for_training_at` is nil and `ect_became_ineligible_for_funding_on` is nil" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  ect_first_became_eligible_for_training_at: nil,
-                                  ect_became_ineligible_for_funding_on: nil)
-              end
+            let(:eligibility_service) { instance_double(API::Teachers::EligibilityForFunding, eligible?: true) }
 
-              it "serializes `eligible_for_funding` as nil" do
-                expect(ect_enrolment["eligible_for_funding"]).to be_nil
-              end
+            before do
+              allow(API::Teachers::EligibilityForFunding).to receive(:new).and_return(eligibility_service)
             end
 
-            context "when only `ect_first_became_eligible_for_training_at` is set" do
-              let(:teacher) { FactoryBot.create(:teacher, ect_first_became_eligible_for_training_at: Time.zone.now) }
-
-              it "serializes `eligible_for_funding` as true" do
-                expect(ect_enrolment["eligible_for_funding"]).to be(true)
-              end
-            end
-
-            context "when only `ect_became_ineligible_for_funding_on` is set" do
-              let(:teacher) { FactoryBot.create(:teacher, ect_became_ineligible_for_funding_on: Date.current) }
-
-              it "serializes `eligible_for_funding` as false" do
-                expect(ect_enrolment["eligible_for_funding"]).to be(false)
-              end
-            end
-
-            context "when `ect_first_became_eligible_for_training_at` is before `ect_became_ineligible_for_funding_on`" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  ect_first_became_eligible_for_training_at: 2.days.ago,
-                                  ect_became_ineligible_for_funding_on: Date.current)
-              end
-
-              it "serializes `eligible_for_funding` as true" do
-                expect(ect_enrolment["eligible_for_funding"]).to be(true)
-              end
-            end
-
-            context "when `ect_became_ineligible_for_funding_on` is before `ect_first_became_eligible_for_training_at`" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  ect_became_ineligible_for_funding_on: 2.days.ago.to_date,
-                                  ect_first_became_eligible_for_training_at: Time.current)
-              end
-
-              it "serializes `eligible_for_funding` as false" do
-                expect(ect_enrolment["eligible_for_funding"]).to be(false)
-              end
+            it "delegates to API::Teachers::EligibilityForFunding" do
+              expect(ect_enrolment["eligible_for_funding"]).to be(true)
+              expect(API::Teachers::EligibilityForFunding).to have_received(:new).with(teacher:, teacher_type: :ect)
             end
           end
 
@@ -387,68 +346,15 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
           end
 
           describe "`eligible_for_funding`" do
-            context "when `mentor_first_became_eligible_for_training_at` is nil and `mentor_became_ineligible_for_funding_on` is nil" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  mentor_first_became_eligible_for_training_at: nil,
-                                  mentor_became_ineligible_for_funding_on: nil,
-                                  mentor_became_ineligible_for_funding_reason: nil)
-              end
+            let(:eligibility_service) { instance_double(API::Teachers::EligibilityForFunding, eligible?: true) }
 
-              it "serializes `eligible_for_funding` as nil" do
-                expect(mentor_enrolment["eligible_for_funding"]).to be_nil
-              end
+            before do
+              allow(API::Teachers::EligibilityForFunding).to receive(:new).and_return(eligibility_service)
             end
 
-            context "when only `mentor_first_became_eligible_for_training_at` is set" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  mentor_first_became_eligible_for_training_at: Time.zone.now,
-                                  mentor_became_ineligible_for_funding_on: nil,
-                                  mentor_became_ineligible_for_funding_reason: nil)
-              end
-
-              it "serializes `eligible_for_funding` as true" do
-                expect(mentor_enrolment["eligible_for_funding"]).to be(true)
-              end
-            end
-
-            context "when only `mentor_became_ineligible_for_funding_on` is set" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  mentor_became_ineligible_for_funding_on: Date.current,
-                                  mentor_became_ineligible_for_funding_reason: "started_not_completed")
-              end
-
-              it "serializes `eligible_for_funding` as false" do
-                expect(mentor_enrolment["eligible_for_funding"]).to be(false)
-              end
-            end
-
-            context "when `mentor_first_became_eligible_for_training_at` is before `mentor_became_ineligible_for_funding_on`" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  mentor_first_became_eligible_for_training_at: 2.days.ago,
-                                  mentor_became_ineligible_for_funding_on: Date.current,
-                                  mentor_became_ineligible_for_funding_reason: "completed_declaration_received")
-              end
-
-              it "serializes `eligible_for_funding` as true" do
-                expect(mentor_enrolment["eligible_for_funding"]).to be(true)
-              end
-            end
-
-            context "when `mentor_became_ineligible_for_funding_on` is before `mentor_first_became_eligible_for_training_at`" do
-              let(:teacher) do
-                FactoryBot.create(:teacher,
-                                  mentor_became_ineligible_for_funding_on: 2.days.ago.to_date,
-                                  mentor_became_ineligible_for_funding_reason: "completed_during_early_roll_out",
-                                  mentor_first_became_eligible_for_training_at: Time.current)
-              end
-
-              it "serializes `eligible_for_funding` as false" do
-                expect(mentor_enrolment["eligible_for_funding"]).to be(false)
-              end
+            it "delegates to API::Teachers::EligibilityForFunding" do
+              expect(mentor_enrolment["eligible_for_funding"]).to be(true)
+              expect(API::Teachers::EligibilityForFunding).to have_received(:new).with(teacher:, teacher_type: :mentor)
             end
           end
 

--- a/spec/services/api/teachers/eligibility_for_funding_spec.rb
+++ b/spec/services/api/teachers/eligibility_for_funding_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe API::Teachers::EligibilityForFunding do
+  describe "#eligible?" do
+    subject { described_class.new(teacher:, teacher_type:).eligible? }
+
+    context "for ECTs" do
+      let(:teacher_type) { :ect }
+
+      context "before ect_first_became_eligible_for_training_at or ect_became_ineligible_for_funding_on becomes filled" do
+        let(:teacher) { FactoryBot.create(:teacher) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when ect_first_became_eligible_for_training_at is populated before ect_became_ineligible_for_funding_on" do
+        let(:teacher) do
+          FactoryBot.create(:teacher,
+                            ect_first_became_eligible_for_training_at: 2.days.ago,
+                            ect_became_ineligible_for_funding_on: Date.current)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when only ect_first_became_eligible_for_training_at is populated" do
+        let(:teacher) do
+          FactoryBot.create(:teacher, ect_first_became_eligible_for_training_at: 1.day.ago)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when ect_became_ineligible_for_funding_on is populated before ect_first_became_eligible_for_training_at" do
+        let(:teacher) do
+          FactoryBot.create(:teacher,
+                            ect_became_ineligible_for_funding_on: 2.days.ago.to_date,
+                            ect_first_became_eligible_for_training_at: Time.current)
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "when only ect_became_ineligible_for_funding_on is populated" do
+        let(:teacher) do
+          FactoryBot.create(:teacher, ect_became_ineligible_for_funding_on: Date.current)
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "for mentors" do
+      let(:teacher_type) { :mentor }
+
+      context "before mentor_first_became_eligible_for_training_at or mentor_became_ineligible_for_funding_on becomes filled" do
+        let(:teacher) { FactoryBot.create(:teacher) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when mentor_first_became_eligible_for_training_at is populated before mentor_became_ineligible_for_funding_on" do
+        let(:teacher) do
+          FactoryBot.create(:teacher,
+                            mentor_first_became_eligible_for_training_at: 2.days.ago,
+                            mentor_became_ineligible_for_funding_on: Date.current,
+                            mentor_became_ineligible_for_funding_reason: "completed_declaration_received")
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when only mentor_first_became_eligible_for_training_at is populated" do
+        let(:teacher) do
+          FactoryBot.create(:teacher, mentor_first_became_eligible_for_training_at: 1.day.ago)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when mentor_became_ineligible_for_funding_on is populated before mentor_first_became_eligible_for_training_at" do
+        let(:teacher) do
+          FactoryBot.create(:teacher,
+                            mentor_became_ineligible_for_funding_on: 2.days.ago.to_date,
+                            mentor_became_ineligible_for_funding_reason: "completed_during_early_roll_out",
+                            mentor_first_became_eligible_for_training_at: Time.current)
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "when only mentor_became_ineligible_for_funding_on is populated" do
+        let(:teacher) do
+          FactoryBot.create(:teacher,
+                            mentor_became_ineligible_for_funding_on: Date.current,
+                            mentor_became_ineligible_for_funding_reason: "started_not_completed")
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3514

### Changes proposed in this pull request

* New service `API::Teachers::EligibilityForFunding` to determine eligibility for funding
* Updated teacher serializer to use the service.

### Guidance to review
