### PR TITLE
Add explicit permissions to build-no-cache workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -6,6 +6,10 @@ on:
     - cron: "30 12 * * 0"
     # Will run once a week on Sunday afternoon
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-no-cache:
     outputs:


### PR DESCRIPTION
### Summary

Addresses [code scanning alert(138)](https://github.com/DFE-Digital/register-early-career-teachers-public/security/code-scanning/138) by adding explicit `GITHUB_TOKEN` permissions to `build-nocache`.

Sets:
- `contents: read` (so `actions/checkout` can read the repo)
- `packages: write` (so the workflow can push the docker image)
