### PR TITLE
Prevent multiple ongoing training periods

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -60,7 +60,7 @@ module Interval
 
     if siblings.any? { |s| s.range.include?(started_on) }
       errors.add(:started_on, "Start date cannot overlap another #{name} period")
-    elsif siblings.any? { |s| s.range.include?(finished_on) }
+    elsif siblings.any? { |s| s.range.include?(finished_on) } || finished_on.nil?
       errors.add(:finished_on, "End date cannot overlap another #{name} period")
     end
   end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -138,7 +138,11 @@ class TrainingPeriod < ApplicationRecord
   def siblings
     return TrainingPeriod.none unless at_school_period
 
-    at_school_period.training_periods.excluding(self)
+    training_periods_for_teacher = TrainingPeriod
+      .includes(at_school_period.model_name.element.to_sym)
+      .where(at_school_period.model_name.element => { teacher: })
+
+    training_periods_for_teacher.excluding(self)
   end
 
   def only_expression_of_interest?

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -344,6 +344,62 @@ describe ECTAtSchoolPeriod do
         end
       end
     end
+
+    describe "concurrent ongoing periods" do
+      subject(:save_concurrent_ongoing_period!) do
+        concurrent_ongoing_period.save!
+      end
+
+      before { freeze_time }
+
+      let(:teacher) { FactoryBot.create(:teacher) }
+      let(:school) { FactoryBot.create(:school) }
+
+      let!(:ongoing_ect_at_school_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          :ongoing,
+          teacher:,
+          school:,
+          started_on: 1.year.ago
+        )
+      end
+
+      context "at different schools" do
+        let(:other_school) { FactoryBot.create(:school) }
+        let(:concurrent_ongoing_period) do
+          FactoryBot.build(
+            :ect_at_school_period,
+            :ongoing,
+            teacher:,
+            school: other_school,
+            started_on: 1.week.from_now
+          )
+        end
+
+        it do
+          expect { save_concurrent_ongoing_period! }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
+      context "at the same school" do
+        let(:concurrent_ongoing_period) do
+          FactoryBot.build(
+            :ect_at_school_period,
+            :ongoing,
+            teacher:,
+            school:,
+            started_on: 1.week.from_now
+          )
+        end
+
+        it do
+          expect { save_concurrent_ongoing_period! }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
   end
 
   describe "check constraints" do

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -185,6 +185,59 @@ describe MentorAtSchoolPeriod do
     end
   end
 
+  describe "concurrent ongoing periods" do
+    subject(:save_concurrent_ongoing_period!) do
+      concurrent_ongoing_period.save!
+    end
+
+    before { freeze_time }
+
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:school) { FactoryBot.create(:school) }
+
+    let!(:ongoing_mentor_at_school_period) do
+      FactoryBot.create(
+        :mentor_at_school_period,
+        :ongoing,
+        teacher:,
+        school:,
+        started_on: 1.year.ago
+      )
+    end
+
+    context "at different schools" do
+      let(:other_school) { FactoryBot.create(:school) }
+      let(:concurrent_ongoing_period) do
+        FactoryBot.build(
+          :mentor_at_school_period,
+          :ongoing,
+          teacher:,
+          school: other_school,
+          started_on: 1.week.from_now
+        )
+      end
+
+      it { expect { save_concurrent_ongoing_period! }.not_to raise_error }
+    end
+
+    context "at the same school" do
+      let(:concurrent_ongoing_period) do
+        FactoryBot.build(
+          :mentor_at_school_period,
+          :ongoing,
+          teacher:,
+          school:,
+          started_on: 1.week.from_now
+        )
+      end
+
+      it do
+        expect { save_concurrent_ongoing_period! }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
   describe "check constraints" do
     subject { FactoryBot.build(:mentor_at_school_period, school:, teacher:, started_on: Date.current, finished_on: Date.current) }
 

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -93,6 +93,167 @@ describe MentorshipPeriod do
       end
     end
 
+    describe "concurrent ongoing periods" do
+      subject(:save_concurrent_ongoing_period!) do
+        concurrent_ongoing_period.save!
+      end
+
+      before { freeze_time }
+
+      context "for mentees" do
+        let(:mentee_teacher) { FactoryBot.create(:teacher) }
+
+        # Mentor mentoring mentee
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            teacher: mentee_teacher,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+        let(:mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            school: ect_at_school_period.school,
+            started_on: 1.year.ago
+          )
+        end
+        let!(:mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            mentee: ect_at_school_period,
+            mentor: mentor_at_school_period,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.ago
+          )
+        end
+
+        # Mentee transferring to a new school and being mentored by a different teacher
+        let(:next_ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            teacher: mentee_teacher,
+            started_on: ect_at_school_period.finished_on.advance(days: 1)
+          )
+        end
+        let(:next_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            school: next_ect_at_school_period.school,
+            started_on: 1.year.ago
+          )
+        end
+        let!(:ongoing_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            :ongoing,
+            mentee: next_ect_at_school_period,
+            mentor: next_mentor_at_school_period,
+            started_on: next_ect_at_school_period.started_on
+          )
+        end
+
+        # Mentee being mentored by the original mentor at the old school
+        let(:concurrent_ongoing_period) do
+          FactoryBot.build(
+            :mentorship_period,
+            :ongoing,
+            mentee: ect_at_school_period,
+            mentor: mentor_at_school_period,
+            started_on: mentorship_period.finished_on
+          )
+        end
+
+        it do
+          expect { save_concurrent_ongoing_period! }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
+      context "for mentors" do
+        let(:mentor_teacher) { FactoryBot.create(:teacher) }
+
+        # Mentor mentoring mentee at one school
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            started_on: 1.year.ago
+          )
+        end
+        let(:mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            school: ect_at_school_period.school,
+            teacher: mentor_teacher,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+        let!(:mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            mentor: mentor_at_school_period,
+            mentee: ect_at_school_period,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+
+        # Mentor tranferring to another school and mentoring another mentee
+        let(:next_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            school: next_ect_at_school_period.school,
+            teacher: mentor_teacher,
+            started_on: mentor_at_school_period.finished_on.advance(days: 1)
+          )
+        end
+        let(:next_ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            started_on: mentor_at_school_period.finished_on.advance(days: 1)
+          )
+        end
+        let!(:ongoing_mentorship_period) do
+          FactoryBot.create(
+            :mentorship_period,
+            :ongoing,
+            mentor: next_mentor_at_school_period,
+            mentee: next_ect_at_school_period,
+            started_on: next_mentor_at_school_period.started_on
+          )
+        end
+
+        # Mentor mentoring another mentee concurrently at that same school
+        let(:other_next_ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            school: next_ect_at_school_period.school,
+            started_on: next_mentor_at_school_period.started_on.advance(weeks: 1)
+          )
+        end
+        let(:concurrent_ongoing_period) do
+          FactoryBot.build(
+            :mentorship_period,
+            :ongoing,
+            mentor: next_mentor_at_school_period,
+            mentee: other_next_ect_at_school_period,
+            started_on: other_next_ect_at_school_period.started_on
+          )
+        end
+
+        it { expect { save_concurrent_ongoing_period! }.not_to raise_error }
+      end
+    end
+
     describe "period containment" do
       describe "#enveloped_by_ect_at_school_period" do
         context "when the ECT at school period contains the mentorship period" do

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -355,6 +355,130 @@ describe TrainingPeriod do
       end
     end
 
+    describe "concurrent ongoing periods" do
+      subject(:save_concurrent_ongoing_period!) do
+        concurrent_ongoing_period.save!
+      end
+
+      before { freeze_time }
+
+      context "for ECT training" do
+        let(:teacher) { FactoryBot.create(:teacher) }
+
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :for_ect,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+
+        let(:next_ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            :ongoing,
+            teacher:,
+            started_on: ect_at_school_period.finished_on.advance(days: 1)
+          )
+        end
+        let!(:ongoing_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :for_ect,
+            :provider_led,
+            ect_at_school_period: next_ect_at_school_period,
+            started_on: next_ect_at_school_period.started_on
+          )
+        end
+
+        let(:concurrent_ongoing_period) do
+          FactoryBot.build(
+            :training_period,
+            :ongoing,
+            :for_ect,
+            :provider_led,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.finished_on
+          )
+        end
+
+        it do
+          expect { save_concurrent_ongoing_period! }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
+      context "for mentor training" do
+        let(:teacher) { FactoryBot.create(:teacher) }
+
+        let(:mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            teacher:,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :for_mentor,
+            :provider_led,
+            mentor_at_school_period:,
+            started_on: 1.year.ago,
+            finished_on: 2.weeks.from_now
+          )
+        end
+
+        let(:next_mentor_at_school_period) do
+          FactoryBot.create(
+            :mentor_at_school_period,
+            :ongoing,
+            teacher:,
+            started_on: mentor_at_school_period.finished_on.advance(days: 1)
+          )
+        end
+        let!(:ongoing_training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :for_mentor,
+            :provider_led,
+            mentor_at_school_period: next_mentor_at_school_period,
+            started_on: next_mentor_at_school_period.started_on
+          )
+        end
+
+        let(:concurrent_ongoing_period) do
+          FactoryBot.build(
+            :training_period,
+            :ongoing,
+            :for_mentor,
+            :provider_led,
+            mentor_at_school_period: next_mentor_at_school_period,
+            started_on: next_mentor_at_school_period.finished_on
+          )
+        end
+
+        it do
+          expect { save_concurrent_ongoing_period! }
+            .to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
     describe "only allows provider-led mentor training" do
       context "for mentor training" do
         subject { FactoryBot.build(:training_period, :for_mentor) }
@@ -927,31 +1051,69 @@ describe TrainingPeriod do
   end
 
   describe "#siblings" do
-    subject { training_period_1.siblings }
+    subject(:siblings) { training_period.siblings }
 
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: "2021-01-01") }
-    let!(:training_period_1) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: "2022-01-01", finished_on: "2022-06-01") }
-    let!(:training_period_2) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: "2022-06-01", finished_on: "2023-01-01") }
+    let(:teacher) { FactoryBot.create(:teacher) }
+
+    let!(:ect_at_school_period) do
+      FactoryBot.create(
+        :ect_at_school_period,
+        teacher:,
+        started_on: "2021-01-01",
+        finished_on: "2023-01-01"
+      )
+    end
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        ect_at_school_period:,
+        started_on: "2022-01-01",
+        finished_on: "2022-06-01"
+      )
+    end
+    let!(:sibling_training_period) do
+      FactoryBot.create(
+        :training_period,
+        ect_at_school_period:,
+        started_on: "2022-06-01",
+        finished_on: "2023-01-01"
+      )
+    end
+
+    let!(:other_ect_at_school_period) do
+      FactoryBot.create(
+        :ect_at_school_period,
+        :ongoing,
+        teacher:,
+        started_on: "2023-01-02"
+      )
+    end
+    let!(:other_sibling_training_period) do
+      FactoryBot.create(
+        :training_period,
+        ect_at_school_period: other_ect_at_school_period,
+        started_on: "2023-01-02",
+        finished_on: "2023-06-01"
+      )
+    end
 
     let!(:unrelated_ect_at_school_period) do
-      FactoryBot.create(:ect_at_school_period, :ongoing, started_on: "2021-01-01")
+      FactoryBot.create(
+        :ect_at_school_period,
+        :ongoing,
+        started_on: "2021-01-01"
+      )
     end
-
     let!(:unrelated_training_period) do
-      FactoryBot.create(:training_period, ect_at_school_period: unrelated_ect_at_school_period, started_on: "2022-06-01", finished_on: "2023-01-01")
+      FactoryBot.create(
+        :training_period,
+        ect_at_school_period: unrelated_ect_at_school_period,
+        started_on: "2022-06-01",
+        finished_on: "2023-01-01"
+      )
     end
 
-    it "only returns records that belong to the same trainee" do
-      expect(subject).to include(training_period_2)
-    end
-
-    it "doesn't include itself" do
-      expect(subject).not_to include(training_period_1)
-    end
-
-    it "doesn't include periods that belong to other trainee" do
-      expect(subject).not_to include(unrelated_training_period)
-    end
+    it { is_expected.to contain_exactly(sibling_training_period, other_sibling_training_period) }
   end
 
   describe "#teacher_completed_training?" do

--- a/spec/services/ect_at_school_periods/switch_mentor_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_mentor_spec.rb
@@ -245,7 +245,7 @@ module ECTAtSchoolPeriods
         end
 
         context "on the last day of the contract period" do
-          let(:travel_date) { Date.new(2026, 5, 31) }
+          let(:overridden_current_date) { contract_period.finished_on }
 
           it "assigns a mentor" do
             expect { switch_mentor }.to change(MentorshipPeriod, :count).by(1)

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe Schools::RegisterECT do
       end
 
       context "when we log a teacher to start on the last day of the current contract period" do
-        let(:travel_date) { Date.new(2026, 5, 31) }
-        let(:started_on) { travel_date }
+        let(:started_on) { contract_period.finished_on }
 
         it "creates a new Teacher record" do
           expect { service.register! }.to change(Teacher, :count).by(1)
@@ -67,28 +66,96 @@ RSpec.describe Schools::RegisterECT do
         end
       end
 
-      context "when provider-led" do
-        let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+      context "when an ActiveLeadProvider exists for the contract_period" do
+        let!(:active_lead_provider) do
+          FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
+        end
         let!(:teacher) { FactoryBot.create(:teacher, trn:) }
 
-        context "when a Teacher record with the same TRN exists but has no ect records" do
+        it "creates an associated ECTAtSchoolPeriod record" do
+          expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
+
+          expect(ect_at_school_period).to have_attributes(
+            teacher_id: Teacher.find_by(trn:).id,
+            started_on:,
+            working_pattern:,
+            email:,
+            school_reported_appropriate_body_id: school_reported_appropriate_body.id
+          )
+        end
+
+        it "sends a provider-led confirmation email to the early career teacher" do
+          expect { service.register! }
+            .to have_enqueued_mail(Schools::ECTRegistrationMailer, :provider_led_confirmation)
+        end
+
+        it "records a teacher_registered_as_ect event" do
+          allow(Events::Record)
+            .to receive(:record_teacher_registered_as_ect_event!)
+            .with(any_args)
+            .and_call_original
+
+          service.register!
+
+          expect(Events::Record)
+            .to have_received(:record_teacher_registered_as_ect_event!)
+            .with(
+              hash_including(author:, ect_at_school_period:, teacher:, school:)
+            )
+        end
+
+        it "sets appropriate body and provider choices for the school" do
+          expect { service.register! }
+            .to change(school, :last_chosen_appropriate_body_id)
+              .to(school_reported_appropriate_body.id)
+            .and change(school, :last_chosen_training_programme)
+              .to(training_programme)
+            .and change(school, :last_chosen_lead_provider_id)
+              .to(lead_provider.id)
+        end
+
+        it "calls `Teachers::SetFundingEligibility` service with correct params" do
+          allow(Teachers::SetFundingEligibility).to receive(:new).and_call_original
+
+          service.register!
+
+          expect(Teachers::SetFundingEligibility).to have_received(:new).with(teacher:, author:)
+        end
+
+        context "when a Teacher has no ECT periods" do
           it "doesn't create a new Teacher record" do
             expect { service.register! }.not_to change(Teacher, :count)
           end
         end
 
-        context "when a Teacher record with the same TRN exists and has ect records at a different school" do
+        context "when a Teacher has an ECT period at a different school" do
           let(:other_school) { FactoryBot.create(:school) }
 
-          before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school: other_school, started_on: Date.new(2024, 1, 1)) }
+          before do
+            FactoryBot.create(
+              :ect_at_school_period,
+              :ongoing,
+              teacher:,
+              school: other_school,
+              started_on: Date.new(2024, 1, 1)
+            )
+          end
 
           it "allows registration (school transfer)" do
             expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
           end
         end
 
-        context "when a Teacher record with the same TRN exists and has ect records at the same school" do
-          before { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, school:, started_on: Date.new(2024, 1, 1)) }
+        context "when a Teacher has an ongoing ECT period at the current school" do
+          before do
+            FactoryBot.create(
+              :ect_at_school_period,
+              :ongoing,
+              teacher:,
+              school:,
+              started_on: Date.new(2024, 1, 1)
+            )
+          end
 
           it "raises an exception" do
             expect { service.register! }.to raise_error(ActiveRecord::RecordInvalid)
@@ -103,28 +170,26 @@ RSpec.describe Schools::RegisterECT do
           end
         end
 
-        context "when a Teacher record with the same TRN exists and has multiple ect records at different schools" do
+        context "when a Teacher has multiple ECT periods at different schools" do
           let(:school_one) { FactoryBot.create(:school) }
           let(:school_two) { FactoryBot.create(:school) }
-          let(:started_on) { Date.current + 1.day }
-          let!(:future_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: started_on.year) }
-          let!(:future_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: future_contract_period) }
+          let(:started_on) { 1.day.from_now }
 
           before do
             # Create finished periods at two different schools with non-overlapping dates
-            FactoryBot.create(:ect_at_school_period, :finished, teacher:, school: school_one, started_on: Date.current - 2.years, finished_on: Date.current - 18.months)
-            FactoryBot.create(:ect_at_school_period, :finished, teacher:, school: school_two, started_on: Date.current - 12.months, finished_on: Date.current - 6.months)
+            FactoryBot.create(:ect_at_school_period, :finished, teacher:, school: school_one, started_on: 2.years.ago, finished_on: 18.months.ago)
+            FactoryBot.create(:ect_at_school_period, :finished, teacher:, school: school_two, started_on: 12.months.ago, finished_on: 6.months.ago)
           end
 
           it "allows registration at a third school (multiple transfers)" do
             expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
 
-            expect(teacher.ect_at_school_periods.count).to eq(3) # 2 existing + 1 new
+            expect(teacher.ect_at_school_periods.count).to eq(3)
           end
 
           context "on the last day of the current contract period" do
-            let(:travel_date) { Date.new(2026, 5, 31) }
-            let(:started_on) { travel_date }
+            let(:overridden_current_date) { contract_period.finished_on }
+            let(:started_on) { overridden_current_date }
 
             it "allows registration at a third school (multiple transfers)" do
               expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
@@ -132,7 +197,7 @@ RSpec.describe Schools::RegisterECT do
           end
         end
 
-        context "when a Teacher record with the same TRN has an ongoing period at different school and finished period at current school" do
+        context "when a Teacher has an ongoing ECT period at a different school and a finished ECT period at the current school" do
           let(:other_school) { FactoryBot.create(:school) }
 
           before do
@@ -155,16 +220,15 @@ RSpec.describe Schools::RegisterECT do
           end
 
           context "on the last day of the current contract period" do
-            let(:travel_date) { Date.new(2026, 5, 31) }
-            let(:started_on) { travel_date }
+            let(:started_on) { contract_period.finished_on }
 
-            it "registers the teach with the correct contrat period" do
+            it "allows registration at the current school" do
               expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
             end
           end
         end
 
-        context "when a Teacher record with the same TRN has a future period at different school" do
+        context "when a Teacher has a future ECT period at a different school" do
           let(:other_school) { FactoryBot.create(:school) }
           let(:started_on) { Date.new(2025, 8, 1) + 1.year }
           let!(:future_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: started_on.year) }
@@ -172,48 +236,18 @@ RSpec.describe Schools::RegisterECT do
 
           before do
             # Future period at other school
-            FactoryBot.create(:ect_at_school_period, teacher:, school: other_school, started_on: Date.current + 1.month, finished_on: Date.current + 2.months)
+            FactoryBot.create(
+              :ect_at_school_period,
+              teacher:,
+              school: other_school,
+              started_on: 1.month.from_now,
+              finished_on: 6.months.from_now
+            )
           end
 
           it "allows registration with non-overlapping future date" do
             expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
           end
-        end
-
-        it "creates an associated ECTAtSchoolPeriod record" do
-          expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
-
-          expect(ect_at_school_period.teacher_id).to eq(Teacher.find_by(trn:).id)
-          expect(ect_at_school_period.started_on).to eq(started_on)
-          expect(ect_at_school_period.working_pattern).to eq(working_pattern)
-          expect(ect_at_school_period.email).to eq(email)
-          expect(ect_at_school_period.school_reported_appropriate_body_id).to eq(school_reported_appropriate_body.id)
-        end
-
-        it "sends a provider-led confirmation email to the early career teacher" do
-          expect { service.register! }
-            .to have_enqueued_mail(Schools::ECTRegistrationMailer, :provider_led_confirmation)
-        end
-
-        describe "recording an event" do
-          before { allow(Events::Record).to receive(:record_teacher_registered_as_ect_event!).with(any_args).and_call_original }
-
-          it "records a teacher_registered_as_ect event with the expected attributes" do
-            service.register!
-
-            expect(Events::Record).to have_received(:record_teacher_registered_as_ect_event!).with(
-              hash_including(author:, ect_at_school_period:, teacher:, school:)
-            )
-          end
-        end
-
-        it "sets ab and provider choices for the school" do
-          expect { service.register! }
-            .to change(school, :last_chosen_appropriate_body_id)
-                  .to(school_reported_appropriate_body.id)
-                  .and change(school, :last_chosen_training_programme)
-                        .to(training_programme)
-                        .and change(school, :last_chosen_lead_provider_id).to(lead_provider.id)
         end
 
         context "when no SchoolPartnerships exist" do
@@ -231,8 +265,38 @@ RSpec.describe Schools::RegisterECT do
           end
 
           context "on the last day of the contract period" do
-            let(:travel_date) { Date.new(2026, 5, 31) }
-            let(:started_on) { travel_date }
+            let(:overridden_current_date) { contract_period.finished_on }
+            let(:started_on) { overridden_current_date }
+
+            it "finds the correct contract period and schedule" do
+              expect { service.register! }.to change(TrainingPeriod, :count).by(1)
+
+              training_period = TrainingPeriod.find_by!(started_on:)
+
+              expect(training_period.started_on).to eq(started_on)
+              expect(training_period.schedule.identifier).to eql("ecf-standard-april")
+              expect(training_period.schedule.contract_period_year).to be(2025)
+            end
+          end
+        end
+
+        context "when a SchoolPartnership exists" do
+          let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
+          let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
+          let!(:school_partnership) { FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:) }
+
+          it "creates a TrainingPeriod with a school_partnership and no expression_of_interest" do
+            expect { service.register! }.to change(TrainingPeriod, :count).by(1)
+
+            training_period = TrainingPeriod.find_by!(started_on:)
+
+            expect(training_period.expression_of_interest).to be_nil
+            expect(training_period.school_partnership).to eq(school_partnership)
+          end
+
+          context "on the last day of the contract period" do
+            let(:overridden_current_date) { contract_period.finished_on }
+            let(:started_on) { overridden_current_date }
 
             it "finds the correct contract period and schedule" do
               expect { service.register! }.to change(TrainingPeriod, :count).by(1)
@@ -259,44 +323,6 @@ RSpec.describe Schools::RegisterECT do
             expect(training_period.schedule.contract_period_year).to eq(contract_period.year)
             expect(training_period.started_on).not_to eq(ect_at_school_period.started_on)
           end
-        end
-
-        context "when a SchoolPartnership exists" do
-          let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-          let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:) }
-          let!(:school_partnership) { FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership:) }
-
-          it "creates a TrainingPeriod with a school_partnership and no expression_of_interest" do
-            expect { service.register! }.to change(TrainingPeriod, :count).by(1)
-
-            training_period = TrainingPeriod.find_by!(started_on:)
-
-            expect(training_period.expression_of_interest).to be_nil
-            expect(training_period.school_partnership).to eq(school_partnership)
-          end
-
-          context "on the last day of the contract period" do
-            let(:travel_date) { Date.new(2026, 5, 31) }
-            let(:started_on) { travel_date }
-
-            it "finds the correct contract period and schedule" do
-              expect { service.register! }.to change(TrainingPeriod, :count).by(1)
-
-              training_period = TrainingPeriod.find_by!(started_on:)
-
-              expect(training_period.started_on).to eq(started_on)
-              expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-              expect(training_period.schedule.contract_period_year).to be(2025)
-            end
-          end
-        end
-
-        it "calls `Teachers::SetFundingEligibility` service with correct params" do
-          allow(Teachers::SetFundingEligibility).to receive(:new).and_call_original
-
-          service.register!
-
-          expect(Teachers::SetFundingEligibility).to have_received(:new).with(teacher:, author:)
         end
       end
     end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -228,28 +228,6 @@ RSpec.describe Schools::RegisterECT do
           end
         end
 
-        context "when a Teacher has a future ECT period at a different school" do
-          let(:other_school) { FactoryBot.create(:school) }
-          let(:started_on) { Date.new(2025, 8, 1) + 1.year }
-          let!(:future_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: started_on.year) }
-          let!(:future_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: future_contract_period) }
-
-          before do
-            # Future period at other school
-            FactoryBot.create(
-              :ect_at_school_period,
-              teacher:,
-              school: other_school,
-              started_on: 1.month.from_now,
-              finished_on: 6.months.from_now
-            )
-          end
-
-          it "allows registration with non-overlapping future date" do
-            expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
-          end
-        end
-
         context "when no SchoolPartnerships exist" do
           it "creates a TrainingPeriod linked to the ECTAtSchoolPeriod and with an expression of interest for the ActiveLeadProvider" do
             expect { service.register! }.to change(TrainingPeriod, :count).by(1)

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -174,8 +174,8 @@ RSpec.describe Schools::RegisterMentor do
         end
 
         context "on the last day of the contract period" do
-          let(:travel_date) { Date.new(2026, 5, 31) }
-          let(:started_on) { travel_date }
+          let(:overridden_current_date) { contract_period.finished_on }
+          let(:started_on) { overridden_current_date }
 
           it "finds the correct contract period and schedule" do
             expect { service.register! }.to change(Teacher, :count).from(0).to(1)
@@ -183,7 +183,7 @@ RSpec.describe Schools::RegisterMentor do
             training_period = TrainingPeriod.find_by!(started_on:)
 
             expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-            expect(training_period.schedule.contract_period_year).to be(2025)
+            expect(training_period.schedule.contract_period_year).to be(contract_period.year)
           end
         end
       end
@@ -212,8 +212,8 @@ RSpec.describe Schools::RegisterMentor do
         end
 
         context "on the last day of the contract period" do
-          let(:travel_date) { Date.new(2026, 5, 31) }
-          let(:started_on) { travel_date }
+          let(:overridden_current_date) { contract_period.finished_on }
+          let(:started_on) { overridden_current_date }
 
           it "finds the correct contract period and schedule" do
             expect { service.register! }.to change(Teacher, :count).from(0).to(1)
@@ -221,7 +221,7 @@ RSpec.describe Schools::RegisterMentor do
             training_period = TrainingPeriod.find_by!(started_on:)
 
             expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-            expect(training_period.schedule.contract_period_year).to be(2025)
+            expect(training_period.schedule.contract_period_year).to be(contract_period.year)
           end
         end
       end

--- a/spec/support/schedule_helpers.rb
+++ b/spec/support/schedule_helpers.rb
@@ -4,9 +4,9 @@
 # Therefore it is best to fix time to a safe point in the year when schedules are known to exist.
 RSpec.shared_context "safe_schedules" do
   let(:mid_year) { Date.new(Date.current.year, 9, 1) }
-  let(:travel_date) { mid_year }
+  let(:overridden_current_date) { mid_year }
 
   around do |example|
-    travel_to(travel_date) { example.run }
+    travel_to(overridden_current_date) { example.run }
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3740

### Changes proposed in this pull request

As part of testing before launch, we uncovered a small [bug].

When an ECT is reported as leaving by a school (or reported as joining by another school), their current school are still able to make changes to their training (e.g via training programme or lead provider) until they have left.

This means it is possible to create training histories that don't make sense semantically. Specifically, you can end up with a Teacher with multiple ongoing training periods.

This isn't supposed to be possible!

We have the `trainee_distinct_period` validation, which is supposed to ensure training periods don't overlap (including preventing multiple ongoing periods), but this wasn't working as expected.

Before, the `#siblings` method only accounted for training periods belonging to the associated `*_at_school_period`.

But in this context, we actually care about all the training periods belonging to `*_at_school_periods` for the same Teacher.

This reworks that method so it returns those records. We have also extended the overlap validation to check whether the `finished_on` is blank (which was previously unaccounted for).

As part of this change, we have added some unit tests to the relevant models that explicitly cover concurrent ongoing periods. This should give us more confidence this isn't possible.

[bug]: https://github.com/DFE-Digital/register-ects-project-board/issues/3651

### Guidance to review
