### PR TITLE
[3642] Allow future event dates

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -108,7 +108,6 @@ class Event < ApplicationRecord
   validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
 
   validate :check_author_present
-  validate :event_happened_in_the_past
 
   scope :earliest_first, -> { order(happened_at: "asc") }
   scope :latest_first, -> { order(happened_at: "desc") }
@@ -123,12 +122,5 @@ private
     return if author_id.present? || author_email.present?
 
     errors.add(:base, "Author is missing")
-  end
-
-  def event_happened_in_the_past
-    return if happened_at.blank?
-    return if happened_at <= Time.zone.now
-
-    errors.add(:happened_at, "Event must have already happened")
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -86,19 +86,13 @@ describe Event do
   describe "#happened_at" do
     it { is_expected.to validate_presence_of(:happened_at) }
 
-    describe "#event_happened_in_the_past" do
+    describe "future dates" do
       subject { FactoryBot.build(:event, happened_at:) }
-
-      before { subject.valid? }
 
       context "when happened_at is in the future" do
         let(:happened_at) { 1.minute.from_now }
 
-        it { is_expected.to(be_invalid) }
-
-        it "has a validation error" do
-          expect(subject.errors.messages[:happened_at]).to include("Event must have already happened")
-        end
+        it { is_expected.to(be_valid) }
       end
 
       context "when happened_at is in the past" do


### PR DESCRIPTION
### Context

Remove the `Event` validation that rejected future `happened_at` values.

This fixes [failures](https://dfe-teacher-services.sentry.io/issues/6871425829/?environment=migration&project=4508369974788096&query=is%3Aunresolved&referrer=issue-stream) when future dated leaving events are recorded asynchronously by `RecordEventJob`.

### Changes proposed

Remove the custom past only validation from `Event`