### PR TITLE
[3646] Fix disparity on `updated_at` on GET schools between ECF1 and RECT, so `updated_at` only shows cohort specific `updated_at` changes in RECT

### DIFF
--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -43,7 +43,11 @@ module API
       end
 
       def sort
-        sort_order(sort: school_params[:sort], model: School, default: { created_at: :asc })
+        sort_order(sort: school_params[:sort], model: sort_model, default: { created_at: :asc })
+      end
+
+      def sort_model
+        school_params[:sort]&.include?("updated_at") ? Metadata::SchoolContractPeriod : School
       end
 
       def urn

--- a/app/migration/legacy_data_importer.rb
+++ b/app/migration/legacy_data_importer.rb
@@ -8,7 +8,10 @@ class LegacyDataImporter
       migrator.queue if migrator.runnable?
     end
 
-    Metadata::Manager.refresh_all_metadata!(async: true) if DataMigration.incomplete.none?
+    if DataMigration.incomplete.none?
+      Metadata::SchoolContractPeriod.bypass_update_restrictions { create_schools_metadata }
+      Metadata::Manager.refresh_all_metadata!(async: true, excluding_handlers: [Metadata::Handlers::School])
+    end
   end
 
   def reset!
@@ -29,5 +32,25 @@ private
 
   def migrators_in_dependency_order
     Migrators::Base.migrators_in_dependency_order
+  end
+
+  # We need to handle this manually to ensure the correct
+  # api_updated_at is pulled across from ECF.
+  def create_schools_metadata
+    school_cohort_updated_at_by_school_urn = Migration::SchoolCohort
+      .joins(:cohort, :school)
+      .pluck("cohorts.start_year, schools.urn, school_cohorts.updated_at, schools.updated_at")
+      .each_with_object(Hash.new { |hash, key| hash[key] = {} }) do |(cohort_start_year, school_urn, school_cohort_updated_at, school_updated_at), hash|
+        hash[school_urn][cohort_start_year] = [school_cohort_updated_at, school_updated_at].max
+      end
+
+    School.includes(:contract_period_metadata).find_each do |school|
+      Metadata::Manager.new.refresh_metadata!(school)
+
+      school_cohort_updated_at_by_school_urn.fetch(school.urn.to_s, {}).each do |contract_period_year, school_cohort_updated_at|
+        metadata = school.contract_period_metadata.reload.find { it.contract_period_year == contract_period_year }
+        metadata.update!(api_updated_at: school_cohort_updated_at)
+      end
+    end
   end
 end

--- a/app/migration/legacy_data_importer.rb
+++ b/app/migration/legacy_data_importer.rb
@@ -8,10 +8,7 @@ class LegacyDataImporter
       migrator.queue if migrator.runnable?
     end
 
-    if DataMigration.incomplete.none?
-      Metadata::SchoolContractPeriod.bypass_update_restrictions { create_schools_metadata }
-      Metadata::Manager.refresh_all_metadata!(async: true, excluding_handlers: [Metadata::Handlers::School])
-    end
+    Metadata::Manager.refresh_all_metadata!(async: true) if DataMigration.incomplete.none?
   end
 
   def reset!
@@ -32,25 +29,5 @@ private
 
   def migrators_in_dependency_order
     Migrators::Base.migrators_in_dependency_order
-  end
-
-  # We need to handle this manually to ensure the correct
-  # api_updated_at is pulled across from ECF.
-  def create_schools_metadata
-    school_cohort_updated_at_by_school_urn = Migration::SchoolCohort
-      .joins(:cohort, :school)
-      .pluck("cohorts.start_year, schools.urn, school_cohorts.updated_at, schools.updated_at")
-      .each_with_object(Hash.new { |hash, key| hash[key] = {} }) do |(cohort_start_year, school_urn, school_cohort_updated_at, school_updated_at), hash|
-        hash[school_urn][cohort_start_year] = [school_cohort_updated_at, school_updated_at].max
-      end
-
-    School.includes(:contract_period_metadata).find_each do |school|
-      Metadata::Manager.new.refresh_metadata!(school)
-
-      school_cohort_updated_at_by_school_urn.fetch(school.urn.to_s, {}).each do |contract_period_year, school_cohort_updated_at|
-        metadata = school.contract_period_metadata.reload.find { it.contract_period_year == contract_period_year }
-        metadata.update!(api_updated_at: school_cohort_updated_at)
-      end
-    end
   end
 end

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -63,8 +63,7 @@ module Migrators
 
         [
           compare_fields(gias_school:, ecf_school:),
-          update_school!(school: gias_school.school, ecf_school:),
-          create_or_update_contract_period_metadata!(school: gias_school.school, ecf_school:),
+          update_school!(school: gias_school.school, ecf_school:)
         ].all?
       end
     end
@@ -126,16 +125,6 @@ module Migrators
       }
 
       school.update_columns(attrs)
-    end
-
-    def create_or_update_contract_period_metadata!(school:, ecf_school:)
-      Metadata::Manager.new.refresh_metadata!(school)
-
-      ecf_school.school_cohorts.map { |school_cohort|
-        contract_period_year = school_cohort.cohort.start_year
-        metadata = school.contract_period_metadata.find { it.contract_period_year == contract_period_year }
-        metadata.update!(api_updated_at: [school.updated_at, school_cohort.updated_at].max)
-      }.all?
     end
   end
 end

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -13,7 +13,7 @@ module Migrators
 
     MISMATCH_FIELD_MESSAGE = ->(school, field, gias_value, ecf_value) { ":#{field} - School #{school.urn} (#{school.name}) mismatch value on field named '#{field}': '#{ecf_value}' on ECF whilst '#{gias_value}' expected on RECT!" }
 
-    def self.dependencies = %i[gias_import gias_childrens_centres]
+    def self.dependencies = %i[contract_period gias_import gias_childrens_centres]
 
     def self.model = :school
 
@@ -64,6 +64,7 @@ module Migrators
         [
           compare_fields(gias_school:, ecf_school:),
           update_school!(school: gias_school.school, ecf_school:),
+          create_or_update_contract_period_metadata!(school: gias_school.school, ecf_school:),
         ].all?
       end
     end
@@ -121,10 +122,20 @@ module Migrators
         api_id: ecf_school.id,
         induction_tutor_name: induction_coordinator&.full_name,
         induction_tutor_email: induction_coordinator&.email,
-        created_at: ecf_school.created_at,
-        api_updated_at: ecf_school.updated_at
+        created_at: ecf_school.created_at
       }
+
       school.update_columns(attrs)
+    end
+
+    def create_or_update_contract_period_metadata!(school:, ecf_school:)
+      Metadata::Manager.new.refresh_metadata!(school)
+
+      ecf_school.school_cohorts.map { |school_cohort|
+        contract_period_year = school_cohort.cohort.start_year
+        metadata = school.contract_period_metadata.find { it.contract_period_year == contract_period_year }
+        metadata.update!(api_updated_at: [school.updated_at, school_cohort.updated_at].max)
+      }.all?
     end
   end
 end

--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -4,7 +4,7 @@ class GIAS::School < ApplicationRecord
 
   include DeclarativeUpdates
 
-  touch -> { school }, when_changing: %i[name], timestamp_attribute: :api_updated_at
+  touch -> { contract_period_metadata }, when_changing: %i[name], timestamp_attribute: :api_updated_at
 
   # Enums
   enum :status,
@@ -18,6 +18,7 @@ class GIAS::School < ApplicationRecord
   # Associations
   has_one :school, foreign_key: :urn, primary_key: :urn, inverse_of: :gias_school
   has_many :gias_school_links, class_name: "GIAS::SchoolLink", foreign_key: :urn, dependent: :destroy, inverse_of: :from_gias_school
+  has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod", through: :school
 
   # Validations
   validates :establishment_number,

--- a/app/models/metadata/school_contract_period.rb
+++ b/app/models/metadata/school_contract_period.rb
@@ -19,6 +19,6 @@ module Metadata
     validates :induction_programme_choice, inclusion: { in: induction_programme_choices.keys }
     validates :school_id, uniqueness: { scope: %i[contract_period_year] }
 
-    touch -> { school }, on_event: :update, when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at
+    touch -> { self }, on_event: :update, when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at
   end
 end

--- a/app/models/metadata/school_lead_provider_contract_period.rb
+++ b/app/models/metadata/school_lead_provider_contract_period.rb
@@ -7,6 +7,7 @@ module Metadata
     belongs_to :school
     belongs_to :lead_provider
     belongs_to :contract_period, foreign_key: :contract_period_year
+    has_many :contract_period_metadata, class_name: "Metadata::SchoolContractPeriod", through: :school
 
     validates :school, presence: true
     validates :lead_provider, presence: true
@@ -14,6 +15,6 @@ module Metadata
     validates :expression_of_interest_or_school_partnership, inclusion: { in: [true, false] }
     validates :school_id, uniqueness: { scope: %i[lead_provider_id contract_period_year] }
 
-    touch -> { school }, on_event: :update, when_changing: %i[expression_of_interest_or_school_partnership], timestamp_attribute: :api_updated_at
+    touch -> { contract_period_metadata }, on_event: :update, when_changing: %i[expression_of_interest_or_school_partnership], timestamp_attribute: :api_updated_at
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -28,7 +28,7 @@ class School < ApplicationRecord
   has_many :training_periods, through: :school_partnerships
   has_many :school_funding_eligibilities, foreign_key: :school_urn, primary_key: :urn, inverse_of: :school
 
-  touch -> { self }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
+  touch -> { contract_period_metadata }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
   touch -> { school_partnerships }, when_changing: %i[urn induction_tutor_name induction_tutor_email], timestamp_attribute: :api_updated_at
   touch -> { ect_teachers }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
   touch -> { mentor_teachers }, when_changing: %i[urn], timestamp_attribute: :api_updated_at

--- a/app/serializers/api/school_serializer.rb
+++ b/app/serializers/api/school_serializer.rb
@@ -29,8 +29,8 @@ class API::SchoolSerializer < Blueprinter::Base
     field :created_at do |data|
       data[:school].created_at
     end
-    field(:updated_at) do |data|
-      data[:school].api_updated_at
+    field(:updated_at) do |data, options|
+      contract_period_metadata(school: data[:school], options:).api_updated_at
     end
 
     class << self

--- a/app/services/api/schools/query.rb
+++ b/app/services/api/schools/query.rb
@@ -100,7 +100,7 @@ module API::Schools
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      scope.merge!(School.where(api_updated_at: updated_since..))
+      scope.merge!(Metadata::SchoolContractPeriod.where(api_updated_at: updated_since..))
     end
 
     def set_sort_by(sort)

--- a/app/services/metadata/manager.rb
+++ b/app/services/metadata/manager.rb
@@ -9,8 +9,9 @@ module Metadata
     end
 
     class << self
-      def refresh_all_metadata!(async: false, track_changes: false)
-        Resolver.all_handlers.each { it.refresh_all_metadata!(async:, track_changes:) }
+      def refresh_all_metadata!(async: false, track_changes: false, excluding_handlers: [])
+        handlers = Resolver.all_handlers.reject { |handler| handler.in?(excluding_handlers) }
+        handlers.each { it.refresh_all_metadata!(async:, track_changes:) }
       end
 
       def destroy_all_metadata!

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -135,7 +135,6 @@ shared:
     - id
     - created_at
     - updated_at
-    - api_updated_at
     - urn
     - induction_tutor_last_nominated_in
     - induction_tutor_name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -361,6 +361,7 @@
   - induction_programme_choice
   - created_at
   - updated_at
+  - api_updated_at
   :metadata_delivery_partners_lead_providers:
   - id
   - delivery_partner_id

--- a/db/migrate/20260408093916_add_api_updated_at_to_metadata_schools_contract_periods.rb
+++ b/db/migrate/20260408093916_add_api_updated_at_to_metadata_schools_contract_periods.rb
@@ -1,0 +1,5 @@
+class AddAPIUpdatedAtToMetadataSchoolsContractPeriods < ActiveRecord::Migration[8.0]
+  def change
+    add_column :metadata_schools_contract_periods, :api_updated_at, :datetime, default: -> { "CURRENT_TIMESTAMP" }
+  end
+end

--- a/db/migrate/20260408101455_remove_api_updated_at_from_schools.rb
+++ b/db/migrate/20260408101455_remove_api_updated_at_from_schools.rb
@@ -1,0 +1,5 @@
+class RemoveAPIUpdatedAtFromSchools < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :schools, :api_updated_at, :datetime
+  end
+end

--- a/db/migrate/20260408171244_switch_not_null_from_metadata_schools_contract_periods.rb
+++ b/db/migrate/20260408171244_switch_not_null_from_metadata_schools_contract_periods.rb
@@ -1,0 +1,5 @@
+class SwitchNotNullFromMetadataSchoolsContractPeriods < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :metadata_schools_contract_periods, :contract_period_year, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -566,12 +566,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_164213) do
   end
 
   create_table "metadata_schools_contract_periods", force: :cascade do |t|
-    t.integer "contract_period_year"
+    t.integer "contract_period_year", null: false
     t.datetime "created_at", null: false
     t.boolean "in_partnership", null: false
     t.enum "induction_programme_choice", null: false, enum_type: "induction_programme_choice"
     t.bigint "school_id", null: false
     t.datetime "updated_at", null: false
+    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["contract_period_year"], name: "idx_on_contract_period_year_e703aaa45a"
     t.index ["school_id", "contract_period_year"], name: "idx_on_school_id_contract_period_year_0dae2d65f6", unique: true
     t.index ["school_id"], name: "index_metadata_schools_contract_periods_on_school_id"
@@ -797,7 +798,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_164213) do
     t.datetime "updated_at", null: false
     t.integer "urn", null: false
     t.index ["api_id"], name: "index_schools_on_api_id", unique: true
-    t.index ["api_updated_at"], name: "index_schools_on_api_updated_at"
     t.index ["last_chosen_appropriate_body_id"], name: "index_schools_on_last_chosen_appropriate_body_id"
     t.index ["last_chosen_lead_provider_id"], name: "index_schools_on_last_chosen_lead_provider_id"
     t.index ["urn"], name: "schools_unique_urn", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -786,7 +786,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_164213) do
 
   create_table "schools", force: :cascade do |t|
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "created_at", null: false
     t.citext "induction_tutor_email"
     t.integer "induction_tutor_last_nominated_in"

--- a/db/scripts/fix_schools_api_updated_at.rb
+++ b/db/scripts/fix_schools_api_updated_at.rb
@@ -1,0 +1,18 @@
+# We need to handle this manually to ensure the correct
+# api_updated_at is pulled across from ECF.
+
+Metadata::SchoolContractPeriod.bypass_update_restrictions do
+  school_cohort_updated_at_by_school_urn = Migration::SchoolCohort
+    .joins(:cohort, :school)
+    .pluck("cohorts.start_year, schools.urn, school_cohorts.updated_at, schools.updated_at")
+    .each_with_object(Hash.new { |hash, key| hash[key] = {} }) do |(cohort_start_year, school_urn, school_cohort_updated_at, school_updated_at), hash|
+      hash[school_urn][cohort_start_year] = [school_cohort_updated_at, school_updated_at].max
+    end
+
+  School.includes(:contract_period_metadata).find_each do |school|
+    school_cohort_updated_at_by_school_urn.fetch(school.urn.to_s, {}).each do |contract_period_year, school_cohort_updated_at|
+      metadata = school.contract_period_metadata.find { it.contract_period_year == contract_period_year }
+      metadata.update!(api_updated_at: school_cohort_updated_at)
+    end
+  end
+end

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -133,7 +133,6 @@ erDiagram
     integer last_chosen_appropriate_body_id
     integer last_chosen_lead_provider_id
     enum last_chosen_training_programme
-    datetime api_updated_at
     string induction_tutor_name
     citext induction_tutor_email
     uuid api_id
@@ -580,6 +579,7 @@ erDiagram
     enum induction_programme_choice
     datetime created_at
     datetime updated_at
+    datetime api_updated_at
   }
   Metadata_SchoolContractPeriod }o--|| School : belongs_to
   Metadata_SchoolContractPeriod }o--|| ContractPeriod : belongs_to

--- a/spec/migration/legacy_data_importer_spec.rb
+++ b/spec/migration/legacy_data_importer_spec.rb
@@ -37,56 +37,8 @@ RSpec.describe LegacyDataImporter, :with_metadata do
       it "initiates an async refresh of the metadata" do
         allow(Migrators::Base).to receive(:migrators).and_return([])
 
-        expect(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true, excluding_handlers: [Metadata::Handlers::School])
+        expect(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true)
         importer.migrate!
-      end
-
-      context "when we have to create school contract period metadata" do
-        let!(:migration_school_1) { FactoryBot.create(:ecf_migration_school) }
-        let!(:migration_school_cohort_1) { FactoryBot.create(:migration_school_cohort, school: migration_school_1) }
-        let!(:migrated_school_1) { FactoryBot.create(:school, urn: migration_school_1.urn) }
-        let!(:migration_school_2) { FactoryBot.create(:ecf_migration_school) }
-        let!(:migration_school_cohort_2) { FactoryBot.create(:migration_school_cohort, school: migration_school_2) }
-        let!(:migrated_school_2) { FactoryBot.create(:school, urn: migration_school_2.urn) }
-
-        around do |example|
-          Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
-        end
-
-        before do
-          allow(Migrators::Base).to receive(:migrators).and_return([])
-          allow(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true, excluding_handlers: [Metadata::Handlers::School])
-        end
-
-        it "calls .refresh_metadata! on the `Metadata::Manager` for each school" do
-          manager = instance_double(Metadata::Manager, refresh_metadata!: nil)
-          allow(Metadata::Manager).to receive(:new) { manager }
-
-          importer.migrate!
-
-          expect(manager).to have_received(:refresh_metadata!).with(migrated_school_1)
-          expect(manager).to have_received(:refresh_metadata!).with(migrated_school_2)
-        end
-
-        it "creates the correct school contract period metadata" do
-          importer.migrate!
-
-          ecf_schools = [migration_school_1, migration_school_2]
-          schools_by_urn = School.where(urn: ecf_schools.map(&:urn)).index_by(&:urn)
-          metadata_by_school_and_year = Metadata::SchoolContractPeriod.where(school: schools_by_urn.values).index_by do |metadata|
-            [metadata.school_id, metadata.contract_period_year]
-          end
-
-          ecf_schools.each do |ecf_school|
-            school = schools_by_urn[ecf_school.urn.to_i]
-            ecf_school.school_cohorts.each do |school_cohort|
-              metadata = metadata_by_school_and_year[[school.id, school_cohort.cohort.start_year]]
-              expect(metadata.contract_period_year).to eq(school_cohort.cohort.start_year)
-              expect(metadata.api_updated_at).to eq([ecf_school.updated_at, school_cohort.updated_at].max)
-              expect(metadata.school).to eq(school)
-            end
-          end
-        end
       end
     end
   end

--- a/spec/migration/legacy_data_importer_spec.rb
+++ b/spec/migration/legacy_data_importer_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe LegacyDataImporter do
+RSpec.describe LegacyDataImporter, :with_metadata do
   include ActiveJob::TestHelper
 
   subject(:importer) { described_class.new }
@@ -37,8 +37,56 @@ RSpec.describe LegacyDataImporter do
       it "initiates an async refresh of the metadata" do
         allow(Migrators::Base).to receive(:migrators).and_return([])
 
-        expect(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true)
+        expect(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true, excluding_handlers: [Metadata::Handlers::School])
         importer.migrate!
+      end
+
+      context "when we have to create school contract period metadata" do
+        let!(:migration_school_1) { FactoryBot.create(:ecf_migration_school) }
+        let!(:migration_school_cohort_1) { FactoryBot.create(:migration_school_cohort, school: migration_school_1) }
+        let!(:migrated_school_1) { FactoryBot.create(:school, urn: migration_school_1.urn) }
+        let!(:migration_school_2) { FactoryBot.create(:ecf_migration_school) }
+        let!(:migration_school_cohort_2) { FactoryBot.create(:migration_school_cohort, school: migration_school_2) }
+        let!(:migrated_school_2) { FactoryBot.create(:school, urn: migration_school_2.urn) }
+
+        around do |example|
+          Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
+        end
+
+        before do
+          allow(Migrators::Base).to receive(:migrators).and_return([])
+          allow(Metadata::Manager).to receive(:refresh_all_metadata!).with(async: true, excluding_handlers: [Metadata::Handlers::School])
+        end
+
+        it "calls .refresh_metadata! on the `Metadata::Manager` for each school" do
+          manager = instance_double(Metadata::Manager, refresh_metadata!: nil)
+          allow(Metadata::Manager).to receive(:new) { manager }
+
+          importer.migrate!
+
+          expect(manager).to have_received(:refresh_metadata!).with(migrated_school_1)
+          expect(manager).to have_received(:refresh_metadata!).with(migrated_school_2)
+        end
+
+        it "creates the correct school contract period metadata" do
+          importer.migrate!
+
+          ecf_schools = [migration_school_1, migration_school_2]
+          schools_by_urn = School.where(urn: ecf_schools.map(&:urn)).index_by(&:urn)
+          metadata_by_school_and_year = Metadata::SchoolContractPeriod.where(school: schools_by_urn.values).index_by do |metadata|
+            [metadata.school_id, metadata.contract_period_year]
+          end
+
+          ecf_schools.each do |ecf_school|
+            school = schools_by_urn[ecf_school.urn.to_i]
+            ecf_school.school_cohorts.each do |school_cohort|
+              metadata = metadata_by_school_and_year[[school.id, school_cohort.cohort.start_year]]
+              expect(metadata.contract_period_year).to eq(school_cohort.cohort.start_year)
+              expect(metadata.api_updated_at).to eq([ecf_school.updated_at, school_cohort.updated_at].max)
+              expect(metadata.school).to eq(school)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -12,6 +12,7 @@ describe Migrators::School do
                       school_type_name: "Academy converter").tap do |ecf_school|
       FactoryBot.create(:ecf_migration_school_local_authority, school: ecf_school)
       FactoryBot.create(:migration_induction_coordinator_profile, schools: [ecf_school])
+      FactoryBot.create(:migration_school_cohort, school: ecf_school)
     end
   end
 
@@ -29,16 +30,46 @@ describe Migrators::School do
                       ukprn: ecf_school.ukprn)
   end
 
-  it_behaves_like "a migrator", :school, %i[gias_import gias_childrens_centres] do
+  around do |example|
+    Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
+  end
+
+  it_behaves_like "a migrator", :school, %i[contract_period gias_import gias_childrens_centres], creates_metadata: true do
     def create_migration_resource = create_ecf_school
 
-    def create_resource(migration_resource) = create_gias_school(migration_resource)
+    def create_resource(migration_resource)
+      migration_resource.school_cohorts.each do |school_cohort|
+        FactoryBot.create(:contract_period, year: school_cohort.cohort.start_year)
+      end
+
+      create_gias_school(migration_resource)
+    end
 
     def setup_failure_state
       ecf_school = create_migration_resource
       gias_school = create_resource(ecf_school)
 
       gias_school.update!(section_41_approved: !ecf_school.section_41_approved)
+    end
+
+    it "creates the correct metadata" do
+      instance.migrate!
+
+      ecf_schools = [migration_resource1, migration_resource2]
+      schools_by_urn = School.where(urn: ecf_schools.map(&:urn)).index_by(&:urn)
+      metadata_by_school_and_year = Metadata::SchoolContractPeriod.where(school: schools_by_urn.values).index_by do |metadata|
+        [metadata.school_id, metadata.contract_period_year]
+      end
+
+      ecf_schools.each do |ecf_school|
+        school = schools_by_urn[ecf_school.urn.to_i]
+        ecf_school.school_cohorts.each do |school_cohort|
+          metadata = metadata_by_school_and_year[[school.id, school_cohort.cohort.start_year]]
+          expect(metadata.contract_period_year).to eq(school_cohort.cohort.start_year)
+          expect(metadata.api_updated_at).to eq([school.updated_at, school_cohort.updated_at].max)
+          expect(metadata.school).to eq(school)
+        end
+      end
     end
   end
 
@@ -64,6 +95,7 @@ describe Migrators::School do
       context "when the school is closed and with induction records" do
         let!(:induction_record) { FactoryBot.create(:migration_induction_record) }
         let!(:ecf_school) { induction_record.school }
+        let!(:contract_period) { FactoryBot.create(:contract_period, year: ecf_school.school_cohorts.first.cohort.start_year) }
         let(:rect_school) { School.find_by_urn(ecf_school.urn) }
 
         before do
@@ -231,7 +263,6 @@ describe Migrators::School do
         expect(data_migration.reload.failure_count).to eq(0)
         gias_school.reload
         expect(gias_school.school.created_at).to eq(ecf_school.created_at)
-        expect(gias_school.school.api_updated_at).to eq(ecf_school.updated_at)
       end
 
       it "syncs the induction coordinator details" do

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -30,11 +30,7 @@ describe Migrators::School do
                       ukprn: ecf_school.ukprn)
   end
 
-  around do |example|
-    Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
-  end
-
-  it_behaves_like "a migrator", :school, %i[contract_period gias_import gias_childrens_centres], creates_metadata: true do
+  it_behaves_like "a migrator", :school, %i[contract_period gias_import gias_childrens_centres] do
     def create_migration_resource = create_ecf_school
 
     def create_resource(migration_resource)
@@ -50,26 +46,6 @@ describe Migrators::School do
       gias_school = create_resource(ecf_school)
 
       gias_school.update!(section_41_approved: !ecf_school.section_41_approved)
-    end
-
-    it "creates the correct metadata" do
-      instance.migrate!
-
-      ecf_schools = [migration_resource1, migration_resource2]
-      schools_by_urn = School.where(urn: ecf_schools.map(&:urn)).index_by(&:urn)
-      metadata_by_school_and_year = Metadata::SchoolContractPeriod.where(school: schools_by_urn.values).index_by do |metadata|
-        [metadata.school_id, metadata.contract_period_year]
-      end
-
-      ecf_schools.each do |ecf_school|
-        school = schools_by_urn[ecf_school.urn.to_i]
-        ecf_school.school_cohorts.each do |school_cohort|
-          metadata = metadata_by_school_and_year[[school.id, school_cohort.cohort.start_year]]
-          expect(metadata.contract_period_year).to eq(school_cohort.cohort.start_year)
-          expect(metadata.api_updated_at).to eq([school.updated_at, school_cohort.updated_at].max)
-          expect(metadata.school).to eq(school)
-        end
-      end
     end
   end
 

--- a/spec/models/gias/school_spec.rb
+++ b/spec/models/gias/school_spec.rb
@@ -33,8 +33,10 @@ describe GIAS::School do
   end
 
   describe "declarative touch" do
-    let(:instance) { target&.gias_school || FactoryBot.create(:gias_school) }
-    let(:target) { FactoryBot.create(:school, :independent) }
+    let(:instance) { FactoryBot.create(:gias_school, :with_school) }
+    let(:target) { instance.contract_period_metadata }
+
+    before { Metadata::Handlers::School.new(instance.school).refresh_metadata! }
 
     it_behaves_like "a declarative touch model", when_changing: %i[name], timestamp_attribute: :api_updated_at
   end
@@ -60,6 +62,7 @@ describe GIAS::School do
   describe "associations" do
     it { is_expected.to have_one(:school).with_primary_key(:urn).with_foreign_key(:urn).inverse_of(:gias_school) }
     it { is_expected.to have_many(:gias_school_links).with_foreign_key(:urn).dependent(:destroy).class_name("GIAS::SchoolLink").inverse_of(:from_gias_school) }
+    it { is_expected.to have_many(:contract_period_metadata).class_name("Metadata::SchoolContractPeriod").through(:school) }
   end
 
   describe "validations" do

--- a/spec/models/metadata/school_contract_period_spec.rb
+++ b/spec/models/metadata/school_contract_period_spec.rb
@@ -2,14 +2,14 @@ describe Metadata::SchoolContractPeriod do
   include_context "restricts updates to the Metadata namespace", :school_contract_period_metadata
 
   describe "declarative touch" do
-    let(:instance) { FactoryBot.create(:school_contract_period_metadata, school: target) }
-    let(:target) { FactoryBot.create(:school) }
+    let(:instance) { FactoryBot.create(:school_contract_period_metadata) }
+    let(:target) { instance }
 
     around do |example|
       Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
     end
 
-    it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at, target_optional: false
+    it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at
   end
 
   describe "enums" do

--- a/spec/models/metadata/school_lead_provider_contract_period_spec.rb
+++ b/spec/models/metadata/school_lead_provider_contract_period_spec.rb
@@ -2,8 +2,12 @@ describe Metadata::SchoolLeadProviderContractPeriod do
   include_context "restricts updates to the Metadata namespace", :school_lead_provider_contract_period_metadata
 
   describe "declarative touch" do
-    let(:instance) { FactoryBot.create(:school_lead_provider_contract_period_metadata, school: target) }
-    let(:target) { FactoryBot.create(:school) }
+    let(:target) { FactoryBot.create(:school_contract_period_metadata) }
+    let(:instance) do
+      FactoryBot.create(:school_lead_provider_contract_period_metadata,
+                        school: target.school,
+                        contract_period: target.contract_period)
+    end
 
     around do |example|
       Metadata::SchoolLeadProviderContractPeriod.bypass_update_restrictions { example.run }
@@ -16,6 +20,7 @@ describe Metadata::SchoolLeadProviderContractPeriod do
     it { is_expected.to belong_to(:school) }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:contract_period).with_foreign_key(:contract_period_year) }
+    it { is_expected.to have_many(:contract_period_metadata).class_name("Metadata::SchoolContractPeriod").through(:school) }
   end
 
   describe "validations" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe School do
       FactoryBot.create(:gias_school, urn: new_value) if attribute_to_change == :urn
     end
 
-    context "target school" do
-      let(:target) { instance }
+    context "target contract_period_metadata" do
+      let(:target) { instance.contract_period_metadata }
+
+      before { Metadata::Handlers::School.new(instance).refresh_metadata! }
 
       it_behaves_like "a declarative touch model", when_changing: %i[urn], timestamp_attribute: :api_updated_at
     end

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
     it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
     it_behaves_like "a filter by delivery_partner_id endpoint", :delivery_partner_when_created
     it_behaves_like "a filter by participant_id endpoint"
-    it_behaves_like "a filter by updated_since endpoint", updated_at_column: :updated_at
+    it_behaves_like "a filter by updated_since endpoint" do
+      def set_updated_at(resource:, value:)
+        resource.update_columns(updated_at: value)
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/requests/api/v3/schools_spec.rb
+++ b/spec/requests/api/v3/schools_spec.rb
@@ -26,9 +26,23 @@ RSpec.describe "Schools API", :with_metadata, type: :request do
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "an index endpoint"
     it_behaves_like "a paginated endpoint"
-    it_behaves_like "a sortable endpoint"
+    it_behaves_like "a sortable endpoint" do
+      def set_updated_at(resource:, value:)
+        resource.contract_period_metadata.update_all(api_updated_at: value)
+      end
+
+      def sort_resources(resources, sort_attribute)
+        return resources.sort_by!(&:"#{sort_attribute}") unless /updated_at/.match?(sort_attribute)
+
+        resources.sort_by! { it.contract_period_metadata.map(&:"#{sort_attribute}") }
+      end
+    end
     it_behaves_like "a filter by a single cohort (contract_period year) endpoint"
-    it_behaves_like "a filter by updated_since endpoint"
+    it_behaves_like "a filter by updated_since endpoint" do
+      def set_updated_at(resource:, value:)
+        resource.contract_period_metadata.update_all(api_updated_at: value)
+      end
+    end
     it_behaves_like "a filter validatable endpoint", %i[cohort]
     it_behaves_like "a filter by urn endpoint"
   end
@@ -40,6 +54,10 @@ RSpec.describe "Schools API", :with_metadata, type: :request do
 
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "a show endpoint"
-    it_behaves_like "a does not filter by updated_since endpoint"
+    it_behaves_like "a does not filter by updated_since endpoint" do
+      def get_updated_at(resource:)
+        resource.contract_period_metadata.map(&:api_updated_at).max
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/transfers_spec.rb
+++ b/spec/requests/api/v3/transfers_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe "Participant transfers API", type: :request do
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "an index endpoint"
     it_behaves_like "a paginated endpoint"
-    it_behaves_like "a filter by updated_since endpoint", updated_at_column: :api_transfer_updated_at do
-      def set_updated_at(resource:, updated_at_column:, value:)
-        resource.ect_training_periods.each { it.update_columns("#{updated_at_column}": value) }
+    it_behaves_like "a filter by updated_since endpoint" do
+      def set_updated_at(resource:, value:)
+        resource.ect_training_periods.each { it.update_columns(api_transfer_updated_at: value) }
       end
     end
   end

--- a/spec/requests/api/v3/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/unfunded_mentors_spec.rb
@@ -44,8 +44,24 @@ RSpec.describe "Unfunded mentors API", type: :request do
     it_behaves_like "a token authenticated endpoint", :get
     it_behaves_like "an index endpoint"
     it_behaves_like "a paginated endpoint"
-    it_behaves_like "a filter by updated_since endpoint", updated_at_column: :api_unfunded_mentor_updated_at
-    it_behaves_like "a sortable endpoint", updated_at_column: :api_unfunded_mentor_updated_at
+    it_behaves_like "a filter by updated_since endpoint" do
+      def set_updated_at(resource:, value:)
+        resource.update_columns(api_unfunded_mentor_updated_at: value)
+      end
+    end
+    it_behaves_like "a sortable endpoint" do
+      def set_updated_at(resource:, value:)
+        resource.update_columns(api_unfunded_mentor_updated_at: value)
+      end
+
+      def transform_sort_attribute(sort_attribute)
+        if sort_attribute == "updated_at"
+          "api_unfunded_mentor_updated_at"
+        else
+          sort_attribute
+        end
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/serializers/api/school_serializer_spec.rb
+++ b/spec/serializers/api/school_serializer_spec.rb
@@ -6,8 +6,8 @@ describe API::SchoolSerializer, type: :serializer do
 
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:contract_period) { FactoryBot.create(:contract_period) }
-  let(:school) { FactoryBot.create(:school, :with_induction_tutor, created_at:, api_updated_at:) }
-  let!(:contract_period_metadata) { FactoryBot.create(:school_contract_period_metadata, school:, contract_period:) }
+  let(:school) { FactoryBot.create(:school, :with_induction_tutor, created_at:) }
+  let!(:contract_period_metadata) { FactoryBot.create(:school_contract_period_metadata, school:, contract_period:, api_updated_at:) }
   let!(:lead_provider_contract_period_metadata) do
     FactoryBot.create(:school_lead_provider_contract_period_metadata,
                       school:,
@@ -49,7 +49,7 @@ describe API::SchoolSerializer, type: :serializer do
       expect(attributes["induction_tutor_email"]).not_to be_nil
       expect(attributes["induction_tutor_email"]).to eq(school.induction_tutor_email)
       expect(attributes["created_at"]).to eq(school.created_at.utc.rfc3339)
-      expect(attributes["updated_at"]).to eq(school.api_updated_at.utc.rfc3339)
+      expect(attributes["updated_at"]).to eq(contract_period_metadata.api_updated_at.utc.rfc3339)
     end
   end
 end

--- a/spec/services/api/schools/query_spec.rb
+++ b/spec/services/api/schools/query_spec.rb
@@ -182,8 +182,10 @@ RSpec.describe API::Schools::Query, :with_metadata do
         end
 
         before do
-          school1.update!(api_updated_at: 2.days.ago)
-          school2.update!(api_updated_at: 10.minutes.ago)
+          Metadata::SchoolContractPeriod.bypass_update_restrictions do
+            school1.contract_period_metadata.find_by(contract_period:).update!(api_updated_at: 2.days.ago)
+            school2.contract_period_metadata.find_by(contract_period:).update!(api_updated_at: 10.minutes.ago)
+          end
         end
 
         it "filters by `updated_since`" do

--- a/spec/services/metadata/manager_spec.rb
+++ b/spec/services/metadata/manager_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe Metadata::Manager do
         refresh_all_metadata
       end
     end
+
+    context "when `excluding_handlers` is provided" do
+      subject(:refresh_all_metadata) { described_class.refresh_all_metadata!(async: true, excluding_handlers: [Metadata::Handlers::School]) }
+
+      it "does not call refresh_metadata! for the excluded handlers" do
+        Metadata::Resolver.all_handlers.each do |handler|
+          if handler == Metadata::Handlers::School
+            expect(handler).not_to receive(:refresh_all_metadata!)
+          else
+            expect(handler).to receive(:refresh_all_metadata!).with(async: true, track_changes: false)
+          end
+        end
+
+        refresh_all_metadata
+      end
+    end
   end
 
   describe ".destroy_all_metadata!" do

--- a/spec/support/shared_contexts/api/filterable_endpoint.rb
+++ b/spec/support/shared_contexts/api/filterable_endpoint.rb
@@ -57,18 +57,18 @@ RSpec.shared_examples "a filter by multiple cohorts (contract_period year) endpo
   end
 end
 
-RSpec.shared_examples "a filter by updated_since endpoint" do |updated_at_column: :api_updated_at|
+RSpec.shared_examples "a filter by updated_since endpoint" do
   let(:options) { defined?(serializer_options) ? serializer_options : {} }
-  let!(:resource_updated_one_week_ago) { create_resource(active_lead_provider:).tap { set_updated_at(resource: it, updated_at_column:, value: 1.week.ago) } }
-  let!(:resource_updated_one_month_ago) { create_resource(active_lead_provider:).tap { set_updated_at(resource: it, updated_at_column:, value: 1.month.ago) } }
+  let!(:resource_updated_one_week_ago) { create_resource(active_lead_provider:).tap { set_updated_at(resource: it, value: 1.week.ago) } }
+  let!(:resource_updated_one_month_ago) { create_resource(active_lead_provider:).tap { set_updated_at(resource: it, value: 1.month.ago) } }
 
   before do
     # Resource updated more than two months ago should not be included.
-    set_updated_at(resource: create_resource(active_lead_provider:), updated_at_column:, value: 3.months.ago)
+    set_updated_at(resource: create_resource(active_lead_provider:), value: 3.months.ago)
   end
 
-  def set_updated_at(resource:, updated_at_column:, value:)
-    resource.update_columns("#{updated_at_column}": value)
+  def set_updated_at(resource:, value:)
+    resource.update_columns(api_updated_at: value)
   end
 
   it "returns only resource that have been updated since the provided date" do
@@ -279,8 +279,12 @@ end
 RSpec.shared_examples "a does not filter by updated_since endpoint" do
   let(:options) { defined?(serializer_options) ? serializer_options : {} }
 
+  def get_updated_at(resource:)
+    resource.api_updated_at
+  end
+
   it "returns the resources, ignoring the `updated_since`" do
-    updated_since_after_resource_updated_at = (resource.api_updated_at + 1.day).utc.iso8601
+    updated_since_after_resource_updated_at = (get_updated_at(resource:) + 1.day).utc.iso8601
     authenticated_api_get(path, params: { filter: { updated_since: updated_since_after_resource_updated_at } })
 
     expect(response).to have_http_status(:ok)

--- a/spec/support/shared_contexts/api/sortable_endpoint.rb
+++ b/spec/support/shared_contexts/api/sortable_endpoint.rb
@@ -1,16 +1,23 @@
-RSpec.shared_examples "a sortable endpoint" do |additional_sorts = [], updated_at_column: :api_updated_at|
+RSpec.shared_examples "a sortable endpoint" do |additional_sorts = []|
   let!(:resources) do
     [
-      travel_to(2.days.ago) { create_resource(active_lead_provider:) }.tap { it.update!("#{updated_at_column}": 2.hours.ago) },
-      create_resource(active_lead_provider:).tap { it.update!("#{updated_at_column}": 3.hours.ago) },
-      travel_to(5.days.ago) { create_resource(active_lead_provider:) }.tap { it.update!("#{updated_at_column}": 1.day.ago) },
+      travel_to(2.days.ago) { create_resource(active_lead_provider:) }.tap { set_updated_at(resource: it, value: 2.hours.ago) },
+      create_resource(active_lead_provider:).tap { set_updated_at(resource: it, value: 3.hours.ago) },
+      travel_to(5.days.ago) { create_resource(active_lead_provider:) }.tap { set_updated_at(resource: it, value: 1.day.ago) },
     ]
   end
-  let(:updated_at_sort_attribute) { updated_at_column.to_s }
+
+  def set_updated_at(resource:, value:)
+    resource.update_columns(api_updated_at: value)
+  end
+
+  def sort_resources(resources, sort_attribute)
+    resources.sort_by!(&:"#{sort_attribute}")
+  end
 
   def transform_sort_attribute(sort_attribute)
     if sort_attribute == "updated_at"
-      updated_at_sort_attribute
+      "api_updated_at"
     else
       sort_attribute
     end
@@ -21,7 +28,7 @@ RSpec.shared_examples "a sortable endpoint" do |additional_sorts = [], updated_a
     it "returns the correct resources in the correct order" do
       # Sort resources based on the specified sort parameter.
       sort_attribute = transform_sort_attribute(sort[1..])
-      resources.sort_by!(&:"#{sort_attribute}").tap { |l| l.reverse! if sort[0] == "-" }
+      sort_resources(resources, sort_attribute).tap { |l| l.reverse! if sort[0] == "-" }
 
       authenticated_api_get(path, params: { sort: })
 

--- a/spec/support/shared_examples/migrator_support.rb
+++ b/spec/support/shared_examples/migrator_support.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: true, creates_metadata: false|
+RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: true|
   let(:worker) { 0 }
   let(:instance) { described_class.new(worker:) }
   let(:data_migration) { FactoryBot.create(:data_migration, model:, worker: 0) }
@@ -159,34 +159,21 @@ RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: tr
       migrate!
     end
 
-    if creates_metadata
-      it "creates metadata" do
-        dump_metadata_database_state = -> {
-          ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
-            rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
-            [table, rows]
-          end
-        }
+    it "does not create any metadata" do
+      dump_metadata_database_state = -> {
+        ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
+          rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
+          [table, rows]
+        end
+      }
 
-        expect { migrate! }.to(change { dump_metadata_database_state.call })
-      end
-    else
-      it "does not create any metadata" do
-        dump_metadata_database_state = -> {
-          ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
-            rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
-            [table, rows]
-          end
-        }
+      # Clear any metadata created via factories.
+      Metadata::Manager.destroy_all_metadata!
 
-        # Clear any metadata created via factories.
-        Metadata::Manager.destroy_all_metadata!
+      migrate!
 
-        migrate!
-
-        # Ensure the database state doesn't change when we clear all metadata (as there should be none).
-        expect { Metadata::Manager.destroy_all_metadata! }.not_to(change { dump_metadata_database_state.call })
-      end
+      # Ensure the database state doesn't change when we clear all metadata (as there should be none).
+      expect { Metadata::Manager.destroy_all_metadata! }.not_to(change { dump_metadata_database_state.call })
     end
 
     context "when retrying a migration" do

--- a/spec/support/shared_examples/migrator_support.rb
+++ b/spec/support/shared_examples/migrator_support.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: true|
+RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: true, creates_metadata: false|
   let(:worker) { 0 }
   let(:instance) { described_class.new(worker:) }
   let(:data_migration) { FactoryBot.create(:data_migration, model:, worker: 0) }
@@ -159,21 +159,34 @@ RSpec.shared_examples "a migrator" do |model, dependencies, multiple_workers: tr
       migrate!
     end
 
-    it "does not create any metadata" do
-      dump_metadata_database_state = -> {
-        ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
-          rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
-          [table, rows]
-        end
-      }
+    if creates_metadata
+      it "creates metadata" do
+        dump_metadata_database_state = -> {
+          ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
+            rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
+            [table, rows]
+          end
+        }
 
-      # Clear any metadata created via factories.
-      Metadata::Manager.destroy_all_metadata!
+        expect { migrate! }.to(change { dump_metadata_database_state.call })
+      end
+    else
+      it "does not create any metadata" do
+        dump_metadata_database_state = -> {
+          ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
+            rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
+            [table, rows]
+          end
+        }
 
-      migrate!
+        # Clear any metadata created via factories.
+        Metadata::Manager.destroy_all_metadata!
 
-      # Ensure the database state doesn't change when we clear all metadata (as there should be none).
-      expect { Metadata::Manager.destroy_all_metadata! }.not_to(change { dump_metadata_database_state.call })
+        migrate!
+
+        # Ensure the database state doesn't change when we clear all metadata (as there should be none).
+        expect { Metadata::Manager.destroy_all_metadata! }.not_to(change { dump_metadata_database_state.call })
+      end
     end
 
     context "when retrying a migration" do


### PR DESCRIPTION
### Context

Ticket: [3646](https://github.com/DFE-Digital/register-ects-project-board/issues/3646)

The school `updated_at` should reflect the filtered cohort in the schools API response.
In ECF it does this by looking at the most recent `updated_at` from the school or the school cohort.

### Changes proposed in this pull request

- De-couple the metadata so that it doesn't touch the school's `api_updated_at`;
- Add a new `api_updated_at` to the metadata;
- Touch the metadata `api_updated_at` when relevant/serialized school attribute change or when the `in_partnership` and `induction_programme_choice` changes;
- Surface the metadata `api_updated_at` in the serializer and use it in the query;
- Remove the school `api_updated_at`;
- Create the metadata for each contract period and populate the `api_updated_at` in the migrator instead of the school's `api_updated_at` (using the max of the ECF school `updated_at` and ECF school cohort `updated_at` as in the ECF serializer);

### Guidance to review

Review app