### PR TITLE
Increase timeout and recreate schema

### DIFF
--- a/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
@@ -84,7 +84,7 @@ runs:
       run: |
         bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 360 -x ${{ inputs.app-name }} -- psql -c "drop schema public cascade; create schema public;"
 
-        bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ec2-${{ inputs.environment }}-web -- psql
+        bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 -x ${{ inputs.app-name }} -- psql
 
     - name: Summary
       if: success()

--- a/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/directly-backup-and-restore-snapshot-database/action.yml
@@ -81,7 +81,10 @@ runs:
 
     - name: Restore snapshot database
       shell: bash
-      run: bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ec2-${{ inputs.environment }}-web -- psql
+      run: |
+        bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 360 -x ${{ inputs.app-name }} -- psql -c "drop schema public cascade; create schema public;"
+
+        bin/konduit.sh -n ${{ env.NAMESPACE }} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ec2-${{ inputs.environment }}-web -- psql
 
     - name: Summary
       if: success()

--- a/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
+++ b/.github/actions/restore-snapshot-database-from-azure-storage/action.yml
@@ -107,7 +107,7 @@ runs:
           COMPRESS_ARG=-c
         fi
 
-        ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 60 -x ${{ inputs.app-name }} -- psql -c "drop schema public cascade; create schema public;"
+        ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -t 360 -x ${{ inputs.app-name }} -- psql -c "drop schema public cascade; create schema public;"
 
         ./konduit.sh ${NAMESPACE_ARG} -d s189p01-cpdec2-pd-pg-snapshot -k s189p01-cpdec2-pd-inf-kv -i ${{ inputs.backup-file }} ${COMPRESS_ARG} -t 7200 -x ${{ inputs.app-name }} -- psql
 


### PR DESCRIPTION
### Context

See #2581 for more context

<img width="1284" height="963" alt="Screenshot 2026-04-09 at 14 29 49" src="https://github.com/user-attachments/assets/3ef6e045-fa77-4f7d-9bf6-25129c53d66f" />

For a prolonged period an 😈 was messing with the nightly snapshot restoration and during this time a manual restore was also failing.

<img width="1281" height="885" alt="Screenshot 2026-04-09 at 15 26 49" src="https://github.com/user-attachments/assets/a88812fd-e2a4-4f2c-84de-6dcf0fd91157" />


The real culprit appears to have been outside our control but could be mitigated by giving `konduit` more time and ensuring both actions implement a schema reset before restoring.

Flaky tunnels are the result of infrastructure, so a retry mechanism could be worked on but provided the manual action works there is not much reason to invest in it.

### Changes proposed in this pull request

- Increase the default timeout 10x when running the schema reset command
- Add the same schema reset command to the on-demand snapshot restoration workflow

### Guidance to review

Things should still just work but 🙏🏼 

- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/24195616123
- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/24195616123/job/70625700127