### PR TITLE
254-confirmation-page-content-changes

### DIFF
--- a/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
@@ -9,11 +9,8 @@ for
 <strong><%= @wizard.context.ect_teacher_full_name %></strong>
 <% end %>
 
-You have successfully registered <%= @wizard.context.ect_teacher_full_name %> for training.
+This completes <%= @wizard.context.ect_teacher_full_name %>’s registration for ECT training at your school.
 
-They do not need to provide us with any further details.
-
-We'll pass on their details to <%= @wizard.context.user_selected_lead_provider&.name || @wizard.context.ect_lead_provider&.name %> 
-who will contact them to arrange mentor training.
+You do not need to give us any more information.
 
 <%= govuk_link_to 'Back to your ECTs', schools_ects_home_path %>

--- a/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/assign_existing_mentor_wizard/confirmation.md.erb
@@ -1,5 +1,5 @@
 ---
-title: You've assigned <%= @wizard.context.mentor_teacher_full_name %> as a mentor
+title: You’ve assigned <%= @wizard.context.mentor_teacher_full_name %> as a mentor
 header: false
 ---
 

--- a/app/views/schools/ects/change_email_address_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_email_address_wizard/confirmation.html.erb
@@ -5,7 +5,7 @@
 
 <%= govuk_panel(
       title_text: <<~TXT
-        You have changed #{@wizard.teacher_full_name}’s email address to
+        You’ve changed #{@wizard.teacher_full_name}’s email address to
         #{@wizard.current_step.new_email}
       TXT
     ) %>

--- a/app/views/schools/ects/change_lead_provider_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_lead_provider_wizard/confirmation.html.erb
@@ -5,7 +5,7 @@
 
 <%= govuk_panel(
       title_text: <<~TXT.squish
-        You have chosen #{@wizard.current_step.new_lead_provider_name} as
+        You’ve chosen #{@wizard.current_step.new_lead_provider_name} as
         the new lead provider for #{@wizard.teacher_full_name}
       TXT
     ) %>

--- a/app/views/schools/ects/change_mentor_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/confirmation.html.erb
@@ -5,14 +5,10 @@
 
 <%= govuk_panel(
       title_text: <<~TXT
-        You have changed #{@wizard.teacher_full_name}’s mentor to
+        You’ve changed #{@wizard.teacher_full_name}’s mentor to
         #{@wizard.current_step.current_mentor_name}
       TXT
     ) %>
-
-<h2 class="govuk-heading-m">
- What happens next?
-</h2>
 
 <p class="govuk-body">
   <%= @wizard.current_step.current_mentor_name %> is now responsible for mentoring

--- a/app/views/schools/ects/change_name_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_name_wizard/confirmation.html.erb
@@ -1,6 +1,6 @@
 <%
   page_data(
-    title: "You have changed the ECT’s name to #{@wizard.teacher_full_name}",
+    title: "You’ve changed the ECT’s name to #{@wizard.teacher_full_name}",
     header: false
   )
 %>

--- a/app/views/schools/ects/change_name_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_name_wizard/confirmation.html.erb
@@ -5,9 +5,7 @@
   )
 %>
 
-<%= govuk_panel(title_text: "You have changed the ECT’s name to #{@wizard.teacher_full_name}") %>
-
-<h2 class="govuk-heading-m">What happens next</h2>
+<%= govuk_panel(title_text: "You’ve changed the ECT’s name to #{@wizard.teacher_full_name}") %>
 
 <p class="govuk-body">The ECT can update their name in their teacher record using the Access your teaching qualifications service.</p>
 

--- a/app/views/schools/ects/change_training_programme_wizard/_provider_led_success.html.erb
+++ b/app/views/schools/ects/change_training_programme_wizard/_provider_led_success.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_panel(
       title_text: <<~TXT.squish
-        You have changed #{@wizard.teacher_full_name}’s training programme to
+        You’ve changed #{@wizard.teacher_full_name}’s training programme to
         provider-led with #{@wizard.current_step.provider_name}
       TXT
     ) %>

--- a/app/views/schools/ects/change_training_programme_wizard/_school_led_success.html.erb
+++ b/app/views/schools/ects/change_training_programme_wizard/_school_led_success.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_panel(
       title_text: <<~TXT.squish
-        You have changed #{@wizard.teacher_full_name}’s training programme to
+        You’ve changed #{@wizard.teacher_full_name}’s training programme to
         school-led
       TXT
     ) %>

--- a/app/views/schools/ects/change_working_pattern_wizard/confirmation.html.erb
+++ b/app/views/schools/ects/change_working_pattern_wizard/confirmation.html.erb
@@ -5,7 +5,7 @@
 
 <%= govuk_panel(
       title_text: <<~TXT.squish
-        You have changed #{@wizard.teacher_full_name}’s working pattern to
+        You’ve changed #{@wizard.teacher_full_name}’s working pattern to
         #{@wizard.current_step.new_working_pattern.humanize.downcase}
       TXT
     ) %>

--- a/app/views/schools/mentors/change_email_address_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_email_address_wizard/confirmation.html.erb
@@ -5,7 +5,7 @@
 
 <%= govuk_panel(
       title_text: <<~TXT
-        You have changed the mentor’s email address to
+        You’ve changed the mentor’s email address to
         #{@wizard.current_step.new_email}
       TXT
     ) %>
@@ -16,7 +16,7 @@
 
 <p class="govuk-body">
   If the mentor is having ECT mentor training, we’ll let their lead provider
-  know
+  know.
 </p>
 
 <p class="govuk-body">

--- a/app/views/schools/mentors/change_lead_provider_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_lead_provider_wizard/confirmation.html.erb
@@ -16,7 +16,7 @@
   What happens next?
 </h2>
 
-<p class="govuk-body">We’ll let <%= @wizard.current_step.new_lead_provider_name %> know your school wants to work with them. They’ll contact us to confirm the change and tell us the delivery partner they'll be working with.</p>
+<p class="govuk-body">We’ll let <%= @wizard.current_step.new_lead_provider_name %> know your school wants to work with them. They’ll contact us to confirm the change and tell us the delivery partner they’ll be working with.</p>
 <p class="govuk-body">We’ll also let the old lead provider know that they’ll no longer be training <%= @wizard.teacher_full_name %>.</p>
 
 <p class="govuk-body">

--- a/app/views/schools/mentors/change_lead_provider_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_lead_provider_wizard/confirmation.html.erb
@@ -7,7 +7,7 @@
 
 <%= govuk_panel(
   title_text: <<~TXT
-    You have chosen #{@wizard.current_step.new_lead_provider_name}
+    You’ve chosen #{@wizard.current_step.new_lead_provider_name}
     as the new lead provider for #{@wizard.teacher_full_name}
   TXT
 ) %>

--- a/app/views/schools/mentors/change_lead_provider_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_lead_provider_wizard/confirmation.html.erb
@@ -1,6 +1,6 @@
 <%
   page_data(
-    title: "You have changed the mentor’s lead provider to #{@wizard.current_step.new_lead_provider_name}",
+    title: "You’ve changed the mentor’s lead provider to #{@wizard.current_step.new_lead_provider_name}",
     header: false
   )
 %>

--- a/app/views/schools/mentors/change_name_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/confirmation.html.erb
@@ -5,9 +5,7 @@
   )
 %>
 
-<%= govuk_panel(title_text: "You have changed the mentor’s name to #{@wizard.teacher_full_name}") %>
-
-<h2 class="govuk-heading-m">What happens next</h2>
+<%= govuk_panel(title_text: "You’ve changed the mentor’s name to #{@wizard.teacher_full_name}") %>
 
 <p class="govuk-body">The mentor can update their name in their teacher record using the Access your teaching qualifications service.</p>
 

--- a/app/views/schools/mentors/change_name_wizard/confirmation.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/confirmation.html.erb
@@ -1,6 +1,6 @@
 <%
   page_data(
-    title: "You have changed the mentor’s name to #{@wizard.teacher_full_name}",
+    title: "You’ve changed the mentor’s name to #{@wizard.teacher_full_name}",
     header: false
   )
 %>

--- a/app/views/schools/mentorships/confirmation.md.erb
+++ b/app/views/schools/mentorships/confirmation.md.erb
@@ -1,5 +1,5 @@
 ---
-title: You've assigned <%= @mentor_name %> as a mentor
+title: You’ve assigned <%= @mentor_name %> as a mentor
 header: false
 ---
 

--- a/app/views/schools/mentorships/confirmation.md.erb
+++ b/app/views/schools/mentorships/confirmation.md.erb
@@ -3,17 +3,14 @@ title: You've assigned <%= @mentor_name %> as a mentor
 header: false
 ---
 
-<%= govuk_panel(title_text: "You've assigned #{@mentor_name} as a mentor") do %>
+<%= govuk_panel(title_text: "You’ve assigned #{@mentor_name} as a mentor") do %>
 for
 <br>
 <strong><%= @ect_name %></strong>
 <% end %>
 
-<%= @mentor_name %> is now <%= @ect_name %>'s mentor, and this completes <%= @ect_name %>'s registration as an ECT at
-your school.
+This completes <%= @ect_name %>’s registration as an ECT at your school.
 
-### What happens next
-
-They do not need to give us any more information.
+You do not need to give us any more information.
 
 <%= govuk_link_to "Back to your ECTs", schools_ects_home_path %>

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -1,9 +1,9 @@
 ---
-title: You've assigned <%= @mentor.full_name %> as a mentor
+title: You’ve assigned <%= @mentor.full_name %> as a mentor
 header: false
 ---
 
-<%= govuk_panel(title_text: "You've assigned #{@mentor.full_name} as a mentor") do %>
+<%= govuk_panel(title_text: "You’ve assigned #{@mentor.full_name} as a mentor") do %>
 for
 <br>
 <strong><%= @ect_name %></strong>

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -24,7 +24,7 @@ We’ll email <%= @mentor.full_name %> to confirm that you’ve registered them 
   We’ll pass on their details to <%= @mentor.lead_provider&.name || @mentor.ect_lead_provider&.name %> who will contact them to arrange mentor training.
 <% else %>
 They cannot do mentor training according to our records.
-This could be because they've undertaken it before.
+This could be because they’ve undertaken it before.
 <% end %>
 <% end %>
 

--- a/app/views/schools/register_mentor_wizard/confirmation.md.erb
+++ b/app/views/schools/register_mentor_wizard/confirmation.md.erb
@@ -9,19 +9,19 @@ for
 <strong><%= @ect_name %></strong>
 <% end %>
 
-You have successfully registered <%= @ect_name %> for training.
+This completes <%= @ect_name %>’s registration for ECT training at your school.
+
+You do not need to give us any more information.
 
 <% unless @mentor.already_active_at_school %>
 ### What happens next
 
-We'll email <%= @mentor.full_name %> to confirm you have registered them.
+We’ll email <%= @mentor.full_name %> to confirm that you’ve registered them as a mentor.
 <% end %>
-
-They do not need to provide us with any further details.
 
 <% if @wizard.ect.provider_led_training_programme? %>
 <% if @mentor.eligible_for_funding? %>
-  We'll pass on their details to <%= @mentor.lead_provider&.name || @mentor.ect_lead_provider&.name %> who will contact them to arrange mentor training.
+  We’ll pass on their details to <%= @mentor.lead_provider&.name || @mentor.ect_lead_provider&.name %> who will contact them to arrange mentor training.
 <% else %>
 They cannot do mentor training according to our records.
 This could be because they've undertaken it before.

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_for_ects_in_closed_contract_periods_spec.rb
@@ -184,7 +184,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have chosen #{@selected_lead_provider_name} as the new lead provider for John Doe"
+      "You’ve chosen #{@selected_lead_provider_name} as the new lead provider for John Doe"
     )
   end
 

--- a/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
@@ -197,7 +197,7 @@ private
   def then_i_see_the_provider_led_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed John Doe’s training programme to provider-led with Other Lead Provider"
+      "You’ve changed John Doe’s training programme to provider-led with Other Lead Provider"
     )
   end
 

--- a/spec/features/schools/ects/change/email_address_spec.rb
+++ b/spec/features/schools/ects/change/email_address_spec.rb
@@ -92,7 +92,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed John Doe’s email address to new@example.com"
+      "You’ve changed John Doe’s email address to new@example.com"
     )
   end
 end

--- a/spec/features/schools/ects/change/lead_provider_spec.rb
+++ b/spec/features/schools/ects/change/lead_provider_spec.rb
@@ -202,7 +202,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have chosen #{@selected_lead_provider_name} as the new lead provider for John Doe"
+      "You’ve chosen #{@selected_lead_provider_name} as the new lead provider for John Doe"
     )
   end
 end

--- a/spec/features/schools/ects/change/mentor_spec.rb
+++ b/spec/features/schools/ects/change/mentor_spec.rb
@@ -318,7 +318,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed John Doe’s mentor to Jane Smith"
+      "You’ve changed John Doe’s mentor to Jane Smith"
     )
   end
 

--- a/spec/features/schools/ects/change/training_programme_spec.rb
+++ b/spec/features/schools/ects/change/training_programme_spec.rb
@@ -195,14 +195,14 @@ private
   def then_i_see_the_provider_led_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed John Doe’s training programme to provider-led with Testing Provider"
+      "You’ve changed John Doe’s training programme to provider-led with Testing Provider"
     )
   end
 
   def then_i_see_the_school_led_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed John Doe’s training programme to school-led"
+      "You’ve changed John Doe’s training programme to school-led"
     )
   end
 end

--- a/spec/features/schools/ects/change_working_pattern_spec.rb
+++ b/spec/features/schools/ects/change_working_pattern_spec.rb
@@ -73,7 +73,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed John Doe’s working pattern to part time"
+      "You’ve changed John Doe’s working pattern to part time"
     )
   end
 end

--- a/spec/features/schools/mentors/change/edge_cases/lead_provider_when_registered_previous_contract_year_spec.rb
+++ b/spec/features/schools/mentors/change/edge_cases/lead_provider_when_registered_previous_contract_year_spec.rb
@@ -160,7 +160,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have chosen Other Lead Provider as the new lead provider for John Doe"
+      "You’ve chosen Other Lead Provider as the new lead provider for John Doe"
     )
   end
 

--- a/spec/features/schools/mentors/change/email_address_spec.rb
+++ b/spec/features/schools/mentors/change/email_address_spec.rb
@@ -92,7 +92,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have changed the mentor’s email address to new@example.com"
+      "You’ve changed the mentor’s email address to new@example.com"
     )
   end
 end

--- a/spec/features/schools/mentors/change/lead_provider_spec.rb
+++ b/spec/features/schools/mentors/change/lead_provider_spec.rb
@@ -187,7 +187,7 @@ private
   def then_i_see_the_confirmation_message
     success_panel = page.locator(".govuk-panel")
     expect(success_panel).to have_text(
-      "You have chosen Other Lead Provider as the new lead provider for John Doe"
+      "You’ve chosen Other Lead Provider as the new lead provider for John Doe"
     )
   end
 

--- a/spec/views/schools/mentorships/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/mentorships/confirmation.md.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "schools/mentorships/confirmation.md.erb" do
   let(:ect_name) { "Michale Dixon" }
   let(:mentor_name) { "Peter Times" }
-  let(:title) { "You've assigned #{mentor_name} as a mentor" }
+  let(:title) { "You’ve assigned #{mentor_name} as a mentor" }
   let(:your_ects_path) { schools_ects_home_path }
 
   before do
@@ -9,7 +9,7 @@ RSpec.describe "schools/mentorships/confirmation.md.erb" do
     assign(:mentor_name, mentor_name)
   end
 
-  it "sets the page title to 'You've assigned <mentor name> as a mentor'" do
+  it "sets the page title to 'You’ve assigned <mentor name> as a mentor'" do
     render
 
     expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))

--- a/spec/views/schools/mentorships/new.html.erb_spec.rb
+++ b/spec/views/schools/mentorships/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "schools/mentorships/new.html.erb" do
     assign(:mentor_form, mentor_form)
   end
 
-  it "sets the page title to 'You've assigned <mentor name> as a mentor'" do
+  it "sets the page title to 'You’ve assigned <mentor name> as a mentor'" do
     render
 
     expect(sanitize(view.content_for(:page_title))).to eql(sanitize(title))

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       render
 
       expect(rendered).not_to have_content("What happens next")
-      expect(rendered).not_to have_content("We'll email #{mentor.full_name} to confirm you’ve registered them.")
+      expect(rendered).not_to have_content("We’ll email #{mentor.full_name} to confirm you’ve registered them.")
     end
   end
 

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       render
 
       expect(rendered).not_to have_content("What happens next")
-      expect(rendered).not_to have_content("We’ll email #{mentor.full_name} to confirm you’ve registered them.")
+      expect(rendered).not_to have_content("We’ll email #{mentor.full_name} to confirm that you’ve registered them as a mentor.")
     end
   end
 
@@ -153,7 +153,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       render
 
       expect(rendered).to have_content("What happens next")
-      expect(rendered).to have_content("We’ll email #{mentor.full_name} to confirm you’ve registered them.")
+      expect(rendered).to have_content("We’ll email #{mentor.full_name} to confirm that you’ve registered them as a mentor.")
     end
   end
 end

--- a/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
+++ b/spec/views/schools/register_mentor_wizard/confirmation.md.erb_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
 
       render
 
-      expect(title).to eql("You've assigned #{mentor.full_name} as a mentor")
+      expect(title).to eql("You’ve assigned #{mentor.full_name} as a mentor")
     end
   end
 
@@ -138,7 +138,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       render
 
       expect(rendered).not_to have_content("What happens next")
-      expect(rendered).not_to have_content("We'll email #{mentor.full_name} to confirm you have registered them.")
+      expect(rendered).not_to have_content("We'll email #{mentor.full_name} to confirm you’ve registered them.")
     end
   end
 
@@ -153,7 +153,7 @@ RSpec.describe "schools/register_mentor_wizard/confirmation.md.erb" do
       render
 
       expect(rendered).to have_content("What happens next")
-      expect(rendered).to have_content("We’ll email #{mentor.full_name} to confirm you have registered them.")
+      expect(rendered).to have_content("We’ll email #{mentor.full_name} to confirm you’ve registered them.")
     end
   end
 end


### PR DESCRIPTION
Various minor confirmation page content changes across ECT, mentor, and SIT journeys.

Including standardising use of contractions, smart quotes, standard lead-in sentence for ECT registration pages, removal of 'Whats next' h2s where appropriate.

Corresponding spec files updated where they exist and as appropriate.

### Context
See above.

### Changes proposed in this pull request
See above

### Guidance to review
Content changes for sanity check. Changes to spec files where they existed.