### PR TITLE
Allow completed ECTs to go premium

### DIFF
--- a/app/migration/teacher_history_converter/migration_strategy.rb
+++ b/app/migration/teacher_history_converter/migration_strategy.rb
@@ -17,7 +17,6 @@ private
 
   def teacher_history_meets_premium_criteria?
     [
-      has_not_completed_induction?,
       dates_are_in_the_right_order_for?(ecf1_teacher_history.ect&.induction_records),
       dates_are_in_the_right_order_for?(ecf1_teacher_history.mentor&.induction_records),
       (below_threshold_for_induction_records || !any_induction_records_overlap?)

--- a/spec/migration/teacher_history_converter/migration_strategy_spec.rb
+++ b/spec/migration/teacher_history_converter/migration_strategy_spec.rb
@@ -66,8 +66,8 @@ describe TeacherHistoryConverter::MigrationStrategy do
       let(:ect) { FactoryBot.build(:ecf1_teacher_history_ect, induction_records: ect_induction_records, induction_completion_date: 2.months.ago.to_date) }
       let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 2) }
 
-      it "does not meet the criteria for premium" do
-        expect(subject.strategy).to eq(:latest_induction_records)
+      it "meets the criteria for premium" do
+        expect(subject.strategy).to eq(:all_induction_records)
       end
     end
 
@@ -145,8 +145,8 @@ describe TeacherHistoryConverter::MigrationStrategy do
       let(:ect_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 2) }
       let(:mentor_induction_records) { FactoryBot.build_list(:ecf1_teacher_history_induction_record_row, 2) }
 
-      it "does not meet the criteria for premium" do
-        expect(subject.strategy).to eq(:latest_induction_records)
+      it "meets the criteria for premium" do
+        expect(subject.strategy).to eq(:all_induction_records)
       end
     end
 

--- a/spec/migration/teacher_history_converter/real_examples/668787fb_6c01_46ee_83bf_2e5362eba446_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/668787fb_6c01_46ee_83bf_2e5362eba446_spec.rb
@@ -298,7 +298,7 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }


### PR DESCRIPTION
### Context

We are handling creating training periods ECTs that have completed induction and have declarations after the fact but we are not allowing ECTs with completed inductions down the premium route. This PR allow completed ECTs to go premium.

### Changes proposed in this pull request

Remove the completed induction check from the migration strategy.

### Guidance to review
