### PR TITLE
Ensure migration mode is set for the real specs

### DIFF
--- a/spec/migration/teacher_history_converter/real_examples/0a1c0ff7_21c4_418d_9efb_45639a849247_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/0a1c0ff7_21c4_418d_9efb_45639a849247_spec.rb
@@ -191,7 +191,7 @@ describe "Real data check for user 0a1c0ff7-21c4-418d-9efb-45639a849247 (ERO men
           ect_at_school_periods: [],
           mentor_at_school_periods: array_including(
             hash_including(
-              started_on: Date.new(2022, 9, 30),
+              started_on: Date.new(2021, 9, 1),
               finished_on: nil,
               school: hash_including(urn: "100001", name: "School 1"),
               email: "a.teacher@example.com",
@@ -200,7 +200,7 @@ describe "Real data check for user 0a1c0ff7-21c4-418d-9efb-45639a849247 (ERO men
                 #       has this combo (participant_profile_id, lead_provider_id and cohort) in the combo check
                 #       list so we don't discard it.
                 hash_including(
-                  started_on: Date.new(2022, 9, 30),
+                  started_on: Date.new(2021, 9, 1),
                   finished_on: Date.new(2022, 10, 1),
                   training_programme: "provider_led",
                   lead_provider_info: {

--- a/spec/migration/teacher_history_converter/real_examples/0a1c0ff7_21c4_418d_9efb_45639a849247_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/0a1c0ff7_21c4_418d_9efb_45639a849247_spec.rb
@@ -132,7 +132,7 @@ describe "Real data check for user 0a1c0ff7-21c4-418d-9efb-45639a849247 (ERO men
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }

--- a/spec/migration/teacher_history_converter/real_examples/3289df21_ce22_45c8_b7a2_b31db3bc8f88_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/3289df21_ce22_45c8_b7a2_b31db3bc8f88_spec.rb
@@ -89,7 +89,12 @@ describe "Real data check for user 3289df21-ce22-45c8-b7a2-b31db3bc8f88 (ERO men
               started_on: Date.new(2021, 9, 1),
               finished_on: nil,
               school: hash_including(urn: "100001", name: "School 1"),
-              training_periods: []
+              training_periods: array_including(
+                hash_including(
+                  started_on: Date.new(2021, 9, 1),
+                  finished_on: Date.new(2021, 9, 2)
+                )
+              )
             )
           ],
           mentor_became_ineligible_for_funding_on: Date.new(2021, 4, 19),

--- a/spec/migration/teacher_history_converter/real_examples/3289df21_ce22_45c8_b7a2_b31db3bc8f88_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/3289df21_ce22_45c8_b7a2_b31db3bc8f88_spec.rb
@@ -75,7 +75,7 @@ describe "Real data check for user 3289df21-ce22-45c8-b7a2-b31db3bc8f88 (ERO men
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }

--- a/spec/migration/teacher_history_converter/real_examples/653c0693_e8ad_4487_8a4a_0d48f678ba70_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/653c0693_e8ad_4487_8a4a_0d48f678ba70_spec.rb
@@ -249,7 +249,7 @@ describe "Real data check for user 653c0693-e8ad-4487-8a4a-0d48f678ba70" do
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }

--- a/spec/migration/teacher_history_converter/real_examples/a0b929e7_658b_4a50_89f4_63f89023b9c0_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/a0b929e7_658b_4a50_89f4_63f89023b9c0_spec.rb
@@ -268,35 +268,23 @@ describe "Real data check for user a0b929e7-658b-4a50-89f4-63f89023b9c0" do
           ect_at_school_periods: [],
           mentor_at_school_periods: array_including(
             hash_including(
-              started_on: Date.new(2023, 7, 31),
-              finished_on: Date.new(2023, 11, 28),
+              started_on: Date.new(2021, 9, 1),
+              finished_on: nil,
               school: hash_including(urn: "100001", name: "School 1"),
               training_periods: array_including(
                 hash_including(
-                  started_on: Date.new(2023, 7, 31),
-                  finished_on: Date.new(2023, 11, 28),
+                  started_on: Date.new(2021, 9, 1),
+                  # one day added to the finished date because the induction record's
+                  # start date is the same as the mentor_completion_date
+                  finished_on: Date.new(2023, 8, 1),
                   training_programme: "provider_led",
                   lead_provider_info: { ecf1_id: "c3bc3cee-a636-42d6-8324-c033a6c38d31", name: "Ambition Institute" },
                   delivery_partner_info: { ecf1_id: "e41816f8-849e-40dd-a360-4a5bf5496fcd", name: "Delivery partner 1" },
                   contract_period_year: 2021
                 )
               )
-            ),
-            hash_including(
-              started_on: Date.new(2025, 1, 30),
-              finished_on: nil,
-              school: { urn: "100001", name: "School 1", school_type_name: nil },
-              training_periods: array_including(
-                hash_including(
-                  started_on: Date.new(2025, 1, 30),
-                  finished_on: Date.new(2025, 1, 31),
-                  training_programme: "provider_led",
-                  lead_provider_info: { ecf1_id: "da470c27-05a6-4f5b-b9a9-58b04bfcc408", name: "Best Practice Network" },
-                  delivery_partner_info: { ecf1_id: "a8b923cf-377f-4707-9014-6598f00d38d7", name: "Delivery partner 2" },
-                  contract_period_year: 2021
-                )
-              )
             )
+            # no further training periods created as the mentor completion date is now in the past
           )
         )
       }

--- a/spec/migration/teacher_history_converter/real_examples/a0b929e7_658b_4a50_89f4_63f89023b9c0_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/a0b929e7_658b_4a50_89f4_63f89023b9c0_spec.rb
@@ -207,7 +207,7 @@ describe "Real data check for user a0b929e7-658b-4a50-89f4-63f89023b9c0" do
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }

--- a/spec/migration/teacher_history_converter/real_examples/a1d38b72_4f11_490c_bee4_5b475f4b224f_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/a1d38b72_4f11_490c_bee4_5b475f4b224f_spec.rb
@@ -168,7 +168,7 @@ describe "Real data check for user a1d38b72-4f11-490c-bee4-5b475f4b224f" do
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:).convert_to_ecf2! }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
 
   context "when using the economy migrator" do
     let(:migration_mode) { :latest_induction_records }

--- a/spec/migration/teacher_history_converter/real_examples/d6a56e86_2841_4e5c_bc53_d52917eebe4f_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/d6a56e86_2841_4e5c_bc53_d52917eebe4f_spec.rb
@@ -139,7 +139,7 @@ describe "Real data check for user d6a56e86-2841-4e5c-bc53-d52917eebe4f" do
   end
 
   let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
-  let(:converter) { TeacherHistoryConverter.new(ecf1_teacher_history:) }
+  let(:converter) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:) }
   let(:ecf2_teacher_history) { converter.convert_to_ecf2! }
 
   context "choosing a migration strategy" do


### PR DESCRIPTION
### Context

We want to ensure we're setting `migration_mode` for all the realistic specs so we don't accidentally test economy when we mean premium or vice versa.

### Changes proposed in this pull request

- **Make the spec generator include migration_mode**
- **Add migration_mode arg to all converter calls**
- **Fix tests caused my forcing migration mode**
