### PR TITLE
Fix missing delivery partner name on Check Your Answers page

### DIFF
--- a/app/views/schools/register_ect_wizard/check_answers.html.erb
+++ b/app/views/schools/register_ect_wizard/check_answers.html.erb
@@ -89,7 +89,7 @@ end %>
     if @ect.use_previous_ect_choices && @ect.lead_provider_has_confirmed_partnership_for_contract_period?(@school)
       summary_list.with_row do |row|
         row.with_key(text: 'Delivery partner')
-        row.with_value(text: @ect.delivery_partner_name)
+        row.with_value(text: @ect.delivery_partner_name(school: @school))
       end
     end
   end

--- a/app/wizards/schools/register_ect_wizard/registration_store.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store.rb
@@ -88,6 +88,10 @@ module Schools
         Teachers::Name.new(self).full_name_in_trs
       end
 
+      def delivery_partner_name(school:)
+        queries.confirmed_delivery_partner_for_contract_period(school:)&.name
+      end
+
       def normalized_start_date
         return store[:start_date_as_date] if store[:start_date_as_date].present?
 

--- a/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
@@ -96,6 +96,12 @@ module Schools
           previous_training_period&.lead_provider
         end
 
+        def confirmed_delivery_partner_for_contract_period(school:)
+          lead_provider_partnerships_for_contract_period(school:)
+          .first
+          &.delivery_partner
+        end
+
       private
 
         attr_reader :registration_store

--- a/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
@@ -98,8 +98,8 @@ module Schools
 
         def confirmed_delivery_partner_for_contract_period(school:)
           lead_provider_partnerships_for_contract_period(school:)
-          .first
-          &.delivery_partner
+            .first
+            &.delivery_partner
         end
 
       private

--- a/spec/features/schools/ects/register/registering_an_ect_reuse_partnership_spec.rb
+++ b/spec/features/schools/ects/register/registering_an_ect_reuse_partnership_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "Registering an ECT - reuse previous partnership", :enable_school
     and_i_submit_the_find_ect_form
     and_i_choose_that_the_details_are_correct
     and_i_click_confirm_and_continue
+    then_i_am_on_the_registered_before_page
+    and_i_click_continue
     then_i_am_on_the_email_address_page
 
     and_i_enter_the_ect_email_address
@@ -45,6 +47,8 @@ RSpec.describe "Registering an ECT - reuse previous partnership", :enable_school
     and_i_submit_the_find_ect_form
     and_i_choose_that_the_details_are_correct
     and_i_click_confirm_and_continue
+    then_i_am_on_the_registered_before_page
+    and_i_click_continue
     then_i_am_on_the_email_address_page
 
     and_i_enter_the_ect_email_address
@@ -110,8 +114,26 @@ RSpec.describe "Registering an ECT - reuse previous partnership", :enable_school
     @current_school = context.school
     @current_contract_period = context.current_contract_period
     @previous_school_partnership = context.previous_school_partnership
+    @current_school_partnership = context.current_school_partnership
     @last_chosen_lead_provider = context.last_chosen_lead_provider
     @previous_year_delivery_partner = context.previous_year_delivery_partner
+
+    teacher = FactoryBot.create(:teacher, trn: "9876543")
+    previous_ect_at_school_period = FactoryBot.create(
+      :ect_at_school_period,
+      teacher:,
+      school: @current_school,
+      started_on: 2.years.ago,
+      finished_on: 1.year.ago
+    )
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      ect_at_school_period: previous_ect_at_school_period,
+      school_partnership: @previous_school_partnership,
+      started_on: previous_ect_at_school_period.started_on,
+      finished_on: previous_ect_at_school_period.finished_on
+    )
 
     @appropriate_body_name = "Golden Leaf Teaching Hub"
     FactoryBot.create(:appropriate_body_period, name: @appropriate_body_name)
@@ -237,6 +259,10 @@ RSpec.describe "Registering an ECT - reuse previous partnership", :enable_school
     end
   end
 
+  def then_i_am_on_the_registered_before_page
+    expect(page).to have_path("/school/register-ect/registered-before")
+  end
+
   def then_i_am_on_the_start_date_page
     expect(page).to have_path("/school/register-ect/start-date")
   end
@@ -297,6 +323,11 @@ RSpec.describe "Registering an ECT - reuse previous partnership", :enable_school
 
     if page.get_by_text(@appropriate_body_name).count.positive?
       expect(page.get_by_text(@appropriate_body_name)).to be_visible
+    end
+
+    if @previous_year_delivery_partner
+      expect(page.get_by_text("Delivery partner").first).to be_visible
+      expect(page.get_by_text(@previous_year_delivery_partner.name)).to be_visible
     end
   end
 

--- a/spec/support/reusable_partnership_helpers.rb
+++ b/spec/support/reusable_partnership_helpers.rb
@@ -3,6 +3,7 @@ module ReusablePartnershipHelpers
     :school,
     :current_contract_period,
     :previous_school_partnership,
+    :current_school_partnership,
     :last_chosen_lead_provider,
     :previous_year_delivery_partner,
     keyword_init: true
@@ -25,7 +26,7 @@ module ReusablePartnershipHelpers
       contract_period: previous_contract_period
     )
 
-    FactoryBot.create(
+    current_year_active_lead_provider = FactoryBot.create(
       :active_lead_provider,
       lead_provider:,
       contract_period: current_contract_period
@@ -34,6 +35,12 @@ module ReusablePartnershipHelpers
     previous_year_delivery_partnership = FactoryBot.create(
       :lead_provider_delivery_partnership,
       active_lead_provider: previous_year_active_lead_provider,
+      delivery_partner:
+    )
+
+    current_year_delivery_partnership = FactoryBot.create(
+      :lead_provider_delivery_partnership,
+      active_lead_provider: current_year_active_lead_provider,
       delivery_partner:
     )
 
@@ -51,10 +58,17 @@ module ReusablePartnershipHelpers
       lead_provider_delivery_partnership: previous_year_delivery_partnership
     )
 
+    current_school_partnership = FactoryBot.create(
+      :school_partnership,
+      school:,
+      lead_provider_delivery_partnership: current_year_delivery_partnership
+    )
+
     ReusablePartnershipContext.new(
       school:,
       current_contract_period:,
       previous_school_partnership:,
+      current_school_partnership:,
       last_chosen_lead_provider: lead_provider,
       previous_year_delivery_partner: delivery_partner
     )

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -157,6 +157,41 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     end
   end
 
+  describe "#confirmed_delivery_partner_for_contract_period" do
+    let(:contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+    let(:start_date) { (contract_period.started_on + 1.day) }
+    let(:school) { FactoryBot.create(:school) }
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:school_partnership) do
+      FactoryBot.create(:school_partnership,
+                        :for_year,
+                        year: contract_period.year,
+                        school:,
+                        lead_provider:)
+    end
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period,
+                        teacher:,
+                        school:)
+    end
+    let!(:training_period) do
+      FactoryBot.create(:training_period,
+                        :for_ect,
+                        ect_at_school_period:,
+                        school_partnership:)
+    end
+
+    it "returns the delivery partner from the confirmed partnership" do
+      expected = school_partnership.delivery_partner
+      expect(queries.confirmed_delivery_partner_for_contract_period(school:)).to eq(expected)
+    end
+
+    it "returns nil when there is no confirmed partnership for the school" do
+      other_school = FactoryBot.create(:school)
+      expect(queries.confirmed_delivery_partner_for_contract_period(school: other_school)).to be_nil
+    end
+  end
+
   describe "previous registration queries" do
     let!(:previous_ect_period) do
       FactoryBot.create(:ect_at_school_period,


### PR DESCRIPTION
### Context

When a school registers a new ECT and chooses to reuse their previous programme choices, the Check Your Answers page was showing a blank Delivery partner row despite a confirmed partnership existing for the current contract period. 

When a school reuses previous programme choices, the lead provider step is skipped so lead_provider_id is never stored in the session. The delivery partner therefore has to be looked up from the confirmed current year school partnership, but delivery_partner_name was never implemented on RegistrationStore, causing it to silently return nil.

### Changes proposed in this pull request
- Added confirmed_delivery_partner_for_contract_period(school:) to Queries
- Added delivery_partner_name(school:) to RegistrationStore
- Updated the check answers view to call @ect.delivery_partner_name(school: @school) when rendering the delivery partner row
- Added a unit test to queries_spec.rb for confirmed_delivery_partner_for_contract_period
- Updated the feature spec to reflect a realistic data setup
- Updated ReusablePartnershipHelpers to create a current year lead_provider_delivery_partnership and school_partnership alongside the existing previous year ones

### Guidance to review
