### PR TITLE
Add Appropriate Body mapper and data

### DIFF
--- a/app/migration/mappers/appropriate_body_mapper.rb
+++ b/app/migration/mappers/appropriate_body_mapper.rb
@@ -1,0 +1,22 @@
+module Mappers
+  class AppropriateBodyMapper
+    class NoMatchingECF1AppropriateBodyID < StandardError; end
+
+    attr_accessor :mapping_data, :indexed_by_ecf1_id
+
+    def initialize(yaml_file = Rails.root.join("app/migration/mappers/appropriate_body_mapping_data.yaml"))
+      @mapping_data = YAML.load_file(yaml_file, symbolize_names: true)
+      @indexed_by_ecf1_id = mapping_data.index_by { it[:ecf1_id] }
+    end
+
+    def get_ecf2_id(ecf1_id)
+      begin
+        match = indexed_by_ecf1_id.fetch(ecf1_id)
+      rescue KeyError
+        raise NoMatchingECF1AppropriateBodyID, "ecf1_id: #{ecf1_id}"
+      end
+
+      match.fetch(:ecf2_id)
+    end
+  end
+end

--- a/app/migration/mappers/appropriate_body_mapping_data.yaml
+++ b/app/migration/mappers/appropriate_body_mapping_data.yaml
@@ -1,0 +1,1079 @@
+---
+- ecf1_id: acff7f4a-2967-44c2-8c2a-99b4552dd9a8
+  ecf1_name: Alban Teaching School Hub (Sandringham School)
+  type: teaching_school_hub
+  ecf2_id: 358
+  ecf2_name: Alban Teaching School Hub
+- ecf1_id: '0271871e-9169-4eec-a6d8-76dba9292310'
+  ecf1_name: Alpha Teaching School Hub (Colchester County High School for Girls)
+  type: teaching_school_hub
+  ecf2_id: 394
+  ecf2_name: Colchester County High School for Girls
+- ecf1_id: e9b8cce5-440e-426f-8eae-e3076e0d687a
+  ecf1_name: Ark Teaching School Hub (Ark St Alban's Academy)
+  type: teaching_school_hub
+  ecf2_id: 321
+  ecf2_name: Ark St Alban's Academy
+- ecf1_id: dac3b20c-2fe8-4d9f-bfa9-6bc0db00d1a8
+  ecf1_name: Arthur Terry Teaching School Hub - North Birmingham (The Arthur Terry
+    School)
+  type: teaching_school_hub
+  ecf2_id: 288
+  ecf2_name: Arthur Terry Teaching School Hub-North Birmingham
+- ecf1_id: 77bf65fb-493b-4d3c-86eb-6a2c9839a32d
+  ecf1_name: Astra Teaching School Hub, Buckinghamshire (Dr Challoner's Grammar School)
+  type: teaching_school_hub
+  ecf2_id: 329
+  ecf2_name: Astra Teaching School Hub, Buckinghamshire
+- ecf1_id: 105eee26-443c-4696-9a9b-3458e394cdee
+  ecf1_name: Balcarras (Balcarras School)
+  type: teaching_school_hub
+  ecf2_id: 355
+  ecf2_name: Balcarras
+- ecf1_id: d39267fc-ded1-49e0-b6ae-1161b3f3b439
+  ecf1_name: Bright Futures Teaching School Hub (Altrincham Grammar School for Girls)
+  type: teaching_school_hub
+  ecf2_id: 383
+  ecf2_name: Bright Futures Teaching School Hub-Salford & Trafford
+- ecf1_id: afd6665a-654f-4916-b0ec-7883c9ed5e12
+  ecf1_name: Calderdale and Kirklees Teaching School Hub (Shelley College, A Share
+    Academy)
+  type: teaching_school_hub
+  ecf2_id: 382
+  ecf2_name: Calderdale and Kirklees Teaching School Hub
+- ecf1_id: c14321bb-cd23-4076-bc9d-9b264cf7255b
+  ecf1_name: Cambridgeshire and Peterborough Teaching School Hub (Histon and Impington
+    Brook Primary School)
+  type: teaching_school_hub
+  ecf2_id: 459
+  ecf2_name: Cambridgeshire and Peterborough Teaching School Hub
+- ecf1_id: 6b433d0a-2244-4132-931f-c7c17b8fa68c
+  ecf1_name: Central London Teaching School Hub (Paddington Academy)
+  type: teaching_school_hub
+  ecf2_id: 316
+  ecf2_name: Central London Teaching School Hub
+- ecf1_id: c99bfcf6-1dc6-49fd-9a28-abe670720883
+  ecf1_name: Chafford Hundred Teaching School Hub (Harris Academy Chafford Hundred)
+  type: teaching_school_hub
+  ecf2_id: 392
+  ecf2_name: Chafford Hundred Teaching School Hub
+- ecf1_id: 98634cc2-e894-4959-82b3-ac27cbbbf72d
+  ecf1_name: Cheshire Teaching School Hub (St Joseph's College)
+  type: teaching_school_hub
+  ecf2_id: 476
+  ecf2_name: Cheshire Teaching School Hub
+- ecf1_id: 1db342ef-4b29-452d-b105-12ae959b631d
+  ecf1_name: Chiltern Teaching School Hub (Denbigh High School)
+  type: teaching_school_hub
+  ecf2_id: 336
+  ecf2_name: Chiltern Teaching School Hub
+- ecf1_id: 98f2a7b6-bc4e-45da-b4fa-6d5424ef1021
+  ecf1_name: Coventry and Central Warwickshire Teaching School Hub (Lawrence Sheriff
+    School)
+  type: teaching_school_hub
+  ecf2_id: 62
+  ecf2_name: Coventry and Central Warwickshire Teaching School Hub
+- ecf1_id: b448a843-3de3-4a0e-9c13-ea4341e08c8d
+  ecf1_name: DRET Teaching School Hub (Humberston Academy)
+  type: teaching_school_hub
+  ecf2_id: 386
+  ecf2_name: DRET Teaching School Hub
+- ecf1_id: e883f73b-48e5-4bb9-b577-d3151f7a94d7
+  ecf1_name: East London Teaching School Hub (Mulberry School for Girls)
+  type: teaching_school_hub
+  ecf2_id: 27
+  ecf2_name: East London Teaching School Hub
+- ecf1_id: 0f6720a7-097c-406a-aa60-29ba7eb1ca21
+  ecf1_name: Embrace Teaching School Hub (SW Lancashire) (Tor View School)
+  type: teaching_school_hub
+  ecf2_id: 57
+  ecf2_name: Embrace Teaching School Hub (SW Lancashire)
+- ecf1_id: e5f5a644-6698-441b-8e52-640fa832a1b2
+  ecf1_name: Exceed Teaching School Hub (Harden Primary Academy School)
+  type: teaching_school_hub
+  ecf2_id: 511
+  ecf2_name: Exceed Teaching School Hub
+- ecf1_id: 1c80a27a-1167-4a4f-a922-55ae84e1631e
+  ecf1_name: Exchange Teaching School Hub (Grange Lane Infant Academy)
+  type: teaching_school_hub
+  ecf2_id: 376
+  ecf2_name: Exchange Teaching School Hub
+- ecf1_id: 6a70cbe0-3df8-4e8b-a80c-5c2cc63a59a2
+  ecf1_name: Five Counties Teaching School Hub - South Gloucestershire and Bath and
+    North East Somerset  (Mangotsfield Church of England Voluntary Controlled Primary
+    School)
+  type: teaching_school_hub
+  ecf2_id: 326
+  ecf2_name: Five Counties Teaching School Hubs Alliance (Somerset)
+- ecf1_id: 86ad4e94-0571-4c27-a0fc-15ac35cdb355
+  ecf1_name: Five Counties Teaching School Hubs Alliance (Bristol/North Somerset)
+    (Bristol Metropolitan Academy)
+  type: teaching_school_hub
+  ecf2_id: 20
+  ecf2_name: Five Counties Teaching School Hubs Alliance (South Glos/BANES)
+- ecf1_id: 3f3a6140-56bc-453b-b945-5a46a224484e
+  ecf1_name: Five Counties Teaching School Hubs Alliance (Somerset) (Bristol Metropolitan
+    Academy)
+  type: teaching_school_hub
+  ecf2_id: 326
+  ecf2_name: Five Counties Teaching School Hubs Alliance (Somerset)
+- ecf1_id: ec9f0d00-4ab7-44d9-97a9-8057bce3f5b4
+  ecf1_name: Flying High Teaching School Hub (The Flying High Academy)
+  type: teaching_school_hub
+  ecf2_id: 531
+  ecf2_name: Flying High Teaching School Hub
+- ecf1_id: 30d88c98-1d82-4e9c-af08-c39bbd78acb0
+  ecf1_name: Generate Teaching School Hub (Evelyn Street Primary Academy and Nursery)
+  type: teaching_school_hub
+  ecf2_id: 43
+  ecf2_name: Generate Teaching Hub
+- ecf1_id: 33f2e3a7-0bf6-4f2f-970f-c5e94c9f2d20
+  ecf1_name: GLF West Sussex Teaching School Hub (Rosebery School)
+  type: teaching_school_hub
+  ecf2_id: 403
+  ecf2_name: GLF West Sussex Teaching School Hub
+- ecf1_id: 9e78be52-5598-4883-881c-814f63fb91e7
+  ecf1_name: Harris City Academy Crystal Palace Teaching School Hub (Harris City Academy
+    Crystal Palace)
+  type: teaching_school_hub
+  ecf2_id: 463
+  ecf2_name: Harris City Academy Crystal Palace Teaching School Hub
+- ecf1_id: ab2d6c9d-d5d8-4224-b2ae-0a83c8be6810
+  ecf1_name: Haybridge Teaching School Hub (Haybridge High School and Sixth Form)
+  type: teaching_school_hub
+  ecf2_id: 520
+  ecf2_name: Haybridge Teaching School Hub
+- ecf1_id: db5d0a2e-7bab-45d8-aa98-3de2b0e19c95
+  ecf1_name: HISP Teaching School Hub (Portswood Primary School)
+  type: teaching_school_hub
+  ecf2_id: 442
+  ecf2_name: HISP Teaching School Hub (Portswood Primary)
+- ecf1_id: 7ca83340-10da-4525-a8fd-3cb6c14f386c
+  ecf1_name: HISP Teaching School Hub (Thornden School)
+  type: teaching_school_hub
+  ecf2_id: 346
+  ecf2_name: HISP Teaching School Hub (Thornden School)
+- ecf1_id: a77df925-7b9e-4957-a3b4-aa9d9318a7cd
+  ecf1_name: Inspiration Teaching School Hub
+  type: teaching_school_hub
+  ecf2_id: 526
+  ecf2_name: Inspiration Teaching School Hub
+- ecf1_id: 3028b162-409f-4143-90d7-e312357b1300
+  ecf1_name: Inspire Learning Teaching School Hub NW (Our Lady of Pity Catholic Primary
+    School)
+  type: teaching_school_hub
+  ecf2_id: 522
+  ecf2_name: Inspire Learning Teaching School Hub NW
+- ecf1_id: 344aadbf-a964-4f9c-ae80-2194a574c236
+  ecf1_name: John Taylor Teaching School Hub  (John Taylor High School)
+  type: teaching_school_hub
+  ecf2_id: 337
+  ecf2_name: John Taylor Teaching School Hub
+- ecf1_id: 6ee878a2-2328-4270-951a-368349fabc48
+  ecf1_name: Kent Teaching School hub (Bennett Memorial Diocesan School)
+  type: teaching_school_hub
+  ecf2_id: 366
+  ecf2_name: Kent Teaching School Hub
+- ecf1_id: 742bdf50-5a2b-45d8-9131-36ddaaccbf08
+  ecf1_name: L.E.A.D. Teaching School Hub Lincolnshire (Witham St Hughs Academy)
+  type: teaching_school_hub
+  ecf2_id: 416
+  ecf2_name: L.E.A.D. Teaching School Hub Lincolnshire
+- ecf1_id: ac48354f-b75b-417e-b9d4-5ef0d2c674df
+  ecf1_name: Leeds Teaching School Hub (The Morley Academy)
+  type: teaching_school_hub
+  ecf2_id: 334
+  ecf2_name: Leeds Teaching School Hub
+- ecf1_id: f68d9fe5-fe43-4186-8495-8ea0b182821d
+  ecf1_name: Leicester & Leicestershire Teaching School Hub (Rushey Mead Academy)
+  type: teaching_school_hub
+  ecf2_id: 273
+  ecf2_name: Leicester & Leicestershire TSH
+- ecf1_id: 5baa0a83-ccf7-4c25-9564-81754b481337
+  ecf1_name: Leicestershire & Rutland TS Hub (Christ the King Catholic Voluntary Academy)
+  type: teaching_school_hub
+  ecf2_id: 4
+  ecf2_name: Leicestershire & Rutland TS Hub
+- ecf1_id: 3fbad505-80d8-4aed-b5cb-141270b3e5c7
+  ecf1_name: London District East Teaching School Hub (Tollgate Primary School)
+  type: teaching_school_hub
+  ecf2_id: 513
+  ecf2_name: London District East Teaching School Hub
+- ecf1_id: da694a86-d043-4aea-b4b1-dfb85a93eb88
+  ecf1_name: London South Teaching School Hub (Charles Dickens Primary School)
+  type: teaching_school_hub
+  ecf2_id: 10
+  ecf2_name: London South Teaching School Hub
+- ecf1_id: f5018a20-0ea5-49f0-8b00-0a51fa478b5b
+  ecf1_name: Manor Teaching School Hub (Manor Primary School)
+  type: teaching_school_hub
+  ecf2_id: 46
+  ecf2_name: Manor Teaching School Hub
+- ecf1_id: cc390aa6-4d13-46a0-8e05-960fe4e198dc
+  ecf1_name: NELT Teaching School Hub (Teesdale School and Sixth Form)
+  type: teaching_school_hub
+  ecf2_id: 37
+  ecf2_name: NELTSH Teaching School Hub
+- ecf1_id: bb014ec5-a974-4173-adcc-8cd9f8573fb0
+  ecf1_name: North East London Teaching School Hub (Harris Chobham Academy)
+  type: teaching_school_hub
+  ecf2_id: 533
+  ecf2_name: North East London Teaching School Hub
+- ecf1_id: 4e316f2f-0d6b-4ea1-a962-a456db2ee203
+  ecf1_name: North East London Teaching School Hub (Walthamstow School for Girls -
+    URN 103103)
+  type: teaching_school_hub
+  ecf2_id: 285
+  ecf2_name: Walthamstow School for Girls
+- ecf1_id: 7a6fa110-9550-4a54-8952-5d063f5d9d1f
+  ecf1_name: North West London Teaching School Hub (NWLTSH) (Wembley High Technology
+    College)
+  type: teaching_school_hub
+  ecf2_id: 424
+  ecf2_name: North West London Teaching School Hub
+- ecf1_id: 80d6265f-8ca4-4604-a3cb-b4512b8e4ae2
+  ecf1_name: Northamptonshire Teaching School Hub (Brooke Weston Academy)
+  type: teaching_school_hub
+  ecf2_id: 422
+  ecf2_name: Northamptonshire Teaching School Hub
+- ecf1_id: 3b9cf79f-5bd4-4b81-b627-0d5ccac8b5bf
+  ecf1_name: 'Northern Lights Teaching School Hub: South Tyne & Wear (Benedict Biscop
+    Church of England Academy)'
+  type: teaching_school_hub
+  ecf2_id: 409
+  ecf2_name: 'Northern Lights TSH: South Tyne & Wear'
+- ecf1_id: dfc0062b-40a6-4fb5-9630-33911bfe024f
+  ecf1_name: Odyssey Teaching School Hub  (Pate's Grammar School)
+  type: teaching_school_hub
+  ecf2_id: 344
+  ecf2_name: Odyssey Teaching School Hub
+- ecf1_id: 87cf3a47-887a-4766-ad15-2b200aa06024
+  ecf1_name: One Cornwall Teaching School Hub  (East Cornwall) (The Roseland Academy)
+  type: teaching_school_hub
+  ecf2_id: 364
+  ecf2_name: One Cornwall Teaching School Hub (East Cornwall)
+- ecf1_id: c0f863cc-d23c-446a-ab09-01ed3c55f92c
+  ecf1_name: One Cornwall Teaching School Hub (West) (Trenance Learning Academy)
+  type: teaching_school_hub
+  ecf2_id: 335
+  ecf2_name: One Cornwall Teaching School Hub (West)
+- ecf1_id: 53eee9d4-7458-4cce-aaac-2358801d1e91
+  ecf1_name: One Cumbria Teaching School Hub (Queen Elizabeth Grammar School Penrith)
+  type: teaching_school_hub
+  ecf2_id: 534
+  ecf2_name: One Cumbria Teaching School Hub
+- ecf1_id: ac3b03c0-f34e-4221-b6f7-d12b49d4ebb4
+  ecf1_name: Oxfordshire Teaching School Hub (The Cherwell School)
+  type: teaching_school_hub
+  ecf2_id: 490
+  ecf2_name: Oxfordshire Teaching School Hub
+- ecf1_id: c1496245-02f3-4dbe-b348-eb7eddc76175
+  ecf1_name: Pathfinder Teaching School Hub  (Archbishop Holgate's School, A Church
+    of England Academy)
+  type: teaching_school_hub
+  ecf2_id: 359
+  ecf2_name: Pathfinder Teaching School Hub
+- ecf1_id: 287967cc-40f7-4e7e-b1b0-786f1767d06c
+  ecf1_name: Potentia Teaching School Hub (Swanwick School)
+  type: teaching_school_hub
+  ecf2_id: 257
+  ecf2_name: Potentia TSH
+- ecf1_id: 7fbadaef-a05e-43c4-acda-1ec176c0e781
+  ecf1_name: Prince Henry's Teaching School Hub (Prince Henry's High School)
+  type: teaching_school_hub
+  ecf2_id: 356
+  ecf2_name: Prince Henry's Teaching School Hub
+- ecf1_id: 4206bdd2-1806-40ff-a44e-41dc52dabd62
+  ecf1_name: Rainbow Teaching School Hub (St Silas Church of England Primary School)
+  type: teaching_school_hub
+  ecf2_id: 44
+  ecf2_name: Rainbow Teaching School Hub
+- ecf1_id: c21360e8-3dbb-4b06-b2a7-0c189d11d962
+  ecf1_name: Red Kite Teaching School Hub (Harrogate Grammar School)
+  type: teaching_school_hub
+  ecf2_id: 437
+  ecf2_name: Red Kite Teaching School Hub
+- ecf1_id: 83ebc588-154b-4afc-87d1-cf3f3005e3d9
+  ecf1_name: Redhill Teaching School Hub (The Carlton Junior Academy)
+  type: teaching_school_hub
+  ecf2_id: 3
+  ecf2_name: Redhill Teaching Hub
+- ecf1_id: 4cb21fcf-d643-4120-9c5b-2d105abcb4af
+  ecf1_name: Saffron Teaching School Hub (Saffron Walden County High School)
+  type: teaching_school_hub
+  ecf2_id: 378
+  ecf2_name: Saffron Teaching School Hub
+- ecf1_id: ba0947b9-3182-4d62-8d9b-9497019d6b85
+  ecf1_name: Selby and Wakefield Teaching School Hub (The Vale Primary Academy)
+  type: teaching_school_hub
+  ecf2_id: 376
+  ecf2_name: Exchange Teaching School Hub
+- ecf1_id: 9f914a53-8e75-4671-ad0f-410645a12850
+  ecf1_name: SFET Teaching School Hub (South Farnham School)
+  type: teaching_school_hub
+  ecf2_id: 469
+  ecf2_name: SFET Teaching School Hub
+- ecf1_id: cb1611b7-ae1a-4e20-88cf-b7691b69d366
+  ecf1_name: South Central Teaching School Hub (The Quay School)
+  type: teaching_school_hub
+  ecf2_id: 475
+  ecf2_name: South Central Teaching School Hub
+- ecf1_id: 8a0739eb-5a6e-40ae-b466-67cfa81346bf
+  ecf1_name: South Yorkshire Teaching School Hub  (Silverdale School)
+  type: teaching_school_hub
+  ecf2_id: 525
+  ecf2_name: South Yorkshire Teaching Hub
+- ecf1_id: a3c3064a-52ba-4bfe-b4b5-3b9991d2b9ce
+  ecf1_name: Spencer Teaching School Hub (Chetwynd Spencer Academy)
+  type: teaching_school_hub
+  ecf2_id: 414
+  ecf2_name: Spencer Teaching School Hub
+- ecf1_id: 2e51f844-31b7-4483-9fea-2ba68b147375
+  ecf1_name: Star Teaching School Hub Birmingham S (Eden Boys’ School Birmingham)
+  type: teaching_school_hub
+  ecf2_id: 25
+  ecf2_name: Star Teaching School Hub Birmingham South
+- ecf1_id: 52697507-c765-4445-91df-35e01bbac58d
+  ecf1_name: Star Teaching School Hub Bolton, Bury, Rochdale (Eden Boys' School Bolton)
+  type: teaching_school_hub
+  ecf2_id: 63
+  ecf2_name: Star Teaching School Hub Pennine Lancashire
+- ecf1_id: 3e7e39de-a62c-4940-bdb1-8c47f3970a92
+  ecf1_name: Star Teaching School Hub North West Lancashire (Eden Boys' School Bolton)
+  type: teaching_school_hub
+  ecf2_id: 63
+  ecf2_name: Star Teaching School Hub Pennine Lancashire
+- ecf1_id: 46469655-8d0f-4a8c-9966-0fae6a00162a
+  ecf1_name: Star Teaching School Hub Pennine Lancashire (Eden Boys' School Bolton)
+  type: teaching_school_hub
+  ecf2_id: 63
+  ecf2_name: Star Teaching School Hub Pennine Lancashire
+- ecf1_id: acf178fc-bf68-46b1-9605-47771d82dba8
+  ecf1_name: STEP (The Priory School)
+  type: teaching_school_hub
+  ecf2_id: 420
+  ecf2_name: STEP
+- ecf1_id: dadd329c-6055-4e1c-b0ef-8ebc68f064a2
+  ecf1_name: STEP Ahead Teaching School Hub (Angel Oak Academy)
+  type: teaching_school_hub
+  ecf2_id: 45
+  ecf2_name: STEP Ahead Teaching School Hub
+- ecf1_id: e300d8d8-caf0-4f90-9147-bee0d6d40e4b
+  ecf1_name: SWIFT Colyton Teaching School Hub (Colyton Grammar School)
+  type: teaching_school_hub
+  ecf2_id: 330
+  ecf2_name: Colyton Teaching School Hub
+- ecf1_id: 3bd3c5fe-8c39-4f9c-af3e-ae992ad0ff30
+  ecf1_name: SWIFT Kingsbridge Teaching School Hub (Kingsbridge Academy)
+  type: teaching_school_hub
+  ecf2_id: 331
+  ecf2_name: Kingsbridge Teaching School Hub
+- ecf1_id: d9f1f6de-bcca-44e7-85e7-b6eb6116ad08
+  ecf1_name: Swindon and Wiltshire Teaching School Hub (Glenmoor Academy)
+  type: teaching_school_hub
+  ecf2_id: 509
+  ecf2_name: Swindon and Wiltshire Teaching School Hub
+- ecf1_id: 658c4468-30d9-4563-8581-0d20c075220f
+  ecf1_name: Teach West London (Twyford Church of England High School)
+  type: teaching_school_hub
+  ecf2_id: 390
+  ecf2_name: Teach West London
+- ecf1_id: 21a0cc8d-e737-4ab4-87f4-d9b80c91d5b0
+  ecf1_name: Teaching School Hub Berkshire (Langley Grammar School)
+  type: teaching_school_hub
+  ecf2_id: 518
+  ecf2_name: TSH Berkshire
+- ecf1_id: ff335729-990b-4e0f-9f05-1fb279491a68
+  ecf1_name: Tees Valley Teaching School Hub (St John Vianney Catholic Primary School,
+    Hartlepool)
+  type: teaching_school_hub
+  ecf2_id: 19
+  ecf2_name: Tees Valley Teaching School Hub
+- ecf1_id: c3e06654-9827-4ded-9ab5-c6bf7bfb6b0e
+  ecf1_name: Thames Gateway Teaching School Hub (Sir Joseph Williamson's Mathematical
+    School)
+  type: teaching_school_hub
+  ecf2_id: 347
+  ecf2_name: Thames Gateway Teaching School Hub
+- ecf1_id: 710e9278-b3fe-4bf6-8b26-e118647ae80a
+  ecf1_name: Thames South Teaching School Hub  (Pickhurst Infant Academy)
+  type: teaching_school_hub
+  ecf2_id: 388
+  ecf2_name: Thames South Teaching School Hub
+- ecf1_id: d4d9529e-aca5-41ff-881b-267a8570aaac
+  ecf1_name: The East Manchester Teaching School Hub (The Blue Coat CofE School)
+  type: teaching_school_hub
+  ecf2_id: 384
+  ecf2_name: The East Manchester Teaching Hub
+- ecf1_id: cacab004-f450-41bd-9947-e263481d035a
+  ecf1_name: The Golden Thread Teaching School Hub (Painsley Catholic College)
+  type: teaching_school_hub
+  ecf2_id: 439
+  ecf2_name: The Golden Thread Teaching School Hub
+- ecf1_id: f8ab3d0e-8b2f-4156-ab18-267c3b651a1d
+  ecf1_name: The Julian Teaching School Hub (Notre Dame High School, Norwich)
+  type: teaching_school_hub
+  ecf2_id: 6
+  ecf2_name: The Julian Teaching School Hub
+- ecf1_id: 9bb3b070-00b9-4881-a118-7c5d71f412de
+  ecf1_name: The Three Rivers Teaching School Hub (The King Edward VI Academy)
+  type: teaching_school_hub
+  ecf2_id: 396
+  ecf2_name: The Three Rivers Teaching School Hub
+- ecf1_id: 28a2de7e-0f10-4885-acbd-6bdd88d9e058
+  ecf1_name: The Vantage Teaching School Hub North Humber (St Mary's College, Voluntary
+    Catholic Academy)
+  type: teaching_school_hub
+  ecf2_id: 7
+  ecf2_name: The Vantage Teaching School Hub North Humber
+- ecf1_id: 832ff85f-ad31-4598-94c1-548e3f34947e
+  ecf1_name: Tudor Grange Teaching School Hub (Tudor Grange Academy, Solihull)
+  type: teaching_school_hub
+  ecf2_id: 340
+  ecf2_name: Tudor Grange Teaching School Hub
+- ecf1_id: 3162da6d-8b35-4861-9939-48cb85d802f7
+  ecf1_name: Unity Teaching School Hub (Churchill Special Free School)
+  type: teaching_school_hub
+  ecf2_id: 507
+  ecf2_name: Unity Teaching School Hub
+- ecf1_id: cda22c42-2e71-45d0-914a-d2fafadd52ea
+  ecf1_name: Wandle Teaching School Hub (Chesterton Primary School)
+  type: teaching_school_hub
+  ecf2_id: 1
+  ecf2_name: Wandle Teaching School Hub
+- ecf1_id: 7c59dc41-d732-4367-b236-564c01aee4c1
+  ecf1_name: Xavier Teaching School Hub (St John the Baptist Catholic Comprehensive
+    School, Woking)
+  type: teaching_school_hub
+  ecf2_id: 53
+  ecf2_name: Xavier Teaching School Hub
+- ecf1_id: 437699da-85a6-4564-9f19-44137ef7b104
+  ecf1_name: Barking and Dagenham
+  type: local_authority
+  ecf2_id: 242
+  ecf2_name: Barking and Dagenham LA
+- ecf1_id: 611b341d-5038-46ad-851c-80f8cc419600
+  ecf1_name: Barnet
+  type: local_authority
+  ecf2_id: 180
+  ecf2_name: Barnet LA
+- ecf1_id: b7d3f4c5-fe27-43df-9e95-461af396ef88
+  ecf1_name: Bedford
+  type: local_authority
+  ecf2_id: 325
+  ecf2_name: Bedford LA
+- ecf1_id: 3b365116-90f0-40c5-9b30-a776eab4f0ec
+  ecf1_name: Bexley
+  type: local_authority
+  ecf2_id: 243
+  ecf2_name: Bexley LA
+- ecf1_id: 5575eb1d-42c7-4346-b9e2-5c9bdcb348cb
+  ecf1_name: Birmingham
+  type: local_authority
+  ecf2_id: 100
+  ecf2_name: Birmingham LA
+- ecf1_id: f27ccac4-c1f7-4239-83e6-26697741a9df
+  ecf1_name: Blackburn with Darwen
+  type: local_authority
+  ecf2_id: 206
+  ecf2_name: Blackburn with Darwen LA
+- ecf1_id: be7fb415-53c2-45b7-b851-2585cb59a33f
+  ecf1_name: Blackpool
+  type: local_authority
+  ecf2_id: 170
+  ecf2_name: Blackpool LA
+- ecf1_id: d23b8170-d4b2-4d16-8f1d-d9a12bc44b1d
+  ecf1_name: Bolton
+  type: local_authority
+  ecf2_id: 123
+  ecf2_name: Bolton LA
+- ecf1_id: ab4ecc56-90bf-4674-8935-0075aae3c0ba
+  ecf1_name: Bracknell Forest
+  type: local_authority
+  ecf2_id: 75
+  ecf2_name: Bracknell Forest LA
+- ecf1_id: 3ca575a0-c067-45e5-91f6-ae4b88487fca
+  ecf1_name: Bradford
+  type: local_authority
+  ecf2_id: 126
+  ecf2_name: Bradford LA
+- ecf1_id: aa696760-df94-4e83-8eeb-07ac6637089e
+  ecf1_name: Brent
+  type: local_authority
+  ecf2_id: 137
+  ecf2_name: Brent LA
+- ecf1_id: 2fed2f74-f33c-4c20-a9c5-23f8856255d7
+  ecf1_name: Brighton and Hove
+  type: local_authority
+  ecf2_id: 207
+  ecf2_name: Brighton and Hove City Council
+- ecf1_id: 271ac143-1234-4685-a183-41d3c8aee17f
+  ecf1_name: Bristol
+  type: local_authority
+  ecf2_id: 110
+  ecf2_name: Bristol LA
+- ecf1_id: 52dbd3a4-0fae-4a93-b505-151be6422353
+  ecf1_name: Buckinghamshire
+  type: local_authority
+  ecf2_id: 134
+  ecf2_name: Buckinghamshire Local Authority
+- ecf1_id: 36682180-6d0f-4a69-8c45-0910a0a9ebea
+  ecf1_name: Calderdale
+  type: local_authority
+  ecf2_id: 193
+  ecf2_name: Calderdale LA
+- ecf1_id: 8dece72b-d949-4b2c-87b5-caffcc7fc8f1
+  ecf1_name: Cambridgeshire
+  type: local_authority
+  ecf2_id: 186
+  ecf2_name: Cambridgeshire LA
+- ecf1_id: 0bbd7ac5-6b37-40a4-a1f7-3907ca2ce949
+  ecf1_name: Camden
+  type: local_authority
+  ecf2_id: 198
+  ecf2_name: Camden LA
+- ecf1_id: 2a2d6c7d-c416-4d72-912a-4cb5c4ca0e0f
+  ecf1_name: Central Bedfordshire
+  type: local_authority
+  ecf2_id: 324
+  ecf2_name: Central Bedfordshire LA
+- ecf1_id: 9f94d730-7e98-4e86-839d-05069a398a45
+  ecf1_name: Cheshire East
+  type: local_authority
+  ecf2_id: 323
+  ecf2_name: Cheshire East LA
+- ecf1_id: f7cfdb93-0f1e-4836-88bf-2c1cdde905ed
+  ecf1_name: Cheshire West and Chester
+  type: local_authority
+  ecf2_id: 322
+  ecf2_name: Cheshire West and Chester LA
+- ecf1_id: 71513a6a-69ba-4a80-9559-b5e60fcd07e4
+  ecf1_name: City of Westminster
+  type: local_authority
+  ecf2_id: 144
+  ecf2_name: Westminster LA
+- ecf1_id: 106bf66a-df14-4c06-9491-c48722a9cbcf
+  ecf1_name: Coventry
+  type: local_authority
+  ecf2_id: 92
+  ecf2_name: Coventry LA
+- ecf1_id: b9517c93-dd11-4306-98ea-3776a9ffc4ba
+  ecf1_name: Croydon
+  type: local_authority
+  ecf2_id: 146
+  ecf2_name: Croydon LA
+- ecf1_id: c49d44f0-5e52-4153-bca6-b2dd9970924f
+  ecf1_name: Darlington
+  type: local_authority
+  ecf2_id: 136
+  ecf2_name: Darlington LA
+- ecf1_id: 70db38b2-2dc1-4c94-aebe-ae953d524771
+  ecf1_name: Derby
+  type: local_authority
+  ecf2_id: 140
+  ecf2_name: Derby LA
+- ecf1_id: b4adcbb4-2ea2-4c90-9031-99fa4e4be8db
+  ecf1_name: Derbyshire
+  type: local_authority
+  ecf2_id: 94
+  ecf2_name: Derbyshire LA
+- ecf1_id: a17ba7cc-2e43-4317-880b-0b25b60947db
+  ecf1_name: Devon
+  type: local_authority
+  ecf2_id: 69
+  ecf2_name: Devon LA
+- ecf1_id: 4b4e5c98-df0b-49b1-9515-ab6073321398
+  ecf1_name: Doncaster
+  type: local_authority
+  ecf2_id: 213
+  ecf2_name: Doncaster LA
+- ecf1_id: 88bb2b82-832e-4090-bc7c-6d1ac8230227
+  ecf1_name: Dorset
+  type: local_authority
+  ecf2_id: 135
+  ecf2_name: Dorset LA
+- ecf1_id: 1d20b3b8-f98d-454d-8119-fc2c98135be2
+  ecf1_name: Durham
+  type: local_authority
+  ecf2_id: 90
+  ecf2_name: Durham LA
+- ecf1_id: 44f7abd2-7e66-4be2-97f3-4efcffd2c7ac
+  ecf1_name: Ealing
+  type: local_authority
+  ecf2_id: 244
+  ecf2_name: Ealing LA
+- ecf1_id: 3efc1a2f-2c52-49b8-9b2e-d038df39d252
+  ecf1_name: East Riding of Yorkshire
+  type: local_authority
+  ecf2_id: 91
+  ecf2_name: East Riding of Yorkshire LA
+- ecf1_id: e7d8fd30-fe1f-4e44-9fa8-2e66b40e6f7a
+  ecf1_name: Enfield
+  type: local_authority
+  ecf2_id: 189
+  ecf2_name: Enfield LA
+- ecf1_id: e2d085a1-c2ef-44c4-92d5-60381808e74f
+  ecf1_name: Essex
+  type: local_authority
+  ecf2_id: 119
+  ecf2_name: Essex LA
+- ecf1_id: 9ab0eba7-217a-43fd-a865-aa5da7386687
+  ecf1_name: Gateshead
+  type: local_authority
+  ecf2_id: 71
+  ecf2_name: Gateshead LA
+- ecf1_id: 7db7fce4-9a0e-492e-b7f4-48939c4659c7
+  ecf1_name: Gloucestershire
+  type: local_authority
+  ecf2_id: 141
+  ecf2_name: Gloucestershire LA
+- ecf1_id: 84023caf-0af6-48b7-bb25-5b22750940a7
+  ecf1_name: Greenwich
+  type: local_authority
+  ecf2_id: 181
+  ecf2_name: Greenwich LA
+- ecf1_id: 25f63f13-5ee9-46ea-9e78-5954ef7fa68b
+  ecf1_name: Hackney
+  type: local_authority
+  ecf2_id: 143
+  ecf2_name: Hackney LA
+- ecf1_id: f1c9df73-8b75-4c09-9c71-85d0e655fb09
+  ecf1_name: Halton
+  type: local_authority
+  ecf2_id: 118
+  ecf2_name: Halton LA
+- ecf1_id: 3f461874-ea53-454f-ae9b-989b7791e1e0
+  ecf1_name: Hammersmith and Fulham
+  type: local_authority
+  ecf2_id: 102
+  ecf2_name: Hammersmith and Fulham LA
+- ecf1_id: 8edfeb7e-5fdd-4490-bed7-36e1ee0deb24
+  ecf1_name: Hampshire
+  type: local_authority
+  ecf2_id: 87
+  ecf2_name: Hampshire LA
+- ecf1_id: 86700172-6adf-445e-b0eb-b5a42167d90b
+  ecf1_name: Haringey
+  type: local_authority
+  ecf2_id: 147
+  ecf2_name: Haringey LA
+- ecf1_id: f1f0424a-d542-4348-97e7-cb95d4213a24
+  ecf1_name: Harrow
+  type: local_authority
+  ecf2_id: 245
+  ecf2_name: Harrow LA
+- ecf1_id: d0323761-6ffa-40a1-a47d-277bfc387521
+  ecf1_name: Havering
+  type: local_authority
+  ecf2_id: 201
+  ecf2_name: Havering LA
+- ecf1_id: edcfadb9-5023-405e-b59e-99883aebf857
+  ecf1_name: Hertfordshire
+  type: local_authority
+  ecf2_id: 205
+  ecf2_name: Hertfordshire LA
+- ecf1_id: 98ce39f2-359d-4623-95b9-a00a15fcf1ac
+  ecf1_name: Hillingdon
+  type: local_authority
+  ecf2_id: 169
+  ecf2_name: Hillingdon LA
+- ecf1_id: b388d850-7f14-4f98-8ae1-af10bc10cc36
+  ecf1_name: Hounslow
+  type: local_authority
+  ecf2_id: 148
+  ecf2_name: Hounslow LA
+- ecf1_id: ae7af9d2-c810-4cdf-8c26-2f842cad4ec9
+  ecf1_name: Islington
+  type: local_authority
+  ecf2_id: 93
+  ecf2_name: Islington LA
+- ecf1_id: 28a08690-9329-4d95-ae03-0dd009220f86
+  ecf1_name: Kensington and Chelsea
+  type: local_authority
+  ecf2_id: 240
+  ecf2_name: Kensington and Chelsea LA
+- ecf1_id: 2e9550c6-7e07-4788-a35a-5985a13f9088
+  ecf1_name: Kent
+  type: local_authority
+  ecf2_id: 210
+  ecf2_name: Kent LA
+- ecf1_id: 638ea41e-5a41-4ae6-bc5f-c6235c08c2bf
+  ecf1_name: Kingston upon Hull
+  type: local_authority
+  ecf2_id: 97
+  ecf2_name: Kingston upon Hull LA
+- ecf1_id: fa219509-5342-4a03-a097-c5b7f1ab7984
+  ecf1_name: Kingston upon Thames
+  type: local_authority
+  ecf2_id: 139
+  ecf2_name: Kingston upon Thames LA
+- ecf1_id: 045f9042-86a1-4840-ab2c-4ba151a2a8ea
+  ecf1_name: Kirklees
+  type: local_authority
+  ecf2_id: 203
+  ecf2_name: Kirklees LA
+- ecf1_id: 5712991d-35dc-4e34-b1fb-08be9fcab45c
+  ecf1_name: Knowsley
+  type: local_authority
+  ecf2_id: 177
+  ecf2_name: Knowsley LA
+- ecf1_id: 756ca197-0fc3-488b-8847-a300f1495f1a
+  ecf1_name: Lambeth
+  type: local_authority
+  ecf2_id: 86
+  ecf2_name: Lambeth LA
+- ecf1_id: d9ebd923-59d2-45b8-9976-f591f60686f6
+  ecf1_name: Lancashire
+  type: local_authority
+  ecf2_id: 80
+  ecf2_name: Lancashire LA
+- ecf1_id: eacb2022-2d16-4584-93f0-d7f554995d2d
+  ecf1_name: Leeds
+  type: local_authority
+  ecf2_id: 114
+  ecf2_name: Leeds LA
+- ecf1_id: c9a68a4d-7c50-4093-a35a-be05ab6baf36
+  ecf1_name: Leicester
+  type: local_authority
+  ecf2_id: 161
+  ecf2_name: Leicester LA
+- ecf1_id: 234ec2f9-46a5-4263-bfab-7fd1cc8ca80d
+  ecf1_name: Leicestershire
+  type: local_authority
+  ecf2_id: 73
+  ecf2_name: Leicestershire LA
+- ecf1_id: a7d1f355-cd88-4a1c-8d6f-138d296abff8
+  ecf1_name: Lewisham
+  type: local_authority
+  ecf2_id: 101
+  ecf2_name: Lewisham LA
+- ecf1_id: b3c0e784-9602-401b-9aff-8cd57dbff334
+  ecf1_name: Liverpool
+  type: local_authority
+  ecf2_id: 113
+  ecf2_name: Liverpool LA
+- ecf1_id: 7671fafd-29c4-479f-af19-3d5268ba4443
+  ecf1_name: Luton
+  type: local_authority
+  ecf2_id: 212
+  ecf2_name: Luton LA
+- ecf1_id: e54ee26b-16a3-4289-9b61-2acace2cad92
+  ecf1_name: Manchester
+  type: local_authority
+  ecf2_id: 196
+  ecf2_name: Manchester LA
+- ecf1_id: d3bea2d3-ffec-406f-b7fc-0069941f4748
+  ecf1_name: Medway
+  type: local_authority
+  ecf2_id: 120
+  ecf2_name: Medway LA
+- ecf1_id: c1c8120d-7637-4b2c-b151-675fd5ee5ee0
+  ecf1_name: Merton
+  type: local_authority
+  ecf2_id: 153
+  ecf2_name: Merton LA
+- ecf1_id: ff7f4320-73eb-424a-8f47-382615cfa39b
+  ecf1_name: Milton Keynes
+  type: local_authority
+  ecf2_id: 215
+  ecf2_name: Milton Keynes LA
+- ecf1_id: f8e382cf-0ab4-4fe3-a1e0-45b6a24f8192
+  ecf1_name: Newham
+  type: local_authority
+  ecf2_id: 179
+  ecf2_name: Newham LA
+- ecf1_id: bdaa69cb-4c50-411e-914c-c64f4c173bfa
+  ecf1_name: Norfolk
+  type: local_authority
+  ecf2_id: 182
+  ecf2_name: Norfolk LA
+- ecf1_id: e6c22511-b23b-4d85-8db2-e8b077504449
+  ecf1_name: North Lincolnshire
+  type: local_authority
+  ecf2_id: 208
+  ecf2_name: North Lincolnshire LA
+- ecf1_id: ca09858e-15e5-443b-9e1e-ea34f74f4977
+  ecf1_name: North Northamptonshire
+  type: local_authority
+  ecf2_id: 21
+  ecf2_name: North Northamptonshire LA
+- ecf1_id: abe77240-15b0-4192-993e-1563e991e280
+  ecf1_name: North Tyneside
+  type: local_authority
+  ecf2_id: 200
+  ecf2_name: North Tyneside LA
+- ecf1_id: b3db9f72-e1f6-4f70-9856-8301de679b65
+  ecf1_name: North Yorkshire
+  type: local_authority
+  ecf2_id: 85
+  ecf2_name: North Yorkshire LA
+- ecf1_id: b7d843b8-c2f9-470d-b1aa-63169c35cbd0
+  ecf1_name: Northumberland
+  type: local_authority
+  ecf2_id: 159
+  ecf2_name: Northumberland LA
+- ecf1_id: ea7a6644-569b-423b-a033-5433e8a39507
+  ecf1_name: Nottingham
+  type: local_authority
+  ecf2_id: 185
+  ecf2_name: Nottingham LA
+- ecf1_id: 65ed7806-d8af-42f7-a4a9-72a766ca2500
+  ecf1_name: Nottinghamshire
+  type: local_authority
+  ecf2_id: 121
+  ecf2_name: Nottinghamshire LA
+- ecf1_id: 63b233f4-1f40-468f-8183-695f3cba5eb2
+  ecf1_name: Peterborough
+  type: local_authority
+  ecf2_id: 77
+  ecf2_name: Peterborough LA
+- ecf1_id: f5b7f074-5d5c-474f-8be6-c986cd1bb7e4
+  ecf1_name: Plymouth
+  type: local_authority
+  ecf2_id: 160
+  ecf2_name: Plymouth LA
+- ecf1_id: 39cc8141-6cea-4ad5-8b32-3447133868b8
+  ecf1_name: Portsmouth
+  type: local_authority
+  ecf2_id: 107
+  ecf2_name: Portsmouth LA
+- ecf1_id: 3f4cbcb4-d3cd-467a-b3d1-f803967bff1c
+  ecf1_name: Reading
+  type: local_authority
+  ecf2_id: 105
+  ecf2_name: Reading LA
+- ecf1_id: cfd970bc-23f2-4560-b0fc-8fdd5595c7d9
+  ecf1_name: Redbridge
+  type: local_authority
+  ecf2_id: 168
+  ecf2_name: Redbridge LA
+- ecf1_id: ff8fa5b7-ad56-4455-8250-10ae5d145be8
+  ecf1_name: Redcar and Cleveland
+  type: local_authority
+  ecf2_id: 138
+  ecf2_name: Redcar and Cleveland LA
+- ecf1_id: 2029a9d9-5841-4bc4-b64e-96ce272947ee
+  ecf1_name: Richmond upon Thames
+  type: local_authority
+  ecf2_id: 158
+  ecf2_name: Richmond upon Thames LA
+- ecf1_id: 544a9d10-5fb5-41d6-aa72-67a756fafadb
+  ecf1_name: Rochdale
+  type: local_authority
+  ecf2_id: 195
+  ecf2_name: Rochdale LA
+- ecf1_id: 0e1f0252-d290-4592-897e-0277cd5164c9
+  ecf1_name: Rotherham
+  type: local_authority
+  ecf2_id: 216
+  ecf2_name: Rotherham LA
+- ecf1_id: 7de45f58-883a-4e9b-a5ac-6c5fb1de3d6b
+  ecf1_name: Salford
+  type: local_authority
+  ecf2_id: 167
+  ecf2_name: Salford LA
+- ecf1_id: fa1b2e36-0755-4644-8c77-8484d18a5551
+  ecf1_name: Sandwell
+  type: local_authority
+  ecf2_id: 72
+  ecf2_name: Sandwell LA
+- ecf1_id: f3b76b4f-79a3-4c88-a7f2-4afe5c7d76d7
+  ecf1_name: Sefton
+  type: local_authority
+  ecf2_id: 150
+  ecf2_name: Sefton LA
+- ecf1_id: a4a723b8-63c4-455f-be93-dce2eda7f1e6
+  ecf1_name: Shropshire
+  type: local_authority
+  ecf2_id: 184
+  ecf2_name: Shropshire LA
+- ecf1_id: 87b05b6c-3a32-4acc-a587-10239e81f3c4
+  ecf1_name: Solihull
+  type: local_authority
+  ecf2_id: 178
+  ecf2_name: Solihull LA
+- ecf1_id: 3d8c09c4-fc1b-48af-9c70-fd41a7a1f1b1
+  ecf1_name: Somerset
+  type: local_authority
+  ecf2_id: 82
+  ecf2_name: Somerset LA
+- ecf1_id: 1aebe971-bd40-4f1c-82e9-f0587c57fba3
+  ecf1_name: South Gloucestershire
+  type: local_authority
+  ecf2_id: 164
+  ecf2_name: South Gloucestershire LA
+- ecf1_id: ca0cf785-7025-44ca-a9dc-dd4bb26c8086
+  ecf1_name: South Tyneside
+  type: local_authority
+  ecf2_id: 127
+  ecf2_name: South Tyneside LA
+- ecf1_id: 26b0e1cb-d58f-4611-8e7c-28ab7e02f32a
+  ecf1_name: Southend-On-Sea
+  type: local_authority
+  ecf2_id: 78
+  ecf2_name: Southend-on-Sea LA
+- ecf1_id: 6b2472d0-57a5-4a43-83af-668238184156
+  ecf1_name: Southwark
+  type: local_authority
+  ecf2_id: 154
+  ecf2_name: Southwark LA
+- ecf1_id: f205fa85-504c-4020-8015-fbe93844a9e3
+  ecf1_name: St Helens
+  type: local_authority
+  ecf2_id: 197
+  ecf2_name: St Helens LA
+- ecf1_id: ae0edcf7-f241-4c45-8e1c-e305e2544140
+  ecf1_name: Staffordshire
+  type: local_authority
+  ecf2_id: 173
+  ecf2_name: Staffordshire LA
+- ecf1_id: 2667daea-89e9-4d08-896f-29a4c6479e67
+  ecf1_name: Stockport
+  type: local_authority
+  ecf2_id: 166
+  ecf2_name: Stockport LA
+- ecf1_id: 1340e135-fba9-4982-91ab-6d5775e3ec74
+  ecf1_name: Stockton-on-Tees
+  type: local_authority
+  ecf2_id: 108
+  ecf2_name: Stockton-on-Tees LA
+- ecf1_id: 1d68c7db-794a-40df-839c-5df09640d1d7
+  ecf1_name: Suffolk
+  type: local_authority
+  ecf2_id: 199
+  ecf2_name: Suffolk LA
+- ecf1_id: 03bf56f7-e4ef-4db7-9ce1-c53324487f54
+  ecf1_name: Sunderland
+  type: local_authority
+  ecf2_id: 128
+  ecf2_name: Sunderland LA
+- ecf1_id: 0d75da2b-fb23-4714-83de-1fc21a8bf68f
+  ecf1_name: Sutton
+  type: local_authority
+  ecf2_id: 155
+  ecf2_name: Sutton LA
+- ecf1_id: 5bd3d584-30fd-4960-b20f-ce8d42710caf
+  ecf1_name: Swindon
+  type: local_authority
+  ecf2_id: 172
+  ecf2_name: Swindon LA
+- ecf1_id: 4222a5e6-dabf-4991-b94b-22735a73f7e1
+  ecf1_name: Telford and Wrekin
+  type: local_authority
+  ecf2_id: 183
+  ecf2_name: Telford and Wrekin LA
+- ecf1_id: 294e72c9-27b9-40b8-84e7-bd1b155dcf9c
+  ecf1_name: Thurrock
+  type: local_authority
+  ecf2_id: 96
+  ecf2_name: Thurrock LA
+- ecf1_id: b3c3bc39-3e22-4ebd-a5b4-038d9d3fde68
+  ecf1_name: Tower Hamlets
+  type: local_authority
+  ecf2_id: 209
+  ecf2_name: Tower Hamlets LA
+- ecf1_id: 9695ac6b-5980-44ea-91d9-347e408327bf
+  ecf1_name: Trafford
+  type: local_authority
+  ecf2_id: 99
+  ecf2_name: Trafford LA
+- ecf1_id: 67827bee-bb60-4510-99b2-d365398e3bde
+  ecf1_name: Wakefield
+  type: local_authority
+  ecf2_id: 192
+  ecf2_name: Wakefield LA
+- ecf1_id: c778cc30-cc04-4d5a-8f6a-8e7683c7824a
+  ecf1_name: Walsall
+  type: local_authority
+  ecf2_id: 188
+  ecf2_name: Walsall LA
+- ecf1_id: 4493444c-ceaf-4fc7-b195-3718e38d7e19
+  ecf1_name: Waltham Forest
+  type: local_authority
+  ecf2_id: 246
+  ecf2_name: Waltham Forest LA
+- ecf1_id: bb7a32db-2eef-42b0-9c32-e31e276c9a37
+  ecf1_name: Wandsworth
+  type: local_authority
+  ecf2_id: 241
+  ecf2_name: Wandsworth LA
+- ecf1_id: 9541e671-7aea-4eb6-8386-7016bf72daf7
+  ecf1_name: Warrington
+  type: local_authority
+  ecf2_id: 70
+  ecf2_name: Warrington LA
+- ecf1_id: 98765b16-f384-424e-8a0c-cb009b794606
+  ecf1_name: Warwickshire
+  type: local_authority
+  ecf2_id: 95
+  ecf2_name: Warwickshire LA
+- ecf1_id: 277e7b9c-e6a8-41a2-af5d-c0d367bec222
+  ecf1_name: West Berkshire
+  type: local_authority
+  ecf2_id: 171
+  ecf2_name: West Berkshire LA
+- ecf1_id: '018939c6-c1c5-4048-a8a9-ea4ce4e23d5b'
+  ecf1_name: West Northamptonshire
+  type: local_authority
+  ecf2_id: 22
+  ecf2_name: West Northamptonshire LA
+- ecf1_id: 203f85ac-2157-427d-b6a7-cf27926c4788
+  ecf1_name: West Sussex
+  type: local_authority
+  ecf2_id: 89
+  ecf2_name: West Sussex LA
+- ecf1_id: e320f431-7bf4-4066-85e8-72828800128a
+  ecf1_name: Wigan
+  type: local_authority
+  ecf2_id: 187
+  ecf2_name: Wigan LA
+- ecf1_id: b35657c6-db47-4766-9746-ef543c7b43c8
+  ecf1_name: Wiltshire
+  type: local_authority
+  ecf2_id: 202
+  ecf2_name: Wiltshire LA
+- ecf1_id: d3d0ab71-558e-491b-89c2-dedd0be82358
+  ecf1_name: Windsor and Maidenshead
+  type: local_authority
+  ecf2_id: 76
+  ecf2_name: Windsor and Maidenhead LA
+- ecf1_id: 4a058289-5710-4077-b89d-c64019929a6b
+  ecf1_name: Wirral
+  type: local_authority
+  ecf2_id: 152
+  ecf2_name: Wirral LA
+- ecf1_id: 730feb37-c89c-4f2f-a5ad-7699fc6ed2d9
+  ecf1_name: Wokingham
+  type: local_authority
+  ecf2_id: 104
+  ecf2_name: Wokingham LA
+- ecf1_id: e1b61b18-1906-4a98-8def-fcb3eec8e3fe
+  ecf1_name: Wolverhampton
+  type: local_authority
+  ecf2_id: 149
+  ecf2_name: Wolverhampton LA
+- ecf1_id: 1fcd139c-2f61-4b57-ad93-cd57abbf1b61
+  ecf1_name: Worcestershire
+  type: local_authority
+  ecf2_id: 79
+  ecf2_name: Worcestershire LA
+- ecf1_id: 66ac8730-3888-44c6-afeb-2c2945fe9559
+  ecf1_name: York
+  type: local_authority
+  ecf2_id: 88
+  ecf2_name: York LA
+- ecf1_id: babb1465-bbee-4a68-b3bf-96677e26758c
+  ecf1_name: Educational Success Partners (ESP)
+  type: national
+  ecf2_id: 23
+  ecf2_name: Educational Success Partners (ESP)
+- ecf1_id: 2b4166b4-efb9-44ea-a848-318882ef5d3c
+  ecf1_name: Independent Schools Teacher Induction Panel (IStip)
+  type: national
+  ecf2_id: 302
+  ecf2_name: Independent Schools Teacher Induction Panel (ISTIP)
+- ecf1_id: 8fa977bf-20e6-421f-a48c-afe5f3626a0b
+  ecf1_name: National Teacher Accreditation (NTA)
+  type: national
+  ecf2_id: 491
+  ecf2_name: National Teacher Accreditation

--- a/spec/migration/mappers/appropriate_body_mapper_spec.rb
+++ b/spec/migration/mappers/appropriate_body_mapper_spec.rb
@@ -1,0 +1,24 @@
+describe Mappers::AppropriateBodyMapper do
+  subject { Mappers::AppropriateBodyMapper.new }
+
+  it "loads the hardcoded mapping data by default" do
+    expect(subject.mapping_data).to be_an(Array)
+    expect(subject.mapping_data.length).to eq(212)
+  end
+
+  describe "#get_ecf2_id" do
+    it "returns the correct ECF2 ID given an ECF1 ID" do
+      expect(subject.get_ecf2_id("d39267fc-ded1-49e0-b6ae-1161b3f3b439")).to eq(383)
+    end
+
+    context "when there is no matching ECF1 ID" do
+      it "raises a NoMatchingECF1AppropriateBodyID error" do
+        absent_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        error_class = Mappers::AppropriateBodyMapper::NoMatchingECF1AppropriateBodyID
+        error_message = "ecf1_id: #{absent_id}"
+
+        expect { subject.get_ecf2_id(absent_id) }.to raise_error(error_class, error_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This mapper gives us a way to identify ECF2 appropriate bodies given an ECF1 ID.

The data was generated using the CSV uploaded to DFE-Digital/register-ects-project-board#3631 using the following script:

```ruby
ab_data = CSV.read('/home/peter/downloads/AB.mapping.csv', headers: true)

File.write(
  '/tmp/mapping_data.yml',
  ab_data
    .map { it.to_h }
    .map { it['ecf2_id'] = it['ecf2_id'].to_i; it }
    .to_yaml
  )
```
