### PR TITLE
[2317] UUID presentation  

### DIFF
--- a/app/assets/stylesheets/admin/teachers.scss
+++ b/app/assets/stylesheets/admin/teachers.scss
@@ -1,18 +1,17 @@
 @use "govuk-frontend/dist/govuk" as *;
 
-.app-code {
+pre {
+  background-color: $govuk-template-background-colour;
+
+  code { padding: unset; }
+}
+
+code {
   padding: 2px 5px;
   font-family: monospace;
   background-color: $govuk-template-background-colour;
   white-space: pre-wrap;
   font-size: 0.8em;
-}
-
-.govuk-summary-list__value .app-code--full-width {
-  display: block;
-  width: 100%;
-  padding: 1em;
-  box-sizing: border-box;
 }
 
 .app-teachers-filters {

--- a/app/components/admin/appropriate_bodies/details_component.html.erb
+++ b/app/components/admin/appropriate_bodies/details_component.html.erb
@@ -22,7 +22,7 @@
 
     sl.with_row do |row|
       row.with_key(text: 'DfE Sign-in organisation ID')
-      row.with_value(text: tag.code(appropriate_body.dfe_sign_in_organisation_id))
+      row.with_value(text: helpers.format_uuid(appropriate_body.dfe_sign_in_organisation_id))
       row.with_action(
         text: 'View',
         href: admin_dsi_org_path(appropriate_body.dfe_sign_in_organisation.uuid),

--- a/app/components/admin/schools/partnerships_summary_component.html.erb
+++ b/app/components/admin/schools/partnerships_summary_component.html.erb
@@ -27,7 +27,7 @@
 
           <% list.with_row do |row| %>
             <% row.with_key(text: "Partnership API ID") %>
-            <% row.with_value { school_partnership.api_id } %>
+            <% row.with_value { helpers.format_uuid(school_partnership.api_id) } %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/admin/teachers/overview_summary_component.rb
+++ b/app/components/admin/teachers/overview_summary_component.rb
@@ -71,7 +71,7 @@ module Admin
       end
 
       def api_participant_id_row
-        { key: "API participant ID", value: content_tag(:code, teacher.api_participant_id, class: "app-code") }
+        { key: "API participant ID", value: helpers.format_uuid(teacher.api_participant_id) }
       end
 
       def current_school_value

--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -140,9 +140,7 @@ module Admin
 
       def api_response_text
         govuk_details(summary_text: "See this participant as they appear over the API for #{lead_provider&.name}") do
-          content_tag(:pre, class: "app-code app-code--full-width") do
-            content_tag(:code, formatted_teacher)
-          end
+          tag.pre(tag.code(formatted_teacher))
         end
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,4 +92,11 @@ module ApplicationHelper
   def govuk_html_element(&block)
     tag.html(lang: "en", class: %w[govuk-template govuk-template--rebranded], &block)
   end
+
+  def format_uuid(uuid)
+    visually_hidden_span = govuk_visually_hidden("Identifier starting with #{uuid.first(6)}")
+    aria_hidden_span = tag.span(uuid, aria: { hidden: true })
+
+    tag.code(safe_join([visually_hidden_span, aria_hidden_span]))
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,9 +94,8 @@ module ApplicationHelper
   end
 
   def format_uuid(uuid)
-    visually_hidden_span = govuk_visually_hidden("Identifier starting with #{uuid.first(6)}")
-    aria_hidden_span = tag.span(uuid, aria: { hidden: true })
+    return if uuid.blank?
 
-    tag.code(safe_join([visually_hidden_span, aria_hidden_span]))
+    tag.code(uuid)
   end
 end

--- a/app/views/admin/appropriate_bodies/show.html.erb
+++ b/app/views/admin/appropriate_bodies/show.html.erb
@@ -6,7 +6,3 @@
 %>
 
 <%= render Admin::AppropriateBodies::DetailsComponent.new(appropriate_body_period: @appropriate_body) %>
-
-<p class='govuk-body'>
-  <%# govuk_link_to('Timeline of events', admin_appropriate_body_timeline_path(@appropriate_body)) %>
-</p>

--- a/app/views/admin/delivery_partners/show.html.erb
+++ b/app/views/admin/delivery_partners/show.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <p class='govuk-body'>
-  API ID: <span class="govuk-body app-mono"><%= @delivery_partner.api_id %></span>
+  API ID: <%= format_uuid(@delivery_partner.api_id) %>
 </p>
 
 <%= render(Admin::LeadProviderPartnershipsTableComponent.new(

--- a/app/views/admin/dfe_sign_in_organisations/show.html.erb
+++ b/app/views/admin/dfe_sign_in_organisations/show.html.erb
@@ -1,7 +1,7 @@
 <%
   page_data(
     title: @organisation.name,
-    caption: "DFE Sign-In Organisation ID: #{@organisation.uuid}"
+    caption: "DFE Sign-In Organisation ID: #{format_uuid(@organisation.uuid)}"
   )
 %>
 

--- a/app/views/admin/dfe_sign_in_organisations/show.html.erb
+++ b/app/views/admin/dfe_sign_in_organisations/show.html.erb
@@ -1,7 +1,7 @@
 <%
   page_data(
     title: @organisation.name,
-    caption: "DFE Sign-In Organisation ID: #{format_uuid(@organisation.uuid)}"
+    caption: "DFE Sign-In Organisation ID: #{@organisation.uuid}"
   )
 %>
 

--- a/app/views/admin/finance/voids/new.html.erb
+++ b/app/views/admin/finance/voids/new.html.erb
@@ -9,7 +9,7 @@
       govuk_summary_list(actions: false) do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Declaration ID" }
-          row.with_value { tag.span(@declaration.api_id, class: "app-mono") }
+          row.with_value { format_uuid(@declaration.api_id) }
         end
 
         summary_list.with_row do |row|

--- a/app/views/admin/teachers/declarations/_declaration.html.erb
+++ b/app/views/admin/teachers/declarations/_declaration.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_details do |details| %>
   <% details.with_summary_html do %>
     <span class="govuk-details__summary-text govuk-!-margin-right-2"><%= declaration.declaration_type %></span>
-    <span class="govuk-body app-mono"><%= declaration.api_id %></span>
+    <%= format_uuid(declaration.api_id) %>
     <%= declaration_state_tag(declaration) %>
   <% end %>
 
@@ -9,7 +9,7 @@
     govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-0") do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Declaration ID" }
-        row.with_value { tag.span(declaration.api_id, class: "govuk-!-margin-0 app-mono") }
+        row.with_value { format_uuid(declaration.api_id) }
       end
 
       summary_list.with_row do |row|

--- a/spec/components/admin/teachers/overview_summary_component_spec.rb
+++ b/spec/components/admin/teachers/overview_summary_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Admin::Teachers::OverviewSummaryComponent, type: :component do
     end
 
     it "shows the API participant ID in a code block" do
-      expect(rendered.css("code.app-code").text).to eq(teacher.api_id)
+      expect(rendered.css("code").text).to include(teacher.api_id)
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -318,25 +318,16 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#format_uuid" do
     subject { format_uuid(uuid) }
 
-    let(:uuid) { "12345678-9999-4444-aaaa-888888888888" }
+    let(:uuid) { SecureRandom.uuid }
 
     it "renders a visually hidden span for screenreader users" do
-      expect(subject).to have_css("code", text: Regexp.new(uuid))
+      expect(subject).to have_css("code", text: uuid)
     end
 
-    describe "for screenreader users" do
-      it "renders a visually hidden span element that contains the first 6 letters of the UUID" do
-        expect(subject).to have_css("code > span.govuk-visually-hidden", text: "Identifier starting with 123456")
+    context "when there is no uuid" do
+      let(:uuid) { nil }
 
-        # only has the first 6 chars of the UUID
-        expect(subject).not_to have_css("code > span.govuk-visually-hidden", text: "Identifier starting with 1234567")
-      end
-    end
-
-    describe "for regular users" do
-      it "renders a aria-hidden span element that contains the whole UUID" do
-        expect(subject).to have_css(%(code > span[aria-hidden="true"]), text: uuid)
-      end
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -314,4 +314,29 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#format_uuid" do
+    subject { format_uuid(uuid) }
+
+    let(:uuid) { "12345678-9999-4444-aaaa-888888888888" }
+
+    it "renders a visually hidden span for screenreader users" do
+      expect(subject).to have_css("code", text: Regexp.new(uuid))
+    end
+
+    describe "for screenreader users" do
+      it "renders a visually hidden span element that contains the first 6 letters of the UUID" do
+        expect(subject).to have_css("code > span.govuk-visually-hidden", text: "Identifier starting with 123456")
+
+        # only has the first 6 chars of the UUID
+        expect(subject).not_to have_css("code > span.govuk-visually-hidden", text: "Identifier starting with 1234567")
+      end
+    end
+
+    describe "for regular users" do
+      it "renders a aria-hidden span element that contains the whole UUID" do
+        expect(subject).to have_css(%(code > span[aria-hidden="true"]), text: uuid)
+      end
+    end
+  end
 end

--- a/spec/support/matchers/have_summary_list_row.rb
+++ b/spec/support/matchers/have_summary_list_row.rb
@@ -10,12 +10,15 @@ module HaveSummaryListRow
       @page = page
       @rows = @page.find_all("dl.govuk-summary-list dt.govuk-summary-list__key", visible: @visible)
       @matching_row = @rows.find { |it| it.text == @key }
+      @sibling = @matching_row&.sibling("dd.govuk-summary-list__value", visible: @visible)
 
-      if @value.blank?
+      case
+      when @value.blank?
         @matching_row && @matching_row.text == @key
+      when @value.is_a?(Regexp)
+        @sibling.text.match?(@value)
       else
-        @sibling = @matching_row&.sibling("dd.govuk-summary-list__value", visible: @visible)
-        @sibling && @sibling.text == @value
+        @sibling.text == @value
       end
     end
 

--- a/spec/views/admin/delivery_partners/show.html.erb_spec.rb
+++ b/spec/views/admin/delivery_partners/show.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "admin/delivery_partners/show.html.erb" do
   it "shows the delivery partner API ID" do
     render
 
-    expect(rendered).to have_css("span.app-mono", text: delivery_partner.api_id)
+    expect(rendered).to have_css("code", text: delivery_partner.api_id)
   end
 
   it "includes backlink with preserved page and query parameters" do

--- a/spec/views/admin/finance/voids/new.html.erb_spec.rb
+++ b/spec/views/admin/finance/voids/new.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "admin/finance/voids/new.html.erb", type: :view do
     expect(view.content_for(:page_title)).to include("Void declaration for Test Teacher")
   end
 
-  it { is_expected.to have_summary_list_row("Declaration ID", value: "test-declaration-uuid", visible: :all) }
+  it { is_expected.to have_summary_list_row("Declaration ID", value: /test-declaration-uuid/, visible: :all) }
   it { is_expected.to have_summary_list_row("Course identifier", value: "ecf-induction", visible: :all) }
   it { is_expected.to have_summary_list_row("Declaration type", value: "started", visible: :all) }
   it { is_expected.to have_summary_list_row("State", value: "Eligible", visible: :all) }

--- a/spec/views/admin/teachers/declarations/_declaration.html.erb_spec.rb
+++ b/spec/views/admin/teachers/declarations/_declaration.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "admin/teachers/declarations/_declaration.html.erb", type: :view 
     render locals: { declaration: }
   end
 
-  it { is_expected.to have_summary_list_row("Declaration ID", value: "test-declaration-uuid", visible: :all) }
+  it { is_expected.to have_summary_list_row("Declaration ID", value: /test-declaration-uuid/, visible: :all) }
   it { is_expected.to have_summary_list_row("Course identifier", value: "declaration-course-identifier", visible: :all) }
   it { is_expected.to have_summary_list_row("Declaration type", value: "started", visible: :all) }
   it { is_expected.to have_summary_list_row("State", value: "declaration-state-tag", visible: :all) }


### PR DESCRIPTION
### Context

This change adds a `format_uuid` helper which

* wraps the UUID in a code tag
* adds a shortened version of the UUID for screenreader users (see [this comment](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2628#issuecomment-4305685105))

### Guidance to review

Is the change actually better for visually impaired users?

Are there any sneaky UUIDs missing?

Note, it also fixed this weird link underline glitch where the line is broken.

| Before | After | 
| ------ | ------- |
| <img width="763" height="81" alt="Screenshot From 2026-05-07 15-53-50" src="https://github.com/user-attachments/assets/b765376f-5a8a-4cb7-a207-bd0bca5446f2" />|<img width="726" height="111" alt="Screenshot From 2026-05-07 15-54-13" src="https://github.com/user-attachments/assets/ee9c0ee1-850c-47ed-9ec9-7683c26b16f6" /> |