### PR TITLE
Add new Blazer queries to seeds

### DIFF
--- a/db/seeds/blazer_queries.rb
+++ b/db/seeds/blazer_queries.rb
@@ -48,6 +48,21 @@ end
     statement: "SELECT * FROM appropriate_body_periods;",
     description: "old data model decommisioning and moving fields to other tables",
   },
+  {
+    name: "TRS name changes",
+    statement: "SELECT teacher_id, heading FROM events WHERE event_type='teacher_name_updated_by_trs'",
+    description: "TRS syncing has updated our teacher records"
+  },
+  {
+    name: "TRS not found",
+    statement: "SELECT id AS teacher_id, trs_not_found FROM teachers WHERE trs_not_found=true",
+    description: "TRS syncing has flagged missing records"
+  },
+  {
+    name: "TRS deactivated",
+    statement: "SELECT id AS teacher_id, trs_deactivated FROM teachers WHERE trs_deactivated=true",
+    description: "TRS syncing has flagged deactivated records"
+  }
 ].each do |query|
   create_query(creator: user_manager, **query)
 end


### PR DESCRIPTION
### Context

Seeded teachers with matching TRNs in deployments with TRS sync enabled will be updated

### Changes proposed in this pull request

2 new queries to give testers an overview of the current state of testing data so they can avoid any wonky records

### Guidance to review

Visit blazer after a seed and sync