### PR TITLE
Populate eligible for funding fields on migrated teachers

### DIFF
--- a/app/migration/ecf2_teacher_history.rb
+++ b/app/migration/ecf2_teacher_history.rb
@@ -163,8 +163,15 @@ private
 
     if found_teacher.present?
       with_failure_recording(teacher: found_teacher, model: found_teacher, migration_item_id: teacher.api_id, profile_type:) do
-        found_teacher.assign_attributes(**teacher.to_hash.except(:trs_first_name, :trs_last_name, :trs_induction_start_date, :api_updated_at))
+        found_teacher.assign_attributes(**teacher.to_hash.except(:trs_first_name,
+                                                                 :trs_last_name,
+                                                                 :trs_induction_start_date,
+                                                                 :api_updated_at,
+                                                                 :ect_first_became_eligible_for_training_at,
+                                                                 :mentor_first_became_eligible_for_training_at))
         found_teacher.trs_induction_start_date ||= teacher.trs_induction_start_date
+        found_teacher.ect_first_became_eligible_for_training_at ||= teacher.ect_first_became_eligible_for_training_at
+        found_teacher.mentor_first_became_eligible_for_training_at ||= teacher.mentor_first_became_eligible_for_training_at
         found_teacher.api_updated_at = [found_teacher.api_updated_at, teacher.api_updated_at].compact.max
         found_teacher.save!
         found_teacher

--- a/app/migration/teacher_history_converter.rb
+++ b/app/migration/teacher_history_converter.rb
@@ -138,7 +138,9 @@ private
       trs_induction_completed_date: ecf1_teacher_history.ect&.induction_completion_date,
       created_at: ecf1_teacher_history.user.created_at,
       updated_at: ecf1_teacher_history.user.updated_at,
-      api_unfunded_mentor_updated_at: ecf1_teacher_history.user.updated_at
+      api_unfunded_mentor_updated_at: ecf1_teacher_history.user.updated_at,
+      ect_first_became_eligible_for_training_at: ecf1_teacher_history.ect&.created_at,
+      mentor_first_became_eligible_for_training_at: ecf1_teacher_history.mentor&.created_at
     )
   end
 

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -159,7 +159,9 @@ describe ECF2TeacherHistory do
             trs_first_name: "Old First Name",
             trs_last_name: "Old Last Name",
             trs_induction_start_date: Date.current,
-            corrected_name: nil
+            corrected_name: nil,
+            ect_first_became_eligible_for_training_at: 1.year.ago,
+            mentor_first_became_eligible_for_training_at: 6.months.ago
           )
         end
 
@@ -176,13 +178,15 @@ describe ECF2TeacherHistory do
           end
         end
 
-        it "does not overwrite the trs_first_name, trs_last_name or trs_induction_start_date fields" do
+        it "does not overwrite the trs_first_name, trs_last_name, trs_induction_start_date, ect_first_became_eligible_for_training_at or mentor_first_became_eligible_for_training_at fields" do
           teacher = subject.save_all_ect_data!
 
           aggregate_failures do
             expect(teacher.trs_first_name).to eql("Old First Name")
             expect(teacher.trs_last_name).to eql("Old Last Name")
             expect(teacher.trs_induction_start_date).to eql(Date.current)
+            expect(teacher.ect_first_became_eligible_for_training_at).to eql(existing_teacher.ect_first_became_eligible_for_training_at)
+            expect(teacher.mentor_first_became_eligible_for_training_at).to eql(existing_teacher.mentor_first_became_eligible_for_training_at)
           end
         end
 


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/3635)

### Changes proposed in this pull request
 
- Populate `ect/mentor_first_became_eligible_for_training_at` fields from the creation date of their respective ECF1 profile

### Guidance to review
