### PR TITLE
Set the `school_reported_appropriate_body` when importing teachers using the economy migrator

### DIFF
--- a/app/migration/ecf1_teacher_history/induction_record.rb
+++ b/app/migration/ecf1_teacher_history/induction_record.rb
@@ -38,6 +38,12 @@ ECF1TeacherHistory::InductionRecord = Struct.new(
                              :ignore
                            end
 
+    hash[:appropriate_body] = if (appropriate_body_info = hash[:appropriate_body]) && appropriate_body_info.present?
+                                Types::AppropriateBodyData.new(**appropriate_body_info)
+                              else
+                                :ignore
+                              end
+
     hash.compact_with_ignore!
 
     if (school = hash[:school])

--- a/app/migration/ecf2_teacher_history.rb
+++ b/app/migration/ecf2_teacher_history.rb
@@ -16,7 +16,6 @@ class ECF2TeacherHistory
 
   MIGRATION_ITEM_TYPE = "Migration::InductionRecord"
 
-  AppropriateBodyData = Data.define(:id, :name)
   MentorData = Data.define(:trn, :urn, :started_on, :finished_on)
 
   attr_reader :teacher,

--- a/app/migration/ecf2_teacher_history/ect_at_school_period.rb
+++ b/app/migration/ecf2_teacher_history/ect_at_school_period.rb
@@ -28,7 +28,7 @@ class ECF2TeacherHistory::ECTAtSchoolPeriod
       finished_on:,
       school: real_school,
       email:,
-      school_reported_appropriate_body: real_appropriate_body,
+      school_reported_appropriate_body_id: appropriate_body&.ecf2_id,
     }
   end
 
@@ -39,7 +39,7 @@ class ECF2TeacherHistory::ECTAtSchoolPeriod
       finished_on:,
       school: school.to_h,
       email:,
-      school_reported_appropriate_body: appropriate_body,
+      school_reported_appropriate_body_id: appropriate_body&.ecf2_id,
       mentorship_periods: mentorship_periods.map(&:to_h),
       training_periods: training_periods.map(&:to_h),
     }
@@ -58,10 +58,6 @@ class ECF2TeacherHistory::ECTAtSchoolPeriod
 
   def real_school
     GIAS::School.find_by!(urn: school.urn).school
-  end
-
-  def real_appropriate_body
-    # AppropriateBodyPeriod.find(appropriate_body.id)
   end
 
   def dates

--- a/app/migration/mappers/appropriate_body_mapper.rb
+++ b/app/migration/mappers/appropriate_body_mapper.rb
@@ -1,7 +1,5 @@
 module Mappers
   class AppropriateBodyMapper
-    class NoMatchingECF1AppropriateBodyID < StandardError; end
-
     attr_accessor :mapping_data, :indexed_by_ecf1_id
 
     def initialize(yaml_file = Rails.root.join("app/migration/mappers/appropriate_body_mapping_data.yaml"))
@@ -10,13 +8,9 @@ module Mappers
     end
 
     def get_ecf2_id(ecf1_id)
-      begin
-        match = indexed_by_ecf1_id.fetch(ecf1_id)
-      rescue KeyError
-        raise NoMatchingECF1AppropriateBodyID, "ecf1_id: #{ecf1_id}"
-      end
+      match = indexed_by_ecf1_id[ecf1_id]
 
-      match.fetch(:ecf2_id)
+      match[:ecf2_id]
     end
   end
 end

--- a/app/migration/spec_generator.rb
+++ b/app/migration/spec_generator.rb
@@ -237,6 +237,7 @@ private
         training_status: ir.training_status,
         preferred_identity_email: ir.preferred_identity_email,
         mentor_profile_id: ir.mentor_profile_id,
+        appropriate_body_info: ir.appropriate_body.to_h,
         training_provider_info: ir.training_provider_info.then do |tpi|
           if ir.training_programme == "full_induction_programme" && tpi.present?
             {

--- a/app/migration/teacher_history_converter/ect/latest_induction_records.rb
+++ b/app/migration/teacher_history_converter/ect/latest_induction_records.rb
@@ -60,7 +60,8 @@ private
         school: induction_record.school,
         email: induction_record.preferred_identity_email,
         mentorship_periods: [mentorship_period].compact,
-        training_periods: [training_period].compact
+        training_periods: [training_period].compact,
+        appropriate_body: induction_record.appropriate_body
       )
     )
   end

--- a/app/migration/types.rb
+++ b/app/migration/types.rb
@@ -1,5 +1,11 @@
 module Types
-  AppropriateBodyData = Data.define(:ecf1_id, :name)
+  AppropriateBodyData = Data.define(:ecf1_id, :name) do
+    def ecf2_id
+      return unless ecf1_id
+
+      Mappers::AppropriateBodyMapper.new.get_ecf2_id(ecf1_id)
+    end
+  end
   DeliveryPartnerInfo = Data.define(:ecf1_id, :name)
   LeadProviderInfo = Data.define(:ecf1_id, :name)
   SchoolData = Struct.new("SchoolData", :urn, :name, :school_type_name) do

--- a/spec/migration/ecf2_teacher_history_spec.rb
+++ b/spec/migration/ecf2_teacher_history_spec.rb
@@ -200,17 +200,17 @@ describe ECF2TeacherHistory do
         let(:other_arguments) { { ect_at_school_periods: } }
         let(:teacher) { subject.save_all_ect_data! }
 
-        let(:appropriate_body_a) { FactoryBot.create(:appropriate_body_period) }
-        let(:appropriate_body_b) { FactoryBot.create(:appropriate_body_period) }
+        let(:appropriate_body_a) { FactoryBot.create(:appropriate_body_period, id: 6) }
+        let(:appropriate_body_b) { FactoryBot.create(:appropriate_body_period, id: 396) }
         let(:appropriate_body_a_data) do
-          ECF2TeacherHistory::AppropriateBodyData.new(
-            id: appropriate_body_a.id,
+          Types::AppropriateBodyData.new(
+            ecf1_id: "f8ab3d0e-8b2f-4156-ab18-267c3b651a1d",
             name: appropriate_body_a.name
           )
         end
         let(:appropriate_body_b_data) do
-          ECF2TeacherHistory::AppropriateBodyData.new(
-            id: appropriate_body_b.id,
+          Types::AppropriateBodyData.new(
+            ecf1_id: "9bb3b070-00b9-4881-a118-7c5d71f412de",
             name: appropriate_body_b.name
           )
         end
@@ -629,17 +629,17 @@ describe ECF2TeacherHistory do
         let(:other_arguments) { { mentor_at_school_periods: } }
         let(:teacher) { subject.save_all_mentor_data! }
 
-        let(:appropriate_body_a) { FactoryBot.create(:appropriate_body_period) }
-        let(:appropriate_body_b) { FactoryBot.create(:appropriate_body_period) }
+        let(:appropriate_body_a) { FactoryBot.create(:appropriate_body_period, id: 347) }
+        let(:appropriate_body_b) { FactoryBot.create(:appropriate_body_period, id: 388) }
         let(:appropriate_body_a_data) do
-          ECF2TeacherHistory::AppropriateBodyData.new(
-            id: appropriate_body_a.id,
+          Types::AppropriateBodyData.new(
+            ecf1: "710e9278-b3fe-4bf6-8b26-e118647ae80a",
             name: appropriate_body_a.name
           )
         end
         let(:appropriate_body_b_data) do
-          ECF2TeacherHistory::AppropriateBodyData.new(
-            id: appropriate_body_b.id,
+          Types::AppropriateBodyData.new(
+            ecf1: "d4d9529e-aca5-41ff-881b-267a8570aaac",
             name: appropriate_body_b.name
           )
         end

--- a/spec/migration/mappers/appropriate_body_mapper_spec.rb
+++ b/spec/migration/mappers/appropriate_body_mapper_spec.rb
@@ -10,15 +10,5 @@ describe Mappers::AppropriateBodyMapper do
     it "returns the correct ECF2 ID given an ECF1 ID" do
       expect(subject.get_ecf2_id("d39267fc-ded1-49e0-b6ae-1161b3f3b439")).to eq(383)
     end
-
-    context "when there is no matching ECF1 ID" do
-      it "raises a NoMatchingECF1AppropriateBodyID error" do
-        absent_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        error_class = Mappers::AppropriateBodyMapper::NoMatchingECF1AppropriateBodyID
-        error_message = "ecf1_id: #{absent_id}"
-
-        expect { subject.get_ecf2_id(absent_id) }.to raise_error(error_class, error_message)
-      end
-    end
   end
 end

--- a/spec/migration/teacher_history_converter/end_to_end/one_induction_record_existing_ect_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/one_induction_record_existing_ect_spec.rb
@@ -7,7 +7,8 @@ describe "One induction record (end to end, existing ECT)" do
 
   # ECF1 data
   let(:ecf1_induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led) }
-  let(:ecf1_induction_record) { FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, created_at: 18.hours.ago.round) }
+  let(:ecf1_appropriate_body) { FactoryBot.create(:migration_appropriate_body, id: "71513a6a-69ba-4a80-9559-b5e60fcd07e4") } # Westminster LA
+  let(:ecf1_induction_record) { FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, appropriate_body: ecf1_appropriate_body, created_at: 18.hours.ago.round) }
   let(:ecf1_teacher_profile) { ecf1_induction_record.participant_profile.teacher_profile }
   let(:ecf1_urn) { ecf1_induction_programme.school_cohort.school.urn.to_i }
 
@@ -19,6 +20,7 @@ describe "One induction record (end to end, existing ECT)" do
   let(:ecf2_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: ecf2_lead_provider, contract_period: ecf2_contract_period) }
   let(:ecf2_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: ecf2_active_lead_provider, delivery_partner: ecf2_delivery_partner) }
 
+  let!(:ecf2_appropriate_body) { FactoryBot.create(:appropriate_body_period, id: 144) }
   let!(:ecf2_teacher) { FactoryBot.create(:teacher, trn: ecf1_teacher_profile.trn, created_at: original_teacher_created_at, trs_first_name: "Janet", trs_last_name: "Fielding") }
   let!(:ecf2_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: ecf1_urn) }
   let!(:ecf2_schedule) { FactoryBot.create(:schedule, contract_period: ecf2_contract_period, identifier: ecf1_induction_record.schedule.schedule_identifier) }
@@ -52,7 +54,7 @@ describe "One induction record (end to end, existing ECT)" do
       expect(teacher.trs_last_name).to eql("Fielding")
     end
 
-    it "creates a single ect_at_school_period linked to the teacher at the right school" do
+    it "creates a single ect_at_school_period linked to the teacher at the right school with the right appropriate body" do
       ect_at_school_periods = teacher.ect_at_school_periods
       ect_at_school_period = ect_at_school_periods.first
 
@@ -60,6 +62,7 @@ describe "One induction record (end to end, existing ECT)" do
         expect(ect_at_school_periods.count).to be(1)
 
         expect(ect_at_school_period.school.urn).to eql(ecf1_urn)
+        expect(ect_at_school_period.school_reported_appropriate_body).to eql(ecf2_appropriate_body)
       end
     end
 

--- a/spec/migration/teacher_history_converter/end_to_end/one_induction_record_new_teacher_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/one_induction_record_new_teacher_spec.rb
@@ -7,9 +7,10 @@ describe "One induction record (end to end, new teacher)" do
   let(:induction_completion_date) { Date.new(2024, 2, 3) }
 
   # ECF1 data
+  let(:ecf1_appropriate_body) { FactoryBot.create(:migration_appropriate_body, id: "1d20b3b8-f98d-454d-8119-fc2c98135be2") } # Durham LA
   let(:ecf1_participant_profile) { FactoryBot.create(:migration_participant_profile, :ect, induction_start_date:, induction_completion_date:) }
   let(:ecf1_induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led) }
-  let(:ecf1_induction_record) { FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, created_at: 18.hours.ago.round, participant_profile: ecf1_participant_profile) }
+  let(:ecf1_induction_record) { FactoryBot.create(:migration_induction_record, induction_programme: ecf1_induction_programme, appropriate_body: ecf1_appropriate_body, created_at: 18.hours.ago.round, participant_profile: ecf1_participant_profile) }
   let(:ecf1_teacher_profile) { ecf1_induction_record.participant_profile.teacher_profile }
   let(:ecf1_urn) { ecf1_induction_programme.school_cohort.school.urn.to_i }
 
@@ -21,6 +22,7 @@ describe "One induction record (end to end, new teacher)" do
   let(:ecf2_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: ecf2_lead_provider, contract_period: ecf2_contract_period) }
   let(:ecf2_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: ecf2_active_lead_provider, delivery_partner: ecf2_delivery_partner) }
 
+  let!(:ecf2_appropriate_body) { FactoryBot.create(:appropriate_body_period, id: 90) }
   let!(:ecf2_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: ecf1_urn) }
   let!(:ecf2_schedule) { FactoryBot.create(:schedule, contract_period: ecf2_contract_period, identifier: ecf1_induction_record.schedule.schedule_identifier) }
   let!(:ecf2_school_partnership) { FactoryBot.create(:school_partnership, school: ecf2_school, lead_provider_delivery_partnership: ecf2_lead_provider_delivery_partnership) }
@@ -55,7 +57,7 @@ describe "One induction record (end to end, new teacher)" do
       expect(teacher.created_at).to eql(user_created_at)
     end
 
-    it "creates a single ect_at_school_period linked to the teacher at the right school" do
+    it "creates a single ect_at_school_period linked to the teacher at the right school with the right appropriate body" do
       ect_at_school_periods = teacher.ect_at_school_periods
       ect_at_school_period = ect_at_school_periods.first
 
@@ -63,6 +65,7 @@ describe "One induction record (end to end, new teacher)" do
         expect(ect_at_school_periods.count).to be(1)
 
         expect(ect_at_school_period.school.urn).to eql(ecf1_urn)
+        expect(ect_at_school_period.school_reported_appropriate_body).to eql(ecf2_appropriate_body)
       end
     end
 

--- a/spec/migration/teacher_history_converter/real_examples/668787fb_6c01_46ee_83bf_2e5362eba446_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/668787fb_6c01_46ee_83bf_2e5362eba446_spec.rb
@@ -41,6 +41,10 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
             training_status: "active",
             preferred_identity_email: "a.teacher@example.com",
             mentor_profile_id: :ignore,
+            appropriate_body: {
+              ecf1_id: "658c4468-30d9-4563-8581-0d20c075220f",
+              name: "Teach West London (Twyford Church of England High School)"
+            },
             training_provider_info: {
               lead_provider: {
                 ecf1_id: "3d7d8c90-a5a3-4838-84b2-563092bf87ee",
@@ -75,6 +79,10 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
             training_status: "active",
             preferred_identity_email: "a.teacher@example.com",
             mentor_profile_id: :ignore,
+            appropriate_body: {
+              ecf1_id: "658c4468-30d9-4563-8581-0d20c075220f",
+              name: "Teach West London (Twyford Church of England High School)"
+            },
             training_provider_info: {
               lead_provider: {
                 ecf1_id: "3d7d8c90-a5a3-4838-84b2-563092bf87ee",
@@ -109,6 +117,10 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
             training_status: "active",
             preferred_identity_email: "a.teacher@example.com",
             mentor_profile_id: "fbe5e836-7f0e-49cd-8d5b-1f7bd2320a8d",
+            appropriate_body: {
+              ecf1_id: "658c4468-30d9-4563-8581-0d20c075220f",
+              name: "Teach West London (Twyford Church of England High School)"
+            },
             training_provider_info: {
               lead_provider: {
                 ecf1_id: "3d7d8c90-a5a3-4838-84b2-563092bf87ee",
@@ -143,6 +155,10 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
             training_status: "active",
             preferred_identity_email: "a.teacher@example.com",
             mentor_profile_id: :ignore,
+            appropriate_body: {
+              ecf1_id: "658c4468-30d9-4563-8581-0d20c075220f",
+              name: "Teach West London (Twyford Church of England High School)"
+            },
             training_provider_info: {
               lead_provider: {
                 ecf1_id: "3d7d8c90-a5a3-4838-84b2-563092bf87ee",
@@ -318,6 +334,7 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
               #       the induction_completion_date is before the start's end date
               started_on: Date.new(2025, 4, 4),
               finished_on: Date.new(2025, 4, 5),
+              school_reported_appropriate_body_id: 390,
               training_periods: array_including(
                 hash_including(
                   started_on: Date.new(2025, 4, 4),
@@ -350,6 +367,12 @@ describe "Real data check for user 668787fb-6c01-46ee-83bf-2e5362eba446" do
 
     it "matches the expected output" do
       expect(actual_output).to include(expected_output)
+    end
+
+    it "sets the appropriate body" do
+      id = actual_output.dig(:teacher, :ect_at_school_periods, 0, :school_reported_appropriate_body_id)
+
+      expect(id).to eq(390)
     end
   end
 


### PR DESCRIPTION
This change adds functionality which uses the appropriate body mapper (#2627) to set the `school_reported_appropriate_body` on an `ECTAtSchoolPeriod` to the corresponding appropriate body in ECF1.

Refs DFE-Digital/register-ects-project-board#3751