### PR TITLE
Fix failing test on main

### DIFF
--- a/spec/migration/teacher_history_converter/end_to_end/multiple_ect_withdrawals_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/multiple_ect_withdrawals_spec.rb
@@ -1,6 +1,10 @@
 describe "ECT with multiple withdrawals" do
   subject(:teacher) { Teacher.find_by(trn:) }
 
+  around do |example|
+    travel_to(Date.new(2026, 4, 12)) { example.run }
+  end
+
   # ECF1 data
 
   let(:ecf1_cohort) { FactoryBot.create(:migration_cohort, start_year: 2024) }


### PR DESCRIPTION
### Summary

Freeze time in multiple ECT withdrawals spec.

Fixes a date sensitive failure caused by the future withdrawn record no longer being in the future.

Failures:

- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/24333639875/job/71045048961?pr=2625

- https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/24334706243/job/71048551516?pr=2636
