### PR TITLE
Move contract columns out of analytics blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -272,3 +272,7 @@ shared:
     - milestone_date
     - created_at
     - updated_at
+  :contracts:
+    - id
+    - contract_type
+    - active_lead_provider_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -468,10 +468,7 @@
   - created_at
   - updated_at
   :contracts:
-  - id
-  - contract_type
   - vat_rate
-  - active_lead_provider_id
   - flat_rate_fee_structure_id
   - banded_fee_structure_id
   - ecf_contract_version


### PR DESCRIPTION
### Summary

Requested by the D&I team, we are moving the following columns out of the blocklist:

```yml
 :contracts:
  - id
  - contract_type
  - active_lead_provider_id
 ```