### PR TITLE
[3106] Update start date validation

### DIFF
--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -42,15 +42,20 @@ module Schools
 
       def start_date_within_4_months
         return if skip_start_date_validation?
+        return if registrations_closed_for_contract_period?
 
         earliest_invalid_start_date = (4.months + 1.day).from_now.to_date
 
         if start_date_as_date >= earliest_invalid_start_date
           errors.add(
             :start_date,
-            "Start date must be before #{earliest_invalid_start_date.to_formatted_s(:govuk)}"
+            "Start date must be before #{earliest_invalid_start_date.to_formatted_s(:govuk)}. You cannot register the ECT this far in advance."
           )
         end
+      end
+
+      def registrations_closed_for_contract_period?
+        start_date_as_date.future? && !start_date_contract_period&.enabled?
       end
 
       def previous_start_date_invalid?(period)

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -61,13 +61,14 @@ module Schools
 
       def started_on_within_4_months
         return if errors.any?
+        return if registrations_closed_for_contract_period?
 
         earliest_invalid_started_on = 4.months.from_now.to_date.next_day
 
         unless started_on_as_date.before?(earliest_invalid_started_on)
           errors.add(
             :started_on,
-            "Start date must be before #{earliest_invalid_started_on.to_formatted_s(:govuk)}"
+            "Start date must be before #{earliest_invalid_started_on.to_formatted_s(:govuk)}. You cannot register the mentor this far in advance."
           )
         end
       end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/changing_start_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/changing_start_date_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Registering a mentor", :enable_schools_interface, :js do
   end
 
   def when_i_enter_a_date_in_a_closed_contract_period
-    mentor_start_date = Date.new(2025, 7, 1)
+    mentor_start_date = Date.new(2026, 7, 1)
     page.get_by_label("Day").fill(mentor_start_date.day.to_s)
     page.get_by_label("Month").fill(mentor_start_date.month.to_s)
     page.get_by_label("Year").fill(mentor_start_date.year.to_s)
@@ -125,7 +125,6 @@ RSpec.describe "Registering a mentor", :enable_schools_interface, :js do
   end
 
   def then_i_see_a_validation_error_message
-    page.screenshot(path: "tmp/validation_error_message.png")
     expect(page.locator(".govuk-error-summary")).to have_text("There is a problem")
     expect(page.locator(".govuk-error-summary a").and(page.get_by_text("Start date must be before 1 October 2025"))).to be_visible
   end
@@ -140,7 +139,8 @@ RSpec.describe "Registering a mentor", :enable_schools_interface, :js do
 
   def and_the_next_contract_period_is_closed
     @contract_period = FactoryBot.create(:contract_period, :with_schedules, year: 2024, enabled: true)
-    FactoryBot.create(:contract_period, :with_schedules, year: 2025, enabled: false)
+    FactoryBot.create(:contract_period, :with_schedules, year: 2025, enabled: true)
+    FactoryBot.create(:contract_period, :with_schedules, year: 2026, enabled: false)
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -90,7 +90,20 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
           it "is invalid over 4 months from today" do
             expect(subject).not_to be_valid
-            expect(subject.errors[:start_date]).to include("Start date must be before 2 May 2025")
+            expect(subject.errors[:start_date]).to include("Start date must be before 2 May 2025. You cannot register the ECT this far in advance.")
+          end
+
+          context "and the start date falls in a contract period that is not yet open" do
+            before do
+              FactoryBot.create(:contract_period, year: 2024, enabled: true, started_on: Date.new(2024, 6, 1), finished_on: Date.new(2025, 5, 31))
+              FactoryBot.create(:contract_period, year: 2025, enabled: false, started_on: Date.new(2025, 6, 1), finished_on: Date.new(2026, 5, 31))
+            end
+
+            let(:start_date) { Date.new(2025, 9, 1) }
+
+            it "does not add the 4-month error so the wizard can route to cannot_register_ect_yet" do
+              expect(subject).to be_valid
+            end
           end
         end
       end

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
@@ -78,7 +78,23 @@ RSpec.shared_examples "a started on step" do |current_step:|
       context "and the start date is more than 4 months in the future" do
         let(:started_on) { 4.months.from_now.advance(days: 1) }
 
-        it { is_expected.to have_error(:started_on, "Start date must be before #{4.months.from_now.to_date.next_day.to_formatted_s(:govuk)}") }
+        context "and the start date is in an open contract period" do
+          before do
+            allow(step).to receive(:registrations_closed_for_contract_period?).and_return(false)
+          end
+
+          it { is_expected.to have_error(:started_on, "Start date must be before #{4.months.from_now.to_date.next_day.to_formatted_s(:govuk)}. You cannot register the mentor this far in advance.") }
+        end
+
+        context "and the start date falls in a contract period that is not yet open" do
+          before do
+            allow(step).to receive(:registrations_closed_for_contract_period?).and_return(true)
+          end
+
+          it "does not add the 4-month error so the wizard can route to cannot_register_mentor_yet" do
+            expect(step).to be_valid
+          end
+        end
       end
 
       context "and the start date is 4 months in the future" do


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3106

### Changes proposed in this pull request

- Give precedence to enabled contract period check over validation that start date is within 4 months
- Tweak validation error message when registration is in an enabled contract period but more than 4 months from today

### Guidance to review
