### PR TITLE
[3718] Bug: Changing LP for deferred or withdrawn ECTs and Mentors changes the contract period

### DIFF
--- a/app/services/concerns/teachers/lead_provider_changer.rb
+++ b/app/services/concerns/teachers/lead_provider_changer.rb
@@ -110,7 +110,11 @@ module Teachers
     end
 
     def existing_schedule
-      training_period&.schedule
+      last_provider_led_training_period&.schedule
+    end
+
+    def last_provider_led_training_period
+      @last_provider_led_training_period ||= period.training_periods.provider_led_training_programme.latest_first.first
     end
 
     def school_partnership

--- a/app/services/concerns/teachers/lead_provider_changer.rb
+++ b/app/services/concerns/teachers/lead_provider_changer.rb
@@ -5,6 +5,7 @@ module Teachers
     extend ActiveSupport::Concern
 
     include TrainingPeriodSources
+    include Schedules::Reuse
 
     class_methods do
       def call(*args, **kwargs)
@@ -84,39 +85,6 @@ module Teachers
       ActiveLeadProvider.find_or_create_by!(lead_provider:, contract_period:)
     end
 
-    def contract_period
-      if reuse_existing_schedule?
-        existing_schedule.contract_period
-      else
-        contract_period_at_transition
-      end
-    end
-
-    def schedule
-      existing_schedule if reuse_existing_schedule?
-    end
-
-    def reuse_existing_schedule?
-      return false unless existing_schedule
-      return false if contract_period_reassignment_required?
-
-      existing_schedule.contract_period != contract_period_at_transition
-    end
-
-    def contract_period_reassignment_required? = false
-
-    def contract_period_at_transition
-      @contract_period_at_transition ||= ContractPeriod.containing_date(date_of_transition)
-    end
-
-    def existing_schedule
-      last_provider_led_training_period&.schedule
-    end
-
-    def last_provider_led_training_period
-      @last_provider_led_training_period ||= period.training_periods.provider_led_training_programme.latest_first.first
-    end
-
     def school_partnership
       earliest_matching_school_partnership
     end
@@ -138,9 +106,8 @@ module Teachers
     def date_of_transition
       return training_period.started_on if current_or_future_training_period?
 
-      [period.started_on, Date.current].max
+      super
     end
-    alias_method :started_on, :date_of_transition
 
     def training_period
       @training_period ||= period.current_or_next_training_period

--- a/app/services/contract_periods/reassignment.rb
+++ b/app/services/contract_periods/reassignment.rb
@@ -9,6 +9,7 @@ module ContractPeriods
 
     def required?
       return false unless training_period&.provider_led_training_programme?
+      return false if training_period&.for_mentor?
 
       contract_period = assigned_contract_period
       return false unless contract_period

--- a/app/services/ect_at_school_periods/change_lead_provider.rb
+++ b/app/services/ect_at_school_periods/change_lead_provider.rb
@@ -26,13 +26,9 @@ module ECTAtSchoolPeriods
     end
 
     def track_payments_frozen_year!
-      return unless contract_period_reassignment_required? && training_period_confirmed?
+      return unless confirmed_training_reassignment_required?
 
       teacher.update!(ect_payments_frozen_year: previous_contract_period.year)
-    end
-
-    def contract_period_reassignment_required?
-      @contract_period_reassignment_required ||= contract_period_reassignment.required?
     end
   end
 end

--- a/app/services/ect_at_school_periods/change_lead_provider.rb
+++ b/app/services/ect_at_school_periods/change_lead_provider.rb
@@ -31,8 +31,6 @@ module ECTAtSchoolPeriods
       teacher.update!(ect_payments_frozen_year: previous_contract_period.year)
     end
 
-    def previous_contract_period = contract_period_reassignment.assigned_contract_period
-
     def contract_period_reassignment_required?
       @contract_period_reassignment_required ||= contract_period_reassignment.required?
     end
@@ -44,11 +42,5 @@ module ECTAtSchoolPeriods
                                            super
                                          end
     end
-
-    def contract_period_reassignment
-      @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period: last_provider_led_training_period)
-    end
-
-    delegate :successor_contract_period, to: :contract_period_reassignment
   end
 end

--- a/app/services/ect_at_school_periods/change_lead_provider.rb
+++ b/app/services/ect_at_school_periods/change_lead_provider.rb
@@ -34,13 +34,5 @@ module ECTAtSchoolPeriods
     def contract_period_reassignment_required?
       @contract_period_reassignment_required ||= contract_period_reassignment.required?
     end
-
-    def contract_period_at_transition
-      @contract_period_at_transition ||= if contract_period_reassignment_required? && training_period_confirmed?
-                                           successor_contract_period
-                                         else
-                                           super
-                                         end
-    end
   end
 end

--- a/app/services/ect_at_school_periods/change_lead_provider.rb
+++ b/app/services/ect_at_school_periods/change_lead_provider.rb
@@ -31,10 +31,6 @@ module ECTAtSchoolPeriods
       teacher.update!(ect_payments_frozen_year: previous_contract_period.year)
     end
 
-    def existing_schedule
-      training_period&.schedule
-    end
-
     def previous_contract_period = contract_period_reassignment.assigned_contract_period
 
     def contract_period_reassignment_required?
@@ -50,7 +46,7 @@ module ECTAtSchoolPeriods
     end
 
     def contract_period_reassignment
-      @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period:)
+      @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period: last_provider_led_training_period)
     end
 
     delegate :successor_contract_period, to: :contract_period_reassignment

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -63,39 +63,27 @@ module ECTAtSchoolPeriods
     def handle_training_period_for_switch!
       return if @training_period.blank?
 
-      if training_not_started? || current_provider_led_training_not_confirmed?
+      if training_not_started? || !keep_existing_training_period?
         @training_period.destroy!
       else
         finish_training_period!
       end
     end
 
-    def current_provider_led_training_not_confirmed?
-      @ect_at_school_period.provider_led_training_programme? && @training_period.school_partnership.blank?
+    def keep_existing_training_period?
+      @ect_at_school_period.school_led_training_programme? || @training_period.school_partnership.present?
     end
+
+    def current_training_period_confirmed? = keep_existing_training_period?
 
     def training_not_started?
       @training_period.started_on.today? || date_of_transition.future?
-    end
-
-    def contract_period
-      if contract_period_reassignment_required?
-        successor_contract_period
-      elsif reuse_existing_schedule?
-        existing_schedule.contract_period
-      else
-        contract_period_at_transition
-      end
     end
 
     def reuse_existing_schedule?
       return false unless @ect_at_school_period.school_led_training_programme?
 
       super
-    end
-
-    def contract_period_reassignment_required?
-      @ect_at_school_period.school_led_training_programme? && super
     end
 
     def set_ect_payments_frozen_year!

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -4,6 +4,7 @@ module ECTAtSchoolPeriods
 
   class SwitchTraining
     include TrainingPeriodSources
+    include Schedules::Reuse
 
     def self.to_school_led(...) = new(...).to_school_led
     def self.to_provider_led(...) = new(...).to_provider_led
@@ -87,37 +88,15 @@ module ECTAtSchoolPeriods
       end
     end
 
-    def schedule
-      existing_schedule if reuse_existing_schedule?
-    end
-
     def reuse_existing_schedule?
       return false unless @ect_at_school_period.school_led_training_programme?
-      return false unless existing_schedule
-      return false if contract_period_reassignment_required?
 
-      existing_schedule.contract_period != contract_period_at_transition
+      super
     end
-
-    def existing_schedule
-      last_provider_led_training_period&.schedule
-    end
-
-    def date_of_transition = [@ect_at_school_period.started_on, Date.current].max
 
     def contract_period_reassignment_required?
-      @ect_at_school_period.school_led_training_programme? && contract_period_reassignment.required?
+      @ect_at_school_period.school_led_training_programme? && super
     end
-
-    def contract_period_reassignment
-      @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period: last_provider_led_training_period)
-    end
-
-    def last_provider_led_training_period
-      @last_provider_led_training_period ||= @ect_at_school_period.training_periods.provider_led_training_programme.latest_first.first
-    end
-
-    delegate :successor_contract_period, to: :contract_period_reassignment
 
     def set_ect_payments_frozen_year!
       return unless contract_period_reassignment_required?
@@ -125,10 +104,6 @@ module ECTAtSchoolPeriods
       @ect_at_school_period
         .teacher
         .update!(ect_payments_frozen_year: contract_period_reassignment.assigned_contract_period.year)
-    end
-
-    def contract_period_at_transition
-      @contract_period_at_transition ||= ContractPeriod.containing_date(date_of_transition)
     end
 
     def finish_training_period!
@@ -204,6 +179,6 @@ module ECTAtSchoolPeriods
       @mentor_at_school_period.teacher.mentor_became_ineligible_for_funding_on.present?
     end
 
-    def started_on = date_of_transition
+    def period = @ect_at_school_period
   end
 end

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -74,7 +74,7 @@ module ECTAtSchoolPeriods
       @ect_at_school_period.school_led_training_programme? || @training_period.school_partnership.present?
     end
 
-    def current_training_period_confirmed? = keep_existing_training_period?
+    def current_or_next_training_period_confirmed? = keep_existing_training_period?
 
     def training_not_started?
       @training_period.started_on.today? || date_of_transition.future?

--- a/app/services/mentor_at_school_periods/change_lead_provider.rb
+++ b/app/services/mentor_at_school_periods/change_lead_provider.rb
@@ -18,7 +18,5 @@ module MentorAtSchoolPeriods
         author:
       ).finish!
     end
-
-    def contract_period_reassignment_required? = false
   end
 end

--- a/app/services/mentor_at_school_periods/change_lead_provider.rb
+++ b/app/services/mentor_at_school_periods/change_lead_provider.rb
@@ -18,5 +18,7 @@ module MentorAtSchoolPeriods
         author:
       ).finish!
     end
+
+    def contract_period_reassignment_required? = false
   end
 end

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -2,6 +2,8 @@ module Schedules
   class Find
     attr_accessor :period, :training_programme, :started_on, :period_type_key, :mentee
 
+    include Schedules::Reuse
+
     def initialize(period:, training_programme:, started_on:, period_type_key:, mentee:)
       @period = period
       @training_programme = training_programme
@@ -39,17 +41,11 @@ module Schedules
       teacher.mentor_training_periods if teacher.mentor_at_school_periods.exists?
     end
 
-    def most_recent_provider_led_period
-      training_periods&.provider_led_training_programme&.latest_first&.first
-    end
-
     def most_recent_schedule
       @most_recent_schedule ||= most_recent_provider_led_period&.schedule
     end
 
-    def latest_start_date
-      [started_on, Time.zone.today].max
-    end
+    alias_method :latest_start_date, :date_of_transition
 
     def schedule_month
       return "september" if extended_schedule?
@@ -106,20 +102,10 @@ module Schedules
       previous_mentor_started_training?
     end
 
-    def extended_schedule?
-      return false unless period_type_key == :ect_at_school_period
-
-      contract_period_reassignment.required?
-    end
-
-    def contract_period_reassignment
-      @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period: most_recent_provider_led_period)
-    end
+    alias_method :extended_schedule?, :contract_period_reassignment_required?
 
     def extended_schedule
       successor_contract_period.schedules.find_by!(identifier:)
     end
-
-    delegate :successor_contract_period, to: :contract_period_reassignment
   end
 end

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -45,7 +45,9 @@ module Schedules
       @most_recent_schedule ||= most_recent_provider_led_period&.schedule
     end
 
-    alias_method :latest_start_date, :date_of_transition
+    def latest_start_date
+      [started_on, Time.zone.today].max
+    end
 
     def schedule_month
       return "september" if extended_schedule?

--- a/app/services/schedules/reuse.rb
+++ b/app/services/schedules/reuse.rb
@@ -1,7 +1,9 @@
 module Schedules
   module Reuse
     def contract_period
-      if reuse_existing_schedule?
+      if contract_period_reassignment_required? && current_training_period_confirmed?
+        successor_contract_period
+      elsif reuse_existing_schedule?
         existing_schedule.contract_period
       else
         contract_period_at_transition
@@ -40,6 +42,14 @@ module Schedules
     end
 
     delegate :training_periods, to: :period
+
+    def current_training_period_confirmed?
+      current_or_next_training_period.school_partnership.present?
+    end
+
+    def current_or_next_training_period
+      @current_or_next_training_period ||= period.current_or_next_training_period
+    end
 
     def existing_schedule
       most_recent_provider_led_period&.schedule

--- a/app/services/schedules/reuse.rb
+++ b/app/services/schedules/reuse.rb
@@ -1,0 +1,53 @@
+module Schedules
+  module Reuse
+    def contract_period
+      if reuse_existing_schedule?
+        existing_schedule.contract_period
+      else
+        contract_period_at_transition
+      end
+    end
+
+    def contract_period_at_transition
+      @contract_period_at_transition ||= ContractPeriod.containing_date(date_of_transition)
+    end
+
+    def date_of_transition = [period.started_on, Date.current].max
+
+    def schedule
+      existing_schedule if reuse_existing_schedule?
+    end
+
+    def reuse_existing_schedule?
+      return false unless existing_schedule
+      return false if contract_period_reassignment_required?
+
+      existing_schedule.contract_period != contract_period_at_transition
+    end
+
+    def contract_period_reassignment_required?
+      return false unless period.is_a?(ECTAtSchoolPeriod)
+
+      contract_period_reassignment.required?
+    end
+
+    def contract_period_reassignment
+      @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period: most_recent_provider_led_period)
+    end
+
+    def most_recent_provider_led_period
+      @most_recent_provider_led_period ||= training_periods&.provider_led_training_programme&.latest_first&.first
+    end
+
+    delegate :training_periods, to: :period
+
+    def existing_schedule
+      most_recent_provider_led_period&.schedule
+    end
+
+    def previous_contract_period = contract_period_reassignment.assigned_contract_period
+
+    delegate :successor_contract_period, to: :contract_period_reassignment
+    alias_method :started_on, :date_of_transition
+  end
+end

--- a/app/services/schedules/reuse.rb
+++ b/app/services/schedules/reuse.rb
@@ -1,7 +1,7 @@
 module Schedules
   module Reuse
     def contract_period
-      if contract_period_reassignment_required? && current_training_period_confirmed?
+      if confirmed_training_reassignment_required?
         successor_contract_period
       elsif reuse_existing_schedule?
         existing_schedule.contract_period
@@ -27,10 +27,8 @@ module Schedules
       existing_schedule.contract_period != contract_period_at_transition
     end
 
-    def contract_period_reassignment_required?
-      return false unless period.is_a?(ECTAtSchoolPeriod)
-
-      contract_period_reassignment.required?
+    def confirmed_training_reassignment_required?
+      contract_period_reassignment_required? && current_or_next_training_period_confirmed?
     end
 
     def contract_period_reassignment
@@ -41,10 +39,8 @@ module Schedules
       @most_recent_provider_led_period ||= training_periods&.provider_led_training_programme&.latest_first&.first
     end
 
-    delegate :training_periods, to: :period
-
-    def current_training_period_confirmed?
-      current_or_next_training_period.school_partnership.present?
+    def current_or_next_training_period_confirmed?
+      current_or_next_training_period&.school_partnership.present?
     end
 
     def current_or_next_training_period
@@ -55,9 +51,11 @@ module Schedules
       most_recent_provider_led_period&.schedule
     end
 
-    def previous_contract_period = contract_period_reassignment.assigned_contract_period
-
+    delegate :training_periods, to: :period
+    delegate :required?, to: :contract_period_reassignment, prefix: true
     delegate :successor_contract_period, to: :contract_period_reassignment
+    delegate :assigned_contract_period, to: :contract_period_reassignment
+    alias_method :previous_contract_period, :assigned_contract_period
     alias_method :started_on, :date_of_transition
   end
 end

--- a/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
@@ -2,6 +2,8 @@ module Schools
   module ECTs
     module ChangeLeadProviderWizard
       class EditStep < Step
+        include Schedules::Reuse
+
         attribute :lead_provider_id, :string
 
         validates :lead_provider_id,
@@ -36,29 +38,15 @@ module Schools
             .select(:id, :name)
         end
 
-        def contract_period
-          @contract_period ||= contract_period_reassignment.required? ? successor_contract_period : contract_period_on_start_date
-        end
-
-        def contract_period_on_start_date
-          ContractPeriod.containing_date(ect_at_school_period.started_on)
-        end
-
-        def contract_period_reassignment
-          @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period:)
-        end
-
-        delegate :successor_contract_period, to: :contract_period_reassignment
-
-        def training_period
-          @training_period ||= ect_at_school_period.latest_training_period
-        end
-
         def current_lead_provider
           @current_lead_provider ||= ECTAtSchoolPeriods::ChangeLeadProviderResolver
             .new(ect_at_school_period)
             .call
         end
+
+        def period = ect_at_school_period
+        def reuse_existing_schedule? = false
+        def date_of_transition = period.started_on
       end
     end
   end

--- a/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/change_lead_provider_wizard/edit_step.rb
@@ -46,6 +46,7 @@ module Schools
 
         def period = ect_at_school_period
         def reuse_existing_schedule? = false
+        def current_or_next_training_period_confirmed? = true
         def date_of_transition = period.started_on
       end
     end

--- a/app/wizards/schools/ects/change_training_programme_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/ects/change_training_programme_wizard/lead_provider_step.rb
@@ -34,16 +34,9 @@ module Schools
           self.lead_provider_id = store.lead_provider_id
         end
 
-        def contract_period
-          if contract_period_reassignment_required?
-            successor_contract_period
-          else
-            super
-          end
-        end
-
         def period = ect_at_school_period
         def reuse_existing_schedule? = false
+        def current_or_next_training_period_confirmed? = true
         def date_of_transition = period.started_on
       end
     end

--- a/app/wizards/schools/ects/change_training_programme_wizard/lead_provider_step.rb
+++ b/app/wizards/schools/ects/change_training_programme_wizard/lead_provider_step.rb
@@ -2,6 +2,8 @@ module Schools
   module ECTs
     module ChangeTrainingProgrammeWizard
       class LeadProviderStep < Step
+        include Schedules::Reuse
+
         attribute :lead_provider_id, :string
 
         validates :lead_provider_id,
@@ -33,22 +35,16 @@ module Schools
         end
 
         def contract_period
-          @contract_period ||= contract_period_reassignment.required? ? successor_contract_period : contract_period_on_start_date
+          if contract_period_reassignment_required?
+            successor_contract_period
+          else
+            super
+          end
         end
 
-        def contract_period_on_start_date
-          ContractPeriod.containing_date(ect_at_school_period.started_on)
-        end
-
-        def contract_period_reassignment
-          @contract_period_reassignment ||= ContractPeriods::Reassignment.new(training_period: last_provider_led_training_period)
-        end
-
-        delegate :successor_contract_period, to: :contract_period_reassignment
-
-        def last_provider_led_training_period
-          @last_provider_led_training_period ||= ect_at_school_period.training_periods.provider_led_training_programme.latest_first.first
-        end
+        def period = ect_at_school_period
+        def reuse_existing_schedule? = false
+        def date_of_transition = period.started_on
       end
     end
   end

--- a/spec/services/contract_periods/reassignment_spec.rb
+++ b/spec/services/contract_periods/reassignment_spec.rb
@@ -1,84 +1,62 @@
 RSpec.describe ContractPeriods::Reassignment do
+  let(:training_period) do
+    instance_double(
+      TrainingPeriod,
+      provider_led_training_programme?: provider_led_training_programme,
+      for_mentor?: for_mentor,
+      contract_period:,
+      expression_of_interest_contract_period:
+    )
+  end
+
+  let(:contract_period) { nil }
+  let(:expression_of_interest_contract_period) { nil }
+  let(:provider_led_training_programme) { true }
+  let(:for_mentor) { false }
+
   describe "#required?" do
     subject { described_class.new(training_period:).required? }
 
-    context "when training period is provider-led in a payments-frozen contract period" do
+    context "when the training period is provider-led in a payments-frozen contract period" do
       let(:contract_period) do
         instance_double(ContractPeriod, payments_frozen?: true)
-      end
-
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          provider_led_training_programme?: true,
-          contract_period:,
-          expression_of_interest_contract_period: nil
-        )
       end
 
       it { is_expected.to be_truthy }
     end
 
-    context "when training period is provider-led but contract period is not payments frozen" do
+    context "when the training period is provider-led but contract period is not payments frozen" do
       let(:contract_period) do
         instance_double(ContractPeriod, payments_frozen?: false)
-      end
-
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          provider_led_training_programme?: true,
-          contract_period:,
-          expression_of_interest_contract_period: nil
-        )
       end
 
       it { is_expected.to be_falsey }
     end
 
-    context "when training period uses expression_of_interest_contract_period" do
-      let(:contract_period) do
+    context "when the training period uses expression_of_interest_contract_period" do
+      let(:expression_of_interest_contract_period) do
         instance_double(ContractPeriod, payments_frozen?: true)
-      end
-
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          provider_led_training_programme?: true,
-          contract_period: nil,
-          expression_of_interest_contract_period: contract_period
-        )
       end
 
       it { is_expected.to be_truthy }
     end
 
-    context "when training period uses expression_of_interest_contract_period that is not payments frozen" do
-      let(:contract_period) do
+    context "when the training period uses expression_of_interest_contract_period that is not payments frozen" do
+      let(:expression_of_interest_contract_period) do
         instance_double(ContractPeriod, payments_frozen?: false)
-      end
-
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          provider_led_training_programme?: true,
-          contract_period: nil,
-          expression_of_interest_contract_period: contract_period
-        )
       end
 
       it { is_expected.to be_falsey }
     end
 
-    context "when training period is not provider-led" do
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          provider_led_training_programme?: false,
-          contract_period: nil,
-          expression_of_interest_contract_period: nil
-        )
-      end
+    context "when the training period is not provider-led" do
+      let(:provider_led_training_programme) { false }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the training period is for a mentor" do
+      let(:for_mentor) { true }
 
       it { is_expected.to be_falsey }
     end
@@ -105,53 +83,23 @@ RSpec.describe ContractPeriods::Reassignment do
 
     context "when training period has a contract period" do
       let(:contract_period) { instance_double(ContractPeriod) }
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period:,
-          expression_of_interest_contract_period: nil
-        )
-      end
 
       it { is_expected.to eq(contract_period) }
     end
 
     context "when training period does not have a contract period but has an expression of interest contract period" do
       let(:expression_of_interest_contract_period) { instance_double(ContractPeriod) }
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period: nil,
-          expression_of_interest_contract_period:
-        )
-      end
 
       it { is_expected.to eq(expression_of_interest_contract_period) }
     end
 
     context "when training period does not have a contract period or an expression of interest contract period" do
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period: nil,
-          expression_of_interest_contract_period: nil
-        )
-      end
-
       it { is_expected.to be_nil }
     end
 
     context "when a training period has both a contract period and an expression of interest contract period" do
       let(:contract_period) { instance_double(ContractPeriod) }
       let(:expression_of_interest_contract_period) { instance_double(ContractPeriod) }
-
-      let(:training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period:,
-          expression_of_interest_contract_period:
-        )
-      end
 
       it { is_expected.to eq(contract_period) }
     end

--- a/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
@@ -74,7 +74,7 @@ module ECTAtSchoolPeriods
         end
       end
 
-      context "when the training period started in the past with a confirmed partnership" do
+      context "when the training period started in the past" do
         it "finishes the existing training period" do
           freeze_time
 
@@ -114,7 +114,7 @@ module ECTAtSchoolPeriods
         end
       end
 
-      context "when the training period starts today with EOI only" do
+      context "when the training period starts today" do
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
@@ -201,6 +201,100 @@ module ECTAtSchoolPeriods
           expect { change_lead_provider }.to change(ect_at_school_period.teacher, :ect_payments_frozen_year).from(nil).to(2021)
         end
       end
+
+      context "when the training period is deferred" do
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :deferred,
+            :provider_led,
+            :with_school_partnership,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on,
+            school_partnership:,
+            
+          )
+        end
+
+        it "creates a new training period with the new lead provider with the original schedule" do
+          change_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(Date.current)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+          expect(new_training_period.schedule.contract_period).to eq(training_period.schedule.contract_period)
+          expect(new_training_period.schedule).to eq(training_period.schedule)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              mentor_at_school_period: nil,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          change_lead_provider
+        end
+      end
+
+      context "when the training period is withdrawn" do
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :withdrawn,
+            :provider_led,
+            :with_school_partnership,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on,
+            school_partnership:,
+            
+          )
+        end
+
+        it "creates a new training period with the new lead provider with the original schedule" do
+          change_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(Date.current)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+          expect(new_training_period.schedule.contract_period).to eq(training_period.schedule.contract_period)
+          expect(new_training_period.schedule).to eq(training_period.schedule)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              mentor_at_school_period: nil,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          change_lead_provider
+        end
+      end
+
+
     end
 
     context "when there is no existing school partnership" do
@@ -216,7 +310,7 @@ module ECTAtSchoolPeriods
         )
       end
 
-      context "when the training period started in the past with EOI only" do
+      context "when the training period started in the past" do
         it "destroys the existing training period" do
           freeze_time
 
@@ -256,7 +350,7 @@ module ECTAtSchoolPeriods
         end
       end
 
-      context "when the training period starts in the future with EOI only" do
+      context "when the training period starts in the future" do
         let(:ect_at_school_period) do
           FactoryBot.create(
             :ect_at_school_period,
@@ -300,6 +394,9 @@ module ECTAtSchoolPeriods
         let!(:contract_period_2021) { FactoryBot.create(:contract_period, :with_schedules, :with_payments_frozen, year: 2021) }
         let!(:current_contract_period) { FactoryBot.create(:contract_period, :current, :with_schedules) }
         let(:contract_period) { contract_period_2021 }
+        let(:contract_period_2024) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
+        let!(:extended_schedule) { FactoryBot.create(:schedule, contract_period: contract_period_2024, identifier: "ecf-extended-september") }
+        
         let(:new_active_lead_provider) do
           FactoryBot.create(
             :active_lead_provider,
@@ -339,6 +436,97 @@ module ECTAtSchoolPeriods
           expect { change_lead_provider }.not_to change(ect_at_school_period.teacher, :ect_payments_frozen_year)
         end
       end
+
+      context "when the training period is deferred" do
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :deferred,
+            :provider_led,
+            :with_only_expression_of_interest,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on,
+            expression_of_interest: current_active_lead_provider
+          )
+        end
+
+        it "creates a new training period" do
+          change_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(Date.current)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+          expect(new_training_period.schedule.contract_period).to eq(training_period.schedule.contract_period)
+          expect(new_training_period.schedule).to eq(training_period.schedule)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.expression_of_interest.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              mentor_at_school_period: nil,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          change_lead_provider
+        end
+      end
+
+      context "when the training period is withdrawn" do
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :withdrawn,
+            :provider_led,
+            :with_only_expression_of_interest,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on,
+            expression_of_interest: current_active_lead_provider
+          )
+        end
+
+        it "creates a new training period" do
+          change_lead_provider
+
+          new_training_period = ect_at_school_period.reload.current_or_next_training_period
+          expect(new_training_period.started_on).to eq(Date.current)
+          expect(new_training_period.expression_of_interest.lead_provider)
+            .to eq(lead_provider)
+          expect(new_training_period.schedule.contract_period).to eq(training_period.schedule.contract_period)
+          expect(new_training_period.schedule).to eq(training_period.schedule)
+        end
+
+        it "records a `teacher_training_lead_provider_updated` event" do
+          freeze_time
+          old_lead_provider = training_period.expression_of_interest.lead_provider
+
+          expect(Events::Record)
+            .to receive(:record_teacher_training_lead_provider_updated_event!)
+            .with(
+              old_lead_provider_name: old_lead_provider.name,
+              new_lead_provider_name: lead_provider.name,
+              author:,
+              ect_at_school_period:,
+              mentor_at_school_period: nil,
+              school: ect_at_school_period.school,
+              teacher: ect_at_school_period.teacher,
+              happened_at: Time.current
+            )
+
+          change_lead_provider
+        end
+      end
+
 
       context "when the ECT is on a school-led programme" do
         let!(:training_period) do

--- a/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
@@ -211,8 +211,7 @@ module ECTAtSchoolPeriods
             :with_school_partnership,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on,
-            school_partnership:,
-            
+            school_partnership:
           )
         end
 
@@ -257,8 +256,7 @@ module ECTAtSchoolPeriods
             :with_school_partnership,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on,
-            school_partnership:,
-            
+            school_partnership:
           )
         end
 
@@ -293,8 +291,6 @@ module ECTAtSchoolPeriods
           change_lead_provider
         end
       end
-
-
     end
 
     context "when there is no existing school partnership" do
@@ -396,7 +392,7 @@ module ECTAtSchoolPeriods
         let(:contract_period) { contract_period_2021 }
         let(:contract_period_2024) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
         let!(:extended_schedule) { FactoryBot.create(:schedule, contract_period: contract_period_2024, identifier: "ecf-extended-september") }
-        
+
         let(:new_active_lead_provider) do
           FactoryBot.create(
             :active_lead_provider,
@@ -526,7 +522,6 @@ module ECTAtSchoolPeriods
           change_lead_provider
         end
       end
-
 
       context "when the ECT is on a school-led programme" do
         let!(:training_period) do

--- a/spec/services/mentor_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/mentor_at_school_periods/change_lead_provider_spec.rb
@@ -140,6 +140,30 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
           expect { subject }.not_to change(teacher, :ect_payments_frozen_year)
         end
       end
+
+      context "when the existing training_period is deferred" do
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :deferred, mentor_at_school_period:, started_on:, school_partnership: old_school_partnership) }
+
+        it "opens a new training period with the previous schedule" do
+          expect { subject }.to change(TrainingPeriod, :count).by(1)
+
+          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          expect(new_training_period.schedule).to eq(training_period.schedule)
+          expect(new_training_period.schedule.contract_period_year).to eq(training_period.schedule.contract_period_year)
+        end
+      end
+
+      context "when the existing training_period is withdrawn" do
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :withdrawn, mentor_at_school_period:, started_on:, school_partnership: old_school_partnership) }
+
+        it "opens a new training period with the previous schedule" do
+          expect { subject }.to change(TrainingPeriod, :count).by(1)
+
+          new_training_period = mentor_at_school_period.training_periods.ongoing.first
+          expect(new_training_period.schedule).to eq(training_period.schedule)
+          expect(new_training_period.schedule.contract_period_year).to eq(training_period.schedule.contract_period_year)
+        end
+      end
     end
 
     context "when there is no school partnership with the old lead provider" do

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     instance_double(
       TrainingPeriod,
       provider_led_training_programme?: provider_led,
+      for_mentor?: false,
       contract_period:,
       expression_of_interest_contract_period: nil,
       lead_provider:


### PR DESCRIPTION
### Context

When a school changes LP for an ECT or mentor in the 2023 or 2024 contract period, a new training period is created with 2025 as the contract period.  This was because the schedule reuse logic was wrong.  We've already applied a similar change to the training programme wizard to fix a similar [bug](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2595).  Both the change LP and change training period wizard must override the schedule that `Schedule::Find` class would assign because of the potential for unconfirmed training periods to be deleted during the wizard.  As this logic has become more complex,  the service classes for these wizards have grown bloated.  Therefore I have introduced a new concern `Schedules::Reuse`.  This could perhaps be named better.

### Guidance to review

I found using George Cole and Imogen Stubbs in Malory Towers would work.  You will need to ensure they are deferred or withdrawn.
