### PR TITLE
Include voided declarations in CSVs

### DIFF
--- a/app/services/statements/declaration_selection.rb
+++ b/app/services/statements/declaration_selection.rb
@@ -39,13 +39,17 @@ module Statements
     end
 
     def selected_ids_for_flat_rate(calculator)
-      filtered_declarations = calculator.declaration_selector.call(current_billable_declarations.or(current_refundable_declarations))
+      declarations_to_filter = current_billable_declarations
+        .or(current_refundable_declarations)
+        .or(current_voided_declarations)
+      filtered_declarations = calculator.declaration_selector.call(declarations_to_filter)
       ordered(filtered_declarations).ids
     end
 
     def selected_ids_for_banded(calculator)
       filtered_current_billable = ordered(calculator.declaration_selector.call(current_billable_declarations))
       filtered_current_refundable = ordered(calculator.declaration_selector.call(current_refundable_declarations))
+      filtered_current_voided = ordered(calculator.declaration_selector.call(current_voided_declarations))
       filtered_previous_billable = calculator.declaration_selector.call(previous_billable_declarations)
       filtered_previous_refundable = calculator.declaration_selector.call(previous_refundable_declarations)
 
@@ -61,7 +65,8 @@ module Statements
       refundable_selection_limits = allocations.group_by(&:declaration_type).transform_values { |rows| rows.sum(&:refundable_count) }
 
       select_ids_by_type(filtered_current_billable, billable_selection_limits) +
-        select_ids_by_type(filtered_current_refundable, refundable_selection_limits)
+        select_ids_by_type(filtered_current_refundable, refundable_selection_limits) +
+        filtered_current_voided.ids
     end
 
     def select_ids_by_type(declarations, selection_limits_by_declaration_type)
@@ -78,6 +83,10 @@ module Statements
 
     def current_refundable_declarations
       @current_refundable_declarations ||= Declaration.where(clawback_statement: statement).refundable
+    end
+
+    def current_voided_declarations
+      @current_voided_declarations ||= Declaration.where(payment_statement: statement).payment_status_voided
     end
 
     def previous_billable_declarations

--- a/spec/services/statements/declaration_selection_spec.rb
+++ b/spec/services/statements/declaration_selection_spec.rb
@@ -212,6 +212,23 @@ RSpec.describe Statements::DeclarationSelection do
     end
   end
 
+  context "when the statement contains voided declarations" do
+    let!(:voided_declaration) do
+      FactoryBot.create(
+        :declaration,
+        **default_declaration_attrs.merge(
+          payment_statement: statement,
+          payment_status: :voided
+        ),
+        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+      )
+    end
+
+    it "includes voided declarations counted on this statement" do
+      expect(selected_declaration_ids).to include(voided_declaration.id)
+    end
+  end
+
   context "when resolver returns a flat rate calculator" do
     let(:flat_rate_calculator) do
       PaymentCalculator::FlatRate.new(
@@ -288,12 +305,25 @@ RSpec.describe Statements::DeclarationSelection do
         training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
       )
     end
+    let!(:voided_declaration) do
+      FactoryBot.create(
+        :declaration,
+        **default_declaration_attrs.merge(
+          payment_statement: statement,
+          payment_status: :voided,
+          declaration_date: base_declaration_date + 4.days,
+          created_at: base_declaration_date + 4.days
+        ),
+        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+      )
+    end
 
     it "includes only started/completed declarations across current billable and current refundable sets in order" do
       expect(selected_declaration_ids).to eq([
         started_billable_declaration.id,
         completed_billable_declaration.id,
         started_refundable_declaration.id,
+        voided_declaration.id,
       ])
     end
   end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3772

### Changes proposed in this pull request

In #2406, we updated the declaration summary section of the financial statements to ensure voided declarations were displayed.

In #2416, we introduced the declarations CSV. But we didn't update the `Statements::DeclarationSelection` to include voided declarations too.

This separation should be addressed, otherwise we will end up with similar discrepancies again.

For now, this addresses the issue though.

Now, voided declarations are included in CSVs of the relevant statement.

### Guidance to review
