### PR TITLE
ParityCheck::Response save calculated 'rect_performance_gain_ratio' in column

### DIFF
--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -68,7 +68,7 @@ module ParityCheck
     end
 
     def rect_performance_gain_ratio
-      ratios = responses.map(&:rect_performance_gain_ratio).compact
+      ratios = responses.pluck(:rect_performance_gain_ratio).compact
 
       return if ratios.empty?
 

--- a/app/models/parity_check/response.rb
+++ b/app/models/parity_check/response.rb
@@ -8,6 +8,7 @@ module ParityCheck
 
     before_validation :clear_bodies, if: :bodies_matching?
     before_validation :calculate_match_rate
+    before_validation :calculate_rect_performance_gain_ratio
 
     validates :request, presence: true
     validates :ecf_status_code, inclusion: { in: 100..599 }
@@ -23,14 +24,6 @@ module ParityCheck
     scope :matching, -> { status_codes_matching.bodies_matching }
     scope :different, -> { status_codes_different.or(bodies_different) }
     scope :ordered_by_page, -> { order(:page) }
-
-    def rect_performance_gain_ratio
-      return unless ecf_time_ms && rect_time_ms
-
-      ratio = ecf_time_ms.to_f / rect_time_ms
-
-      (ratio < 1 ? -(1 / ratio) : ratio).round(1)
-    end
 
     def matching?
       !different?
@@ -118,6 +111,14 @@ module ParityCheck
 
       self.match_rate =
         (100 * (1 - diff_lines.to_f / total_lines)).floor
+    end
+
+    def calculate_rect_performance_gain_ratio
+      return unless ecf_time_ms && rect_time_ms
+
+      ratio = ecf_time_ms.to_f / rect_time_ms
+
+      self.rect_performance_gain_ratio = (ratio < 1 ? -(1 / ratio) : ratio).round(1)
     end
 
     def format_body(body)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -337,6 +337,7 @@
   - page
   - created_at
   - updated_at
+  - rect_performance_gain_ratio
   :parity_check_endpoints:
   - id
   - path

--- a/db/migrate/20260413164213_add_rect_performance_gain_ratio_to_parity_check_responses.rb
+++ b/db/migrate/20260413164213_add_rect_performance_gain_ratio_to_parity_check_responses.rb
@@ -1,0 +1,5 @@
+class AddRectPerformanceGainRatioToParityCheckResponses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :parity_check_responses, :rect_performance_gain_ratio, :decimal, precision: 6, scale: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_07_110223) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_13_164213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -650,6 +650,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_110223) do
     t.datetime "updated_at", null: false
     t.bigint "endpoint_id"
     t.enum "state", default: "pending", null: false, enum_type: "parity_check_request_states"
+    t.decimal "rect_performance_gain_ratio", precision: 6, scale: 1
     t.index ["endpoint_id"], name: "index_parity_check_requests_on_endpoint_id"
     t.index ["lead_provider_id"], name: "index_parity_check_requests_on_lead_provider_id"
     t.index ["run_id"], name: "index_parity_check_requests_on_run_id"
@@ -670,6 +671,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_110223) do
     t.string "rect_request_uri"
     t.jsonb "request_body"
     t.integer "match_rate", default: 0, null: false
+    t.decimal "rect_performance_gain_ratio", precision: 6, scale: 1
     t.index ["request_id", "page"], name: "index_parity_check_responses_on_request_id_and_page", unique: true
     t.index ["request_id"], name: "index_parity_check_responses_on_request_id"
   end

--- a/spec/models/parity_check/response_spec.rb
+++ b/spec/models/parity_check/response_spec.rb
@@ -78,6 +78,54 @@ describe ParityCheck::Response do
         it { is_expected.to eq(0) }
       end
     end
+
+    describe "calculating the rect_performance_gain_ratio" do
+      subject { response.tap(&:validate).rect_performance_gain_ratio }
+
+      let(:response) { FactoryBot.build(:parity_check_response, ecf_time_ms:, rect_time_ms:) }
+
+      context "when there are no response times" do
+        let(:rect_time_ms) { nil }
+        let(:ecf_time_ms) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the response times are equal" do
+        let(:rect_time_ms) { 100 }
+        let(:ecf_time_ms) { rect_time_ms }
+
+        it { is_expected.to eq(1.0) }
+      end
+
+      context "when the RECT response times are faster" do
+        let(:rect_time_ms) { 87 }
+        let(:ecf_time_ms) { 253 }
+
+        it { is_expected.to eq(2.9) }
+      end
+
+      context "when the ECF response times are faster" do
+        let(:rect_time_ms) { 253 }
+        let(:ecf_time_ms) { 87 }
+
+        it { is_expected.to eq(-2.9) }
+      end
+
+      context "when the response times are very close together (RECT faster)" do
+        let(:rect_time_ms) { 253 }
+        let(:ecf_time_ms) { 260 }
+
+        it { is_expected.to eq(1.0) }
+      end
+
+      context "when the response times are very close together (RECT slower)" do
+        let(:rect_time_ms) { 260 }
+        let(:ecf_time_ms) { 253 }
+
+        it { is_expected.to eq(-1.0) }
+      end
+    end
   end
 
   describe "validations" do
@@ -184,54 +232,6 @@ describe ParityCheck::Response do
 
         it { expect(response.rect_body).to eq("not json") }
       end
-    end
-  end
-
-  describe "#rect_performance_gain_ratio" do
-    subject { response.rect_performance_gain_ratio }
-
-    let(:response) { FactoryBot.build(:parity_check_response, ecf_time_ms:, rect_time_ms:) }
-
-    context "when there are no response times" do
-      let(:rect_time_ms) { nil }
-      let(:ecf_time_ms) { nil }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "when the response times are equal" do
-      let(:rect_time_ms) { 100 }
-      let(:ecf_time_ms) { rect_time_ms }
-
-      it { is_expected.to eq(1.0) }
-    end
-
-    context "when the RECT response times are faster" do
-      let(:rect_time_ms) { 87 }
-      let(:ecf_time_ms) { 253 }
-
-      it { is_expected.to eq(2.9) }
-    end
-
-    context "when the ECF response times are faster" do
-      let(:rect_time_ms) { 253 }
-      let(:ecf_time_ms) { 87 }
-
-      it { is_expected.to eq(-2.9) }
-    end
-
-    context "when the response times are very close together (RECT faster)" do
-      let(:rect_time_ms) { 253 }
-      let(:ecf_time_ms) { 260 }
-
-      it { is_expected.to eq(1.0) }
-    end
-
-    context "when the response times are very close together (RECT slower)" do
-      let(:rect_time_ms) { 260 }
-      let(:ecf_time_ms) { 253 }
-
-      it { is_expected.to eq(-1.0) }
     end
   end
 


### PR DESCRIPTION
### Context

`ParityCheck::Response.rect_performance_gain_ratio` is a calculated method, is timing out for declarations endpoint.

### Changes proposed in this pull request

* Add new column `ParityCheck::Response.rect_performance_gain_ratio`, save calculated value on before_validation

### Guidance to review
