### PR TITLE
[3648] Add metadata refreshable endpoint shared context to api requests specs

### DIFF
--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
         it_behaves_like "a token authenticated endpoint", :post
         it_behaves_like "an API create endpoint"
+        it_behaves_like "an endpoint that refreshes metadata", :post
 
         context "when the `declaration_type` is invalid" do
           let(:declaration_type) { "invalid" }
@@ -132,6 +133,7 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
         it_behaves_like "a token authenticated endpoint", :put
         it_behaves_like "an API update endpoint", accepts_request_body: false
+        it_behaves_like "an endpoint that refreshes metadata", :put
       end
     end
 
@@ -141,6 +143,7 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
       it_behaves_like "a token authenticated endpoint", :put
       it_behaves_like "an API update endpoint", accepts_request_body: false
+      it_behaves_like "an endpoint that refreshes metadata", :put
     end
 
     context "when the declaration is in `voided` status" do

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe "Participants API", :with_metadata, :with_touches, type: :request
 
     it_behaves_like "a token authenticated endpoint", :put
     it_behaves_like "an API update endpoint"
+    it_behaves_like "an endpoint that refreshes metadata", :put
   end
 
   describe "#defer" do
@@ -125,6 +126,7 @@ RSpec.describe "Participants API", :with_metadata, :with_touches, type: :request
 
     it_behaves_like "a token authenticated endpoint", :put
     it_behaves_like "an API update endpoint"
+    it_behaves_like "an endpoint that refreshes metadata", :put
   end
 
   describe "#resume" do
@@ -153,6 +155,7 @@ RSpec.describe "Participants API", :with_metadata, :with_touches, type: :request
 
     it_behaves_like "a token authenticated endpoint", :put
     it_behaves_like "an API update endpoint"
+    it_behaves_like "an endpoint that refreshes metadata", :put
   end
 
   describe "#withdraw" do
@@ -184,5 +187,6 @@ RSpec.describe "Participants API", :with_metadata, :with_touches, type: :request
 
     it_behaves_like "a token authenticated endpoint", :put
     it_behaves_like "an API update endpoint"
+    it_behaves_like "an endpoint that refreshes metadata", :put
   end
 end

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Partnerships API", :with_touches, type: :request do
 
     it_behaves_like "a token authenticated endpoint", :post
     it_behaves_like "an API create endpoint"
+    it_behaves_like "an endpoint that refreshes metadata", :post
   end
 
   describe "#update" do
@@ -98,5 +99,6 @@ RSpec.describe "Partnerships API", :with_touches, type: :request do
 
     it_behaves_like "a token authenticated endpoint", :put
     it_behaves_like "an API update endpoint"
+    it_behaves_like "an endpoint that refreshes metadata", :put
   end
 end

--- a/spec/support/shared_contexts/api/metadata_refreshable_endpoint.rb
+++ b/spec/support/shared_contexts/api/metadata_refreshable_endpoint.rb
@@ -1,0 +1,14 @@
+shared_examples "an endpoint that refreshes metadata" do |request_method|
+  it "refreshes all required metadata" do
+    send(request_method, path, headers: api_headers, params:)
+
+    dump_metadata_database_state = -> {
+      ActiveRecord::Base.connection.tables.select { it.start_with?("metadata_") }.to_h do |table|
+        rows = ActiveRecord::Base.connection.execute("SELECT * FROM #{table}").to_a
+        [table, rows]
+      end
+    }.call
+
+    expect { Metadata::Manager.refresh_all_metadata! }.not_to(change { dump_metadata_database_state })
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [3648](https://github.com/DFE-Digital/register-ects-project-board/issues/3648)

We're seeing some alerts on Sentry about metadata refresh.

### Changes proposed in this pull request

- Add metadata refreshable endpoint shared context to api requests specs so we make sure that the alerts are not being created when an API endpoint is hit;
- Do we need to `track_changes` set to true on the daily job `RefreshAllMetadataJob`?

On the Sentry alerts:
- All events on Sentry are happening after 12am (utc):
  - <img width="507" height="326" alt="Screenshot 2026-04-14 at 09 25 30" src="https://github.com/user-attachments/assets/431af8ad-adab-451e-8cda-1c8826944847" />
- `RefreshAllMetadataJob` is running every day at 12am (utc).
  - `Metadata::Manager.refresh_all_metadata!(async: true, track_changes: true)` is run with `track_changes` flag `true`;
  - `Metadata::Handlers` spawns multiple `RefreshMetadataJob` with `track_changes` flag `true`;
  - `Metadata::Manager.new.refresh_metadata!(objects, track_changes:)` is run with `track_changes` flag `true`;
  - Metadata is refreshed and alerts are created on Sentry as `alert_on_changes` is flag is set to `true`;
    ```
      Array.wrap(objects).each do
        handler = resolve_handler(it)
        handler.track_changes! if track_changes
        handler.refresh_metadata!
      end

    def track_changes!
      @alert_on_changes = true
    end

    def upsert_all(model:, changes_to_upsert:, unique_by:)
      return if changes_to_upsert.empty?

      model.upsert_all(changes_to_upsert.values, unique_by:)
      alert_on_changes(changes: changes_to_upsert)
    end
    ```