### PR TITLE
Improve metadata change tracking

### DIFF
--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -47,10 +47,17 @@ module Metadata::Handlers
       return unless @alert_on_changes
 
       changes.each do |metadata, changed_attributes|
+        changed_attributes_with_history = changed_attributes.transform_values.with_index do |new_value, key|
+          {
+            old: metadata.attributes[key],
+            new: new_value
+          }
+        end
+
         attrs = {
           class: metadata.class.name,
           id: metadata.id,
-          changed_attributes:,
+          changed_attributes: changed_attributes_with_history,
         }
 
         Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")


### PR DESCRIPTION
Previously we were passing all attributes to Sentry when any of them are updated on some existing metadata. This is misleading because it looks like all the attributes have changed. Instead, we want to just surface the attributes that actually had their value changed due to refreshing the metadata.

It's awkward to extend the existing tests to cover this change, but they should already do a good enough job of testing the bits we care about.
