### PR TITLE
Ensure metadata updates trigger callbacks

### DIFF
--- a/app/models/metadata/school_contract_period.rb
+++ b/app/models/metadata/school_contract_period.rb
@@ -19,7 +19,6 @@ module Metadata
     validates :induction_programme_choice, inclusion: { in: induction_programme_choices.keys }
     validates :school_id, uniqueness: { scope: %i[contract_period_year] }
 
-    touch -> { school }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
     touch -> { school }, on_event: :update, when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at
   end
 end

--- a/app/models/metadata/school_lead_provider_contract_period.rb
+++ b/app/models/metadata/school_lead_provider_contract_period.rb
@@ -14,7 +14,6 @@ module Metadata
     validates :expression_of_interest_or_school_partnership, inclusion: { in: [true, false] }
     validates :school_id, uniqueness: { scope: %i[lead_provider_id contract_period_year] }
 
-    touch -> { school }, on_event: %i[create destroy], timestamp_attribute: :api_updated_at
     touch -> { school }, on_event: :update, when_changing: %i[expression_of_interest_or_school_partnership], timestamp_attribute: :api_updated_at
   end
 end

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -33,11 +33,12 @@ module Metadata::Handlers
     end
 
     def changes?(metadata, changes)
+      changes.stringify_keys!
       metadata.attributes.slice(*changes.keys) != changes
     end
 
     def commit_changes!(metadata, changes)
-      return unless changes?(metadata, changes)
+      return unless metadata.new_record? || changes?(metadata, changes)
 
       # As we touch other models when metadata is updated via ActiveRecord callbacks,
       # we need to ensure this remains a method that will trigger those callbacks

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -36,36 +36,37 @@ module Metadata::Handlers
       metadata.attributes.slice(*changes.keys) != changes
     end
 
-    def upsert_all(model:, changes_to_upsert:, unique_by:)
-      return if changes_to_upsert.empty?
+    def commit_changes!(metadata, changes)
+      return unless changes?(metadata, changes)
 
-      model.upsert_all(changes_to_upsert.values, unique_by:)
-      alert_on_changes(changes: changes_to_upsert)
+      # As we touch other models when metadata is updated via ActiveRecord callbacks,
+      # we need to ensure this remains a method that will trigger those callbacks
+      # (rather than using something like upsert_all which would otherwise be quicker).
+      metadata.update!(changes)
+      alert_on_changes(metadata, changes)
     end
 
-    def alert_on_changes(changes:)
+    def alert_on_changes(metadata, changes)
       return unless @alert_on_changes
 
-      changes.each do |metadata, changed_attributes|
-        changed_attributes_with_history = changed_attributes.transform_values.with_index do |new_value, key|
-          {
-            old: metadata.attributes[key],
-            new: new_value
-          }
-        end
-
-        attrs = {
-          class: metadata.class.name,
-          id: metadata.id,
-          changed_attributes: changed_attributes_with_history,
+      changed_attributes_with_history = changes.transform_values.with_index do |new_value, key|
+        {
+          old: metadata.attributes[key],
+          new: new_value
         }
+      end
 
-        Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")
+      attrs = {
+        class: metadata.class.name,
+        id: metadata.id,
+        changed_attributes: changed_attributes_with_history,
+      }
 
-        Sentry.with_scope do |scope|
-          scope.set_context("metadata_changes", attrs) if scope
-          Sentry.capture_message("[Metadata] #{metadata.class.name} change")
-        end
+      Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")
+
+      Sentry.with_scope do |scope|
+        scope.set_context("metadata_changes", attrs) if scope
+        Sentry.capture_message("[Metadata] #{metadata.class.name} change")
       end
     end
   end

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -49,9 +49,13 @@ module Metadata::Handlers
     def alert_on_changes(metadata, changes)
       return unless @alert_on_changes
 
-      changed_attributes_with_history = changes.transform_values.with_index do |new_value, key|
-        {
-          old: metadata.attributes[key],
+      changed_attributes_with_history = changes.each_with_object({}) do |(key, new_value), hash|
+        old_value = metadata.attributes[key]
+
+        next if old_value == new_value
+
+        hash[key] = {
+          old: old_value,
           new: new_value
         }
       end

--- a/app/services/metadata/handlers/delivery_partner.rb
+++ b/app/services/metadata/handlers/delivery_partner.rb
@@ -19,7 +19,7 @@ module Metadata::Handlers
   private
 
     def upsert_lead_provider_metadata!
-      changes_to_upsert = lead_provider_ids.each_with_object({}) do |lead_provider_id, hash|
+      lead_provider_ids.each do |lead_provider_id|
         metadata = existing_lead_provider_metadata[lead_provider_id] ||
           Metadata::DeliveryPartnerLeadProvider.new(delivery_partner:, lead_provider_id:)
 
@@ -29,12 +29,8 @@ module Metadata::Handlers
           contract_period_years: contract_period_years_by_lead_provider[lead_provider_id] || []
         }
 
-        next unless changes?(metadata, changes)
-
-        hash[metadata] = changes if changes?(metadata, changes)
+        commit_changes!(metadata, changes)
       end
-
-      upsert_all(model: Metadata::DeliveryPartnerLeadProvider, changes_to_upsert:, unique_by: %i[delivery_partner_id lead_provider_id])
     end
 
     def existing_lead_provider_metadata

--- a/app/services/metadata/handlers/school.rb
+++ b/app/services/metadata/handlers/school.rb
@@ -20,7 +20,7 @@ module Metadata::Handlers
   private
 
     def upsert_contract_period_metadata!
-      changes_to_upsert = contract_period_years.each_with_object({}) do |contract_period_year, hash|
+      contract_period_years.each do |contract_period_year|
         metadata = existing_contract_period_metadata[contract_period_year] ||
           Metadata::SchoolContractPeriod.new(school:, contract_period_year:)
 
@@ -31,14 +31,12 @@ module Metadata::Handlers
           induction_programme_choice: school.training_programme_for(contract_period_year)
         }
 
-        hash[metadata] = changes if changes?(metadata, changes)
+        commit_changes!(metadata, changes)
       end
-
-      upsert_all(model: Metadata::SchoolContractPeriod, changes_to_upsert:, unique_by: %i[school_id contract_period_year])
     end
 
     def upsert_lead_provider_contract_period_metadata!
-      changes_to_upsert = lead_provider_id_contract_period_years.each_with_object({}) do |(lead_provider_id, contract_period_year), hash|
+      lead_provider_id_contract_period_years.each do |lead_provider_id, contract_period_year|
         metadata = existing_lead_provider_contract_period_metadata[[lead_provider_id, contract_period_year]] ||
           Metadata::SchoolLeadProviderContractPeriod.new(school:, lead_provider_id:, contract_period_year:)
 
@@ -51,10 +49,8 @@ module Metadata::Handlers
           expression_of_interest_or_school_partnership:
         }
 
-        hash[metadata] = changes if changes?(metadata, changes)
+        commit_changes!(metadata, changes)
       end
-
-      upsert_all(model: Metadata::SchoolLeadProviderContractPeriod, changes_to_upsert:, unique_by: %i[school_id lead_provider_id contract_period_year])
     end
 
     def expression_of_interest_or_school_partnership_pairings

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -19,7 +19,7 @@ module Metadata::Handlers
   private
 
     def upsert_lead_provider_metadata!
-      changes_to_upsert = lead_provider_ids.each_with_object({}) do |lead_provider_id, hash|
+      lead_provider_ids.each do |lead_provider_id|
         metadata = existing_lead_provider_metadata[lead_provider_id] ||
           Metadata::TeacherLeadProvider.new(teacher:, lead_provider_id:)
 
@@ -42,10 +42,8 @@ module Metadata::Handlers
           involved_in_school_transfer:
         }
 
-        hash[metadata] = changes if changes?(metadata, changes)
+        commit_changes!(metadata, changes)
       end
-
-      upsert_all(model: Metadata::TeacherLeadProvider, changes_to_upsert:, unique_by: %i[teacher_id lead_provider_id])
     end
 
     def existing_lead_provider_metadata

--- a/spec/models/metadata/school_contract_period_spec.rb
+++ b/spec/models/metadata/school_contract_period_spec.rb
@@ -9,7 +9,6 @@ describe Metadata::SchoolContractPeriod do
       Metadata::SchoolContractPeriod.bypass_update_restrictions { example.run }
     end
 
-    it_behaves_like "a declarative touch model", on_event: %i[create destroy], timestamp_attribute: :api_updated_at
     it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[in_partnership induction_programme_choice], timestamp_attribute: :api_updated_at, target_optional: false
   end
 

--- a/spec/models/metadata/school_lead_provider_contract_period_spec.rb
+++ b/spec/models/metadata/school_lead_provider_contract_period_spec.rb
@@ -9,7 +9,6 @@ describe Metadata::SchoolLeadProviderContractPeriod do
       Metadata::SchoolLeadProviderContractPeriod.bypass_update_restrictions { example.run }
     end
 
-    it_behaves_like "a declarative touch model", on_event: %i[create destroy], timestamp_attribute: :api_updated_at
     it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[expression_of_interest_or_school_partnership], timestamp_attribute: :api_updated_at, target_optional: false
   end
 

--- a/spec/services/metadata/handlers/delivery_partner_spec.rb
+++ b/spec/services/metadata/handlers/delivery_partner_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Metadata::Handlers::DeliveryPartner do
         end
 
         it "does not update the metadata if no changes are made" do
+          instance.track_changes!
+          expect(Sentry).not_to receive(:capture_message).with(/DeliveryPartnerLeadProvider/)
           expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
         end
       end

--- a/spec/services/metadata/handlers/school_spec.rb
+++ b/spec/services/metadata/handlers/school_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe Metadata::Handlers::School do
         end
 
         it "does not update the metadata if no changes are made" do
-          expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
+          instance.track_changes!
+          expect(Sentry).not_to receive(:capture_message).with(/SchoolContractPeriod/)
+          expect { refresh_metadata }.not_to(change { metadata.reload.updated_at })
         end
       end
     end
@@ -131,6 +133,8 @@ RSpec.describe Metadata::Handlers::School do
         end
 
         it "does not update the metadata if no changes are made" do
+          instance.track_changes!
+          expect(Sentry).not_to receive(:capture_message).with(/SchoolLeadProviderContractPeriod/)
           expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
         end
       end

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -360,5 +360,47 @@ RSpec.describe Metadata::Handlers::Teacher do
         end
       end
     end
+
+    context "when metadata already exists for a teacher and lead provider" do
+      let!(:metadata) do
+        FactoryBot.create(
+          :teacher_lead_provider_metadata,
+          teacher: teacher1,
+          lead_provider: lead_provider1,
+          latest_ect_training_period_id: nil,
+          latest_mentor_training_period_id: nil,
+          latest_ect_contract_period_year: nil,
+          latest_mentor_contract_period_year: nil,
+          api_mentor_id: nil,
+          involved_in_school_transfer: false
+        )
+      end
+
+      it "does not create metadata" do
+        expect { refresh_metadata }.not_to change(Metadata::TeacherLeadProvider, :count)
+      end
+
+      it "updates the metadata when the latest_ect_training_period_id changes" do
+        ect_at_school_period = FactoryBot.create(
+          :ect_at_school_period,
+          school: school1,
+          teacher: teacher1
+        )
+        training_period = FactoryBot.create(
+          :training_period,
+          :for_ect,
+          ect_at_school_period:,
+          school_partnership: school_partnership1
+        )
+
+        expect { refresh_metadata }.to change { metadata.reload.latest_ect_training_period_id }.from(nil).to(training_period.id)
+      end
+
+      it "does not update the metadata if no changes are made" do
+        instance.track_changes!
+        expect(Sentry).not_to receive(:capture_message).with(/TeacherLeadProvider/)
+        expect { refresh_metadata }.not_to(change { metadata.reload.attributes })
+      end
+    end
   end
 end


### PR DESCRIPTION
> ⚠️ I've tested this on the parity check, prior to this change refreshing all metadata took ~50 minutes and after this change it took a little less time, oddly. I can't really explain it, but I expect the main chunk of time is spent querying to populate a bit of metadata and the inserts are negligible. The `upsert_all` also seemed to lock up the database and slow the web UI down, which no longer happens using `update!` individually.

- Ensure metadata refresh triggers callbacks

We use `upsert_all` for speed when updating batches of metadata, however this will skip the lifecycle callbacks that we rely on for our touch model updates (`create`, `update`, etc). This means when metadata is updated its not triggering a refresh of various `api_updated_at` columns on related models.

Make updates individually on the models with `update!` so that callbacks are triggered.

- Don't issue `touch` on metadata creation

The `touch` on creation should always be redundant, given we create metadata when the object itself is created.

The exception to this is after migration, where we create all metadata and also wouldn't want to issue any `touch` updates (as they would overwrite our pre-determined `api_updated_at` values that we set during migration!).

- Remove old/new values from error when they are the same

We only care about the values that change.

- Fix bug around metadata change reporting

Previously, we were reporting `changes?` as `true` inconsistently and even when the attributes match the changes. This was due to comparing a `metadata.attributes` - which is a stringified hash - with `changes` which uses symbolic keys.

Call `stringify_keys!` on `changes` to ensure a like for like comparison.

Also ensure we always commit new records, as they can sometimes be instantiated with enough attributes to cause `changes?` to be `false` even though the record has not yet persisted.

Testing this without coupling it tightly to the private implementation was a bit tricky, but I opted to assert that if `track_changes!` is enabled and not called then we aren't calling update on the metadata.