### PR TITLE
[3744] Add validation for leaving date and new school start date when teacher is moving schools

### DIFF
--- a/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
@@ -6,6 +6,7 @@ module Schools
 
         validate :leaving_on_valid
         validate :leaving_after_start_date
+        validate :leaving_after_training_started
 
         def self.permitted_params
           %i[
@@ -40,15 +41,43 @@ module Schools
           errors.add(:leaving_on, leaving_on_input.error_message)
         end
 
+        def skip_leaving_on_validation?
+          errors[:leaving_on].any?
+        end
+
         def leaving_after_start_date
-          return unless leaving_on_input.valid?
-          return if leaving_on_input.value_as_date > ect_at_school_period.started_on
+          return if skip_leaving_on_validation?
+          return unless period_start_date_valid?(ect_at_school_period)
+          return if after_started_on(ect_at_school_period)
 
           errors.add(
             :leaving_on,
-            "Our records show that #{name_for(ect_at_school_period.teacher)} started teaching at your school on
-            #{ect_at_school_period.started_on.to_formatted_s(:govuk)}. Enter a later date."
+            "Our records show that #{name_for(ect_at_school_period.teacher)} started teaching at your school on #{ect_at_school_period.started_on.to_formatted_s(:govuk)}. Enter a later date."
           )
+        end
+
+        def leaving_after_training_started
+          return if skip_leaving_on_validation?
+          return unless period_start_date_valid?(latest_started_training_period)
+          return if after_started_on(latest_started_training_period)
+
+          errors.add(
+            :leaving_on,
+            "Our records show that #{name_for(ect_at_school_period.teacher)} started their latest training at your school on #{latest_started_training_period.started_on.to_formatted_s(:govuk)}. Enter a later date."
+          )
+        end
+
+        def after_started_on(period)
+          leaving_on_input.value_as_date > period.started_on
+        end
+
+        def period_start_date_valid?(period)
+          period&.started_on.present?
+        end
+
+        # Unstarted training periods (ie starting today or in the future) will be deleted and should not prevent the leaving date from being valid
+        def latest_started_training_period
+          ect_at_school_period&.training_periods&.started_before(Time.zone.today)&.latest_first&.first
         end
 
         def leaving_on_input

--- a/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
@@ -5,8 +5,7 @@ module Schools
         attr_accessor :leaving_on
 
         validate :leaving_on_valid
-        validate :leaving_after_start_date
-        validate :leaving_after_training_started
+        validate :leaving_on_after_previous_school_or_training_period_start
 
         def self.permitted_params
           %i[
@@ -45,44 +44,36 @@ module Schools
           errors[:leaving_on].any?
         end
 
-        def leaving_after_start_date
+        def leaving_on_after_previous_school_or_training_period_start
           return if skip_leaving_on_validation?
-          return unless period_start_date_valid?(ect_at_school_period)
-          return if after_started_on(ect_at_school_period)
+          return if leaving_on_boundary_validator.valid?
 
-          errors.add(
-            :leaving_on,
-            "Our records show that #{name_for(ect_at_school_period.teacher)} started teaching at your school on #{ect_at_school_period.started_on.to_formatted_s(:govuk)}. Enter a later date."
-          )
+          errors.add(:leaving_on, invalid_period_error_message)
         end
 
-        def leaving_after_training_started
-          return if skip_leaving_on_validation?
-          return unless period_start_date_valid?(latest_started_training_period)
-          return if after_started_on(latest_started_training_period)
-
-          errors.add(
-            :leaving_on,
-            "Our records show that #{name_for(ect_at_school_period.teacher)} started their latest training at your school on #{latest_started_training_period.started_on.to_formatted_s(:govuk)}. Enter a later date."
-          )
-        end
-
-        def after_started_on(period)
-          leaving_on_input.value_as_date > period.started_on
-        end
-
-        def period_start_date_valid?(period)
-          period&.started_on.present?
-        end
-
-        # Unstarted training periods (ie starting today or in the future) will be deleted and should not prevent the leaving date from being valid
-        def latest_started_training_period
-          ect_at_school_period&.training_periods&.started_before(Time.zone.today)&.latest_first&.first
+        def invalid_period_error_message
+          "Our records show that #{name_for(ect_at_school_period.teacher)} started " \
+          "#{invalid_period_type} at your school on " \
+          "#{invalid_period_started_on_formatted}." \
+          " Enter a date after #{earliest_valid_input_date_formatted}."
         end
 
         def leaving_on_input
           @leaving_on_input ||= Schools::Validation::LeavingDate.new(date_as_hash: leaving_on)
         end
+
+        def leaving_on_boundary_validator
+          @leaving_on_boundary_validator ||= Schools::Validation::PeriodBoundary.new(
+            ect_at_school_period:,
+            input_date: leaving_on_input.value_as_date
+          )
+        end
+
+        delegate  :type,
+                  :started_on_formatted,
+                  to: :leaving_on_boundary_validator,
+                  prefix: :invalid_period
+        delegate :earliest_valid_input_date_formatted, to: :leaving_on_boundary_validator
       end
     end
   end

--- a/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
+++ b/app/wizards/schools/ects/teacher_leaving_wizard/edit_step.rb
@@ -64,7 +64,7 @@ module Schools
 
         def leaving_on_boundary_validator
           @leaving_on_boundary_validator ||= Schools::Validation::PeriodBoundary.new(
-            ect_at_school_period:,
+            input_period: ect_at_school_period,
             input_date: leaving_on_input.value_as_date
           )
         end

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -4,8 +4,7 @@ module Schools
       attr_accessor :start_date
 
       validates :start_date, ect_start_date: true
-      validate :start_date_not_before_previous_school
-      validate :start_date_not_before_last_training_period
+      validate :start_date_after_previous_school_or_training_period_start
       validate :start_date_within_4_months, if: :currently_ect_at_another_school?
 
       def self.permitted_params
@@ -26,33 +25,6 @@ module Schools
 
     private
 
-      def start_date_not_before_previous_school
-        return if skip_start_date_validation?
-
-        return unless period_start_date_valid?(previous_period)
-        return if start_date_after_period_starts?(previous_period)
-
-        errors.add(
-          :start_date,
-          "Our records show that #{wizard.ect.full_name} started teaching at #{previous_period.school&.name} on #{previous_period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
-        )
-      end
-
-      def start_date_not_before_last_training_period
-        return if skip_start_date_validation?
-        return unless period_start_date_valid?(latest_started_training_period)
-        return if start_date_after_period_starts?(latest_started_training_period)
-
-        errors.add(
-          :start_date,
-          "Our records show that #{wizard.ect.full_name} started their latest training at #{latest_started_training_period.school&.name} on #{latest_started_training_period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
-        )
-      end
-
-      def start_date_after_period_starts?(period)
-        start_date_as_date > period.started_on
-      end
-
       def currently_ect_at_another_school?
         ect.previously_registered? && previous_period.ongoing?
       end
@@ -61,9 +33,18 @@ module Schools
         ect.previous_ect_at_school_period
       end
 
-      # Unstarted training periods (ie starting today or in the future) will be deleted and should not prevent a start date at a new school from being valid
-      def latest_started_training_period
-        previous_period&.training_periods&.started_before(Time.zone.today)&.latest_first&.first
+      def start_date_after_previous_school_or_training_period_start
+        return if skip_start_date_validation?
+        return if start_date_boundary_validator.valid?
+
+        errors.add(:start_date, invalid_period_error_message)
+      end
+
+      def invalid_period_error_message
+        "Our records show that #{wizard.ect.full_name} started " \
+        "#{invalid_period_type} at #{previous_period&.school&.name} on " \
+        "#{invalid_period_started_on_formatted}." \
+        " Enter a start date after #{earliest_valid_input_date_formatted}."
       end
 
       def start_date_within_4_months
@@ -82,10 +63,6 @@ module Schools
 
       def registrations_closed_for_contract_period?
         start_date_as_date.future? && !start_date_contract_period&.enabled?
-      end
-
-      def period_start_date_valid?(period)
-        period&.started_on.present?
       end
 
       def skip_start_date_validation?
@@ -121,6 +98,19 @@ module Schools
       def start_date_obj
         @start_date_obj ||= Schools::Validation::ECTStartDate.new(date_as_hash: start_date)
       end
+
+      def start_date_boundary_validator
+        @start_date_boundary_validator ||= Schools::Validation::PeriodBoundary.new(
+          ect_at_school_period: previous_period,
+          input_date: start_date_as_date
+        )
+      end
+
+      delegate :type,
+               :started_on_formatted,
+               to: :start_date_boundary_validator,
+               prefix: :invalid_period
+      delegate :earliest_valid_input_date_formatted, to: :start_date_boundary_validator
     end
   end
 end

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -101,7 +101,7 @@ module Schools
 
       def start_date_boundary_validator
         @start_date_boundary_validator ||= Schools::Validation::PeriodBoundary.new(
-          ect_at_school_period: previous_period,
+          input_period: previous_period,
           input_date: start_date_as_date
         )
       end

--- a/app/wizards/schools/register_ect_wizard/start_date_step.rb
+++ b/app/wizards/schools/register_ect_wizard/start_date_step.rb
@@ -5,6 +5,7 @@ module Schools
 
       validates :start_date, ect_start_date: true
       validate :start_date_not_before_previous_school
+      validate :start_date_not_before_last_training_period
       validate :start_date_within_4_months, if: :currently_ect_at_another_school?
 
       def self.permitted_params
@@ -28,16 +29,41 @@ module Schools
       def start_date_not_before_previous_school
         return if skip_start_date_validation?
 
-        previous_period = ect.previous_ect_at_school_period
-        return unless previous_start_date_invalid?(previous_period)
+        return unless period_start_date_valid?(previous_period)
+        return if start_date_after_period_starts?(previous_period)
 
-        if start_date_as_date <= previous_period.started_on
-          add_start_date_too_early_error(previous_period)
-        end
+        errors.add(
+          :start_date,
+          "Our records show that #{wizard.ect.full_name} started teaching at #{previous_period.school&.name} on #{previous_period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
+        )
+      end
+
+      def start_date_not_before_last_training_period
+        return if skip_start_date_validation?
+        return unless period_start_date_valid?(latest_started_training_period)
+        return if start_date_after_period_starts?(latest_started_training_period)
+
+        errors.add(
+          :start_date,
+          "Our records show that #{wizard.ect.full_name} started their latest training at #{latest_started_training_period.school&.name} on #{latest_started_training_period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
+        )
+      end
+
+      def start_date_after_period_starts?(period)
+        start_date_as_date > period.started_on
       end
 
       def currently_ect_at_another_school?
-        ect.previously_registered? && ect.previous_ect_at_school_period.ongoing?
+        ect.previously_registered? && previous_period.ongoing?
+      end
+
+      def previous_period
+        ect.previous_ect_at_school_period
+      end
+
+      # Unstarted training periods (ie starting today or in the future) will be deleted and should not prevent a start date at a new school from being valid
+      def latest_started_training_period
+        previous_period&.training_periods&.started_before(Time.zone.today)&.latest_first&.first
       end
 
       def start_date_within_4_months
@@ -58,15 +84,8 @@ module Schools
         start_date_as_date.future? && !start_date_contract_period&.enabled?
       end
 
-      def previous_start_date_invalid?(period)
+      def period_start_date_valid?(period)
         period&.started_on.present?
-      end
-
-      def add_start_date_too_early_error(period)
-        errors.add(
-          :start_date,
-          "Our records show that #{wizard.ect.full_name} started teaching at #{period.school&.name} on #{period.started_on.to_formatted_s(:govuk)}. Enter a later start date."
-        )
       end
 
       def skip_start_date_validation?

--- a/app/wizards/schools/register_mentor_wizard/started_on_step.rb
+++ b/app/wizards/schools/register_mentor_wizard/started_on_step.rb
@@ -4,7 +4,7 @@ module Schools
       attr_accessor :started_on
 
       validates :started_on, mentor_start_date: true
-      validate :started_on_after_all_previous_period_started_on_dates
+      validate :started_on_after_previous_school_or_training_period_start
       validate :started_on_within_4_months, if: :currently_mentor_at_another_school?
 
       def self.permitted_params = %i[started_on]
@@ -41,22 +41,22 @@ module Schools
         self.started_on = Schools::Validation::MentorStartDate.new(date_as_hash: mentor.started_on).date_as_hash unless started_on
       end
 
-      def started_on_after_all_previous_period_started_on_dates
+      def previous_period
+        mentor.previous_school_mentor_at_school_periods&.last
+      end
+
+      def started_on_after_previous_school_or_training_period_start
         return if errors.any?
+        return if start_date_boundary_validator.valid?
 
-        latest_started_on_at_previous_school = mentor
-          .previous_school_mentor_at_school_periods
-          .maximum(:started_on)
-        return unless latest_started_on_at_previous_school
+        errors.add(:started_on, invalid_period_error_message)
+      end
 
-        unless started_on_as_date.after?(latest_started_on_at_previous_school)
-          error_message = <<~TXT.squish
-            #{mentor.full_name} was registered as a mentor at their last school
-            starting on the #{latest_started_on_at_previous_school.to_fs(:govuk)}.
-            Enter a later date.
-          TXT
-          errors.add(:started_on, error_message)
-        end
+      def invalid_period_error_message
+        "Our records show that #{wizard.mentor.full_name} started " \
+        "#{invalid_period_type} at #{previous_period&.school&.name} on " \
+        "#{invalid_period_started_on_formatted}." \
+        " Enter a start date after #{earliest_valid_input_date_formatted}."
       end
 
       def started_on_within_4_months
@@ -92,6 +92,19 @@ module Schools
       def contract_period
         @contract_period ||= ContractPeriod.containing_date(started_on_as_date)
       end
+
+      def start_date_boundary_validator
+        @start_date_boundary_validator ||= Schools::Validation::PeriodBoundary.new(
+          input_period: previous_period,
+          input_date: started_on_as_date
+        )
+      end
+
+      delegate :type,
+               :started_on_formatted,
+               to: :start_date_boundary_validator,
+               prefix: :invalid_period
+      delegate :earliest_valid_input_date_formatted, to: :start_date_boundary_validator
     end
   end
 end

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -944,9 +944,18 @@ FactoryBot.create(:training_period,
                   :for_ect,
                   :with_schedule,
                   ect_at_school_period: terry_thomas_ect_at_abbey_grove_school,
-                  started_on: terry_thomas_started_date,
-                  finished_on: nil,
+                  started_on: terry_thomas_started_date + 1.month,
+                  finished_on: terry_thomas_started_date + 1.month + 2.days,
                   school_partnership: teach_first_grain_abbey_grove_2025,
+                  training_programme: "provider_led").tap { |tp| describe_training_period(tp) }
+
+FactoryBot.create(:training_period,
+                  :for_ect,
+                  :with_schedule,
+                  ect_at_school_period: terry_thomas_ect_at_abbey_grove_school,
+                  started_on: terry_thomas_started_date + 1.month + 3.days,
+                  finished_on: nil,
+                  school_partnership: ambition_artisan_abbey_grove_2025,
                   training_programme: "provider_led").tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Sid James (ECT) provider-led with schedule ecf-standard-september", indent: 2, colour: ECT_COLOUR)

--- a/lib/schools/validation/period_boundary.rb
+++ b/lib/schools/validation/period_boundary.rb
@@ -1,10 +1,10 @@
 module Schools
   module Validation
     class PeriodBoundary
-      attr_reader :ect_at_school_period, :input_date
+      attr_reader :input_period, :input_date
 
-      def initialize(ect_at_school_period:, input_date:)
-        @ect_at_school_period = ect_at_school_period
+      def initialize(input_period:, input_date:)
+        @input_period = input_period
         @input_date = input_date
       end
 
@@ -19,7 +19,8 @@ module Schools
       def type
         case invalid_period
         when ECTAtSchoolPeriod then "teaching"
-        when TrainingPeriod    then "their latest training"
+        when MentorAtSchoolPeriod then "teaching"
+        when TrainingPeriod then "their latest training"
         end
       end
 
@@ -39,10 +40,11 @@ module Schools
 
       def validate_periods
         return if input_date.blank?
-        return unless ect_at_school_period
+        return unless input_period
+        return unless input_period_is_at_school_period?
 
-        if input_date_present_and_before_period_starts?(ect_at_school_period)
-          ect_at_school_period
+        if input_date_present_and_before_period_starts?(input_period)
+          input_period
         elsif input_date_present_and_before_period_starts?(latest_started_training_period)
           latest_started_training_period
         end
@@ -54,13 +56,17 @@ module Schools
         input_date <= earliest_valid_input_date(period)
       end
 
+      def input_period_is_at_school_period?
+        input_period.is_a?(ECTAtSchoolPeriod) || input_period.is_a?(MentorAtSchoolPeriod)
+      end
+
       def earliest_valid_input_date(period)
         period.started_on.next_day
       end
 
       # Unstarted training periods (ie starting in the future) will be deleted and should not prevent a start date at a new school from being valid
       def latest_started_training_period
-        @latest_started_training_period ||= ect_at_school_period
+        @latest_started_training_period ||= input_period
           .training_periods
           .started_on_or_before(Time.zone.today)
           .latest_first

--- a/lib/schools/validation/period_boundary.rb
+++ b/lib/schools/validation/period_boundary.rb
@@ -1,0 +1,71 @@
+module Schools
+  module Validation
+    class PeriodBoundary
+      attr_reader :ect_at_school_period, :input_date
+
+      def initialize(ect_at_school_period:, input_date:)
+        @ect_at_school_period = ect_at_school_period
+        @input_date = input_date
+      end
+
+      def valid?
+        invalid_period.nil?
+      end
+
+      def invalid_period
+        @invalid_period ||= validate_periods
+      end
+
+      def type
+        case invalid_period
+        when ECTAtSchoolPeriod then "teaching"
+        when TrainingPeriod    then "their latest training"
+        end
+      end
+
+      def started_on_formatted
+        return unless invalid_period
+
+        invalid_period.started_on.to_formatted_s(:govuk)
+      end
+
+      def earliest_valid_input_date_formatted
+        return unless invalid_period
+
+        invalid_period.started_on.next_day.to_formatted_s(:govuk)
+      end
+
+    private
+
+      def validate_periods
+        return if input_date.blank?
+        return unless ect_at_school_period
+
+        if input_date_present_and_before_period_starts?(ect_at_school_period)
+          ect_at_school_period
+        elsif input_date_present_and_before_period_starts?(latest_started_training_period)
+          latest_started_training_period
+        end
+      end
+
+      def input_date_present_and_before_period_starts?(period)
+        return false if period&.started_on.blank?
+
+        input_date <= earliest_valid_input_date(period)
+      end
+
+      def earliest_valid_input_date(period)
+        period.started_on.next_day
+      end
+
+      # Unstarted training periods (ie starting in the future) will be deleted and should not prevent a start date at a new school from being valid
+      def latest_started_training_period
+        @latest_started_training_period ||= ect_at_school_period
+          .training_periods
+          .started_on_or_before(Time.zone.today)
+          .latest_first
+          .first
+      end
+    end
+  end
+end

--- a/lib/tasks/product_review/2662.rake
+++ b/lib/tasks/product_review/2662.rake
@@ -1,0 +1,175 @@
+namespace :product_review do
+  desc "Set up school transfer scenarios (#2662)"
+  namespace :"2662" do
+    desc "Create test ECTs and mentors (#2662)"
+    task "create" => :environment do
+      require "faker"
+      include FactoryBot::Syntax::Methods
+
+      Rails.logger.info "Setting up school transfer scenarios for product review #2662"
+
+      abbey_grove_school = School.find_by!(urn: 1_759_427)
+
+      teach_first = LeadProvider.find_by!(name: "Teach First")
+      ambition_institute = LeadProvider.find_by!(name: "Ambition Institute")
+
+      cp_2025 = ContractPeriod.find_by!(year: 2025)
+
+      grain_teaching_school_hub = DeliveryPartner.find_by!(name: "Grain Teaching School Hub")
+      artisan_education_group = DeliveryPartner.find_by!(name: "Artisan Education Group")
+
+      south_yorkshire_studio_hub = AppropriateBodyPeriod.find_by!(name: "South Yorkshire Studio Hub")
+
+      teach_first_grain_abbey_grove_2025 = find_or_create_school_partnership!(
+        school: abbey_grove_school,
+        lead_provider: teach_first,
+        delivery_partner: grain_teaching_school_hub,
+        contract_period: cp_2025
+      )
+
+      ambition_artisan_abbey_grove_2025 = find_or_create_school_partnership!(
+        school: abbey_grove_school,
+        lead_provider: ambition_institute,
+        delivery_partner: artisan_education_group,
+        contract_period: cp_2025
+      )
+
+      Rails.logger.info "Created school partnership for Teach First and Grain Teaching School Hub at Abbey Grove School for 2025"
+
+      CANDIDATE_TEACHERS.each do |teacher_attrs|
+        teacher = Teacher.find_or_initialize_by(trn: teacher_attrs[:trn])
+
+        started_on = teacher_attrs[:started_on] || Date.new(2025, 9, 1)
+
+        teacher.trs_first_name = teacher_attrs[:first_name]
+        teacher.trs_last_name = teacher_attrs[:last_name]
+        teacher.trs_induction_status = "RequiredToComplete"
+        teacher.trs_qts_awarded_on = Date.new(2025, 1, 1)
+
+        teacher.save!
+
+        if teacher_attrs[:type] == :mentor_at_school_period
+          mentor_at_school_period = FactoryBot.create(:mentor_at_school_period,
+                                                      teacher:,
+                                                      school: abbey_grove_school,
+                                                      email: Faker::Internet.email(name: "#{teacher.trs_first_name} #{teacher.trs_last_name}"),
+                                                      started_on:,
+                                                      finished_on: nil)
+
+          Rails.logger.info "Created mentor at school period for #{teacher.trs_first_name} #{teacher.trs_last_name} starting on #{mentor_at_school_period.started_on}"
+
+          ect_at_school_period = nil
+          training_period_type = :for_mentor
+        else
+          ect_at_school_period = FactoryBot.create(:ect_at_school_period,
+                                                   teacher:,
+                                                   school: abbey_grove_school,
+                                                   email: Faker::Internet.email(name: "#{teacher.trs_first_name} #{teacher.trs_last_name}"),
+                                                   started_on:,
+                                                   finished_on: nil,
+                                                   school_reported_appropriate_body: south_yorkshire_studio_hub)
+
+          Rails.logger.info "Created ECT at school period for #{teacher.trs_first_name} #{teacher.trs_last_name} starting on #{ect_at_school_period.started_on}"
+
+          mentor_at_school_period = nil
+          training_period_type = :for_ect
+        end
+
+        traing_periods = teacher_attrs.fetch(:training_periods, [])
+
+        traing_periods.each do |training_period_attrs|
+          training_programme = training_period_attrs[:training_programme] || :provider_led
+          school_partnership = training_period_attrs[:school_partnership] == :ambition ? ambition_artisan_abbey_grove_2025 : teach_first_grain_abbey_grove_2025
+          school_partnership = nil if training_programme == :school_led
+
+          training_period = FactoryBot.create(:training_period,
+                                              training_period_type,
+                                              :with_schedule,
+                                              training_programme,
+                                              ect_at_school_period:,
+                                              mentor_at_school_period:,
+                                              started_on: training_period_attrs[:started_on],
+                                              finished_on: training_period_attrs[:finished_on],
+                                              school_partnership:)
+          Rails.logger.info "Created #{training_period.training_programme} training period for #{teacher.trs_first_name} #{teacher.trs_last_name} starting on #{training_period.started_on}"
+
+          if training_programme == :provider_led
+            heading = "#{teacher.trs_first_name} #{teacher.trs_last_name}’s #{training_programme} training period schedule was set to #{training_period.schedule.description}"
+            FactoryBot.create(:event,
+                              event_type: "teacher_schedule_assigned_to_training_period",
+                              teacher:,
+                              training_period:,
+                              heading:,
+                              happened_at: Time.current,
+                              **AUTHOR_ATTRIBUTES)
+          end
+
+          next unless training_period_attrs[:finished_on]
+
+          heading = "#{teacher.trs_first_name} #{teacher.trs_last_name} finished their #{training_programme} training period"
+          FactoryBot.create(:event,
+                            event_type: "teacher_schedule_assigned_to_training_period",
+                            teacher:,
+                            training_period:,
+                            ect_at_school_period:,
+                            mentor_at_school_period:,
+                            school: abbey_grove_school,
+                            heading:,
+                            happened_at: Time.current,
+                            **AUTHOR_ATTRIBUTES)
+        end
+      end
+    end
+
+    desc "Remove test ECTs and mentors (#2662)"
+    task "cleanup" => :environment do
+      CANDIDATE_TEACHERS.each do |teacher_attrs|
+        teacher = Teacher.find_by(trn: teacher_attrs[:trn])
+        next unless teacher
+
+        teacher.ect_at_school_periods.each do |ect|
+          ect.training_periods.destroy_all
+          ect.destroy!
+        end
+
+        teacher.mentor_at_school_periods.each do |mentor|
+          mentor.training_periods.destroy_all
+          mentor.destroy!
+        end
+      end
+    end
+  end
+end
+
+CANDIDATE_TEACHERS = [
+  { trn: "3002577", first_name: "Jonas",    last_name: "Bloggs",  type: :ect_at_school_period,    started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 9, 1) }] },
+  { trn: "3002578", first_name: "Cynthia",  last_name: "Parks",   type: :ect_at_school_period,    started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 10, 1) }] },
+  { trn: "3002579", first_name: "Taylor",   last_name: "Hawkins", type: :ect_at_school_period,    started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 10, 1), finished_on: Date.new(2025, 10, 31) }, { training_programme: :provider_led, started_on: Date.new(2025, 11, 1),  school_partnership: :ambition }] },
+  { trn: "3002580", first_name: "Muhammed", last_name: "Ali",     type: :ect_at_school_period,    started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :school_led,   started_on: Date.new(2025, 10, 1), finished_on: Date.new(2025, 10, 31)  }, { training_programme: :provider_led, started_on: Date.new(2025, 11, 1), school_partnership: :ambition }] },
+  { trn: "3002582", first_name: "Robson",   last_name: "Scottie", type: :ect_at_school_period,    started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 10, 1), finished_on: Date.new(2025, 10, 31)  }, { training_programme: :school_led,   started_on: Date.new(2025, 11, 1), finished_on: Date.new(2025, 11, 30) }, { training_programme: :provider_led, started_on: Date.new(2025, 12, 1) }] },
+  { trn: "3012858", first_name: "Dave",     last_name: "Teacher", type: :mentor_at_school_period, started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 9, 1) }] },
+  { trn: "3003943", first_name: "Dona",     last_name: "Msa",     type: :mentor_at_school_period, started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 10, 1) }] },
+  { trn: "3012235", first_name: "Claire",   last_name: "Cool",    type: :mentor_at_school_period, started_on: Date.new(2025, 9, 1), training_periods: [{ training_programme: :provider_led, started_on: Date.new(2025, 10, 1), finished_on: Date.new(2025, 10, 31) }, { training_programme: :provider_led, started_on: Date.new(2025, 11, 1), school_partnership: :ambition }] },
+].freeze
+
+AUTHOR_ATTRIBUTES = {
+  author_name: "TEST",
+  author_type: "lead_provider_api"
+}.freeze
+
+def find_or_create_school_partnership!(school:, delivery_partner:, lead_provider:, contract_period:)
+  active_lead_provider = ActiveLeadProvider.find_by!(
+    lead_provider:,
+    contract_period_year: contract_period.year
+  )
+
+  lead_provider_delivery_partnership = LeadProviderDeliveryPartnership.find_or_create_by!(
+    active_lead_provider:,
+    delivery_partner:
+  )
+
+  SchoolPartnership.find_or_create_by!(
+    school:,
+    lead_provider_delivery_partnership:
+  )
+end

--- a/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
@@ -49,29 +49,31 @@ RSpec.describe "Moving School - backdated start spec" do
     end
 
     context "when both periods have back-dated start dates" do
-      scenario "the training period at the first school which has not started is deleted" do
+      scenario "the schools are prevented from registering the ECTs on the same day" do
         given_there_are_two_schools
         and_there_are_partnerships_at_the_schools
         and_the_two_schools_want_to_register_the_same_teacher_on_different_dates_of_which_are_both_backdated
 
         given_a_school_has_registered_a_teacher
-        and_another_school_has_registered_the_same_teacher_at_a_later_date
-
-        then_the_training_period_at_the_first_school_which_has_not_started_yet_should_be_deleted
-        and_the_training_period_for_the_second_school_should_be_ongoing
+        and_another_school_has_registered_the_same_teacher_on_the_same_day
+        then_the_second_school_cannot_register_the_same_teacher
       end
     end
   end
 
   def given_a_school_has_registered_a_teacher
-    register_ect(school: @school_one, start_date: @school_one_start_date, previously_registered: false)
+    register_ect(school: @school_one, start_date: @school_one_start_date, previously_registered: false, valid_start_date: true)
   end
 
   def and_another_school_has_registered_the_same_teacher_at_a_later_date
-    register_ect(school: @school_two, start_date: @school_two_start_date, previously_registered: true)
+    register_ect(school: @school_two, start_date: @school_two_start_date, previously_registered: true, valid_start_date: true)
   end
 
-  def register_ect(school:, start_date:, previously_registered:)
+  def and_another_school_has_registered_the_same_teacher_on_the_same_day
+    register_ect(school: @school_two, start_date: @school_two_start_date, previously_registered: true, valid_start_date: false)
+  end
+
+  def register_ect(school:, start_date:, previously_registered:, valid_start_date:)
     given_i_am_logged_in_as(school)
 
     and_i_am_on_the_schools_landing_page
@@ -89,27 +91,31 @@ RSpec.describe "Moving School - backdated start spec" do
       then_i_should_be_taken_to_the_registered_before_page
       and_i_click_continue
     end
+
     then_i_should_be_taken_to_the_email_address_page
 
     when_i_enter_the_ect_email_address
     and_i_click_continue
     then_i_should_be_taken_to_the_ect_start_date_page
 
-    when_i_enter_a_valid_start_date(start_date)
+    when_i_enter_a_start_date(start_date)
     and_i_click_continue
-    then_i_should_i_should_be_taken_to_the_working_pattern_page
 
-    when_i_select_full_time
-    and_i_click_continue
-    then_i_should_be_taken_to_the_use_previous_ect_choices_page
+    if valid_start_date
+      then_i_should_i_should_be_taken_to_the_working_pattern_page
 
-    when_i_choose_to_reuse_previous_choices
-    and_i_click_continue
-    then_i_should_be_taken_to_the_check_answers_page
-    and_i_should_see_all_the_ect_data_on_the_page(start_date)
+      when_i_select_full_time
+      and_i_click_continue
+      then_i_should_be_taken_to_the_use_previous_ect_choices_page
 
-    when_i_click_confirm_details
-    then_i_should_be_taken_to_the_confirmation_page
+      when_i_choose_to_reuse_previous_choices
+      and_i_click_continue
+      then_i_should_be_taken_to_the_check_answers_page
+      and_i_should_see_all_the_ect_data_on_the_page(start_date)
+
+      when_i_click_confirm_details
+      then_i_should_be_taken_to_the_confirmation_page
+    end
   end
 
   def and_the_two_schools_want_to_register_the_same_teacher_on_different_dates_which_are_not_backdated
@@ -145,12 +151,6 @@ RSpec.describe "Moving School - backdated start spec" do
     expect(training_period.finished_on).to eq(@school_two_start_date - 1.day)
   end
 
-  def then_the_training_period_at_the_first_school_which_has_not_started_yet_should_be_deleted
-    ect_at_school_period = ECTAtSchoolPeriod.first
-
-    expect(ect_at_school_period.training_periods.count).to eq(0)
-  end
-
   def and_the_training_period_for_the_second_school_should_be_ongoing
     ect_at_school_period = ECTAtSchoolPeriod.last
 
@@ -169,10 +169,6 @@ RSpec.describe "Moving School - backdated start spec" do
 
   def given_i_am_logged_in_as(school)
     sign_in_as_school_user(school:)
-  end
-
-  def when_i_click_sign_out
-    page.get_by_role("button", name: "Sign out").click
   end
 
   def and_i_am_on_the_schools_landing_page
@@ -228,14 +224,6 @@ RSpec.describe "Moving School - backdated start spec" do
     page.get_by_label("What is Kirk Van Houten’s email address?").fill("example@example.com")
   end
 
-  def then_i_should_be_taken_to_the_training_programme_page
-    expect(page).to have_path("/school/register-ect/training-programme")
-  end
-
-  def when_i_select_provider_led
-    page.get_by_label("Provider-led").check
-  end
-
   def when_i_select_full_time
     page.get_by_label("Full time").check
   end
@@ -248,7 +236,7 @@ RSpec.describe "Moving School - backdated start spec" do
     expect(page).to have_path("/school/register-ect/start-date")
   end
 
-  def when_i_enter_a_valid_start_date(start_date)
+  def when_i_enter_a_start_date(start_date)
     page.get_by_label("day").fill(start_date.day.to_s)
     page.get_by_label("month").fill(start_date.month.to_s)
     page.get_by_label("year").fill(start_date.year.to_s)
@@ -264,6 +252,12 @@ RSpec.describe "Moving School - backdated start spec" do
 
   def then_i_should_i_should_be_taken_to_the_working_pattern_page
     expect(page).to have_path("/school/register-ect/working-pattern")
+  end
+
+  def then_the_second_school_cannot_register_the_same_teacher
+    expect(page).to have_path("/school/register-ect/start-date")
+    expect(page.get_by_text("There is a problem")).to be_visible
+    expect(page.get_by_text("Our records show that Kirk Van Houten started their latest training at #{@school_one.name} on 16 June 2025. Enter a start date after 17 June 2025.").first).to be_visible
   end
 
   def then_i_should_be_taken_to_the_check_answers_page

--- a/spec/lib/schools/validation/period_boundary_spec.rb
+++ b/spec/lib/schools/validation/period_boundary_spec.rb
@@ -74,19 +74,19 @@ RSpec.shared_examples "it clashes with the ect at school period if the date is a
   context "when the date entered is before the ect at school period started" do
     let(:input_date) { base_date - 1.day }
 
-    it { is_expected.to eq(ect_at_school_period) }
+    it { is_expected.to eq(input_period) }
   end
 
   context "when the date entered is the same as the ect at school period started" do
     let(:input_date) { base_date }
 
-    it { is_expected.to eq(ect_at_school_period) }
+    it { is_expected.to eq(input_period) }
   end
 
   context "when the date entered is one day after the ect at school period started" do
     let(:input_date) { base_date + 1.day }
 
-    it { is_expected.to eq(ect_at_school_period) }
+    it { is_expected.to eq(input_period) }
   end
 
   context "when the date entered is more than one day after the ect at school period started" do
@@ -116,17 +116,8 @@ RSpec.shared_examples "it does not clash with either period" do
   end
 end
 
-RSpec.describe Schools::Validation::PeriodBoundary do
-  subject { described_class.new(ect_at_school_period:, input_date:) }
-
-  let(:input_date) { ect_at_school_period.started_on + 1.day }
-
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: ect_at_school_period_started_on) }
-  let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
-
-  around do |example|
-    travel_to(Date.new(2025, 1, 1)) { example.run }
-  end
+RSpec.shared_examples "period boundary validations" do
+  subject { described_class.new(input_period:, input_date:) }
 
   describe "#valid?" do
     context "when there is no date" do
@@ -135,45 +126,43 @@ RSpec.describe Schools::Validation::PeriodBoundary do
       it { is_expected.to be_valid }
     end
 
-    context "when there is no ect_at_school_period" do
-      let(:ect_at_school_period) { nil }
+    context "when there is no input_period" do
+      let(:input_period) { nil }
       let(:input_date) { Date.new(2024, 9, 1) }
 
       it { is_expected.to be_valid }
     end
 
-    context "when there is an ect_at_school_period" do
+    context "when there is an input_period" do
       context "when there are no training periods" do
-        let(:base_date) { ect_at_school_period.started_on }
+        let(:base_date) { input_period.started_on }
 
         it_behaves_like "it is only valid two days after"
       end
 
       context "when there is one training period" do
-        let!(:training_period) do
-          FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
-        end
+        let!(:training_period) { build_training_period(period: input_period, started_on: training_period_started_on) }
 
         context "when the training period has the same start date as the ect at school period" do
-          let(:training_period_started_on) { ect_at_school_period_started_on }
+          let(:training_period_started_on) { input_period_started_on }
 
           context "when the periods started in the past" do
-            let(:ect_at_school_period_started_on) { 1.day.ago }
-            let(:base_date) { ect_at_school_period.started_on }
+            let(:input_period_started_on) { 1.day.ago }
+            let(:base_date) { input_period.started_on }
 
             it_behaves_like "it is only valid two days after"
           end
 
           context "when the periods started today" do
-            let(:ect_at_school_period_started_on) { Time.zone.today }
-            let(:base_date) { ect_at_school_period.started_on }
+            let(:input_period_started_on) { Time.zone.today }
+            let(:base_date) { input_period.started_on }
 
             it_behaves_like "it is only valid two days after"
           end
 
           context "when the periods start in the future" do
-            let(:ect_at_school_period_started_on) { 1.day.from_now }
-            let(:base_date) { ect_at_school_period.started_on }
+            let(:input_period_started_on) { 1.day.from_now }
+            let(:base_date) { input_period.started_on }
 
             it_behaves_like "it is only valid two days after"
           end
@@ -181,7 +170,7 @@ RSpec.describe Schools::Validation::PeriodBoundary do
 
         context "when the training period has a different start date to the ect at school period" do
           context "when the ect at school period started in the past" do
-            let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+            let(:input_period_started_on) { Date.new(2024, 9, 1) }
 
             context "when the training period started in the past" do
               let(:training_period_started_on) { 1.day.ago }
@@ -210,11 +199,11 @@ RSpec.describe Schools::Validation::PeriodBoundary do
             # because it cannot start before the ECT period, or on the same day
             # In which case it does not affect the validations
 
-            let(:ect_at_school_period_started_on) { Time.zone.today }
+            let(:input_period_started_on) { Time.zone.today }
 
             context "when the training period starts one day from now" do
               let(:training_period_started_on) { 1.day.from_now }
-              let(:base_date) { ect_at_school_period.started_on }
+              let(:base_date) { input_period.started_on }
 
               it_behaves_like "it is only valid two days after"
             end
@@ -224,18 +213,18 @@ RSpec.describe Schools::Validation::PeriodBoundary do
             # In this case the training period must start at least two days from now,
             # because it cannot start before the ECT period, or on the same day
             # In which case it does not affect the validations
-            let(:ect_at_school_period_started_on) { 1.day.from_now }
+            let(:input_period_started_on) { 1.day.from_now }
 
             context "when the training period starts one day after the ect at school period" do
               let(:training_period_started_on) { 2.days.from_now }
-              let(:base_date) { ect_at_school_period.started_on }
+              let(:base_date) { input_period.started_on }
 
               it_behaves_like "it is only valid two days after"
             end
 
             context "when the training period starts two days after the ect at school period" do
               let(:training_period_started_on) { 3.days.from_now }
-              let(:base_date) { ect_at_school_period.started_on }
+              let(:base_date) { input_period.started_on }
 
               it_behaves_like "it is only valid two days after"
             end
@@ -245,19 +234,12 @@ RSpec.describe Schools::Validation::PeriodBoundary do
 
       context "when there are multiple training periods" do
         let!(:first_training_period) do
-          FactoryBot.create(:training_period,
-                            :ongoing,
-                            ect_at_school_period:,
-                            started_on: first_training_period_started_on,
-                            finished_on: first_training_period_started_on + 1.day)
+          build_training_period(period: input_period,
+                                started_on: first_training_period_started_on,
+                                finished_on: first_training_period_started_on + 1.day)
         end
 
-        let!(:second_training_period) do
-          FactoryBot.create(:training_period,
-                            :ongoing,
-                            ect_at_school_period:,
-                            started_on: second_training_period_started_on)
-        end
+        let!(:second_training_period) { build_training_period(period: input_period, started_on: second_training_period_started_on) }
 
         let(:first_training_period_started_on) { Date.new(2024, 10, 1) }
         let(:second_training_period_started_on) { Date.new(2024, 12, 31) }
@@ -272,7 +254,7 @@ RSpec.describe Schools::Validation::PeriodBoundary do
   end
 
   describe "#invalid_period" do
-    subject { described_class.new(ect_at_school_period:, input_date:).invalid_period }
+    subject { described_class.new(input_period:, input_date:).invalid_period }
 
     context "when there is no date" do
       let(:input_date) { nil }
@@ -280,15 +262,15 @@ RSpec.describe Schools::Validation::PeriodBoundary do
       it { is_expected.to be_nil }
     end
 
-    context "when there is no ect_at_school_period" do
-      let(:ect_at_school_period) { nil }
+    context "when there is no input_period" do
+      let(:input_period) { nil }
       let(:input_date) { Date.new(2024, 9, 1) }
 
       it { is_expected.to be_nil }
     end
 
-    context "when there is an ect_at_school_period" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+    context "when there is an input_period" do
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
 
       context "when there are no training periods" do
         let(:base_date) { Date.new(2024, 9, 1) }
@@ -298,29 +280,27 @@ RSpec.describe Schools::Validation::PeriodBoundary do
     end
 
     context "when there is one training period" do
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
-      end
+      let!(:training_period) { build_training_period(period: input_period, started_on: training_period_started_on) }
 
       context "when the training period has the same start date as the ect at school period" do
-        let(:training_period_started_on) { ect_at_school_period_started_on }
+        let(:training_period_started_on) { input_period_started_on }
 
         context "when the periods started in the past" do
-          let(:ect_at_school_period_started_on) { 1.day.ago }
+          let(:input_period_started_on) { 1.day.ago }
           let(:base_date) { 1.day.ago }
 
           it_behaves_like "it clashes with the ect at school period if the date is around"
         end
 
         context "when the periods started today" do
-          let(:ect_at_school_period_started_on) { Time.zone.today }
+          let(:input_period_started_on) { Time.zone.today }
           let(:base_date) { Time.zone.today }
 
           it_behaves_like "it clashes with the ect at school period if the date is around"
         end
 
         context "when the periods start in the future" do
-          let(:ect_at_school_period_started_on) { 1.day.from_now }
+          let(:input_period_started_on) { 1.day.from_now }
           let(:base_date) { 1.day.from_now }
 
           it_behaves_like "it clashes with the ect at school period if the date is around"
@@ -331,7 +311,7 @@ RSpec.describe Schools::Validation::PeriodBoundary do
         let(:input_date) { Time.zone.today }
 
         context "when the ect at school period started in the past" do
-          let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+          let(:input_period_started_on) { Date.new(2024, 9, 1) }
 
           context "when the training period started in the past" do
             let(:training_period_started_on) { 1.day.ago }
@@ -360,7 +340,7 @@ RSpec.describe Schools::Validation::PeriodBoundary do
           # because it cannot start before the ECT period, or on the same day
           # In which case it does not affect the validations
 
-          let(:ect_at_school_period_started_on) { Time.zone.today }
+          let(:input_period_started_on) { Time.zone.today }
 
           context "when the training period starts one day from now" do
             let(:training_period_started_on) { 1.day.from_now }
@@ -374,7 +354,7 @@ RSpec.describe Schools::Validation::PeriodBoundary do
           # In this case the training period must start at least two days from now,
           # because it cannot start before the ECT period, or on the same day
           # In which case it does not affect the validations
-          let(:ect_at_school_period_started_on) { 1.day.from_now }
+          let(:input_period_started_on) { 1.day.from_now }
 
           context "when the training period starts one day after the ect at school period" do
             let(:training_period_started_on) { 2.days.from_now }
@@ -395,19 +375,12 @@ RSpec.describe Schools::Validation::PeriodBoundary do
 
     context "when there are multiple training periods" do
       let!(:first_training_period) do
-        FactoryBot.create(:training_period,
-                          :ongoing,
-                          ect_at_school_period:,
-                          started_on: first_training_period_started_on,
-                          finished_on: first_training_period_started_on + 1.day)
+        build_training_period(period: input_period,
+                              started_on: first_training_period_started_on,
+                              finished_on: first_training_period_started_on + 1.day)
       end
 
-      let!(:second_training_period) do
-        FactoryBot.create(:training_period,
-                          :ongoing,
-                          ect_at_school_period:,
-                          started_on: second_training_period_started_on)
-      end
+      let!(:second_training_period) { build_training_period(period: input_period, started_on: second_training_period_started_on) }
 
       let(:first_training_period_started_on) { Date.new(2024, 10, 1) }
       let(:second_training_period_started_on) { 1.day.ago }
@@ -422,19 +395,17 @@ RSpec.describe Schools::Validation::PeriodBoundary do
   end
 
   describe "#type" do
-    subject { described_class.new(ect_at_school_period:, input_date:).type }
+    subject { described_class.new(input_period:, input_date:).type }
 
     context "when the invalid period is an ECT at school period" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
       let(:input_date) { Date.new(2024, 8, 1) }
 
       it { is_expected.to eq("teaching") }
     end
 
     context "when the invalid period is a training period" do
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
-      end
+      let!(:training_period) { build_training_period(period: input_period, started_on: training_period_started_on) }
 
       let(:training_period_started_on) { Date.new(2024, 10, 1) }
       let(:input_date) { Date.new(2024, 9, 30) }
@@ -443,10 +414,8 @@ RSpec.describe Schools::Validation::PeriodBoundary do
     end
 
     context "when the date is before the start of both periods" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
-      end
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) { build_training_period(period: input_period, started_on: Date.new(2024, 10, 1)) }
       let(:input_date) { Date.new(2024, 8, 1) }
 
       it { is_expected.to eq("teaching") }
@@ -454,19 +423,17 @@ RSpec.describe Schools::Validation::PeriodBoundary do
   end
 
   describe "#started_on_formatted" do
-    subject { described_class.new(ect_at_school_period:, input_date:).started_on_formatted }
+    subject { described_class.new(input_period:, input_date:).started_on_formatted }
 
     context "when the invalid period is an ECT at school period" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
       let(:input_date) { Date.new(2024, 8, 1) }
 
       it { is_expected.to eq("1 September 2024") }
     end
 
     context "when the invalid period is a training period" do
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
-      end
+      let!(:training_period) { build_training_period(period: input_period, started_on: training_period_started_on) }
 
       let(:training_period_started_on) { Date.new(2024, 10, 1) }
       let(:input_date) { Date.new(2024, 9, 30) }
@@ -475,10 +442,8 @@ RSpec.describe Schools::Validation::PeriodBoundary do
     end
 
     context "when the date is before the start of both periods" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
-      end
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) { build_training_period(period: input_period, started_on: Date.new(2024, 10, 1)) }
 
       let(:input_date) { Date.new(2024, 8, 1) }
 
@@ -488,10 +453,9 @@ RSpec.describe Schools::Validation::PeriodBoundary do
     end
 
     context "when there are no invalid periods" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
-      end
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) { build_training_period(period: input_period, started_on: Date.new(2024, 10, 1)) }
+
       let(:input_date) { Date.new(2024, 11, 1) }
 
       it { is_expected.to be_nil }
@@ -499,19 +463,17 @@ RSpec.describe Schools::Validation::PeriodBoundary do
   end
 
   describe "#earliest_valid_input_date_formatted" do
-    subject { described_class.new(ect_at_school_period:, input_date:).earliest_valid_input_date_formatted }
+    subject { described_class.new(input_period:, input_date:).earliest_valid_input_date_formatted }
 
     context "when the invalid period is an ECT at school period" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
       let(:input_date) { Date.new(2024, 8, 1) }
 
       it { is_expected.to eq("2 September 2024") }
     end
 
     context "when the invalid period is a training period" do
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
-      end
+      let!(:training_period) { build_training_period(period: input_period, started_on: training_period_started_on) }
 
       let(:training_period_started_on) { Date.new(2024, 10, 1) }
       let(:input_date) { Date.new(2024, 9, 30) }
@@ -520,10 +482,8 @@ RSpec.describe Schools::Validation::PeriodBoundary do
     end
 
     context "when the date is before the start of both periods" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
-      end
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) { build_training_period(period: input_period, started_on: Date.new(2024, 10, 1)) }
 
       let(:input_date) { Date.new(2024, 8, 1) }
 
@@ -533,13 +493,41 @@ RSpec.describe Schools::Validation::PeriodBoundary do
     end
 
     context "when there are no invalid periods" do
-      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
-      end
+      let(:input_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) { build_training_period(period: input_period, started_on: Date.new(2024, 10, 1)) }
       let(:input_date) { Date.new(2024, 11, 1) }
 
       it { is_expected.to be_nil }
     end
+  end
+
+  def build_training_period(period:, started_on:, finished_on: nil)
+    case period
+    when ECTAtSchoolPeriod
+      FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period: period, started_on:, finished_on:)
+    when MentorAtSchoolPeriod
+      FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period: period, started_on:, finished_on:)
+    end
+  end
+end
+
+RSpec.describe Schools::Validation::PeriodBoundary do
+  let(:input_date) { input_period.started_on + 1.day }
+  let(:input_period_started_on) { Date.new(2024, 9, 1) }
+
+  around do |example|
+    travel_to(Date.new(2025, 1, 1)) { example.run }
+  end
+
+  context "when validating an ECT at school period" do
+    let(:input_period) { FactoryBot.create(:ect_at_school_period, started_on: input_period_started_on) }
+
+    it_behaves_like "period boundary validations"
+  end
+
+  context "when validating a mentor at school period" do
+    let(:input_period) { FactoryBot.create(:mentor_at_school_period, started_on: input_period_started_on) }
+
+    it_behaves_like "period boundary validations"
   end
 end

--- a/spec/lib/schools/validation/period_boundary_spec.rb
+++ b/spec/lib/schools/validation/period_boundary_spec.rb
@@ -1,0 +1,545 @@
+RSpec.shared_examples "it is only valid two days after" do
+  context "when the date is before the period started" do
+    let(:input_date) { base_date - 1.day }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when the date is the same as the period started" do
+    let(:input_date) { base_date }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when the date is one day after the period started" do
+    let(:input_date) { base_date + 1.day }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when the date is more than one day after the period started" do
+    let(:input_date) { base_date + 2.days }
+
+    it { is_expected.to be_valid }
+  end
+end
+
+RSpec.shared_examples "all dates are valid" do
+  context "when the date is before the period started" do
+    let(:input_date) { base_date - 1.day }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when the date is the same as the period started" do
+    let(:input_date) { base_date }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when the date is after the period started" do
+    let(:input_date) { base_date + 1.day }
+
+    it { is_expected.to be_valid }
+  end
+end
+
+RSpec.shared_examples "it clashes with the training period if the date is around" do
+  context "when the date entered is before the training period started" do
+    let(:input_date) { base_date - 1.day }
+
+    it { is_expected.to eq(training_period) }
+  end
+
+  context "when the date entered is the same as the training period started" do
+    let(:input_date) { base_date }
+
+    it { is_expected.to eq(training_period) }
+  end
+
+  context "when the date entered is one day after the training period started" do
+    let(:input_date) { base_date + 1.day }
+
+    it { is_expected.to eq(training_period) }
+  end
+
+  context "when the date entered is more than one day after the training period started" do
+    let(:input_date) { base_date + 2.days }
+
+    it { is_expected.to be_nil }
+  end
+end
+
+RSpec.shared_examples "it clashes with the ect at school period if the date is around" do
+  context "when the date entered is before the ect at school period started" do
+    let(:input_date) { base_date - 1.day }
+
+    it { is_expected.to eq(ect_at_school_period) }
+  end
+
+  context "when the date entered is the same as the ect at school period started" do
+    let(:input_date) { base_date }
+
+    it { is_expected.to eq(ect_at_school_period) }
+  end
+
+  context "when the date entered is one day after the ect at school period started" do
+    let(:input_date) { base_date + 1.day }
+
+    it { is_expected.to eq(ect_at_school_period) }
+  end
+
+  context "when the date entered is more than one day after the ect at school period started" do
+    let(:input_date) { base_date + 2.days }
+
+    it { is_expected.to be_nil }
+  end
+end
+
+RSpec.shared_examples "it does not clash with either period" do
+  context "when the date entered is before the training period started" do
+    let(:input_date) { base_date - 1.day }
+
+    it { is_expected.to be_nil }
+  end
+
+  context "when the date entered is the same as the training period started" do
+    let(:input_date) { base_date }
+
+    it { is_expected.to be_nil }
+  end
+
+  context "when the date entered is one day after the training period started" do
+    let(:input_date) { base_date + 1.day }
+
+    it { is_expected.to be_nil }
+  end
+end
+
+RSpec.describe Schools::Validation::PeriodBoundary do
+  subject { described_class.new(ect_at_school_period:, input_date:) }
+
+  let(:input_date) { ect_at_school_period.started_on + 1.day }
+
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: ect_at_school_period_started_on) }
+  let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+
+  around do |example|
+    travel_to(Date.new(2025, 1, 1)) { example.run }
+  end
+
+  describe "#valid?" do
+    context "when there is no date" do
+      let(:input_date) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when there is no ect_at_school_period" do
+      let(:ect_at_school_period) { nil }
+      let(:input_date) { Date.new(2024, 9, 1) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when there is an ect_at_school_period" do
+      context "when there are no training periods" do
+        let(:base_date) { ect_at_school_period.started_on }
+
+        it_behaves_like "it is only valid two days after"
+      end
+
+      context "when there is one training period" do
+        let!(:training_period) do
+          FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
+        end
+
+        context "when the training period has the same start date as the ect at school period" do
+          let(:training_period_started_on) { ect_at_school_period_started_on }
+
+          context "when the periods started in the past" do
+            let(:ect_at_school_period_started_on) { 1.day.ago }
+            let(:base_date) { ect_at_school_period.started_on }
+
+            it_behaves_like "it is only valid two days after"
+          end
+
+          context "when the periods started today" do
+            let(:ect_at_school_period_started_on) { Time.zone.today }
+            let(:base_date) { ect_at_school_period.started_on }
+
+            it_behaves_like "it is only valid two days after"
+          end
+
+          context "when the periods start in the future" do
+            let(:ect_at_school_period_started_on) { 1.day.from_now }
+            let(:base_date) { ect_at_school_period.started_on }
+
+            it_behaves_like "it is only valid two days after"
+          end
+        end
+
+        context "when the training period has a different start date to the ect at school period" do
+          context "when the ect at school period started in the past" do
+            let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+
+            context "when the training period started in the past" do
+              let(:training_period_started_on) { 1.day.ago }
+              let(:base_date) { training_period.started_on }
+
+              it_behaves_like "it is only valid two days after"
+            end
+
+            context "when the training period started today" do
+              let(:training_period_started_on) { Time.zone.today }
+              let(:base_date) { training_period.started_on }
+
+              it_behaves_like "it is only valid two days after"
+            end
+
+            context "when the training period started in the future" do
+              let(:training_period_started_on) { 1.day.from_now }
+              let(:base_date) { training_period.started_on }
+
+              it_behaves_like "all dates are valid"
+            end
+          end
+
+          context "when the ect at school period starts today" do
+            # In this case the training period must start at least one day from now,
+            # because it cannot start before the ECT period, or on the same day
+            # In which case it does not affect the validations
+
+            let(:ect_at_school_period_started_on) { Time.zone.today }
+
+            context "when the training period starts one day from now" do
+              let(:training_period_started_on) { 1.day.from_now }
+              let(:base_date) { ect_at_school_period.started_on }
+
+              it_behaves_like "it is only valid two days after"
+            end
+          end
+
+          context "when the ect at school period starts in the future" do
+            # In this case the training period must start at least two days from now,
+            # because it cannot start before the ECT period, or on the same day
+            # In which case it does not affect the validations
+            let(:ect_at_school_period_started_on) { 1.day.from_now }
+
+            context "when the training period starts one day after the ect at school period" do
+              let(:training_period_started_on) { 2.days.from_now }
+              let(:base_date) { ect_at_school_period.started_on }
+
+              it_behaves_like "it is only valid two days after"
+            end
+
+            context "when the training period starts two days after the ect at school period" do
+              let(:training_period_started_on) { 3.days.from_now }
+              let(:base_date) { ect_at_school_period.started_on }
+
+              it_behaves_like "it is only valid two days after"
+            end
+          end
+        end
+      end
+
+      context "when there are multiple training periods" do
+        let!(:first_training_period) do
+          FactoryBot.create(:training_period,
+                            :ongoing,
+                            ect_at_school_period:,
+                            started_on: first_training_period_started_on,
+                            finished_on: first_training_period_started_on + 1.day)
+        end
+
+        let!(:second_training_period) do
+          FactoryBot.create(:training_period,
+                            :ongoing,
+                            ect_at_school_period:,
+                            started_on: second_training_period_started_on)
+        end
+
+        let(:first_training_period_started_on) { Date.new(2024, 10, 1) }
+        let(:second_training_period_started_on) { Date.new(2024, 12, 31) }
+
+        context "the dates of the first training period do not affect the validation" do
+          let(:base_date) { second_training_period.started_on }
+
+          it_behaves_like "it is only valid two days after"
+        end
+      end
+    end
+  end
+
+  describe "#invalid_period" do
+    subject { described_class.new(ect_at_school_period:, input_date:).invalid_period }
+
+    context "when there is no date" do
+      let(:input_date) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is no ect_at_school_period" do
+      let(:ect_at_school_period) { nil }
+      let(:input_date) { Date.new(2024, 9, 1) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is an ect_at_school_period" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+
+      context "when there are no training periods" do
+        let(:base_date) { Date.new(2024, 9, 1) }
+
+        it_behaves_like "it clashes with the ect at school period if the date is around"
+      end
+    end
+
+    context "when there is one training period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
+      end
+
+      context "when the training period has the same start date as the ect at school period" do
+        let(:training_period_started_on) { ect_at_school_period_started_on }
+
+        context "when the periods started in the past" do
+          let(:ect_at_school_period_started_on) { 1.day.ago }
+          let(:base_date) { 1.day.ago }
+
+          it_behaves_like "it clashes with the ect at school period if the date is around"
+        end
+
+        context "when the periods started today" do
+          let(:ect_at_school_period_started_on) { Time.zone.today }
+          let(:base_date) { Time.zone.today }
+
+          it_behaves_like "it clashes with the ect at school period if the date is around"
+        end
+
+        context "when the periods start in the future" do
+          let(:ect_at_school_period_started_on) { 1.day.from_now }
+          let(:base_date) { 1.day.from_now }
+
+          it_behaves_like "it clashes with the ect at school period if the date is around"
+        end
+      end
+
+      context "when the training period has a different start date to the ect at school period" do
+        let(:input_date) { Time.zone.today }
+
+        context "when the ect at school period started in the past" do
+          let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+
+          context "when the training period started in the past" do
+            let(:training_period_started_on) { 1.day.ago }
+            let(:base_date) { 1.day.ago }
+
+            it_behaves_like "it clashes with the training period if the date is around"
+          end
+
+          context "when the training period started today" do
+            let(:training_period_started_on) { Time.zone.today }
+            let(:base_date) { Time.zone.today }
+
+            it_behaves_like "it clashes with the training period if the date is around"
+          end
+
+          context "when the training period started in the future" do
+            let(:training_period_started_on) { 1.day.from_now }
+            let(:base_date) { 1.day.from_now }
+
+            it_behaves_like "it does not clash with either period"
+          end
+        end
+
+        context "when the ect at school period starts today" do
+          # In this case the training period must start at least one day from now,
+          # because it cannot start before the ECT period, or on the same day
+          # In which case it does not affect the validations
+
+          let(:ect_at_school_period_started_on) { Time.zone.today }
+
+          context "when the training period starts one day from now" do
+            let(:training_period_started_on) { 1.day.from_now }
+            let(:base_date) { Time.zone.today }
+
+            it_behaves_like "it clashes with the ect at school period if the date is around"
+          end
+        end
+
+        context "when the ect at school period starts in the future" do
+          # In this case the training period must start at least two days from now,
+          # because it cannot start before the ECT period, or on the same day
+          # In which case it does not affect the validations
+          let(:ect_at_school_period_started_on) { 1.day.from_now }
+
+          context "when the training period starts one day after the ect at school period" do
+            let(:training_period_started_on) { 2.days.from_now }
+            let(:base_date) { 1.day.from_now }
+
+            it_behaves_like "it clashes with the ect at school period if the date is around"
+          end
+
+          context "when the training period starts two days after the ect at school period" do
+            let(:training_period_started_on) { 3.days.from_now }
+            let(:base_date) { 1.day.from_now }
+
+            it_behaves_like "it clashes with the ect at school period if the date is around"
+          end
+        end
+      end
+    end
+
+    context "when there are multiple training periods" do
+      let!(:first_training_period) do
+        FactoryBot.create(:training_period,
+                          :ongoing,
+                          ect_at_school_period:,
+                          started_on: first_training_period_started_on,
+                          finished_on: first_training_period_started_on + 1.day)
+      end
+
+      let!(:second_training_period) do
+        FactoryBot.create(:training_period,
+                          :ongoing,
+                          ect_at_school_period:,
+                          started_on: second_training_period_started_on)
+      end
+
+      let(:first_training_period_started_on) { Date.new(2024, 10, 1) }
+      let(:second_training_period_started_on) { 1.day.ago }
+
+      context "the dates of the first training period do not affect the validation" do
+        let(:training_period) { second_training_period }
+        let(:base_date) { 1.day.ago }
+
+        it_behaves_like "it clashes with the training period if the date is around"
+      end
+    end
+  end
+
+  describe "#type" do
+    subject { described_class.new(ect_at_school_period:, input_date:).type }
+
+    context "when the invalid period is an ECT at school period" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let(:input_date) { Date.new(2024, 8, 1) }
+
+      it { is_expected.to eq("teaching") }
+    end
+
+    context "when the invalid period is a training period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
+      end
+
+      let(:training_period_started_on) { Date.new(2024, 10, 1) }
+      let(:input_date) { Date.new(2024, 9, 30) }
+
+      it { is_expected.to eq("their latest training") }
+    end
+
+    context "when the date is before the start of both periods" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
+      end
+      let(:input_date) { Date.new(2024, 8, 1) }
+
+      it { is_expected.to eq("teaching") }
+    end
+  end
+
+  describe "#started_on_formatted" do
+    subject { described_class.new(ect_at_school_period:, input_date:).started_on_formatted }
+
+    context "when the invalid period is an ECT at school period" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let(:input_date) { Date.new(2024, 8, 1) }
+
+      it { is_expected.to eq("1 September 2024") }
+    end
+
+    context "when the invalid period is a training period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
+      end
+
+      let(:training_period_started_on) { Date.new(2024, 10, 1) }
+      let(:input_date) { Date.new(2024, 9, 30) }
+
+      it { is_expected.to eq("1 October 2024") }
+    end
+
+    context "when the date is before the start of both periods" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
+      end
+
+      let(:input_date) { Date.new(2024, 8, 1) }
+
+      it "returns the start date of the ect at school period" do
+        expect(subject).to eq("1 September 2024")
+      end
+    end
+
+    context "when there are no invalid periods" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
+      end
+      let(:input_date) { Date.new(2024, 11, 1) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#earliest_valid_input_date_formatted" do
+    subject { described_class.new(ect_at_school_period:, input_date:).earliest_valid_input_date_formatted }
+
+    context "when the invalid period is an ECT at school period" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let(:input_date) { Date.new(2024, 8, 1) }
+
+      it { is_expected.to eq("2 September 2024") }
+    end
+
+    context "when the invalid period is a training period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
+      end
+
+      let(:training_period_started_on) { Date.new(2024, 10, 1) }
+      let(:input_date) { Date.new(2024, 9, 30) }
+
+      it { is_expected.to eq("2 October 2024") }
+    end
+
+    context "when the date is before the start of both periods" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
+      end
+
+      let(:input_date) { Date.new(2024, 8, 1) }
+
+      it "returns the earliest valid date based on the training period" do
+        expect(subject).to eq("2 September 2024")
+      end
+    end
+
+    context "when there are no invalid periods" do
+      let(:ect_at_school_period_started_on) { Date.new(2024, 9, 1) }
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 10, 1))
+      end
+      let(:input_date) { Date.new(2024, 11, 1) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
@@ -33,122 +33,20 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
   end
 
   describe "validations" do
-    let(:leaving_date_before_start_message) { "Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a later date." }
-    let(:leaving_date_before_training_period_message) { "Our records show that #{teacher_name} started their latest training at your school on 31 December 2024. Enter a later date." }
+    let(:validator) { instance_double(Schools::Validation::PeriodBoundary) }
 
     around do |example|
       travel_to(Date.new(2025, 1, 1)) { example.run }
     end
 
-    context "when date is more than 4 months in the future" do
-      let(:leaving_on) { { 1 => 2025, 2 => 5, 3 => 2 } }
+    context "when leaving date is not present" do
+      let(:leaving_on) { nil }
 
       it "is invalid with the correct error message" do
         expect(step).not_to be_valid
-        expect(step.errors[:leaving_on]).to include("Enter a date no further than 4 months from today")
-      end
-    end
-
-    context "when date is valid" do
-      let(:leaving_on) { { 1 => 2025, 2 => 5, 3 => 1 } }
-
-      it { is_expected.to be_valid }
-    end
-
-    context "when leaving date is before the start date" do
-      let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 31 } }
-
-      it { is_expected.to have_error(:leaving_on, leaving_date_before_start_message) }
-    end
-
-    context "when leaving date is the same as the start date" do
-      let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
-
-      it { is_expected.to have_error(:leaving_on, leaving_date_before_start_message) }
-
-      context "when there is also training period that started after the leaving date" do
-        let!(:training_period) do
-          FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 12, 31))
-        end
-
-        it "is invalid with an error message about the start date, not training date" do
-          expect(step).to have_error(:leaving_on, leaving_date_before_start_message)
-          expect(step).not_to have_error(:leaving_on, leaving_date_before_training_period_message)
-        end
-      end
-    end
-
-    describe "leave date must be after previous training period started_on date" do
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 1)) }
-      let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 30 } }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
-      end
-
-      context "when the previous training_period started in the past" do
-        let(:training_period_started_on) { Date.new(2024, 12, 31) }
-
-        context "when the leave date is before the training period started_on date" do
-          let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 30 } }
-
-          it { is_expected.to have_error(:leaving_on, leaving_date_before_training_period_message) }
-        end
-
-        context "when the leave date is the same as the training period started_on date" do
-          let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 31 } }
-
-          it { is_expected.to have_error(:leaving_on, leaving_date_before_training_period_message) }
-        end
-
-        context "when the leave date is after the training period started_on date" do
-          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
-
-          it { is_expected.to be_valid }
-        end
-      end
-
-      context "when the previous training_period started today" do
-        let(:training_period_started_on) { Date.new(2025, 1, 1) }
-
-        context "when the leave date is before the training period started_on date" do
-          let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 31 } }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the leave date is the same as the training period started_on date" do
-          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the leave date is after the training period started_on date" do
-          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 2 } }
-
-          it { is_expected.to be_valid }
-        end
-      end
-
-      context "when the previous training_period started in the future" do
-        let(:training_period_started_on) { Date.new(2025, 1, 2) }
-
-        context "when the leave date is before the training period started_on date" do
-          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the leave date is the same as the training period started_on date" do
-          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 2 } }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the leave date is after the training period started_on date" do
-          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 3 } }
-
-          it { is_expected.to be_valid }
-        end
+        expect(step.errors[:leaving_on].map(&:squish)).to include(
+          "Enter the date the teacher left or will be leaving your school"
+        )
       end
     end
 
@@ -160,6 +58,79 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
         expect(step.errors[:leaving_on].map(&:squish)).to include(
           "Enter the date in the correct format, for example 30 06 2001"
         )
+      end
+    end
+
+    context "when date is valid" do
+      let(:leaving_on) { { 1 => 2025, 2 => 5, 3 => 1 } }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when date is more than 4 months in the future" do
+      let(:leaving_on) { { 1 => 2025, 2 => 5, 3 => 2 } }
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:leaving_on]).to include("Enter a date no further than 4 months from today")
+      end
+    end
+
+    context "when the date clashes with the ect at school period" do
+      before do
+        allow(Schools::Validation::PeriodBoundary)
+          .to receive(:new)
+          .and_return(validator)
+
+        allow(validator).to receive_messages(
+          valid?: false,
+          invalid_period: ect_at_school_period,
+          type: "teaching",
+          started_on_formatted: "1 January 2025",
+          earliest_valid_input_date_formatted: "2 January 2025"
+        )
+      end
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:leaving_on]).to include("Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a date after 2 January 2025.")
+      end
+    end
+
+    context "when the date clashes with the latest training period" do
+      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 12, 31)) }
+
+      before do
+        allow(Schools::Validation::PeriodBoundary)
+          .to receive(:new)
+          .and_return(validator)
+
+        allow(validator).to receive_messages(
+          valid?: false,
+          invalid_period: training_period,
+          type: "their latest training",
+          started_on_formatted: "31 December 2024",
+          earliest_valid_input_date_formatted: "1 January 2025"
+        )
+      end
+
+      it "is invalid with the correct error message" do
+        expect(step).not_to be_valid
+        expect(step.errors[:leaving_on]).to include("Our records show that #{teacher_name} started their latest training at your school on 31 December 2024. Enter a date after 1 January 2025.")
+      end
+    end
+
+    context "when the date does not clash with any periods" do
+      before do
+        allow(Schools::Validation::PeriodBoundary)
+          .to receive(:new)
+          .and_return(validator)
+
+        allow(validator).to receive(:valid?).and_return(true)
+      end
+
+      it "is valid" do
+        expect(step).to be_valid
       end
     end
   end

--- a/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
   subject(:step) { described_class.new(wizard:, leaving_on:) }
 
   let(:wizard) { instance_double(Schools::ECTs::TeacherLeavingWizard::Wizard, store:, ect_at_school_period:) }
-  let(:ect_at_school_period) { FactoryBot.build_stubbed(:ect_at_school_period, started_on: Date.new(2025, 1, 1)) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: Date.new(2025, 1, 1)) }
   let(:teacher_name) { Teachers::Name.new(ect_at_school_period.teacher).full_name }
   let(:store) { FactoryBot.build(:session_repository, form_key: :teacher_leaving_wizard) }
   let(:leaving_on) { { "day" => "1", "month" => "3", "year" => "2025" } }
@@ -33,6 +33,9 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
   end
 
   describe "validations" do
+    let(:leaving_date_before_start_message) { "Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a later date." }
+    let(:leaving_date_before_training_period_message) { "Our records show that #{teacher_name} started their latest training at your school on 31 December 2024. Enter a later date." }
+
     around do |example|
       travel_to(Date.new(2025, 1, 1)) { example.run }
     end
@@ -55,22 +58,97 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
     context "when leaving date is before the start date" do
       let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 31 } }
 
-      it "is invalid with the correct error message" do
-        expect(step).not_to be_valid
-        expect(step.errors[:leaving_on].map(&:squish)).to include(
-          "Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a later date."
-        )
-      end
+      it { is_expected.to have_error(:leaving_on, leaving_date_before_start_message) }
     end
 
     context "when leaving date is the same as the start date" do
       let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
 
-      it "is invalid with the correct error message" do
-        expect(step).not_to be_valid
-        expect(step.errors[:leaving_on].map(&:squish)).to include(
-          "Our records show that #{teacher_name} started teaching at your school on 1 January 2025. Enter a later date."
-        )
+      it { is_expected.to have_error(:leaving_on, leaving_date_before_start_message) }
+
+      context "when there is also training period that started after the leaving date" do
+        let!(:training_period) do
+          FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 12, 31))
+        end
+
+        it "is invalid with an error message about the start date, not training date" do
+          expect(step).to have_error(:leaving_on, leaving_date_before_start_message)
+          expect(step).not_to have_error(:leaving_on, leaving_date_before_training_period_message)
+        end
+      end
+    end
+
+    describe "leave date must be after previous training period started_on date" do
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 1)) }
+      let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 30 } }
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: training_period_started_on)
+      end
+
+      context "when the previous training_period started in the past" do
+        let(:training_period_started_on) { Date.new(2024, 12, 31) }
+
+        context "when the leave date is before the training period started_on date" do
+          let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 30 } }
+
+          it { is_expected.to have_error(:leaving_on, leaving_date_before_training_period_message) }
+        end
+
+        context "when the leave date is the same as the training period started_on date" do
+          let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 31 } }
+
+          it { is_expected.to have_error(:leaving_on, leaving_date_before_training_period_message) }
+        end
+
+        context "when the leave date is after the training period started_on date" do
+          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when the previous training_period started today" do
+        let(:training_period_started_on) { Date.new(2025, 1, 1) }
+
+        context "when the leave date is before the training period started_on date" do
+          let(:leaving_on) { { 1 => 2024, 2 => 12, 3 => 31 } }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the leave date is the same as the training period started_on date" do
+          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the leave date is after the training period started_on date" do
+          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 2 } }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when the previous training_period started in the future" do
+        let(:training_period_started_on) { Date.new(2025, 1, 2) }
+
+        context "when the leave date is before the training period started_on date" do
+          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 1 } }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the leave date is the same as the training period started_on date" do
+          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 2 } }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the leave date is after the training period started_on date" do
+          let(:leaving_on) { { 1 => 2025, 2 => 1, 3 => 3 } }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
 

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
     let(:validator) { instance_double(Schools::Validation::PeriodBoundary) }
 
+    let(:teacher) { FactoryBot.create(:teacher) }
+    let(:previous_school) do
+      FactoryBot.create(:school, :independent).tap do |school|
+        school.gias_school.update!(name: "Springfield Primary")
+      end
+    end
+
     context "when the start_date is not present" do
       let(:start_date) { nil }
 
@@ -69,8 +76,6 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
       it { is_expected.to be_valid }
 
       context "and the ECT has a previous registration" do
-        let(:teacher) { FactoryBot.create(:teacher) }
-
         before do
           store.trn = teacher.trn
           FactoryBot.create(:ect_at_school_period, previous_period, teacher:, school: FactoryBot.create(:school))
@@ -112,14 +117,6 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
     end
 
     context "when the date clashes with the ect at school period" do
-      let(:previous_school) do
-        FactoryBot.create(:school, :independent).tap do |school|
-          school.gias_school.update!(name: "Springfield Primary")
-        end
-      end
-
-      let(:teacher) { FactoryBot.create(:teacher) }
-
       let(:previous_period) do
         FactoryBot.create(:ect_at_school_period,
                           teacher:,
@@ -149,14 +146,6 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
     context "when the date clashes with the latest training period" do
       let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: Date.new(2024, 12, 31)) }
-
-      let(:previous_school) do
-        FactoryBot.create(:school, :independent).tap do |school|
-          school.gias_school.update!(name: "Springfield Primary")
-        end
-      end
-
-      let(:teacher) { FactoryBot.create(:teacher) }
 
       let(:previous_period) do
         FactoryBot.create(:ect_at_school_period,

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
   let(:provided_start_date) { { 1 => "2024", 2 => "12", 3 => "01" } }
   let(:school) { FactoryBot.build(:school) }
   let(:step_params) { {} }
-  let(:store) { FactoryBot.build(:session_repository, start_date: prepopulated_start_date) }
+  let(:store) { FactoryBot.build(:session_repository, start_date: prepopulated_start_date, trs_first_name: "Johnnie", trs_last_name: "Walker") }
   let(:wizard) { FactoryBot.build(:register_ect_wizard, current_step: :start_date, school:, store:, step_params:) }
 
   describe "#initialize" do
@@ -30,6 +30,8 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
   describe "validations" do
     subject { described_class.new(start_date:, wizard:) }
+
+    let(:validator) { instance_double(Schools::Validation::PeriodBoundary) }
 
     context "when the start_date is not present" do
       let(:start_date) { nil }
@@ -109,7 +111,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
       end
     end
 
-    describe "start date must be after previous ECTAtSchoolPeriod started_on date" do
+    context "when the date clashes with the ect at school period" do
       let(:previous_school) do
         FactoryBot.create(:school, :independent).tap do |school|
           school.gias_school.update!(name: "Springfield Primary")
@@ -118,7 +120,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
 
       let(:teacher) { FactoryBot.create(:teacher) }
 
-      let!(:previous_period) do
+      let(:previous_period) do
         FactoryBot.create(:ect_at_school_period,
                           teacher:,
                           school: previous_school,
@@ -126,162 +128,75 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
                           finished_on: Date.new(2025, 3, 31))
       end
 
-      let(:wizard) do
-        FactoryBot.build(:register_ect_wizard, current_step: :start_date, store:, school:).tap do |instance|
-          allow(instance).to receive(:ect).and_return(
-            Schools::RegisterECTWizard::RegistrationStore.new(store).tap do |registration_store|
-              allow(registration_store).to receive_messages(trs_first_name: "Johnnie", trs_last_name: "Walker")
-            end
-          )
-        end
+      let(:start_date) { { 1 => "2024", 2 => "07", 3 => "01" } }
+
+      before do
+        allow(Schools::Validation::PeriodBoundary)
+          .to receive(:new)
+          .and_return(validator)
+
+        allow(validator).to receive_messages(
+          valid?: false,
+          invalid_period: previous_period,
+          type: "teaching",
+          started_on_formatted: "1 September 2024",
+          earliest_valid_input_date_formatted: "2 September 2024"
+        )
       end
 
-      let(:start_date_too_early_message) { "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a later start date." }
-
-      context "when the start_date is before the previous ECTAtSchoolPeriod started_on date" do
-        let(:start_date) { previous_period.started_on - 1.day }
-
-        it { is_expected.to have_error(:start_date, start_date_too_early_message) }
-      end
-
-      context "when the start_date is on the previous ECTAtSchoolPeriod started_on date" do
-        let(:start_date) { previous_period.started_on }
-
-        it { is_expected.to have_error(:start_date, start_date_too_early_message) }
-      end
-
-      context "when the start_date is after the previous ECTAtSchoolPeriod started_on date" do
-        let(:start_date) { previous_period.started_on + 1.day }
-
-        it { is_expected.to be_valid }
-      end
-
-      context "when the start_date is blank" do
-        let(:start_date) { nil }
-
-        it { is_expected.to have_error(:start_date, "Enter the date the ECT started or will start teaching at your school") }
-      end
-
-      context "when there is also a previous training period which starts after the new start date" do
-        let(:start_date) { previous_period.started_on }
-        let!(:training_period) do
-          FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: Date.new(2024, 9, 1))
-        end
-        let(:start_date_before_training_period_message) { "Our records show that Johnnie Walker started their latest training at Springfield Primary on 1 October 2024. Enter a later start date." }
-
-        it "only shows the error about the previous ECTAtSchoolPeriod and not the training period" do
-          subject.valid?
-
-          expect(subject.errors[:start_date]).to include(start_date_too_early_message)
-          expect(subject.errors[:start_date]).not_to include(start_date_before_training_period_message)
-        end
-      end
+      it { is_expected.to have_error(:start_date, "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a start date after 2 September 2024.") }
     end
 
-    describe "start date must be after previous training period started_on date" do
+    context "when the date clashes with the latest training period" do
+      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: Date.new(2024, 12, 31)) }
+
       let(:previous_school) do
-        FactoryBot.create(:school).tap do |school|
+        FactoryBot.create(:school, :independent).tap do |school|
           school.gias_school.update!(name: "Springfield Primary")
         end
       end
 
       let(:teacher) { FactoryBot.create(:teacher) }
 
-      let!(:previous_period) do
+      let(:previous_period) do
         FactoryBot.create(:ect_at_school_period,
                           teacher:,
                           school: previous_school,
-                          started_on: Date.new(2024, 9, 1))
+                          started_on: Date.new(2024, 9, 1),
+                          finished_on: Date.new(2025, 3, 31))
       end
 
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: training_period_start_date)
+      let(:start_date) { { 1 => "2024", 2 => "12", 3 => "01" } }
+
+      before do
+        allow(Schools::Validation::PeriodBoundary)
+          .to receive(:new)
+          .and_return(validator)
+
+        allow(validator).to receive_messages(
+          valid?: false,
+          invalid_period: training_period,
+          type: "their latest training",
+          started_on_formatted: "31 December 2024",
+          earliest_valid_input_date_formatted: "1 January 2025"
+        )
       end
 
-      let(:wizard) do
-        FactoryBot.build(:register_ect_wizard, current_step: :start_date, store:, school:).tap do |instance|
-          allow(instance).to receive(:ect).and_return(
-            Schools::RegisterECTWizard::RegistrationStore.new(store).tap do |registration_store|
-              allow(registration_store).to receive_messages(trs_first_name: "Johnnie", trs_last_name: "Walker")
-            end
-          )
-        end
+      it { is_expected.to have_error(:start_date, "Our records show that Johnnie Walker started their latest training at Springfield Primary on 31 December 2024. Enter a start date after 1 January 2025.") }
+    end
+
+    context "when the date does not clash with any periods" do
+      let(:start_date) { { 1 => "2024", 2 => "01", 3 => "01" } }
+
+      before do
+        allow(Schools::Validation::PeriodBoundary)
+          .to receive(:new)
+          .and_return(validator)
+
+        allow(validator).to receive(:valid?).and_return(true)
       end
 
-      let(:start_date_before_training_period_message) { "Our records show that Johnnie Walker started their latest training at Springfield Primary on 1 October 2024. Enter a later start date." }
-      let(:training_period_start_date) { Date.new(2024, 10, 1) }
-
-      context "when the start_date is blank" do
-        let(:start_date) { nil }
-
-        it { is_expected.to have_error(:start_date, "Enter the date the ECT started or will start teaching at your school") }
-      end
-
-      context "when the previous training_period started in the past" do
-        let(:training_period_start_date) { Date.new(2024, 10, 1) }
-
-        context "when the start_date is before the previous training period started_on date" do
-          let(:start_date) { training_period_start_date - 1.day }
-
-          it { is_expected.to have_error(:start_date, start_date_before_training_period_message) }
-        end
-
-        context "when the start_date is on the previous training period started_on date" do
-          let(:start_date) { training_period_start_date }
-
-          it { is_expected.to have_error(:start_date, start_date_before_training_period_message) }
-        end
-
-        context "when the start_date is after the previous training period started_on date" do
-          let(:start_date) { training_period_start_date + 1.day }
-
-          it { is_expected.to be_valid }
-        end
-      end
-
-      context "when the training_period starts today" do
-        let(:training_period_start_date) { Time.zone.today }
-
-        context "when the start_date is before the previous training period started_on date" do
-          let(:start_date) { training_period_start_date - 1.day }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the start_date is on the previous training period started_on date" do
-          let(:start_date) { training_period_start_date }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the start_date is after the previous training period started_on date" do
-          let(:start_date) { training_period_start_date + 1.day }
-
-          it { is_expected.to be_valid }
-        end
-      end
-
-      context "when the previous training_period starts in the future" do
-        let(:training_period_start_date) { Date.tomorrow }
-
-        context "when the start_date is before the previous training period started_on date" do
-          let(:start_date) { training_period_start_date - 1.day }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the start_date is on the previous training period started_on date" do
-          let(:start_date) { training_period_start_date }
-
-          it { is_expected.to be_valid }
-        end
-
-        context "when the start_date is after the previous training period started_on date" do
-          let(:start_date) { training_period_start_date + 1.day }
-
-          it { is_expected.to be_valid }
-        end
-      end
+      it { is_expected.to be_valid }
     end
   end
 

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -153,13 +153,134 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
       context "when the start_date is after the previous ECTAtSchoolPeriod started_on date" do
         let(:start_date) { previous_period.started_on + 1.day }
 
-        it { is_expected.not_to have_error(:start_date) }
+        it { is_expected.to be_valid }
       end
 
       context "when the start_date is blank" do
         let(:start_date) { nil }
 
         it { is_expected.to have_error(:start_date, "Enter the date the ECT started or will start teaching at your school") }
+      end
+
+      context "when there is also a previous training period which starts after the new start date" do
+        let(:start_date) { previous_period.started_on }
+        let!(:training_period) do
+          FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: Date.new(2024, 9, 1))
+        end
+        let(:start_date_before_training_period_message) { "Our records show that Johnnie Walker started their latest training at Springfield Primary on 1 October 2024. Enter a later start date." }
+
+        it "only shows the error about the previous ECTAtSchoolPeriod and not the training period" do
+          subject.valid?
+
+          expect(subject.errors[:start_date]).to include(start_date_too_early_message)
+          expect(subject.errors[:start_date]).not_to include(start_date_before_training_period_message)
+        end
+      end
+    end
+
+    describe "start date must be after previous training period started_on date" do
+      let(:previous_school) do
+        FactoryBot.create(:school).tap do |school|
+          school.gias_school.update!(name: "Springfield Primary")
+        end
+      end
+
+      let(:teacher) { FactoryBot.create(:teacher) }
+
+      let!(:previous_period) do
+        FactoryBot.create(:ect_at_school_period,
+                          teacher:,
+                          school: previous_school,
+                          started_on: Date.new(2024, 9, 1))
+      end
+
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: training_period_start_date)
+      end
+
+      let(:wizard) do
+        FactoryBot.build(:register_ect_wizard, current_step: :start_date, store:, school:).tap do |instance|
+          allow(instance).to receive(:ect).and_return(
+            Schools::RegisterECTWizard::RegistrationStore.new(store).tap do |registration_store|
+              allow(registration_store).to receive_messages(trs_first_name: "Johnnie", trs_last_name: "Walker")
+            end
+          )
+        end
+      end
+
+      let(:start_date_before_training_period_message) { "Our records show that Johnnie Walker started their latest training at Springfield Primary on 1 October 2024. Enter a later start date." }
+      let(:training_period_start_date) { Date.new(2024, 10, 1) }
+
+      context "when the start_date is blank" do
+        let(:start_date) { nil }
+
+        it { is_expected.to have_error(:start_date, "Enter the date the ECT started or will start teaching at your school") }
+      end
+
+      context "when the previous training_period started in the past" do
+        let(:training_period_start_date) { Date.new(2024, 10, 1) }
+
+        context "when the start_date is before the previous training period started_on date" do
+          let(:start_date) { training_period_start_date - 1.day }
+
+          it { is_expected.to have_error(:start_date, start_date_before_training_period_message) }
+        end
+
+        context "when the start_date is on the previous training period started_on date" do
+          let(:start_date) { training_period_start_date }
+
+          it { is_expected.to have_error(:start_date, start_date_before_training_period_message) }
+        end
+
+        context "when the start_date is after the previous training period started_on date" do
+          let(:start_date) { training_period_start_date + 1.day }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when the training_period starts today" do
+        let(:training_period_start_date) { Time.zone.today }
+
+        context "when the start_date is before the previous training period started_on date" do
+          let(:start_date) { training_period_start_date - 1.day }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the start_date is on the previous training period started_on date" do
+          let(:start_date) { training_period_start_date }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the start_date is after the previous training period started_on date" do
+          let(:start_date) { training_period_start_date + 1.day }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when the previous training_period starts in the future" do
+        let(:training_period_start_date) { Date.tomorrow }
+
+        context "when the start_date is before the previous training period started_on date" do
+          let(:start_date) { training_period_start_date - 1.day }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the start_date is on the previous training period started_on date" do
+          let(:start_date) { training_period_start_date }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when the start_date is after the previous training period started_on date" do
+          let(:start_date) { training_period_start_date + 1.day }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "a started on step" do |current_step:|
   let(:wizard) do
     FactoryBot.build(:register_mentor_wizard, current_step:, store:)
   end
-  let(:store) { FactoryBot.build(:session_repository) }
+  let(:store) { FactoryBot.build(:session_repository, trs_first_name: "Johnnie", trs_last_name: "Walker") }
   let(:contract_period) do
     FactoryBot.create(:contract_period, year: 2025, enabled: true)
   end
@@ -65,9 +65,16 @@ RSpec.shared_examples "a started on step" do |current_step:|
 
     context "when the mentor is currently mentoring at another school" do
       let(:currently_mentor_at_another_school) { true }
-      let(:previous_school_mentor_at_school_periods) do
-        [FactoryBot.build_stubbed(:mentor_at_school_period, started_on: 2.months.ago)]
+      let(:previous_school) do
+        FactoryBot.create(:school, :independent).tap do |school|
+          school.gias_school.update!(name: "Springfield Primary")
+        end
       end
+
+      let(:previous_school_mentor_at_school_periods) { [previous_period] }
+      let(:previous_period) { FactoryBot.build_stubbed(:mentor_at_school_period, started_on: 2.months.ago) }
+
+      let(:validator) { instance_double(Schools::Validation::PeriodBoundary) }
 
       context "and the start_date is invalid" do
         let(:started_on_params) { { "day" => "30", "month" => "2", "year" => "2025" } }
@@ -109,10 +116,74 @@ RSpec.shared_examples "a started on step" do |current_step:|
         it { is_expected.to be_valid }
       end
 
-      context "and the start date is before the previous school mentor at school period" do
-        let(:started_on) { 3.months.ago }
+      context "when the date clashes with the previous school period" do
+        let(:previous_period) do
+          FactoryBot.create(:mentor_at_school_period,
+                            school: previous_school,
+                            started_on: Date.new(2024, 9, 1),
+                            finished_on: Date.new(2025, 3, 31))
+        end
 
-        it { is_expected.to have_error(:started_on, "was registered as a mentor at their last school starting on the #{2.months.ago.to_date.to_formatted_s(:govuk)}. Enter a later date.") }
+        let(:start_date) { { 1 => "2024", 2 => "07", 3 => "01" } }
+
+        before do
+          allow(Schools::Validation::PeriodBoundary)
+            .to receive(:new)
+            .and_return(validator)
+
+          allow(validator).to receive_messages(
+            valid?: false,
+            invalid_period: previous_period,
+            type: "teaching",
+            started_on_formatted: "1 September 2024",
+            earliest_valid_input_date_formatted: "2 September 2024"
+          )
+        end
+
+        it { is_expected.to have_error(:started_on, "Our records show that Johnnie Walker started teaching at Springfield Primary on 1 September 2024. Enter a start date after 2 September 2024.") }
+      end
+
+      context "when the date clashes with the latest training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period: previous_period, started_on: Date.new(2024, 12, 31)) }
+
+        let(:previous_period) do
+          FactoryBot.create(:mentor_at_school_period,
+                            school: previous_school,
+                            started_on: Date.new(2024, 9, 1),
+                            finished_on: Date.new(2025, 3, 31))
+        end
+
+        let(:start_date) { { 1 => "2024", 2 => "12", 3 => "01" } }
+
+        before do
+          allow(Schools::Validation::PeriodBoundary)
+            .to receive(:new)
+            .and_return(validator)
+
+          allow(validator).to receive_messages(
+            valid?: false,
+            invalid_period: training_period,
+            type: "their latest training",
+            started_on_formatted: "31 December 2024",
+            earliest_valid_input_date_formatted: "1 January 2025"
+          )
+        end
+
+        it { is_expected.to have_error(:started_on, "Our records show that Johnnie Walker started their latest training at Springfield Primary on 31 December 2024. Enter a start date after 1 January 2025.") }
+      end
+
+      context "when the date does not clash with any periods" do
+        let(:start_date) { { 1 => "2024", 2 => "01", 3 => "01" } }
+
+        before do
+          allow(Schools::Validation::PeriodBoundary)
+            .to receive(:new)
+            .and_return(validator)
+
+          allow(validator).to receive(:valid?).and_return(true)
+        end
+
+        it { is_expected.to be_valid }
       end
     end
   end


### PR DESCRIPTION
### Context
NB please note that the error message has changed slightly from the card with agreement from @mason-emily.   
ACs
1. Validation on new school start date added to block a start date earlier than the latest training period start date at the previous school.

2. Error message for this scenario will say: Our records show that {{teacher name}} started their latest training at {{school}} on {{latest training period start date}}. Enter a start date after {{earliest end date of latest training period}}.

3. The existing school start date error message will take priority over this new one if there are no training periods with a later start date.

4. Validation on school date leaving date to block a date that is earlier than the latest training period start date at the current school.

Error message for leaving school scenario should say: Our records show that {{teacher name}} started their latest training on {{latest training period start date}}. Enter a date after {{earliest end date of latest training period}}.

### Changes proposed in this pull request

When we were discussing this we thought there might be hidden complexity. The first issue we discovered was to do with backdated training periods.  The second issue was to do with the interplay of `ect_at_school_periods` and `training_periods`.

<img width="1693" height="929" alt="image" src="https://github.com/user-attachments/assets/8699498a-5f58-41f1-bf46-06db0b7e06fb" />

Here we are trying to create a new ECT period at a separate school.  The existing ECT and training period may not start on the same day.  There may be several training periods.  We need to ensure that the latest start date of either period is used for validation.  In addition if the entered date is before the start of both the ECT and training period we need to prioritise errors from the ECT period.

Since any open periods need to be finished, and can't be zero length we need to take this into account when giving the earliest date the ECT period can be created at a new school.  For instance, consider an ECT with a training period that starts on 1st Jan.  This cannot be zero length so the earliest it can finish is 2nd Jan.  Therefore the earliest valid start date at a new school is 3rd Jan.

Additionally there may be several training periods, of which we only consider the latest.  If that training period starts in the future it will be deleted by the ECT registration process and we therefore don't let it affect validation.  However if the ECT was registered today, and their first training period started today, then that ECT period would block registration at another school today.  The earliest registration date would be the day after tomorrow.  Similarly we now ensure that if a training period has started today, the earliest registration date at another school is the day after tomorrow.  

Due to the variety of combinations present to make this validation work, I have introduced a custom validation class, which exhaustively tests these combinations.  The wizard steps then handle error messages given the period which overlaps and the earliest valid date.

In the tests for the service class there are shared examples which include the logic above that states an entered date is invalid yesterday, today, and tomorrow, but valid the day after tomorrow, if it clashes with a period that starts today.  I've tried to make that as readable as possible.  The easiest way I found to think of it was this four day period around the entered date, with the last day being a valid date.

We have recently updated the logic around backdated ECT periods, in this [PR](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2688).  This means that when registering an ECT in the past their first training period starts today.  Previously we allowed the niche case where two schools do that on the same day.  This validation blocks that, and insists that the second school cannot back date their registration.

### Guidance to review

I found that for some reason many of the listed teachers could not be registered, and therefore you will have to use these very specific ones listed below.

| TRN     | Name           | Type                     | Period Start | Training Period 1 | Training Period 2 | Training Period 3 |
|---------|----------------|--------------------------|--------------|-------------------|-------------------|-------------------|
| 3002577 | Jonas Bloggs   | ect_at_school_period     | 2025-09-01   | provider_led (2025-09-01 → ongoing) |  |  |
| 3002578 | Cynthia Parks  | ect_at_school_period     | 2025-09-01   | provider_led (2025-10-01 → ongoing) |  |  |
| 3002579 | Taylor Hawkins | ect_at_school_period     | 2025-09-01   | provider_led (2025-10-01 → 2025-10-31) | provider_led / ambition (2025-11-01 → ongoing) |  |
| 3002580 | Muhammed Ali   | ect_at_school_period     | 2025-09-01   | school_led (2025-10-01 → 2025-10-31) | provider_led / ambition (2025-11-01 → ongoing) |  |
| 3002582 | Robson Scottie | ect_at_school_period     | 2025-09-01   | provider_led (2025-10-01 → 2025-10-31) | school_led (2025-11-01 → 2025-11-30) | provider_led (2025-12-01 → ongoing) |
| 3012858 | Dave Teacher   | mentor_at_school_period  | 2025-09-01   | provider_led (2025-09-01 → ongoing) |  |  |
| 3003943 | Donna Msa      | mentor_at_school_period  | 2025-09-01   | provider_led (2025-10-01 → ongoing) |  |  |
| 3012235 | Claire Cool    | mentor_at_school_period  | 2025-09-01   | provider_led (2025-10-01 → 2025-10-31) | provider_led / ambition (2025-11-01 → ongoing) |  |