### PR TITLE
Fix mentor search to preserve search box when no results found

### DIFF
--- a/app/controllers/schools/mentors_controller.rb
+++ b/app/controllers/schools/mentors_controller.rb
@@ -11,10 +11,9 @@ module Schools
     before_action :set_ects, only: :show
 
     def index
-      search = Teachers::Search.new(mentor_at_school: school, query_string: params[:q])
-
+      @number_of_mentors = Teachers::Search.new(mentor_at_school: school).count
+      search                   = Teachers::Search.new(mentor_at_school: school, query_string: params[:q])
       @pagy, @filtered_mentors = pagy_array(search.search, limit: 20)
-      @number_of_mentors       = search.count
     end
 
     def show

--- a/spec/features/schools/mentors/search_spec.rb
+++ b/spec/features/schools/mentors/search_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe "Searching for a mentor", :enable_schools_interface do
     and_i_should_not_see_the_non_matching_teacher
   end
 
+  scenario "when no results are found, keeps the search box visible and shows a no-results message" do
+    when_i_search_for_a_teacher_that_does_not_exist
+
+    then_i_should_see_the_search_box
+    and_i_should_see_the_no_results_message
+    and_i_should_not_see_the_no_mentors_registered_message
+  end
+
+  scenario "shows a no mentors message and no search box when the school has no mentors" do
+    given_the_school_has_no_mentors
+
+    then_i_should_see_the_no_mentors_message
+    and_i_should_not_see_the_search_box
+  end
+
   def when_i_search_for_a_teacher_by_trn
     page.get_by_label("Search by name or teacher reference number (TRN)").fill(@matching_teacher.trn)
     page.get_by_role("button", name: "Search").click
@@ -55,5 +70,35 @@ RSpec.describe "Searching for a mentor", :enable_schools_interface do
 
   def and_i_should_not_see_the_non_matching_teacher
     expect(page.get_by_role("link", name: "Bob Invisible")).not_to be_visible
+  end
+
+  def when_i_search_for_a_teacher_that_does_not_exist
+    page.get_by_label("Search by name or teacher reference number (TRN)").fill("Nonexistent Person")
+    page.get_by_role("button", name: "Search").click
+  end
+
+  def then_i_should_see_the_search_box
+    expect(page.get_by_label("Search by name or teacher reference number (TRN)")).to be_visible
+  end
+
+  def and_i_should_see_the_no_results_message
+    expect(page.get_by_text("There are no mentors that match your search")).to be_visible
+  end
+
+  def and_i_should_not_see_the_no_mentors_registered_message
+    expect(page.get_by_text("no registered mentors", exact: false)).not_to be_visible
+  end
+
+  def given_the_school_has_no_mentors
+    MentorAtSchoolPeriod.where(school: @school).find_each(&:destroy)
+    page.goto("/school/home/mentors")
+  end
+
+  def then_i_should_see_the_no_mentors_message
+    expect(page.get_by_text("Your school currently has no registered mentors")).to be_visible
+  end
+
+  def and_i_should_not_see_the_search_box
+    expect(page.get_by_label("Search by name or teacher reference number (TRN)")).not_to be_visible
   end
 end


### PR DESCRIPTION
This ticket

### Context
- The mentor list controller was setting @number_of_mentors from the filtered search result rather than the total count of mentors at the school so when a search returned no results, the view couldn't distinguish between 'no mentors registered' and 'no mentors matching the search' therefore incorrectly rendered the no-mentors state, hiding the search box entirely

### Changes proposed in this pull request
- Controller now makes two separate `Teachers::Search` calls — one without a query to get the true total, and one with the query string to get the filtered results
- This mirrors the existing pattern in `ECTsController`

### Guidance to review
1. Go to mentors list page
2. Search for a name/trn that doesn't exist and confirm the search box stays visible and "There are no mentors that match your search" appears 
3. Clear the search — confirm the mentor list returns to normal
4. Search for a name that does exist — confirm only the matching mentor appears
5.  Find a school with no mentors and go to the mentor list — confirm "Your school currently has no registered mentors" appears with no search box
