### PR TITLE
Add guidance for connecting to the RECT API

### DIFF
--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -20,7 +20,7 @@ Lead providers are responsible for delivering high-quality early career teacher 
 
 ## Where to manage participant training data 
 
-Lead providers must use the register early career teachers API `https://register-early-career-teachers.education.gov.uk/api/v3` to submit and update data about:
+Lead providers must use the register early career teachers API, `https://register-early-career-teachers.education.gov.uk/api/v3`, to submit and update data about:
 
 * early career teachers
 * mentors
@@ -37,7 +37,7 @@ This data enables:
 
 ## Testing and going live 
 
-Lead providers should use the sandbox environment `https://sandbox.register-early-career-teachers.education.gov.uk/api` to test sending data before moving to production when it goes live. This will help ensure: 
+Lead providers should use the sandbox environment, `https://sandbox.register-early-career-teachers.education.gov.uk/api`, to test sending data before moving to production when it goes live. This will help ensure: 
 
 * their integration works correctly
 * errors can be fixed early

--- a/app/views/api/guidance/guidance_for_lead_providers.md
+++ b/app/views/api/guidance/guidance_for_lead_providers.md
@@ -20,7 +20,7 @@ Lead providers are responsible for delivering high-quality early career teacher 
 
 ## Where to manage participant training data 
 
-Lead providers must use the [‘Register early career teachers’ API](/api) to submit and update data about:
+Lead providers must use the register early career teachers API `https://register-early-career-teachers.education.gov.uk/api/v3` to submit and update data about:
 
 * early career teachers
 * mentors
@@ -37,7 +37,7 @@ This data enables:
 
 ## Testing and going live 
 
-Lead providers should use the [sandbox environment](https://sandbox.register-early-career-teachers.education.gov.uk/api) to test sending data before moving to production when it goes live. This will help ensure: 
+Lead providers should use the sandbox environment `https://sandbox.register-early-career-teachers.education.gov.uk/api` to test sending data before moving to production when it goes live. This will help ensure: 
 
 * their integration works correctly
 * errors can be fixed early

--- a/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
@@ -6,11 +6,10 @@ A unique API token is needed to connect to the register early career teachers AP
 
 Each token is associated with a single provider and will give lead providers access to information about ECTs and mentors they are training, or have trained.
 
-Authentication tokens do not expire. However, if you need to change your API token for any reason, please let us know via email or your Teams channel.
 
 ## Request an API token
 
-Lead providers must contact us via email or their Teams channel to request a token for production and sandbox environments. API tokens are distributed via Galaxkey.
+Lead providers must contact us via email or their Teams channel to request a new token for production and sandbox environments. API tokens are distributed via Galaxkey and do not expire.
 
 Providers must not share tokens in publicly accessible documents or repositories.
 

--- a/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
@@ -40,7 +40,7 @@ The production environment is the live environment which processes real data.
 
 Do not perform testing in the production environment as real participant and payment data may be affected.
 
-`[PLACEHOLDER]`
+`https://register-early-career-teachers.education.gov.uk/api/v3`
 
 ### Sandbox environment
 

--- a/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
@@ -48,6 +48,6 @@ The sandbox environment is used to test API integrations without affecting real 
 
 `https://sandbox.register-early-career-teachers.education.gov.uk/api`
 
-There are some custom API headers that can only be used in the sandbox, such as `X-With-Server-Date`, which allows for [testing the ability to submit declarations in the sandbox ahead of time](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively#test-declaration-submissions-using-x-with-server-date).
+There are some custom API headers that can only be used in the sandbox, such as `X-With-Server-Date`, which allows for [testing the ability to submit declarations in the sandbox ahead of time](/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively#test-declaration-submissions-using-x-with-server-date).
 
-Visit our [API testing guidance](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively) for further information on testing the API.
+Visit our [API testing guidance](/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively) for further information on testing the API.

--- a/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
@@ -2,9 +2,6 @@
 title: Connect to the RECT API
 sidebar_position: 14
 ---
-
-## Connect to the RECT API
-
 A unique API token is needed to connect to the register early career teachers API.
 
 Each token is associated with a single provider and will give lead providers access to information about ECTs and mentors they are training, or have trained.
@@ -29,7 +26,7 @@ Unauthenticated requests will receive an UnauthorizedResponse with a 401 error c
 
 Provider development teams can also access the OpenAPI spec in YAML format:
 
-'https://cpd-ec2-sandbox-web.teacherservices.cloud/api/docs/v3/swagger.yaml'
+`https://cpd-ec2-sandbox-web.teacherservices.cloud/api/docs/v3/swagger.yaml`
 
 Providers can use API testing tools such as [Postman](https://www.postman.com) to make test API calls. Providers can import the API as a collection by using Postman's import feature and copying in the YAML URL of the API spec.
 
@@ -37,24 +34,20 @@ Providers can use API testing tools such as [Postman](https://www.postman.com) t
 
 The API is available via production (live) and sandbox (testing) environments.
 
-## Production environment
+### Production environment
 
 The production environment is the live environment which processes real data.
 
 Do not perform testing in the production environment as real participant and payment data may be affected.
 
-`API v3: [PLACEHOLDER]`
+`[PLACEHOLDER]`
 
-## Sandbox environment
+### Sandbox environment
 
 The sandbox environment is used to test API integrations without affecting real data.
 
-`API v3: https://sandbox.register-early-career-teachers.education.gov.uk/api`
+`https://sandbox.register-early-career-teachers.education.gov.uk/api`
 
-Note, there are some custom API headers that can only be used in the sandbox.
+There are some custom API headers that can only be used in the sandbox, such as `X-With-Server-Date`, which allows for [testing the ability to submit declarations in the sandbox ahead of time](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively#test-declaration-submissions-using-x-with-server-date).
 
-[Test the ability to submit declarations in the sandbox ahead of time](#)
-
-## Rate limits
-
-Providers are limited to 1,000 requests per 5 minutes when using the API in the production environment. If the limit is exceeded, providers will see a 429 HTTP status code.
+Visit our [API testing guidance](https://sandbox.register-early-career-teachers.education.gov.uk/api/guidance/guidance-for-lead-providers/how-to-test-the-api-effectively) for further information on testing the API.

--- a/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
@@ -1,0 +1,60 @@
+---
+title: Connect to the RECT API
+sidebar_position: 14
+---
+
+## Connect to the RECT API
+
+A unique API token is needed to connect to the register early career teachers API.
+
+Each token is associated with a single provider and will give lead providers access to information about ECTs and mentors they are training, or have trained.
+
+Authentication tokens do not expire. However, if you need to change your API token for any reason, please let us know via email or your Teams channel.
+
+### Request an API token
+
+Lead providers must contact us via email or their Teams channel to request a token for production and sandbox environments. API tokens are distributed via Galaxkey.
+
+Providers must not share tokens in publicly accessible documents or repositories.
+
+### How to use an authentication token
+
+Include an authentication token in all requests to the API by adding an Authorization request header (not as part of the URL) in the following format:
+
+`Authorization: Bearer {token}`
+
+Unauthenticated requests will receive an UnauthorizedResponse with a 401 error code.
+
+### Access YAML format API specs
+
+Provider development teams can also access the OpenAPI spec in YAML format:
+
+'https://cpd-ec2-sandbox-web.teacherservices.cloud/api/docs/v3/swagger.yaml'
+
+Providers can use API testing tools such as [Postman](https://www.postman.com) to make test API calls. Providers can import the API as a collection by using Postman's import feature and copying in the YAML URL of the API spec.
+
+### Production and sandbox environments
+
+The API is available via production (live) and sandbox (testing) environments.
+
+#### Production environment
+
+The production environment is the live environment which processes real data.
+
+Do not perform testing in the production environment as real participant and payment data may be affected.
+
+`API v3: [PLACEHOLDER]`
+
+#### Sandbox environment
+
+The sandbox environment is used to test API integrations without affecting real data.
+
+`API v3: https://sandbox.register-early-career-teachers.education.gov.uk/api`
+
+Note, there are some custom API headers that can only be used in the sandbox.
+
+[Test the ability to submit declarations in the sandbox ahead of time](#)
+
+### Rate limits
+
+Providers are limited to 1,000 requests per 5 minutes when using the API in the production environment. If the limit is exceeded, providers will see a 429 HTTP status code.

--- a/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
+++ b/app/views/api/guidance/guidance_for_lead_providers/connect_to_rect_api.md
@@ -11,13 +11,13 @@ Each token is associated with a single provider and will give lead providers acc
 
 Authentication tokens do not expire. However, if you need to change your API token for any reason, please let us know via email or your Teams channel.
 
-### Request an API token
+## Request an API token
 
 Lead providers must contact us via email or their Teams channel to request a token for production and sandbox environments. API tokens are distributed via Galaxkey.
 
 Providers must not share tokens in publicly accessible documents or repositories.
 
-### How to use an authentication token
+## How to use an authentication token
 
 Include an authentication token in all requests to the API by adding an Authorization request header (not as part of the URL) in the following format:
 
@@ -25,7 +25,7 @@ Include an authentication token in all requests to the API by adding an Authoriz
 
 Unauthenticated requests will receive an UnauthorizedResponse with a 401 error code.
 
-### Access YAML format API specs
+## Access YAML format API specs
 
 Provider development teams can also access the OpenAPI spec in YAML format:
 
@@ -33,11 +33,11 @@ Provider development teams can also access the OpenAPI spec in YAML format:
 
 Providers can use API testing tools such as [Postman](https://www.postman.com) to make test API calls. Providers can import the API as a collection by using Postman's import feature and copying in the YAML URL of the API spec.
 
-### Production and sandbox environments
+## Production and sandbox environments
 
 The API is available via production (live) and sandbox (testing) environments.
 
-#### Production environment
+## Production environment
 
 The production environment is the live environment which processes real data.
 
@@ -45,7 +45,7 @@ Do not perform testing in the production environment as real participant and pay
 
 `API v3: [PLACEHOLDER]`
 
-#### Sandbox environment
+## Sandbox environment
 
 The sandbox environment is used to test API integrations without affecting real data.
 
@@ -55,6 +55,6 @@ Note, there are some custom API headers that can only be used in the sandbox.
 
 [Test the ability to submit declarations in the sandbox ahead of time](#)
 
-### Rate limits
+## Rate limits
 
 Providers are limited to 1,000 requests per 5 minutes when using the API in the production environment. If the limit is exceeded, providers will see a 429 HTTP status code.


### PR DESCRIPTION
This document outlines how lead providers can connect to the RECT API, including obtaining an API token, using it in requests, and understanding the production and sandbox environments.

### Context

### Changes proposed in this pull request

### Guidance to review
