### PR TITLE
[3639] funding eligibility should be set for all ect_at_school_periods include future ones

### DIFF
--- a/app/services/teachers/set_funding_eligibility.rb
+++ b/app/services/teachers/set_funding_eligibility.rb
@@ -42,7 +42,7 @@ private
   end
 
   def eligible_for_ect_training?
-    teacher.induction_periods.ongoing_today.any? && teacher.ect_at_school_periods.ongoing_today.any?
+    teacher.induction_periods.ongoing_today.any? && teacher.ect_at_school_periods.any?
   end
 
   def eligible_for_mentor_training?

--- a/spec/services/teachers/set_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_funding_eligibility_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe Teachers::SetFundingEligibility do
       end
     end
 
+    context "when teacher has an ongoing induction but only a finished ECT at school period" do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:ect_at_school_period,
+                          teacher:,
+                          started_on: 6.months.ago,
+                          finished_on: 1.month.ago)
+      end
+
+      it "sets `ect_first_became_eligible_for_training_at`" do
+        freeze_time do
+          expect { service.set! }.to change(teacher, :ect_first_became_eligible_for_training_at).from(nil).to(Time.zone.now)
+        end
+      end
+    end
+
     context "when teacher has an ongoing induction but no ECT at school periods" do
       before do
         FactoryBot.create(:induction_period, :ongoing, teacher:)

--- a/spec/services/teachers/set_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_funding_eligibility_spec.rb
@@ -49,6 +49,32 @@ RSpec.describe Teachers::SetFundingEligibility do
       end
     end
 
+    context "when teacher has an ongoing induction but only a future-dated ECT at school period" do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, teacher:)
+        FactoryBot.create(:ect_at_school_period,
+                          teacher:,
+                          started_on: 1.month.from_now,
+                          finished_on: nil)
+      end
+
+      it "sets `ect_first_became_eligible_for_training_at`" do
+        freeze_time do
+          expect { service.set! }.to change(teacher, :ect_first_became_eligible_for_training_at).from(nil).to(Time.zone.now)
+        end
+      end
+    end
+
+    context "when teacher has an ongoing induction but no ECT at school periods" do
+      before do
+        FactoryBot.create(:induction_period, :ongoing, teacher:)
+      end
+
+      it "does not set `ect_first_became_eligible_for_training_at`" do
+        expect { service.set! }.not_to change(teacher, :ect_first_became_eligible_for_training_at)
+      end
+    end
+
     context "when teacher is not eligible for ECT training" do
       it "does not set `ect_first_became_eligible_for_training_at`" do
         expect { service.set! }.not_to change(teacher, :ect_first_became_eligible_for_training_at)


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3639

### Changes proposed in this pull request

* Updated `Teachers::SetFundingEligibility.eligible_for_ect_training?` to check for all `teacher.ect_at_school_periods`, including future

### Guidance to review
