### PR TITLE
Ensure schools can change an ECTs training before reported leaving date

### DIFF
--- a/app/services/concerns/teachers/lead_provider_changer.rb
+++ b/app/services/concerns/teachers/lead_provider_changer.rb
@@ -56,7 +56,8 @@ module Teachers
     def create_training_period!
       TrainingPeriods::Create.provider_led(
         period:,
-        started_on:,
+        started_on: date_of_transition,
+        finished_on: period.finished_on,
         school_partnership:,
         expression_of_interest:,
         schedule:,

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -106,7 +106,8 @@ module ECTAtSchoolPeriods
     def create_school_led_training_period!
       TrainingPeriods::Create.school_led(
         period: @ect_at_school_period,
-        started_on: date_of_transition
+        started_on: date_of_transition,
+        finished_on: @ect_at_school_period.finished_on
       ).call
     end
 
@@ -114,6 +115,7 @@ module ECTAtSchoolPeriods
       TrainingPeriods::Create.provider_led(
         period: @ect_at_school_period,
         started_on: date_of_transition,
+        finished_on: @ect_at_school_period.finished_on,
         school_partnership: earliest_matching_school_partnership,
         expression_of_interest:,
         author: @author,
@@ -129,6 +131,7 @@ module ECTAtSchoolPeriods
       TrainingPeriods::Create.provider_led(
         period: @mentor_at_school_period,
         started_on: date_of_transition,
+        finished_on: @mentor_at_school_period.finished_on,
         school_partnership: earliest_matching_school_partnership,
         expression_of_interest:,
         author: @author

--- a/app/services/schedules/reuse.rb
+++ b/app/services/schedules/reuse.rb
@@ -56,6 +56,5 @@ module Schedules
     delegate :successor_contract_period, to: :contract_period_reassignment
     delegate :assigned_contract_period, to: :contract_period_reassignment
     alias_method :previous_contract_period, :assigned_contract_period
-    alias_method :started_on, :date_of_transition
   end
 end

--- a/app/services/training_periods/create.rb
+++ b/app/services/training_periods/create.rb
@@ -15,8 +15,8 @@ module TrainingPeriods
       @mentee = mentee
     end
 
-    def self.school_led(period:, started_on:)
-      new(period:, started_on:, training_programme: "school_led")
+    def self.school_led(period:, started_on:, finished_on: nil)
+      new(period:, started_on:, finished_on:, training_programme: "school_led")
     end
 
     def self.provider_led(period:, started_on:, school_partnership:, expression_of_interest:, finished_on: nil, schedule: nil, author: nil, mentee: nil)

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
@@ -1,0 +1,223 @@
+RSpec.describe "Changing lead provider before the ECTs reported leaving date", :enable_schools_interface do
+  include ChangesBeforeReportedLeavingDateHelpers
+
+  include_context "test TRS API returns a teacher"
+
+  before do
+    freeze_time
+    given_there_is_a_school
+    and_there_is_an_ect_at_the_school
+    and_the_ect_is_doing_provider_led_training
+    and_there_is_another_school
+    and_there_is_another_lead_provider
+  end
+
+  context "when changing lead provider " \
+          "before transfer date " \
+          "after being reported as leaving" do
+    before do
+      given_i_am_logged_in_as_a_school_user(@school)
+      @leaving_date = @ect_at_school_period.started_on.advance(months: 6)
+      and_i_report_the_ect_as_leaving(on: @leaving_date)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_lead_provider
+      and_i_can_choose_a_different_lead_provider
+
+      when_i_change_the_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_lead_provider_confirmation_message
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @school, start: @ect_at_school_period.started_on, end: @leaving_date }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @another_lead_provider,
+          start: Date.current,
+          end: @leaving_date
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @lead_provider,
+          start: @ect_at_school_period.started_on,
+          end: Date.current
+        }
+      )
+    end
+  end
+
+  context "when changing lead provider " \
+          "before transfer date " \
+          "after being reported as joining by another school" do
+    before do
+      @joining_date = @ect_at_school_period.started_on.advance(months: 6)
+      given_the_ect_has_been_registered_by_another_school(on: @joining_date)
+      and_i_am_logged_in_as_a_school_user(@school)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_lead_provider
+      and_i_can_choose_a_different_lead_provider
+
+      when_i_change_the_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_lead_provider_confirmation_message
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @another_school, start: @joining_date, end: nil },
+        { school: @school, start: @ect_at_school_period.started_on, end: @joining_date.yesterday }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        {
+          school: @another_school,
+          type: "School-led",
+          start: @joining_date,
+          end: nil
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @another_lead_provider,
+          start: Date.current,
+          end: @joining_date.yesterday
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @lead_provider,
+          start: @ect_at_school_period.started_on,
+          end: Date.current
+        }
+      )
+    end
+  end
+
+  context "when changing lead provider " \
+          "before transfer date " \
+          "after being reported as leaving " \
+          "and later reported as joining on a different date" do
+    before do
+      given_i_am_logged_in_as_a_school_user(@school)
+      @leaving_date = @ect_at_school_period.started_on.advance(months: 6)
+      and_i_report_the_ect_as_leaving(on: @leaving_date)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_lead_provider
+      and_i_can_choose_a_different_lead_provider
+
+      when_i_change_the_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_lead_provider_confirmation_message
+
+      @joining_date = @leaving_date.advance(weeks: -2)
+      given_the_ect_has_been_registered_by_another_school(on: @joining_date)
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @another_school, start: @joining_date, end: nil },
+        { school: @school, start: @ect_at_school_period.started_on, end: @joining_date.yesterday }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        {
+          school: @another_school,
+          type: "School-led",
+          start: @joining_date,
+          end: nil
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @another_lead_provider,
+          start: Date.current,
+          end: @joining_date.yesterday
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @lead_provider,
+          start: @ect_at_school_period.started_on,
+          end: Date.current
+        }
+      )
+    end
+  end
+
+private
+
+  def and_the_ect_is_doing_provider_led_training
+    @contract_period = FactoryBot.create(:contract_period, :current, :with_schedules)
+    active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      contract_period: @contract_period
+    )
+    @lead_provider = active_lead_provider.lead_provider
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      :ongoing,
+      :provider_led,
+      :with_active_lead_provider,
+      ect_at_school_period: @ect_at_school_period,
+      active_lead_provider:
+    )
+  end
+
+  def and_there_is_another_lead_provider
+    active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      contract_period: @contract_period
+    )
+    @another_lead_provider = active_lead_provider.lead_provider
+  end
+
+  def then_i_can_change_the_lead_provider
+    row = page.locator(".govuk-summary-list__row", hasText: "Lead provider")
+    row.get_by_role("link", name: "Change").click
+  end
+
+  def and_i_can_choose_a_different_lead_provider
+    heading = page.locator("h1")
+    expect(heading).to have_text("Change lead provider for Mr Teacher")
+  end
+
+  def when_i_change_the_lead_provider
+    page.get_by_label(@another_lead_provider.name).check
+  end
+
+  def then_i_see_the_lead_provider_confirmation_message
+    lead_provider_message = <<~TXT.squish
+      You’ve chosen #{@another_lead_provider.name} as the new lead provider for
+      Mr Teacher
+    TXT
+    then_panel_is_visible_with(message: lead_provider_message)
+  end
+end

--- a/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
@@ -1,0 +1,226 @@
+RSpec.describe "Changing to provider-led training before the ECTs reported leaving date", :enable_schools_interface do
+  include ChangesBeforeReportedLeavingDateHelpers
+
+  include_context "test TRS API returns a teacher"
+
+  before do
+    freeze_time
+    given_there_is_a_school
+    and_there_is_an_ect_at_the_school
+    and_the_ect_is_doing_school_led_training
+    and_there_is_another_school
+    and_there_is_an_active_lead_provider
+  end
+
+  context "when changing to provider-led training " \
+          "before transfer date " \
+          "after being reported as leaving" do
+    before do
+      given_i_am_logged_in_as_a_school_user(@school)
+      @leaving_date = @ect_at_school_period.started_on.advance(months: 6)
+      and_i_report_the_ect_as_leaving(on: @leaving_date)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_training_programme
+      and_i_can_change_the_training_programme_to_provider_led
+
+      when_i_change_the_training_programme
+      then_i_am_asked_to_choose_a_lead_provider
+
+      when_i_choose_a_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_provider_led_confirmation_message
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @school, start: @ect_at_school_period.started_on, end: @leaving_date }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @lead_provider,
+          start: Date.current,
+          end: @leaving_date
+        },
+        {
+          school: @school,
+          type: "School-led",
+          start: @ect_at_school_period.started_on,
+          end: Date.current
+        }
+      )
+    end
+  end
+
+  context "when changing to provider-led training " \
+          "before transfer date " \
+          "after being reported as joining by another school" do
+    before do
+      @joining_date = @ect_at_school_period.started_on.advance(months: 6)
+      given_the_ect_has_been_registered_by_another_school(on: @joining_date)
+      and_i_am_logged_in_as_a_school_user(@school)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_training_programme
+      and_i_can_change_the_training_programme_to_provider_led
+
+      when_i_change_the_training_programme
+      then_i_am_asked_to_choose_a_lead_provider
+
+      when_i_choose_a_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_provider_led_confirmation_message
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @another_school, start: @joining_date, end: nil },
+        { school: @school, start: @ect_at_school_period.started_on, end: @joining_date.yesterday }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        {
+          school: @another_school,
+          type: "School-led",
+          start: @joining_date,
+          end: nil
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @lead_provider,
+          start: Date.current,
+          end: @joining_date.yesterday
+        },
+        {
+          school: @school,
+          type: "School-led",
+          start: @ect_at_school_period.started_on,
+          end: Date.current
+        }
+      )
+    end
+  end
+
+  context "when changing to provider-led training " \
+          "before transfer date " \
+          "after being reported as leaving " \
+          "and later reported as joining on a different date" do
+    before do
+      given_i_am_logged_in_as_a_school_user(@school)
+      @leaving_date = @ect_at_school_period.started_on.advance(months: 6)
+      and_i_report_the_ect_as_leaving(on: @leaving_date)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_training_programme
+      and_i_can_change_the_training_programme_to_provider_led
+
+      when_i_change_the_training_programme
+      then_i_am_asked_to_choose_a_lead_provider
+
+      when_i_choose_a_lead_provider
+      and_i_continue
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_provider_led_confirmation_message
+
+      @joining_date = @leaving_date.advance(weeks: -2)
+      given_the_ect_has_been_registered_by_another_school(on: @joining_date)
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @another_school, start: @joining_date, end: nil },
+        { school: @school, start: @ect_at_school_period.started_on, end: @joining_date.yesterday }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        {
+          school: @another_school,
+          type: "School-led",
+          start: @joining_date,
+          end: nil
+        },
+        {
+          school: @school,
+          type: "Provider-led",
+          lead_provider: @lead_provider,
+          start: Date.current,
+          end: @joining_date.yesterday
+        },
+        {
+          school: @school,
+          type: "School-led",
+          start: @ect_at_school_period.started_on,
+          end: Date.current
+        }
+      )
+    end
+  end
+
+private
+
+  def and_there_is_an_active_lead_provider
+    contract_period = FactoryBot.create(:contract_period, :current, :with_schedules)
+    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period:)
+    @lead_provider = @active_lead_provider.lead_provider
+  end
+
+  def and_the_ect_is_doing_school_led_training
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      :ongoing,
+      :school_led,
+      ect_at_school_period: @ect_at_school_period
+    )
+  end
+
+  def then_i_can_change_the_training_programme
+    row = page.locator(".govuk-summary-list__row", hasText: "Training programme")
+    row.get_by_role("link", name: "Change").click
+  end
+
+  def and_i_can_change_the_training_programme_to_provider_led
+    heading = page.locator("h1", hasText: "Change Mr Teacher’s training programme to provider-led")
+    expect(heading).to be_visible
+  end
+
+  def when_i_change_the_training_programme
+    page.get_by_role("button", name: "Change training programme").click
+  end
+
+  def then_i_am_asked_to_choose_a_lead_provider
+    heading = page.locator("h1")
+    expect(heading).to have_text("Which lead provider will be training Mr Teacher?")
+  end
+  alias_method :and_i_am_asked_to_choose_a_lead_provider, :then_i_am_asked_to_choose_a_lead_provider
+
+  def when_i_choose_a_lead_provider
+    page.get_by_label(@active_lead_provider.lead_provider.name).check
+  end
+
+  def then_i_see_the_provider_led_confirmation_message
+    provider_led_message = "You’ve changed Mr Teacher’s training programme to provider-led"
+    then_panel_is_visible_with(message: provider_led_message)
+  end
+end

--- a/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
@@ -1,0 +1,163 @@
+RSpec.describe "Changing to school-led training before the ECTs reported leaving date", :enable_schools_interface do
+  include ChangesBeforeReportedLeavingDateHelpers
+
+  include_context "test TRS API returns a teacher"
+
+  before do
+    freeze_time
+    given_there_is_a_school
+    and_there_is_an_ect_at_the_school
+    and_the_ect_is_doing_provider_led_training
+    and_there_is_another_school
+  end
+
+  context "when changing to school-led training " \
+          "before transfer date " \
+          "after being reported as leaving" do
+    before do
+      given_i_am_logged_in_as_a_school_user(@school)
+      @leaving_date = @ect_at_school_period.started_on.advance(months: 6)
+      and_i_report_the_ect_as_leaving(on: @leaving_date)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_training_programme
+      and_i_can_change_the_training_programme_to_school_led
+
+      when_i_change_the_training_programme
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_school_led_confirmation_message
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @school, start: @ect_at_school_period.started_on, end: @leaving_date }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        { school: @school, type: "School-led", start: Date.current, end: @leaving_date },
+        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.current }
+      )
+    end
+  end
+
+  context "when changing to school-led training " \
+          "before transfer date " \
+          "after being reported as joining by another school" do
+    before do
+      @joining_date = @ect_at_school_period.started_on.advance(months: 6)
+      given_the_ect_has_been_registered_by_another_school(on: @joining_date)
+      and_i_am_logged_in_as_a_school_user(@school)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_training_programme
+      and_i_can_change_the_training_programme_to_school_led
+
+      when_i_change_the_training_programme
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_school_led_confirmation_message
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @another_school, start: @joining_date, end: nil },
+        { school: @school, start: @ect_at_school_period.started_on, end: @joining_date.yesterday }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        { school: @another_school, type: "School-led", start: @joining_date, end: nil },
+        { school: @school, type: "School-led", start: Date.current, end: @joining_date.yesterday },
+        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.current }
+      )
+    end
+  end
+
+  context "when changing to school-led training " \
+          "before transfer date " \
+          "after being reported as leaving " \
+          "and later reported as joining on a different date" do
+    before do
+      given_i_am_logged_in_as_a_school_user(@school)
+      @leaving_date = @ect_at_school_period.started_on.advance(months: 6)
+      and_i_report_the_ect_as_leaving(on: @leaving_date)
+    end
+
+    it "allows the change and creates training periods with the correct dates" do
+      when_i_visit_the_ect_page
+      then_i_can_change_the_training_programme
+      and_i_can_change_the_training_programme_to_school_led
+
+      when_i_change_the_training_programme
+      then_i_am_asked_to_check_and_confirm_the_change
+
+      when_i_confirm_the_change
+      then_i_see_the_school_led_confirmation_message
+
+      @joining_date = @leaving_date.advance(weeks: -2)
+      given_the_ect_has_been_registered_by_another_school(on: @joining_date)
+
+      given_i_am_logged_in_as_an_admin
+      when_i_visit_the_admin_teacher_school_page
+      then_i_see_the_correct_ect_at_school_periods(
+        { school: @another_school, start: @joining_date, end: nil },
+        { school: @school, start: @ect_at_school_period.started_on, end: @joining_date.yesterday }
+      )
+
+      when_i_visit_the_admin_teacher_training_page
+      then_i_see_the_correct_training_periods(
+        { school: @another_school, type: "School-led", start: @joining_date, end: nil },
+        { school: @school, type: "School-led", start: Date.current, end: @joining_date.yesterday },
+        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.current }
+      )
+    end
+  end
+
+private
+
+  def and_the_ect_is_doing_provider_led_training
+    contract_period = FactoryBot.create(:contract_period, :current)
+    active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period:)
+    FactoryBot.create(
+      :training_period,
+      :for_ect,
+      :ongoing,
+      :provider_led,
+      :with_active_lead_provider,
+      ect_at_school_period: @ect_at_school_period,
+      active_lead_provider:
+    )
+    @lead_provider = active_lead_provider.lead_provider
+  end
+
+  def then_i_can_change_the_training_programme
+    row = page.locator(".govuk-summary-list__row", hasText: "Training programme")
+    row.get_by_role("link", name: "Change").click
+  end
+
+  def and_i_can_change_the_training_programme_to_school_led
+    heading = page.locator("h1", hasText: "Change Mr Teacher’s training programme to school-led")
+    expect(heading).to be_visible
+  end
+
+  def when_i_change_the_training_programme
+    page.get_by_role("button", name: "Change training programme").click
+  end
+
+  def then_i_see_the_school_led_confirmation_message
+    school_led_message = "You’ve changed Mr Teacher’s training programme to school-led"
+    then_panel_is_visible_with(message: school_led_message)
+  end
+
+  def when_i_visit_the_admin_teacher_training_page
+    page.goto(admin_teacher_training_path(@ect_at_school_period.teacher))
+  end
+end

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -179,6 +179,37 @@ module ECTAtSchoolPeriods
         end
       end
 
+      context "when the `ECTAtSchoolPeriod` has a `finished_on` date" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            started_on: 2.weeks.ago,
+            finished_on: 6.months.from_now
+          )
+        end
+
+        it "creates a training period that finishes on the same date" do
+          SwitchTraining.to_school_led(ect_at_school_period, author:)
+
+          new_training_period = ect_at_school_period.reload.latest_training_period
+          expect(new_training_period).not_to be_ongoing
+          expect(new_training_period.finished_on).to eq(ect_at_school_period.finished_on)
+        end
+      end
+
+      context "when the `ECTAtSchoolPeriod` does not have a `finished_on` date" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(:ect_at_school_period, :ongoing)
+        end
+
+        it "creates an ongoing training period" do
+          SwitchTraining.to_school_led(ect_at_school_period, author:)
+
+          new_training_period = ect_at_school_period.reload.latest_training_period
+          expect(new_training_period).to be_ongoing
+        end
+      end
+
       context "when the record is not a `ECTAtSchoolPeriod`" do
         let(:ect_at_school_period) do
           FactoryBot.create(:mentor_at_school_period, :ongoing)
@@ -752,6 +783,37 @@ module ECTAtSchoolPeriods
         end
       end
 
+      context "when the `ECTAtSchoolPeriod` has a `finished_on` date" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            started_on: 2.weeks.ago,
+            finished_on: 6.months.from_now
+          )
+        end
+
+        it "creates a training period that finishes on the same date" do
+          SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
+
+          new_training_period = ect_at_school_period.reload.latest_training_period
+          expect(new_training_period).not_to be_ongoing
+          expect(new_training_period.finished_on).to eq(ect_at_school_period.finished_on)
+        end
+      end
+
+      context "when the `ECTAtSchoolPeriod` does not have a `finished_on` date" do
+        let(:ect_at_school_period) do
+          FactoryBot.create(:ect_at_school_period, :ongoing)
+        end
+
+        it "creates an ongoing training period" do
+          SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
+
+          new_training_period = ect_at_school_period.reload.latest_training_period
+          expect(new_training_period).to be_ongoing
+        end
+      end
+
       context "when the record is not a `ECTAtSchoolPeriod`" do
         let(:ect_at_school_period) do
           FactoryBot.create(:mentor_at_school_period, :ongoing)
@@ -923,6 +985,24 @@ module ECTAtSchoolPeriods
                 expect(new_training_period.schedule.identifier).to eq("ecf-standard-april")
                 expect(new_training_period.schedule.contract_period.year).to eq(2025)
               end
+            end
+          end
+
+          context "when the mentor is leaving the school" do
+            let(:mentor_at_school_period) do
+              FactoryBot.create(
+                :mentor_at_school_period,
+                started_on: ect_at_school_period.started_on,
+                finished_on: ect_at_school_period.started_on.advance(years: 1),
+                school: ect_at_school_period.school
+              )
+            end
+
+            it "assigns a `finished_on` date for the training period" do
+              SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
+
+              new_training_period = mentor_at_school_period.training_periods.last
+              expect(new_training_period.finished_on).to eq(mentor_at_school_period.finished_on)
             end
           end
         end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -228,6 +228,47 @@ RSpec.describe Schools::RegisterECT do
           end
         end
 
+        context "when a Teacher has an ECT period finishing in future at a different school (reported leaving)" do
+          let(:other_school) { FactoryBot.create(:school) }
+          let(:started_on) { Date.new(2025, 8, 1) + 1.year }
+
+          before do
+            FactoryBot.create(
+              :ect_at_school_period,
+              teacher:,
+              school: other_school,
+              started_on: 6.months.ago,
+              finished_on: 6.months.from_now
+            )
+          end
+
+          it "allows registration with non-overlapping future date" do
+            expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
+          end
+        end
+
+        context "when a Teacher already has an ongoing ECT period starting in future at a different school (reported joining)" do
+          let(:other_school) { FactoryBot.create(:school) }
+          let(:started_on) { Date.new(2025, 8, 1) + 1.year }
+
+          before do
+            FactoryBot.create(
+              :ect_at_school_period,
+              :ongoing,
+              teacher:,
+              school: other_school,
+              started_on: started_on.advance(weeks: 2)
+            )
+          end
+
+          it "raises an error" do
+            expect { service.register! }.to raise_error(
+              ActiveRecord::RecordInvalid,
+              "Validation failed: Finished on End date cannot overlap another Teacher ECT period"
+            )
+          end
+        end
+
         context "when no SchoolPartnerships exist" do
           it "creates a TrainingPeriod linked to the ECTAtSchoolPeriod and with an expression of interest for the ActiveLeadProvider" do
             expect { service.register! }.to change(TrainingPeriod, :count).by(1)

--- a/spec/services/training_periods/create_spec.rb
+++ b/spec/services/training_periods/create_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe TrainingPeriods::Create do
     it "calls new with the school_led arguments" do
       allow(TrainingPeriods::Create).to receive(:new).and_return(true)
 
-      TrainingPeriods::Create.school_led(period:, started_on:)
+      TrainingPeriods::Create.school_led(period:, started_on:, finished_on:)
 
-      expect(TrainingPeriods::Create).to have_received(:new).with(period:, started_on:, training_programme: "school_led")
+      expect(TrainingPeriods::Create).to have_received(:new).with(period:, started_on:, finished_on:, training_programme: "school_led")
     end
 
     it "does not record an event" do

--- a/spec/support/features/changes_before_reported_leaving_date_helpers.rb
+++ b/spec/support/features/changes_before_reported_leaving_date_helpers.rb
@@ -1,0 +1,187 @@
+module ChangesBeforeReportedLeavingDateHelpers
+private
+
+  # Setup
+  def given_there_is_a_school
+    @school = FactoryBot.create(:school, :state_funded)
+  end
+
+  def and_there_is_another_school
+    @another_school = FactoryBot.create(:school, :state_funded)
+  end
+
+  def and_there_is_an_ect_at_the_school
+    @teacher = FactoryBot.create(:teacher, corrected_name: "Mr Teacher")
+    @ect_at_school_period = FactoryBot.create(
+      :ect_at_school_period,
+      :ongoing,
+      school: @school,
+      teacher: @teacher,
+      started_on: 2.months.ago
+    )
+  end
+
+  def given_i_am_logged_in_as_a_school_user(school)
+    sign_in_as_school_user(school:)
+  end
+  alias_method :and_i_am_logged_in_as_a_school_user, :given_i_am_logged_in_as_a_school_user
+
+  def given_i_am_logged_in_as_an_admin
+    sign_in_as_dfe_user(role: :admin)
+  end
+  alias_method :and_i_am_logged_in_as_an_admin, :given_i_am_logged_in_as_an_admin
+
+  def and_i_report_the_ect_as_leaving(on:)
+    when_i_visit_the_ect_page
+    leaving_cta = page.get_by_role("link", name: "Tell us if Mr Teacher is leaving permanently")
+    leaving_cta.click
+    leaving_date_question = "When did or when will Mr Teacher be leaving your school?"
+    leaving_date_fieldset = page.locator("fieldset", hasText: leaving_date_question)
+    leaving_date_fieldset.get_by_label("Day").fill(on.day.to_s)
+    leaving_date_fieldset.get_by_label("Month").fill(on.month.to_s)
+    leaving_date_fieldset.get_by_label("Year").fill(on.year.to_s)
+    and_i_continue
+    and_i_confirm_and_continue
+    confirmation_message = "Mr Teacher will be removed from your school’s ECT list"
+    then_panel_is_visible_with(message: confirmation_message)
+  end
+
+  def given_the_ect_has_been_registered_by_another_school(on:)
+    admin = Sessions::Users::SchoolPersona.new(
+      email: "admin@example.com",
+      name: "Admin",
+      school_urn: @another_school.urn
+    )
+    appropriate_body = FactoryBot.create(:appropriate_body_period, :teaching_school_hub)
+    Schools::RegisterECT.new(
+      trn: @teacher.trn,
+      trs_first_name: @teacher.trs_first_name,
+      trs_last_name: @teacher.trs_last_name,
+      corrected_name: @teacher.corrected_name,
+      email: "test@example.com",
+      school: @another_school,
+      started_on: on,
+      school_reported_appropriate_body: appropriate_body,
+      training_programme: "school_led",
+      working_pattern: "full_time",
+      author: admin,
+      lead_provider: nil
+    ).register!
+  end
+
+  # Navigation
+  def when_i_visit_the_ect_page
+    page.goto(schools_ect_path(@ect_at_school_period))
+    expect(page.locator("h1")).to have_text("Mr Teacher")
+  end
+
+  def when_i_visit_the_schools_landing_page
+    page.goto(schools_ects_home_path)
+  end
+
+  def when_i_visit_the_admin_teacher_school_page
+    page.goto(admin_teacher_school_path(@ect_at_school_period.teacher))
+  end
+
+  def when_i_visit_the_admin_teacher_training_page
+    page.goto(admin_teacher_training_path(@ect_at_school_period.teacher))
+  end
+
+  # Actions
+  def when_i_continue
+    page.get_by_role("button", name: "Continue").click
+  end
+  alias_method :and_i_continue, :when_i_continue
+
+  def when_i_confirm_and_continue
+    page.get_by_role("button", name: "Confirm and continue").click
+  end
+  alias_method :and_i_confirm_and_continue, :when_i_confirm_and_continue
+
+  def when_i_confirm_the_change
+    page.get_by_role("button", name: "Confirm change").click
+  end
+  alias_method :and_i_confirm_the_change, :when_i_confirm_the_change
+
+  def when_i_confirm_details
+    page.get_by_role("button", name: "Confirm details").click
+  end
+  alias_method :and_i_confirm_details, :when_i_confirm_details
+
+  # Assertions
+  def then_i_am_asked_to_check_and_confirm_the_change
+    heading = page.locator("h1", hasText: "Check and confirm change")
+    expect(heading).to be_visible
+  end
+
+  def then_panel_is_visible_with(message:)
+    panel = page.locator(".govuk-panel")
+    expect(panel).to have_text(message)
+  end
+
+  def then_i_see_the_correct_ect_at_school_periods(*period_hashes)
+    summary_cards = page.locator(".govuk-summary-card").all
+    expect(summary_cards.size).to eq(period_hashes.size)
+
+    period_hashes.each do |period_hash|
+      school = period_hash[:school]
+      summary_card = summary_cards.find { it.inner_text.include?(school.name) }
+
+      urn_row = summary_card
+        .locator("dl dt", hasText: "School URN")
+        .locator("..") # Navigate "up" to the parent summary list row
+      expect(urn_row.locator("dd")).to have_text(school.urn.to_s)
+
+      start_date_row = summary_card
+        .locator("dl dt", hasText: "School start date")
+        .locator("..")
+      start_date = period_hash[:start].to_fs(:govuk)
+      expect(start_date_row.locator("dd")).to have_text(start_date)
+
+      end_date_row = summary_card
+        .locator("dl dt", hasText: "School end date")
+        .locator("..")
+      end_date = period_hash[:end]&.to_fs(:govuk) || "No end date recorded"
+      expect(end_date_row.locator("dd")).to have_text(end_date)
+    end
+  end
+
+  def then_i_see_the_correct_training_periods(*period_hashes)
+    summary_cards = page.locator(".govuk-summary-card").all
+    expect(summary_cards.size).to eq(period_hashes.size)
+
+    period_hashes.each_with_index do |period_hash, index|
+      summary_card = summary_cards[index]
+
+      training_row = summary_card
+        .locator("dl dt", hasText: "Training programme")
+        .locator("..") # Navigate "up" to the parent summary list row
+      expect(training_row.locator("dd")).to have_text(period_hash[:type])
+
+      school_row = summary_card
+        .locator("dl dt", hasText: "School")
+        .locator("..")
+      expect(school_row.locator("dd")).to have_text(period_hash[:school].name)
+
+      if period_hash.key?(:lead_provider)
+        lead_provider_row = summary_card
+          .locator("dl dt", hasText: "Lead provider")
+          .locator("..")
+        lead_provider_name = period_hash[:lead_provider].name
+        expect(lead_provider_row.locator("dd")).to have_text(lead_provider_name)
+      end
+
+      start_date_row = summary_card
+        .locator("dl dt", hasText: "Start date")
+        .locator("..")
+      start_date = period_hash[:start].to_fs(:govuk)
+      expect(start_date_row.locator("dd")).to have_text(start_date)
+
+      end_date_row = summary_card
+        .locator("dl dt", hasText: "End date")
+        .locator("..")
+      end_date = period_hash[:end]&.to_fs(:govuk) || "No end date recorded"
+      expect(end_date_row.locator("dd")).to have_text(end_date)
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3651

### Changes proposed in this pull request

Before, a school could report that an ECT was leaving (or another school could register the ECT as joining) *and* make changes to their training up until the date they left.

Until #2616, this resulted in multiple ongoing training periods —which didn't make sense!

After #2616, this was no longer possible and the validation would prevent the change from happening.

We do want schools to be able to make these changes, though.

This adds some feature tests to handle these edge cases, as well as the changes to ensure training periods finish on the relevant date (i.e the `ECTAtSchoolPeriod#finished_on` if it's present).

Now, we pass the `finished_on` date from the `ect_at_school_period` for the school making the change. If the school period is due to finish in the future (i.e they have reported the teacher is leaving), then the new training period created by the change will be curtailed at that date. If the school period is ongoing, then the new training period will be ongoing too.

### Guidance to review
