### PR TITLE
Move patches CSV to `DATA_PATCHES` global constant

### DIFF
--- a/app/migration/ecf1_teacher_history/data_patcher.rb
+++ b/app/migration/ecf1_teacher_history/data_patcher.rb
@@ -1,9 +1,7 @@
 class ECF1TeacherHistory::DataPatcher
-  PATCHES_PATH = Rails.root.join("app/migration/ecf1_teacher_history/data_patches.csv")
-
   attr_reader :data_patches
 
-  def initialize(data_patches: CSV.table(PATCHES_PATH))
+  def initialize(data_patches: DATA_PATCHES)
     @data_patches = data_patches
   end
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -37,3 +37,6 @@ INDUCTION_OUTCOMES = {
   pass: "Passed",
   fail: "Failed"
 }.freeze
+
+# Migration patch data, remove once RECT migration is done
+DATA_PATCHES = CSV.table("app/migration/ecf1_teacher_history/data_patches.csv")


### PR DESCRIPTION
This change will allow us to load the CSV once when the app boots rather than once per participant. It's intended to ease the migration and will be removed immediately once it's done.

The other options were:

* loading it into the database - which would be fine but also be more work as we'd need migrations/model and a way of syncing/overwriting data
* loading it into Redis when the app boots - also a good option but some more legwork would be required in setting it up and making sure it refreshes nicely each time the app boots (without leaving remnants of previous versions behind, etc)

This is the simplest approach and I don't think there's really much that can go wrong, providing the CSV doesn't grow too large. We can boost the RAM in prod for a fortnight if necessary, but I think it'll be fine as is.