### PR TITLE
[3771] Update logic for training period start date

### DIFF
--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -191,9 +191,11 @@ module Schools
     end
 
     def training_period_started_on
-      # If an ECT is backdated before the start of the registration CP,
-      # we still register them in the registration CP for programme/schedule purposes
-      [ect_at_school_period.started_on, registration_contract_period.started_on].max
+      if ContractPeriods::Reassignment.new(training_period: previous_training_period).required?
+        [ect_at_school_period.started_on, registration_contract_period.started_on].max
+      else
+        [ect_at_school_period.started_on, Date.current].max
+      end
     end
 
     def contract_period

--- a/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Moving School - backdated start spec", :enable_schools_interface
     end
 
     context "when the first period has a back-dated start date" do
-      scenario "the training period at the first school is aligned to the current contract period" do
+      scenario "the training period at the first school starts on the registration date" do
         given_there_are_two_schools
         and_there_are_partnerships_at_the_schools
         and_the_two_schools_want_to_register_the_same_teacher_on_different_dates_of_which_the_earliest_is_backdated
@@ -40,7 +40,7 @@ RSpec.describe "Moving School - backdated start spec", :enable_schools_interface
         given_a_school_has_registered_a_teacher
         and_another_school_has_registered_the_same_teacher_at_a_later_date
 
-        then_the_training_period_for_the_first_school_should_start_on_the_first_day_of_the_current_contract_period
+        then_the_training_period_for_the_first_school_should_start_on_the_registration_date
         and_the_training_period_for_the_second_school_should_start_on_the_date_entered_by_the_school
 
         and_the_training_period_for_the_first_school_should_finish_on_the_day_before_training_starts_at_the_second_school
@@ -113,13 +113,13 @@ RSpec.describe "Moving School - backdated start spec", :enable_schools_interface
   end
 
   def and_the_two_schools_want_to_register_the_same_teacher_on_different_dates_which_are_not_backdated
-    @school_one_start_date = Date.new(2025, 6, 1)
-    @school_two_start_date = Date.new(2025, 6, 3)
+    @school_one_start_date = Date.new(2025, 6, 16)
+    @school_two_start_date = Date.new(2025, 6, 18)
   end
 
   def and_the_two_schools_want_to_register_the_same_teacher_on_different_dates_of_which_the_earliest_is_backdated
     @school_one_start_date = Date.new(2025, 4, 1)
-    @school_two_start_date = Date.new(2025, 6, 3)
+    @school_two_start_date = Date.new(2025, 6, 18)
   end
 
   def and_the_two_schools_want_to_register_the_same_teacher_on_different_dates_of_which_are_both_backdated
@@ -159,12 +159,12 @@ RSpec.describe "Moving School - backdated start spec", :enable_schools_interface
     expect(training_period.finished_on).to be_nil
   end
 
-  def then_the_training_period_for_the_first_school_should_start_on_the_first_day_of_the_current_contract_period
+  def then_the_training_period_for_the_first_school_should_start_on_the_registration_date
     ect_at_school_period = @school_one.ect_at_school_periods.first
 
     training_period = ect_at_school_period.training_periods.first
 
-    expect(training_period.started_on).to eq(Date.new(2025, 6, 1))
+    expect(training_period.started_on).to eq(Date.current)
   end
 
   def given_i_am_logged_in_as(school)

--- a/spec/features/schools/ects/register/registering_an_ect_backdated_start_date_spec.rb
+++ b/spec/features/schools/ects/register/registering_an_ect_backdated_start_date_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Registering an ECT - backdated start date", :enable_schools_inte
     training_period = ect_at_school_period.training_periods.order(:created_at).last
 
     expect(ect_at_school_period.started_on).to eq(@entered_start_date)
-    expect(training_period.started_on).to eq(@current_contract_period.started_on)
+    expect(training_period.started_on).to eq(Date.current)
     expect(training_period.schedule.contract_period_year).to eq(@current_contract_period.year)
     expect(ect_at_school_period.started_on).not_to eq(training_period.started_on)
   end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe Schools::RegisterECT do
   include ActiveJob::TestHelper
-  let(:store) { nil }
   subject(:service) do
     described_class.new(school_reported_appropriate_body:,
                         corrected_name:,
@@ -17,8 +16,7 @@ RSpec.describe Schools::RegisterECT do
                         store:)
   end
 
-  include_context "safe_schedules"
-
+  let(:store) { nil }
   let(:author) { FactoryBot.create(:school_user, school_urn: school.urn) }
   let(:school_reported_appropriate_body) { FactoryBot.create(:appropriate_body_period) }
   let(:corrected_name) { "Randy Marsh" }
@@ -31,6 +29,8 @@ RSpec.describe Schools::RegisterECT do
   let(:working_pattern) { "full_time" }
   let(:ect_at_school_period) { subject.teacher.ect_at_school_periods.first }
   let!(:contract_period) { FactoryBot.create(:contract_period, :with_schedules, :current) }
+
+  include_context "safe_schedules"
 
   describe "#register!" do
     context "when a Teacher record with the same TRN does not exist" do

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Schools::RegisterECT do
   include ActiveJob::TestHelper
+  let(:store) { nil }
   subject(:service) do
     described_class.new(school_reported_appropriate_body:,
                         corrected_name:,
@@ -12,7 +13,8 @@ RSpec.describe Schools::RegisterECT do
                         trs_first_name:,
                         trs_last_name:,
                         working_pattern:,
-                        author:)
+                        author:,
+                        store:)
   end
 
   include_context "safe_schedules"
@@ -22,7 +24,7 @@ RSpec.describe Schools::RegisterECT do
   let(:corrected_name) { "Randy Marsh" }
   let(:email) { "randy@tegridyfarms.com" }
   let(:school) { FactoryBot.create(:school) }
-  let(:started_on) { mid_year - 1.day }
+  let(:started_on) { mid_year }
   let(:trn) { "3002586" }
   let(:trs_first_name) { "Dusty" }
   let(:trs_last_name) { "Rhodes" }
@@ -249,13 +251,13 @@ RSpec.describe Schools::RegisterECT do
         context "when the ECT start date is backdated before the registration contract period" do
           let(:started_on) { contract_period.started_on - 1.day }
 
-          it "keeps the ECTAtSchoolPeriod started_on backdated, but normalises TrainingPeriod started_on to the registration contract period start" do
+          it "keeps the ECTAtSchoolPeriod started_on backdated, but uses the registration date for the TrainingPeriod started_on" do
             expect { service.register! }.to change(TrainingPeriod, :count).by(1)
 
             training_period = ect_at_school_period.training_periods.order(:created_at).last
 
             expect(ect_at_school_period.started_on).to eq(started_on)
-            expect(training_period.started_on).to eq(contract_period.started_on)
+            expect(training_period.started_on).to eq(Date.current)
             expect(training_period.schedule.contract_period_year).to eq(contract_period.year)
             expect(training_period.started_on).not_to eq(ect_at_school_period.started_on)
           end
@@ -297,6 +299,46 @@ RSpec.describe Schools::RegisterECT do
           service.register!
 
           expect(Teachers::SetFundingEligibility).to have_received(:new).with(teacher:, author:)
+        end
+      end
+
+      context "when contract period reassignment is required" do
+        let(:started_on) { Date.new(2024, 1, 1) }
+        let!(:frozen_cp) { FactoryBot.create(:contract_period, :with_payments_frozen, year: 2022) }
+        let!(:successor_cp) { FactoryBot.create(:contract_period, :with_schedules, :with_extended_schedule, year: 2024) }
+        let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: successor_cp) }
+        let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+
+        let(:previous_school) { FactoryBot.create(:school) }
+        let!(:previous_ect_period) do
+          FactoryBot.create(:ect_at_school_period,
+                            teacher:,
+                            school: previous_school,
+                            started_on: Date.new(2022, 9, 1),
+                            finished_on: Date.new(2023, 8, 31))
+        end
+
+        let!(:previous_training_period) do
+          FactoryBot.create(:training_period,
+                            ect_at_school_period: previous_ect_period,
+                            mentor_at_school_period: nil,
+                            training_programme: "provider_led",
+                            school_partnership: FactoryBot.create(:school_partnership, :for_year, year: 2022, school: previous_school),
+                            schedule: FactoryBot.create(:schedule, contract_period: frozen_cp, identifier: "ecf-standard-september"),
+                            started_on: Date.new(2022, 9, 1),
+                            finished_on: Date.new(2023, 8, 31))
+        end
+
+        let(:store) { double("store", previous_training_period:, school_partnership_to_reuse_id: nil) }
+
+        it "uses the reassigned contract period start date, not the registration date" do
+          service.register!
+
+          new_ect_period = service.ect_at_school_period
+          training_period = new_ect_period.training_periods.order(:created_at).last
+
+          expect(training_period.started_on).to eq(successor_cp.started_on)
+          expect(training_period.started_on).not_to eq(Date.current)
         end
       end
     end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3771

### Changes proposed in this pull request

Unless the ECT is having their contract period reassigned from a frozen one, the effective training start date should be the later of when they started at the school and the registration date.

### Guidance for review

There was concern about side-effects elsewhere in the application, I've tried to research these as much as I can, I'd welcome any knowledge of other places to check:

#### Schedule assignment no change

[`Schedules::Find`](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/72ccb48b7794edcd10638cd59ff7367ceda671f9/app/services/schedules/find.rb#L49) already uses `[started_on, Time.zone.today].max` internally to select the schedule. Since both the old and new logic feed into this same max, the schedule selected is identical in all cases.

#### Contract period reassignment (PR #2562 interaction)

`ContractPeriods::ForECTRegistration` can return a past contract period (2024) for ECTs reassigned from closed 2021/2022 contract periods. Confirmed that [`Schedules::Find` bypasses `started_on` for the extended-schedule path](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/72ccb48b7794edcd10638cd59ff7367ceda671f9/app/services/schedules/find.rb#L24), so the schedule is unaffected. In the changes to the registration service in this PR, I preserved the old logic for the reassignment case to keep `training_period.started_on` within its contract period.

#### Validations on `TrainingPeriod`

- `enveloped_by_trainee_at_school_period` only fires when `finished_on` is present; new training periods are open-ended, so no risk.
- `contract_period_consistent_across_associations` still passes because schedule contract period selection is unchanged.

#### Registration flows (partnership reuse, EOI reuse, no reuse)

`RegisterECT#training_period_started_on` is the single point where the date is determined for all paths. The wizard's reuse steps populate the store, then `RegisterECT#register!` creates the training period — no parallel creation logic exists.

#### Transfer / moving school behaviour change

When a backdated ECT transfers to another school, `ECTAtSchoolPeriods::Finish` closes their ECT period. Under the old logic the training period started on the contract period start (often before the transfer date), so it survived. Under the new logic it starts on `Date.current`, which may be after the transfer date, in which case the training period is treated as "not started yet" and deleted. This is consistent with the existing "both backdated" scenario behaviour.

#### API surface

`training_period.started_on` is exposed in the [school transfer serializer](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/app/serializers/api/teachers/school_transfer_serializer.rb). Lead providers will see the registration date instead of the contract period start for backdated registrations. Based on ticket comments from Aamina / Emily I think this is fine / expected.

#### Mentor registration

`Schools::RegisterMentor` uses `mentor_at_school_period.started_on` directly, no `max` logic. Unchanged and already inconsistent with ECT registration, not in scope for this ticket. (Maybe warrants looking at separately?)

#### Misc unaffected

  - Events/audit trail (records the training period as-is, no date-specific logic)
  - Declarations/statements (tied to contract period via schedule, which is unchanged)
  - Scopes filtering by started_on (queries in the registration wizard use <= against contract period finished_on, still satisfied)
  - `ContractPeriods::Reassignment` (never reads training_period.started_on)