### PR TITLE
Fix flaky specs

### DIFF
--- a/app/services/api_seed_data/ect_participant_action_scenarios.rb
+++ b/app/services/api_seed_data/ect_participant_action_scenarios.rb
@@ -7,21 +7,27 @@ module APISeedData
 
       log_plant_info("api testing 2024 ECT participant seed scenarios")
 
+      results = { resumable_training_periods: [], started_with_another_lead_provider_training_periods: [], billable_declaration_training_periods: [] }
+
       NUMBER_OF_RECORDS_PER_SCENARIO.times do
         # Allowing lead providers to resume a participant without errors
-        seed_resumable_participants
+        results[:resumable_training_periods] += seed_resumable_participants
 
         # Preventing lead providers from resuming a participant as the participant has started with another lead provider
-        seed_participants_started_with_another_lead_provider
+        results[:started_with_another_lead_provider_training_periods] += seed_participants_started_with_another_lead_provider
 
         # Participant with billable declaration that can have their contract period and schedule identifier changed
-        seed_participant_with_billable_declaration_that_can_have_contract_period_and_schedule_changed
+        results[:billable_declaration_training_periods] += seed_participant_with_billable_declaration_that_can_have_contract_period_and_schedule_changed
       end
+
+      results
     end
 
   private
 
     def seed_resumable_participants
+      training_periods = []
+
       active_lead_providers.find_each do |active_lead_provider|
         # Withdrawn training period at ongoing school period, with ongoing induction period
         school_partnership = school_partnerships(active_lead_provider:).sample
@@ -30,14 +36,18 @@ module APISeedData
         teacher = create_teacher(school_time_period:)
         ect_at_school_period = create_at_school_period(school_time_period:, teacher:, school:)
         training_time_period = { started_on: school_time_period[:started_on], finished_on: school_time_period[:started_on] + rand(50..100).days }
-        create_training_period(ect_at_school_period:, school_partnership:, training_time_period:, traits: [:withdrawn])
+        training_periods << create_training_period(ect_at_school_period:, school_partnership:, training_time_period:, traits: [:withdrawn])
         create_ongoing_induction_period(teacher:, school_time_period:)
 
         log_plant_info("Created resumable participant for #{school_partnership.active_lead_provider.lead_provider.name}")
       end
+
+      training_periods
     end
 
     def seed_participants_started_with_another_lead_provider
+      training_periods = []
+
       active_lead_providers.find_each do |active_lead_provider|
         # Withdrawn training period at ongoing school period, with ongoing induction period
         # Where the school has a partnership with another active lead provider in the same year
@@ -51,6 +61,7 @@ module APISeedData
         ect_at_school_period = create_at_school_period(school_time_period:, teacher:, school:)
         training_time_period = { started_on: school_time_period[:started_on], finished_on: school_time_period[:started_on] + rand(50..100).days }
         training_period_at_first_school = create_training_period(ect_at_school_period:, school_partnership:, training_time_period:, traits: [:withdrawn])
+        training_periods << training_period_at_first_school
         create_ongoing_induction_period(teacher:, school_time_period:)
 
         # Active training period at the same school but with a different lead provider
@@ -60,9 +71,13 @@ module APISeedData
 
         log_plant_info("Created participant started with another lead provider for #{school_partnership.active_lead_provider.lead_provider.name}")
       end
+
+      training_periods
     end
 
     def seed_participant_with_billable_declaration_that_can_have_contract_period_and_schedule_changed
+      training_periods = []
+
       active_lead_providers.find_each do |active_lead_provider|
         # Ongoing training period/school period/induction period at a school where the lead provider
         # has a school partnership with the same school in a different contract period.
@@ -75,6 +90,7 @@ module APISeedData
         ect_at_school_period = create_at_school_period(school_time_period:, teacher:, school:)
         training_time_period = { started_on: school_time_period[:started_on], finished_on: nil }
         training_period = create_training_period(ect_at_school_period:, school_partnership:, training_time_period:)
+        training_periods << training_period
         create_ongoing_induction_period(teacher:, school_time_period:)
 
         # Started, paid declaration for the training period.
@@ -82,6 +98,8 @@ module APISeedData
 
         log_plant_info("Created participant with declaration that can change contract period/schedule for #{school_partnership.active_lead_provider.lead_provider.name}")
       end
+
+      training_periods
     end
 
     def contract_period

--- a/app/services/api_seed_data/teachers_with_histories.rb
+++ b/app/services/api_seed_data/teachers_with_histories.rb
@@ -337,7 +337,12 @@ module APISeedData
       return unless rand_boolean(ASSIGN_ECT_TO_MENTOR_RATIO)
 
       # Assign an ECT to the mentor for the same period excluding ECTs who are already mentees
-      ect_at_school_period = school.ect_at_school_periods.where.not(teacher_id: teacher.id).where.not(id: MentorshipPeriod.distinct.pluck(:ect_at_school_period_id)).started_on_or_after(mentor_at_school_period_record.started_on).finished_before(mentor_at_school_period_record.finished_on).last
+      ect_at_school_period = school.ect_at_school_periods
+        .where.not(teacher_id: teacher.id)
+        .where.not(id: MentorshipPeriod.distinct.pluck(:ect_at_school_period_id))
+        .started_on_or_after(mentor_at_school_period_record.started_on)
+        .finished_before(mentor_at_school_period_record.finished_on)
+        .last
 
       return if ect_at_school_period.blank?
 

--- a/spec/services/api/declarations/clawback_spec.rb
+++ b/spec/services/api/declarations/clawback_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
     before do
       FactoryBot.create(
         :statement,
+        deadline_date: declaration.declaration_date + 1.month,
         active_lead_provider: declaration.training_period.active_lead_provider
       )
     end

--- a/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
@@ -41,10 +41,9 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
     end
 
     it "creates a resumable 2024 participant for the lead provider" do
-      plant
+      results = plant
 
-      # The first training period/teacher created is for the first scenario for the first LP.
-      training_period = TrainingPeriod.first
+      training_period = results[:resumable_training_periods].first
       teacher = training_period.teacher
 
       Metadata::Manager.new.refresh_metadata!(teacher)
@@ -66,11 +65,9 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
     end
 
     it "creates a 2024 participant that has started with another lead provider" do
-      plant
+      results = plant
 
-      # A training period is created for the first scenario for each LP
-      # so this is the first training period/teacher of the second scenario.
-      training_period = TrainingPeriod.all[LeadProvider.count]
+      training_period = results[:started_with_another_lead_provider_training_periods].first
       teacher = training_period.teacher
 
       Metadata::Manager.refresh_all_metadata!
@@ -93,10 +90,9 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
     end
 
     it "creates a 2024 participant with a billable declaration that can have their contract period and schedule changed" do
-      plant
+      results = plant
 
-      # The last training period/teacher created is for this scenario.
-      training_period = TrainingPeriod.joins(:declarations).first
+      training_period = results[:billable_declaration_training_periods].first
       teacher = training_period.teacher
 
       Metadata::Manager.refresh_all_metadata!

--- a/spec/services/api_seed_data/teachers_with_histories_spec.rb
+++ b/spec/services/api_seed_data/teachers_with_histories_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
         school_partnerships.each do |school_partnership|
           school = school_partnership.school
           contract_period = school_partnership.contract_period
-          started_on = Date.new(contract_period.year, 9, 15)
+          started_on = Date.new(contract_period.year, 9, 30)
           # finished_on must be before the mentor's finished_on which is started_on + 200..300 days
           FactoryBot.create(:ect_at_school_period, school:, started_on:, finished_on: started_on + 150.days)
         end

--- a/spec/services/api_seed_data/teachers_with_histories_spec.rb
+++ b/spec/services/api_seed_data/teachers_with_histories_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe APISeedData::TeachersWithHistories do
     # of the school partnerships.
     school_partnerships.each do |school_partnership|
       schedule = FactoryBot.create(:schedule, contract_period: school_partnership.contract_period)
-      other_identifier = Schedule.excluding_replacement_schedules.identifiers.keys.excluding(schedule.identifier).sample
+      other_identifier = Schedule.identifiers.keys.excluding(Schedule::REPLACEMENT_SCHEDULE_IDENTIFIERS).excluding(schedule.identifier).sample
       FactoryBot.create(:schedule, contract_period: school_partnership.contract_period, identifier: other_identifier)
     end
   end


### PR DESCRIPTION
Fixes the main flakey specs I found when looking back through recent failures on deploying `main`.

- Ensure output fee statement exists

Occasionally the `deadline_date` of the statement we generate is earlier than the `declaration_date` and we therefore hit a validation error.

Ensure `deadline_date` is always after `declaration_date`.

- Fix bug removing replacement schedules

We ignore replacement schedules when picking a schedule in the seeds  and the intent of the test is to not generate these when checking we create teachers for different schedules, however there was a bug.

Calling `excluding_replacement_schedules.identifiers` actually returns all of the `identifiers` as it ends up calling the Rails-generated helper method for the `identifier` enum _after_ excluding  replacement schedules.

What we want is all the identifiers (not just a scope of non-replacement in the DB) and to then exclude replacement schedules from those (and the already generated schedule).

- Ensure ECT always exists that meets criteria for mentorship

Previously the test was generating an ECT that started training on the 15/9, however the seeds generate a mentor that starts randomly between 1st and 30th of September. If it generated between the 1st and 14th it would exclude the ECT (as thet ECT has to start on or after the mentor's school period).

Pin the ECT in the spec to the 30th so it will always start on or after the mentor's school period starts.

- Fix flakiness around testing scenarios

The seed creates three separate scenarios around ECT participant actions. We didn't have a mechanism to cleanly isolate a particular training periods so we try and pick them out based on ordering, which is proving to be flaky.

Return a hash of the created training periods for each scenario so that we can reliably reference them in the specs.