### PR TITLE
Prevent exceptions when doing range checks

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -56,6 +56,7 @@ module Interval
   end
 
   def overlap_validation(name:)
+    return unless valid_date_order?
     return unless has_overlap_with_siblings?
 
     if siblings.any? { |s| s.range.include?(started_on) }

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -1,7 +1,8 @@
 FakePeriod = Struct.new(:started_on, :finished_on)
 
 describe Interval do
-  let(:school_id) { FactoryBot.create(:school, urn: "1234567").id }
+  let(:school) { FactoryBot.create(:school, urn: "1234567") }
+  let(:school_id) { school.id }
   let(:teacher_id) { FactoryBot.create(:teacher, trs_first_name: "Teacher", trs_last_name: "One").id }
 
   describe "validations" do
@@ -13,6 +14,30 @@ describe Interval do
 
         it "adds an error" do
           expect(subject.errors.messages).to include(finished_on: ["The end date must be later than the start date (#{Date.yesterday.to_fs(:govuk)})"])
+        end
+      end
+    end
+
+    describe "sibling overlap checks" do
+      subject { FactoryBot.build(:ect_at_school_period, school:, teacher: sibling.teacher, started_on: 1.day.ago, finished_on:) }
+
+      before { subject.valid? }
+
+      let(:sibling) { FactoryBot.create(:ect_at_school_period, started_on: 3.weeks.ago, finished_on: 2.weeks.ago) }
+
+      context "when finished_on is before started_on" do
+        let(:finished_on) { 2.days.ago }
+
+        it "doesn't cause an exception when the dates are the wrong way round" do
+          expect(subject.errors.messages.keys).to contain_exactly(:finished_on)
+        end
+      end
+
+      context "when finished_on is nil" do
+        let(:finished_on) { nil }
+
+        it "doesn't cause an exception when the dates are the wrong way round" do
+          expect(subject.errors.messages.keys).to be_empty
         end
       end
     end

--- a/spec/services/teachers/resume_spec.rb
+++ b/spec/services/teachers/resume_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Teachers::Resume do
           it "raises an error" do
             expect {
               service.resume
-            }.to raise_error(ActiveRecord::StatementInvalid, /range lower bound must be less than or equal to range upper bound/)
+            }.to raise_error(ActiveRecord::RecordInvalid, /The end date must be later than the start date/)
           end
         end
 


### PR DESCRIPTION
The range check uses a database range to check for overlaps with siblings, which is simple and fast. However, if we try to construct an invalid range while building our sibling check query, it crashes with a `PG::DataException: ERROR: range lower bound must be less than or equal to range upper bound` error.

We should only perform the sibling check if the dates are in the right order and should fail validation rather than fail outright.
