### PR TITLE
Fix error when reporting a mentor leaving after their ECT's leaving date

### DIFF
--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -25,7 +25,9 @@ private
     destroy_unstarted_mentorship_periods!(period)
 
     period.mentorship_periods.ongoing_on(finished_on).each do |mentorship_period|
-      MentorshipPeriods::Finish.new(mentorship_period:, finished_on:, author:).finish!
+      effective_date = [finished_on, mentorship_period.mentee.finished_on].compact.min
+
+      MentorshipPeriods::Finish.new(mentorship_period:, finished_on: effective_date, author:).finish!
     end
   end
 

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -77,6 +77,50 @@ describe MentorAtSchoolPeriods::Finish do
       end
     end
 
+    context "when the mentor's leaving date is earlier than the ECT's leaving date" do
+      subject { MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: mentor_finished_on, author:, reported_by_school_id:) }
+
+      let(:mentor_finished_on) { finished_on + 1.month }
+      let(:ect_finished_on) { finished_on + 2.months }
+
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: mentor_at_school_period.school) }
+      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
+
+      before do
+        ect_at_school_period.update_column(:finished_on, ect_finished_on)
+      end
+
+      it "sets the mentorship period finished_on to the mentor's earlier leaving date" do
+        subject.finish_existing_at_school_periods!
+
+        expect(mentorship_period.reload.finished_on).to eq(mentor_finished_on)
+      end
+    end
+
+    context "when the ECT is already reported as leaving on an earlier date than the mentor's leaving date" do
+      subject { MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: mentor_finished_on, author:, reported_by_school_id:) }
+
+      let(:mentor_finished_on) { finished_on + 2.months }
+      let(:ect_finished_on) { finished_on + 1.month }
+
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: mentor_at_school_period.school) }
+      let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
+
+      before do
+        ect_at_school_period.update_column(:finished_on, ect_finished_on)
+      end
+
+      it "does not raise an error" do
+        expect { subject.finish_existing_at_school_periods! }.not_to raise_error
+      end
+
+      it "sets the mentorship period finished_on to the ECT's leaving date, not the mentor's" do
+        subject.finish_existing_at_school_periods!
+
+        expect(mentorship_period.reload.finished_on).to eq(ect_finished_on)
+      end
+    end
+
     it "finishes all the associated periods" do
       expect(training_period.finished_on).to be_nil
       expect(mentorship_period.finished_on).to be_nil


### PR DESCRIPTION
[Ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/3774)

Possibly fixed / relating to [#3740](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2616)

### Context
When reporting a mentor as leaving on a date after their ECT's leaving date, the service was trying to finish the mentorship period on the mentor's later date, which failed validation as it fell outside the ECT's school period.

The fix allows the earlier date to be used as the mentorship period's end date — the mentor's leaving date or the ECT's finished_on date

While this can't currently be reproduced through the UI, the data can exist from before [#3740](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2616), so the fix is a precaution.

### Changes proposed in this pull request
- Updates to `finish_mentorship_periods!` in app/services/mentor_at_school_periods/finish.rb and corresponding specs in spec/services/mentor_at_school_periods/finish_spec.rb

### Guidance to review
I haven't been able to reproduce this through the UI, but as the data can exist  from before #3740, this is a precautionary fix
