### PR TITLE
Fix overlapping training periods in transfer seeds

### DIFF
--- a/app/services/api_seed_data/teachers/school_transfers.rb
+++ b/app/services/api_seed_data/teachers/school_transfers.rb
@@ -27,12 +27,8 @@ module APISeedData
 
   private
 
-    def ect_teachers
-      @ect_teachers ||= Teacher.where.missing(:ect_at_school_periods).order("RANDOM()")
-    end
-
-    def mentor_teachers
-      @mentor_teachers ||= Teacher.where.missing(:mentor_at_school_periods).order("RANDOM()")
+    def available_teachers
+      @available_teachers ||= Teacher.where.missing(:ect_at_school_periods, :mentor_at_school_periods).order("RANDOM()")
     end
 
     def select_different_lead_provider(excluding_lead_providers: [])
@@ -41,8 +37,7 @@ module APISeedData
     end
 
     def select_random_teacher(excluding_teachers: [], type: :ect)
-      teachers = type == :ect ? ect_teachers : mentor_teachers
-      teacher = (teachers - excluding_teachers).sample.presence ||
+      teacher = (available_teachers - excluding_teachers).sample.presence ||
         FactoryBot.create(:teacher, :with_realistic_name, trn: Helpers::TRNGenerator.next)
       teacher.tap { @transferred_teachers[type] << it }
     end


### PR DESCRIPTION
Previously, when creating a transfer we will try and find an existing ECT or mentor with no ECT or mentor training periods, depending on the type of teacher we are using in the transfer.

This used to work because ECT and mentor school periods could have overlapping training periods, however #2616 tightened the validation here to prevent that.

The issue in the transfer seeds is that when setting up the training history for an ECT we just find an existing teacher with no ECT school periods so that we can add our own training history. If we happen to pick one with mentor training periods, we will often generate an overlapping training history.

To prevent this we can instead only use teachers with no training periods at all in the transfer scenarios (so we have a clean slate for each one). The seeds already fallback to creating a new teacher if there are no teachers available in this state.
