### PR TITLE
Fix change name event name

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -33,6 +33,7 @@ class Event < ApplicationRecord
     teacher_imported_from_trs
     teacher_induction_status_reset
     teacher_name_updated_by_trs
+    teacher_name_updated_by_user
     teacher_passes_induction
     teacher_registered_as_ect
     teacher_left_school_as_ect

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -180,6 +180,12 @@ module Events
       new(event_type:, author:, appropriate_body_period:, teacher:, heading:, happened_at:).record_event!
     end
 
+    def self.teacher_name_updated_by_user_event!(old_name:, new_name:, author:, teacher:, happened_at: Time.zone.now)
+      event_type = :teacher_name_updated_by_user
+      heading = TransitionDescription.for("name", from: old_name, to: new_name)
+      new(event_type:, author:, appropriate_body_period: nil, teacher:, heading:, happened_at:).record_event!
+    end
+
     def self.teacher_induction_status_changed_in_trs_event!(old_induction_status:, new_induction_status:, author:, teacher:, appropriate_body_period: nil, happened_at: Time.zone.now)
       event_type = :teacher_trs_induction_status_updated
       heading = TransitionDescription.for("induction_status", from: old_induction_status, to: new_induction_status)

--- a/app/wizards/schools/ects/change_name_wizard/check_answers_step.rb
+++ b/app/wizards/schools/ects/change_name_wizard/check_answers_step.rb
@@ -22,7 +22,7 @@ module Schools
       private
 
         def record_event(old_name, new_name)
-          ::Events::Record.teacher_name_changed_in_trs_event!(
+          ::Events::Record.teacher_name_updated_by_user_event!(
             old_name:,
             new_name:,
             author:,

--- a/app/wizards/schools/mentors/change_name_wizard/check_answers_step.rb
+++ b/app/wizards/schools/mentors/change_name_wizard/check_answers_step.rb
@@ -17,7 +17,7 @@ module Schools
       private
 
         def record_event(old_name, new_name)
-          ::Events::Record.teacher_name_changed_in_trs_event!(
+          ::Events::Record.teacher_name_updated_by_user_event!(
             old_name:,
             new_name:,
             author:,

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -390,7 +390,6 @@ RSpec.describe Events::Record do
         Events::Record.teacher_name_updated_by_user_event!(author:, teacher:, old_name:, new_name:)
         expect(RecordEventJob).to have_received(:perform_later).with(
           teacher:,
-          appropriate_body_period: nil,
           heading: "Name changed from 'Wilfred Bramble' to 'Willy Brambs'",
           event_type: :teacher_name_updated_by_user,
           happened_at: Time.zone.now,

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -381,6 +381,25 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".teacher_name_updated_by_user_event!" do
+    let(:old_name) { "Wilfred Bramble" }
+    let(:new_name) { "Willy Brambs" }
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        Events::Record.teacher_name_updated_by_user_event!(author:, teacher:, old_name:, new_name:)
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          teacher:,
+          appropriate_body_period: nil,
+          heading: "Name changed from 'Wilfred Bramble' to 'Willy Brambs'",
+          event_type: :teacher_name_updated_by_user,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe ".teacher_induction_status_changed_in_trs_event!" do
     let(:old_induction_status) { "InProgress" }
     let(:new_induction_status) { "Exempt" }

--- a/spec/wizards/schools/ects/change_name_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_name_wizard/check_answers_step_spec.rb
@@ -27,8 +27,14 @@ RSpec.describe Schools::ECTs::ChangeNameWizard::CheckAnswersStep, type: :model d
       expect { current_step.save! }.to change(wizard.ect_at_school_period.teacher, :corrected_name).from(nil).to("Terry Pratchett")
     end
 
-    it "records an event" do
-      expect { current_step.save! }.to have_enqueued_job(RecordEventJob)
+    it "records a teacher_name_updated_by_user event" do
+      expect(Events::Record).to receive(:teacher_name_updated_by_user_event!).with(
+        old_name: anything,
+        new_name: "Terry Pratchett",
+        author:,
+        teacher: ect_at_school_period.teacher
+      )
+      current_step.save!
     end
   end
 end

--- a/spec/wizards/schools/mentors/change_name_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_name_wizard/check_answers_step_spec.rb
@@ -27,8 +27,14 @@ RSpec.describe Schools::Mentors::ChangeNameWizard::CheckAnswersStep, type: :mode
       expect { current_step.save! }.to change(wizard.mentor_at_school_period.teacher, :corrected_name).from(nil).to("Terry Pratchett")
     end
 
-    it "records an event" do
-      expect { current_step.save! }.to have_enqueued_job(RecordEventJob)
+    it "records a teacher_name_updated_by_user event" do
+      expect(Events::Record).to receive(:teacher_name_updated_by_user_event!).with(
+        old_name: anything,
+        new_name: "Terry Pratchett",
+        author:,
+        teacher: mentor_at_school_period.teacher
+      )
+      current_step.save!
     end
   end
 end


### PR DESCRIPTION
### Context
This [ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/2742) 
When a school user manually corrects an ECT or mentor's name, the event recorded was teacher_name_updated_by_trs, implying the change originated from TRS. This was misleading and possibly added in error

### Changes proposed in this pull request
- Adds `teacher_name_updated_by_user` to `Event::EVENT_TYPES`
- Adds `Events::Record.teacher_name_updated_by_user_event!` method to sit alongside the existing `teacher_name_changed_in_trs_event!`
- Updates both `Schools::ECTs::ChangeNameWizard::CheckAnswersStep` and `Schools::Mentors::ChangeNameWizard::CheckAnswersStep` to call the new method
- Tightens the existing specs to assert the correct event type, rather than just that a RecordEventJob was enqueued

### Guidance to review
To verify the fix, trigger a name change as a school user for both an ECT and a mentor, then check the event log to confirm the event type shows `teacher_name_updated_by_user` rather than `teacher_name_updated_by_trs`
