### PR TITLE
Migrate last contract periods correctly

### DIFF
--- a/app/migration/migrators/contract_period.rb
+++ b/app/migration/migrators/contract_period.rb
@@ -48,7 +48,7 @@ module Migrators
     def finished_on_for(cohort)
       next_cohort = cohort.next
 
-      return cohort.registration_start_date.next_year.prev_day if next_cohort.blank?
+      return cohort.registration_start_date.next_year.prev_month.end_of_month if next_cohort.blank?
 
       next_cohort.registration_start_date.prev_day
     end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3814

### Changes proposed in this pull request

The 2025 contract period started on 16th June 2025.

Currently we are migrating the 2025 contract period so that it ends on 15th June 2026.

We want the 2025 contract period to end on 31st May 2026.

This updates the migrator for cohorts so this happens.

### Guidance to review

- [ ] Check dates on migration once it's merged and has run
