### PR TITLE
[3746] Stop erasing schedule changes on defer/withdraw

### DIFF
--- a/app/services/api/teachers/defer.rb
+++ b/app/services/api/teachers/defer.rb
@@ -55,9 +55,8 @@ module API::Teachers
     def training_for_at_least_one_day
       return if errors[:teacher_api_id].any?
       return unless training_period&.started_on&.today?
-      return if training_period.predecessors.any? { it.lead_provider.id == lead_provider_id }
 
-      errors.add(:teacher_api_id, "You cannot defer #/teacher_api_id. This is because they have not been training with you for at least one day.")
+      errors.add(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.")
     end
   end
 end

--- a/app/services/api/teachers/withdraw.rb
+++ b/app/services/api/teachers/withdraw.rb
@@ -46,9 +46,8 @@ module API::Teachers
     def training_for_at_least_one_day
       return if errors[:teacher_api_id].any?
       return unless training_period&.started_on&.today?
-      return if training_period.predecessors.any? { it.lead_provider.id == lead_provider_id }
 
-      errors.add(:teacher_api_id, "You cannot withdraw #/teacher_api_id. This is because they have not been training with you for at least one day.")
+      errors.add(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.")
     end
   end
 end

--- a/app/services/teachers/defer.rb
+++ b/app/services/teachers/defer.rb
@@ -11,8 +11,6 @@ module Teachers
     end
 
     def defer
-      rollback_redundant_training_period!
-
       ActiveRecord::Base.transaction do
         training_period.deferred_at = Time.zone.now
         training_period.deferral_reason = reason.underscore
@@ -26,20 +24,6 @@ module Teachers
     end
 
   private
-
-    def rollback_redundant_training_period!
-      return unless training_period.started_on.today? && previous_training_period_for_lead_provider
-
-      training_period.destroy!
-      @training_period = previous_training_period_for_lead_provider
-    end
-
-    def previous_training_period_for_lead_provider
-      @previous_training_period_for_lead_provider ||= training_period
-        .predecessors
-        .latest_first
-        .find { it.lead_provider == lead_provider }
-    end
 
     def record_deferred_event!
       return unless training_period.saved_changes?

--- a/app/services/teachers/withdraw.rb
+++ b/app/services/teachers/withdraw.rb
@@ -11,8 +11,6 @@ module Teachers
     end
 
     def withdraw
-      rollback_redundant_training_period!
-
       ActiveRecord::Base.transaction do
         training_period.withdrawn_at = Time.zone.now
         training_period.withdrawal_reason = reason.underscore
@@ -26,20 +24,6 @@ module Teachers
     end
 
   private
-
-    def rollback_redundant_training_period!
-      return unless training_period.started_on.today? && previous_training_period_for_lead_provider
-
-      training_period.destroy!
-      @training_period = previous_training_period_for_lead_provider
-    end
-
-    def previous_training_period_for_lead_provider
-      @previous_training_period_for_lead_provider ||= training_period
-        .predecessors
-        .latest_first
-        .find { it.lead_provider == lead_provider }
-    end
 
     def record_withdraw_event!
       return unless training_period.saved_changes?

--- a/spec/services/api/teachers/defer_spec.rb
+++ b/spec/services/api/teachers/defer_spec.rb
@@ -69,12 +69,13 @@ RSpec.describe API::Teachers::Defer, type: :model do
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", "#{trainee_type}_at_school_period": at_school_period, started_on: Time.zone.today) }
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot defer #/teacher_api_id. This is because they have not been training with you for at least one day.") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.") }
 
             context "when an earlier training period exists for the lead provider" do
               let!(:previous_training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", "#{trainee_type}_at_school_period": at_school_period, school_partnership: training_period.school_partnership, started_on: 3.days.ago, finished_on: 1.day.ago) }
 
-              it { is_expected.to be_valid }
+              it { is_expected.to have_one_error_per_attribute }
+              it { is_expected.to have_error(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.") }
             end
           end
 

--- a/spec/services/api/teachers/withdraw_spec.rb
+++ b/spec/services/api/teachers/withdraw_spec.rb
@@ -62,12 +62,13 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
             let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", "#{trainee_type}_at_school_period": at_school_period, started_on: Time.zone.today) }
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot withdraw #/teacher_api_id. This is because they have not been training with you for at least one day.") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.") }
 
             context "when an earlier training period exists for the lead provider" do
               let!(:previous_training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", "#{trainee_type}_at_school_period": at_school_period, school_partnership: training_period.school_partnership, started_on: 3.days.ago, finished_on: 1.day.ago) }
 
-              it { is_expected.to be_valid }
+              it { is_expected.to have_one_error_per_attribute }
+              it { is_expected.to have_error(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.") }
             end
           end
 

--- a/spec/services/teachers/defer_spec.rb
+++ b/spec/services/teachers/defer_spec.rb
@@ -83,41 +83,6 @@ RSpec.describe Teachers::Defer do
           end
         end
 
-        context "when training period starts today and there is a previous training period" do
-          let!(:previous_training_period) do
-            FactoryBot.create(
-              :training_period,
-              :"for_#{trainee_type}",
-              :withdrawn,
-              "#{trainee_type}_at_school_period": at_school_period,
-              school_partnership: training_period.school_partnership,
-              started_on: 5.months.ago,
-              finished_on: 1.month.ago
-            )
-          end
-          let!(:training_period) do
-            FactoryBot.create(
-              :training_period,
-              :"for_#{trainee_type}",
-              :ongoing,
-              "#{trainee_type}_at_school_period": at_school_period,
-              started_on: Time.zone.today
-            )
-          end
-
-          it "destroys the redundant training period and defers the previous one" do
-            freeze_time
-
-            expect(service.defer).not_to be(false)
-
-            expect(TrainingPeriod).not_to exist(training_period.id)
-
-            previous_training_period.reload
-            expect(previous_training_period.deferred_at).to eq(Time.zone.now)
-            expect(previous_training_period.deferral_reason.dasherize).to eq(reason)
-          end
-        end
-
         context "event recording" do
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 

--- a/spec/services/teachers/withdraw_spec.rb
+++ b/spec/services/teachers/withdraw_spec.rb
@@ -83,41 +83,6 @@ RSpec.describe Teachers::Withdraw do
           end
         end
 
-        context "when training period starts today and there is a previous training period" do
-          let!(:previous_training_period) do
-            FactoryBot.create(
-              :training_period,
-              :"for_#{trainee_type}",
-              :deferred,
-              "#{trainee_type}_at_school_period": at_school_period,
-              school_partnership: training_period.school_partnership,
-              started_on: 5.months.ago,
-              finished_on: 1.month.ago
-            )
-          end
-          let!(:training_period) do
-            FactoryBot.create(
-              :training_period,
-              :"for_#{trainee_type}",
-              :ongoing,
-              "#{trainee_type}_at_school_period": at_school_period,
-              started_on: Time.zone.today
-            )
-          end
-
-          it "destroys the redundant training period and withdraws the previous one" do
-            freeze_time
-
-            expect(service.withdraw).not_to be(false)
-
-            expect(TrainingPeriod).not_to exist(training_period.id)
-
-            previous_training_period.reload
-            expect(previous_training_period.withdrawn_at).to eq(Time.zone.now)
-            expect(previous_training_period.withdrawal_reason.dasherize).to eq(reason)
-          end
-        end
-
         context "event recording" do
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3746

### Changes proposed in this pull request

- `Teachers::Defer` and `Teachers::Withdraw`: removed `rollback_redundant_training_period!` and the `previous_training_period_for_lead_provider` helper. Services no longer mutate training periods outside the one they were given.
- `API::Teachers::Defer` and `API::Teachers::Withdraw`: `training_for_at_least_one_day` now always errors when the training period started today (previously bypassed when predecessors existed for the LP). New error message per ticket:
  > You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.
- Service specs: removed the "destroys the redundant training period" contexts.
- API validator specs: flipped the "earlier training period exists" context to expect the new validation error.

### Guidance to review
