### PR TITLE
Move `school_funding_eligibilities` columns out of analytics blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -141,6 +141,14 @@ shared:
     - induction_tutor_email
     - api_id
     - marked_as_eligible
+  :school_funding_eligibilities:
+    - id
+    - school_urn
+    - contract_period_year
+    - pupil_premium_uplift
+    - sparsity_uplift
+    - created_at
+    - updated_at
   :school_partnerships:
     - id
     - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -503,11 +503,3 @@
   - ecf_id
   :lead_provider_delivery_partnerships:
   - ecf_id
-  :school_funding_eligibilities:
-  - id
-  - school_urn
-  - contract_period_year
-  - pupil_premium_uplift
-  - sparsity_uplift
-  - created_at
-  - updated_at


### PR DESCRIPTION
### Summary

Requested by the D&I team, we are moving the following columns out of the blocklist:

```yml
  :school_funding_eligibilities:
  - id
  - school_urn
  - contract_period_year
  - pupil_premium_uplift
  - sparsity_uplift
  - created_at
  - updated_at
 ```
