### PR TITLE
Return a single boolean value after migrating an ECT/Mentor on second attempt.

### DIFF
--- a/app/migration/migrators/ect.rb
+++ b/app/migration/migrators/ect.rb
@@ -38,7 +38,7 @@ module Migrators
       # success, fall back to economy (latest_induction_records)
       return success if success || migration_mode == :latest_induction_records
 
-      migrate_one_second_attempt(teacher_profile)
+      migrate_one_second_attempt(teacher_profile).first
     end
 
   private

--- a/app/migration/migrators/mentor.rb
+++ b/app/migration/migrators/mentor.rb
@@ -31,9 +31,12 @@ module Migrators
     # success, fall back to economy (latest_induction_records)
     def migrate_one!(teacher_profile)
       success, migration_mode = migrate_one_first_attempt(teacher_profile)
+
+      # if we have tried premium (all_induction_records) and it wasn't a
+      # success, fall back to economy (latest_induction_records)
       return success if success || migration_mode == :latest_induction_records
 
-      migrate_one_second_attempt(teacher_profile)
+      migrate_one_second_attempt(teacher_profile).first
     end
 
   private

--- a/spec/migration/migrators/ect_spec.rb
+++ b/spec/migration/migrators/ect_spec.rb
@@ -61,12 +61,13 @@ RSpec.describe Migrators::ECT do
       FactoryBot.create(:migration_participant_profile, :ect, teacher_profile:, user: teacher_profile.user, participant_identity:)
 
       migrator = Migrators::ECT.new
-      migrator.migrate_one!(teacher_profile)
+      result = migrator.migrate_one!(teacher_profile)
 
       expect(TeacherHistoryConverter).to have_received(:new).twice
       expect(economy_fake_converter).to have_received(:convert_to_ecf2!).once
       expect(premium_fake_converter).to have_received(:convert_to_ecf2!).once
       expect(fake_ecf2_teacher_history).to have_received(:save_all_ect_data!).twice
+      expect(result).to be_falsey
     end
   end
 


### PR DESCRIPTION
### Context

We are having a few combination failures on `latest_indunction_records` (economy) mode.
That should make their associated ECT or mentor to fully fail migration.

However, we currently have 100% migration on both ECTs and Mentors.
That can't be possible. At least the teachers associated to those failed combinations should be flagged as failures in the migration UI and the percentage decrease a bit down from 100%.

### Changes proposed in this pull request

Attempt methods to migrate and ECT or mentor currently return an array `[success?, migration_mode]`.
The `migrate_one` method calling those methods is handling correctly the value to be returned to `migrate!` for the first attempt but not the second.

This PR will fix that to return only `success?` value and not the whole array.

### Guidance to review
