### PR TITLE
Fix `api_updated_at` migration from ECF

### DIFF
--- a/db/scripts/fix_schools_api_updated_at.rb
+++ b/db/scripts/fix_schools_api_updated_at.rb
@@ -2,15 +2,39 @@
 # api_updated_at is pulled across from ECF.
 
 Metadata::SchoolContractPeriod.bypass_update_restrictions do
-  school_cohort_updated_at_by_school_urn = Migration::SchoolCohort
-    .joins(:cohort, :school)
-    .pluck("cohorts.start_year, schools.urn, school_cohorts.updated_at, schools.updated_at")
-    .each_with_object(Hash.new { |hash, key| hash[key] = {} }) do |(cohort_start_year, school_urn, school_cohort_updated_at, school_updated_at), hash|
-      hash[school_urn][cohort_start_year] = [school_cohort_updated_at, school_updated_at].max
+  all_years = Migration::Cohort.pluck(:start_year)
+
+  ecf_updated_at_by_urn = Migration::School
+    .left_joins(school_cohorts: :cohort)
+    .pluck(
+      "schools.urn",
+      "cohorts.start_year",
+      "school_cohorts.updated_at",
+      "schools.updated_at"
+    )
+    .group_by { |urn, _, _, _| urn } # Group by school URN.
+    .transform_values do |rows|
+      # Get the school's updated_at timestamp (it's the same for all rows)
+      # so we just grab the first.
+      school_updated_at = rows.first[3]
+
+      # Ensure we have an entry for all cohort years.
+      all_years.index_with do |year|
+        # Find the row for the current year, if it exists.
+        match = rows.find { |_, y, _, _| y == year }
+
+        # If it exists, take the max of the school's updated_at and the school_cohort's updated_at.
+        if match
+          [match[2], school_updated_at].max
+        else
+          # If it doesn't exist, just use the school's updated_at.
+          school_updated_at
+        end
+      end
     end
 
   School.includes(:contract_period_metadata).find_each do |school|
-    school_cohort_updated_at_by_school_urn.fetch(school.urn.to_s, {}).each do |contract_period_year, school_cohort_updated_at|
+    ecf_updated_at_by_urn.fetch(school.urn.to_s, {}).each do |contract_period_year, school_cohort_updated_at|
       metadata = school.contract_period_metadata.find { it.contract_period_year == contract_period_year }
       metadata.update!(api_updated_at: school_cohort_updated_at)
     end


### PR DESCRIPTION
The previous query had an issue; if a `SchoolCohort` doesn't exist the `api_updated_at` would be set to the default/migration date.

Query on `School` rather than `SchoolCohort` to ensure all schools are covered and fill in dates for cohorts when there is no `SchoolCohort`.

Tested on parity check env.