### PR TITLE
Prevent 2021 and 2022 cohort ongoing periods

### DIFF
--- a/app/migration/teacher_history_converter/cleaner.rb
+++ b/app/migration/teacher_history_converter/cleaner.rb
@@ -48,7 +48,7 @@ private
       .then { close_ongoing_records_after_induction_completion(it) }
       .then { remove_records_with_matching_withdrawn_and_deferred_states(it) }
       .then { remove_2021_and_2022_cohort_ect_records_starting_after_cohort_closure(it) }
-      .then { close_2021_and_2022_cohort_records_ongoing_or_ending_after_cohort_closure(it) }
+      .then { close_2021_and_2022_cohort_ect_records_ending_after_cohort_closure(it) }
   end
 
   def remove_british_schools_overseas(induction_records)
@@ -111,7 +111,7 @@ private
     TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure.new(induction_records, participant_type).induction_records
   end
 
-  def close_2021_and_2022_cohort_records_ongoing_or_ending_after_cohort_closure(induction_records)
-    induction_records
+  def close_2021_and_2022_cohort_ect_records_ending_after_cohort_closure(induction_records)
+    TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterThanCohortClosure.new(induction_records, participant_type).induction_records
   end
 end

--- a/app/migration/teacher_history_converter/cleaner.rb
+++ b/app/migration/teacher_history_converter/cleaner.rb
@@ -47,6 +47,8 @@ private
       .then { remove_post_induction_completion_records(it) }
       .then { close_ongoing_records_after_induction_completion(it) }
       .then { remove_records_with_matching_withdrawn_and_deferred_states(it) }
+      .then { remove_2021_and_2022_cohort_ect_records_starting_after_cohort_closure(it) }
+      .then { close_2021_and_2022_cohort_records_ongoing_or_ending_after_cohort_closure(it) }
   end
 
   def remove_british_schools_overseas(induction_records)
@@ -103,5 +105,13 @@ private
 
   def close_ongoing_records_after_induction_completion(induction_records)
     TeacherHistoryConverter::Cleaner::CloseOngoingRecordsAfterInductionCompletion.new(induction_records, induction_completion_date:).induction_records
+  end
+
+  def remove_2021_and_2022_cohort_ect_records_starting_after_cohort_closure(induction_records)
+    TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure.new(induction_records, participant_type).induction_records
+  end
+
+  def close_2021_and_2022_cohort_records_ongoing_or_ending_after_cohort_closure(induction_records)
+    induction_records
   end
 end

--- a/app/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure.rb
+++ b/app/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure.rb
@@ -1,0 +1,34 @@
+class TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterThanCohortClosure
+  include TeacherHistoryConverter::Cleaner::CohortCutOffDates
+
+  def initialize(raw_induction_records, participant_type)
+    @raw_induction_records = raw_induction_records
+    @participant_type = participant_type
+  end
+
+  def induction_records
+    return @raw_induction_records unless ect?
+
+    close_post_cohort_closure_ending_records!
+  end
+
+private
+
+  def ect?
+    @participant_type == :ect
+  end
+
+  def close_post_cohort_closure_ending_records!
+    @raw_induction_records.each do |induction_record|
+      if needs_end_date_change?(induction_record:, cohort_year: 2021, cutoff_date: COHORT_2021_CUTOFF_DATE)
+        induction_record.end_date = COHORT_2021_CUTOFF_DATE
+      elsif needs_end_date_change?(induction_record:, cohort_year: 2022, cutoff_date: COHORT_2022_CUTOFF_DATE)
+        induction_record.end_date = COHORT_2022_CUTOFF_DATE
+      end
+    end
+  end
+
+  def needs_end_date_change?(induction_record:, cohort_year:, cutoff_date:)
+    induction_record.cohort_year == cohort_year && (induction_record.end_date.blank? || induction_record.end_date > cutoff_date)
+  end
+end

--- a/app/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure.rb
+++ b/app/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure.rb
@@ -1,5 +1,7 @@
 class TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterThanCohortClosure
-  include TeacherHistoryConverter::Cleaner::CohortCutOffDates
+  # NOTE: this assumes that the `RemoveECTInductionRecordsStartingLaterThanCohortClosure` cleaner
+  # has been run before this one, so there are no induction_records present with a start_date
+  # later than the cohort closure date
 
   def initialize(raw_induction_records, participant_type)
     @raw_induction_records = raw_induction_records
@@ -20,15 +22,14 @@ private
 
   def close_post_cohort_closure_ending_records!
     @raw_induction_records.each do |induction_record|
-      if needs_end_date_change?(induction_record:, cohort_year: 2021, cutoff_date: COHORT_2021_CUTOFF_DATE)
-        induction_record.end_date = COHORT_2021_CUTOFF_DATE
-      elsif needs_end_date_change?(induction_record:, cohort_year: 2022, cutoff_date: COHORT_2022_CUTOFF_DATE)
-        induction_record.end_date = COHORT_2022_CUTOFF_DATE
-      end
+      cut_off_date = cut_off_dates.cut_off_date_for(cohort_year: induction_record.cohort_year)
+      next if cut_off_date.blank?
+
+      induction_record.end_date = cut_off_date if induction_record.end_date.blank? || induction_record.end_date > cut_off_date
     end
   end
 
-  def needs_end_date_change?(induction_record:, cohort_year:, cutoff_date:)
-    induction_record.cohort_year == cohort_year && (induction_record.end_date.blank? || induction_record.end_date > cutoff_date)
+  def cut_off_dates
+    @cut_off_dates ||= TeacherHistoryConverter::CohortCutOffDate.new
   end
 end

--- a/app/migration/teacher_history_converter/cleaner/cohort_cut_off_dates.rb
+++ b/app/migration/teacher_history_converter/cleaner/cohort_cut_off_dates.rb
@@ -1,0 +1,4 @@
+module TeacherHistoryConverter::Cleaner::CohortCutOffDates
+  COHORT_2021_CUTOFF_DATE = Date.new(2024, 7, 31)
+  COHORT_2022_CUTOFF_DATE = Date.new(2025, 7, 31)
+end

--- a/app/migration/teacher_history_converter/cleaner/cohort_cut_off_dates.rb
+++ b/app/migration/teacher_history_converter/cleaner/cohort_cut_off_dates.rb
@@ -1,4 +1,0 @@
-module TeacherHistoryConverter::Cleaner::CohortCutOffDates
-  COHORT_2021_CUTOFF_DATE = Date.new(2024, 7, 31)
-  COHORT_2022_CUTOFF_DATE = Date.new(2025, 7, 31)
-end

--- a/app/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure.rb
+++ b/app/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure.rb
@@ -1,0 +1,27 @@
+class TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure
+  include TeacherHistoryConverter::Cleaner::CohortCutOffDates
+
+  def initialize(raw_induction_records, participant_type)
+    @raw_induction_records = raw_induction_records
+    @participant_type = participant_type
+  end
+
+  def induction_records
+    return @raw_induction_records unless ect?
+
+    remove_post_cohort_closure_records!
+  end
+
+private
+
+  def ect?
+    @participant_type == :ect
+  end
+
+  def remove_post_cohort_closure_records!
+    @raw_induction_records.reject do |induction_record|
+      (induction_record.cohort_year == 2021 && induction_record.start_date >= COHORT_2021_CUTOFF_DATE) ||
+        (induction_record.cohort_year == 2022 && induction_record.start_date >= COHORT_2022_CUTOFF_DATE)
+    end
+  end
+end

--- a/app/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure.rb
+++ b/app/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure.rb
@@ -1,6 +1,4 @@
 class TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure
-  include TeacherHistoryConverter::Cleaner::CohortCutOffDates
-
   def initialize(raw_induction_records, participant_type)
     @raw_induction_records = raw_induction_records
     @participant_type = participant_type
@@ -20,8 +18,13 @@ private
 
   def remove_post_cohort_closure_records!
     @raw_induction_records.reject do |induction_record|
-      (induction_record.cohort_year == 2021 && induction_record.start_date >= COHORT_2021_CUTOFF_DATE) ||
-        (induction_record.cohort_year == 2022 && induction_record.start_date >= COHORT_2022_CUTOFF_DATE)
+      cut_off_date = cut_off_dates.cut_off_date_for(cohort_year: induction_record.cohort_year)
+
+      cut_off_date.present? && induction_record.start_date >= cut_off_date
     end
+  end
+
+  def cut_off_dates
+    @cut_off_dates ||= TeacherHistoryConverter::CohortCutOffDate.new
   end
 end

--- a/app/migration/teacher_history_converter/cohort_cut_off_date.rb
+++ b/app/migration/teacher_history_converter/cohort_cut_off_date.rb
@@ -1,0 +1,13 @@
+class TeacherHistoryConverter::CohortCutOffDate
+  COHORT_2021_CUTOFF_DATE = Date.new(2024, 7, 31)
+  COHORT_2022_CUTOFF_DATE = Date.new(2025, 7, 31)
+
+  def cut_off_date_for(cohort_year:)
+    case cohort_year
+    when 2021
+      Date.new(2024, 7, 31)
+    when 2022
+      Date.new(2025, 7, 31)
+    end
+  end
+end

--- a/app/migration/teacher_history_converter/mentor/all_induction_records.rb
+++ b/app/migration/teacher_history_converter/mentor/all_induction_records.rb
@@ -106,13 +106,17 @@ private
         @current_training_period.deferral_reason = deferral_data[:deferral_reason]
       end
 
-      @current_training_period.finished_on = mentor_finished_on(
+      finished_on = mentor_finished_on(
         start_date: started_on,
         end_date: finished_on,
         withdrawal_date: withdrawal_data[:withdrawn_at]&.to_date,
         deferral_date: deferral_data[:deferred_at]&.to_date,
         mentor_completion_date:
       )
+
+      cohort_cut_off_date = cut_off_dates.cut_off_date_for(cohort_year: induction_record.cohort_year)
+
+      @current_training_period.finished_on = [finished_on, cohort_cut_off_date].compact.min
     end
   end
 
@@ -131,15 +135,17 @@ private
     lead_provider_id = induction_record.training_provider_info.lead_provider_info.ecf1_id
     withdrawal_data = withdrawal_data(state_changed_at:, lead_provider_id:)
     deferral_data = deferral_data(state_changed_at:, lead_provider_id:)
+    cohort_cut_off_date = cut_off_dates.cut_off_date_for(cohort_year: induction_record.cohort_year)
 
     if overrides[:finished_on].blank?
-      overrides[:finished_on] = mentor_finished_on(
+      finished_on = mentor_finished_on(
         start_date: induction_record.start_date,
         end_date: induction_record.end_date,
         withdrawal_date: withdrawal_data[:withdrawn_at]&.to_date,
         deferral_date: deferral_data[:deferred_at]&.to_date,
         mentor_completion_date:
       )
+      overrides[:finished_on] = [finished_on, cohort_cut_off_date].compact.min
     end
 
     training_attrs = {
@@ -264,6 +270,9 @@ private
     lead_provider = induction_record.training_provider_info&.lead_provider_info
     return false if lead_provider.blank?
 
+    cohort_cut_off_date = cut_off_dates.cut_off_date_for(cohort_year: induction_record.cohort_year)
+    return false if cohort_cut_off_date.present? && induction_record.start_date >= cohort_cut_off_date
+
     if mentor_completion_date.present? && induction_record.start_date >= mentor_completion_date
       combo_checker.keep?(profile_id:,
                           lead_provider_id: lead_provider.ecf1_id,
@@ -277,5 +286,9 @@ private
 
   def combo_checker
     @combo_checker ||= TeacherHistoryConverter::PostMentorCompletionComboCheck.new
+  end
+
+  def cut_off_dates
+    @cut_off_dates ||= TeacherHistoryConverter::CohortCutOffDate.new
   end
 end

--- a/spec/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure_spec.rb
@@ -1,9 +1,6 @@
 describe TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterThanCohortClosure do
   subject(:cleaner) { described_class.new(raw_induction_records, participant_type) }
 
-  # let(:cohort_2021_cut_off) { TeacherHistoryConverter::CohortCutOffDates::COHORT_2021_CUTOFF_DATE }
-  # let(:cohort_2022_cut_off) { TeacherHistoryConverter::CohortCutOffDates::COHORT_2022_CUTOFF_DATE }
-
   describe "#induction_records" do
     let(:cut_off_date) { TeacherHistoryConverter::CohortCutOffDate.new.cut_off_date_for(cohort_year:) }
     let(:end_date) { cut_off_date + 1.week }

--- a/spec/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure_spec.rb
@@ -1,0 +1,81 @@
+describe TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterThanCohortClosure do
+  subject(:cleaner) { described_class.new(raw_induction_records, participant_type) }
+
+  let(:cohort_2021_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2021_CUTOFF_DATE }
+  let(:cohort_2022_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2022_CUTOFF_DATE }
+
+  describe "#induction_records" do
+    let(:end_date) { cohort_2021_cut_off + 1.week }
+    let(:cohort_year) { 2021 }
+
+    let(:participant_type) { :ect }
+
+    let(:induction_record_1) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2021, 9, 1),
+        end_date: Date.new(2022, 3, 15),
+        cohort_year:
+      )
+    end
+    let(:induction_record_2) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2022, 6, 1),
+        end_date: Date.new(2023, 3, 31),
+        cohort_year:
+      )
+    end
+    let(:induction_record_3) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2023, 4, 1),
+        end_date:,
+        cohort_year:
+      )
+    end
+    let(:raw_induction_records) { [induction_record_1, induction_record_2, induction_record_3] }
+
+    it "sets the end_date of induction records that end after the cut-off date" do
+      expect(cleaner.induction_records.last.end_date).to eq(cohort_2021_cut_off)
+    end
+
+    it "does not change induction records that do not end after the cut-off date" do
+      expect(cleaner.induction_records.first.end_date).to eq(Date.new(2022, 3, 15))
+      expect(cleaner.induction_records.second.end_date).to eq(Date.new(2023, 3, 31))
+    end
+
+    context "when the end_date is not set" do
+      let(:end_date) { nil }
+
+      it "sets the end_date of induction records that end after the cut-off date" do
+        expect(cleaner.induction_records.last.end_date).to eq(cohort_2021_cut_off)
+      end
+    end
+
+    context "when the cohort is 2022" do
+      let(:end_date) { cohort_2022_cut_off + 1.week }
+      let(:cohort_year) { 2022 }
+
+      it "sets the end_date of induction records that end after the cut-off date" do
+        expect(cleaner.induction_records.last.end_date).to eq(cohort_2022_cut_off)
+      end
+
+      context "when the end_date is not set" do
+        let(:end_date) { nil }
+
+        it "sets the end_date of induction records that end after the cut-off date" do
+          expect(cleaner.induction_records.last.end_date).to eq(cohort_2022_cut_off)
+        end
+      end
+    end
+
+    context "when the participant_type is a Mentor" do
+      let(:participant_type) { :mentor }
+
+      it "does not remove any records" do
+        expect(cleaner.induction_records).to match_array raw_induction_records
+      end
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/close_ect_induction_records_ending_later_than_cohort_closure_spec.rb
@@ -1,11 +1,12 @@
 describe TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterThanCohortClosure do
   subject(:cleaner) { described_class.new(raw_induction_records, participant_type) }
 
-  let(:cohort_2021_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2021_CUTOFF_DATE }
-  let(:cohort_2022_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2022_CUTOFF_DATE }
+  # let(:cohort_2021_cut_off) { TeacherHistoryConverter::CohortCutOffDates::COHORT_2021_CUTOFF_DATE }
+  # let(:cohort_2022_cut_off) { TeacherHistoryConverter::CohortCutOffDates::COHORT_2022_CUTOFF_DATE }
 
   describe "#induction_records" do
-    let(:end_date) { cohort_2021_cut_off + 1.week }
+    let(:cut_off_date) { TeacherHistoryConverter::CohortCutOffDate.new.cut_off_date_for(cohort_year:) }
+    let(:end_date) { cut_off_date + 1.week }
     let(:cohort_year) { 2021 }
 
     let(:participant_type) { :ect }
@@ -37,7 +38,7 @@ describe TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterTh
     let(:raw_induction_records) { [induction_record_1, induction_record_2, induction_record_3] }
 
     it "sets the end_date of induction records that end after the cut-off date" do
-      expect(cleaner.induction_records.last.end_date).to eq(cohort_2021_cut_off)
+      expect(cleaner.induction_records.last.end_date).to eq(cut_off_date)
     end
 
     it "does not change induction records that do not end after the cut-off date" do
@@ -49,23 +50,22 @@ describe TeacherHistoryConverter::Cleaner::CloseECTInductionRecordsEndingLaterTh
       let(:end_date) { nil }
 
       it "sets the end_date of induction records that end after the cut-off date" do
-        expect(cleaner.induction_records.last.end_date).to eq(cohort_2021_cut_off)
+        expect(cleaner.induction_records.last.end_date).to eq(cut_off_date)
       end
     end
 
     context "when the cohort is 2022" do
-      let(:end_date) { cohort_2022_cut_off + 1.week }
       let(:cohort_year) { 2022 }
 
       it "sets the end_date of induction records that end after the cut-off date" do
-        expect(cleaner.induction_records.last.end_date).to eq(cohort_2022_cut_off)
+        expect(cleaner.induction_records.last.end_date).to eq(cut_off_date)
       end
 
       context "when the end_date is not set" do
         let(:end_date) { nil }
 
         it "sets the end_date of induction records that end after the cut-off date" do
-          expect(cleaner.induction_records.last.end_date).to eq(cohort_2022_cut_off)
+          expect(cleaner.induction_records.last.end_date).to eq(cut_off_date)
         end
       end
     end

--- a/spec/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure_spec.rb
@@ -1,0 +1,61 @@
+describe TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure do
+  subject(:cleaner) { described_class.new(raw_induction_records, participant_type) }
+
+  let(:cohort_2021_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2021_CUTOFF_DATE }
+  let(:cohort_2022_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2022_CUTOFF_DATE }
+
+  describe "#induction_records" do
+    let(:start_date) { cohort_2021_cut_off + 1.week }
+    let(:cohort_year) { 2021 }
+
+    let(:participant_type) { :ect }
+
+    let(:induction_record_1) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2021, 9, 1),
+        end_date: Date.new(2022, 3, 15),
+        cohort_year:
+      )
+    end
+    let(:induction_record_2) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date: Date.new(2022, 6, 1),
+        end_date: start_date,
+        cohort_year:
+      )
+    end
+    let(:induction_record_3) do
+      FactoryBot.build(
+        :ecf1_teacher_history_induction_record_row,
+        start_date:,
+        end_date: start_date + 1.year,
+        cohort_year:
+      )
+    end
+    let(:raw_induction_records) { [induction_record_1, induction_record_2, induction_record_3] }
+
+    it "removes induction records that start after the cut off date" do
+      expect(cleaner.induction_records).to contain_exactly(induction_record_1, induction_record_2)
+    end
+
+    context "when the cohort is 2022" do
+      let(:start_date) { cohort_2022_cut_off + 1.week }
+      let(:cohort_year) { 2022 }
+
+      it "removes induction records that start after the cut off date" do
+        expect(cleaner.induction_records).to contain_exactly(induction_record_1, induction_record_2)
+      end
+
+    end
+
+    context "when the participant_type is a Mentor" do
+      let(:participant_type) { :mentor }
+
+      it "does not remove any records" do
+        expect(cleaner.induction_records).to match_array raw_induction_records
+      end
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure_spec.rb
@@ -47,7 +47,6 @@ describe TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLate
       it "removes induction records that start after the cut off date" do
         expect(cleaner.induction_records).to contain_exactly(induction_record_1, induction_record_2)
       end
-
     end
 
     context "when the participant_type is a Mentor" do

--- a/spec/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner/remove_ect_induction_records_starting_later_than_cohort_closure_spec.rb
@@ -1,11 +1,9 @@
 describe TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure do
   subject(:cleaner) { described_class.new(raw_induction_records, participant_type) }
 
-  let(:cohort_2021_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2021_CUTOFF_DATE }
-  let(:cohort_2022_cut_off) { TeacherHistoryConverter::Cleaner::CohortCutOffDates::COHORT_2022_CUTOFF_DATE }
-
   describe "#induction_records" do
-    let(:start_date) { cohort_2021_cut_off + 1.week }
+    let(:cut_off_date) { TeacherHistoryConverter::CohortCutOffDate.new.cut_off_date_for(cohort_year:) }
+    let(:start_date) { cut_off_date + 1.week }
     let(:cohort_year) { 2021 }
 
     let(:participant_type) { :ect }
@@ -41,7 +39,7 @@ describe TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLate
     end
 
     context "when the cohort is 2022" do
-      let(:start_date) { cohort_2022_cut_off + 1.week }
+      # let(:start_date) { cohort_2022_cut_off + 1.week }
       let(:cohort_year) { 2022 }
 
       it "removes induction records that start after the cut off date" do

--- a/spec/migration/teacher_history_converter/cleaner_spec.rb
+++ b/spec/migration/teacher_history_converter/cleaner_spec.rb
@@ -54,6 +54,7 @@ describe TeacherHistoryConverter::Cleaner do
         TeacherHistoryConverter::Cleaner::RemovePostInductionCompletionRecords,
         TeacherHistoryConverter::Cleaner::CloseOngoingRecordsAfterInductionCompletion,
         TeacherHistoryConverter::Cleaner::RemoveRecordsWithMatchingWithdrawnAndDeferredStates,
+        TeacherHistoryConverter::Cleaner::RemoveECTInductionRecordsStartingLaterThanCohortClosure,
       ]
     end
 

--- a/spec/migration/teacher_history_converter/cohort_cut_off_date_spec.rb
+++ b/spec/migration/teacher_history_converter/cohort_cut_off_date_spec.rb
@@ -1,0 +1,27 @@
+describe TeacherHistoryConverter::CohortCutOffDate do
+  describe "#cut_off_date_for" do
+    subject(:cut_off_date) { described_class.new.cut_off_date_for(cohort_year:) }
+
+    let(:cohort_year) { 2021 }
+
+    it "returns the date the cohort was closed" do
+      expect(cut_off_date).to eq Date.new(2024, 7, 31)
+    end
+
+    context "when the cohort is 2022" do
+      let(:cohort_year) { 2022 }
+
+      it "returns the date the cohort was closed" do
+        expect(cut_off_date).to eq Date.new(2025, 7, 31)
+      end
+    end
+
+    context "when the cohort is not closed" do
+      let(:cohort_year) { 2023 }
+
+      it "returns the nil" do
+        expect(cut_off_date).to be_nil
+      end
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter/end_to_end/mentor_in_closed_cohort_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/mentor_in_closed_cohort_spec.rb
@@ -1,0 +1,137 @@
+describe "Mentor with 2 induction records (the second starting after the cohort closure)" do
+  subject(:teacher) { Teacher.find_by(trn: ecf1_teacher_profile.trn) }
+
+  let(:user_created_at) { 3.years.ago.round }
+  let(:ecf1_participant_profile) { FactoryBot.create(:migration_participant_profile, :mentor) }
+
+  # ECF1 data
+  let(:cohort_year) { 2022 }
+  let(:ecf1_school) { FactoryBot.create(:ecf_migration_school) }
+  let(:ecf1_cohort) { FactoryBot.create(:migration_cohort, start_year: cohort_year) }
+  let(:cohort_cut_off_date) { TeacherHistoryConverter::CohortCutOffDate.new.cut_off_date_for(cohort_year:) }
+  let(:ecf1_school_cohort) { FactoryBot.create(:migration_school_cohort, school: ecf1_school, cohort: ecf1_cohort) }
+  let(:ecf1_schedule) { FactoryBot.create(:migration_schedule, cohort: ecf1_cohort, schedule_identifier: "ecf-standard-september") }
+
+  # - first record
+  let(:ecf1_lead_provider) { FactoryBot.create(:migration_lead_provider, :ambition) }
+  let(:ecf1_delivery_partner) { FactoryBot.create(:migration_delivery_partner) }
+  let(:ecf1_partnership) { FactoryBot.create(:migration_partnership, lead_provider: ecf1_lead_provider, delivery_partner: ecf1_delivery_partner, cohort: ecf1_cohort, school: ecf1_school) }
+  let!(:ecf1_induction_programme) { FactoryBot.create(:migration_induction_programme, :provider_led, school_cohort: ecf1_school_cohort, partnership: ecf1_partnership) }
+
+  let(:record_change_date) { cohort_cut_off_date + 5.days }
+  let(:ir2_end_date) { nil }
+
+  let!(:ecf1_induction_record_1) do
+    FactoryBot.create(
+      :migration_induction_record,
+      participant_profile: ecf1_participant_profile,
+      induction_programme: ecf1_induction_programme,
+      created_at: 18.hours.ago.round,
+      start_date: Date.new(cohort_year, 11, 1),
+      end_date: record_change_date,
+      schedule: ecf1_schedule
+    )
+  end
+
+  # - second record
+  let!(:ecf1_induction_record_2) do
+    FactoryBot.create(
+      :migration_induction_record,
+      participant_profile: ecf1_participant_profile,
+      induction_programme: ecf1_induction_programme,
+      created_at: 2.years.ago.round,
+      start_date: record_change_date,
+      end_date: ir2_end_date,
+      schedule: ecf1_schedule
+    )
+  end
+
+  let(:ecf1_teacher_profile) { ecf1_participant_profile.participant_identity.user.teacher_profile }
+
+  # ECF2 data
+  let!(:ecf2_gias_school) { FactoryBot.create(:gias_school, :with_school, urn: ecf1_school.urn) }
+  let(:ecf2_school) { ecf2_gias_school.school }
+  let!(:ecf2_contract_period) { FactoryBot.create(:contract_period, year: ecf1_cohort.start_year) }
+
+  let!(:ecf2_lead_provider) { FactoryBot.create(:lead_provider, name: ecf1_lead_provider.name, ecf_id: ecf1_lead_provider.id) }
+  let!(:ecf2_delivery_partner) { FactoryBot.create(:delivery_partner, name: ecf1_delivery_partner.name, api_id: ecf1_delivery_partner.id) }
+
+  # - first school partnership
+  let!(:ecf2_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider: ecf2_lead_provider, contract_period: ecf2_contract_period) }
+  let!(:ecf2_lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: ecf2_active_lead_provider, delivery_partner: ecf2_delivery_partner) }
+  let!(:ecf2_school_partnership) { FactoryBot.create(:school_partnership, school: ecf2_school, lead_provider_delivery_partnership: ecf2_lead_provider_delivery_partnership) }
+
+  let!(:ecf2_schedule) { FactoryBot.create(:schedule, contract_period: ecf2_contract_period, identifier: ecf1_schedule.schedule_identifier) }
+
+  # Conversion objects
+  let(:ecf1_teacher_history) { ECF1TeacherHistory.build(teacher_profile: ecf1_teacher_profile) }
+  let(:teacher_history_converter) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:) }
+
+  before do
+    ecf2_teacher_history = teacher_history_converter.convert_to_ecf2!
+    ecf2_teacher_history.save_all_mentor_data!
+  end
+
+  context "when in latest_induction_records mode (economy)" do
+    let(:migration_mode) { :latest_induction_records }
+
+    it "creates the teacher record" do
+      expect(teacher).to be_persisted
+      expect(teacher.migration_mode).to eq "latest_induction_records"
+    end
+
+    it "creates a mentor_at_school_period" do
+      expect(teacher.mentor_at_school_periods.count).to be(1)
+    end
+
+    it "creates one training_period on the mentor_at_school_period" do
+      expect(teacher.mentor_at_school_periods[0].training_periods.count).to be(1)
+    end
+
+    it "sets the school_period as ongoing" do
+      expect(teacher.mentor_at_school_periods.first).to be_ongoing
+    end
+
+    it "sets the training_period as ongoing" do
+      expect(teacher.mentor_at_school_periods[0].training_periods.first).to be_ongoing
+    end
+  end
+
+  context "when in all_induction_records mode (premium)" do
+    let(:migration_mode) { :all_induction_records }
+
+    it "creates the teacher record" do
+      expect(teacher).to be_persisted
+      expect(teacher.migration_mode).to eq "all_induction_records"
+    end
+
+    it "creates one mentor_at_school_period" do
+      expect(teacher.mentor_at_school_periods.count).to eq(1)
+    end
+
+    it "creates one training_period at the mentor_at_school_period" do
+      expect(teacher.mentor_at_school_periods.first.training_periods.count).to eq(1)
+    end
+
+    it "sets the school_period as ongoing" do
+      expect(teacher.mentor_at_school_periods.first).to be_ongoing
+    end
+
+    it "uses the cohort cut off date for the end of the training period" do
+      expect(teacher.mentor_at_school_periods[0].training_periods.first.finished_on).to eq(cohort_cut_off_date)
+    end
+
+    context "when the 2nd record has an end date later than the cut off date" do
+      let(:record_change_date) { cohort_cut_off_date - 1.month }
+      let(:ir2_end_date) { cohort_cut_off_date + 1.month }
+
+      it "ends the school_period" do
+        expect(teacher.mentor_at_school_periods.first.finished_on).to eq(ir2_end_date)
+      end
+
+      it "uses the cohort cut off date for the end of the training period" do
+        expect(teacher.mentor_at_school_periods[0].training_periods.first.finished_on).to eq(cohort_cut_off_date)
+      end
+    end
+  end
+end

--- a/spec/migration/teacher_history_converter/end_to_end/mentor_ongoing_at_school_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/mentor_ongoing_at_school_spec.rb
@@ -22,7 +22,7 @@ describe "Mentor at a school with a few induction records" do
 
   # ECF1 data
   let(:ecf1_school) { FactoryBot.create(:ecf_migration_school) }
-  let(:ecf1_cohort) { FactoryBot.create(:migration_cohort, start_year: 2022) }
+  let(:ecf1_cohort) { FactoryBot.create(:migration_cohort, start_year: 2023) }
   let(:ecf1_school_cohort) { FactoryBot.create(:migration_school_cohort, school: ecf1_school, cohort: ecf1_cohort) }
   let(:ecf1_schedule) { FactoryBot.create(:migration_schedule, cohort: ecf1_cohort, schedule_identifier: "ecf-standard-september") }
 

--- a/spec/migration/teacher_history_converter/end_to_end/two_ect_induction_records_withdrawal_spec.rb
+++ b/spec/migration/teacher_history_converter/end_to_end/two_ect_induction_records_withdrawal_spec.rb
@@ -6,7 +6,7 @@ describe "Two ECT induction records (with the second being a withdrawal)" do
 
   # ECF1 data
   let(:ecf1_school) { FactoryBot.create(:ecf_migration_school) }
-  let(:ecf1_cohort) { FactoryBot.create(:migration_cohort, start_year: 2022) }
+  let(:ecf1_cohort) { FactoryBot.create(:migration_cohort, start_year: 2023) }
   let(:ecf1_school_cohort) { FactoryBot.create(:migration_school_cohort, school: ecf1_school, cohort: ecf1_cohort) }
   let(:ecf1_schedule) { FactoryBot.create(:migration_schedule, cohort: ecf1_cohort, schedule_identifier: "ecf-standard-september") }
 


### PR DESCRIPTION
### Context

The 2021 and 2022 cohorts are closed. When migrating teacher histories from those cohorts we want to:
For ECTs:
1. ignore induction records that start later than the cut off date
2. close induction records that are ongoing
3. adjust the `induction_record.end_date` if later than the cut off date

For mentors:
1. do not use induction records that start later than the cut off date for new or existing training periods but allow them for school periods
2. use the cohort cut off date as the `trianing_period.finished_on` when induction records are ongoing
3. adjust the `training_period.finished_on` to the cohort cut off date if it is later than the cut off date

### Changes proposed in this pull request
- Adds new cleaners to handle the ECT changes
- Modifies the `all_induction_records` process for mentors to be aware of the cut off date when building training periods
- Adds small service to provide the cohort cut off date given a cohort year
