### PR TITLE
Always display the secondary `<nav>` on the admin teachers page

### DIFF
--- a/app/views/admin/teachers/_navigation.html.erb
+++ b/app/views/admin/teachers/_navigation.html.erb
@@ -1,3 +1,1 @@
-<% if Rails.application.config.enable_schools_interface %>
-  <%= render Navigation::SecondaryNavigationComponent.new(items: navigation_items) %>
-<% end %>
+<%= render Navigation::SecondaryNavigationComponent.new(items: navigation_items) %>

--- a/spec/requests/admin/teachers/schools_spec.rb
+++ b/spec/requests/admin/teachers/schools_spec.rb
@@ -24,26 +24,9 @@ RSpec.describe "Admin::Teachers::Schools", type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      context "when the schools interface flag is enabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-        end
-
-        it "renders the teacher navigation" do
-          get admin_teacher_school_path(teacher)
-          expect(response.body).to include("x-govuk-secondary-navigation")
-        end
-      end
-
-      context "when the schools interface flag is disabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(false)
-        end
-
-        it "does not render the teacher navigation" do
-          get admin_teacher_school_path(teacher)
-          expect(response.body).not_to include("x-govuk-secondary-navigation")
-        end
+      it "renders the teacher navigation" do
+        get admin_teacher_school_path(teacher)
+        expect(response.body).to include("x-govuk-secondary-navigation")
       end
 
       context "when the teacher has an ECT school period" do

--- a/spec/requests/admin/teachers/show_spec.rb
+++ b/spec/requests/admin/teachers/show_spec.rb
@@ -27,26 +27,9 @@ RSpec.describe "Admin::Teachers#show", type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      context "when the schools interface flag is enabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-        end
-
-        it "renders the teacher navigation" do
-          get admin_teacher_induction_path(teacher)
-          expect(response.body).to include("x-govuk-secondary-navigation")
-        end
-      end
-
-      context "when the schools interface flag is disabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(false)
-        end
-
-        it "does not render the teacher navigation" do
-          get admin_teacher_induction_path(teacher)
-          expect(response.body).not_to include("x-govuk-secondary-navigation")
-        end
+      it "renders the teacher navigation" do
+        get admin_teacher_induction_path(teacher)
+        expect(response.body).to include("x-govuk-secondary-navigation")
       end
 
       context "when teacher has migration failures" do
@@ -78,26 +61,9 @@ RSpec.describe "Admin::Teachers#show", type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      context "when the schools interface flag is enabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-        end
-
-        it "renders the teacher navigation" do
-          get admin_teacher_path(teacher)
-          expect(response.body).to include("x-govuk-secondary-navigation")
-        end
-      end
-
-      context "when the schools interface flag is disabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(false)
-        end
-
-        it "does not render the teacher navigation" do
-          get admin_teacher_path(teacher)
-          expect(response.body).not_to include("x-govuk-secondary-navigation")
-        end
+      it "renders the teacher navigation" do
+        get admin_teacher_path(teacher)
+        expect(response.body).to include("x-govuk-secondary-navigation")
       end
     end
   end

--- a/spec/requests/admin/teachers/trainings_spec.rb
+++ b/spec/requests/admin/teachers/trainings_spec.rb
@@ -35,26 +35,9 @@ RSpec.describe "Admin::Teachers::Training", type: :request do
         expect(response).to have_http_status(:success)
       end
 
-      context "when the schools interface flag is enabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(true)
-        end
-
-        it "renders the teacher navigation" do
-          get admin_teacher_training_path(teacher)
-          expect(response.body).to include("x-govuk-secondary-navigation")
-        end
-      end
-
-      context "when the schools interface flag is disabled" do
-        before do
-          allow(Rails.application.config).to receive(:enable_schools_interface).and_return(false)
-        end
-
-        it "does not render the teacher navigation" do
-          get admin_teacher_training_path(teacher)
-          expect(response.body).not_to include("x-govuk-secondary-navigation")
-        end
+      it "renders the teacher navigation" do
+        get admin_teacher_training_path(teacher)
+        expect(response.body).to include("x-govuk-secondary-navigation")
       end
 
       context "when the teacher has an ECT training period" do


### PR DESCRIPTION
Before, we only displayed the secondary `<nav>` for the admin teachers page if `ENABLE_SCHOOLS_INTERFACE` was `true` (it's `false` in production).

This was fine when the cards on the admin teachers index page linked directly to the admin teachers induction page.

But we stopped doing that as part of the redesign in #2689.

We didn't notice this in staging or review apps, since `ENABLE_SCHOOLS_INTERFACE` is `true` in those environments.

This removes the conditional, so we always display the secondary `<nav>`.

Now, you can always navigate to the different tabs.

This feels low risk because we're going live on Tuesday anyway, plus it only impacts the admin console.