### PR TITLE
[3752] Use Teachers::InductionStatus in TrainingPeriods::Status

### DIFF
--- a/app/services/api/teachers/induction_status.rb
+++ b/app/services/api/teachers/induction_status.rb
@@ -6,14 +6,17 @@ module API::Teachers
       @teacher = teacher
     end
 
+    # @return [Date, nil]
     def induction_end_date
       teacher.finished_induction_period&.finished_on || teacher.trs_induction_completed_date
     end
 
+    # @return [Date, nil]
     def induction_start_date
       teacher.started_induction_period&.started_on || teacher.trs_induction_start_date
     end
 
+    # @return [Boolean]
     def completed_induction?
       induction_end_date.present?
     end

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -1,39 +1,47 @@
 module API::TrainingPeriods
   class TeacherStatus
-    attr_reader :latest_training_period, :teacher
+    attr_reader :latest_training_period, :teacher, :induction_status
 
     delegate :started_on, :finished_on, to: :latest_training_period, private: true
-    delegate :finished_induction_period, :mentor_became_ineligible_for_funding_on, to: :teacher, private: true
+    delegate :mentor_became_ineligible_for_funding_on, to: :teacher, private: true
 
     def initialize(latest_training_period:, teacher:)
       @latest_training_period = latest_training_period
       @teacher = teacher
+      @induction_status = API::Teachers::InductionStatus.new(teacher:)
     end
 
+    # @return [Symbol]
     def status
       if finished_on.present?
         finished_on.future? ? :leaving : :left
       elsif started_on.future?
         :joining
-      elsif mentor_became_ineligible_for_funding_on || finished_induction_period&.finished_on || finished_on.nil?
+      elsif mentor_became_ineligible_for_funding_on ||
+          induction_status.completed_induction? ||
+          finished_on.nil?
         :active
       else
         :left
       end
     end
 
+    # @return [Boolean]
     def active?
       status == :active
     end
 
+    # @return [Boolean]
     def joining?
       status == :joining
     end
 
+    # @return [Boolean]
     def leaving?
       status == :leaving
     end
 
+    # @return [Boolean]
     def left?
       status == :left
     end


### PR DESCRIPTION
### Context

The API recently added a service to ensure induction status falls back to TRS values.
This ensures teachers who do not have their induction in the service will still be accurate.

### Changes proposed in this pull request

Update one service to leverage the other

### Guidance to review

See @craigmdavidson's #2735 too
