### PR TITLE
[3680] Scope training programme method by contract period year

### DIFF
--- a/app/services/schools/training_programme.rb
+++ b/app/services/schools/training_programme.rb
@@ -50,9 +50,11 @@ module Schools
     end
 
     def ect_training_programme(contract_period_year:)
-      ect_at_school_period_id = ((ect_expressions_of_interest_ids_by_contract_period_year[contract_period_year] || []) +
+      ect_at_school_period_id = (
+        (ect_expressions_of_interest_ids_by_contract_period_year[contract_period_year] || []) +
         (ect_at_school_period_ids_by_contract_period_year[contract_period_year] || []) +
-        school_led_ect_at_school_period_ids).compact
+        (school_led_ect_at_school_period_ids_by_contract_period_year[contract_period_year] || [])
+      ).compact
 
       training_programmes_by_ect_at_school_period_id&.slice(*ect_at_school_period_id)&.values&.first
     end
@@ -62,7 +64,7 @@ module Schools
         ect_at_school_period_id = (
           ect_expressions_of_interest_ids_by_contract_period_year.values.flatten +
           ect_at_school_period_ids_by_contract_period_year.values.flatten +
-          school_led_ect_at_school_period_ids
+          school_led_ect_at_school_period_ids_by_contract_period_year.values.flatten
         ).uniq
 
         TrainingPeriod
@@ -81,12 +83,22 @@ module Schools
       "provider_led"
     end
 
-    def school_led_ect_at_school_period_ids
-      @school_led_ect_at_school_period_ids ||= school.ect_at_school_periods.joins(:training_periods)
-        .where(training_periods: { training_programme: "school_led" })
-        .where(training_periods: { expression_of_interest_id: nil, school_partnership_id: nil })
-        .distinct
-        .ids
+    def school_led_ect_at_school_period_ids_by_contract_period_year
+      @school_led_ect_at_school_period_ids_by_contract_period_year ||= school
+        .ect_at_school_periods
+        .joins(:training_periods)
+        .joins("INNER JOIN contract_periods ON training_periods.started_on >= contract_periods.started_on AND training_periods.started_on <= contract_periods.finished_on")
+        .where(training_periods: {
+          training_programme: :school_led,
+          expression_of_interest_id: nil,
+          school_partnership_id: nil
+        })
+        .group("contract_periods.year")
+        .pluck(
+          "contract_periods.year",
+          Arel.sql("ARRAY_AGG(DISTINCT ect_at_school_periods.id)")
+        )
+        .to_h
     end
   end
 end

--- a/spec/services/schools/training_programme_spec.rb
+++ b/spec/services/schools/training_programme_spec.rb
@@ -109,11 +109,29 @@ describe Schools::TrainingProgramme do
             FactoryBot.create(:training_period,
                               :school_led,
                               ect_at_school_period:,
-                              started_on: "2022-01-01",
-                              finished_on: "2022-06-01")
+                              started_on: contract_period.started_on,
+                              finished_on: contract_period.finished_on)
           end
 
           it { is_expected.to eq("school_led") }
+        end
+
+        context "when the only `school_led` ect training was created for a different contract period" do
+          let(:ect_at_school_period) do
+            FactoryBot.create(:ect_at_school_period,
+                              :ongoing,
+                              school:,
+                              started_on: "2021-01-01")
+          end
+          let!(:training_period) do
+            FactoryBot.create(:training_period,
+                              :school_led,
+                              ect_at_school_period:,
+                              started_on: contract_period.finished_on + 1.day,
+                              finished_on: contract_period.finished_on + 6.months)
+          end
+
+          it { is_expected.to eq("not_yet_known") }
         end
 
         context "when there is a mix of `provider_led` and `school_led` as the ects training programmes" do
@@ -142,8 +160,8 @@ describe Schools::TrainingProgramme do
             FactoryBot.create(:training_period,
                               :school_led,
                               ect_at_school_period: ect_at_school_period_2,
-                              started_on: "2022-01-01",
-                              finished_on: "2022-06-01")
+                              started_on: contract_period.started_on,
+                              finished_on: contract_period.started_on + 6.months)
           end
 
           it { is_expected.to eq("provider_led") }
@@ -155,7 +173,7 @@ describe Schools::TrainingProgramme do
           FactoryBot.create(:ect_at_school_period,
                             :ongoing,
                             school:,
-                            started_on: "2021-01-01")
+                            started_on: contract_period.started_on)
         end
         let!(:training_period) do
           FactoryBot.create(:training_period,


### PR DESCRIPTION
### Context

Ticket: [3680](https://github.com/DFE-Digital/register-ects-project-board/issues/3680)

Schools in 2025 (and potentially other cohorts) are showing as 'school_led' on induction_programme_choice on GET schools even though they should be 'not_yet_known'.

### Changes proposed in this pull request

Fix schools training programme service to scope `school_led_ect_at_school_period_ids` by contract period year, matching the `created_at` year of the training period against the contract period year being queried as well.

### Guidance to review

Review app