### PR TITLE
Refactor TeacherStatus

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -37,7 +37,7 @@ class API::TeacherSerializer < Blueprinter::Base
         end
       end
       field(:training_status) { |(training_period, _, _)| API::TrainingPeriods::TrainingStatus.new(training_period:).status }
-      field(:participant_status) { |(training_period, teacher, _)| API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status }
+      field(:participant_status) { |(training_period, _, _)| API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period).status }
       field(:eligible_for_funding) do |(training_period, teacher, _)|
         teacher_type = training_period.for_ect? ? :ect : :mentor
         API::Teachers::EligibilityForFunding.new(teacher:, teacher_type:).eligible?

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -1,41 +1,20 @@
 module API::TrainingPeriods
   class TeacherStatus
-    attr_reader :latest_training_period, :teacher
+    attr_reader :started_on, :finished_on
 
-    delegate :started_on, :finished_on, to: :latest_training_period, private: true
-    delegate :finished_induction_period, :mentor_became_ineligible_for_funding_on, to: :teacher, private: true
-
-    def initialize(latest_training_period:, teacher:)
-      @latest_training_period = latest_training_period
-      @teacher = teacher
+    def initialize(latest_training_period:)
+      @started_on = latest_training_period.started_on
+      @finished_on = latest_training_period.finished_on
     end
 
     def status
+      return :joining if started_on&.future?
+
       if finished_on.present?
         finished_on.future? ? :leaving : :left
-      elsif started_on.future?
-        :joining
-      elsif mentor_became_ineligible_for_funding_on || finished_induction_period&.finished_on || finished_on.nil?
-        :active
       else
-        :left
+        :active # includes complete
       end
-    end
-
-    def active?
-      status == :active
-    end
-
-    def joining?
-      status == :joining
-    end
-
-    def leaving?
-      status == :leaving
-    end
-
-    def left?
-      status == :left
     end
   end
 end

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -8,10 +8,10 @@ module API::TrainingPeriods
     end
 
     def status
-      return :joining if started_on&.future?
-
       if finished_on.present?
         finished_on.future? ? :leaving : :left
+      elsif started_on&.future?
+        :joining
       else
         :active # includes complete
       end

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -94,11 +94,11 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
       before do
         if defined?(ect_training_period)
-          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: ect_training_period, teacher:).and_return(mock_teacher_status)
+          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: ect_training_period).and_return(mock_teacher_status)
         end
 
         if defined?(mentor_training_period)
-          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: mentor_training_period, teacher:).and_return(mock_teacher_status)
+          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: mentor_training_period).and_return(mock_teacher_status)
         end
       end
 

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe API::TrainingPeriods::TeacherStatus do
-  let(:service) { described_class.new(latest_training_period: training_period, teacher:) }
+  let(:service) { described_class.new(latest_training_period: training_period) }
   let(:teacher) { training_period.teacher }
 
   describe "#status" do
@@ -9,10 +9,6 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       let(:training_period) { FactoryBot.build(:training_period, :ongoing) }
 
       it { is_expected.to eq(:active) }
-      it { expect(service).to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).not_to be_left }
     end
 
     context "when 'teacher.mentor_became_ineligible_for_funding_on' is set (indicating the mentor has completed training)" do
@@ -26,10 +22,6 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       end
 
       it { is_expected.to eq(:active) }
-      it { expect(service).to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).not_to be_left }
     end
 
     context "when 'finished_induction_period.finished_on' is set (indicating the ECT has completed training)" do
@@ -40,40 +32,24 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       end
 
       it { is_expected.to eq(:active) }
-      it { expect(service).to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).not_to be_left }
     end
 
     context "when training period set to start in the future" do
       let(:training_period) { FactoryBot.build(:training_period, :not_started_yet) }
 
       it { is_expected.to eq(:joining) }
-      it { expect(service).not_to be_active }
-      it { expect(service).to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).not_to be_left }
     end
 
     context "when training period set to finish in the future" do
       let(:training_period) { FactoryBot.build(:training_period, started_on: 3.months.ago, finished_on: 5.months.from_now) }
 
       it { is_expected.to eq(:leaving) }
-      it { expect(service).not_to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).to be_leaving }
-      it { expect(service).not_to be_left }
     end
 
     context "when training period has already finished" do
       let(:training_period) { FactoryBot.build(:training_period, started_on: 12.months.ago, finished_on: 2.months.ago) }
 
       it { is_expected.to eq(:left) }
-      it { expect(service).not_to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).to be_left }
     end
 
     context "when the mentor had left and completes the training afterwards" do
@@ -87,10 +63,6 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       end
 
       it { is_expected.to eq(:left) }
-      it { expect(service).not_to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).to be_left }
     end
 
     context "when the ECT had left and passes/fails induction afterwards" do
@@ -101,10 +73,6 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       end
 
       it { is_expected.to eq(:left) }
-      it { expect(service).not_to be_active }
-      it { expect(service).not_to be_joining }
-      it { expect(service).not_to be_leaving }
-      it { expect(service).to be_left }
     end
   end
 end

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       it { is_expected.to eq(:left) }
     end
 
+    context "when training period set to both start and finish in the future" do
+      let(:training_period) { FactoryBot.build(:training_period, started_on: 1.month.from_now, finished_on: 2.months.from_now) }
+
+      it { is_expected.to eq(:leaving) }
+    end
+
     context "when the mentor had left and completes the training afterwards" do
       let(:training_period) { FactoryBot.create(:training_period, :finished) }
 

--- a/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
       Metadata::Manager.refresh_all_metadata!
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:withdrawn)
-      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status).to eq(:left)
+      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period).status).to eq(:left)
       expect(training_period.at_school_period).to be_ongoing
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil
@@ -98,7 +98,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
       Metadata::Manager.refresh_all_metadata!
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:active)
-      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status).to eq(:active)
+      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period).status).to eq(:active)
       expect(training_period.at_school_period).to be_ongoing
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
           expect(ects_leaving.count + mentors_leaving.count).to eq(4)
 
           # make sure all created participants have 'leaving' status
-          expect((ects_leaving.map(&:ect_training_periods) + mentors_leaving.map(&:mentor_training_periods)).flatten.map { |tp| API::TrainingPeriods::TeacherStatus.new(latest_training_period: tp, teacher: tp.teacher).status }.uniq).to eq(%i[leaving])
+          expect((ects_leaving.map(&:ect_training_periods) + mentors_leaving.map(&:mentor_training_periods)).flatten.map { |tp| API::TrainingPeriods::TeacherStatus.new(latest_training_period: tp).status }.uniq).to eq(%i[leaving])
         end
       end
     end
@@ -261,15 +261,12 @@ RSpec.describe APISeedData::ParticipantScenarios do
             mentors_joining.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(
-              latest_training_period: it,
-              teacher: it.teacher
-            )
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
           end
-          expect(participant_statuses).to be_all(&:joining?)
+          expect(participant_statuses).to(be_all { |s| s.status == :joining })
           expect(training_statuses).to be_all(&:active?)
         end
       end
@@ -313,15 +310,12 @@ RSpec.describe APISeedData::ParticipantScenarios do
             mentors_leaving.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(
-              latest_training_period: it,
-              teacher: it.teacher
-            )
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
           end
-          expect(participant_statuses).to be_all(&:leaving?)
+          expect(participant_statuses).to(be_all { |s| s.status == :leaving })
           expect(training_statuses).to be_all(&:active?)
         end
       end
@@ -367,15 +361,12 @@ RSpec.describe APISeedData::ParticipantScenarios do
             withdrawn_mentors_left.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(
-              latest_training_period: it,
-              teacher: it.teacher
-            )
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
           end
-          expect(participant_statuses).to be_all(&:left?)
+          expect(participant_statuses).to(be_all { |s| s.status == :left })
           expect(training_statuses).to be_all(&:withdrawn?)
         end
       end
@@ -421,15 +412,12 @@ RSpec.describe APISeedData::ParticipantScenarios do
             active_mentors_left.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(
-              latest_training_period: it,
-              teacher: it.teacher
-            )
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
           end
-          expect(participant_statuses).to be_all(&:left?)
+          expect(participant_statuses).to(be_all { |s| s.status == :left })
           expect(training_statuses).to be_all(&:active?)
         end
       end


### PR DESCRIPTION
### Context

This PR is to address issue: https://github.com/DFE-Digital/register-ects-project-board/issues/3752 

> We added an InductionStatus service for this a while ago:
>
> [https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/app/services/api/teachers/induction_status.rb#L10](https://github.com.mcas.ms/DFE-Digital/register-early-career-teachers-public/blob/main/app/services/api/teachers/induction_status.rb?McasCtx=4&McasTsid=11760#L10)
>
> But I noticed we still only look at the InductionPeriod when determining TeacherStatus:
>
> [https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/app/services/api/training_periods/teacher_status.rb#L18](https://github.com.mcas.ms/DFE-Digital/register-early-career-teachers-public/blob/main/app/services/api/training_periods/teacher_status.rb?McasCtx=4&McasTsid=11760#L18)

### Changes proposed in this pull request

Originally the plan was to improve how we evaluate whether an induction is complete by using InductionStatus. But removing the logical anomaly hidden in the original structure makes that change redundant — it turns out the status is determined entirely by the training period's start and end dates.

If a teacher isn't joining, the only thing that matters is whether they have a finish date. If they do, they're either leaving (finish date in the future) or left (finish date in the past). If they don't, they're active. That's it. There's no situation where `mentor_became_ineligible_for_funding_on` or `finished_induction_period` could change that outcome — so any logic referencing them is redundant.

The only callers of `active?`, `joining?`, `leaving?`, and `left?` were the specs — and those specs were testing internal implementation rather than desired behaviour. When the methods are initially made private, then removed the whole thing collapses down to a few simple date checks.

### Guidance to review

* ~Review on a commit by commit basis.~ Only 1 commit ;-P
* The initial commit leaves the specs intact to demonstrate the behaviour preserving change. 
* I was originally going to then simplify the specs, but I think I will leave these in place to provide confidence initially. These can then be superseded come API v4.