### PR TITLE
Fix race condition in schools migrator

### DIFF
--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -20,10 +20,12 @@ module Migrators
       end
 
       def queue
-        DataMigration.where(model:).update!(queued_at: Time.zone.now)
+        data_migrations = DataMigration.where(model:).order(:worker)
 
-        number_of_workers.times do |worker|
-          MigratorJob.perform_later(migrator: self, worker:)
+        data_migrations.update!(queued_at: Time.zone.now)
+
+        data_migrations.each do |data_migration|
+          MigratorJob.perform_later(migrator: self, worker: data_migration.worker)
         end
       end
 

--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -26,8 +26,8 @@ module Migrators
     end
 
     def self.schools
-      # All RECT schools
-      rect_school_urns = ::School.pluck(:urn)
+      # All RECT schools (query GIASSchool as School records are created in another migrator).
+      rect_school_urns = ::GIAS::School.pluck(:urn)
 
       # All ECF schools that are returned by the API
       ecf_schools_with_partnerships = ::Migration::School


### PR DESCRIPTION
There is an issue  with the schools migrator where we prepare 9 jobs but then attempt to later queue 11.

This is due to `prepare!` being called for all migrators before any of them run, and the number of instances created depends on the number of `School` records in both ECF and RECT.

The issue is that the `GIASImportOnlyCreateSchools` runs before the `School` migrator is queued and it can create new `School` records in RECT, which has the knock on effect of changing the `number_of_workers` in the schools migrator.

Update the `queue` method so that it will always try and queue the same number of data migration instances that were prepared.

Change `School` migrator to grab RECT urns from `GIAS::School` instead of `School` so they are available before the migration starts.

Tested on parity check env:

<img width="631" height="512" alt="Screenshot 2026-04-22 at 11 49 38" src="https://github.com/user-attachments/assets/de606781-e4e7-4d6f-aedd-65901bde1bda" />

```
rect = School.pluck(:urn, :api_id).to_h.transform_keys(&:to_s)
ecf = Migration::School.where(urn: rect.keys).pluck(:urn, :id).to_h

mismatched = []

rect.each do |urn, rect_id|
  ecf_id = ecf[urn]

  if ecf_id && ecf_id != rect_id
    mismatched << { urn:, rect_id:, ecf_id: }
  end
end

mismatched.count
=> 0
```