### PR TITLE
Add validation on change schedule service so we return an error message when the schedule identifier is invalid

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -6,7 +6,10 @@ module API::Teachers
     attribute :schedule_identifier
 
     validates :schedule_identifier, presence: { message: "The property '#/schedule_identifier' must be present and correspond to a valid schedule." }
-
+    validates :schedule_identifier, inclusion: {
+      in: Schedule.identifiers.keys,
+      message: "Enter a valid schedule identifier."
+    }, allow_blank: true
     validate :schedule_exists
     validate :training_period_not_withdrawn
     validate :change_to_different_schedule

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -100,7 +100,21 @@ RSpec.describe "Participants API", :with_touches, type: :request do
     end
 
     it_behaves_like "a token authenticated endpoint", :put
-    it_behaves_like "an API update endpoint"
+    it_behaves_like "an API update endpoint" do
+      context "when the `schedule_identifier` is invalid" do
+        let(:schedule_identifier) { "invalid" }
+
+        it "returns `unprocessable_content`" do
+          authenticated_api_put(path, params:)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(parsed_response[:errors]).to contain_exactly(
+            title: "schedule_identifier",
+            detail: "Enter a valid schedule identifier."
+          )
+        end
+      end
+    end
     it_behaves_like "an endpoint that refreshes metadata", :put
     it_behaves_like "a N+1 queries free endpoint", :put
   end

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
           it { is_expected.to be_valid }
 
           it { is_expected.to validate_presence_of(:schedule_identifier).with_message("The property '#/schedule_identifier' must be present and correspond to a valid schedule.") }
+          it { is_expected.to validate_inclusion_of(:schedule_identifier).in_array(Schedule.identifiers.keys).with_message("Enter a valid schedule identifier.") }
 
           context "when schedule does not exist" do
             before do


### PR DESCRIPTION
### Context

Sending an invalid schedule identifier in the params to change-schedule endpoint is raising an exception.

<img width="965" height="780" alt="Screenshot 2026-04-22 at 12 01 32" src="https://github.com/user-attachments/assets/80996f0a-2b11-4c4f-9f6b-550a0a22dae6" />

### Changes proposed in this pull request
- Add validation on change schedule service so we return an error message when the schedule identifier is invalid;

<img width="913" height="234" alt="Screenshot 2026-04-22 at 12 02 46" src="https://github.com/user-attachments/assets/6062ecdf-6660-4dc1-a96c-ecca52b463f5" />

### Guidance to review

Review app