### PR TITLE
Add missing full stops

### DIFF
--- a/app/views/admin/teachers/declarations/index.html.erb
+++ b/app/views/admin/teachers/declarations/index.html.erb
@@ -16,7 +16,7 @@
     <%= render "admin/teachers/declarations/declaration", declaration: declaration %>
   <% end %>
 <% else %>
-  <p class="govuk-body">There are no ECT training declarations for <%= teacher_full_name(@teacher) %></p>
+  <p class="govuk-body">There are no ECT training declarations for <%= teacher_full_name(@teacher) %>.</p>
 <% end %>
 
 <h3 class="govuk-heading-s">Mentor training declarations</h3>
@@ -26,5 +26,5 @@
     <%= render "admin/teachers/declarations/declaration", declaration: declaration %>
   <% end %>
 <% else %>
-  <p class="govuk-body">There are no mentor training declarations for <%= teacher_full_name(@teacher) %></p>
+  <p class="govuk-body">There are no mentor training declarations for <%= teacher_full_name(@teacher) %>.</p>
 <% end %>

--- a/app/views/admin/teachers/trainings/show.html.erb
+++ b/app/views/admin/teachers/trainings/show.html.erb
@@ -26,5 +26,5 @@
 <% end %>
 
 <% if @ect_training_periods.blank? && @mentor_training_periods.blank? %>
-  <p class="govuk-body">There is no training history recorded for this teacher</p>
+  <p class="govuk-body">There is no training history recorded for this teacher.</p>
 <% end %>

--- a/spec/requests/admin/teachers/trainings_spec.rb
+++ b/spec/requests/admin/teachers/trainings_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Admin::Teachers::Training", type: :request do
 
         it "shows the empty state message" do
           get admin_teacher_training_path(teacher)
-          expect(response.body).to include("There is no training history recorded for this teacher")
+          expect(response.body).to include("There is no training history recorded for this teacher.")
         end
       end
 

--- a/spec/views/admin/teachers/declarations/index.html.erb_spec.rb
+++ b/spec/views/admin/teachers/declarations/index.html.erb_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe "admin/teachers/declarations/index.html.erb" do
     let(:mentor_declarations) { [] }
 
     it "displays the ECT empty state message" do
-      expect(rendered).to include("There are no ECT training declarations for Floella Benjamin")
+      expect(rendered).to include("There are no ECT training declarations for Floella Benjamin.")
     end
 
     it "displays the mentor empty state message" do
-      expect(rendered).to include("There are no mentor training declarations for Floella Benjamin")
+      expect(rendered).to include("There are no mentor training declarations for Floella Benjamin.")
     end
 
     it "displays the ECT training declarations heading" do
@@ -100,7 +100,7 @@ RSpec.describe "admin/teachers/declarations/index.html.erb" do
     let(:mentor_declarations) { [mentor_declaration] }
 
     it "displays the ECT empty state message" do
-      expect(rendered).to include("There are no ECT training declarations for Floella Benjamin")
+      expect(rendered).to include("There are no ECT training declarations for Floella Benjamin.")
     end
 
     it "does not display the mentor empty state message" do


### PR DESCRIPTION
### Summary

Add missing full stops on support pages