### PR TITLE
Set `induction_tutor_last_nominated_in` in the School migrator

### DIFF
--- a/app/migration/migrators/school.rb
+++ b/app/migration/migrators/school.rb
@@ -116,11 +116,13 @@ module Migrators
 
     def update_school!(school:, ecf_school:)
       induction_coordinator = ecf_school.induction_coordinators.first
+      last_nominated_in = 2025 if induction_coordinator.present?
 
       attrs = {
         api_id: ecf_school.id,
         induction_tutor_name: induction_coordinator&.full_name,
         induction_tutor_email: induction_coordinator&.email,
+        induction_tutor_last_nominated_in: last_nominated_in,
         created_at: ecf_school.created_at
       }
 

--- a/spec/migration/migrators/school_spec.rb
+++ b/spec/migration/migrators/school_spec.rb
@@ -224,6 +224,7 @@ describe Migrators::School do
     context "when schools match" do
       let!(:ecf_school) { create_ecf_school }
       let!(:gias_school) { create_gias_school(ecf_school) }
+      let!(:induction_tutor_contract_period) { ContractPeriod.find_by(year: 2025) || FactoryBot.create(:contract_period, year: 2025) }
 
       before do
         described_class.new(worker: 0).migrate!
@@ -243,8 +244,10 @@ describe Migrators::School do
 
       it "syncs the induction coordinator details" do
         gias_school.reload
+
         expect(gias_school.school.induction_tutor_name).to eq(ecf_school.induction_coordinators.first.full_name)
         expect(gias_school.school.induction_tutor_email).to eq(ecf_school.induction_coordinators.first.email)
+        expect(gias_school.school.induction_tutor_last_nominated_in).to eq(induction_tutor_contract_period)
       end
     end
   end


### PR DESCRIPTION
### Context

When we are migrating School records, when there is an induction tutor present we want to set the `School.induction_tutor_last_nominated_in` to `2025` otherwise if ca be left blank.

### Changes proposed in this pull request

- Sets `School.induction_tutor_last_nominated_in` to `2025` when updating the school's induction tutor attributes (if present).


