### PR TITLE
[3827] Migrate remaining cohort flags to contract periods

### DIFF
--- a/app/migration/migrators/contract_period.rb
+++ b/app/migration/migrators/contract_period.rb
@@ -28,11 +28,17 @@ module Migrators
       contract_period = ::ContractPeriod.find_or_initialize_by(year: cohort.start_year)
 
       contract_period.update!(
+        # dates
         started_on: cohort.registration_start_date,
         finished_on: finished_on_for(cohort),
-        enabled: contract_period_enabled?(cohort),
+        payments_frozen_at: cohort.payments_frozen_at,
         created_at: cohort.created_at,
-        updated_at: cohort.updated_at
+        updated_at: cohort.updated_at,
+        # flags
+        detailed_evidence_types_enabled: cohort.detailed_evidence_types_enabled,
+        mentor_funding_enabled: cohort.mentor_funding,
+        uplift_fees_enabled: uplift_fees_enabled?(cohort),
+        enabled: contract_period_enabled?(cohort)
       )
 
       contract_period
@@ -43,6 +49,10 @@ module Migrators
     def contract_period_enabled?(cohort)
       cohort.start_year.to_s != "2020" &&
         !(cohort.payments_frozen_at.present? && Time.current >= cohort.payments_frozen_at)
+    end
+
+    def uplift_fees_enabled?(cohort)
+      cohort.start_year <= 2024
     end
 
     def finished_on_for(cohort)

--- a/app/migration/migrators/contract_period.rb
+++ b/app/migration/migrators/contract_period.rb
@@ -35,7 +35,7 @@ module Migrators
         created_at: cohort.created_at,
         updated_at: cohort.updated_at,
         # flags
-        detailed_evidence_types_enabled: cohort.detailed_evidence_types_enabled,
+        detailed_evidence_types_enabled: cohort.detailed_evidence_types,
         mentor_funding_enabled: cohort.mentor_funding,
         uplift_fees_enabled: uplift_fees_enabled?(cohort),
         enabled: contract_period_enabled?(cohort)

--- a/db/ecf_schema.rb
+++ b/db/ecf_schema.rb
@@ -263,7 +263,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_135429) do
     t.date "automatic_assignment_period_end_date"
     t.datetime "payments_frozen_at"
     t.boolean "mentor_funding", default: false, null: false
-    t.boolean "detailed_evidence_types_enabled", default: false, null: false
+    t.boolean "detailed_evidence_types", default: false, null: false
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 

--- a/spec/factories/migration/cohort_factory.rb
+++ b/spec/factories/migration/cohort_factory.rb
@@ -18,6 +18,6 @@ FactoryBot.define do
     end
 
     detailed_evidence_types { false }
-    mentor_funding { false }
+    mentor_funding { true }
   end
 end

--- a/spec/factories/migration/cohort_factory.rb
+++ b/spec/factories/migration/cohort_factory.rb
@@ -16,5 +16,8 @@ FactoryBot.define do
     trait :payments_frozen do
       payments_frozen_at { 2.months.ago }
     end
+
+    detailed_evidence_types { false }
+    mentor_funding { false }
   end
 end

--- a/spec/migration/migrators/contract_period_spec.rb
+++ b/spec/migration/migrators/contract_period_spec.rb
@@ -14,15 +14,42 @@ describe Migrators::ContractPeriod do
     end
 
     describe "#migrate!" do
-      it "sets the created contract_period attributes correctly" do
-        instance.migrate!
+      before { instance.migrate! }
 
-        contract_period = ContractPeriod.find_by(year: migration_resource1.start_year)
-        expect(contract_period).to have_attributes(migration_resource1.attributes.slice("created_at", "updated_at"))
+      let(:contract_period) do
+        ContractPeriod.find_by(year: migration_resource1.start_year)
+      end
+
+      it "sets the created contract_period attributes correctly" do
+        expect(contract_period).to have_attributes(migration_resource1.attributes.slice(
+                                                     "created_at",
+                                                     "updated_at",
+                                                     "payments_frozen_at",
+                                                     "detailed_evidence_types_enabled"
+                                                   ))
         expect(contract_period.id).to eq(migration_resource1.start_year)
         expect(contract_period.started_on.to_date).to eq(migration_resource1.registration_start_date.to_date)
         expect(contract_period.finished_on).to eq(contract_period.started_on.next_year.prev_day)
         expect(contract_period.enabled).to be(true)
+        expect(contract_period.mentor_funding_enabled).to eq(migration_resource1.mentor_funding)
+      end
+
+      describe "uplift fees" do
+        def create_migration_resource
+          FactoryBot.create(:migration_cohort, start_year:)
+        end
+
+        context "when start year is 2024 or earlier" do
+          let(:start_year) { (2021..2024).to_a.sample }
+
+          it { expect(contract_period).to be_uplift_fees_enabled }
+        end
+
+        context "when start year is 2025 or later" do
+          let(:start_year) { (2025..2100).to_a.sample }
+
+          it { expect(contract_period).not_to be_uplift_fees_enabled }
+        end
       end
     end
   end

--- a/spec/migration/migrators/contract_period_spec.rb
+++ b/spec/migration/migrators/contract_period_spec.rb
@@ -40,7 +40,7 @@ describe Migrators::ContractPeriod do
         end
 
         context "when start year is 2024 or earlier" do
-          let(:start_year) { (2021..2024).to_a.sample }
+          let(:start_year) { (2020..2024).to_a.sample }
 
           it { expect(contract_period).to be_uplift_fees_enabled }
         end

--- a/spec/migration/migrators/contract_period_spec.rb
+++ b/spec/migration/migrators/contract_period_spec.rb
@@ -24,14 +24,14 @@ describe Migrators::ContractPeriod do
         expect(contract_period).to have_attributes(migration_resource1.attributes.slice(
                                                      "created_at",
                                                      "updated_at",
-                                                     "payments_frozen_at",
-                                                     "detailed_evidence_types_enabled"
+                                                     "payments_frozen_at"
                                                    ))
         expect(contract_period.id).to eq(migration_resource1.start_year)
         expect(contract_period.started_on.to_date).to eq(migration_resource1.registration_start_date.to_date)
         expect(contract_period.finished_on).to eq(contract_period.started_on.next_year.prev_day)
         expect(contract_period.enabled).to be(true)
         expect(contract_period.mentor_funding_enabled).to eq(migration_resource1.mentor_funding)
+        expect(contract_period.detailed_evidence_types_enabled).to eq(migration_resource1.detailed_evidence_types)
       end
 
       describe "uplift fees" do


### PR DESCRIPTION
### Context

ECF1 has cohort attributes we are not yet migrating

### Changes proposed in this pull request

**Migrate:**

- `detailed_evidence_types` => `detailed_evidence_types_enabled` ([required an attribute correction](https://github.com/DFE-Digital/register-early-career-teachers-public/commit/0ceb5f02cde8d6255c9944a099a6872f94f61cc3#diff-d0f6b1bce616292a512815fc441a4a034a48a793751fdd84ac8f16e81d6d099f)) 
- `payments_frozen_at`
- `mentor_funding` => `mentor_funding_enabled`

**Add:**

`uplift_fees_enabled`

### Guidance to review

A 2024 cohort will receive uplift but a 2025 will not.
