### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
         with:
           message: |
             Review app deployed to ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/refresh-mermaid-erd.yml
+++ b/.github/workflows/refresh-mermaid-erd.yml
@@ -3,7 +3,7 @@ name: "Refresh mermaid ERD"
 on:
   schedule:
     - cron: '0 8 * * 1' # Monday at 8am
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   refresh_mermaid_erd:
@@ -66,7 +66,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # Pinned at v7.0.11
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: nightly-refresh-mermaid-erd
@@ -80,5 +80,5 @@ jobs:
             it raises this commit in a PR so that we can keep our ERD inline with our models.
           title: Refresh mermaid ERD
           body: |
-            We run the mermaid ERD generation in CI on a schedule; once complete 
+            We run the mermaid ERD generation in CI on a schedule; once complete
             it raises this commit in a PR so that we can keep our ERD inline with our models.

--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -3,7 +3,7 @@ name: "Refresh Knapsack manifest"
 on:
   schedule:
     - cron: '0 0 1 * *' # 1st day of the month
-  workflow_dispatch: 
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -72,8 +72,8 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Create pull request 
-        uses: peter-evans/create-pull-request@v7
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # Pinned at v7.0.11
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: refresh-knapsack-manifest


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR
