### PR TITLE
Decrease number of jobs per migration worker

### DIFF
--- a/app/migration/migrators/base.rb
+++ b/app/migration/migrators/base.rb
@@ -58,7 +58,7 @@ module Migrators
       end
 
       def records_per_worker
-        3_000
+        1_000
       end
 
       def reset!


### PR DESCRIPTION
We are hitting issues during a migration where a worker fails to send a heartbeat, presumably because it is locking up as CPU/DB bound, and the process is identified as being 'dead' and pruned.

We think we're running too many records per worker; reducing from 3k to 1k will result in more jobs but less for each worker to process, hopefully preventing it from being overloaded.
