### PR TITLE
[3695] Return only one prioritised error message from the API when multiple error messages

### DIFF
--- a/app/services/api/concerns/teachers/shared_action.rb
+++ b/app/services/api/concerns/teachers/shared_action.rb
@@ -12,12 +12,10 @@ module API::Concerns::Teachers
       attribute :teacher_api_id
       attribute :teacher_type
 
-      validates :lead_provider_id, presence: { message: "Enter a '#/lead_provider_id'." }
-      validate :lead_provider_exists
-
       validates :teacher_api_id, presence: { message: "Enter a '#/teacher_api_id'." }
       validate :teacher_exists
-
+      validates :lead_provider_id, presence: { message: "Enter a '#/lead_provider_id'." }
+      validate :lead_provider_exists
       validates :teacher_type, presence: { message: "Enter a '#/teacher_type'." }
       validates :teacher_type,
                 inclusion: {
@@ -40,6 +38,7 @@ module API::Concerns::Teachers
 
     def lead_provider_exists
       return if errors[:lead_provider_id].any?
+      return if errors[:teacher_api_id].any?
       return if lead_provider
 
       errors.add(:lead_provider_id, "The '#/lead_provider_id' you have entered is invalid.")
@@ -54,6 +53,8 @@ module API::Concerns::Teachers
 
     def teacher_type_exists
       return if errors[:teacher_type].any?
+      return if errors[:teacher_api_id].any?
+      return if errors[:lead_provider_id].any?
       return if training_period
 
       errors.add(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.")

--- a/app/services/api/declarations/clawback.rb
+++ b/app/services/api/declarations/clawback.rb
@@ -37,6 +37,7 @@ module API::Declarations
 
     def output_fee_statement_available
       return if errors[:declaration_api_id].any?
+      return if errors[:lead_provider_id].any?
       return if clawback_service.next_available_output_fee_statement.present?
 
       no_output_fee_statement_error_message = <<~TXT.squish

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -12,31 +12,31 @@ module API::Declarations
 
     validates :teacher_api_id, presence: { message: "Enter a '#/teacher_api_id'." }
     validate :teacher_exists
-    validates :teacher_type, presence: { message: "Enter a '#/teacher_type'." }
+    validates :teacher_type, presence: { message: "Enter a '#/teacher_type'." }, if: -> { errors.empty? }
     validates :teacher_type, inclusion: {
       in: TEACHER_TYPES,
       message: "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again."
     }, allow_blank: true
+    validates :declaration_date, presence: { message: "Enter a '#/declaration_date'." }, if: -> { errors.empty? }
     validate :teacher_type_exists
-    validates :declaration_type, presence: { message: "Enter a '#/declaration_type'." }
+    validates :declaration_type, presence: { message: "Enter a '#/declaration_type'." }, if: -> { errors.empty? }
     validates :declaration_type, inclusion: {
       in: Declaration.declaration_types.keys,
       message: "Enter a valid declaration type."
-    }, allow_blank: true
+    }, allow_blank: true, if: -> { errors.empty? }
     validate :validates_billable_slot_available
-    validates :declaration_date, presence: { message: "Enter a '#/declaration_date'." }
     validate :declaration_date_in_the_past
     validates :declaration_date,
               declaration_date_within_milestone: true,
               api_date_time_format: true,
               allow_blank: true
-    validates :evidence_type, evidence_type: true
     validate :validate_only_started_or_completed_if_mentor
+    validates :evidence_type, evidence_type: true, if: -> { errors.empty? }
     validate :teacher_not_withdrawn_before_declaration_date
-    validate :validate_milestone_exists
-    validate :payment_statement_available
-    validate :declaration_in_sequence
     validate :not_eligible_in_frozen_contract_period
+    validate :payment_statement_available
+    validate :validate_milestone_exists
+    validate :declaration_in_sequence
 
     def create
       return false unless valid?
@@ -125,6 +125,9 @@ module API::Declarations
 
     def declaration_date_in_the_past
       return if errors[:declaration_date].any?
+      return if errors[:declaration_type].any?
+      return if errors[:teacher_api_id].any?
+      return if errors[:teacher_type].any?
 
       if declaration_date && declaration_date > Time.zone.now
         errors.add(:declaration_date, "The '#/declaration_date' value cannot be a future date. Check the date and try again.")
@@ -133,6 +136,7 @@ module API::Declarations
 
     def teacher_exists
       return if errors[:teacher_api_id].any?
+      return if errors[:teacher_type].any?
       return if teacher
 
       errors.add(:teacher_api_id, "Your update cannot be made as the '#/teacher_api_id' is not recognised. Check participant details and try again.")
@@ -141,15 +145,21 @@ module API::Declarations
     def teacher_type_exists
       return if errors[:teacher_type].any?
       return if errors[:teacher_api_id].any?
+      return if errors[:lead_provider_id].any?
+      return if errors[:declaration_type].any?
+      return if errors[:declaration_date].any?
       return if training_period
 
       errors.add(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.")
     end
 
     def validate_milestone_exists
+      return if errors[:declaration_date].any?
       return if errors[:declaration_type].any?
       return if errors[:teacher_api_id].any?
       return if errors[:teacher_type].any?
+      return if errors[:lead_provider_id].any?
+      return if errors[:contract_period_year].any?
 
       if milestone.blank?
         errors.add(:declaration_type, "The property '#/declaration_type' does not exist for this schedule.")
@@ -166,6 +176,7 @@ module API::Declarations
 
     def validate_only_started_or_completed_if_mentor
       return if errors[:declaration_type].any?
+      return if errors[:contract_period_year].any?
       return if declaration_type&.in?(%w[started completed])
       return unless training_period&.for_mentor?
       return unless contract_period.mentor_funding_enabled?
@@ -175,6 +186,7 @@ module API::Declarations
 
     def validates_billable_slot_available
       return if errors[:declaration_type].any?
+      return if errors[:declaration_date].any?
       return unless training_period
       return unless existing_declarations.billable_or_changeable_for_declaration_type(declaration_type).exists?
 
@@ -183,6 +195,7 @@ module API::Declarations
 
     def payment_statement_available
       return if errors[:declaration_type].any?
+      return if errors[:contract_period_year].any?
       return unless training_period&.eligible_for_funding?
       return if payment_statement.present?
 

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -23,6 +23,7 @@ module API::Declarations
       in: Declaration.declaration_types.keys,
       message: "Enter a valid declaration type."
     }, allow_blank: true
+    validate :validates_billable_slot_available
     validates :declaration_date, presence: { message: "Enter a '#/declaration_date'." }
     validate :declaration_date_in_the_past
     validates :declaration_date,
@@ -33,7 +34,6 @@ module API::Declarations
     validate :validate_only_started_or_completed_if_mentor
     validate :teacher_not_withdrawn_before_declaration_date
     validate :validate_milestone_exists
-    validate :validates_billable_slot_available
     validate :payment_statement_available
     validate :declaration_in_sequence
     validate :not_eligible_in_frozen_contract_period
@@ -140,6 +140,7 @@ module API::Declarations
 
     def teacher_type_exists
       return if errors[:teacher_type].any?
+      return if errors[:teacher_api_id].any?
       return if training_period
 
       errors.add(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.")

--- a/app/validators/declaration_date_within_milestone_validator.rb
+++ b/app/validators/declaration_date_within_milestone_validator.rb
@@ -10,6 +10,7 @@ private
   def declaration_within_milestone(record)
     return if record.errors[:declaration_date].any?
     return if record.errors[:declaration_type].any?
+    return if record.errors[:contract_period_year].any?
 
     return unless record.milestone && record.declaration_date.present?
 

--- a/app/validators/evidence_type_validator.rb
+++ b/app/validators/evidence_type_validator.rb
@@ -7,6 +7,7 @@ class EvidenceTypeValidator < ActiveModel::Validator
 
   def validate(record)
     return if record.errors[:evidence_type].any?
+    return if record.errors[:declaration_date].any?
     return if record.training_period.blank?
 
     evidence_type_is_present(record) if self.class.evidence_type_required?(record)

--- a/spec/services/api/declarations/clawback_spec.rb
+++ b/spec/services/api/declarations/clawback_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
     let(:declaration) { FactoryBot.create(:declaration, :paid) }
     let(:lead_provider_id) { nil }
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
     it { is_expected.to have_error(:lead_provider_id, "Enter a '#/lead_provider_id'.") }
   end
 
@@ -20,21 +20,21 @@ RSpec.describe API::Declarations::Clawback, type: :model do
     let(:declaration) { FactoryBot.create(:declaration, :paid) }
     let(:lead_provider_id) { 123_456_789 }
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
     it { is_expected.to have_error(:lead_provider_id, "The '#/lead_provider_id' you have entered is invalid.") }
   end
 
   context "when declaration is awaiting clawback" do
     let(:declaration) { FactoryBot.create(:declaration, :awaiting_clawback) }
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
     it { is_expected.to have_error(:declaration_api_id, "The declaration will or has been refunded") }
   end
 
   context "when declaration has been clawed back" do
     let(:declaration) { FactoryBot.create(:declaration, :clawed_back) }
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
     it { is_expected.to have_error(:declaration_api_id, "The declaration will or has been refunded") }
   end
 
@@ -47,7 +47,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
       Statement.where("deadline_date > ?", payment_statement.deadline_date).destroy_all
     end
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
 
     it { is_expected.not_to be_valid }
 
@@ -66,7 +66,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
 
     before { declaration.payment_statement.update!(fee_type: :service) }
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
 
     it "has the correct error message" do
       error_message = <<~TXT.squish
@@ -83,7 +83,7 @@ RSpec.describe API::Declarations::Clawback, type: :model do
 
     before { declaration.payment_statement.update!(deadline_date: Date.yesterday) }
 
-    it { is_expected.to have_one_error_per_attribute }
+    it { is_expected.to have_one_error_only }
 
     it "has the correct error message" do
       error_message = <<~TXT.squish

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -40,35 +40,35 @@ RSpec.describe API::Declarations::Create, type: :model do
         context "when the `lead_provider` does not exist" do
           let(:lead_provider_id) { 9999 }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:lead_provider_id, "The '#/lead_provider_id' you have entered is invalid.") }
         end
 
         context "when a matching training period does not exist (different teacher type)" do
           let(:teacher_type) { trainee_type == :ect ? :mentor : :ect }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
         context "when a matching training period does not exist (different lead provider)" do
           let(:lead_provider_id) { FactoryBot.create(:lead_provider, name: "Different to #{lead_provider.name}").id }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
         context "when the teacher does not exist" do
           let(:teacher_api_id) { "non-existent-participant-id" }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_api_id, "Your update cannot be made as the '#/teacher_api_id' is not recognised. Check participant details and try again.") }
         end
 
         context "when a non-existent teacher type is provided" do
           let(:teacher_type) { :other }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
@@ -87,21 +87,21 @@ RSpec.describe API::Declarations::Create, type: :model do
         context "when `declaration_date` is nil" do
           let!(:declaration_date) { nil }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "Enter a '#/declaration_date'.") }
         end
 
         context "when `declaration_date` is in the future" do
           let!(:declaration_date) { 1.day.from_now.rfc3339 }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "The '#/declaration_date' value cannot be a future date. Check the date and try again.") }
         end
 
         context "when `declaration_date` is not in the correct format" do
           let!(:declaration_date) { declaration_datetime.to_s }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "Enter a valid RCF3339 '#/declaration_date'.") }
         end
 
@@ -109,14 +109,14 @@ RSpec.describe API::Declarations::Create, type: :model do
           let!(:milestone) { FactoryBot.create(:milestone, declaration_type: "started", schedule:) }
           let!(:declaration_type) { nil }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_type, "Enter a '#/declaration_type'.") }
         end
 
         context "when `evidence_type` is invalid for the given `declaration_type`" do
           let!(:evidence_type) { "75-percent-engagement-met" }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.") }
         end
 
@@ -125,21 +125,21 @@ RSpec.describe API::Declarations::Create, type: :model do
             milestone.destroy!
           end
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_type, "The property '#/declaration_type' does not exist for this schedule.") }
         end
 
         context "when declaration date does not match the milestone start date" do
           let(:declaration_date) { Date.new(2024, 10, 25).rfc3339 }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "Declaration date must be on or after the milestone start date for the same declaration type.") }
         end
 
         context "when declaration date does not match the milestone date" do
           let(:declaration_date) { Date.new(2024, 12, 25).rfc3339 }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:declaration_date, "Declaration date must be on or before the milestone date for the same declaration type.") }
         end
 
@@ -150,7 +150,7 @@ RSpec.describe API::Declarations::Create, type: :model do
             training_period.update!(withdrawn_at:, withdrawal_reason: "other")
           end
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_api_id, "This participant withdrew from this course on #{withdrawn_at.utc.rfc3339}. Enter a '#/declaration_date' that's on or before the withdrawal date.") }
         end
 
@@ -158,7 +158,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           context "when declaration type is not started or completed" do
             let(:declaration_type) { "retained-1" }
 
-            it { is_expected.to have_one_error_per_attribute }
+            it { is_expected.to have_one_error_only }
             it { is_expected.to have_error(:declaration_type, "You cannot send retained or extended declarations for participants who began their mentor training after June 2025. Resubmit this declaration with either a started or completed declaration.") }
 
             context "when contract period mentor funding is not enabled" do
@@ -190,7 +190,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                 teacher.update!("#{trainee_type}_first_became_eligible_for_training_at": 3.years.ago)
               end
 
-              it { is_expected.to have_one_error_per_attribute }
+              it { is_expected.to have_one_error_only }
               it { is_expected.to have_error(:contract_period_year, "You cannot submit or void declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.") }
             end
           end
@@ -206,7 +206,7 @@ RSpec.describe API::Declarations::Create, type: :model do
               contract_period.update!(payments_frozen_at: Time.zone.now)
             end
 
-            it { is_expected.to have_one_error_per_attribute }
+            it { is_expected.to have_one_error_only }
             it { is_expected.to have_error(:contract_period_year, "You cannot submit declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.") }
           end
 
@@ -267,7 +267,7 @@ RSpec.describe API::Declarations::Create, type: :model do
               teacher.update!(eligible_at_field => 3.years.ago)
             end
 
-            it { is_expected.to have_one_error_per_attribute }
+            it { is_expected.to have_one_error_only }
             it { is_expected.to have_error(:contract_period_year, "You cannot submit declarations for the #{frozen_contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.") }
           end
 
@@ -303,7 +303,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                                   declaration_type:)
               end
 
-              it { is_expected.to have_one_error_per_attribute }
+              it { is_expected.to have_one_error_only }
               it { is_expected.to have_error(:declaration_type, "A declaration has already been submitted that will be, or has been, paid for this event.") }
             end
           end
@@ -439,7 +439,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                 # New declaration with declaration date set 1 week before `started`
                 let(:declaration_date) { (started_declaration.declaration_date - 1.week).rfc3339 }
 
-                it { is_expected.to have_one_error_per_attribute }
+                it { is_expected.to have_one_error_only }
                 it { is_expected.to have_error(:declaration_date, "This '#/declaration_date' is invalid. Check that it is in sequence with existing declaration dates for this participant.") }
               end
 
@@ -474,7 +474,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                 # New declaration with declaration date set 1 week after `completed`
                 let(:declaration_date) { (completed_declaration.declaration_date + 1.week).rfc3339 }
 
-                it { is_expected.to have_one_error_per_attribute }
+                it { is_expected.to have_one_error_only }
                 it { is_expected.to have_error(:declaration_date, "This '#/declaration_date' is invalid. Check that it is in sequence with existing declaration dates for this participant.") }
               end
 
@@ -523,7 +523,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                     # New declaration with declaration date set 1 day before `started`
                     let(:declaration_date) { (started_declaration.declaration_date - 1.day).rfc3339 }
 
-                    it { is_expected.to have_one_error_per_attribute }
+                    it { is_expected.to have_one_error_only }
                     it { is_expected.to have_error(:declaration_date, "This '#/declaration_date' is invalid. Check that it is in sequence with existing declaration dates for this participant.") }
                   end
 
@@ -531,7 +531,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                     # New declaration with declaration date set 1 day after `completed`
                     let(:declaration_date) { (completed_declaration.declaration_date + 1.day).rfc3339 }
 
-                    it { is_expected.to have_one_error_per_attribute }
+                    it { is_expected.to have_one_error_only }
                     it { is_expected.to have_error(:declaration_date, "This '#/declaration_date' is invalid. Check that it is in sequence with existing declaration dates for this participant.") }
                   end
                 end

--- a/spec/services/api/declarations/void_spec.rb
+++ b/spec/services/api/declarations/void_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe API::Declarations::Void, type: :model do
       let(:declaration) { FactoryBot.create(:declaration, :payable) }
       let(:lead_provider_id) { nil }
 
-      it { is_expected.to have_one_error_per_attribute }
+      it { is_expected.to have_one_error_only }
       it { is_expected.to have_error(:lead_provider_id, "Enter a '#/lead_provider_id'.") }
     end
 
@@ -18,21 +18,21 @@ RSpec.describe API::Declarations::Void, type: :model do
       let(:declaration) { FactoryBot.create(:declaration, :payable) }
       let(:lead_provider_id) { 123_456_789 }
 
-      it { is_expected.to have_one_error_per_attribute }
+      it { is_expected.to have_one_error_only }
       it { is_expected.to have_error(:lead_provider_id, "The '#/lead_provider_id' you have entered is invalid.") }
     end
 
     context "when declaration is voided" do
       let(:declaration) { FactoryBot.create(:declaration, :voided) }
 
-      it { is_expected.to have_one_error_per_attribute }
+      it { is_expected.to have_one_error_only }
       it { is_expected.to have_error(:declaration_api_id, "The declaration has already been voided.") }
     end
 
     context "when declaration is paid" do
       let(:declaration) { FactoryBot.create(:declaration, :paid) }
 
-      it { is_expected.to have_one_error_per_attribute }
+      it { is_expected.to have_one_error_only }
       it { is_expected.to have_error(:declaration_api_id, "This declaration has been clawed-back, so you can only view it.") }
     end
 

--- a/spec/support/matchers/have_one_error_only_matcher.rb
+++ b/spec/support/matchers/have_one_error_only_matcher.rb
@@ -1,0 +1,17 @@
+RSpec::Matchers.define :have_one_error_only do
+  match do |actual|
+    actual.invalid? && actual.errors.count == 1
+  end
+
+  failure_message do |_actual|
+    "expected #{actual.class} to have 1 error, but it had #{actual.errors.count} with messages: #{actual.errors.full_messages.join("\n")}"
+  end
+
+  failure_message_when_negated do |_actual|
+    "expected exactly one error message in total, but found more"
+  end
+
+  description do
+    "have exactly one error message in total across all attributes"
+  end
+end

--- a/spec/support/shared_examples/api_teacher_shared_action_support.rb
+++ b/spec/support/shared_examples/api_teacher_shared_action_support.rb
@@ -20,35 +20,35 @@ RSpec.shared_examples "an API teacher shared action", :with_metadata do
         context "when the `lead_provider` does not exist" do
           let(:lead_provider_id) { 9999 }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:lead_provider_id, "The '#/lead_provider_id' you have entered is invalid.") }
         end
 
         context "when a matching training period does not exist (different teacher type)" do
           let(:teacher_type) { trainee_type == :ect ? :mentor : :ect }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
         context "when a matching training period does not exist (different lead provider)" do
           let(:lead_provider_id) { FactoryBot.create(:lead_provider, name: "Different to #{lead_provider.name}").id }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 
         context "when the teacher does not exist" do
           let(:teacher_api_id) { "non-existent-participant-id" }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_api_id, "Your update cannot be made as the '#/teacher_api_id' is not recognised. Check participant details and try again.") }
         end
 
         context "when a non-existent teacher type is provided" do
           let(:teacher_type) { :other }
 
-          it { is_expected.to have_one_error_per_attribute }
+          it { is_expected.to have_one_error_only }
           it { is_expected.to have_error(:teacher_type, "The entered '#/teacher_type' is not recognised for the given participant. Check details and try again.") }
         end
 

--- a/spec/validators/evidence_type_validator_spec.rb
+++ b/spec/validators/evidence_type_validator_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -69,7 +69,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
@@ -79,7 +79,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -107,7 +107,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
@@ -117,7 +117,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -139,7 +139,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
@@ -149,7 +149,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -187,7 +187,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -209,7 +209,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
@@ -219,7 +219,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -247,7 +247,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
@@ -257,7 +257,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end
@@ -279,7 +279,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter a '#/evidence_type' value for this participant.")
             end
           end
@@ -289,7 +289,7 @@ RSpec.describe EvidenceTypeValidator, type: :model do
 
             it "has a meaningful error", :aggregate_failures do
               expect(subject).to be_invalid
-              expect(subject).to have_one_error_per_attribute
+              expect(subject).to have_one_error_only
               expect(subject).to have_error(:evidence_type, "Enter an available '#/evidence_type' type for this participant.")
             end
           end


### PR DESCRIPTION
### Context

Ticket: [3695](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3695)

When a lead provider submits a POST or PUT declaration, if there are multiple errors, we show all of them.

### Changes proposed in this pull request

- Most endpoints only show one in RECT, ECF1 also only shows one, and RECT should do the same.
- Checked the precedence/order of the validations/error messages, and all seems fine to me.

### Guidance to review

Review app
