### PR TITLE
Increase the parity check worker memory

### DIFF
--- a/config/terraform/application/config/paritycheck.tfvars.json
+++ b/config/terraform/application/config/paritycheck.tfvars.json
@@ -3,7 +3,7 @@
     "namespace": "cpd-production",
     "environment": "paritycheck",
     "enable_logit": true,
-    "worker_memory_max": "4Gi",
+    "worker_memory_max": "6Gi",
     "webapp_memory_max": "2Gi",
     "worker_replicas": 10,
     "webapp_replicas": 6,


### PR DESCRIPTION
We seem to get more jobs that hang/are pruned than the migration environment; updating the worker memory to match migration env so its hopefully more reliable.
