### PR TITLE
Remove `enable_migration_testing` check from `Migration::Base`

### DIFF
--- a/app/models/migration/base.rb
+++ b/app/models/migration/base.rb
@@ -2,7 +2,7 @@ module Migration
   class Base < ApplicationRecord
     self.abstract_class = true
 
-    connects_to database: { reading: :legacy, writing: :legacy } if Rails.application.config.enable_migration_testing
+    connects_to database: { reading: :legacy, writing: :legacy }
     connects_to database: { reading: :ecf, writing: :ecf } if Rails.env.test?
 
     def readonly?


### PR DESCRIPTION
This is necessary for the migration on Monday but it would be nice to test it out in production first.
