### PR TITLE
One off script to close teachers-who-passed-away periods right after live migration

### DIFF
--- a/db/scripts/close_teacher_periods.rb
+++ b/db/scripts/close_teacher_periods.rb
@@ -1,0 +1,19 @@
+# Close at_school, training and mentorship periods for the teachers in the list of trns
+#
+def close_teacher_periods(trns:, author_email:, finished_on: Date.current)
+  ActiveRecord::Base.transaction do
+    author = User.find_by!(email: author_email)
+
+    trns.each do |trn|
+      teacher = Teacher.find_by!(trn:)
+
+      # ect_at_school_periods + associated periods
+      teacher.ect_at_school_periods.ongoing.each do |period|
+        ECTAtSchoolPeriods::Finish.new(ect_at_school_period: period, finished_on:, author:).finish!
+      end
+
+      # mentor_at_school_periods + associated periods
+      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on:, author:).finish_existing_at_school_periods!
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Issue](https://github.com/DFE-Digital/register-ects-project-board/issues/3816)

To prevent known teachers that passed away to be listed in the school views, we need to close their at_school, mentorship and training periods

### Changes proposed in this pull request
Script to be run right after the live migration takes place.
This will close these teachers' periods so that schools can't see them listed anymore.


### Guidance to review
