### PR TITLE
Remove access to migration reset functionality

### DIFF
--- a/app/controllers/migration/migrations_controller.rb
+++ b/app/controllers/migration/migrations_controller.rb
@@ -27,11 +27,6 @@ class Migration::MigrationsController < ::AdminController
     redirect_to migration_migrations_path
   end
 
-  def reset
-    LegacyDataImporter.new.reset!
-    redirect_to migration_migrations_path
-  end
-
   def cache_stats
     @data_migrations = DataMigration.complete.where.not(cache_stats: nil).order(:id)
 

--- a/app/views/migration/migrations/index.html.erb
+++ b/app/views/migration/migrations/index.html.erb
@@ -6,7 +6,6 @@
   <%= render(partial: "in_progress_migration") %>
 <% elsif @completed_migration %>
   <%= render(partial: "completed_migration") %>
-  <%= govuk_button_to("Reset all migration data", { action: :reset }, warning: true) if Rails.application.config.enable_migration_testing %>
 <% else %>
   <%= govuk_button_to "Run migration", { action: :create }, warning: true, disabled: @data_migrations.present? %>
 <% end %>

--- a/config/routes/migration.rb
+++ b/config/routes/migration.rb
@@ -4,7 +4,6 @@ constraints -> { Rails.application.config.enable_migration_interface } do
       collection do
         get "cache_stats", action: :cache_stats, as: :cache_stats
         get "download_report/:model", action: :download_report, as: :download_report
-        post "reset", action: :reset, as: :reset
       end
     end
 


### PR DESCRIPTION
### Context

Prepping for launch, just for belt and braces this PR removes the ability to reset the database from the UI.

### Changes proposed in this pull request

- Removes button from the view
- Removed the controller method and route

