### PR TITLE
Fix `ECTDeclarationScenarios` api seeds

### DIFF
--- a/app/services/api_seed_data/ect_declaration_scenarios.rb
+++ b/app/services/api_seed_data/ect_declaration_scenarios.rb
@@ -28,7 +28,9 @@ module APISeedData
         training_time_period = { started_on: school_time_period[:started_on], finished_on: nil }
         training_period = create_training_period(ect_at_school_period:, school_partnership:, training_time_period:)
         create_ongoing_induction_period(teacher:, school_time_period:)
-        create_declaration(state: :paid, declaration_type: :"retained-1", training_period:, declaration_date: Date.new(2026, 1, 1))
+
+        milestone = training_period.schedule.milestones.where(declaration_type: :"retained-1").sample
+        create_declaration(state: :paid, declaration_type: :"retained-1", training_period:, declaration_date: milestone.start_date + 2.months)
 
         log_plant_info("Created participant for #{school_partnership.active_lead_provider.lead_provider.name} with retained-1 declaration and no started declaration")
       end
@@ -44,8 +46,12 @@ module APISeedData
         training_time_period = { started_on: school_time_period[:started_on], finished_on: nil }
         training_period = create_training_period(ect_at_school_period:, school_partnership:, training_time_period:)
         create_ongoing_induction_period(teacher:, school_time_period:)
-        create_declaration(state: :paid, declaration_type: :started, training_period:, declaration_date: Date.new(2025, 9, 1))
-        create_declaration(state: :no_payment, declaration_type: :"retained-2", training_period:, declaration_date: Date.new(2025, 9, 2))
+
+        milestone = training_period.schedule.milestones.where(declaration_type: :started).sample
+        create_declaration(state: :paid, declaration_type: :started, training_period:, declaration_date: milestone.start_date + 1.month)
+
+        milestone = training_period.schedule.milestones.where(declaration_type: :"retained-2").sample
+        create_declaration(state: :no_payment, declaration_type: :"retained-2", training_period:, declaration_date: milestone.start_date + 3.months)
 
         log_plant_info("Created participant for #{school_partnership.active_lead_provider.lead_provider.name} with paid started declaration and submitted retained-2 declaration")
       end

--- a/spec/services/api_seed_data/ect_declaration_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_declaration_scenarios_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe APISeedData::ECTDeclarationScenarios do
 
   def setup_test_data(lead_provider:)
     school_partnership = FactoryBot.create(:school_partnership, :for_year, year: contract_period.year, lead_provider:)
-    FactoryBot.create(:schedule, contract_period:, identifier: "ecf-standard-september").tap do |schedule|
-      Declaration.declaration_types.each_key do |declaration_type|
-        schedule.milestones.create!(declaration_type:, start_date: Date.new(2025, 6, 1))
-      end
-    end
+    FactoryBot.create(:schedule, :with_milestones, contract_period:, identifier: "ecf-standard-september")
 
     # API::Declarations::Create validates that an open output fee statement with a
     # future deadline exists for the lead provider's contract period
@@ -66,18 +62,23 @@ RSpec.describe APISeedData::ECTDeclarationScenarios do
       expect(teacher.finished_induction_period).to be_nil
 
       expect(teacher.ect_declarations.count).to eq(1)
-      expect(teacher.ect_declarations.first).to have_attributes(
+
+      retained_1_declaration = teacher.ect_declarations.first
+      milestone = training_period.schedule.milestones.find_by(declaration_type: :"retained-1")
+      expect(retained_1_declaration.declaration_date).to eq((milestone.start_date + 2.months).in_time_zone)
+
+      expect(retained_1_declaration).to have_attributes(
         declaration_type: "retained-1",
-        declaration_date: Date.new(2026, 1, 1).in_time_zone,
         overall_status: "paid"
       )
 
+      milestone = training_period.schedule.milestones.find_by(declaration_type: :started)
       service = API::Declarations::Create.new(
         lead_provider_id: lead_provider.id,
         teacher_api_id: teacher.api_id,
         teacher_type: :ect,
         evidence_type: "other",
-        declaration_date: "2025-11-21T08:46:29Z",
+        declaration_date: milestone.start_date.rfc3339,
         declaration_type: "started"
       )
 
@@ -109,15 +110,21 @@ RSpec.describe APISeedData::ECTDeclarationScenarios do
 
       expect(teacher.ect_declarations.count).to eq(2)
       started_declaration = teacher.ect_declarations.find_by(declaration_type: "started")
+
+      milestone = training_period.schedule.milestones.find_by(declaration_type: :started)
+      expect(started_declaration.declaration_date).to eq((milestone.start_date + 1.month).in_time_zone)
+
       expect(started_declaration).to have_attributes(
         declaration_type: "started",
-        declaration_date: Date.new(2025, 9, 1).in_time_zone,
         overall_status: "paid"
       )
+
       retained_2_declaration = teacher.ect_declarations.find_by(declaration_type: "retained-2")
+      milestone = training_period.schedule.milestones.find_by(declaration_type: :"retained-2")
+      expect(retained_2_declaration.declaration_date).to eq((milestone.start_date + 3.months).in_time_zone)
+
       expect(retained_2_declaration).to have_attributes(
         declaration_type: "retained-2",
-        declaration_date: Date.new(2025, 9, 2).in_time_zone,
         overall_status: "no_payment"
       )
 
@@ -134,7 +141,7 @@ RSpec.describe APISeedData::ECTDeclarationScenarios do
         teacher_api_id: teacher.api_id,
         teacher_type: :ect,
         evidence_type: "other",
-        declaration_date: "2025-09-02T08:46:29Z",
+        declaration_date: (retained_2_declaration.declaration_date - 1.day).rfc3339,
         declaration_type: "retained-1"
       )
 


### PR DESCRIPTION
### Context

When we run normal seeds and api seeds after, the api seeds `ECTDeclarationScenarios` is broken.

### Changes proposed in this pull request

- Fix it so we can run both seeds with no errors;

### Guidance to review

Run locally:

`rake db:reset`
and straight after
`rake api_seed_data:generate`

No errors should be displayed.