### PR TITLE
Update schedule when extending training period

### DIFF
--- a/app/migration/ecf2_teacher_history/training_period.rb
+++ b/app/migration/ecf2_teacher_history/training_period.rb
@@ -3,7 +3,6 @@ class ECF2TeacherHistory::TrainingPeriod
               :lead_provider_info,
               :delivery_partner_info,
               :contract_period_year,
-              :schedule_info,
               :created_at,
               :ecf_start_induction_record_id,
               :is_ect,
@@ -11,7 +10,7 @@ class ECF2TeacherHistory::TrainingPeriod
               :school,
               :combination
 
-  attr_accessor :started_on, :finished_on, :deferred_at, :deferral_reason, :withdrawn_at, :withdrawal_reason
+  attr_accessor :started_on, :finished_on, :deferred_at, :deferral_reason, :withdrawn_at, :withdrawal_reason, :schedule_info
 
   def initialize(started_on:,
                  finished_on:,
@@ -68,7 +67,7 @@ class ECF2TeacherHistory::TrainingPeriod
       started_on:,
       finished_on:,
       training_programme:,
-      schedule: schedule_info,
+      schedule: schedule_info.to_h,
       created_at:,
       ecf_start_induction_record_id:,
       lead_provider_info: lead_provider_info.to_h,

--- a/app/migration/teacher_history_converter/ect/all_induction_records.rb
+++ b/app/migration/teacher_history_converter/ect/all_induction_records.rb
@@ -79,6 +79,9 @@ private
         elsif last_training_period.present? && !induction_record.ignore_training?
           # extend training period
 
+          # ensure the most recent schedule is used on the period
+          last_training_period.schedule_info = induction_record.schedule_info
+
           # we should check for withdrawn here and ensure we close it or not overwrite the finished_at
           state_changed_at = induction_record.end_date
           lead_provider_id = induction_record.training_provider_info&.lead_provider_info&.ecf1_id

--- a/app/migration/teacher_history_converter/mentor/all_induction_records.rb
+++ b/app/migration/teacher_history_converter/mentor/all_induction_records.rb
@@ -90,6 +90,10 @@ private
         @current_school_period.training_periods << @current_training_period if @current_training_period.present?
       end
     elsif @current_training_period.present? && not_withdrawn_or_deferred? && !induction_record.ignore_training?
+
+      # ensure the most recent schedule is used on the period
+      @current_training_period.schedule_info = induction_record.schedule_info
+
       state_changed_at = induction_record.end_date
       lead_provider_id = induction_record.training_provider_info&.lead_provider_info&.ecf1_id
 

--- a/spec/migration/teacher_history_converter/real_examples/018dc077_4682_4dac_ad2c_5fe225d80595_spec.rb
+++ b/spec/migration/teacher_history_converter/real_examples/018dc077_4682_4dac_ad2c_5fe225d80595_spec.rb
@@ -1,0 +1,319 @@
+describe "Real data check for user 018dc077-4682-4dac-ad2c-5fe225d80595 (schedule change)" do
+  subject(:actual_output) { ecf2_teacher_history.to_h }
+
+  let(:input) do
+    {
+      trn: "1111111",
+      full_name: "A Teacher",
+      user_id: "018dc077-4682-4dac-ad2c-5fe225d80595",
+      created_at: Time.zone.local(2022, 4, 6, 13, 8, 9),
+      updated_at: Time.zone.local(2025, 9, 12, 10, 28, 6),
+      ect: {
+        participant_profile_id: "381473ce-22a2-40ca-847d-27a5e106ea26",
+        created_at: Time.zone.local(2022, 4, 6, 13, 8, 9),
+        updated_at: Time.zone.local(2025, 9, 12, 10, 28, 6),
+        induction_start_date: Date.new(2021, 9, 1),
+        induction_completion_date: Date.new(2023, 7, 21),
+        pupil_premium_uplift: true,
+        sparsity_uplift: false,
+        payments_frozen_cohort_start_year: :ignore,
+        states: [
+          {
+            state: "active",
+            reason: :ignore,
+            created_at: Time.zone.local(2022, 4, 6, 13, 8, 9),
+            cpd_lead_provider_id: "22727fdc-816a-4a3c-9675-030e724bbf89"
+          }
+        ],
+        induction_records: [
+          {
+            induction_record_id: "50e44811-d99d-48a7-b316-230d1c577611",
+            start_date: Date.new(2021, 9, 1),
+            end_date: Date.new(2023, 9, 25),
+            created_at: Time.zone.local(2022, 4, 6, 13, 8, 9),
+            updated_at: Time.zone.local(2024, 1, 9, 15, 25, 11),
+            training_programme: "full_induction_programme",
+            cohort_year: 2021,
+            school: {
+              urn: "100001",
+              name: "School 1"
+            },
+            induction_status: "changed",
+            training_status: "active",
+            preferred_identity_email: "a.teacher@example.com",
+            mentor_profile_id: "85a73b53-c02d-4325-94b4-6b5238c6d949",
+            appropriate_body: {},
+            training_provider_info: {
+              lead_provider: {
+                ecf1_id: "c3bc3cee-a636-42d6-8324-c033a6c38d31",
+                name: "Ambition Institute"
+              },
+              delivery_partner: {
+                ecf1_id: "daef2be8-f1aa-4a1e-a290-ff9da053289c",
+                name: "Delivery partner 1"
+              },
+              cohort_year: 2021
+            },
+            schedule_info: {
+              schedule_id: "84d07efd-ef9b-49c4-b25c-85b8b57cf8d0",
+              identifier: "ecf-standard-january",
+              name: "ECF Standard January",
+              cohort_year: 2021
+            }
+          },
+          {
+            induction_record_id: "a0f58a10-eb17-4b8a-9b07-3bd723fae337",
+            start_date: Date.new(2023, 9, 25),
+            end_date: :ignore,
+            created_at: Time.zone.local(2023, 9, 25, 2, 38, 5),
+            updated_at: Time.zone.local(2023, 9, 25, 2, 38, 5),
+            training_programme: "full_induction_programme",
+            cohort_year: 2021,
+            school: {
+              urn: "100001",
+              name: "School 1"
+            },
+            induction_status: "completed",
+            training_status: "active",
+            preferred_identity_email: "a.teacher@example.com",
+            mentor_profile_id: :ignore,
+            appropriate_body: {},
+            training_provider_info: {
+              lead_provider: {
+                ecf1_id: "c3bc3cee-a636-42d6-8324-c033a6c38d31",
+                name: "Ambition Institute"
+              },
+              delivery_partner: {
+                ecf1_id: "daef2be8-f1aa-4a1e-a290-ff9da053289c",
+                name: "Delivery partner 1"
+              },
+              cohort_year: 2021
+            },
+            schedule_info: {
+              schedule_id: "84d07efd-ef9b-49c4-b25c-85b8b57cf8d0",
+              identifier: "ecf-standard-january",
+              name: "ECF Standard January",
+              cohort_year: 2021
+            }
+          }
+        ],
+        mentor_at_school_periods: []
+      },
+      mentor: {
+        participant_profile_id: "4f25f80b-eaed-495c-958e-0f9579b120c7",
+        created_at: Time.zone.local(2024, 5, 22, 11, 41, 26),
+        updated_at: Time.zone.local(2025, 9, 12, 10, 28, 6),
+        mentor_completion_date: :ignore,
+        mentor_completion_reason: :ignore,
+        payments_frozen_cohort_start_year: :ignore,
+        induction_records: [
+          {
+            induction_record_id: "47d4552f-b59b-4253-9721-d9ccee356162",
+            start_date: Date.new(2023, 6, 1),
+            end_date: Date.new(2024, 7, 29),
+            training_programme: "full_induction_programme",
+            cohort_year: 2023,
+            school: {
+              urn: "100001",
+              name: "School 1"
+            },
+            induction_status: "changed",
+            training_status: "active",
+            preferred_identity_email: "a.teacher@example.com",
+            mentor_profile_id: :ignore,
+            training_provider_info: {
+              lead_provider: {
+                ecf1_id: "c3bc3cee-a636-42d6-8324-c033a6c38d31",
+                name: "Ambition Institute"
+              },
+              delivery_partner: {
+                ecf1_id: "daef2be8-f1aa-4a1e-a290-ff9da053289c",
+                name: "Delivery partner 1"
+              },
+              cohort_year: 2023
+            },
+            schedule_info: {
+              schedule_id: "db3d8a81-94b6-46ff-95dd-55f0e9b964e3",
+              identifier: "ecf-standard-september",
+              name: "ECF Standard September",
+              cohort_year: 2023
+            }
+          },
+          {
+            induction_record_id: "dafa854c-dbf0-49ce-9ff7-4a8b6f718c48",
+            start_date: Date.new(2024, 7, 29),
+            end_date: :ignore,
+            training_programme: "full_induction_programme",
+            cohort_year: 2023,
+            school: {
+              urn: "100001",
+              name: "School 1"
+            },
+            induction_status: "active",
+            training_status: "active",
+            preferred_identity_email: "a.teacher@example.com",
+            mentor_profile_id: :ignore,
+            training_provider_info: {
+              lead_provider: {
+                ecf1_id: "c3bc3cee-a636-42d6-8324-c033a6c38d31",
+                name: "Ambition Institute"
+              },
+              delivery_partner: {
+                ecf1_id: "daef2be8-f1aa-4a1e-a290-ff9da053289c",
+                name: "Delivery partner 1"
+              },
+              cohort_year: 2023
+            },
+            schedule_info: {
+              schedule_id: "c27a4bcf-0073-4b74-bf8f-d8075d39724c",
+              identifier: "ecf-standard-april",
+              name: "ECF Standard April",
+              cohort_year: 2023
+            }
+          }
+        ],
+        states: [
+          {
+            state: "active",
+            reason: :ignore,
+            created_at: Time.zone.local(2024, 5, 22, 11, 41, 26),
+            cpd_lead_provider_id: "22727fdc-816a-4a3c-9675-030e724bbf89"
+          }
+        ],
+        school_mentors: [
+          {
+            school: {
+              urn: "100001",
+              name: "School 1"
+            },
+            preferred_identity_email: "a.teacher@example.com",
+            created_at: Time.zone.local(2024, 5, 22, 11, 41, 26)
+          }
+        ]
+      }
+    }
+  end
+
+  let(:ecf1_teacher_history) { ECF1TeacherHistory.from_hash(input) }
+  let(:ecf2_teacher_history) { TeacherHistoryConverter.new(ecf1_teacher_history:, migration_mode:).convert_to_ecf2! }
+
+  context "when using the economy migrator" do
+    let(:migration_mode) { :latest_induction_records }
+
+    let(:expected_output) do
+      {
+        teacher: hash_including(
+          trn: "1111111",
+          ect_at_school_periods: array_including(
+            hash_including(
+              started_on: Date.new(2023, 7, 21),
+              finished_on: Date.new(2023, 7, 22),
+              school: hash_including(urn: "100001", name: "School 1"),
+              training_periods: array_including(
+                hash_including(
+                  started_on: Date.new(2023, 7, 21),
+                  finished_on: Date.new(2023, 7, 22),
+                  training_programme: "provider_led",
+                  lead_provider_info: hash_including(name: "Ambition Institute"),
+                  delivery_partner_info: hash_including(name: "Delivery partner 1"),
+                  contract_period_year: 2021,
+                  schedule: hash_including(
+                    identifier: "ecf-standard-january",
+                    name: "ECF Standard January",
+                    cohort_year: 2021
+                  )
+                )
+              )
+            )
+          ),
+          mentor_at_school_periods: array_including(
+            hash_including(
+              started_on: Date.new(2024, 7, 29),
+              finished_on: nil,
+              school: hash_including(urn: "100001", name: "School 1"),
+              training_periods: array_including(
+                hash_including(
+                  started_on: Date.new(2024, 7, 29),
+                  finished_on: nil,
+                  training_programme: "provider_led",
+                  lead_provider_info: hash_including(name: "Ambition Institute"),
+                  delivery_partner_info: hash_including(name: "Delivery partner 1"),
+                  contract_period_year: 2023,
+                  schedule: hash_including(
+                    identifier: "ecf-standard-april",
+                    name: "ECF Standard April",
+                    cohort_year: 2023
+                  )
+                )
+              )
+            )
+          )
+        )
+      }
+    end
+
+    it "matches the expected output" do
+      expect(actual_output).to include(expected_output)
+    end
+  end
+
+  context "when using the premium migrator" do
+    let(:migration_mode) { :all_induction_records }
+
+    let(:expected_output) do
+      {
+        teacher: hash_including(
+          trn: "1111111",
+          ect_at_school_periods: array_including(
+            hash_including(
+              started_on: Date.new(2021, 9, 1),
+              finished_on: Date.new(2023, 9, 25),
+              school: hash_including(urn: "100001", name: "School 1"),
+              training_periods: array_including(
+                hash_including(
+                  started_on: Date.new(2021, 9, 1),
+                  finished_on: Date.new(2023, 9, 25),
+                  training_programme: "provider_led",
+                  lead_provider_info: hash_including(name: "Ambition Institute"),
+                  delivery_partner_info: hash_including(name: "Delivery partner 1"),
+                  contract_period_year: 2021,
+                  schedule: hash_including(
+                    identifier: "ecf-standard-january",
+                    name: "ECF Standard January",
+                    cohort_year: 2021
+                  )
+                )
+              )
+            )
+          ),
+          mentor_at_school_periods: array_including(
+            hash_including(
+              started_on: Date.new(2024, 5, 22),
+              finished_on: nil,
+              school: hash_including(urn: "100001", name: "School 1"),
+              training_periods: array_including(
+                hash_including(
+                  started_on: Date.new(2024, 5, 22),
+                  finished_on: nil,
+                  training_programme: "provider_led",
+                  lead_provider_info: hash_including(name: "Ambition Institute"),
+                  delivery_partner_info: hash_including(name: "Delivery partner 1"),
+                  contract_period_year: 2023,
+                  schedule: hash_including(
+                    identifier: "ecf-standard-april",
+                    name: "ECF Standard April",
+                    cohort_year: 2023
+                  )
+                )
+              )
+            )
+          )
+        )
+      }
+    end
+
+    it "matches the expected output" do
+      expect(actual_output).to include(expected_output)
+    end
+  end
+end


### PR DESCRIPTION
### Context

When migrating training periods, we should update the schedule if we extend the period in case it has changed so we have the most recently set schedule on the training period.

### Changes proposed in this pull request

- Update the training period schedule with the induction record schedule when extending the period
- adds a real spec illustrating handling a switch from September to April schedules.
