### PR TITLE
[3672] schedule change validation error for a participant who has left

### DIFF
--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -99,8 +99,10 @@ module API::Teachers
     end
 
     def participant_status
-      @participant_status ||= API::TrainingPeriods::TeacherStatus
-        .new(latest_training_period: training_period)
+      @participant_status ||= API::TrainingPeriods::TeacherStatus.new(
+        latest_training_period: training_period,
+        teacher:
+      )
     end
 
     def lead_provider_is_currently_training_teacher

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -57,6 +57,7 @@ module API::Teachers
 
     def training_period_not_withdrawn
       return if errors[:teacher_api_id].any?
+      return unless training_period
       return unless training_status&.withdrawn?
 
       errors.add(:teacher_api_id, "Cannot perform actions on a withdrawn participant")
@@ -97,11 +98,21 @@ module API::Teachers
         )
     end
 
+    def participant_status
+      @participant_status ||= API::TrainingPeriods::TeacherStatus.new(
+        latest_training_period: training_period,
+        teacher:
+      )
+    end
+
     def lead_provider_is_currently_training_teacher
       return if errors[:teacher_api_id].any?
       return unless training_period
+      return if participant_status.active? || participant_status.leaving?
 
-      errors.add(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") unless training_period.ongoing_today?
+      if participant_status.left?
+        errors.add(:teacher_api_id, "You cannot change this participant’s schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.")
+      end
     end
 
     def no_future_training_periods_exist

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -99,10 +99,8 @@ module API::Teachers
     end
 
     def participant_status
-      @participant_status ||= API::TrainingPeriods::TeacherStatus.new(
-        latest_training_period: training_period,
-        teacher:
-      )
+      @participant_status ||= API::TrainingPeriods::TeacherStatus
+        .new(latest_training_period: training_period)
     end
 
     def lead_provider_is_currently_training_teacher

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -106,11 +106,9 @@ module API::Teachers
     def lead_provider_is_currently_training_teacher
       return if errors[:teacher_api_id].any?
       return unless training_period
-      return if participant_status.active? || participant_status.leaving?
+      return unless participant_status.left?
 
-      if participant_status.left?
-        errors.add(:teacher_api_id, "You cannot change this participant’s schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.")
-      end
+      errors.add(:teacher_api_id, "You cannot change this participant’s schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.")
     end
 
     def no_future_training_periods_exist

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -11,12 +11,12 @@ module API::Teachers
       message: "Enter a valid schedule identifier."
     }, allow_blank: true
     validate :schedule_exists
-    validate :training_period_not_withdrawn
     validate :change_to_different_schedule
     validate :schedule_applicable_for_trainee
     validate :school_partnership_exists_if_changing_contract_period
     validate :trainee_not_completed
     validate :lead_provider_is_currently_training_teacher
+    validate :training_period_not_withdrawn
     validate :no_future_training_periods_exist
     validate :can_move_to_frozen_contract_period
     validate :schedule_does_not_invalidate_declarations
@@ -110,7 +110,7 @@ module API::Teachers
       return unless training_period
       return unless participant_status.left?
 
-      errors.add(:teacher_api_id, "You cannot change this participant’s schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.")
+      errors.add(:teacher_api_id, "You cannot change this participant's schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.")
     end
 
     def no_future_training_periods_exist
@@ -118,7 +118,7 @@ module API::Teachers
       return unless training_period
 
       if future_training_periods.exists?
-        errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they are due to start with another lead provider in the future.")
+        errors.add(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.")
       end
     end
 
@@ -150,7 +150,7 @@ module API::Teachers
       return if errors[:teacher_api_id].any?
       return unless training_period&.teacher_completed_training?
 
-      errors.add(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training or induction.")
+      errors.add(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
     end
 
     def schedule_does_not_invalidate_declarations

--- a/app/services/api/teachers/school_transfers/query.rb
+++ b/app/services/api/teachers/school_transfers/query.rb
@@ -71,7 +71,7 @@ module API::Teachers::SchoolTransfers
     def where_updated_since(updated_since, lead_provider_id)
       return if ignore?(filter: updated_since)
 
-      # This includes a teacher’s first and last training periods, even if they aren't true transfers.
+      # This includes a teacher's first and last training periods, even if they aren't true transfers.
       # Excluding them is complex, and this is still an improvement over ECF. As a result, some teachers
       # may appear even if their transfer periods weren't necessarily updated — it's a best-effort approach.
       @scope = scope

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -22,6 +22,22 @@ module API::TrainingPeriods
       end
     end
 
+    def joining?
+      status == :joining
+    end
+
+    def active?
+      status == :active
+    end
+
+    def leaving?
+      status == :leaving
+    end
+
+    def left?
+      status == :left
+    end
+
   private
 
     def teacher_is_ect_and_completed_induction?

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,6 +21,32 @@
 #
 #     **bold** and _italic_ text
 
+- title: Updates to schedule and cohort changes for deferred and withdrawn participants
+  date: 2026-04-28
+  tags:
+    - sandbox-release
+    - production-release
+  body: |
+    In Register ECTs, you cannot change the schedule or cohort for a participant who has a participant_status of 'left'.  This is because making changes while a participant is not actively training would lead to inaccurate data. It also reflects changes in our data model, which separates active training from paused or ended training.
+
+    We have also updated the validation messages shown to make this clearer when it is attempted.
+
+    ## What's changed
+
+    You cannot change the schedule or cohort for a participant whose participant status is 'left'.
+
+    If their participant status is 'left' only because you have deferred or withdrawn them, you can resume them then change the schedule or cohort.
+
+    Lead providers should not change the schedule for a participant before it is confirmed they will definitely be moving to that schedule. For example, if a participant is deferred, they should not be changed to an extended schedule until it is confirmed they are returning to training and you have resumed them over the API. This is so we have accurate data for which schedule a participant is currently on.
+
+    ## What you need to do
+
+    Make sure to keep schedules and cohorts up to date for participants, so you don't need to update them later when they may have already left their school or training with you.
+
+    If you need to change the schedule or cohort for a deferred or withdrawn participant, resume them first and then submit the update. Don't update schedules or cohorts until you're certain they have returned to training.
+
+    If this becomes an issue, contact DfE by Teams or email.
+
 - title: Register early career teachers service launched
   date: 2026-04-28
   tags:

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -22,7 +22,7 @@
 #     **bold** and _italic_ text
 
 - title: Updates to schedule and cohort changes for deferred and withdrawn participants
-  date: 2026-04-28
+  date: 2026-05-05
   tags:
     - sandbox-release
     - production-release

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -56,7 +56,7 @@
   body: |
     We've launched the Register early career teachers (RECT) service.
 
-    This service replaces the Manage training for early career teachers service (ECF1). 
+    This service replaces the Manage training for early career teachers service (ECF1).
 
     The base URL for the API is:
 
@@ -70,16 +70,16 @@
 
     ## What providers need to do
 
-    On 28 April, providers must point their integrations to the RECT base URL and use the RECT API bearer token that was shared before launch by Galaxkey.  
+    On 28 April, providers must point their integrations to the RECT base URL and use the RECT API bearer token that was shared before launch by Galaxkey.
 
-    We recommend that providers perform full syncs with the new RECT API for all endpoints, and that they do this within the time window agreed with DfE. This will ensure all the data is up to date after the migration. 
+    We recommend that providers perform full syncs with the new RECT API for all endpoints, and that they do this within the time window agreed with DfE. This will ensure all the data is up to date after the migration.
 
     Providers should also:
 
     - update their systems to ensure they're no longer calling data from the old ECF1 service - This will include changing base URLs and making use of the new RECT API tokens
     - check downstream processes to make sure none are broken or have been impacted by the migration or changes to the service
     - ensure that all data flows and integrations continue to work as expected
-    - test their internal processes to ensure that data is being handled appropriately    
+    - test their internal processes to ensure that data is being handled appropriately
 
 - title: Schedule and cohort changes now allowed for ECTs and mentors transferring to you from another provider
   date: 2026-04-15
@@ -269,7 +269,7 @@
 
     **Participant is due to start with another lead provider**
     ```
-    You cannot change this participant’s schedule as they are due to start with another lead provider in the future.
+    You cannot change this participant's schedule as they are due to start with another lead provider in the future.
     ```
 
     **Moving a participant to a payments frozen cohort they were not previously part of**
@@ -284,7 +284,7 @@
 
     **Participant has completed training or induction**
     ```
-    You cannot change this participant’s schedule as they have completed their training or induction.
+    You cannot change this participant's schedule as they have completed their training or induction.
     ```
 
 - title: Unfunded mentors endpoint now available in the Register ECTs sandbox

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -77,11 +77,17 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             it { is_expected.to have_error(:contract_period_year, "You cannot change a participant to this contract_period as you do not have a partnership with the school for the contract_period. Contact the DfE for assistance.") }
           end
 
-          context "when the training period is not ongoing today" do
+          context "when the participant is leaving" do
+            before { training_period.update!(finished_on: 1.day.from_now) }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when the participant has left" do
             before { training_period.update!(finished_on: 1.day.ago) }
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. Only the lead provider currently training this participant can update their schedule.") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant’s schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.") }
           end
 
           context "when there are future training periods (for the same teacher)" do

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -41,10 +41,23 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
           end
 
           context "when training_period is withdrawn" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :withdrawn, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: 1.week.from_now) }
+            let!(:training_period) do
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", :withdrawn,
+                                "#{trainee_type}_at_school_period": at_school_period,
+                                started_on: at_school_period.started_on,
+                                finished_on: 1.week.from_now)
+            end
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "Cannot perform actions on a withdrawn participant") }
+
+            context "and participant_status is left" do
+              before { training_period.update!(finished_on: 1.day.ago) }
+
+              it { is_expected.to have_one_error_per_attribute }
+
+              it { expect(subject).to have_error(:teacher_api_id, "You cannot change this participant's schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.") }
+            end
           end
 
           context "when changing to the same schedule" do
@@ -87,7 +100,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             before { training_period.update!(finished_on: 1.day.ago) }
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant’s schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule. This is because the participant has a 'left' participant_status, so they are not training with you currently.") }
           end
 
           context "when there are future training periods (for the same teacher)" do
@@ -96,7 +109,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
             end
 
             it { is_expected.to have_one_error_per_attribute }
-            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they are due to start with another lead provider in the future.") }
+            it { is_expected.to have_error(:teacher_api_id, "You cannot change this participant's schedule as they are due to start with another lead provider in the future.") }
           end
 
           context "when there are future training periods (for a different teacher)" do
@@ -128,7 +141,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
             it "returns error" do
               expect(subject).to have_one_error_per_attribute
-              expect(subject).to have_error(:teacher_api_id, "You cannot change this participant’s schedule as they have completed their training or induction.")
+              expect(subject).to have_error(:teacher_api_id, "You cannot change this participant's schedule as they have completed their training or induction.")
             end
           end
 

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       let(:training_period) { FactoryBot.create(:training_period, :ongoing) }
 
       it { is_expected.to eq(:active) }
+      it { expect(service).to be_active }
+      it { expect(service).not_to be_joining }
+      it { expect(service).not_to be_leaving }
+      it { expect(service).not_to be_left }
     end
 
     context "when training period is to finish in the future" do
@@ -37,6 +41,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
         let(:training_period) { FactoryBot.create(:training_period, :for_ect, :finished) }
 
         it { is_expected.to eq(:left) }
+        it { expect(service).not_to be_active }
+        it { expect(service).not_to be_joining }
+        it { expect(service).not_to be_leaving }
+        it { expect(service).to be_left }
 
         context "when completed induction (pass or fail are treated the same)" do
           before do
@@ -47,6 +55,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
           end
 
           it { is_expected.to eq(:active) }
+          it { expect(service).to be_active }
+          it { expect(service).not_to be_joining }
+          it { expect(service).not_to be_leaving }
+          it { expect(service).not_to be_left }
         end
 
         context "when completed induction after training period" do
@@ -60,6 +72,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
           end
 
           it { is_expected.to eq(:left) }
+          it { expect(service).not_to be_active }
+          it { expect(service).not_to be_joining }
+          it { expect(service).not_to be_leaving }
+          it { expect(service).to be_left }
         end
       end
 
@@ -67,6 +83,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
         let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :finished) }
 
         it { is_expected.to eq(:left) }
+        it { expect(service).not_to be_active }
+        it { expect(service).not_to be_joining }
+        it { expect(service).not_to be_leaving }
+        it { expect(service).to be_left }
 
         context "when teacher becomes ineligible before period has finished" do
           before do
@@ -77,6 +97,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
           end
 
           it { is_expected.to eq(:active) }
+          it { expect(service).to be_active }
+          it { expect(service).not_to be_joining }
+          it { expect(service).not_to be_leaving }
+          it { expect(service).not_to be_left }
         end
 
         context "when teacher becomes ineligible when period has finished" do
@@ -88,6 +112,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
           end
 
           it { is_expected.to eq(:active) }
+          it { expect(service).to be_active }
+          it { expect(service).not_to be_joining }
+          it { expect(service).not_to be_leaving }
+          it { expect(service).not_to be_left }
         end
 
         context "when teacher becomes ineligible after period has finished" do
@@ -99,6 +127,10 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
           end
 
           it { is_expected.to eq(:left) }
+          it { expect(service).not_to be_active }
+          it { expect(service).not_to be_joining }
+          it { expect(service).not_to be_leaving }
+          it { expect(service).to be_left }
         end
       end
     end

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
           end
-          expect(participant_statuses).to(be_all { |s| s.status == :left })
+          expect(participant_statuses).to be_all(&:left?)
           expect(training_statuses).to be_all(&:withdrawn?)
         end
       end
@@ -417,7 +417,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
           end
-          expect(participant_statuses).to(be_all { |s| s.status == :left })
+          expect(participant_statuses).to be_all(&:left?)
           expect(training_statuses).to be_all(&:active?)
         end
       end


### PR DESCRIPTION
### Context

Once a participant's status means they have "left" an establishment changes are not permitted and the error message clearly communicates this.

A status of "leaving" still permits edits until the leaving date has passed.

### Changes proposed in this pull request

Update "change schedule" validation and release notes.

~`API::Teachers::ChangeSchedule` now uses `API::TrainingPeriods;;TrainingStatus` as the source of truth. `#ongoing_today?` is the same as `active? || leaving?` and felt right to replace as we check `left?`.~

This meant restoring some predicates that were pruned.

Post-review changes: reordered validations so this new validation takes precedent over `withdrawn`

### Guidance to review
