### PR TITLE
Return :active status for ECTs and mentors who have completed with finished training period

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -37,7 +37,7 @@ class API::TeacherSerializer < Blueprinter::Base
         end
       end
       field(:training_status) { |(training_period, _, _)| API::TrainingPeriods::TrainingStatus.new(training_period:).status }
-      field(:participant_status) { |(training_period, _, _)| API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period).status }
+      field(:participant_status) { |(training_period, teacher, _)| API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status }
       field(:eligible_for_funding) do |(training_period, teacher, _)|
         teacher_type = training_period.for_ect? ? :ect : :mentor
         API::Teachers::EligibilityForFunding.new(teacher:, teacher_type:).eligible?

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -25,7 +25,7 @@ module API::TrainingPeriods
   private
 
     def teacher_is_ect_and_completed_induction?
-      for_ect? && API::Teachers::InductionStatus.new(teacher:).completed_induction?
+      for_ect? && teacher_completed_induction_on_or_before_training_period_finished?
     end
 
     def teacher_is_mentor_and_completed_training?
@@ -38,6 +38,14 @@ module API::TrainingPeriods
       return true if finished_on.blank?
 
       !mentor_became_ineligible_for_funding_on.after?(finished_on)
+    end
+
+    def teacher_completed_induction_on_or_before_training_period_finished?
+      induction_status = API::Teachers::InductionStatus.new(teacher:)
+      return false unless induction_status.completed_induction?
+      return true if finished_on.blank?
+
+      !induction_status.induction_end_date.after?(finished_on)
     end
   end
 end

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -29,7 +29,15 @@ module API::TrainingPeriods
     end
 
     def teacher_is_mentor_and_completed_training?
-      for_mentor? && mentor_became_ineligible_for_funding_on.present?
+      for_mentor? &&
+        mentor_became_ineligible_for_funding_on_or_before_training_period_finished?
+    end
+
+    def mentor_became_ineligible_for_funding_on_or_before_training_period_finished?
+      return false if mentor_became_ineligible_for_funding_on.blank?
+      return true if finished_on.blank?
+
+      !mentor_became_ineligible_for_funding_on.after?(finished_on)
     end
   end
 end

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -1,20 +1,34 @@
 module API::TrainingPeriods
   class TeacherStatus
-    attr_reader :started_on, :finished_on
+    attr_reader :training_period
+
+    delegate :teacher, :started_on, :finished_on, :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
+    delegate :mentor_became_ineligible_for_funding_on, to: :teacher, allow_nil: true
 
     def initialize(latest_training_period:)
-      @started_on = latest_training_period.started_on
-      @finished_on = latest_training_period.finished_on
+      @training_period = latest_training_period
     end
 
     def status
-      if finished_on.present?
+      if teacher_is_ect_and_completed_induction? || teacher_is_mentor_and_completed_training?
+        :active # longer term we would prefer something like :complete
+      elsif finished_on.present?
         finished_on.future? ? :leaving : :left
       elsif started_on&.future?
         :joining
       else
-        :active # includes complete
+        :active
       end
+    end
+
+  private
+
+    def teacher_is_ect_and_completed_induction?
+      for_ect? && API::Teachers::InductionStatus.new(teacher:).completed_induction?
+    end
+
+    def teacher_is_mentor_and_completed_training?
+      for_mentor? && mentor_became_ineligible_for_funding_on.present?
     end
   end
 end

--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -1,12 +1,13 @@
 module API::TrainingPeriods
   class TeacherStatus
-    attr_reader :training_period
+    attr_reader :training_period, :teacher
 
-    delegate :teacher, :started_on, :finished_on, :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
+    delegate :started_on, :finished_on, :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
     delegate :mentor_became_ineligible_for_funding_on, to: :teacher, allow_nil: true
 
-    def initialize(latest_training_period:)
+    def initialize(latest_training_period:, teacher:)
       @training_period = latest_training_period
+      @teacher = teacher
     end
 
     def status

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -38,8 +38,8 @@ FactoryBot.define do
     end
 
     trait :finished do
-      started_on  { ect_at_school_period&.started_on || 1.year.ago }
-      finished_on { ect_at_school_period&.started_on&.+(1.month) || 2.weeks.ago }
+      started_on  { ect_at_school_period&.started_on || mentor_at_school_period&.started_on || 1.year.ago }
+      finished_on { ect_at_school_period&.started_on&.+(1.month) || mentor_at_school_period&.started_on&.+(1.month) || 2.weeks.ago }
     end
 
     trait(:school_led) do

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -94,11 +94,11 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
 
       before do
         if defined?(ect_training_period)
-          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: ect_training_period).and_return(mock_teacher_status)
+          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: ect_training_period, teacher:).and_return(mock_teacher_status)
         end
 
         if defined?(mentor_training_period)
-          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: mentor_training_period).and_return(mock_teacher_status)
+          allow(API::TrainingPeriods::TeacherStatus).to receive(:new).with(latest_training_period: mentor_training_period, teacher:).and_return(mock_teacher_status)
         end
       end
 

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe API::TrainingPeriods::TeacherStatus do
-  let(:service) { described_class.new(latest_training_period: training_period) }
+  let(:service) { described_class.new(latest_training_period: training_period, teacher:) }
   let(:teacher) { training_period.teacher }
 
   describe "#status" do

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -5,80 +5,78 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
   describe "#status" do
     subject { service.status }
 
-    context "when training period has started and not set to finish" do
-      let(:training_period) { FactoryBot.build(:training_period, :ongoing) }
-
-      it { is_expected.to eq(:active) }
-    end
-
-    context "when 'teacher.mentor_became_ineligible_for_funding_on' is set (indicating the mentor has completed training)" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing) }
-
-      before do
-        teacher.update!(
-          mentor_became_ineligible_for_funding_on: 3.months.ago,
-          mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
-        )
-      end
-
-      it { is_expected.to eq(:active) }
-    end
-
-    context "when 'finished_induction_period.finished_on' is set (indicating the ECT has completed training)" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing) }
-
-      before do
-        FactoryBot.create(:induction_period, :pass, teacher:)
-      end
-
-      it { is_expected.to eq(:active) }
-    end
-
     context "when training period set to start in the future" do
-      let(:training_period) { FactoryBot.build(:training_period, :not_started_yet) }
+      let(:training_period) { FactoryBot.create(:training_period, :not_started_yet) }
 
       it { is_expected.to eq(:joining) }
     end
 
-    context "when training period set to finish in the future" do
-      let(:training_period) { FactoryBot.build(:training_period, started_on: 3.months.ago, finished_on: 5.months.from_now) }
+    context "when training period has started and not finished" do
+      let(:training_period) { FactoryBot.create(:training_period, :ongoing) }
+
+      it { is_expected.to eq(:active) }
+    end
+
+    context "when training period is to finish in the future" do
+      let(:started_on) { 3.months.ago }
+      let(:finished_on) { 1.month.from_now }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on:, finished_on:) }
+      let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:, started_on:, finished_on:) }
 
       it { is_expected.to eq(:leaving) }
+
+      context "when training period set to both start and finish in the future" do
+        let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:, started_on: 1.week.from_now, finished_on:) }
+
+        it { is_expected.to eq(:leaving) }
+      end
     end
 
     context "when training period has already finished" do
-      let(:training_period) { FactoryBot.build(:training_period, started_on: 12.months.ago, finished_on: 2.months.ago) }
+      context "when the teacher is acting as an ECT for this training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :finished) }
 
-      it { is_expected.to eq(:left) }
-    end
+        it { is_expected.to eq(:left) }
 
-    context "when training period set to both start and finish in the future" do
-      let(:training_period) { FactoryBot.build(:training_period, started_on: 1.month.from_now, finished_on: 2.months.from_now) }
+        context "when completed induction (pass or fail are treated the same)" do
+          before do
+            # complete induction
+            FactoryBot.create(:induction_period, :pass, teacher:)
+          end
 
-      it { is_expected.to eq(:leaving) }
-    end
+          it { is_expected.to eq(:active) }
+        end
 
-    context "when the mentor had left and completes the training afterwards" do
-      let(:training_period) { FactoryBot.create(:training_period, :finished) }
+        context "when completed induction after training period" do
+          before do
+            # complete induction
+            FactoryBot.create(
+              :induction_period, :pass, teacher:,
+                                        started_on: training_period.started_on,
+                                        finished_on: training_period.finished_on + 1.week
+            )
+          end
 
-      before do
-        teacher.update!(
-          mentor_became_ineligible_for_funding_on: training_period.finished_on + 1.week,
-          mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
-        )
+          it { is_expected.to eq(:active) }
+        end
       end
 
-      it { is_expected.to eq(:left) }
-    end
+      context "when the teacher is acting as a mentor for this training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :finished) }
 
-    context "when the ECT had left and passes/fails induction afterwards" do
-      let(:training_period) { FactoryBot.build(:training_period, started_on: 12.months.ago, finished_on: 2.months.ago) }
+        it { is_expected.to eq(:left) }
 
-      before do
-        FactoryBot.create(:induction_period, :pass, teacher:, started_on: 1.month.ago, finished_on: 1.week.ago)
+        context "when teacher becomes ineligible after period has finished" do
+          before do
+            teacher.update!(
+              mentor_became_ineligible_for_funding_on: training_period.finished_on + 1.week,
+              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
+            )
+          end
+
+          it { is_expected.to eq(:active) }
+        end
       end
-
-      it { is_expected.to eq(:left) }
     end
   end
 end

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
         context "when completed induction (pass or fail are treated the same)" do
           before do
             # complete induction
-            FactoryBot.create(:induction_period, :pass, teacher:)
+            FactoryBot.create(:induction_period, :pass, teacher:,
+                                                        started_on: training_period.started_on,
+                                                        finished_on: training_period.finished_on)
           end
 
           it { is_expected.to eq(:active) }
@@ -57,7 +59,7 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
             )
           end
 
-          it { is_expected.to eq(:active) }
+          it { is_expected.to eq(:left) }
         end
       end
 

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -66,15 +66,37 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
 
         it { is_expected.to eq(:left) }
 
-        context "when teacher becomes ineligible after period has finished" do
+        context "when teacher becomes ineligible before period has finished" do
           before do
             teacher.update!(
-              mentor_became_ineligible_for_funding_on: training_period.finished_on + 1.week,
+              mentor_became_ineligible_for_funding_on: training_period.finished_on - 1.week,
               mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
             )
           end
 
           it { is_expected.to eq(:active) }
+        end
+
+        context "when teacher becomes ineligible when period has finished" do
+          before do
+            teacher.update!(
+              mentor_became_ineligible_for_funding_on: training_period.finished_on,
+              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
+            )
+          end
+
+          it { is_expected.to eq(:active) }
+        end
+
+        context "when teacher becomes ineligible after period has finished" do
+          before do
+            teacher.update!(
+              mentor_became_ineligible_for_funding_on: training_period.finished_on + 1.day,
+              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
+            )
+          end
+
+          it { is_expected.to eq(:left) }
         end
       end
     end

--- a/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
+++ b/spec/services/api_seed_data/ect_participant_action_scenarios_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
       Metadata::Manager.refresh_all_metadata!
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:withdrawn)
-      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period).status).to eq(:left)
+      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status).to eq(:left)
       expect(training_period.at_school_period).to be_ongoing
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil
@@ -98,7 +98,7 @@ RSpec.describe APISeedData::ECTParticipantActionScenarios do
       Metadata::Manager.refresh_all_metadata!
 
       expect(API::TrainingPeriods::TrainingStatus.new(training_period:).status).to eq(:active)
-      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period).status).to eq(:active)
+      expect(API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status).to eq(:active)
       expect(training_period.at_school_period).to be_ongoing
       expect(teacher.induction_periods).to be_present
       expect(teacher.finished_induction_period).to be_nil

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
           expect(ects_leaving.count + mentors_leaving.count).to eq(4)
 
           # make sure all created participants have 'leaving' status
-          expect((ects_leaving.map(&:ect_training_periods) + mentors_leaving.map(&:mentor_training_periods)).flatten.map { |tp| API::TrainingPeriods::TeacherStatus.new(latest_training_period: tp).status }.uniq).to eq(%i[leaving])
+          expect((ects_leaving.map(&:ect_training_periods) + mentors_leaving.map(&:mentor_training_periods)).flatten.map { |tp| API::TrainingPeriods::TeacherStatus.new(latest_training_period: tp, teacher: tp.teacher).status }.uniq).to eq(%i[leaving])
         end
       end
     end
@@ -261,7 +261,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             mentors_joining.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it, teacher: it.teacher)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
@@ -310,7 +310,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             mentors_leaving.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it, teacher: it.teacher)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
@@ -361,7 +361,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             withdrawn_mentors_left.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it, teacher: it.teacher)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)
@@ -412,7 +412,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
             active_mentors_left.map(&:mentor_training_periods)
           ).flatten
           participant_statuses = training_periods.map do
-            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it)
+            API::TrainingPeriods::TeacherStatus.new(latest_training_period: it, teacher: it.teacher)
           end
           training_statuses = training_periods.map do
             API::TrainingPeriods::TrainingStatus.new(training_period: it)


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3838

Currently if a training period is finished the participant_status returns as `:left` (or `:leaving` if the date is in the future).

### Changes proposed in this pull request

If the teacher has "completed" in their role in this training period (for an ECT this would be completed induction, for a mentor this would be that they became ineligible for funding), then their status should be :active rather than :left when the training_period is finished. 

### Guidance to review

Relatively small change. Some restructuring of test logic.