### PR TITLE
Record teacher_name_updated_by_user event when name is corrected during registration

### DIFF
--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -174,6 +174,11 @@ module Schools
 
     def record_event!
       Events::Record.record_teacher_registered_as_ect_event!(author:, ect_at_school_period:, teacher:, school:, training_period:)
+
+      if corrected_name.present?
+        old_name = Teachers::Name.new(teacher).full_name_in_trs
+        Events::Record.teacher_name_updated_by_user_event!(old_name:, new_name: corrected_name, author:, teacher:)
+      end
     end
 
     def reuse_old_partnership

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -133,6 +133,11 @@ module Schools
 
     def record_event!
       Events::Record.record_teacher_registered_as_mentor_event!(author:, mentor_at_school_period:, teacher:, school:, training_period:, lead_provider:)
+
+      if corrected_name.present?
+        old_name = Teachers::Name.new(teacher).full_name_in_trs
+        Events::Record.teacher_name_updated_by_user_event!(old_name:, new_name: corrected_name, author:, teacher:)
+      end
     end
   end
 end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Schools::RegisterECT do
         let!(:active_lead_provider) do
           FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
         end
-        let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+        let!(:teacher) { FactoryBot.create(:teacher, trn:, trs_first_name:, trs_last_name:) }
 
         it "creates an associated ECTAtSchoolPeriod record" do
           expect { service.register! }.to change(ECTAtSchoolPeriod, :count).by(1)
@@ -104,6 +104,25 @@ RSpec.describe Schools::RegisterECT do
             .with(
               hash_including(author:, ect_at_school_period:, teacher:, school:)
             )
+        end
+
+        it "records a teacher_name_updated_by_user event when a corrected name is provided" do
+          expect(Events::Record).to receive(:teacher_name_updated_by_user_event!).with(
+            old_name: "#{trs_first_name} #{trs_last_name}",
+            new_name: "Randy Marsh",
+            author:,
+            teacher: anything
+          )
+          service.register!
+        end
+
+        context "when no corrected name is provided" do
+          let(:corrected_name) { nil }
+
+          it "does not record a teacher_name_updated_by_user event" do
+            expect(Events::Record).not_to receive(:teacher_name_updated_by_user_event!)
+            service.register!
+          end
         end
 
         it "sets appropriate body and provider choices for the school" do

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -68,6 +68,25 @@ RSpec.describe Schools::RegisterMentor do
           expect { service.register! }
             .to have_enqueued_mail(Schools::MentorRegistrationMailer, :confirmation)
         end
+
+        it "records a teacher_name_updated_by_user event when a corrected name is provided" do
+          expect(Events::Record).to receive(:teacher_name_updated_by_user_event!).with(
+            old_name: "#{trs_first_name} #{trs_last_name}",
+            new_name: "Randy Marsh",
+            author:,
+            teacher: anything
+          )
+          service.register!
+        end
+
+        context "when no corrected name is provided" do
+          let(:corrected_name) { nil }
+
+          it "does not record a teacher_name_updated_by_user event" do
+            expect(Events::Record).not_to receive(:teacher_name_updated_by_user_event!)
+            service.register!
+          end
+        end
       end
 
       context "when a Teacher record with the same trn exists" do


### PR DESCRIPTION
Ticket [here](https://github.com/DFE-Digital/register-ects-project-board/issues/3834)

### Context
When a school user corrects a teacher's name during the ECT or mentor registration journey, no event was recorded. This meant there was no audit trail for name corrections made at the point of registration, only for corrections made post-registration via the change name wizard

### Changes proposed in this pull request
- Updated `Schools::RegisterECT#record_event!` and `Schools::RegisterMentor#record_event!` to create a `teacher_name_updated_by_user` event when a `corrected_name` is present

### Guidance to review
-  register an ECT or mentor and correct their name at the confirm name step, then check the event log to confirm a `teacher_name_updated_by_user` event appears with the expected heading alongside the `teacher_registered_as_ect / teacher_registered_as_mentor event`
