### PR TITLE
Travel in time!

### DIFF
--- a/app/components/time_traveller_component.rb
+++ b/app/components/time_traveller_component.rb
@@ -1,0 +1,39 @@
+class TimeTravellerComponent < ApplicationComponent
+  erb_template <<~ERB
+    <% if Current.date_after_time_travel.present? %>
+      <%= govuk_phase_banner(tag: {colour: "purple", text: "Warning 📆🚨"}) do %>
+        <%= message %>
+        <%= govuk_link_to("Change it or reset it", new_time_traveller_path) %>
+      <% end %>
+    <% else %>
+      <%= govuk_phase_banner(tag: {colour: "purple", text: "Travel in time ⏪"}) do %>
+        <%= govuk_link_to("Choose a date", new_time_traveller_path) %>
+      <% end %>
+    <% end %>
+  ERB
+
+  def render? = Rails.application.config.enable_time_travel
+
+private
+
+  def message
+    <<~TXT.squish
+      Today is #{Current.date_after_time_travel.to_fs(:govuk)}, which is
+      #{relative_date_in_words}!
+    TXT
+  end
+
+  def relative_date_in_words
+    distance_in_words = helpers.distance_of_time_in_words(
+      Current.date_before_time_travel,
+      Current.date_after_time_travel
+    )
+    suffix = if Current.date_after_time_travel.after?(Current.date_before_time_travel)
+               "from now"
+             else
+               "ago"
+             end
+
+    "#{distance_in_words} #{suffix}"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include DfE::Analytics::Requests
+  include TimeTravellable
 
   before_action :set_sentry_user
 

--- a/app/controllers/concerns/time_travellable.rb
+++ b/app/controllers/concerns/time_travellable.rb
@@ -1,0 +1,25 @@
+require "active_support/testing/time_helpers"
+
+module TimeTravellable
+  extend ActiveSupport::Concern
+  include ActiveSupport::Testing::TimeHelpers
+
+  included do
+    around_action :travel_in_time,
+                  if: -> { Rails.application.config.enable_time_travel }
+  end
+
+private
+
+  def travel_in_time
+    if session["date_after_time_travel"].present?
+      Current.date_before_time_travel = Date.current
+      Current.date_after_time_travel = Date.parse(session["date_after_time_travel"])
+      travel_to Current.date_after_time_travel
+    end
+
+    yield
+  ensure
+    travel_back
+  end
+end

--- a/app/controllers/time_travellers_controller.rb
+++ b/app/controllers/time_travellers_controller.rb
@@ -1,0 +1,37 @@
+class TimeTravellersController < ApplicationController
+  include MultiparameterDateErrorHandling
+
+  layout "full"
+
+  skip_around_action :travel_in_time
+
+  def new
+    @time_traveller = TimeTraveller.new
+  end
+
+  def create
+    @time_traveller = TimeTraveller.new(**travel_to_params)
+
+    if @time_traveller.valid?
+      session["date_after_time_travel"] = @time_traveller.travel_to_date.value_as_date
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::MultiparameterAssignmentErrors => e
+    @time_traveller = TimeTraveller.new
+    add_multiparameter_date_errors(@time_traveller, e, param_key: :time_traveller)
+    render :new, status: :unprocessable_entity
+  end
+
+  def destroy
+    session["date_after_time_travel"] = nil
+    redirect_to root_path
+  end
+
+private
+
+  def travel_to_params
+    params.expect(time_traveller: :travel_to)
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -2,7 +2,9 @@ class Current < ActiveSupport::CurrentAttributes
   attribute :session, default: {}
   attribute :user,
             :administrator,
-            :role
+            :role,
+            :date_after_time_travel,
+            :date_before_time_travel
 
   def user=(user)
     super

--- a/app/services/time_traveller.rb
+++ b/app/services/time_traveller.rb
@@ -1,0 +1,21 @@
+class TimeTraveller
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attribute :travel_to, :date
+
+  validate :travel_to_valid
+
+  def travel_to_date
+    @travel_to_date ||= Schools::Validation::HashDate.new(travel_to)
+  end
+
+private
+
+  def travel_to_valid
+    return if travel_to_date.valid?
+
+    errors.add(:travel_to, travel_to_date.error_message)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
     <div class="govuk-width-container">
       <%= render partial: "layouts/shared/banners" %>
+      <%= render TimeTravellerComponent.new %>
       <%= render Admin::ImpersonationBannerComponent.new(user: current_user, school: @school) %>
       <%= yield(:backlink_or_breadcrumb) %>
 

--- a/app/views/layouts/full.html.erb
+++ b/app/views/layouts/full.html.erb
@@ -10,6 +10,7 @@
     <div class="govuk-width-container">
       <div class="govuk-!-display-none-print">
         <%= render partial: "layouts/shared/banners" %>
+        <%= render TimeTravellerComponent.new %>
         <%= render Admin::ImpersonationBannerComponent.new(user: current_user, school: @school) %>
         <%= yield(:backlink_or_breadcrumb) %>
       </div>

--- a/app/views/time_travellers/new.html.erb
+++ b/app/views/time_travellers/new.html.erb
@@ -1,0 +1,30 @@
+<% page_data(
+    title: "What date do you want to travel to?",
+    error: @time_traveller.errors.any?,
+    backlink_href: backlink_with_fallback(fallback: root_path)
+  ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @time_traveller, url: time_traveller_path) do |form| %>
+    <%= content_for(:error_summary) { form.govuk_error_summary } %>
+
+    <%= form.govuk_date_field(
+          :travel_to,
+          width: "two-thirds",
+          legend: { text: "Travel to date", size: "m", tag: "h3", hidden: true },
+          hint: { text: "For example, 17 9 #{Date.current.year.next}" }
+        ) %>
+
+    <%= govuk_inset_text do %>
+      Time travel is not thread-safe. If you’re travelling through time, it’s
+      possible you might run into other time-travellers. If you do, you might see
+      some unexpected behaviour. If that happens, reset and try again later.
+    <% end %>
+
+    <%= form.govuk_submit "Back to the future!" %>
+  <% end %>
+
+  <%= govuk_button_to "Reset", time_traveller_path, method: :delete, warning: true %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,7 @@ module RegisterEarlyCareerTeachers
     config.enable_sentry = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_SENTRY", false))
     config.enable_blazer = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_BLAZER", false))
     config.enable_api = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_API", false))
+    config.enable_time_travel = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_TIME_TRAVEL", false))
     config.bypass_filter_parameter_logging = false
     config.sentry_dsn = ENV["SENTRY_DSN"]
     config.enable_request_specs_timeout = ActiveModel::Type::Boolean.new.cast(ENV.fetch("CI", false))
@@ -104,7 +105,7 @@ module RegisterEarlyCareerTeachers
 
     config.middleware.use API::RequestMiddleware
 
-    if ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENABLE_TIME_TRAVEL", false))
+    if config.enable_time_travel
       config.middleware.use API::TimeTravelerMiddleware
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,10 @@ Rails.application.routes.draw do
     resources :personas, only: %i[index]
   end
 
+  constraints -> { Rails.application.config.enable_time_travel } do
+    resource :time_traveller, only: %i[new create destroy]
+  end
+
   draw :admin
   draw :appropriate_body
   draw :school

--- a/spec/controllers/concerns/time_travellable_spec.rb
+++ b/spec/controllers/concerns/time_travellable_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe TimeTravellable, type: :controller do
+  controller(ActionController::Base) do
+    include TimeTravellable
+
+    def show
+      render plain: "It's #{Date.current.strftime('%Y-%m-%d')}"
+    end
+  end
+
+  before do
+    routes.draw { get "show" => "anonymous#show" }
+    allow(Rails.application.config)
+      .to receive(:enable_time_travel)
+      .and_return(time_travel_enabled)
+  end
+
+  let!(:todays_date) { Date.current }
+
+  context "when time travel is enabled" do
+    let(:time_travel_enabled) { true }
+
+    context "when the date after time travel is set in the session" do
+      let(:session) { { "date_after_time_travel" => "2025-12-25" } }
+
+      it "returns the time-travelled date" do
+        get(:show, session:)
+
+        expect(response.body).to eq("It's 2025-12-25")
+      end
+    end
+
+    context "when the date after time travel is not set in the session" do
+      let(:session) { {} }
+
+      it "returns the non-time-travelled date" do
+        get(:show, session:)
+
+        expect(response.body).to eq("It's #{todays_date.strftime('%Y-%m-%d')}")
+      end
+    end
+  end
+
+  context "when time travel is disabled" do
+    let(:time_travel_enabled) { false }
+
+    context "when the date after time travel is set in the session" do
+      let(:session) { { "date_after_time_travel" => "2025-12-25" } }
+
+      it "returns the non-time-travelled date" do
+        get(:show, session:)
+
+        expect(response.body).to eq("It's #{todays_date.strftime('%Y-%m-%d')}")
+      end
+    end
+
+    context "when the date after time travel is not set in the session" do
+      let(:session) { {} }
+
+      it "returns the non-time-travelled date" do
+        get(:show, session:)
+
+        expect(response.body).to eq("It's #{todays_date.strftime('%Y-%m-%d')}")
+      end
+    end
+  end
+end

--- a/spec/requests/time_travellers_spec.rb
+++ b/spec/requests/time_travellers_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe "Time Travellers", type: :request do
+  before do
+    allow(Rails.application.config)
+      .to receive(:enable_time_travel)
+      .and_return(true)
+  end
+
+  describe "GET #new" do
+    subject(:new_time_traveller) do
+      get new_time_traveller_path
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+  end
+
+  describe "POST #create" do
+    subject(:create_time_traveller) do
+      post(time_traveller_path, params:)
+      response
+    end
+
+    context "when the date is valid" do
+      let(:params) do
+        {
+          time_traveller: {
+            "travel_to(1i)": "2025",
+            "travel_to(2i)": "12",
+            "travel_to(3i)": "25"
+          }
+        }
+      end
+
+      it { is_expected.to redirect_to(root_path) }
+
+      it "assigns the date after time travel to the session" do
+        create_time_traveller
+        expect(session["date_after_time_travel"]).to eq(Date.new(2025, 12, 25))
+      end
+    end
+
+    context "when the date is invalid" do
+      let(:params) do
+        {
+          time_traveller: {
+            "travel_to(1i)": "2025",
+            "travel_to(2i)": "12",
+            "travel_to(3i)": ""
+          }
+        }
+      end
+
+      it { is_expected.to have_http_status(:unprocessable_content) }
+
+      it "does not assign a date after time travel to the session" do
+        create_time_traveller
+        expect(session["date_after_time_travel"]).to be_nil
+      end
+    end
+
+    context "when the date is in the wrong format" do
+      let(:params) do
+        {
+          time_traveller: {
+            "travel_to(1i)": "2025",
+            "travel_to(2i)": "23",
+            "travel_to(3i)": "1"
+          }
+        }
+      end
+
+      it { is_expected.to have_http_status(:unprocessable_content) }
+
+      it "does not assign a date after time travel to the session" do
+        create_time_traveller
+        expect(session["date_after_time_travel"]).to be_nil
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject(:destroy_time_traveller) do
+      delete(time_traveller_path)
+      response
+    end
+
+    it { is_expected.to redirect_to(root_path) }
+
+    it "removes the date after time travel from the session" do
+      post time_traveller_path, params: {
+        time_traveller: {
+          "travel_to(1i)": "2025",
+          "travel_to(2i)": "12",
+          "travel_to(3i)": "25"
+        }
+      }
+      expect(session["date_after_time_travel"]).to eq(Date.new(2025, 12, 25))
+
+      destroy_time_traveller
+      expect(session["date_after_time_travel"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Context

Driven by #2922 

### Changes proposed in this pull request

Since https://github.com/DFE-Digital/register-early-career-teachers-public/commit/f8d8513bd8a50acb62953c0cb92fb0cdd937112f, it has been possible to travel in time when submitting API requests.

This has proved really useful for testing, especially when we want to setup data
or simulate scenarios happening on specific dates.

This was limited to the API though, and there was no capability for us to do the
same across the application.

This extends the functionality enabled by setting `ENABLE_TIME_TRAVEL` to
`true`.

We're storing the dates in the session and leaning on `Current` attributes to
set and access the dates on a per-request basis.

Users can change or reset the date via a simple form.

Now, (except in Production) users can "Choose a date" they want to travel to,
and be transported through space and time!

**Note:** this is definitely not thread-safe, and it might break if pushed too
hard. So bear that in mind! It definitely isn't intended to ever be run in
Production, and its usefulness might degrade the closer an environment gets to
being Production-like (e.g Staging). So also bear that in mind!

### Guidance to review

Play around with the functionality in the review app 📆
