### PR TITLE
Optimise API endpoints

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -10,7 +10,7 @@ module API
           delivery_partner_api_ids: extract_conditions(delivery_partner_api_ids, type: :uuid),
           updated_since:,
         }
-        paginated_declarations = declarations_query(conditions:).declarations { paginate(it) }
+        paginated_declarations = paginate(declarations_query(conditions:).declarations)
 
         render json: to_json(paginated_declarations)
       end

--- a/app/controllers/api/v3/delivery_partners_controller.rb
+++ b/app/controllers/api/v3/delivery_partners_controller.rb
@@ -6,7 +6,7 @@ module API
           contract_period_years: extract_conditions(contract_period_years, type: :integer),
           sort:
         }
-        paginated_delivery_partners = delivery_partners_query(conditions:).delivery_partners { paginate(it) }
+        paginated_delivery_partners = paginate(delivery_partners_query(conditions:).delivery_partners)
 
         render json: to_json(paginated_delivery_partners)
       end

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -11,7 +11,7 @@ module API
           api_from_teacher_id:,
           sort:
         }
-        paginated_teachers = teachers_query(conditions:).teachers { paginate(it) }
+        paginated_teachers = paginate(teachers_query(conditions:).teachers)
 
         render json: to_json(paginated_teachers)
       end

--- a/app/controllers/api/v3/partnerships_controller.rb
+++ b/app/controllers/api/v3/partnerships_controller.rb
@@ -8,7 +8,7 @@ module API
           delivery_partner_api_ids: extract_conditions(delivery_partner_api_ids),
           sort:
         }
-        paginated_school_partnerships = partnerships_query(conditions:).school_partnerships { paginate(it) }
+        paginated_school_partnerships = paginate(partnerships_query(conditions:).school_partnerships)
 
         render json: to_json(paginated_school_partnerships)
       end

--- a/app/controllers/api/v3/schools_controller.rb
+++ b/app/controllers/api/v3/schools_controller.rb
@@ -5,7 +5,7 @@ module API
 
       def index
         conditions = { updated_since:, urn:, sort: }
-        paginated_schools = schools_query(conditions:).schools { paginate(it) }
+        paginated_schools = paginate(schools_query(conditions:).schools)
 
         render json: to_json(paginated_schools)
       end

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -6,7 +6,7 @@ module API
           contract_period_years: extract_conditions(contract_period_years, type: :integer),
           updated_since:,
         }
-        paginated_statements = statements_query(conditions:).statements { paginate(it) }
+        paginated_statements = paginate(statements_query(conditions:).statements)
 
         render json: to_json(paginated_statements)
       end

--- a/app/controllers/api/v3/transfers_controller.rb
+++ b/app/controllers/api/v3/transfers_controller.rb
@@ -3,8 +3,7 @@ module API
     class TransfersController < APIController
       def index
         conditions = { updated_since:, sort: }
-        paginated_school_transfers = school_transfers_query(conditions:)
-          .school_transfers { paginate(it) }
+        paginated_school_transfers = paginate(school_transfers_query(conditions:).school_transfers)
 
         render json: to_json(paginated_school_transfers)
       end

--- a/app/controllers/api/v3/unfunded_mentors_controller.rb
+++ b/app/controllers/api/v3/unfunded_mentors_controller.rb
@@ -3,7 +3,7 @@ module API
     class UnfundedMentorsController < APIController
       def index
         conditions = { updated_since:, sort: }
-        paginated_unfunded_mentors = unfunded_mentors_query(conditions:).unfunded_mentors { paginate(it) }
+        paginated_unfunded_mentors = paginate(unfunded_mentors_query(conditions:).unfunded_mentors)
 
         render json: to_json(paginated_unfunded_mentors)
       end

--- a/app/controllers/concerns/api/paginatable.rb
+++ b/app/controllers/concerns/api/paginatable.rb
@@ -6,7 +6,7 @@ module API
   private
 
     def paginate(scope)
-      _pagy, paginated_records = pagy(scope, limit: per_page, page:)
+      _pagy, paginated_records = pagy_countless(scope, limit: per_page, page:)
 
       paginated_records
     rescue Pagy::VariableError

--- a/app/models/parity_check/request.rb
+++ b/app/models/parity_check/request.rb
@@ -2,7 +2,7 @@ module ParityCheck
   class Request < ApplicationRecord
     self.table_name = "parity_check_requests"
 
-    MAX_RESPONSES_TO_DIFF = 15
+    MAX_RESPONSES_TO_DIFF = 5
 
     belongs_to :run
     belongs_to :lead_provider

--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -145,21 +145,20 @@ module API::Declarations
     def where_teacher_is(teacher_api_ids)
       return if ignore?(filter: teacher_api_ids, ignore_empty_array: false)
 
-      teacher_ids = Teacher.where(api_id: teacher_api_ids).ids
-
+      teacher_subquery = Teacher.where(api_id: teacher_api_ids).select(:id)
       @scope = scope
         .left_joins(training_period: %i[ect_at_school_period mentor_at_school_period])
         .where(
           "ect_at_school_periods.teacher_id IN (:ids) OR mentor_at_school_periods.teacher_id IN (:ids)",
-          ids: teacher_ids
+          ids: teacher_subquery
         )
     end
 
     def where_delivery_partner_is(delivery_partner_api_ids)
       return if ignore?(filter: delivery_partner_api_ids, ignore_empty_array: false)
 
-      delivery_partner_ids = DeliveryPartner.where(api_id: delivery_partner_api_ids).ids
-      @scope = scope.where(delivery_partner_when_created_id: delivery_partner_ids)
+      delivery_partner_subquery = DeliveryPartner.where(api_id: delivery_partner_api_ids).select(:id)
+      @scope = scope.where(delivery_partner_when_created_id: delivery_partner_subquery)
     end
 
     def where_updated_since(updated_since)

--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -12,7 +12,7 @@ module API::Declarations
       updated_since: :ignore
     )
       @lead_provider_id = lead_provider_id
-      @scope = Declaration.order(:created_at).distinct
+      @scope = Declaration.order(:created_at)
 
       where_lead_provider_is(lead_provider_id)
       where_contract_period_year_in(contract_period_years)

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,3 +1,4 @@
+require "pagy/extras/countless"
 require "pagy/extras/array"
 require "pagy/extras/overflow"
 require "pagy/extras/size"

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -385,6 +385,13 @@ get:
       exclude:
         - type
         - has_passed
+
+  - "/api/v3/participant-declarations":
+      paginate: false
+      exclude:
+        - type
+        - has_passed
+
   - "/api/v3/participant-declarations":
       paginate: true
       query:

--- a/db/migrate/20260423150346_add_indexes_for_declarations_query.rb
+++ b/db/migrate/20260423150346_add_indexes_for_declarations_query.rb
@@ -1,0 +1,18 @@
+class AddIndexesForDeclarationsQuery < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    # Metadata teachers lead providers OR optimisation.
+    add_index :metadata_teachers_lead_providers,
+              %i[lead_provider_id teacher_id],
+              name: "idx_metadata_lead_provider_ect_active",
+              algorithm: :concurrently,
+              where: "latest_ect_training_period_id IS NOT NULL"
+
+    add_index :metadata_teachers_lead_providers,
+              %i[lead_provider_id teacher_id],
+              name: "idx_metadata_lead_provider_mentor_active",
+              algorithm: :concurrently,
+              where: "latest_mentor_training_period_id IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_181740) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_150346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -605,6 +605,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_181740) do
     t.datetime "updated_at", null: false
     t.index ["latest_ect_training_period_id"], name: "idx_on_latest_ect_training_period_id_2d0632b258"
     t.index ["latest_mentor_training_period_id"], name: "idx_on_latest_mentor_training_period_id_862127afaf"
+    t.index ["lead_provider_id", "teacher_id"], name: "idx_metadata_lead_provider_ect_active", where: "(latest_ect_training_period_id IS NOT NULL)"
+    t.index ["lead_provider_id", "teacher_id"], name: "idx_metadata_lead_provider_mentor_active", where: "(latest_mentor_training_period_id IS NOT NULL)"
     t.index ["lead_provider_id", "teacher_id"], name: "idx_on_lead_provider_id_teacher_id_74c7a13188", where: "((latest_ect_training_period_id IS NOT NULL) OR (latest_mentor_training_period_id IS NOT NULL))"
     t.index ["lead_provider_id"], name: "index_metadata_teachers_lead_providers_on_lead_provider_id"
     t.index ["teacher_id", "lead_provider_id"], name: "idx_on_teacher_id_lead_provider_id_23bbab847a", unique: true


### PR DESCRIPTION
### Context

We used to use `pagy_countless` in the API (and we use it in ECF) however we switched from it a while ago thinking a pattern of having `pagy` run a `COUNT(*)` on the minimal query (without any `includes`) and then running `includes` on the single page of results would be more performant. It turns out this isn't the case; probably because a lot of our queries end up joining on most of the tables we include anyway in order to perform various filtering.

### Changes proposed in this pull request

- Use pagy_countless for API pagination

The `COUNT(*)` query performed by `pagy` is particularly expensive for the declarations query (~10x that of the subsequent query for the page contents!).

With most of our queries we run a pattern of paginating on the minimal query (sans `includes`) and then we `include` whatever is needed for the serializer for the query of a particular page that we are rendering.

This works out reasonably well for most of our queries, however the declarations query results in an very expensive `COUNT(*)` operation. in this instance, its much quicker to use `pagy_countless`, which omits the count (we don't need it as we don't display metadata on pages anyway).

- Minor updates to declarations query

Minor tweaks to the filter queries and adds an index that improves the query plan.

- Minor updates to the parity check

Add an endpoint to compare a single page of declarations for convenience/speed.

Lower the amount of pages compared in the 'big diff' as it was timing out occasionally.

### Guidance to review

On testing the other endpoints in the parity check they are either as fast or faster using `pagy_countless`:

| Category             | ECF    | pagy  | countless |
|----------------------|--------|-------|-----------|
| Delivery partners    | 185ms  | 165ms | 75ms      |
| Declarations         | 1000ms | 6000ms| 3000ms    |
| Participants         | 2200ms | 400ms | 250ms     |
| Partnerships         | 150ms  | 200ms | 200ms     |
| Schools              | 150ms  | 220ms | 100ms     |
| Statements           | 100ms  | 750ms | 85ms      |
| Unfunded mentors     | 3500ms | 330ms | 225ms     |
| Transfers            | 450ms  | 240ms | 150ms     |

I checked all the response ids for duplicates after this change against declarations in 2023 for Ambition:

```
request = ParityCheck::Request.find(412)
ids = request.rect_response_body_ids
ids.count == ids.uniq.count
=> true
```