### PR TITLE
Switch declarations to use `api_updated_at`

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -22,7 +22,7 @@ class API::DeclarationSerializer < Blueprinter::Base
       status == "no_payment" ? "submitted" : status.dasherize
     end
 
-    field(:updated_at)
+    field(:api_updated_at, name: :updated_at)
     field(:created_at)
     field(:delivery_partner_id) { |declaration| declaration.delivery_partner_when_created.api_id }
     field(:statement_id) { |declaration| declaration.payment_statement&.api_id unless declaration.payment_status_voided? }

--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -165,7 +165,7 @@ module API::Declarations
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      @scope = scope.where(updated_at: updated_since..)
+      @scope = scope.where(api_updated_at: updated_since..)
     end
   end
 end

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -33,11 +33,7 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
     it_behaves_like "a filter by multiple cohorts (contract_period year) endpoint"
     it_behaves_like "a filter by delivery_partner_id endpoint", :delivery_partner_when_created
     it_behaves_like "a filter by participant_id endpoint"
-    it_behaves_like "a filter by updated_since endpoint" do
-      def set_updated_at(resource:, value:)
-        resource.update_columns(updated_at: value)
-      end
-    end
+    it_behaves_like "a filter by updated_since endpoint"
     it_behaves_like "a N+1 queries free endpoint", :get
   end
 

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -29,7 +29,7 @@ describe API::DeclarationSerializer, type: :serializer do
       expect(attributes["declaration_type"]).to eq(declaration.declaration_type)
       expect(attributes["declaration_date"]).to eq(declaration.declaration_date.utc.rfc3339)
 
-      expect(attributes["updated_at"]).to eq(declaration.updated_at.utc.rfc3339)
+      expect(attributes["updated_at"]).to eq(declaration.api_updated_at.utc.rfc3339)
       expect(attributes["created_at"]).to eq(declaration.created_at.utc.rfc3339)
       expect(attributes["delivery_partner_id"]).to eq(delivery_partner.api_id)
       expect(attributes["ineligible_for_funding_reason"]).to be_nil

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
 
       describe "by `updated_since`" do
         it "filters by `updated_since`" do
-          FactoryBot.create(:declaration).tap { it.update(updated_at: 2.days.ago) }
+          FactoryBot.create(:declaration).tap { it.update(api_updated_at: 2.days.ago) }
           declaration2 = FactoryBot.create(:declaration)
 
           query = described_class.new(updated_since: 1.day.ago)
@@ -379,15 +379,15 @@ RSpec.describe API::Declarations::Query, :with_metadata do
         end
 
         it "does not filter by `updated_since` if omitted" do
-          declaration1 = FactoryBot.create(:declaration).tap { it.update(updated_at: 1.week.ago) }
-          declaration2 = FactoryBot.create(:declaration).tap { it.update(updated_at: 2.weeks.ago) }
+          declaration1 = FactoryBot.create(:declaration).tap { it.update(api_updated_at: 1.week.ago) }
+          declaration2 = FactoryBot.create(:declaration).tap { it.update(api_updated_at: 2.weeks.ago) }
 
           expect(instance.declarations).to contain_exactly(declaration1, declaration2)
         end
 
         it "does not filter by `updated_since` if blank" do
-          declaration1 = FactoryBot.create(:declaration).tap { it.update(updated_at: 1.week.ago) }
-          declaration2 = FactoryBot.create(:declaration).tap { it.update(updated_at: 2.weeks.ago) }
+          declaration1 = FactoryBot.create(:declaration).tap { it.update(api_updated_at: 1.week.ago) }
+          declaration2 = FactoryBot.create(:declaration).tap { it.update(api_updated_at: 2.weeks.ago) }
 
           query = described_class.new(updated_since: " ")
 


### PR DESCRIPTION
In our API endpoints we should always be serializing and filtering on the relevant `api_updated_at` attribute of the model.

We had missed updating the declarations query/serializer to use the `api_updated_at`.
