### PR TITLE
Fix declarations query ordering

### DIFF
--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -12,7 +12,7 @@ module API::Declarations
       updated_since: :ignore
     )
       @lead_provider_id = lead_provider_id
-      @scope = Declaration.distinct
+      @scope = Declaration.order(:created_at).distinct
 
       where_lead_provider_is(lead_provider_id)
       where_contract_period_year_in(contract_period_years)

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -78,6 +78,16 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       expect(declarations).to include(result.first)
     end
 
+    it "orders declarations by created_at in ascending order" do
+      declaration1 = travel_to(2.days.ago) { FactoryBot.create(:declaration) }
+      declaration2 = travel_to(1.day.ago) { FactoryBot.create(:declaration) }
+      declaration3 = FactoryBot.create(:declaration)
+
+      query = described_class.new
+
+      expect(query.declarations).to eq([declaration1, declaration2, declaration3])
+    end
+
     describe "filtering" do
       describe "by `lead_provider_id`" do
         let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing) }


### PR DESCRIPTION
We should be ordering declarations by `created_at` in ascending order to match ECF.
