### PR TITLE
[3199] Harden test coverage for release notes

### DIFF
--- a/app/components/api/guidance/release_notes/tags_component.rb
+++ b/app/components/api/guidance/release_notes/tags_component.rb
@@ -43,7 +43,13 @@ module API
         end
 
         def render_tag(tag)
-          colour = TAG_MAPPINGS[tag] or raise UnknownTagError, "Tag not recognised: #{tag}"
+          colour = TAG_MAPPINGS[tag]
+
+          unless colour
+            valid_tags = TAG_MAPPINGS.keys.sort.join(", ")
+            raise UnknownTagError, "Tag not recognised: '#{tag}'. Valid tags are: #{valid_tags}"
+          end
+
           text = tag.tr("-", " ").capitalize
 
           govuk_tag(text:, colour:)

--- a/app/services/api/release_note.rb
+++ b/app/services/api/release_note.rb
@@ -1,5 +1,7 @@
 module API
   class ReleaseNote
+    class InvalidNoteError < StandardError; end
+
     attr_accessor :title, :date, :body, :tags, :slug
 
     def initialize(title:, date:, body:, tags:)
@@ -8,11 +10,15 @@ module API
       @body = render(body)
       @tags = tags
       @slug = [date.iso8601, title].join("-").parameterize
+    rescue NoMethodError => _e
+      raise InvalidNoteError, "Invalid release note"
     end
 
   private
 
     def render(markdown)
+      raise InvalidNoteError, "Invalid release note" if markdown.blank?
+
       GovukMarkdown.render(markdown.to_str, { strip_front_matter: false, headings_start_with: "l" })
     end
   end

--- a/spec/components/api/guidance/release_notes/tags_component_spec.rb
+++ b/spec/components/api/guidance/release_notes/tags_component_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe API::Guidance::ReleaseNotes::TagsComponent, type: :component do
+  describe "TAG_MAPPINGS" do
+    let(:tags) { described_class::TAG_MAPPINGS.keys.sort }
+
+    it "maps all tags" do
+      notes_file_path = Rails.root.join("app/views/api/release_notes/release_notes.yml")
+      notes_data = YAML.load_file(notes_file_path, permitted_classes: [Date])
+      all_tags = notes_data.flat_map { |note| note["tags"] || [] }.uniq
+
+      expect(all_tags).to all be_in(tags)
+    end
+  end
+
   describe "initialization" do
     subject(:component) do
-      described_class.new(
-        tags:
-      )
+      described_class.new(tags:)
     end
 
     let(:tags) { %w[bug-fix new-feature] }
@@ -28,13 +38,13 @@ RSpec.describe API::Guidance::ReleaseNotes::TagsComponent, type: :component do
         expect(rendered_content).to eql(expected_output)
       end
 
-      context "when a tag is are not mapped" do
+      context "when a tag is unknown" do
         let(:tags) { %w[new-tag] }
 
-        it "raises an error" do
+        it "raises an error with guidance" do
           expect {
             render_inline(component)
-          }.to raise_error(described_class::UnknownTagError, "Tag not recognised: new-tag")
+          }.to raise_error(described_class::UnknownTagError, /Tag not recognised: 'new-tag'. Valid tags are: breaking-change/)
         end
       end
 

--- a/spec/requests/api/release_notes_spec.rb
+++ b/spec/requests/api/release_notes_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe "Release Notes" do
+  describe "GET /api/guidance/release-notes" do
+    it "renders valid notes" do
+      expect { get(api_guidance_release_notes_path) }.not_to raise_error
+      expect(response).to be_successful
+      expect(response.body).to include("Release notes")
+    end
+  end
+
+  describe "GET /api/guidance/release-notes/:slug" do
+    let(:notes_file_path) { Rails.root.join("app/views/api/release_notes/release_notes.yml") }
+    let(:notes_data) { YAML.load_file(notes_file_path, permitted_classes: [Date]) }
+    let(:api_release_notes) do
+      notes_data.map do
+        API::ReleaseNote.new(**it.symbolize_keys)
+      end
+    end
+
+    context "with valid slug" do
+      let(:note) { api_release_notes.sample }
+
+      it "renders the note" do
+        get(api_guidance_release_note_path(note.slug))
+
+        expect(response).to be_successful
+        expect(response.body).to include(note.title)
+        expect(response.body).to include(note.body)
+        expect(response.body).to include(note.date)
+        expect(response.body).to include(note.tags.sample.titleize.humanize)
+      end
+    end
+
+    context "with unknown slug" do
+      it "returns 404" do
+        get(api_guidance_release_note_path("non-existent-slug"))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/services/api/release_note_spec.rb
+++ b/spec/services/api/release_note_spec.rb
@@ -23,5 +23,25 @@ describe API::ReleaseNote do
         expect(release_note.body).to eql(expected_body_with_markdown)
       end
     end
+
+    context "when body is missing" do
+      let(:body) { nil }
+
+      it do
+        expect {
+          release_note
+        }.to raise_error(API::ReleaseNote::InvalidNoteError, "Invalid release note")
+      end
+    end
+
+    context "when date format is invalid" do
+      let(:date) { nil }
+
+      it do
+        expect {
+          release_note
+        }.to raise_error(API::ReleaseNote::InvalidNoteError, "Invalid release note")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

If a release note has mistakes it may raise an error and the page will not render, but the author will not be flagged without sufficient test coverage.

### Changes proposed in this pull request

- [x] add a request spec for the release notes page
- [x] improve note tagging and feedback for content editors 

### Guidance to review

Create an invalid release note. A collection specs will fail:

 Feature specs
 - `./spec/features/api/guidance/pages_spec.rb`
 - `./spec/features/api/guidance/release_notes_spec.rb`

 Request specs
 - `./spec/requests/api/release_notes_spec.rb`
 - `./spec/requests/api/guidance_spec.rb`
 - `./spec/requests/rate_limiting_spec.rb`

 View specs
 - `./spec/views/api/guidance/show.html.erb_spec.rb`

 Component specs
 - `./spec/components/api/guidance/release_notes/tags_component_spec.rb`

 Service specs
 - `./spec/services/api/release_note_spec.rb`