### PR TITLE
Remove incorrect details from maintenance page footer

### DIFF
--- a/maintenance_page/html/index.html
+++ b/maintenance_page/html/index.html
@@ -68,18 +68,6 @@
       <div class="govuk-width-container">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <h2 class="govuk-heading-m">Get help</h2>
-            <p class="govuk-body-s govuk-!-margin-bottom-1">
-              Call 0800 389 2500 or
-              <a
-                class="govuk-link govuk-footer__link"
-                href="https://getintoteaching.education.gov.uk/help-and-support?utm_source=apply-for-teacher-training.service.gov.uk&amp;utm_medium=referral&amp;utm_campaign=candidate_interface%2Fstart_page-create_account_or_sign_in&amp;utm_content=candidate_not_logged_in"
-                >chat online</a
-              >.
-            </p>
-            <p class="govuk-body-s govuk-!-margin-bottom-1">
-              Monday to Friday, 8:30am to 5:30pm (except public&nbsp;holidays)
-            </p>
           </div>
           <div class="govuk-footer__meta-item">
             <a


### PR DESCRIPTION
This was accidentally copied over when the maintenance page was introduced in #402 