### PR TITLE
Optimise `Declarations::Query`

### DIFF
--- a/app/services/api/declarations/query.rb
+++ b/app/services/api/declarations/query.rb
@@ -12,7 +12,7 @@ module API::Declarations
       updated_since: :ignore
     )
       @lead_provider_id = lead_provider_id
-      @scope = Declaration.order(:created_at)
+      @scope = join_school_period(Declaration.order(:created_at))
 
       where_lead_provider_is(lead_provider_id)
       where_contract_period_year_in(contract_period_years)
@@ -58,14 +58,11 @@ module API::Declarations
     def where_lead_provider_is(lead_provider_id)
       return if ignore?(filter: lead_provider_id)
 
-      @scope = scope.where(id: declarations_matching_lead_provider(lead_provider_id).select(:id))
+      declarations_matching_lead_provider(lead_provider_id)
     end
 
-    # Keeps the lead-provider join chain in a sub-relation so the outer scope
-    # is filtered via WHERE id IN (subquery). This makes pagination COUNT(*)
-    # cheaper and lets other filters compose against a clean outer scope.
     def declarations_matching_lead_provider(lead_provider_id)
-      Declaration
+      @scope = scope
         # Join the lead provider for the declaration.
         .joins(
           training_period: {
@@ -74,11 +71,7 @@ module API::Declarations
             }
           }
         )
-        # Join the ECT and mentor school periods (left join as its one or the other).
-        .left_joins(training_period: %i[ect_at_school_period mentor_at_school_period])
-        # Join the latest ECT and mentor training period for the lead provider we are filtering by.
-        # This will restrict declarations to only those for teachers associated with the lead provider we are filtering by.
-        # The manual sanitisation is needed as Rails does not support binding parameters in JOINs.
+        # Join the metadata for the lead provider and teacher.
         .joins(
           ActiveRecord::Base.send(
             :sanitize_sql_array,
@@ -87,51 +80,51 @@ module API::Declarations
                 JOIN metadata_teachers_lead_providers
                   ON metadata_teachers_lead_providers.lead_provider_id = ?
                 AND (
-                  (metadata_teachers_lead_providers.teacher_id = ect_at_school_periods.teacher_id
-                    AND latest_ect_training_period_id IS NOT NULL)
-                OR (metadata_teachers_lead_providers.teacher_id = mentor_at_school_periods.teacher_id
-                    AND latest_mentor_training_period_id IS NOT NULL)
+                  metadata_teachers_lead_providers.teacher_id = CASE
+                    WHEN ect_at_school_periods.id IS NOT NULL
+                      THEN ect_at_school_periods.teacher_id
+                    WHEN mentor_at_school_periods.id IS NOT NULL
+                      THEN mentor_at_school_periods.teacher_id
+                  END
                 )
               SQL
               lead_provider_id
             ]
           )
         )
-        .joins(<<-SQL)
-          LEFT JOIN training_periods latest_mentor_training_period
-          ON latest_mentor_training_period.id = metadata_teachers_lead_providers.latest_mentor_training_period_id
-        SQL
-        .joins(<<-SQL)
-          LEFT JOIN training_periods latest_ect_training_period ON
-          latest_ect_training_period.id = metadata_teachers_lead_providers.latest_ect_training_period_id
+        # Join latest ECT/mentor training period for the lead provider; this will ensure that:
+        #   * If the declaration is for an ECT, the ECT has been trained by the lead provider.
+        #   * If the declaration is for a mentor, the mentor has been trained by the lead provider.
+        .joins(<<~SQL)
+          JOIN training_periods latest_training_period
+            ON latest_training_period.id = CASE
+              WHEN ect_at_school_periods.id IS NOT NULL
+                THEN metadata_teachers_lead_providers.latest_ect_training_period_id
+              WHEN mentor_at_school_periods.id IS NOT NULL
+                THEN metadata_teachers_lead_providers.latest_mentor_training_period_id
+            END
         SQL
         # Restrict to either:
-        #   * Declarations directly associated with the lead provider we are filtering by.
-        #   * Billable declarations dated earlier than the latest ECT/mentor training period for the lead provider we are filtering by.
+        #   * Declarations directly associated with the lead provider.
+        #   * Billable declarations dated earlier than the latest ECT/mentor training period for the lead provider.
         .where(<<-SQL, payment_statuses: Declaration::BILLABLE_OR_CHANGEABLE_PAYMENT_STATUSES, lead_provider_id:)
           active_lead_providers.lead_provider_id = :lead_provider_id
-          OR
-          (
-            (
-              CASE
-                WHEN ect_at_school_periods.id IS NOT NULL THEN
-                  latest_ect_training_period.finished_on
-                ELSE
-                  latest_mentor_training_period.finished_on
-              END IS NULL
-              OR
-              declarations.declaration_date <=
-              CASE
-                WHEN ect_at_school_periods.id IS NOT NULL THEN
-                  latest_ect_training_period.finished_on
-                ELSE
-                  latest_mentor_training_period.finished_on
-              END
-            )
-            AND declarations.payment_status IN (:payment_statuses)
+          OR (
+            declarations.payment_status IN (:payment_statuses)
             AND declarations.clawback_status = 'no_clawback'
+            AND (
+              latest_training_period.finished_on IS NULL
+              OR declarations.declaration_date <= latest_training_period.finished_on
+            )
           )
         SQL
+    end
+
+    def join_school_period(scope)
+      # Join the ECT or mentor school period (this will only ever be one or the other).
+      scope
+        .joins(:training_period)
+        .left_joins(training_period: %i[ect_at_school_period mentor_at_school_period])
     end
 
     def where_contract_period_year_in(contract_period_years)
@@ -147,7 +140,6 @@ module API::Declarations
 
       teacher_subquery = Teacher.where(api_id: teacher_api_ids).select(:id)
       @scope = scope
-        .left_joins(training_period: %i[ect_at_school_period mentor_at_school_period])
         .where(
           "ect_at_school_periods.teacher_id IN (:ids) OR mentor_at_school_periods.teacher_id IN (:ids)",
           ids: teacher_subquery


### PR DESCRIPTION
### Context

The declarations query is hard to understand and not very performant. We want to improve the readability and make it faster/closer to ECF performance-wise.

### Changes proposed in this pull request

Remove re-query of declarations by id, instead we can chain onto the existing `@scope` which is more optimal now that `pagy_countless` doesn't issue a `COUNT(*)`.

Optimise join on `training_periods` for `latest_training_period` so that we only end up with one training period (instead of an ECT and mentor training period) so that the subsequent filtering is simpler. Tweak ordering of filtering on previous declarations to be more efficient.

Join on the school periods at the top-level to avoid duplicating as most paths need these tables.

### Guidance to review

I checked this in the parity check with ambition 2023 declarations and it returned the same results before/after the refactor. The performance improved from ~3s to ~1-2s (with ECF being around 1s).