### PR TITLE
Spike: add `rails_semantic_logger`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,10 @@ gem "diffy"
 
 gem "zendesk_api", "~> 3.1", ">= 3.1.1"
 
+group :development, :production do
+  gem "rails_semantic_logger", group: %w[development production]
+end
+
 group :development do
   gem "better_errors"
   gem "binding_of_caller"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -627,6 +627,10 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_semantic_logger (4.20.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -754,6 +758,8 @@ GEM
       nori (~> 2.4)
       wasabi (>= 3.7, < 6)
     securerandom (0.4.1)
+    semantic_logger (4.18.0)
+      concurrent-ruby (~> 1.0)
     sentry-rails (6.5.0)
       railties (>= 5.2.0)
       sentry-ruby (~> 6.5.0)
@@ -912,6 +918,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-attack
   rails (~> 8.1.3)
+  rails_semantic_logger
   redis
   redis-session-store
   rotp
@@ -940,7 +947,7 @@ DEPENDENCIES
   zendesk_api (~> 3.1, >= 3.1.1)
 
 RUBY VERSION
-   ruby 4.0.3p72
+  ruby 4.0.3p72
 
 BUNDLED WITH
-   4.0.10
+  4.0.10

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -16,6 +16,13 @@ private
     current_lead_provider
   end
 
+  def append_info_to_payload(payload)
+    super
+
+    payload[:current_user_class] = current_lead_provider&.class&.name
+    payload[:current_user_id] = current_lead_provider&.id
+  end
+
 protected
 
   def respond_with_service(service:, action:)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,12 @@ class ApplicationController < ActionController::Base
   def set_sentry_user
     Sentry.set_user(email: current_user&.email)
   end
+
+private
+
+  def append_info_to_payload(payload)
+    super
+    payload[:current_user_class] = current_user&.class&.name
+    payload[:current_user_id] = current_user&.id
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,10 +58,14 @@ Rails.application.configure do
     },
   }
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  # Log to STDOUT with the = request id as a default log tag.
+  config.log_tags = [:request_id]
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+                                      .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+                                      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  config.log_format = :json # Logit expects JSON-formatted logs
+  config.rails_semantic_logger.add_file_appender = false # Don't log to file, only STDOUT
+  config.active_record.logger = nil # Don't log SQL
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
> ⚠️ WIP - up for discussion, do not merge!

### Context

We don't have rich logging in production as we're formatting logs as a single text line that logit can't parse (it expects JSON). We have tagging ability but we'd have to manually add a bunch of tags for it to be useful. `rails_semantic_logger` would give us all this for free.

### Changes proposed in this pull request

- Our logger is not formatting in JSON or structuring the log in a way that is useful for logit to consume and parse, so we result in only a couple of fields we are able to filter or query on in Kibana.

Add `rails_semantic_logger`, which gives us a richer, pre-structured JSON log message.

Include the user type and id in the payload.

### Guidance to review

> ⚠️ Before moving this forward we would need to filter out any PII, probably with a custom appender.
