### PR TITLE
Fix database bottlenecking on metadata jobs

### DIFF
--- a/app/jobs/refresh_metadata_job.rb
+++ b/app/jobs/refresh_metadata_job.rb
@@ -1,6 +1,8 @@
 class RefreshMetadataJob < ApplicationJob
   queue_as :metadata
 
+  limits_concurrency to: 2, key: :refresh_metadata
+
   def perform(object_type:, object_ids:, track_changes: false)
     objects = object_type.where(id: object_ids)
     Metadata::Manager.new.refresh_metadata!(objects, track_changes:)

--- a/app/services/gias/importer.rb
+++ b/app/services/gias/importer.rb
@@ -15,10 +15,7 @@ module GIAS
     end
 
     def fetch
-      DeclarativeUpdates.skip(:metadata) do
-        import_only? ? fetch_and_import_only : fetch_and_update
-      end
-      Metadata::Handlers::School.refresh_all_metadata!(async: true)
+      import_only? ? fetch_and_import_only : fetch_and_update
     end
 
     def foreach_school_row(&block)
@@ -73,8 +70,14 @@ module GIAS
     # import only doesn't try to work out what has changed and does not include "closed" schools
     # we need to import schools first in an empty DB
     def fetch_and_import_only
-      import_schools
-      import_school_links
+      # It's more efficient to skip metadata during import and refresh it
+      # all in background jobs at the end when creating a lot of schools.
+      DeclarativeUpdates.skip(:metadata) do
+        import_schools
+        import_school_links
+      end
+
+      Metadata::Handlers::School.refresh_all_metadata!(async: true)
     end
 
     def fetch_and_update

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -2,67 +2,122 @@ default: &default
   dispatchers:
     - polling_interval: 1
       batch_size: 500
+
   workers:
-    - queues: [mailers, process_batch, events, metadata, parity_check_requests, trs_sync, dfe_analytics, api_seeds, "*"]
-      threads: 3
-      processes: 3
+    # Dedicated critical queues
+    - queues: [mailers]
+      threads: 2
+      processes: 2
       polling_interval: 0.1
 
-migration:
-  <<: *default
-  workers:
-    - queues: [mailers, events, metadata, parity_check_requests, trs_sync, dfe_analytics]
-      threads: 3
-      processes: 3
+    - queues: [default]
+      threads: 2
+      processes: 2
       polling_interval: 0.1
-    - queues: [parity_check_requests]
-      threads: 3
-      processes: 3
-      polling_interval: 0.1
-    - queues: [migration]
+
+    # Metadata workers (2 jobs max, will be 2 jobs with 2 workers)
+    # The jobs to refresh school metadata have DB-heavy and can
+    # lock up the database if we run too many at once.
+    - queues: [metadata]
       threads: 1
       processes: 1
+      polling_interval: 0.1
+
+    # Everything else
+    - queues: [process_batch, trs_sync, events, dfe_analytics]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
+migration: &migration
+  workers:
+    # Dedicated critical queues
+    - queues: [mailers]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
+    - queues: [default]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
+    # Metadata workers (2 jobs max, will be 2 jobs with 2 workers)
+    # The jobs to refresh school metadata have DB-heavy and can
+    # lock up the database if we run too many at once.
+    - queues: [metadata]
+      threads: 1
+      processes: 1
+      polling_interval: 0.1
+
+    # Everything else
+    - queues: [process_batch, trs_sync, events, dfe_analytics]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
+    # Parity check
+    - queues: [parity_check_requests]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
+    # Migration
+    - queues: [migration]
+      threads: 2
+      processes: 2
       polling_interval: 0.1
 
 paritycheck:
-  <<: *default
+  <<: *migration
+
+non_production: &non_production
   workers:
-    - queues: [mailers, events, metadata, parity_check_requests, trs_sync, dfe_analytics]
-      threads: 3
-      processes: 3
+    # Dedicated critical queues
+    - queues: [mailers]
+      threads: 2
+      processes: 2
       polling_interval: 0.1
-    - queues: [parity_check_requests]
-      threads: 3
-      processes: 3
+
+    - queues: [default]
+      threads: 2
+      processes: 2
       polling_interval: 0.1
-    - queues: [migration]
+
+    # Metadata workers (2 jobs max, will be 2 jobs with 2 workers)
+    # The jobs to refresh school metadata have DB-heavy and can
+    # lock up the database if we run too many at once.
+    - queues: [metadata]
       threads: 1
       processes: 1
       polling_interval: 0.1
 
+    # Everything else
+    - queues: [process_batch, trs_sync, events, dfe_analytics]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
+    # API seeds
+    - queues: [api_seeds]
+      threads: 2
+      processes: 2
+      polling_interval: 0.1
+
 review:
-  <<: *default
+  <<: *non_production
 
 staging:
-  <<: *default
+  <<: *non_production
 
 sandbox:
-  <<: *default
+  <<: *non_production
 
 development:
-  <<: *default
-  workers:
-    - queues: [mailers, process_batch, events, metadata, parity_check_requests, trs_sync, dfe_analytics, api_seeds]
-      threads: 3
-      processes: 3
-      polling_interval: 0.1
-    - queues: [migration]
-      threads: 1
-      processes: <%= ENV.fetch('MIGRATION_QUEUE_PROCESSES', 3) %>
-      polling_interval: 0.1
+  <<: *non_production
 
 test:
-  <<: *default
+  <<: *non_production
 
 production:
   <<: *default

--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -5,7 +5,7 @@
     "enable_logit": true,
     "worker_memory_max": "6Gi",
     "webapp_memory_max": "2Gi",
-    "worker_replicas": 10,
+    "worker_replicas": 2,
     "webapp_replicas": 1,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }

--- a/config/terraform/application/config/paritycheck.tfvars.json
+++ b/config/terraform/application/config/paritycheck.tfvars.json
@@ -5,7 +5,7 @@
     "enable_logit": true,
     "worker_memory_max": "6Gi",
     "webapp_memory_max": "2Gi",
-    "worker_replicas": 10,
-    "webapp_replicas": 6,
+    "worker_replicas": 2,
+    "webapp_replicas": 2,
     "postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
 }

--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -16,5 +16,5 @@
     "worker_memory_max": "2Gi",
     "webapp_memory_max": "4Gi",
     "webapp_replicas": 4,
-    "worker_replicas": 10
+    "worker_replicas": 2
 }

--- a/spec/services/gias/importer_spec.rb
+++ b/spec/services/gias/importer_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe GIAS::Importer, type: :service do
 
         importer.fetch
       end
+
+      it "does not call any metadata refresh handlers during the process" do
+        expect(Metadata::Resolver).not_to receive(:resolve_handler)
+
+        importer.fetch
+      end
+
+      it "calls an async refresh of all the metadata" do
+        expect(Metadata::Handlers::School).to receive(:refresh_all_metadata!).with(async: true)
+
+        importer.fetch
+      end
     end
 
     context "when schools already exist in the database" do
@@ -31,18 +43,18 @@ RSpec.describe GIAS::Importer, type: :service do
 
         importer.fetch
       end
-    end
 
-    it "does not call any metadata refresh handlers during the process" do
-      expect(Metadata::Resolver).not_to receive(:resolve_handler)
+      it "does not call any metadata refresh handlers during the process" do
+        expect(Metadata::Resolver).not_to receive(:resolve_handler)
 
-      importer.fetch
-    end
+        importer.fetch
+      end
 
-    it "calls an async refresh of the metadata" do
-      expect(Metadata::Handlers::School).to receive(:refresh_all_metadata!).with(async: true)
+      it "does not call a refresh of all the metadata" do
+        expect(Metadata::Handlers::School).not_to receive(:refresh_all_metadata!)
 
-      importer.fetch
+        importer.fetch
+      end
     end
   end
 


### PR DESCRIPTION
### Context

The metadata refresh in production is causing the database to be CPU-bound for the duration of the refresh, which results in dropped connections and failed jobs.

We want to scale back the jobs so that the metadata jobs don't overwhelm the database.

### Changes proposed in this pull request

- Only refresh metadata when importing all schools

I think we put this in as a bit of a safety net, but looking at the hooks in `School` we only refresh the metadata on `create`, so refreshing all metadata at the end of an update/import is overkill.

Switch to refreshing metadata inline, which will only happen when the `GIAS::Importer` adds a new school - presumably an infrequent event.

Retain the async metadata refresh for the scenario where there are no `GIAS::School` records in the database and we are importing them all for the first time, as this will be more efficient.

- Rework the queues/workers

We are finding in production that the volume of workers is overloading the database; we currently have a maximum of 3 processes * 3 threads * 10 workers, so 90 concurrent jobs.

As we have an `*` in one of our workers it will end up picking up any pending job potentially blocking the more critical/time-sensitive queues such as `mailer`.

Scale the number of physical workers down to 2.

Ensure we have a dedicated workers for mailers/default/metadata/everything else and scale the metadata workers down to a maximum of 2 at any given time (1 thread, 1 process and 2 workers). This is also enforced in `limits_concurrency` on the job in case we scale the workers up from 2 in the future.

Only run parity check/migration/seed jobs in relevant environments.

### Guidance to review

It's the school handler metadata jobs specifically that seem to cause the high CPU usage rather than the other handlers.

I tried various process/thread settings for the metadata refresh, at around 4 total concurrent jobs it was still hovering at ~95% max CPU. Dropping to 2 concurrent jobs brings the CPU usage down to a steady 70% - note they go into a new `Blocked Jobs` tab due to the concurrency restrictions:

<img width="1248" height="123" alt="Screenshot 2026-04-28 at 13 57 48" src="https://github.com/user-attachments/assets/455eff8a-e392-458e-b636-a3d1319b1e70" />

<img width="1424" height="742" alt="Screenshot 2026-04-28 at 14 55 02" src="https://github.com/user-attachments/assets/3a89100b-83a8-4de9-bdc9-6aec6fc2abf2" />

The UI remained responsive during the full sync on the parity check environment. The refresh took a little longer than previously, but its not time-sensitive so still fine.

