### PR TITLE
Exclude any admin routes from creating `dfe_analytics` requests events

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -97,7 +97,7 @@ DfE::Analytics.configure do |config|
   # Translation missing: en.dfe.analytics.config.excluded_paths.description
   #
   # config.excluded_paths = Translation missing: en.dfe.analytics.config.excluded_paths.default
-  config.excluded_paths = ["/healthcheck"]
+  config.excluded_paths = ["/healthcheck", %r{^/admin(/.*)?$}]
 
   # A proc which will be called during model initialization. It allows to disable models
   # which should not be used. Each model is passed to bloc and if bloc returns true for the model,

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe "DfE Analytics", type: :request do
     it "does not send a web request event for GET /healthcheck" do
       expect { get "/healthcheck" }.not_to have_sent_analytics_event_types(:web_request)
     end
+
+    context "when logged in as admin" do
+      include_context "sign in as DfE user"
+
+      it "does not send a web request event for GET /admin" do
+        expect { get "/admin" }.not_to have_sent_analytics_event_types(:web_request)
+        expect { get "/admin/teachers" }.not_to have_sent_analytics_event_types(:web_request)
+      end
+    end
   end
 
   context "with lead provider API requests" do


### PR DESCRIPTION
### Context

Browsing `/admin` and any other admin path is creating `dfe_analytics` web requests jobs and events to be created.

### Changes proposed in this pull request

- Prevent calls to `/admin` and any other admin path to raise `dfe_analaytics` jobs and events.

### Guidance to review

Review app