### PR TITLE
Increase production webapp resource

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -14,7 +14,7 @@
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true,
     "worker_memory_max": "2Gi",
-    "webapp_memory_max": "2Gi",
-    "webapp_replicas": 2,
+    "webapp_memory_max": "4Gi",
+    "webapp_replicas": 4,
     "worker_replicas": 10
 }


### PR DESCRIPTION
We only have 2 web apps with 2GB of memory in production; we're seeing high memory usage in Grafana.

By comparison in ECF we were running 4GB memory and 6 web apps.

Whilst we expect high usage from lead providers during the syncing windows (and maybe just to give a bit of headroom regardless?) this scales up to 4 web apps with 4GB memory.
