### PR TITLE
Show all contract periods on delivery partner page

### DIFF
--- a/app/components/admin/lead_provider_partnerships_table_component.html.erb
+++ b/app/components/admin/lead_provider_partnerships_table_component.html.erb
@@ -19,7 +19,11 @@
           lead_provider_names(partnerships)
         end
         row.with_cell do
-          govuk_link_to("Change", change_link_path(contract_period))
+          if partnerships.empty?
+            govuk_link_to("Add", change_link_path(contract_period))
+          else
+            govuk_link_to("Change", change_link_path(contract_period))
+          end
         end
       end
     end

--- a/app/components/admin/lead_provider_partnerships_table_component.rb
+++ b/app/components/admin/lead_provider_partnerships_table_component.rb
@@ -25,6 +25,8 @@ module Admin
     end
 
     def lead_provider_names(partnerships)
+      return "Not reported" if partnerships.empty?
+
       partnerships.map(&:lead_provider).map(&:name).join(", ")
     end
   end

--- a/spec/components/admin/lead_provider_partnerships_table_component_spec.rb
+++ b/spec/components/admin/lead_provider_partnerships_table_component_spec.rb
@@ -91,16 +91,14 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
         expect(page).to have_content("2025")
         expect(page).to have_content("Lead Provider One, Lead Provider Two")
 
-        # Find the row for 2025 and check it has an empty lead providers cell
         rows = page.all("tbody tr")
         expect(rows.size).to eq(2)
 
-        # The second row should be for 2025 with empty partnerships
         row_2025 = rows.last
         cells = row_2025.all("td")
-        expect(cells[0]).to have_content("2025") # Year column
-        expect(cells[1].text.strip).to be_empty # Lead providers column should be empty
-        expect(cells[2]).to have_link("Change") # Action column
+        expect(cells[0]).to have_content("2025")
+        expect(cells[1]).to have_content("Not reported")
+        expect(cells[2]).to have_link("Add")
       end
     end
 
@@ -151,9 +149,9 @@ RSpec.describe Admin::LeadProviderPartnershipsTableComponent, type: :component d
         expect(names).to eq("Lead Provider One, Lead Provider Two")
       end
 
-      it "returns empty string when no partnerships exist" do
+      it "returns 'Not reported' when no partnerships exist" do
         names = component.send(:lead_provider_names, [])
-        expect(names).to eq("")
+        expect(names).to eq("Not reported")
       end
     end
 

--- a/spec/features/admin/manage_delivery_partner_lead_providers_spec.rb
+++ b/spec/features/admin/manage_delivery_partner_lead_providers_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe "Admin: Managing delivery partner lead providers", type: :feature
     and_i_should_see_both_partnerships
   end
 
+  scenario "Contract period with no lead provider shows 'Not reported' and 'Add' link" do
+    given_i_am_logged_in_as_an_admin
+    and_delivery_partner_and_lead_providers_exist
+
+    when_i_visit_the_delivery_partner_page
+    then_i_should_see_not_reported_for_the_contract_period
+    and_i_should_see_an_add_link_not_a_change_link
+  end
+
+  scenario "Contract period with a lead provider shows the name and 'Change' link" do
+    given_i_am_logged_in_as_an_admin
+    and_delivery_partner_and_lead_providers_exist
+    and_an_existing_partnership_exists
+
+    when_i_visit_the_delivery_partner_page
+    then_i_should_see_existing_partnership
+    and_i_should_see_change_link
+    and_i_should_not_see_an_add_link
+  end
+
 private
 
   def given_i_am_logged_in_as_an_admin
@@ -175,5 +195,21 @@ private
   def and_the_partnership_should_exist_in_database
     expect(@delivery_partner.lead_provider_delivery_partnerships.count).to eq(1)
     expect(@delivery_partner.lead_provider_delivery_partnerships.first.lead_provider).to eq(@lead_provider_1)
+  end
+
+  def then_i_should_see_not_reported_for_the_contract_period
+    row = page.locator("table.govuk-table tbody tr").filter(hasText: "2025")
+    expect(row.get_by_text("Not reported")).to be_visible
+  end
+
+  def and_i_should_see_an_add_link_not_a_change_link
+    row = page.locator("table.govuk-table tbody tr").filter(hasText: "2025")
+    expect(row.get_by_role("link", name: "Add")).to be_visible
+    expect(row.get_by_role("link", name: "Change")).not_to be_visible
+  end
+
+  def and_i_should_not_see_an_add_link
+    row = page.locator("table.govuk-table tbody tr").filter(hasText: "2025")
+    expect(row.get_by_role("link", name: "Add")).not_to be_visible
   end
 end


### PR DESCRIPTION
### Context

When a contract period has no lead provider paired with the delivery
partner, the table now shows 'Not reported' and an 'Add' link instead
of a blank cell and 'Change' link.

### Changes proposed in this pull request
- Updated `Admin::LeadProviderPartnershipsTableComponent` to show "Not 
  reported" in the lead providers cell when no partnership exists for a 
  contract period
- Updated the component template to render an "Add" link instead of 
  "Change" when no partnership exists for a contract period
- Added feature spec coverage for both cases

### Guidance to review
