### PR TITLE
[3872] Add rails_semantic_logger for JSON logs in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :development do
   gem "pg_query"
 end
 
-group :production, :review, :staging, :sandbox do
+group :production, :review, :staging, :sandbox, :paritycheck do
   gem "rails_semantic_logger"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,10 @@ group :development do
   gem "pg_query"
 end
 
+group :production, :review, :staging, :sandbox do
+  gem "rails_semantic_logger"
+end
+
 group :test do
   gem "capybara"
   gem "playwright-ruby-client"

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :development do
   gem "pg_query"
 end
 
-group :production do
+group :production, :review, :staging, :sandbox, :paritycheck, :migration do
   gem "rails_semantic_logger"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :development do
   gem "pg_query"
 end
 
-group :production, :review, :staging, :sandbox, :paritycheck do
+group :production do
   gem "rails_semantic_logger"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -627,6 +627,10 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_semantic_logger (4.20.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -754,6 +758,8 @@ GEM
       nori (~> 2.4)
       wasabi (>= 3.7, < 6)
     securerandom (0.4.1)
+    semantic_logger (4.18.0)
+      concurrent-ruby (~> 1.0)
     sentry-rails (6.5.0)
       railties (>= 5.2.0)
       sentry-ruby (~> 6.5.0)
@@ -912,6 +918,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-attack
   rails (~> 8.1.3)
+  rails_semantic_logger
   redis
   redis-session-store
   rotp
@@ -940,7 +947,7 @@ DEPENDENCIES
   zendesk_api (~> 3.1, >= 3.1.1)
 
 RUBY VERSION
-   ruby 4.0.3p72
+  ruby 4.0.3p72
 
 BUNDLED WITH
-   4.0.10
+  4.0.10

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -16,6 +16,12 @@ private
     current_lead_provider
   end
 
+  def append_info_to_payload(payload)
+    super
+    payload[:current_user_class] = current_lead_provider&.class&.name
+    payload[:current_user_id] = current_lead_provider&.id
+  end
+
 protected
 
   def respond_with_service(service:, action:)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,12 @@ class ApplicationController < ActionController::Base
   def set_sentry_user
     Sentry.set_user(email: current_user&.email)
   end
+
+private
+
+  def append_info_to_payload(payload)
+    super
+    payload[:current_user_class] = current_user&.class&.name
+    payload[:current_user_id] = current_user.try(:id)
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,10 +62,9 @@ Rails.application.configure do
   # the Rails logger and honours config.log_tags + config.filter_parameters.
   config.log_tags = [:request_id]
   config.semantic_logger.application = "" # No need to send the application name as logstash reads it from Cloud Foundry log tags
-  config.rails_semantic_logger.format = :json # Logit expects JSON-formatted logs
   config.rails_semantic_logger.add_file_appender = false # Don't log to file, only STDOUT
   config.active_record.logger = nil # Don't log SQL
-  config.semantic_logger.add_appender(io: $stdout, formatter: :json) # Log to STDOUT
+  config.semantic_logger.add_appender(io: $stdout, formatter: :json) # Log to STDOUT JSON-formatted logs
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   # Log to STDOUT in JSON for logit ingestion. rails_semantic_logger replaces
   # the Rails logger and honours config.log_tags + config.filter_parameters.
   config.log_tags = [:request_id]
+  config.semantic_logger.application = "" # No need to send the application name as logstash reads it from Cloud Foundry log tags
   config.rails_semantic_logger.format = :json # Logit expects JSON-formatted logs
   config.rails_semantic_logger.add_file_appender = false # Don't log to file, only STDOUT
   config.active_record.logger = nil # Don't log SQL

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,13 +58,13 @@ Rails.application.configure do
     },
   }
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
-  # Prepend all log lines with the following tags.
+  # Log to STDOUT in JSON for logit ingestion. rails_semantic_logger replaces
+  # the Rails logger and honours config.log_tags + config.filter_parameters.
   config.log_tags = [:request_id]
+  config.rails_semantic_logger.format = :json # Logit expects JSON-formatted logs
+  config.rails_semantic_logger.add_file_appender = false # Don't log to file, only STDOUT
+  config.active_record.logger = nil # Don't log SQL
+  config.semantic_logger.add_appender(io: $stdout, formatter: :json) # Log to STDOUT
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -11,7 +11,6 @@ unless Rails.application.config.bypass_filter_parameter_logging
     author_email
     author_name
     certificate
-    code
     commit
     corrected_name
     crypt

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -11,6 +11,7 @@ unless Rails.application.config.bypass_filter_parameter_logging
     author_email
     author_name
     certificate
+    code
     commit
     corrected_name
     crypt


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3872

### Changes proposed in this pull request

* Using `rails_semantic_logger` for JSON logs
* Rails 8.1 Structured Event we would need to create our own JSON formatter, STDOUT appender and parameter filtering.

### Guidance to review
