### PR TITLE
Preserve previous contract period for provider-led transfers

### DIFF
--- a/app/services/contract_periods/for_ect_registration.rb
+++ b/app/services/contract_periods/for_ect_registration.rb
@@ -2,10 +2,11 @@ module ContractPeriods
   class ForECTRegistration
     class NoContractPeriodFoundForStartedOnDate < StandardError; end
 
-    def initialize(started_on:, previous_training_period: nil, reassignment: nil)
+    def initialize(started_on:, previous_training_period: nil, reassignment: nil, preserve: false)
       @started_on = started_on
       @previous_training_period = previous_training_period
       @reassignment = reassignment
+      @preserve = preserve
     end
 
     def call
@@ -22,6 +23,7 @@ module ContractPeriods
   private
 
     def preserve_previous_contract_period?
+      return false unless @preserve
       return false unless @previous_training_period
       return false unless @previous_training_period.provider_led_training_programme?
       return false unless previous_contract_period

--- a/app/services/contract_periods/for_ect_registration.rb
+++ b/app/services/contract_periods/for_ect_registration.rb
@@ -2,11 +2,10 @@ module ContractPeriods
   class ForECTRegistration
     class NoContractPeriodFoundForStartedOnDate < StandardError; end
 
-    def initialize(started_on:, previous_training_period: nil, reassignment: nil, preserve: true)
+    def initialize(started_on:, previous_training_period: nil, reassignment: nil)
       @started_on = started_on
       @previous_training_period = previous_training_period
       @reassignment = reassignment
-      @preserve = preserve
     end
 
     def call
@@ -23,7 +22,6 @@ module ContractPeriods
   private
 
     def preserve_previous_contract_period?
-      return false unless @preserve
       return false unless @previous_training_period
       return false unless @previous_training_period.provider_led_training_programme?
       return false unless previous_contract_period

--- a/app/services/contract_periods/for_ect_registration.rb
+++ b/app/services/contract_periods/for_ect_registration.rb
@@ -2,7 +2,7 @@ module ContractPeriods
   class ForECTRegistration
     class NoContractPeriodFoundForStartedOnDate < StandardError; end
 
-    def initialize(started_on:, previous_training_period: nil, reassignment: nil, preserve: false)
+    def initialize(started_on:, previous_training_period: nil, reassignment: nil, preserve: true)
       @started_on = started_on
       @previous_training_period = previous_training_period
       @reassignment = reassignment

--- a/app/services/contract_periods/for_ect_registration.rb
+++ b/app/services/contract_periods/for_ect_registration.rb
@@ -10,6 +10,7 @@ module ContractPeriods
 
     def call
       return contract_period_reassignment.successor_contract_period if contract_period_reassignment.required?
+      return @previous_training_period.contract_period if @previous_training_period.present?
 
       ContractPeriod.for_registration_start_date(@started_on) ||
         raise(

--- a/app/services/contract_periods/for_ect_registration.rb
+++ b/app/services/contract_periods/for_ect_registration.rb
@@ -10,9 +10,9 @@ module ContractPeriods
 
     def call
       return contract_period_reassignment.successor_contract_period if contract_period_reassignment.required?
-      return @previous_training_period.contract_period if @previous_training_period.present?
+      return previous_contract_period if preserve_previous_contract_period?
 
-      ContractPeriod.for_registration_start_date(@started_on) ||
+      registration_contract_period ||
         raise(
           NoContractPeriodFoundForStartedOnDate,
           "No contract period found for started_on=#{@started_on}"
@@ -20,6 +20,23 @@ module ContractPeriods
     end
 
   private
+
+    def preserve_previous_contract_period?
+      return false unless @previous_training_period
+      return false unless @previous_training_period.provider_led_training_programme?
+      return false unless previous_contract_period
+      return false if previous_contract_period.payments_frozen?
+
+      registration_contract_period.present?
+    end
+
+    def previous_contract_period
+      @previous_training_period.contract_period
+    end
+
+    def registration_contract_period
+      @registration_contract_period ||= ContractPeriod.for_registration_start_date(@started_on)
+    end
 
     def contract_period_reassignment
       @contract_period_reassignment ||= @reassignment || ContractPeriods::Reassignment.new(

--- a/app/services/contract_periods/for_ect_registration.rb
+++ b/app/services/contract_periods/for_ect_registration.rb
@@ -31,7 +31,11 @@ module ContractPeriods
     end
 
     def previous_contract_period
-      @previous_training_period.contract_period
+      @previous_contract_period ||=
+        @previous_training_period.contract_period ||
+        @previous_training_period.expression_of_interest&.contract_period ||
+        @previous_training_period.school_partnership&.active_lead_provider&.contract_period ||
+        @previous_training_period.schedule&.contract_period
     end
 
     def registration_contract_period

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -4,12 +4,13 @@ module Schedules
 
     include Schedules::Reuse
 
-    def initialize(period:, training_programme:, started_on:, period_type_key:, mentee:)
+    def initialize(period:, training_programme:, started_on:, period_type_key:, mentee:, contract_period: nil)
       @period = period
       @training_programme = training_programme
       @started_on = started_on
       @period_type_key = period_type_key
       @mentee = mentee
+      @contract_period = contract_period
     end
 
     def call
@@ -67,7 +68,9 @@ module Schedules
     def contract_period_year
       return successor_contract_period if extended_schedule?
 
-      ContractPeriod.containing_date(latest_start_date)&.year || raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
+      @contract_period&.year ||
+        ContractPeriod.containing_date(latest_start_date)&.year ||
+        raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
     end
 
     def identifier

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -67,7 +67,7 @@ module Schedules
     def contract_period_year
       return successor_contract_period if extended_schedule?
 
-      contract_period&.year || raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
+      ContractPeriod.containing_date(latest_start_date)&.year || raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
     end
 
     def identifier

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -67,7 +67,7 @@ module Schedules
     def contract_period_year
       return successor_contract_period if extended_schedule?
 
-      ContractPeriod.containing_date(latest_start_date)&.year || raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
+      contract_period&.year || raise(ActiveRecord::RecordNotFound, "No contract period for #{latest_start_date}")
     end
 
     def identifier

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -23,6 +23,7 @@ module Schedules
 
     def schedule_for_target_period
       return extended_schedule if extended_schedule?
+      return schedule if reuse_existing_schedule?
       return most_recent_schedule if most_recent_schedule&.contract_period_year == contract_period_year
 
       Schedule.find_by(contract_period_year:, identifier: most_recent_schedule&.identifier) || Schedule.find_by(contract_period_year:, identifier:)

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -23,7 +23,6 @@ module Schedules
 
     def schedule_for_target_period
       return extended_schedule if extended_schedule?
-      return schedule if reuse_existing_schedule?
       return most_recent_schedule if most_recent_schedule&.contract_period_year == contract_period_year
 
       Schedule.find_by(contract_period_year:, identifier: most_recent_schedule&.identifier) || Schedule.find_by(contract_period_year:, identifier:)

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -98,6 +98,7 @@ module Schools
             started_on: training_period_started_on,
             school_partnership:,
             expression_of_interest:,
+            schedule: preserved_schedule,
             author:
           ).call
         end
@@ -211,6 +212,16 @@ module Schools
 
     def previous_training_period
       store&.previous_training_period
+    end
+
+    def preserved_schedule
+      return nil unless preserving_previous_contract_period?
+
+      previous_training_period&.schedule
+    end
+
+    def preserving_previous_contract_period?
+      contract_period == previous_training_period&.contract_period
     end
   end
 end

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -98,7 +98,7 @@ module Schools
             started_on: training_period_started_on,
             school_partnership:,
             expression_of_interest:,
-            schedule: preserved_schedule,
+            contract_period: preserved_contract_period,
             author:
           ).call
         end
@@ -218,14 +218,10 @@ module Schools
       store&.previous_training_period
     end
 
-    def preserved_schedule
-      return nil unless preserving_previous_contract_period?
+    def preserved_contract_period
+      return nil unless contract_period == previous_training_period&.contract_period
 
-      previous_training_period&.schedule
-    end
-
-    def preserving_previous_contract_period?
-      contract_period == previous_training_period&.contract_period
+      contract_period
     end
   end
 end

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -206,7 +206,8 @@ module Schools
     def registration_contract_period
       @registration_contract_period ||= ContractPeriods::ForECTRegistration.new(
         started_on:,
-        previous_training_period:
+        previous_training_period:,
+        preserve: false
       ).call
     end
 

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -187,13 +187,13 @@ module Schools
           previous_school_partnership_id: previous_id,
           school:,
           author:,
-          current_contract_period_year: registration_contract_period.year
+          current_contract_period_year: contract_period.year
         )
     end
 
     def training_period_started_on
       if ContractPeriods::Reassignment.new(training_period: previous_training_period).required?
-        [ect_at_school_period.started_on, registration_contract_period.started_on].max
+        [ect_at_school_period.started_on, contract_period.started_on].max
       else
         [ect_at_school_period.started_on, Date.current].max
       end
@@ -203,14 +203,6 @@ module Schools
       @contract_period ||= ContractPeriods::ForECTRegistration.new(
         started_on:,
         previous_training_period:
-      ).call
-    end
-
-    def registration_contract_period
-      @registration_contract_period ||= ContractPeriods::ForECTRegistration.new(
-        started_on:,
-        previous_training_period:,
-        preserve: false
       ).call
     end
 

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -200,7 +200,10 @@ module Schools
     end
 
     def contract_period
-      @contract_period ||= registration_contract_period
+      @contract_period ||= ContractPeriods::ForECTRegistration.new(
+        started_on:,
+        previous_training_period:
+      ).call
     end
 
     def registration_contract_period

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -99,6 +99,7 @@ module Schools
             school_partnership:,
             expression_of_interest:,
             contract_period: preserved_contract_period,
+            schedule:,
             author:
           ).call
         end
@@ -211,9 +212,22 @@ module Schools
     end
 
     def preserved_contract_period
-      return nil unless contract_period == previous_training_period&.contract_period
+      return nil unless previous_training_period
+      return nil unless contract_period == previous_contract_period
 
       contract_period
+    end
+
+    def previous_contract_period
+      @previous_contract_period ||=
+        previous_training_period.contract_period ||
+        previous_training_period.expression_of_interest&.contract_period ||
+        previous_training_period.school_partnership&.active_lead_provider&.contract_period ||
+        previous_training_period.schedule&.contract_period
+    end
+
+    def schedule
+      previous_training_period&.schedule if preserved_contract_period
     end
   end
 end

--- a/app/services/training_periods/create.rb
+++ b/app/services/training_periods/create.rb
@@ -3,7 +3,7 @@ module TrainingPeriods
     class ScheduleNotFound < StandardError; end
 
     def initialize(period:, started_on:, training_programme:, school_partnership: nil, expression_of_interest: nil,
-                   finished_on: nil, schedule: nil, author: nil, mentee: nil)
+                   finished_on: nil, schedule: nil, author: nil, mentee: nil, contract_period: nil)
       @period = period
       @started_on = started_on
       @school_partnership = school_partnership
@@ -13,14 +13,15 @@ module TrainingPeriods
       @schedule = schedule
       @author = author
       @mentee = mentee
+      @contract_period = contract_period
     end
 
     def self.school_led(period:, started_on:, finished_on: nil)
       new(period:, started_on:, finished_on:, training_programme: "school_led")
     end
 
-    def self.provider_led(period:, started_on:, school_partnership:, expression_of_interest:, finished_on: nil, schedule: nil, author: nil, mentee: nil)
-      new(period:, started_on:, school_partnership:, expression_of_interest:, training_programme: "provider_led", finished_on:, schedule:, author:, mentee:)
+    def self.provider_led(period:, started_on:, school_partnership:, expression_of_interest:, finished_on: nil, schedule: nil, author: nil, mentee: nil, contract_period: nil)
+      new(period:, started_on:, school_partnership:, expression_of_interest:, training_programme: "provider_led", finished_on:, schedule:, author:, mentee:, contract_period:)
     end
 
     def call
@@ -67,7 +68,7 @@ module TrainingPeriods
     def schedule
       return if @training_programme == "school_led"
 
-      @schedule ||= Schedules::Find.new(period: @period, training_programme: @training_programme, started_on: @started_on, period_type_key:, mentee: @mentee).call
+      @schedule ||= Schedules::Find.new(period: @period, training_programme: @training_programme, started_on: @started_on, period_type_key:, mentee: @mentee, contract_period: @contract_period).call
 
       return @schedule if @schedule.present?
 

--- a/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
@@ -32,8 +32,7 @@ module Schools
 
           @registration_contract_period ||= ContractPeriods::ForECTRegistration.new(
             started_on: start_date,
-            previous_training_period:,
-            preserve: false
+            previous_training_period:
           ).call
         end
 

--- a/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
+++ b/app/wizards/schools/register_ect_wizard/registration_store/queries.rb
@@ -32,7 +32,8 @@ module Schools
 
           @registration_contract_period ||= ContractPeriods::ForECTRegistration.new(
             started_on: start_date,
-            previous_training_period:
+            previous_training_period:,
+            preserve: false
           ).call
         end
 

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
-    context "when there is a previous training period in an earlier contract period" do
+    context "when there is a previous provider-led training period and no reassignment is required" do
       let(:started_on) { Date.new(2025, 9, 1) }
 
       let(:previous_training_period) do
@@ -81,10 +81,7 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
 
       let(:reassignment) do
-        instance_double(
-          ContractPeriods::Reassignment,
-          required?: false
-        )
+        instance_double(ContractPeriods::Reassignment, required?: false)
       end
 
       it "returns the previous training period's contract period" do
@@ -92,9 +89,10 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
-    context "when the training period should be reassigned" do
+    context "when reassignment is required" do
       let(:started_on) { Date.new(2025, 9, 1) }
       let(:previous_training_period) { instance_double(TrainingPeriod) }
+
       let(:reassignment) do
         instance_double(
           ContractPeriods::Reassignment,
@@ -104,29 +102,6 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
 
       it "returns the successor contract period" do
-        expect(resolver.call).to eq(contract_2024)
-      end
-    end
-
-    context "when the training period should not be reassigned" do
-      let(:started_on) { Date.new(2025, 9, 1) }
-
-      let(:previous_training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period: contract_2024,
-          provider_led_training_programme?: true
-        )
-      end
-
-      let(:reassignment) do
-        instance_double(
-          ContractPeriods::Reassignment,
-          required?: false
-        )
-      end
-
-      it "returns the previous training period's contract period" do
         expect(resolver.call).to eq(contract_2024)
       end
     end

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -89,6 +89,50 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
+    context "when there is a previous school-led training period" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024,
+          provider_led_training_programme?: false
+        )
+      end
+
+      let(:reassignment) do
+        instance_double(ContractPeriods::Reassignment, required?: false)
+      end
+
+      it "returns the registration contract period" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+
+    context "when the previous provider-led contract period is payments frozen" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024,
+          provider_led_training_programme?: true
+        )
+      end
+
+      let(:reassignment) do
+        instance_double(ContractPeriods::Reassignment, required?: false)
+      end
+
+      before do
+        allow(contract_2024).to receive(:payments_frozen?).and_return(true)
+      end
+
+      it "returns the registration contract period" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+
     context "when reassignment is required" do
       let(:started_on) { Date.new(2025, 9, 1) }
       let(:previous_training_period) { instance_double(TrainingPeriod) }

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -89,6 +89,35 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
+    context "when preserve is false and the previous training period is provider-led in a non-frozen contract period" do
+      subject(:resolver) do
+        described_class.new(
+          started_on:,
+          previous_training_period:,
+          reassignment:,
+          preserve: false
+        )
+      end
+
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024,
+          provider_led_training_programme?: true
+        )
+      end
+
+      let(:reassignment) do
+        instance_double(ContractPeriods::Reassignment, required?: false)
+      end
+
+      it "returns the registration contract period, not the previous one" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+
     context "when there is a previous school-led training period" do
       let(:started_on) { Date.new(2025, 9, 1) }
 

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -69,6 +69,28 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
+    context "when there is a previous training period in an earlier contract period" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024
+        )
+      end
+
+      let(:reassignment) do
+        instance_double(
+          ContractPeriods::Reassignment,
+          required?: false
+        )
+      end
+
+      it "returns the previous training period's contract period" do
+        expect(resolver.call).to eq(contract_2024)
+      end
+    end
+
     context "when the training period should be reassigned" do
       let(:started_on) { Date.new(2025, 9, 1) }
       let(:previous_training_period) { instance_double(TrainingPeriod) }
@@ -87,7 +109,14 @@ RSpec.describe ContractPeriods::ForECTRegistration do
 
     context "when the training period should not be reassigned" do
       let(:started_on) { Date.new(2025, 9, 1) }
-      let(:previous_training_period) { instance_double(TrainingPeriod) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024
+        )
+      end
+
       let(:reassignment) do
         instance_double(
           ContractPeriods::Reassignment,
@@ -95,8 +124,8 @@ RSpec.describe ContractPeriods::ForECTRegistration do
         )
       end
 
-      it "returns the current contract period" do
-        expect(resolver.call).to eq(contract_2025)
+      it "returns the previous training period's contract period" do
+        expect(resolver.call).to eq(contract_2024)
       end
     end
   end

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       let(:previous_training_period) do
         instance_double(
           TrainingPeriod,
-          contract_period: contract_2024
+          contract_period: contract_2024,
+          provider_led_training_programme?: true
         )
       end
 
@@ -113,7 +114,8 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       let(:previous_training_period) do
         instance_double(
           TrainingPeriod,
-          contract_period: contract_2024
+          contract_period: contract_2024,
+          provider_led_training_programme?: true
         )
       end
 

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -89,35 +89,6 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
-    context "when preserve is false and the previous training period is provider-led in a non-frozen contract period" do
-      subject(:resolver) do
-        described_class.new(
-          started_on:,
-          previous_training_period:,
-          reassignment:,
-          preserve: false
-        )
-      end
-
-      let(:started_on) { Date.new(2025, 9, 1) }
-
-      let(:previous_training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period: contract_2024,
-          provider_led_training_programme?: true
-        )
-      end
-
-      let(:reassignment) do
-        instance_double(ContractPeriods::Reassignment, required?: false)
-      end
-
-      it "returns the registration contract period, not the previous one" do
-        expect(resolver.call).to eq(contract_2025)
-      end
-    end
-
     context "when there is a previous school-led training period" do
       let(:started_on) { Date.new(2025, 9, 1) }
 

--- a/spec/services/contract_periods/for_ect_registration_spec.rb
+++ b/spec/services/contract_periods/for_ect_registration_spec.rb
@@ -109,6 +109,39 @@ RSpec.describe ContractPeriods::ForECTRegistration do
       end
     end
 
+    context "when the previous provider-led training period used an EOI" do
+      let(:started_on) { Date.new(2026, 5, 1) }
+
+      let(:active_lead_provider) do
+        instance_double(
+          ActiveLeadProvider,
+          contract_period: contract_2024
+        )
+      end
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: nil,
+          expression_of_interest: active_lead_provider,
+          school_partnership: nil,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      let(:reassignment) do
+        instance_double(
+          ContractPeriods::Reassignment,
+          required?: false
+        )
+      end
+
+      it "returns the expression of interest contract period" do
+        expect(resolver.call).to eq(contract_2024)
+      end
+    end
+
     context "when the previous provider-led contract period is payments frozen" do
       let(:started_on) { Date.new(2025, 9, 1) }
 

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -463,8 +463,7 @@ RSpec.describe Schools::RegisterECT do
           expect(new_training_period.schedule.identifier)
             .to eq(previous_training_period.schedule.identifier)
 
-          expect(new_training_period.schedule.contract_period)
-  .not_to eq(contract_period)
+          expect(new_training_period.schedule.contract_period.year).to eq(2024)
         end
 
         context "when the new school has a matching partnership in the previous contract period" do

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -386,6 +386,149 @@ RSpec.describe Schools::RegisterECT do
           expect(training_period.started_on).not_to eq(Date.current)
         end
       end
+
+      context "when the ECT is continuing provider-led training from a previous school" do
+        let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+        let(:previous_school) { FactoryBot.create(:school) }
+        let(:previous_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
+        let(:started_on) { Date.new(2025, 9, 1) }
+
+        let(:previous_active_lead_provider) do
+          FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period)
+        end
+
+        let(:previous_lead_provider_delivery_partnership) do
+          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: previous_active_lead_provider)
+        end
+
+        let(:previous_school_partnership) do
+          FactoryBot.create(
+            :school_partnership,
+            school: previous_school,
+            lead_provider_delivery_partnership: previous_lead_provider_delivery_partnership
+          )
+        end
+
+        let(:previous_ect_period) do
+          FactoryBot.create(
+            :ect_at_school_period,
+            teacher:,
+            school: previous_school,
+            started_on: Date.new(2024, 9, 1),
+            finished_on: Date.new(2025, 8, 31)
+          )
+        end
+
+        let(:previous_schedule) do
+          FactoryBot.create(
+            :schedule,
+            contract_period: previous_contract_period,
+            identifier: "ecf-standard-september"
+          )
+        end
+
+        let!(:previous_training_period) do
+          FactoryBot.create(
+            :training_period,
+            ect_at_school_period: previous_ect_period,
+            training_programme: "provider_led",
+            school_partnership: previous_school_partnership,
+            schedule: previous_schedule,
+            started_on: Date.new(2024, 9, 1),
+            finished_on: Date.new(2025, 8, 31)
+          )
+        end
+
+        let(:store) do
+          double(
+            "store",
+            previous_training_period:,
+            school_partnership_to_reuse_id: nil
+          )
+        end
+
+        it "keeps the previous contract period for the new EOI training period" do
+          service.register!
+
+          new_training_period = service.ect_at_school_period.training_periods.order(:created_at).last
+
+          expect(new_training_period.expression_of_interest.contract_period)
+            .to eq(previous_contract_period)
+
+          expect(new_training_period.school_partnership).to be_nil
+
+          expect(new_training_period.schedule.contract_period)
+            .to eq(previous_contract_period)
+
+          expect(new_training_period.schedule.identifier)
+            .to eq(previous_training_period.schedule.identifier)
+
+          expect(new_training_period.schedule.contract_period)
+  .not_to eq(contract_period)
+        end
+
+        context "when the new school has a matching partnership in the previous contract period" do
+          let!(:new_school_partnership) do
+            FactoryBot.create(
+              :school_partnership,
+              school:,
+              lead_provider_delivery_partnership: FactoryBot.create(
+                :lead_provider_delivery_partnership,
+                active_lead_provider: previous_active_lead_provider
+              )
+            )
+          end
+
+          it "keeps the previous contract period and uses the matching school partnership" do
+            service.register!
+
+            new_training_period = service.ect_at_school_period.training_periods.order(:created_at).last
+
+            expect(new_training_period.school_partnership).to eq(new_school_partnership)
+            expect(new_training_period.expression_of_interest).to be_nil
+
+            expect(new_training_period.school_partnership.active_lead_provider.contract_period)
+              .to eq(previous_contract_period)
+
+            expect(new_training_period.schedule.contract_period)
+              .to eq(previous_contract_period)
+
+            expect(new_training_period.schedule.identifier)
+              .to eq(previous_training_period.schedule.identifier)
+          end
+        end
+
+        context "when the new school has a partnership but in a different contract period" do
+          let!(:different_active_lead_provider) do
+            FactoryBot.create(
+              :active_lead_provider,
+              lead_provider:,
+              contract_period:
+            )
+          end
+
+          let!(:new_school_partnership) do
+            FactoryBot.create(
+              :school_partnership,
+              school:,
+              lead_provider_delivery_partnership: FactoryBot.create(
+                :lead_provider_delivery_partnership,
+                active_lead_provider: different_active_lead_provider
+              )
+            )
+          end
+
+          it "falls back to EOI in the previous contract period" do
+            service.register!
+
+            new_training_period = service.ect_at_school_period.training_periods.last
+
+            expect(new_training_period.school_partnership).to be_nil
+            expect(new_training_period.expression_of_interest.contract_period)
+              .to eq(previous_contract_period)
+          end
+        end
+      end
     end
 
     context "when school-led" do

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe Schools::RegisterECT do
         let(:previous_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
         let(:started_on) { Date.new(2025, 9, 1) }
 
-        let(:previous_active_lead_provider) do
+        let!(:previous_active_lead_provider) do
           FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period)
         end
 

--- a/spec/services/training_periods/create_spec.rb
+++ b/spec/services/training_periods/create_spec.rb
@@ -208,7 +208,8 @@ RSpec.describe TrainingPeriods::Create do
         finished_on:,
         schedule:,
         mentee:,
-        author:
+        author:,
+        contract_period: nil
       )
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -151,32 +151,13 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
     end
 
-    context "when the previous training period is provider-led in closed 2021" do
-      let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
-      let!(:contract_period_2024) { create_contract_period(year: 2024, payments_frozen: true) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
-
-      let(:start_date) { contract_period_2025.started_on.to_s }
-
-      let(:previous_training_period) do
-        build_previous_training_period_double(
-          provider_led: true,
-          contract_period: contract_period_2021
-        )
-      end
-
-      before { stub_previous_training(previous_training_period, previous_ect_period:) }
-
-      it "returns the 2024 contract period" do
-        expect(queries.registration_contract_period).to eq(contract_period_2024)
-      end
-    end
-
     context "when the previous training period is provider-led in a non-frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021) }
       let!(:contract_period_2025) { create_contract_period(year: 2025) }
 
       let(:start_date) { contract_period_2025.started_on.to_s }
+      let!(:lead_provider_2021) { FactoryBot.create(:lead_provider, name: "LP 2021") }
+      let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -185,10 +166,45 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
         )
       end
 
-      before { stub_previous_training(previous_training_period, previous_ect_period:) }
+      before do
+        create_active_lead_provider(contract_period: contract_period_2021, lead_provider: lead_provider_2021)
+        create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
+        stub_previous_training(previous_training_period, previous_ect_period:)
+      end
 
-      it "returns the normal registration contract period" do
-        expect(queries.registration_contract_period).to eq(contract_period_2025)
+      it "returns lead providers for the previous contract period" do
+        expect(queries.lead_providers_within_contract_period.map(&:name)).to contain_exactly("LP 2021")
+      end
+    end
+
+    context "when the previous training period is provider-led in a non-frozen contract period" do
+      let!(:contract_period_2021) { create_contract_period(year: 2021) }
+
+      let(:start_date) { Date.new(2025, 9, 1).to_s }
+      let(:school) { FactoryBot.create(:school) }
+      let(:lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
+
+      let(:previous_training_period) do
+        build_previous_training_period_double(
+          provider_led: true,
+          contract_period: contract_period_2021,
+          lead_provider:
+        )
+      end
+
+      let!(:school_partnership_2021) { create_school_partnership(year: 2021, school:, lead_provider:) }
+      let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
+      let!(:other_school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider: other_lead_provider) }
+
+      before do
+        registration_store.lead_provider_id = lead_provider.id
+        stub_previous_training(previous_training_period, previous_ect_period:)
+      end
+
+      it "returns partnerships for the previous contract period" do
+        expect(queries.lead_provider_partnerships_for_contract_period(school:))
+          .to contain_exactly(school_partnership_2021)
       end
     end
 
@@ -319,6 +335,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       let!(:contract_period_2025) { create_contract_period(year: 2025) }
 
       let(:start_date) { contract_period_2025.started_on.to_s }
+      let!(:lead_provider_2021) { FactoryBot.create(:lead_provider, name: "LP 2021") }
       let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
 
       let(:previous_training_period) do
@@ -329,12 +346,13 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       before do
+        create_active_lead_provider(contract_period: contract_period_2021, lead_provider: lead_provider_2021)
         create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
         stub_previous_training(previous_training_period, previous_ect_period:)
       end
 
-      it "returns lead providers for the normal contract period" do
-        expect(queries.lead_providers_within_contract_period.map(&:name)).to contain_exactly("LP 2025")
+      it "returns lead providers for the previous contract period" do
+        expect(queries.lead_providers_within_contract_period.map(&:name)).to contain_exactly("LP 2021")
       end
     end
 
@@ -473,7 +491,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
         )
       end
 
-      let!(:school_partnership_2024) { create_school_partnership(year: 2024, school:, lead_provider:) }
+      let!(:school_partnership_2021) { create_school_partnership(year: 2021, school:, lead_provider:) }
       let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
       let!(:other_school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider: other_lead_provider) }
 
@@ -484,7 +502,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
       it "returns partnerships for the normal contract period" do
         expect(queries.lead_provider_partnerships_for_contract_period(school:))
-          .to contain_exactly(school_partnership_2025)
+          .to contain_exactly(school_partnership_2021)
       end
     end
 

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -151,13 +151,12 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
     end
 
-    context "when the previous training period is provider-led in a non-frozen contract period" do
-      let!(:contract_period_2021) { create_contract_period(year: 2021) }
+    context "when the previous training period is provider-led in closed 2021" do
+      let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
+      let!(:contract_period_2024) { create_contract_period(year: 2024, payments_frozen: true) }
       let!(:contract_period_2025) { create_contract_period(year: 2025) }
 
       let(:start_date) { contract_period_2025.started_on.to_s }
-      let!(:lead_provider_2021) { FactoryBot.create(:lead_provider, name: "LP 2021") }
-      let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -166,45 +165,30 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
         )
       end
 
-      before do
-        create_active_lead_provider(contract_period: contract_period_2021, lead_provider: lead_provider_2021)
-        create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
-        stub_previous_training(previous_training_period, previous_ect_period:)
-      end
+      before { stub_previous_training(previous_training_period, previous_ect_period:) }
 
-      it "returns lead providers for the previous contract period" do
-        expect(queries.lead_providers_within_contract_period.map(&:name)).to contain_exactly("LP 2021")
+      it "returns the 2024 contract period" do
+        expect(queries.registration_contract_period).to eq(contract_period_2024)
       end
     end
 
     context "when the previous training period is provider-led in a non-frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021) }
+      let!(:contract_period_2025) { create_contract_period(year: 2025) }
 
-      let(:start_date) { Date.new(2025, 9, 1).to_s }
-      let(:school) { FactoryBot.create(:school) }
-      let(:lead_provider) { FactoryBot.create(:lead_provider) }
-      let(:other_lead_provider) { FactoryBot.create(:lead_provider) }
+      let(:start_date) { contract_period_2025.started_on.to_s }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
           provider_led: true,
-          contract_period: contract_period_2021,
-          lead_provider:
+          contract_period: contract_period_2021
         )
       end
 
-      let!(:school_partnership_2021) { create_school_partnership(year: 2021, school:, lead_provider:) }
-      let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
-      let!(:other_school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider: other_lead_provider) }
+      before { stub_previous_training(previous_training_period, previous_ect_period:) }
 
-      before do
-        registration_store.lead_provider_id = lead_provider.id
-        stub_previous_training(previous_training_period, previous_ect_period:)
-      end
-
-      it "returns partnerships for the previous contract period" do
-        expect(queries.lead_provider_partnerships_for_contract_period(school:))
-          .to contain_exactly(school_partnership_2021)
+      it "returns the previous training period's contract period" do
+        expect(queries.registration_contract_period).to eq(contract_period_2021)
       end
     end
 

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     end
 
     context "when the previous training period is provider-led in a non-frozen contract period" do
-      let!(:contract_period_2021) { create_contract_period(year: 2021) }
+      let!(:contract_period_2023) { create_contract_period(year: 2023) }
       let!(:contract_period_2025) { create_contract_period(year: 2025) }
 
       let(:start_date) { contract_period_2025.started_on.to_s }
@@ -181,14 +181,14 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       let(:previous_training_period) do
         build_previous_training_period_double(
           provider_led: true,
-          contract_period: contract_period_2021
+          contract_period: contract_period_2023
         )
       end
 
       before { stub_previous_training(previous_training_period, previous_ect_period:) }
 
       it "returns the previous training period's contract period" do
-        expect(queries.registration_contract_period).to eq(contract_period_2021)
+        expect(queries.registration_contract_period).to eq(contract_period_2023)
       end
     end
 


### PR DESCRIPTION
[Ticket](https://github.com/DFE-Digital/register-ects-project-board/issues/3875)

### Context
When registering an ECT who is continuing provider-led training from a previous school, we should keep the original contract period where appropriate rather than defaulting to the current one.

### Changes proposed in this pull request
- Update contract period selection to preserve the previous training period's contract period (unless reassignment applies or payments are frozen)
- Introduce a `preserve: option` on `ContractPeriods::ForECTRegistration` to separate wizard and registration concerns
- Align schedule selection with the resolved contract period by passing preserved_schedule explicitly to - `TrainingPeriods::Create`
- Ensure school partnership matching is scoped to the preserved contract period, falling back to an expression of interest when no matching partnership exists

### Guidance to review
The main thing to sense check is the intended behaviour around contract period selection:

- When continuing provider-led training in a non-frozen contract period, we prioritise the previous contract period over the current one
- preserve: false is passed in two places — `Queries#registration_contract_period` and `RegisterECT#registration_contract_period` — both of which need the date-based CP rather than the preserved one
- Schedule selection always aligns with the chosen contract period via preserved_schedule
- Worth checking the Schedules::Find logic to confirm we are not accidentally overriding the preserved contract period in edge cases

Also worth checking this against the logic in Schedules::Find, as it previously “pinned” the contract period based on dates — want to make sure we’re not accidentally overriding the preserved contract period in edge cases.
