### PR TITLE
[3802] Add working pattern for ECTs to the API

### DIFF
--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -95,6 +95,12 @@ class API::TeacherSerializer < Blueprinter::Base
       end
       field(:mentor_ineligible_for_funding_reason) { |(training_period, teacher, _)| teacher.mentor_became_ineligible_for_funding_reason if training_period.for_mentor? }
 
+      field(:working_pattern) do |(training_period, teacher, _)|
+        if training_period.for_ect?
+          teacher.latest_ect_at_school_period&.working_pattern
+        end
+      end
+
       class << self
         def uplift_value(training_period, metadata, uplift_type)
           contract_period = if training_period.for_ect?

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -50,6 +50,7 @@ module API::Teachers
           :finished_induction_period,
           :earliest_ect_at_school_period,
           :earliest_mentor_at_school_period,
+          :latest_ect_at_school_period,
           lead_provider_metadata: {
             latest_ect_training_period: {
               school_partnership: [

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -49,6 +49,7 @@
     ## Why we’ve made this change
 
     By exposing this data through the API, lead providers can:
+    
     - better understand whether an ECT is working part‑time or full‑time
     - tailor training and support more effectively
     - reduce manual follow‑up with schools

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -27,16 +27,16 @@
     - sandbox-release
     - production-release
   body: |
-    We’ve added a new optional field, working_pattern, to the GET participants endpoint for early career teachers (ECTs).
+    We’ve added a new optional field, `working_pattern`, to the GET participants endpoint for early career teachers (ECTs).
 
     This change has been released ahead of the 2026 cohort opening so lead providers can access more accurate information when onboarding new ECTs to training.
 
     ## What’s changed
-    The working_pattern field indicates whether an ECT is working:
+    The `working_pattern` field indicates whether an ECT is working:
 
-    - full_time
-    - part_time
-    - null (if no working pattern has been provided)
+    - `full_time`
+    - `part_time`
+    - `null` (if no working pattern has been provided)
 
     The value shown in the API always reflects the most recent working pattern selected by a school for that ECT. If a school updates an ECT’s working pattern, the updated value will be returned automatically.
 
@@ -58,7 +58,7 @@
 
     No action is required. This is a non‑breaking, optional field.
 
-    If your integration supports additional fields, you can start using working_pattern now.
+    If your integration supports additional fields, you can start using `working_pattern` now.
 
 - title: Updates to schedule and cohort changes for deferred and withdrawn participants
   date: 2026-05-05

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,6 +21,45 @@
 #
 #     **bold** and _italic_ text
 
+- title: Add working_pattern field for early career teachers
+  date: 2026-05-07
+  tags:
+    - sandbox-release
+    - production-release
+  body: |
+    We’ve added a new optional field, working_pattern, to the GET participants endpoint for early career teachers (ECTs).
+
+    This change has been released ahead of the 2026 cohort opening so lead providers can access more accurate information when onboarding new ECTs to training.
+
+    ## What’s changed
+    The working_pattern field indicates whether an ECT is working:
+
+    - full_time
+    - part_time
+    - null (if no working pattern has been provided)
+
+    The value shown in the API always reflects the most recent working pattern selected by a school for that ECT. If a school updates an ECT’s working pattern, the updated value will be returned automatically.
+
+    ## Who this applies to
+
+    The field is only available for early career teachers. It does not apply to mentors. The field is populated for newly registered ECTs, or ECTs who have been re‑registered by a new school due to a transfer.
+
+    For example, an ECT who started in 2023 may have a working pattern if they move to a new school. Most populated values are expected for 2025 and 2026 ECTs.
+
+    ## Why we’ve made this change
+
+    By exposing this data through the API, lead providers can:
+    - better understand whether an ECT is working part‑time or full‑time
+    - tailor training and support more effectively
+    - reduce manual follow‑up with schools
+    - improve data accuracy, the assignment of extended schedules and speed up onboarding to training
+
+    ## What you need to do
+
+    No action is required. This is a non‑breaking, optional field.
+
+    If your integration supports additional fields, you can start using working_pattern now.
+
 - title: Updates to schedule and cohort changes for deferred and withdrawn participants
   date: 2026-05-05
   tags:

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -264,6 +264,7 @@ paths:
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           school_urn: '123456'
                           participant_type: ect
+                          working_pattern: full_time
                           cohort: '2021'
                           training_status: active
                           participant_status: active
@@ -326,6 +327,7 @@ paths:
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           school_urn: '123456'
                           participant_type: ect
+                          working_pattern: full_time
                           cohort: '2021'
                           training_status: active
                           participant_status: active
@@ -394,6 +396,7 @@ paths:
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           school_urn: '123456'
                           participant_type: ect
+                          working_pattern: full_time
                           cohort: '2021'
                           training_status: withdrawn
                           participant_status: active
@@ -481,6 +484,7 @@ paths:
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           school_urn: '123456'
                           participant_type: ect
+                          working_pattern: full_time
                           cohort: '2021'
                           training_status: deferred
                           participant_status: active
@@ -568,6 +572,7 @@ paths:
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           school_urn: '123456'
                           participant_type: ect
+                          working_pattern: full_time
                           cohort: '2021'
                           training_status: active
                           participant_status: active
@@ -653,6 +658,7 @@ paths:
                           mentor_id: 42a9ef2f-9059-400a-92ff-4830a629d0c5
                           school_urn: '123456'
                           participant_type: ect
+                          working_pattern: full_time
                           cohort: '2021'
                           training_status: active
                           participant_status: active
@@ -2821,6 +2827,7 @@ components:
       - email
       - school_urn
       - participant_type
+      - working_pattern
       - cohort
       - training_status
       - participant_status
@@ -2859,6 +2866,14 @@ components:
           - ect
           - mentor
           example: ect
+        working_pattern:
+          description: The current working pattern of an ECT. Reported as full or
+            part-time by the school.
+          type: string
+          enum:
+          - full_time
+          - part_time
+          example: full_time
         cohort:
           description: Indicates which call-off contract funds this participant's
             training. 2021 indicates a participant that has started, or will start,

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -181,6 +181,26 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             expect(ect_enrolment["cohort_changed_after_payments_frozen"]).to eq(teacher.ect_payments_frozen_year.present?)
           end
 
+          describe "`working pattern`" do
+            context "when latest `working_pattern` is `full_time`" do
+              before { ect_at_school_period.update!(working_pattern: :full_time) }
+
+              it { expect(ect_enrolment["working_pattern"]).to eq("full_time") }
+            end
+
+            context "when latest `working_pattern` is `part_time`" do
+              before { ect_at_school_period.update!(working_pattern: :part_time) }
+
+              it { expect(ect_enrolment["working_pattern"]).to eq("part_time") }
+            end
+
+            context "when latest `working_pattern` is nil" do
+              before { ect_at_school_period.update!(working_pattern: nil) }
+
+              it { expect(ect_enrolment["working_pattern"]).to be_nil }
+            end
+          end
+
           context "when `uplift_fees_enabled` is `false` for the contract period" do
             before { ect_training_period.school_partnership.contract_period.update!(uplift_fees_enabled: false) }
 
@@ -383,6 +403,8 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
             expect(mentor_enrolment["mentor_ineligible_for_funding_reason"]).to eq(teacher.mentor_became_ineligible_for_funding_reason)
 
             expect(mentor_enrolment["cohort_changed_after_payments_frozen"]).to eq(teacher.mentor_payments_frozen_year.present?)
+
+            expect(mentor_enrolment["working_pattern"]).to be_nil
           end
 
           context "when `uplift_fees_enabled` is `false` for the contract period" do

--- a/spec/swagger_schemas/models/participants/ecf_enrolment.rb
+++ b/spec/swagger_schemas/models/participants/ecf_enrolment.rb
@@ -6,6 +6,7 @@ PARTICIPANT_ECF_ENROLMENT = {
     email
     school_urn
     participant_type
+    working_pattern
     cohort
     training_status
     participant_status
@@ -45,6 +46,12 @@ PARTICIPANT_ECF_ENROLMENT = {
       type: :string,
       enum: %w[ect mentor],
       example: "ect"
+    },
+    working_pattern: {
+      description: "The current working pattern of an ECT. Reported as full or part-time by the school.",
+      type: :string,
+      enum: %w[full_time part_time],
+      example: "full_time"
     },
     cohort: {
       description: "Indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year.",


### PR DESCRIPTION
### Context

> As a lead provider
I need to understand the working pattern of an ECT
So that I can provide them with tailored training if they are working part-time

### Changes proposed in this pull request

Add `working_pattern` for latest `ect_at_school_period` to the participant API endpoint.

### Guidance to review

**School Periods**
                                                                                                                                                                         
| School Period ID | Start | End   | Working Pattern |
|-----------|------------|------------|-----------------|
| 483       | 2021-09-06 | 2022-07-03 | full_time       |
| 1638      | 2022-07-04 | -    | **part_time**   |
                                                                                                                                                                         
**Training Periods**
                                                                                                                                                                                                                                                                                                                                                  
| Training Period ID | School Period ID | Start   | End   |
|-------------------|---------------|------------|------------|
| 500               | 483           | 2021-10-17 | 2022-04-15 |
| **2657**          | **1638**      | 2022-07-04 | —          |

```json                                                                           
# GET /api/v3/participants/14e5a3b5-7dff-48f8-a643-d67d338e10eb                   

   {                                                                               
     "id": "14e5a3b5-7dff-48f8-a643-d67d338e10eb",                                 
     "attributes": {                                                               
       "full_name": "Lindsay Tromp",                                               
       "teacher_reference_number": "1608618",                                      
       "updated_at": "2026-04-23T14:13:25Z",                                       
       "ecf_enrolments": [                                                         
         {                                                                         
           "training_record_id": "5938cde4-5e78-48b9-ac23-e4cb6e82d2e2",           
           "school_urn": "3375958",                                                
           "participant_type": "ect",                                              
           "cohort": "2021",                                                       
           "training_status": "active",                                            
           "participant_status": "active",                                         
           "eligible_for_funding": true,                                           
           "working_pattern": "part_time"                                          
         }                                                                         
       ],                                                                          
       "participant_id_changes": []                                                
     }                                                                             
   }                                                                               
```  

<img width="2058" height="3846" alt="cpd-ec2-review-2800-web test teacherservices cloud_api_guidance_release-notes_2026-05-07-add-working_pattern-field-for-early-career-teachers (1)" src="https://github.com/user-attachments/assets/9e69e7ce-7837-4271-89bd-b03fee0b1b41" />

