### PR TITLE
Remove data patches csv file data from application constant

### DIFF
--- a/app/migration/ecf1_teacher_history/data_patcher.rb
+++ b/app/migration/ecf1_teacher_history/data_patcher.rb
@@ -1,7 +1,9 @@
 class ECF1TeacherHistory::DataPatcher
   attr_reader :data_patches
 
-  def initialize(data_patches: DATA_PATCHES)
+  PATCHES_PATH = "app/migration/ecf1_teacher_history/data_patches.csv"
+
+  def initialize(data_patches: CSV.table(PATCHES_PATH))
     @data_patches = data_patches
   end
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -37,6 +37,3 @@ INDUCTION_OUTCOMES = {
   pass: "Passed",
   fail: "Failed"
 }.freeze
-
-# Migration patch data, remove once RECT migration is done
-DATA_PATCHES = CSV.table("app/migration/ecf1_teacher_history/data_patches.csv")


### PR DESCRIPTION
### Context

For migration performance we moved the large patches CSV file into a constant that was loaded at start up. This meant that Rails server and console took longer to start up. Now that we're done, revert to it being loaded when the data patcher is instantiated.  This means some of the migration and real example specs take a bit longer to run now but the application stack loads noticeably quicker.

### Changes proposed in this pull request

Remove the application level constant and revert to loading the CSV each time it's needed.

### Guidance to review

Fixes #2760 
