### PR TITLE
Amend `worker_memory_max` values

### DIFF
--- a/config/terraform/application/config/migration.tfvars.json
+++ b/config/terraform/application/config/migration.tfvars.json
@@ -3,7 +3,7 @@
     "namespace": "cpd-production",
     "environment": "migration",
     "enable_logit": true,
-    "worker_memory_max": "6Gi",
+    "worker_memory_max": "2Gi",
     "webapp_memory_max": "2Gi",
     "worker_replicas": 2,
     "webapp_replicas": 1,

--- a/config/terraform/application/config/paritycheck.tfvars.json
+++ b/config/terraform/application/config/paritycheck.tfvars.json
@@ -3,7 +3,7 @@
     "namespace": "cpd-production",
     "environment": "paritycheck",
     "enable_logit": true,
-    "worker_memory_max": "6Gi",
+    "worker_memory_max": "2Gi",
     "webapp_memory_max": "2Gi",
     "worker_replicas": 2,
     "webapp_replicas": 2,

--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -13,7 +13,7 @@
     "deploy_snapshot_database": true,
     "postgres_enable_high_availability": true,
     "azure_enable_backup_storage": true,
-    "worker_memory_max": "2Gi",
+    "worker_memory_max": "6Gi",
     "webapp_memory_max": "4Gi",
     "webapp_replicas": 4,
     "worker_replicas": 2


### PR DESCRIPTION
### Context

Workers memory usage in production is reaching high tops.

### Changes proposed in this pull request

- Increase workers memory in prod;
- Decrease workers memory in migration and parity check envs;

### Guidance to review
