### PR TITLE
Disable active_storage.variant_processor as we dont use it

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,6 +117,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # ActiveStorage isn't used
+  config.active_storage.variant_processor = :disabled
+
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com


### PR DESCRIPTION
### Context

Seeing error in production:
```
{"host":"cpd-ec2-production-web-576d8fd7bb-bq2q9","application":"","environment":"production","timestamp":"2026-04-29T11:05:10.365948Z","level":"warn","level_index":3,"pid":1,"thread":"3408","name":"Rails","message":"Generating image variants require the image_processing gem. Please add `gem \"image_processing\", \"~\u003e 1.2\"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`."}
```

### Changes proposed in this pull request

* Disable variant processor for production

### Guidance to review
