### PR TITLE
Stop trying (and failing) to sync `trnless` teachers with TRS

### DIFF
--- a/app/jobs/teachers/schedule_trs_sync_job.rb
+++ b/app/jobs/teachers/schedule_trs_sync_job.rb
@@ -5,7 +5,8 @@ module Teachers
     BATCH_SIZE = 50
 
     def perform
-      teachers = Teacher.found_in_trs
+      teachers = Teacher.not_trnless
+                        .found_in_trs
                         .active_in_trs
                         .ordered_by_trs_data_last_refreshed_at_nulls_first
                         .limit(BATCH_SIZE)

--- a/app/jobs/teachers/schedule_trs_sync_job.rb
+++ b/app/jobs/teachers/schedule_trs_sync_job.rb
@@ -5,7 +5,10 @@ module Teachers
     BATCH_SIZE = 50
 
     def perform
-      teachers = Teacher.found_in_trs.active_in_trs.ordered_by_trs_data_last_refreshed_at_nulls_first.limit(BATCH_SIZE)
+      teachers = Teacher.found_in_trs
+                        .active_in_trs
+                        .ordered_by_trs_data_last_refreshed_at_nulls_first
+                        .limit(BATCH_SIZE)
 
       teachers.each_with_index do |teacher, i|
         Teachers::SyncTeacherWithTRSJob.set(wait: i.seconds).perform_later(teacher:)

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -124,6 +124,8 @@ class Teacher < ApplicationRecord
   scope :active_in_trs, -> { where(trs_deactivated: false) }
   scope :not_found_in_trs, -> { where(trs_not_found: true) } # TRS returned either 404 or 308
   scope :found_in_trs, -> { where(trs_not_found: false) }
+  scope :trnless, -> { where(trnless: true) }
+  scope :not_trnless, -> { where(trnless: false) }
   scope :without_qts_award, -> { where(trs_qts_awarded_on: nil) }
   scope :induction_status_missing, -> { where(trs_induction_status: nil) }
   scope :induction_status_passed, -> { where(trs_induction_status: "Passed") }

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -92,5 +92,10 @@ FactoryBot.define do
     trait :induction_exempt do
       trs_induction_status { "Exempt" }
     end
+
+    trait :trnless do
+      trn { nil }
+      trnless { true }
+    end
   end
 end

--- a/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
+++ b/spec/jobs/teachers/schedule_trs_sync_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Teachers::ScheduleTRSSyncJob, type: :job do
     let!(:teacher5) { FactoryBot.create(:teacher, trs_data_last_refreshed_at: 1.day.ago) }
     let!(:teacher6) { FactoryBot.create(:teacher, :deactivated_in_trs, trs_data_last_refreshed_at: 0.days.ago) }
     let!(:teacher7) { FactoryBot.create(:teacher, :not_found_in_trs, trs_data_last_refreshed_at: 0.days.ago) }
+    let!(:teacher8) { FactoryBot.create(:teacher, :trnless, trs_data_last_refreshed_at: 0.days.ago) }
 
     it "schedules sync jobs for teachers ordered by trs_data_last_refreshed_at" do
       [

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -445,6 +445,22 @@ describe Teacher do
       end
     end
 
+    describe ".not_trnless" do
+      it "only includes records where trnless = FALSE" do
+        expected_clause = %("teachers"."trnless" = FALSE)
+
+        expect(Teacher.not_trnless.to_sql).to end_with(expected_clause)
+      end
+    end
+
+    describe ".trnless" do
+      it "only includes records where trnless = TRUE" do
+        expected_clause = %("teachers"."trnless" = TRUE)
+
+        expect(Teacher.trnless.to_sql).to end_with(expected_clause)
+      end
+    end
+
     context "induction status scopes" do
       let!(:teacher_without_induction_status) { FactoryBot.create(:teacher) }
       let!(:in_progress_teacher) { FactoryBot.create(:teacher, :induction_in_progress) }


### PR DESCRIPTION
### Context

We're currently [creating lots of errors](https://dfe-teacher-services.sentry.io/issues/6967055333/?environment=production&project=4508369974788096&query=&referrer=issue-stream) in production where we have several `trnless` teachers.

When we try to sync these with TRS, the API produces a 500.

@gunndabad is going to make a tweak to the API so it responds with a more descriptive error, and this change should stop us from sending the bad requests.

### Changes proposed in this pull request

- **Indent chained methods on teacher selection**
- **Add trnless trait to teacher factory**
- **Add trnless and corresponding not_trnless scope**
- **Stop including trnless teachers in TRS sync**
