### PR TITLE
Reopen SemanticLogger.reopen on puma boot

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,6 +8,10 @@ if ENV["RAILS_ENV"] == "production"
   workers worker_count if worker_count > 1
 end
 
+on_worker_boot do
+  SemanticLogger.reopen if defined?(SemanticLogger)
+end
+
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 port ENV.fetch("PORT", 3000)
 environment ENV.fetch("RAILS_ENV", "development")


### PR DESCRIPTION
### Context

Puma crash likely stops streaming log to semantic logger

### Changes proposed in this pull request

Reopen SemanticLogger on puma boot

### Guidance to review
