### PR TITLE
Mitigate `Authentication failure! csrf_detected` errors

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,6 +38,11 @@ class SessionsController < ApplicationController
     redirect_to post_login_redirect_path
   end
 
+  def failure
+    Sentry.capture_message("[Authentication failure] #{params[:message]}")
+    session_manager.end_session!
+  end
+
 private
 
   delegate :id_token, to: :user_builder

--- a/app/views/sessions/failure.md.erb
+++ b/app/views/sessions/failure.md.erb
@@ -1,0 +1,9 @@
+---
+title: There was a problem signing in
+---
+
+We were unable to sign you in.
+
+Please try again.
+
+<%= school_sign_in_cta("Continue to DfE Sign-in") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   # omniauth sign-in
   get "/auth/:provider/callback", to: "sessions#create"
   post "/auth/:provider/callback", to: "sessions#create"
+  get "/auth/failure", to: "sessions#failure"
   get "/sign-in", to: "sessions#new"
   get "/sign-out", to: "sessions#destroy"
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -223,4 +223,53 @@ RSpec.describe "Sessions", type: :request do
       end
     end
   end
+
+  describe "GET /auth/failure" do
+    subject(:failure) do
+      get("/auth/failure", params: { message: "csrf_detected" })
+      response
+    end
+
+    let(:school) { FactoryBot.create(:school) }
+    let(:user) do
+      Sessions::Users::SchoolUser.new(
+        email: "test@example.com",
+        name: "Test User",
+        school_urn: school.urn,
+        dfe_sign_in_organisation_id: school.id,
+        dfe_sign_in_user_id: SecureRandom.uuid,
+        dfe_sign_in_roles: %w[SchoolUser]
+      )
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+
+    it "prompts users to try again" do
+      expect(failure.body).to include("Please try again")
+    end
+
+    it "clears the session" do
+      session_manager = instance_double(
+        Sessions::Manager,
+        current_user: user,
+        requested_path: nil,
+        end_session!: true
+      )
+      allow(Sessions::Manager).to receive(:new).and_return(session_manager)
+
+      failure
+
+      expect(session_manager).to have_received(:end_session!).once
+    end
+
+    it "logs a message in Sentry" do
+      allow(Sentry).to receive(:capture_message)
+
+      failure
+
+      expect(Sentry)
+        .to have_received(:capture_message).once
+        .with("[Authentication failure] csrf_detected")
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3885

### Changes proposed in this pull request

Before, we didn't handle [this error] when it was raised by omniauth and requests were redirected to `/auth/failure`.

This meant users were redirected to "Page not found" (which also happens quietly).

This is problematic, because it doesn't give users a clear idea of what happened, nor what they can do to remedy the issue.

This routes requests to `/auth/failure` to `SessionsController#failure` and adds some explicit logging to Sentry so we can track issues more easily. The session is ended too, which should give users a clean slate from which to sign in.
    
The page also prompts users to "try again", which resolves the issue in our experience.

[this error]: https://github.com/omniauth/omniauth_openid_connect/blob/4847685183147ff80697079481a72c27d3ad378d/lib/omniauth/strategies/openid_connect.rb#L133

### Guidance to review
