### PR TITLE
Align local PostgreSQL version with production in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 terraform 1.14.5
 nodejs 22.14.0
 ruby 4.0.3
-postgres 16.8
+postgres 16.12


### PR DESCRIPTION
Using the same Postgres version locally and in production helps avoid surprises and keeps behavior consistent across environments.