### PR TITLE
Force HTML format on ErrorsController renders

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,18 +2,18 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def not_found
-    render "not_found", status: :not_found
+    render "not_found", formats: :html, status: :not_found
   end
 
   def unprocessable_content
-    render "unprocessable_content", status: :unprocessable_content
+    render "unprocessable_content", formats: :html, status: :unprocessable_content
   end
 
   def too_many_requests
-    render "too_many_requests", status: :too_many_requests
+    render "too_many_requests", formats: :html, status: :too_many_requests
   end
 
   def internal_server_error
-    render "internal_server_error", status: :internal_server_error
+    render "internal_server_error", formats: :html, status: :internal_server_error
   end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -54,4 +54,27 @@ RSpec.describe "Errors", type: :request do
       expect(response.body).to include("Retry later")
     end
   end
+
+  context "when the request format is not HTML" do
+    it "renders the 404 HTML page for /404.pdf" do
+      get "/404.pdf"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+
+    it "renders the 422 HTML page for /422.pdf" do
+      get "/422.pdf"
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+    end
+
+    it "renders the 500 HTML page for /500.pdf" do
+      get "/500.pdf"
+
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+    end
+  end
 end


### PR DESCRIPTION
### Context

We're getting 404 for PDF and other formats, which is raising `Internal Server Error`

### Changes proposed in this pull request

Error pages respond in HTML only

### Guidance to review
