### PR TITLE
Limit semantic_logger backtraces to :fatal level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,6 +62,7 @@ Rails.application.configure do
   # the Rails logger and honours config.log_tags + config.filter_parameters.
   config.log_tags = [:request_id]
   config.semantic_logger.application = "" # No need to send the application name as logstash reads it from Cloud Foundry log tags
+  config.semantic_logger.backtrace_level = :fatal # Only attach backtraces at :fatal so error/warn lines stay small enough for Logit ingestion
   config.rails_semantic_logger.add_file_appender = false # Don't log to file, only STDOUT
   config.active_record.logger = nil # Don't log SQL
   config.semantic_logger.add_appender(io: $stdout, formatter: :json) # Log to STDOUT JSON-formatted logs


### PR DESCRIPTION
### Context

Some error logs dont get ingested by logit, eg:
```
{"host":"cpd-ec2-production-web-7774b5d469-m4vgh","application":"","environment":"production","timestamp":"2026-04-29T15:02:20.506906Z","level":"error","level_index":4,"pid":21,"thread":"puma srv tp 003","file":"/usr/local/bundle/gems/activesupport-8.1.3/lib/active_support/deprecation/deprecators.rb","line":86,"tags":["407b0553c6e8e02439b5da6df6b4c730"],"name":"Rails","exception":{"name":"ActionController::RoutingError","message":"No route matches [GET] \"/api-reference/manage-training-for-early-career-teachers.education.gov.uk/images/govuk-large.png\"","stack_trace":["/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/debug_exceptions.rb:35:in 'ActionDispatch::DebugExceptions#call'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry/rack/capture_exceptions.rb:30:in 'block (2 levels) in Sentry::Rack::CaptureExceptions#call'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry/hub.rb:333:in 'Sentry::Hub#with_session_tracking'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry-ruby.rb:419:in 'Sentry.with_session_tracking'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry/rack/capture_exceptions.rb:21:in 'block in Sentry::Rack::CaptureExceptions#call'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry/hub.rb:89:in 'Sentry::Hub#with_scope'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry-ruby.rb:399:in 'Sentry.with_scope'","/usr/local/bundle/gems/sentry-ruby-6.5.0/lib/sentry/rack/capture_exceptions.rb:20:in 'Sentry::Rack::CaptureExceptions#call'","/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/show_exceptions.rb:32:in 'ActionDispatch::ShowExceptions#call'","/usr/local/bundle/gems/rails_semantic_logger-4.20.0/lib/rails_semantic_logger/rack/logger.rb:53:in 'RailsSemanticLogger::Rack::Logger#call_app'","/usr/local/bundle/gems/rails_semantic_logger-4.20.0/lib/rails_semantic_logger/rack/logger.rb:26:in 'block in RailsSemanticLogger::Rack::Logger#call'","/usr/local/bundle/gems/semantic_logger-4.18.0/lib/semantic_logger/base.rb:202:in 'block in SemanticLogger::Base#tagged'","/usr/local/bundle/gems/semantic_logger-4.18.0/lib/semantic_logger/semantic_logger.rb:319:in 'SemanticLogger.fast_tag'","/usr/local/bundle/gems/semantic_logger-4.18.0/lib/semantic_logger/semantic_logger.rb:351:in 'SemanticLogger.tagged'","/usr/local/bundle/gems/semantic_logger-4.18.0/lib/semantic_logger/base.rb:214:in 'SemanticLogger::Base#tagged'","/usr/local/bundle/gems/rails_semantic_logger-4.20.0/lib/rails_semantic_logger/rack/logger.rb:26:in 'RailsSemanticLogger::Rack::Logger#call'","/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/remote_ip.rb:98:in 'ActionDispatch::RemoteIp#call'","/usr/local/bundle/gems/request_store_rails-2.0.0/lib/request_store_rails/middleware.rb:17:in 'RequestStoreRails::Middleware#call'","/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/request_id.rb:34:in 'ActionDispatch::RequestId#call'","/usr/local/bundle/gems/rack-3.2.6/lib/rack/method_override.rb:28:in 'Rack::MethodOverride#call'","/usr/local/bundle/gems/rack-3.2.6/lib/rack/runtime.rb:24:in 'Rack::Runtime#call'","/usr/local/bundle/gems/activesupport-8.1.3/lib/active_support/cache/strategy/local_cache_middleware.rb:30:in 'ActiveSupport::Cache::Strategy::LocalCache::Middleware#call'","/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/executor.rb:20:in 'ActionDispatch::Executor#call'","/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/static.rb:27:in 'ActionDispatch::Static#call'","/usr/local/bundle/bundler/gems/dfe-analytics-b8dd37585c87/lib/dfe/analytics/middleware/send_cached_page_request_event.rb:16:in 'DfE::Analytics::Middleware::SendCachedPageRequestEvent#call'","/usr/local/bundle/gems/rack-3.2.6/lib/rack/sendfile.rb:131:in 'Rack::Sendfile#call'","/usr/local/bundle/gems/actionpack-8.1.3/lib/action_dispatch/middleware/ssl.rb:92:in 'ActionDispatch::SSL#call'","/usr/local/bundle/gems/railties-8.1.3/lib/rails/engine.rb:534:in 'Rails::Engine#call'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/configuration.rb:305:in 'Puma::Configuration::ConfigMiddleware#call'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/response.rb:79:in 'block in Puma::Response#handle_request'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/thread_pool.rb:434:in 'Puma::ThreadPool#with_force_shutdown'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/response.rb:78:in 'Puma::Response#handle_request'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/server.rb:508:in 'Puma::Server#process_client'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/server.rb:263:in 'block in Puma::Server#run'","/usr/local/bundle/gems/puma-8.0.1/lib/puma/thread_pool.rb:246:in 'block in Puma::ThreadPool#spawn_thread'"]}}
```

### Changes proposed in this pull request

* Don't include backtrace unless its `:fatal`
* We should still see the full errors in Sentry

### Guidance to review
