### PR TITLE
Add lead provider short name

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -20,4 +20,16 @@ class LeadProvider < ApplicationRecord
   normalizes :name, with: -> { it.squish }
 
   touch -> { training_periods }, when_changing: %i[name], timestamp_attribute: :api_transfer_updated_at
+
+  def name=(name)
+    super
+
+    return unless name
+
+    self.short_name ||= if name.include?(" ")
+                          name.downcase.split.map(&:first)&.join
+                        else
+                          name.downcase
+                        end
+  end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -499,6 +499,7 @@
   - range
   :lead_providers:
   - ecf_id
+  - short_name
   :statement_adjustments:
   - ecf_id
   :lead_provider_delivery_partnerships:

--- a/db/migrate/20260430085049_add_short_name_to_lead_providers.rb
+++ b/db/migrate/20260430085049_add_short_name_to_lead_providers.rb
@@ -1,0 +1,30 @@
+class AddShortNameToLeadProviders < ActiveRecord::Migration[8.1]
+  def up
+    add_column :lead_providers, :short_name, :string, null: true
+
+    short_names = {
+      "Ambition Institute" => "ambition",
+      "Best Practice Network" => "bpn",
+      "Capita" => "capita",
+      "Education Development Trust" => "edt",
+      "National Institute of Teaching" => "niot",
+      "Teach First" => "tf",
+      "UCL Institute of Education" => "ucl",
+    }
+
+    unknown_short_names = LeadProvider.where.not(name: short_names.keys).pluck(:name)
+
+    if unknown_short_names.any?
+      raise ActiveRecord::MigrationError,
+            "Missing short_names for: #{unknown_short_names.join(', ')}"
+    end
+
+    LeadProvider.find_each do |lead_provider|
+      lead_provider.update!(short_name: short_names[lead_provider.name])
+    end
+  end
+
+  def down
+    remove_column :lead_providers, :short_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -499,6 +499,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_105743) do
     t.uuid "ecf_cpd_lead_provider_id"
     t.uuid "ecf_id"
     t.string "name", null: false
+    t.string "short_name"
     t.datetime "updated_at", null: false
     t.boolean "vat_registered", default: true, null: false
     t.index ["ecf_id"], name: "index_lead_providers_on_ecf_id", unique: true

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -384,33 +384,6 @@ erDiagram
     string name
     datetime updated_at
   }
-  Declaration {
-    integer id
-    uuid api_id
-    datetime api_updated_at
-    integer clawback_statement_id
-    enum clawback_status
-    datetime created_at
-    datetime declaration_date
-    enum declaration_type
-    integer delivery_partner_when_created_id
-    enum evidence_type
-    integer mentorship_period_id
-    integer payment_statement_id
-    enum payment_status
-    boolean pupil_premium_uplift
-    boolean sparsity_uplift
-    integer training_period_id
-    datetime updated_at
-    datetime voided_by_user_at
-    integer voided_by_user_id
-  }
-  Declaration }o--|| TrainingPeriod : belongs_to
-  Declaration }o--|| User : belongs_to
-  Declaration }o--|| MentorshipPeriod : belongs_to
-  Declaration }o--|| DeliveryPartner : belongs_to
-  Declaration }o--|| Statement : belongs_to
-  Declaration }o--|| Statement : belongs_to
   DataMigrationTeacherCombination {
     integer id
     uuid api_id
@@ -540,6 +513,33 @@ erDiagram
     datetime updated_at
     integer zendesk_id
   }
+  Declaration {
+    integer id
+    uuid api_id
+    datetime api_updated_at
+    integer clawback_statement_id
+    enum clawback_status
+    datetime created_at
+    datetime declaration_date
+    enum declaration_type
+    integer delivery_partner_when_created_id
+    enum evidence_type
+    integer mentorship_period_id
+    integer payment_statement_id
+    enum payment_status
+    boolean pupil_premium_uplift
+    boolean sparsity_uplift
+    integer training_period_id
+    datetime updated_at
+    datetime voided_by_user_at
+    integer voided_by_user_id
+  }
+  Declaration }o--|| TrainingPeriod : belongs_to
+  Declaration }o--|| User : belongs_to
+  Declaration }o--|| MentorshipPeriod : belongs_to
+  Declaration }o--|| DeliveryPartner : belongs_to
+  Declaration }o--|| Statement : belongs_to
+  Declaration }o--|| Statement : belongs_to
   Metadata_TeacherLeadProvider {
     integer id
     uuid api_mentor_id
@@ -573,13 +573,13 @@ erDiagram
   Metadata_SchoolLeadProviderContractPeriod }o--|| ContractPeriod : belongs_to
   Metadata_SchoolContractPeriod {
     integer id
+    datetime api_updated_at
     integer contract_period_year
     datetime created_at
     boolean in_partnership
     enum induction_programme_choice
     integer school_id
     datetime updated_at
-    datetime api_updated_at
   }
   Metadata_SchoolContractPeriod }o--|| School : belongs_to
   Metadata_SchoolContractPeriod }o--|| ContractPeriod : belongs_to

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -51,4 +51,36 @@ describe LeadProvider do
       expect(subject.name).to eql("Some lead provider")
     end
   end
+
+  context "when setting the name" do
+    let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some lead provider") }
+
+    it "sets the short name to the initials of the name" do
+      expect(lead_provider.short_name).to eq("slp")
+    end
+
+    context "when the name is only one word" do
+      let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Provider") }
+
+      it "sets the short name to the lowercase version of the name" do
+        expect(lead_provider.short_name).to eq("provider")
+      end
+    end
+
+    context "when the name is nil" do
+      let(:lead_provider) { FactoryBot.build(:lead_provider, name: nil) }
+
+      it "does not set the short name" do
+        expect(lead_provider.short_name).to be_nil
+      end
+    end
+
+    context "when the short name is already set" do
+      let(:lead_provider) { FactoryBot.build(:lead_provider, name: "Some lead provider", short_name: "Custom") }
+
+      it "does not override the existing short name" do
+        expect(lead_provider.short_name).to eq("Custom")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a short name to lead providers; we often refer to lead providers internally with this terminology and it will let us tag our request logs with the lead provider somewhat obfuscated.

Initially I made short name unique, but its going to require fixing a whole bunch of specs as `name` isn't unique, so I've back-peddled on that for now -- we can pick it up separately for both `name` and `short_name`.