### PR TITLE
[3892] Fix empty `training_record_id` bug for some participants

### DIFF
--- a/app/migration/parity_check/dynamic_request_content.rb
+++ b/app/migration/parity_check/dynamic_request_content.rb
@@ -280,7 +280,7 @@ module ParityCheck
     end
 
     def course_identifier_for(participant)
-      if participant.api_ect_training_record_id.present?
+      if participant.ect_training_periods.any?
         "ecf-induction"
       else
         "ecf-mentor"
@@ -387,7 +387,7 @@ module ParityCheck
       training_period = latest_training_period(participant)
       return unless training_period
 
-      course_identifier = participant.api_ect_training_record_id.present? ? "ecf-mentor" : "ecf-induction"
+      course_identifier = participant.mentor_training_periods.any? ? "ecf-mentor" : "ecf-induction"
 
       participant_change_schedule_payload(
         course_identifier:,
@@ -547,7 +547,7 @@ module ParityCheck
       metadata = participant.lead_provider_metadata.find_by(lead_provider_id: lead_provider.id)
       return unless metadata
 
-      if participant.api_ect_training_record_id.present?
+      if metadata.latest_ect_training_period_id.present?
         metadata.latest_ect_training_period
       else
         metadata.latest_mentor_training_period

--- a/app/services/api_seed_data/ect_become_mentor_scenarios.rb
+++ b/app/services/api_seed_data/ect_become_mentor_scenarios.rb
@@ -36,9 +36,7 @@ module APISeedData
           teacher = FactoryBot.create(
             :teacher,
             :with_realistic_name,
-            trn: Helpers::TRNGenerator.next,
-            api_ect_training_record_id: SecureRandom.uuid,
-            api_mentor_training_record_id: SecureRandom.uuid
+            trn: Helpers::TRNGenerator.next
           )
 
           create_completed_ect(

--- a/app/services/api_seed_data/teachers_with_histories.rb
+++ b/app/services/api_seed_data/teachers_with_histories.rb
@@ -300,10 +300,6 @@ module APISeedData
     end
 
     def set_ect_attributes(teacher:)
-      teacher.update!(
-        api_ect_training_record_id: SecureRandom.uuid
-      )
-
       return unless rand_boolean(ECT_ELIGIBLE_FOR_TRAINING_RATIO)
 
       teacher.update!(
@@ -312,10 +308,6 @@ module APISeedData
     end
 
     def set_mentor_attributes(teacher:)
-      teacher.update!(
-        api_mentor_training_record_id: SecureRandom.uuid
-      )
-
       return unless rand_boolean(MENTOR_ELIGIBLE_FOR_TRAINING_RATIO)
 
       teacher.update!(mentor_first_became_eligible_for_training_at: teacher.created_at + 2.months)

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -79,8 +79,7 @@ module Schools
       @teacher = ::Teacher.create_with(
         trs_first_name:,
         trs_last_name:,
-        corrected_name:,
-        api_ect_training_record_id: SecureRandom.uuid
+        corrected_name:
       ).find_or_create_by!(trn:)
     end
 

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -87,8 +87,7 @@ module Schools
       @teacher = ::Teacher.create_with(
         trs_first_name:,
         trs_last_name:,
-        corrected_name:,
-        api_mentor_training_record_id: SecureRandom.uuid
+        corrected_name:
       ).find_or_create_by!(trn:)
     end
 

--- a/db/migrate/20260430093052_set_default_value_for_teachers_api_ect_mentor_training_record_ids.rb
+++ b/db/migrate/20260430093052_set_default_value_for_teachers_api_ect_mentor_training_record_ids.rb
@@ -1,0 +1,6 @@
+class SetDefaultValueForTeachersAPIECTMentorTrainingRecordIds < ActiveRecord::Migration[8.1]
+  change_table :teachers, bulk: true do |t|
+    t.change_default :api_ect_training_record_id, from: nil, to: -> { "gen_random_uuid()" }
+    t.change_default :api_mentor_training_record_id, from: nil, to: -> { "gen_random_uuid()" }
+  end
+end

--- a/db/migrate/20260430103643_backfill_empty_teachers_training_record_ids.rb
+++ b/db/migrate/20260430103643_backfill_empty_teachers_training_record_ids.rb
@@ -1,0 +1,15 @@
+class BackfillEmptyTeachersTrainingRecordIds < ActiveRecord::Migration[8.1]
+  def up
+    Teacher.where(api_ect_training_record_id: nil).find_each do |teacher|
+      teacher.update_column(:api_ect_training_record_id, SecureRandom.uuid)
+    end
+
+    Teacher.where(api_mentor_training_record_id: nil).find_each do |teacher|
+      teacher.update_column(:api_mentor_training_record_id, SecureRandom.uuid)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_150346) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_103643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -993,9 +993,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_150346) do
   end
 
   create_table "teachers", force: :cascade do |t|
-    t.uuid "api_ect_training_record_id"
+    t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_mentor_training_record_id"
+    t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }
     t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.string "corrected_name"

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -12,14 +12,7 @@ FactoryBot.define do
       end_date { (started_on || start_date) + rand(6.months..1.year) }
     end
 
-    teacher { association :teacher, :with_realistic_name, api_ect_training_record_id: SecureRandom.uuid }
-
-    after(:create) do |ect_at_school_period|
-      teacher = ect_at_school_period.teacher
-      if teacher&.api_ect_training_record_id.blank?
-        teacher.update!(api_ect_training_record_id: SecureRandom.uuid)
-      end
-    end
+    teacher { association :teacher, :with_realistic_name }
 
     association :school
 

--- a/spec/migration/parity_check/dynamic_request_content_spec.rb
+++ b/spec/migration/parity_check/dynamic_request_content_spec.rb
@@ -730,7 +730,7 @@ RSpec.describe ParityCheck::DynamicRequestContent, :with_metadata do
             data: {
               type: "participant-change-schedule",
               attributes: {
-                course_identifier: "ecf-mentor",
+                course_identifier: "ecf-induction",
                 schedule_identifier: training_period.schedule.identifier,
                 cohort: training_period.contract_period.year,
               }

--- a/spec/serializers/api/teacher_serializer_spec.rb
+++ b/spec/serializers/api/teacher_serializer_spec.rb
@@ -10,8 +10,6 @@ describe API::TeacherSerializer, :with_metadata, type: :serializer do
     FactoryBot.create(
       :teacher,
       :ineligible_for_mentor_funding,
-      api_ect_training_record_id: SecureRandom.uuid,
-      api_mentor_training_record_id: SecureRandom.uuid,
       api_updated_at:
     )
   end

--- a/spec/services/api_seed_data/teachers_with_histories_spec.rb
+++ b/spec/services/api_seed_data/teachers_with_histories_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe APISeedData::TeachersWithHistories do
       end
     end
 
+    context "when creating teachers with `first_became_eligible_for_training_at`" do
+      before do
+        stub_const("#{described_class}::ECT_MENTOR_RATIO", 1.0)
+        stub_const("#{described_class}::ECT_ELIGIBLE_FOR_TRAINING_RATIO", 1.0)
+        stub_const("#{described_class}::MENTOR_ELIGIBLE_FOR_TRAINING_RATIO", 1.0)
+        stub_const("#{described_class}::TEACHER_ID_CHANGE_RATIO", 0.0)
+      end
+
+      it "creates correct data" do
+        plant
+
+        expect(Teacher.where(ect_first_became_eligible_for_training_at: nil, mentor_first_became_eligible_for_training_at: nil)).to be_empty
+      end
+    end
+
     context "when creating teachers with `cohort_changed_after_payments_frozen`" do
       before do
         stub_const("#{described_class}::ECT_MENTOR_RATIO", 0.0)

--- a/spec/services/teachers/set_ect_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_ect_funding_eligibility_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Teachers::SetECTFundingEligibility do
-  let(:teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: SecureRandom.uuid) }
+  let(:teacher) { FactoryBot.create(:teacher) }
   let(:author) { Events::SystemAuthor.new }
   let(:service) { described_class.new(teacher:, author:) }
 

--- a/spec/services/teachers/set_mentor_funding_eligibility_spec.rb
+++ b/spec/services/teachers/set_mentor_funding_eligibility_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Teachers::SetMentorFundingEligibility do
-  let(:teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: SecureRandom.uuid) }
+  let(:teacher) { FactoryBot.create(:teacher) }
   let(:author) { Events::SystemAuthor.new }
   let(:service) { described_class.new(teacher:, author:) }
 


### PR DESCRIPTION
### Context

Ticket: [3892](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3892)

Some lead providers shared with us that a training record ID is NULL for a participant over the API. This shouldn't happen.

### Changes proposed in this pull request

- set the `api_ect_training_record_id` and `api_mentor_training_record_id` by default in the DB/remove explicitly setting them in register ECT/mentor services and backfill existing records where they are null;

### Guidance to review
