### PR TITLE
[3892] Make teachers `api_ect_training_record_id` and `api_mentor_training_record_id` not nullable

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -103,8 +103,8 @@ class Teacher < ApplicationRecord
             presence: { message: "Choose the reason why the mentor became ineligible for funding" },
             if: -> { mentor_became_ineligible_for_funding_on.present? }
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another teacher" }
-  validates :api_ect_training_record_id, uniqueness: { case_sensitive: false, message: "API ect training record id already exists for another teacher" }, allow_nil: true
-  validates :api_mentor_training_record_id, uniqueness: { case_sensitive: false, message: "API mentor training record id already exists for another teacher" }, allow_nil: true
+  validates :api_ect_training_record_id, uniqueness: { case_sensitive: false, message: "API ect training record id already exists for another teacher" }
+  validates :api_mentor_training_record_id, uniqueness: { case_sensitive: false, message: "API mentor training record id already exists for another teacher" }
   validates :ect_first_became_eligible_for_training_at, immutable_once_set: true
   validates :mentor_first_became_eligible_for_training_at, immutable_once_set: true
 

--- a/db/migrate/20260430105743_make_teachers_api_ect_mentor_training_record_ids_required.rb
+++ b/db/migrate/20260430105743_make_teachers_api_ect_mentor_training_record_ids_required.rb
@@ -1,0 +1,6 @@
+class MakeTeachersAPIECTMentorTrainingRecordIdsRequired < ActiveRecord::Migration[8.1]
+  change_table :teachers, bulk: true do |t|
+    t.change_null :api_ect_training_record_id, false
+    t.change_null :api_mentor_training_record_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_103643) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_105743) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -993,9 +993,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_103643) do
   end
 
   create_table "teachers", force: :cascade do |t|
-    t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }
+    t.uuid "api_ect_training_record_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "api_id", default: -> { "gen_random_uuid()" }, null: false
-    t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }
+    t.uuid "api_mentor_training_record_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "api_unfunded_mentor_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "api_updated_at", default: -> { "CURRENT_TIMESTAMP" }
     t.string "corrected_name"

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -241,8 +241,8 @@ describe Teacher do
     it { is_expected.to validate_length_of(:trs_induction_status).with_message("TRS induction status must be shorter than 18 characters") }
 
     it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another teacher") }
-    it { is_expected.to validate_uniqueness_of(:api_ect_training_record_id).case_insensitive.with_message("API ect training record id already exists for another teacher").allow_nil }
-    it { is_expected.to validate_uniqueness_of(:api_mentor_training_record_id).case_insensitive.with_message("API mentor training record id already exists for another teacher").allow_nil }
+    it { is_expected.to validate_uniqueness_of(:api_ect_training_record_id).case_insensitive.with_message("API ect training record id already exists for another teacher") }
+    it { is_expected.to validate_uniqueness_of(:api_mentor_training_record_id).case_insensitive.with_message("API mentor training record id already exists for another teacher") }
 
     describe "trn" do
       it { is_expected.to validate_presence_of(:trn).with_message("Enter the teacher reference number (TRN)") }


### PR DESCRIPTION
### Context

Follow up PR for https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2823

Ticket: [3892](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3892)

### Changes proposed in this pull request

- Make teachers `api_ect_training_record_id` and `api_mentor_training_record_id` not nullable

### Guidance to review
