### PR TITLE
Remove `MIGRATION_DATABASE_URL` from Blazer config

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -26,11 +26,6 @@ data_sources:
       induction_period_id: "/admin/teachers/N/induction-periods/{value}/edit"
       zendesk_ticket_id: "https://becomingateacher.zendesk.com/agent/tickets/{value}"
 
-  # http://localhost:3000/admin/blazer/queries/docs?data_source=ecf
-  ecf:
-    url: <%= ENV.fetch("MIGRATION_DATABASE_URL", "postgres://localhost:5432") %>
-
-
 # statement timeout, in seconds
 # none by default
 # timeout: 15


### PR DESCRIPTION
I think this is what's stopping Blazer from working in prod now we've /removed the MIGRATION_DATABASE_URL from the keyvault.
