### PR TITLE
Redirect old ECF routes

### DIFF
--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -4,6 +4,8 @@ module API
 
     layout "api_guidance"
 
+    after_action :allow_search_engine_indexing, only: :show
+
     def show
       @latest_release_note = release_notes.first
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,13 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def allow_search_engine_indexing
+    return unless Rails.application.config.search_engine_indexing_enabled
+    return unless response.status == 200
+
+    response.headers["X-Robots-Tag"] = "all"
+  end
+
   def append_info_to_payload(payload)
     super
     payload[:current_user_class] = current_user&.class&.name

--- a/app/controllers/appropriate_bodies/landing_controller.rb
+++ b/app/controllers/appropriate_bodies/landing_controller.rb
@@ -4,6 +4,7 @@ module AppropriateBodies
                        :authenticate,
                        :set_appropriate_body,
                        only: :show
+    after_action :allow_search_engine_indexing, only: :show
 
     def show = nil
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  after_action :allow_search_engine_indexing, only: :home
+
   def home
     redirect_to(post_login_redirect_path) and return if authenticated?
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,8 +3,6 @@
 # 2. Sessions::Manager#current_user -> Sessions::User.from_session
 #
 class SessionsController < ApplicationController
-  after_action :prevent_search_engine_indexing, only: :new
-
   def new
     render :new
   end
@@ -48,10 +46,6 @@ class SessionsController < ApplicationController
 private
 
   delegate :id_token, to: :user_builder
-
-  def prevent_search_engine_indexing
-    response.headers["X-Robots-Tag"] = "none"
-  end
 
   def record_school_user_signs_in_event
     return unless session_user.is_a?(Sessions::Users::SchoolUser)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,8 @@
 # 2. Sessions::Manager#current_user -> Sessions::User.from_session
 #
 class SessionsController < ApplicationController
+  after_action :prevent_search_engine_indexing, only: :new
+
   def new
     render :new
   end
@@ -46,6 +48,10 @@ class SessionsController < ApplicationController
 private
 
   delegate :id_token, to: :user_builder
+
+  def prevent_search_engine_indexing
+    response.headers["X-Robots-Tag"] = "none"
+  end
 
   def record_school_user_signs_in_event
     return unless session_user.is_a?(Sessions::Users::SchoolUser)

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,8 +77,8 @@ module RegisterEarlyCareerTeachers
     config.gias_supplemental_schools_path = Rails.root.join("config/gias/schools.csv")
     config.gias_supplemental_links_path = Rails.root.join("config/gias/links.csv")
 
-    allow_indexing = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ALLOW_INDEXING", true))
-    (config.action_dispatch.default_headers["X-Robots-Tag"] = "none") unless allow_indexing
+    config.search_engine_indexing_enabled = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ALLOW_INDEXING", true))
+    config.action_dispatch.default_headers["X-Robots-Tag"] = "none"
 
     requested_timeout = ENV.fetch("MAX_SESSION_IDLE_TIME", 7200).to_i
     requested_timeout = 7200 if requested_timeout <= 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   # Redirect old ECF1 URLs that appear in early Google results.
   # Remove these once the old URLs are no longer indexed.
   get "/users/sign_in", to: redirect("/")
+  get "/users/confirm_sign_in", to: redirect("/")
   get "/check-account", to: redirect("/")
   get "/nominations/resend-email", to: redirect("/")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,12 @@ Rails.application.routes.draw do
     end
   end
 
+  # Redirect old ECF1 URLs that appear in early Google results.
+  # Remove these once the old URLs are no longer indexed.
+  get "/users/sign_in", to: redirect("/")
+  get "/check-account", to: redirect("/")
+  get "/nominations/resend-email", to: redirect("/")
+
   root to: "pages#home"
   get "/support", to: "pages#support"
   get "/cookies", to: "pages#cookies"

--- a/spec/requests/legacy_ecf1_redirects_spec.rb
+++ b/spec/requests/legacy_ecf1_redirects_spec.rb
@@ -1,0 +1,18 @@
+# These redirects handle old ECF1 service URLs that may still appear in search
+# engine results and send users to the new service root page.
+RSpec.describe "Legacy ECF1 redirects", type: :request do
+  %w[
+    /users/sign_in
+    /check-account
+    /nominations/resend-email
+  ].each do |path|
+    describe "GET #{path}" do
+      it "redirects to the root path" do
+        get path
+
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/legacy_ecf1_redirects_spec.rb
+++ b/spec/requests/legacy_ecf1_redirects_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe "Legacy ECF1 redirects", type: :request do
   %w[
     /users/sign_in
+    /users/confirm_sign_in
     /check-account
     /nominations/resend-email
   ].each do |path|

--- a/spec/requests/search_engine_indexing_spec.rb
+++ b/spec/requests/search_engine_indexing_spec.rb
@@ -1,9 +1,43 @@
 describe "Search engine indexing", type: :request do
   context "when ALLOW_INDEXING is true (default)" do
-    it "allows the site to be indexed" do
+    before do
+      allow(Rails.application.config).to receive(:search_engine_indexing_enabled).and_return(true)
+    end
+
+    it "allows the home page to be indexed" do
       get("/")
 
-      expect(response.headers["X-Robots-Tag"]).to be_nil
+      expect(response.headers["X-Robots-Tag"]).to eq("all")
+    end
+
+    it "allows the appropriate body landing page to be indexed" do
+      get("/appropriate-body")
+
+      expect(response.headers["X-Robots-Tag"]).to eq("all")
+    end
+
+    it "prevents other pages from being indexed" do
+      get("/sign-in")
+
+      expect(response.headers["X-Robots-Tag"]).to eq("none")
+    end
+  end
+
+  context "when ALLOW_INDEXING is false" do
+    before do
+      allow(Rails.application.config).to receive(:search_engine_indexing_enabled).and_return(false)
+    end
+
+    it "prevents the home page from being indexed" do
+      get("/")
+
+      expect(response.headers["X-Robots-Tag"]).to eq("none")
+    end
+
+    it "prevents the appropriate body landing page from being indexed" do
+      get("/appropriate-body")
+
+      expect(response.headers["X-Robots-Tag"]).to eq("none")
     end
   end
 end

--- a/spec/requests/search_engine_indexing_spec.rb
+++ b/spec/requests/search_engine_indexing_spec.rb
@@ -16,6 +16,12 @@ describe "Search engine indexing", type: :request do
       expect(response.headers["X-Robots-Tag"]).to eq("all")
     end
 
+    it "allows the API guidance page to be indexed" do
+      get("/api/guidance")
+
+      expect(response.headers["X-Robots-Tag"]).to eq("all")
+    end
+
     it "prevents other pages from being indexed" do
       get("/sign-in")
 
@@ -36,6 +42,12 @@ describe "Search engine indexing", type: :request do
 
     it "prevents the appropriate body landing page from being indexed" do
       get("/appropriate-body")
+
+      expect(response.headers["X-Robots-Tag"]).to eq("none")
+    end
+
+    it "prevents the API guidance page from being indexed" do
+      get("/api/guidance")
 
       expect(response.headers["X-Robots-Tag"]).to eq("none")
     end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "Sessions", type: :request do
         expect(response).to be_successful
         expect(sanitize(response.body)).to include("Select a sign in method")
       end
+
+      it "prevents search engine indexing" do
+        expect(response.headers["X-Robots-Tag"]).to eq("none")
+      end
     end
 
     context "when signed in" do


### PR DESCRIPTION
### Summary

- Redirect legacy ECF1 URLs that appear in early Google results for "Register early career teachers" to the new service root

- Default pages to `X-Robots-Tag: none`, and explicitly allow indexing for `/` and `/appropriate-body` when indexing is enabled

We have marked the Google results as outdated and requested a refresh. Once Google no longer indexes these URLs, [we should remove the legacy redirect routes and their request specs](https://github.com/DFE-Digital/register-early-career-teachers-public/issues/2827).