### PR TITLE
[#3836] Bug: Mentor reported leaving at one school finishes at all schools

### DIFF
--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -10,16 +10,38 @@ class MentorAtSchoolPeriods::Finish
 
   def finish_existing_at_school_periods!
     ActiveRecord::Base.transaction do
-      teacher.mentor_at_school_periods.ongoing_on(finished_on).each do |period|
-        finish_mentorship_periods!(period)
-        finish_training_periods!(period)
-        finish_mentor_at_school_period!(period)
-        record_mentor_left_school_event!(period)
+      ongoing_mentor_at_school_periods.each do |period|
+        finish!(period)
+      end
+    end
+  end
+
+  def finish_periods_at_reported_school!
+    raise ArgumentError, "reported_by_school_id is required to finish periods at reported school" unless reported_by_school_id
+
+    ActiveRecord::Base.transaction do
+      ongoing_mentor_at_school_periods_at_reported_school.each do |period|
+        finish!(period)
       end
     end
   end
 
 private
+
+  def finish!(period)
+    finish_mentorship_periods!(period)
+    finish_training_periods!(period)
+    finish_mentor_at_school_period!(period)
+    record_mentor_left_school_event!(period)
+  end
+
+  def ongoing_mentor_at_school_periods
+    teacher.mentor_at_school_periods.ongoing_on(finished_on)
+  end
+
+  def ongoing_mentor_at_school_periods_at_reported_school
+    ongoing_mentor_at_school_periods.for_school(reported_by_school_id)
+  end
 
   def finish_mentorship_periods!(period)
     destroy_unstarted_mentorship_periods!(period)

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -8,7 +8,7 @@ class MentorAtSchoolPeriods::Finish
     @reported_by_school_id = reported_by_school_id
   end
 
-  def finish_existing_at_school_periods!
+  def finish_periods_at_all_schools!
     ActiveRecord::Base.transaction do
       ongoing_mentor_at_school_periods.each do |period|
         finish!(period)

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -45,7 +45,7 @@ module Schools
     def register!
       ActiveRecord::Base.transaction do
         create_teacher!
-        finish_existing_at_school_periods! if finish_existing_at_school_periods
+        finish_periods_at_all_schools! if finish_existing_at_school_periods
         start_at_school!
         create_training_period! unless mentoring_at_several_schools?
         set_eligibility_for_funding!
@@ -95,8 +95,8 @@ module Schools
       @school ||= School.find_by(urn: school_urn)
     end
 
-    def finish_existing_at_school_periods!
-      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: started_on, author:).finish_existing_at_school_periods!
+    def finish_periods_at_all_schools!
+      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: started_on, author:).finish_periods_at_all_schools!
     end
 
     def mentoring_at_several_schools?

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -15,7 +15,7 @@ module Schools
                 :mentor_at_school_period,
                 :lead_provider,
                 :training_period,
-                :finish_existing_at_school_periods,
+                :mentoring_at_new_school_only,
                 :mentee
 
     def initialize(trs_first_name:,
@@ -25,7 +25,7 @@ module Schools
                    school_urn:,
                    email:,
                    author:,
-                   finish_existing_at_school_periods: false,
+                   mentoring_at_new_school_only: false,
                    started_on: nil,
                    lead_provider: nil,
                    mentee: nil)
@@ -38,14 +38,14 @@ module Schools
       @started_on = started_on&.to_date || Date.current
       @trn = trn
       @lead_provider = lead_provider
-      @finish_existing_at_school_periods = finish_existing_at_school_periods
+      @mentoring_at_new_school_only = mentoring_at_new_school_only
       @mentee = mentee
     end
 
     def register!
       ActiveRecord::Base.transaction do
         create_teacher!
-        finish_periods_at_all_schools! if finish_existing_at_school_periods
+        finish_periods_at_all_schools! if mentoring_at_new_school_only?
         start_at_school!
         create_training_period! unless mentoring_at_several_schools?
         set_eligibility_for_funding!
@@ -100,7 +100,7 @@ module Schools
     end
 
     def mentoring_at_several_schools?
-      return false if finish_existing_at_school_periods
+      return false if mentoring_at_new_school_only?
 
       teacher
         .mentor_at_school_periods
@@ -129,5 +129,7 @@ module Schools
     def record_event!
       Events::Record.record_teacher_registered_as_mentor_event!(author:, mentor_at_school_period:, teacher:, school:, training_period:, lead_provider:)
     end
+
+    alias_method :mentoring_at_new_school_only?, :mentoring_at_new_school_only
   end
 end

--- a/app/wizards/schools/mentors/teacher_leaving_wizard/check_answers_step.rb
+++ b/app/wizards/schools/mentors/teacher_leaving_wizard/check_answers_step.rb
@@ -59,7 +59,7 @@ module Schools
             finished_on:,
             author:,
             reported_by_school_id: mentor_at_school_period.school_id
-          ).finish_existing_at_school_periods!
+          ).finish_periods_at_reported_school!
         end
       end
     end

--- a/app/wizards/schools/register_mentor_wizard/registration_store.rb
+++ b/app/wizards/schools/register_mentor_wizard/registration_store.rb
@@ -64,7 +64,7 @@ module Schools
                                     email:,
                                     author:,
                                     started_on:,
-                                    finish_existing_at_school_periods:,
+                                    mentoring_at_new_school_only: mentoring_at_new_school_only?,
                                     lead_provider:,
                                     mentee: ect)
                 .register!
@@ -73,11 +73,6 @@ module Schools
 
       def active_at_school?
         active_record_at_school.present?
-      end
-
-      # The form submits a symbol (:yes or :no), but Rails stores it as a string ('yes'/'no').
-      def finish_existing_at_school_periods
-        mentoring_at_new_school_only?
       end
 
       def ect_lead_provider

--- a/db/scripts/close_teacher_periods.rb
+++ b/db/scripts/close_teacher_periods.rb
@@ -13,7 +13,7 @@ def close_teacher_periods(trns:, author_email:, finished_on: Date.current)
       end
 
       # mentor_at_school_periods + associated periods
-      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on:, author:).finish_existing_at_school_periods!
+      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on:, author:).finish_periods_at_all_schools!
     end
   end
 end

--- a/spec/features/schools/mentors/leaving_spec.rb
+++ b/spec/features/schools/mentors/leaving_spec.rb
@@ -3,9 +3,10 @@ describe "School user reports a mentor leaving" do
     travel_to(Date.new(2025, 1, 1)) { example.run }
   end
 
-  it "completes the leaving flow" do
+  it "completes the leaving flow for this school" do
     given_there_is_a_school
     and_there_is_an_ongoing_mentor
+    and_the_mentor_is_also_a_mentor_at_another_school
     and_i_am_logged_in_as_a_school_user
 
     when_i_visit_the_mentor_page
@@ -19,6 +20,10 @@ describe "School user reports a mentor leaving" do
 
     when_i_return_to_the_mentor_details
     then_i_see_the_leaving_message_and_no_cta
+
+    when_the_other_school_logs_in
+    and_visits_the_mentor_page
+    then_they_do_not_see_the_leaving_message
   end
 
 private
@@ -42,12 +47,31 @@ private
     )
   end
 
+  def and_the_mentor_is_also_a_mentor_at_another_school
+    @other_school = FactoryBot.create(:school)
+    @other_mentor_at_school_period = FactoryBot.create(
+      :mentor_at_school_period,
+      :ongoing,
+      teacher: @teacher,
+      school: @other_school,
+      started_on: Date.new(2024, 10, 1)
+    )
+  end
+
   def and_i_am_logged_in_as_a_school_user
     sign_in_as_school_user(school: @school)
   end
 
+  def when_the_other_school_logs_in
+    sign_in_as_school_user(school: @other_school)
+  end
+
   def when_i_visit_the_mentor_page
     page.goto(schools_mentor_path(@mentor_at_school_period))
+  end
+
+  def and_visits_the_mentor_page
+    page.goto(schools_mentor_path(@other_mentor_at_school_period))
   end
 
   def then_i_can_start_the_mentor_leaving_flow
@@ -83,5 +107,10 @@ private
   def then_i_see_the_leaving_message_and_no_cta
     expect(page.locator("h2", hasText: "Batman is leaving your school")).to be_visible
     expect(page.get_by_role("link", name: "Tell us if Batman is leaving permanently")).not_to be_visible
+  end
+
+  def then_they_do_not_see_the_leaving_message
+    expect(page.locator("h2", hasText: "Batman is leaving your school")).not_to be_visible
+    expect(page.get_by_role("link", name: "Tell us if Batman is leaving permanently")).to be_visible
   end
 end

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -12,7 +12,7 @@ describe MentorAtSchoolPeriods::Finish do
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: mentor_at_school_period.school) }
   let!(:mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: mentor_at_school_period, mentee: ect_at_school_period, started_on:) }
 
-  describe "#finish_existing_at_school_periods!" do
+  describe "#finish_periods_at_all_schools!" do
     context "when finished_on is already set" do
       let(:training_period) { nil }
       let(:mentorship_period) { nil }
@@ -28,7 +28,7 @@ describe MentorAtSchoolPeriods::Finish do
         end
 
         it "does not overwrite the existing finished_on" do
-          expect { subject.finish_existing_at_school_periods! }.not_to(change { mentor_at_school_period.reload.finished_on })
+          expect { subject.finish_periods_at_all_schools! }.not_to(change { mentor_at_school_period.reload.finished_on })
         end
       end
 
@@ -43,7 +43,7 @@ describe MentorAtSchoolPeriods::Finish do
         end
 
         it "does not rewrite the finished_on date" do
-          expect { subject.finish_existing_at_school_periods! }.not_to(change { mentor_at_school_period.reload.finished_on })
+          expect { subject.finish_periods_at_all_schools! }.not_to(change { mentor_at_school_period.reload.finished_on })
         end
       end
     end
@@ -60,7 +60,7 @@ describe MentorAtSchoolPeriods::Finish do
       end
 
       it "deletes the mentorship period" do
-        expect { subject.finish_existing_at_school_periods! }.to change(MentorshipPeriod, :count).by(-1)
+        expect { subject.finish_periods_at_all_schools! }.to change(MentorshipPeriod, :count).by(-1)
       end
 
       it "deletes any events associated with the mentorship period" do
@@ -70,7 +70,7 @@ describe MentorAtSchoolPeriods::Finish do
 
         expect(Event.where(mentorship_period:).count).to eq(2)
 
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
 
         expect(Event.where(mentorship_period:)).to be_empty
         expect(Event.exists?(other_event.id)).to be true
@@ -91,7 +91,7 @@ describe MentorAtSchoolPeriods::Finish do
       end
 
       it "sets the mentorship period finished_on to the mentor's earlier leaving date" do
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
 
         expect(mentorship_period.reload.finished_on).to eq(mentor_finished_on)
       end
@@ -111,11 +111,11 @@ describe MentorAtSchoolPeriods::Finish do
       end
 
       it "does not raise an error" do
-        expect { subject.finish_existing_at_school_periods! }.not_to raise_error
+        expect { subject.finish_periods_at_all_schools! }.not_to raise_error
       end
 
       it "sets the mentorship period finished_on to the ECT's leaving date, not the mentor's" do
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
 
         expect(mentorship_period.reload.finished_on).to eq(ect_finished_on)
       end
@@ -126,7 +126,7 @@ describe MentorAtSchoolPeriods::Finish do
       expect(mentorship_period.finished_on).to be_nil
       expect(mentor_at_school_period.finished_on).to be_nil
 
-      subject.finish_existing_at_school_periods!
+      subject.finish_periods_at_all_schools!
 
       expect(training_period.reload.finished_on).not_to be_nil
       expect(mentorship_period.reload.finished_on).not_to be_nil
@@ -142,14 +142,14 @@ describe MentorAtSchoolPeriods::Finish do
         happened_at: finished_on
       )
 
-      subject.finish_existing_at_school_periods!
+      subject.finish_periods_at_all_schools!
     end
 
     context "when reported_by_school_id is provided" do
       let(:reported_by_school_id) { mentor_at_school_period.school_id }
 
       it "stores the reporting school id" do
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
         expect(mentor_at_school_period.reload.reported_leaving_by_school_id).to eq(reported_by_school_id)
       end
     end
@@ -162,7 +162,7 @@ describe MentorAtSchoolPeriods::Finish do
         author:
       ).and_return(mentorships_finish)
 
-      subject.finish_existing_at_school_periods!
+      subject.finish_periods_at_all_schools!
 
       expect(mentorships_finish).to have_received(:finish!).once
     end
@@ -176,7 +176,7 @@ describe MentorAtSchoolPeriods::Finish do
         author:
       ).and_return(training_periods_finish)
 
-      subject.finish_existing_at_school_periods!
+      subject.finish_periods_at_all_schools!
 
       expect(training_periods_finish).to have_received(:finish!).once
     end
@@ -191,14 +191,14 @@ describe MentorAtSchoolPeriods::Finish do
       it "does not record any events when there are no ongoing periods to finish" do
         expect(Events::Record).not_to receive(:record_teacher_left_school_as_mentor!)
 
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
       end
 
       it "does not call any finishing services when there are no ongoing periods" do
         expect(MentorshipPeriods::Finish).not_to receive(:new)
         expect(TrainingPeriods::Finish).not_to receive(:mentor_training)
 
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
       end
     end
 
@@ -212,7 +212,7 @@ describe MentorAtSchoolPeriods::Finish do
       let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
 
       it "finishes the periods at other schools" do
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
 
         expect(mentor_at_school_period.reload.finished_on).not_to be_nil
         expect(other_mentor_at_school_period.reload.finished_on).not_to be_nil
@@ -238,7 +238,7 @@ describe MentorAtSchoolPeriods::Finish do
           happened_at: finished_on
         ).once
 
-        subject.finish_existing_at_school_periods!
+        subject.finish_periods_at_all_schools!
       end
 
       context "when the mentor has already finished at the other school" do
@@ -251,14 +251,14 @@ describe MentorAtSchoolPeriods::Finish do
         end
 
         it "does not update the finished_on for the already finished period" do
-          subject.finish_existing_at_school_periods!
+          subject.finish_periods_at_all_schools!
 
           expect(other_mentor_at_school_period.reload.finished_on).to eq(started_on + 1.month)
           expect(other_mentorship_period.reload.finished_on).to eq(started_on + 1.month)
         end
 
         it "finishes the unfinished periods" do
-          subject.finish_existing_at_school_periods!
+          subject.finish_periods_at_all_schools!
 
           expect(mentor_at_school_period.reload.finished_on).not_to be_nil
           expect(training_period.reload.finished_on).not_to be_nil

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -306,12 +306,13 @@ describe MentorAtSchoolPeriods::Finish do
       end
 
       context "when the mentor is training at another school" do
-        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: other_mentor_at_school_period, started_on:) }
+        let(:training_period) { nil }
+        let!(:other_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: other_mentor_at_school_period, started_on:) }
 
         it "does not finish the training period at the other school" do
           subject.finish_periods_at_reported_school!
 
-          expect(training_period.reload.finished_on).to be_nil
+          expect(other_training_period.reload.finished_on).to be_nil
         end
       end
 

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -201,5 +201,127 @@ describe MentorAtSchoolPeriods::Finish do
         subject.finish_existing_at_school_periods!
       end
     end
+
+    context "when there are ongoing mentor at school periods at other schools" do
+      let(:other_school) { FactoryBot.create(:school) }
+      let(:other_mentor_at_school_period) do
+        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school, started_on:)
+      end
+
+      let(:other_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: other_school) }
+      let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
+
+      it "finishes the periods at other schools" do
+        subject.finish_existing_at_school_periods!
+
+        expect(mentor_at_school_period.reload.finished_on).not_to be_nil
+        expect(other_mentor_at_school_period.reload.finished_on).not_to be_nil
+        expect(training_period.reload.finished_on).not_to be_nil
+        expect(mentorship_period.reload.finished_on).not_to be_nil
+        expect(other_mentorship_period.reload.finished_on).not_to be_nil
+      end
+
+      it "records events for each school" do
+        expect(Events::Record).to receive(:record_teacher_left_school_as_mentor!).with(
+          author:,
+          mentor_at_school_period:,
+          teacher:,
+          school: mentor_at_school_period.school,
+          happened_at: finished_on
+        ).once
+
+        expect(Events::Record).to receive(:record_teacher_left_school_as_mentor!).with(
+          author:,
+          mentor_at_school_period: other_mentor_at_school_period,
+          teacher:,
+          school: other_school,
+          happened_at: finished_on
+        ).once
+
+        subject.finish_existing_at_school_periods!
+      end
+
+      context "when the mentor has already finished at the other school" do
+        let(:other_mentor_at_school_period) do
+          FactoryBot.create(:mentor_at_school_period, teacher:, school: other_school, started_on:, finished_on: started_on + 1.month)
+        end
+
+        let!(:other_mentorship_period) do
+          FactoryBot.create(:mentorship_period, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:, finished_on: started_on + 1.month)
+        end
+
+        it "does not update the finished_on for the already finished period" do
+          subject.finish_existing_at_school_periods!
+
+          expect(other_mentor_at_school_period.reload.finished_on).to eq(started_on + 1.month)
+          expect(other_mentorship_period.reload.finished_on).to eq(started_on + 1.month)
+        end
+
+        it "finishes the unfinished periods" do
+          subject.finish_existing_at_school_periods!
+
+          expect(mentor_at_school_period.reload.finished_on).not_to be_nil
+          expect(training_period.reload.finished_on).not_to be_nil
+          expect(mentorship_period.reload.finished_on).not_to be_nil
+        end
+      end
+    end
+  end
+
+  describe "finish_periods_at_reported_school!" do
+    context "when there are ongoing mentor at school periods at other schools" do
+      let(:other_school) { FactoryBot.create(:school) }
+      let(:other_mentor_at_school_period) do
+        FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, school: other_school, started_on:)
+      end
+
+      let(:other_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on:, school: other_school) }
+      let!(:other_mentorship_period) { FactoryBot.create(:mentorship_period, :ongoing, mentor: other_mentor_at_school_period, mentee: other_ect_at_school_period, started_on:) }
+
+      let(:reported_by_school_id) { mentor_at_school_period.school_id }
+
+      it "only finishes the periods at the reported school" do
+        subject.finish_periods_at_reported_school!
+
+        expect(mentor_at_school_period.reload.reported_leaving_by_school_id).to eq(reported_by_school_id)
+        expect(mentor_at_school_period.finished_on).not_to be_nil
+        expect(training_period.reload.finished_on).not_to be_nil
+        expect(mentorship_period.reload.finished_on).not_to be_nil
+
+        expect(other_mentor_at_school_period.reload.reported_leaving_by_school_id).to be_nil
+        expect(other_mentor_at_school_period.finished_on).to be_nil
+        expect(other_mentorship_period.reload.finished_on).to be_nil
+      end
+
+      it "only records an event at the reported school" do
+        expect(Events::Record).to receive(:record_teacher_left_school_as_mentor!).with(
+          author:,
+          mentor_at_school_period:,
+          teacher:,
+          school: mentor_at_school_period.school,
+          happened_at: finished_on
+        ).once
+
+        subject.finish_periods_at_reported_school!
+      end
+
+      context "when the mentor is training at another school" do
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: other_mentor_at_school_period, started_on:) }
+
+        it "does not finish the training period at the other school" do
+          subject.finish_periods_at_reported_school!
+
+          expect(training_period.reload.finished_on).to be_nil
+        end
+      end
+
+      context "when reported_by_school_id is not provided" do
+        let(:reported_by_school_id) { nil }
+
+        it "raises an error" do
+          expect { subject.finish_periods_at_reported_school! }.to raise_error(ArgumentError, "reported_by_school_id is required to finish periods at reported school")
+        end
+      end
+    end
   end
 end

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Schools::RegisterMentor do
                         school_urn: school.urn,
                         email:,
                         lead_provider:,
-                        finish_existing_at_school_periods:,
+                        mentoring_at_new_school_only:,
                         started_on:,
                         author:)
   end
@@ -26,7 +26,7 @@ RSpec.describe Schools::RegisterMentor do
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let!(:contract_period) { FactoryBot.create(:contract_period, :with_schedules, :current) }
   let(:mentor_at_school_period) { teacher.mentor_at_school_periods.first }
-  let(:finish_existing_at_school_periods) { false }
+  let(:mentoring_at_new_school_only) { false }
 
   describe "#register!" do
     context "when the mentor is not registered" do
@@ -82,8 +82,8 @@ RSpec.describe Schools::RegisterMentor do
           let!(:existing_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, mentor_at_school_period: existing_mentor_at_school_period, started_on: existing_mentor_at_school_period.started_on) }
           let(:mentor_at_school_period) { teacher.mentor_at_school_periods.excluding(existing_mentor_at_school_period).first }
 
-          context "with :finish_existing_at_school_periods set to false" do
-            let(:finish_existing_at_school_periods) { false }
+          context "with :mentoring_at_new_school_only set to false" do
+            let(:mentoring_at_new_school_only) { false }
 
             it "creates a new MentorATSchoolPeriod without finishing existing MentorAtSchoolPeriod" do
               expect { service.register! }.to change(MentorAtSchoolPeriod, :count).from(1).to(2)
@@ -124,8 +124,8 @@ RSpec.describe Schools::RegisterMentor do
             end
           end
 
-          context "with :finish_existing_at_school_periods set to true" do
-            let(:finish_existing_at_school_periods) { true }
+          context "with :mentoring_at_new_school_only set to true" do
+            let(:mentoring_at_new_school_only) { true }
 
             it "creates a new MentorATSchoolPeriod and finishes existing MentorAtSchoolPeriod" do
               expect { service.register! }.to change(MentorAtSchoolPeriod, :count).from(1).to(2)

--- a/spec/wizards/schools/mentors/teacher_leaving_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/mentors/teacher_leaving_wizard/check_answers_step_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::CheckAnswersStep do
     end
 
     context "when leaving_on is present" do
-      let(:finish_service) { instance_double(MentorAtSchoolPeriods::Finish, finish_existing_at_school_periods!: true) }
+      let(:finish_service) { instance_double(MentorAtSchoolPeriods::Finish, finish_periods_at_reported_school!: true) }
 
       before do
         allow(MentorAtSchoolPeriods::Finish).to receive(:new).and_return(finish_service)
@@ -100,7 +100,7 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::CheckAnswersStep do
       it "finishes the mentor at school period" do
         expect(step.save!).to be_truthy
         expect(MentorAtSchoolPeriods::Finish).to have_received(:new)
-        expect(finish_service).to have_received(:finish_existing_at_school_periods!)
+        expect(finish_service).to have_received(:finish_periods_at_reported_school!)
       end
     end
   end

--- a/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
@@ -300,20 +300,6 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
     end
   end
 
-  describe "#finish_existing_at_school_periods" do
-    context "when mentoring_at_new_school_only set to yes" do
-      before { store.mentoring_at_new_school_only = "yes" }
-
-      it { expect(registration_store.finish_existing_at_school_periods).to be(true) }
-    end
-
-    context "when mentoring_at_new_school_only set to no" do
-      before { store.mentoring_at_new_school_only = "no" }
-
-      it { expect(registration_store.finish_existing_at_school_periods).to be(false) }
-    end
-  end
-
   describe "#lead_providers_within_contract_period" do
     let!(:contract_period) do
       FactoryBot.create(


### PR DESCRIPTION
### Context

When a mentor is mentoring across multiple schools, when one school reports them as leaving, this is populating their end date for their at_school periods at all other schools and training periods (where the training wasn't associated with that school).

### Changes proposed in this pull request

The `MentorAtSchoolPeriods::Finish` class explicitly looks for all mentor_at_school/training/mentorship periods associated with the teacher and closes them.  I have created a new method that closes only those from the reporting school, and renamed the existing method so the difference between the two is clear.  Other classes should continue to use the method which closes all periods.

### Guidance to review
