### PR TITLE
Make `mentor_at_school_periods` range colum have inclusive end

### DIFF
--- a/db/migrate/20260430160220_make_mentor_at_school_period_ranges_inclusive_end.rb
+++ b/db/migrate/20260430160220_make_mentor_at_school_period_ranges_inclusive_end.rb
@@ -1,0 +1,8 @@
+class MakeMentorAtSchoolPeriodRangesInclusiveEnd < ActiveRecord::Migration[8.1]
+  def change
+    # rubocop:disable Rails/BulkChangeTable
+    remove_column :mentor_at_school_periods, :range, :daterange
+    add_column :mentor_at_school_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on, '[]')", stored: true
+    # rubocop:enable Rails/BulkChangeTable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_105743) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_160220) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -523,7 +523,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_105743) do
     t.uuid "ecf_start_induction_record_id"
     t.citext "email"
     t.date "finished_on"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
     t.bigint "reported_leaving_by_school_id"
     t.bigint "school_id", null: false
     t.date "started_on", null: false

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -256,7 +256,7 @@ describe Interval do
     end
 
     context "without overlapping sibling intervals" do
-      before { DummyMentor.create(teacher_id:, school_id:, started_on: 1.week.ago, finished_on: 5.days.ago) }
+      before { DummyMentor.create(teacher_id:, school_id:, started_on: 1.week.ago, finished_on: 6.days.ago) }
 
       it { is_expected.not_to have_overlap_with_siblings }
     end

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Schools::RegisterMentor do
             end
 
             context "when the existing mentor_at_school_period has finished" do
-              let!(:existing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 2.years.ago, finished_on: Time.zone.today) }
+              let!(:existing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: 2.years.ago, finished_on: Time.zone.yesterday) }
 
               it "creates a new training period and finishes the old period" do
                 expect { service.register! }.to change(TrainingPeriod, :count).by(1)


### PR DESCRIPTION
### Context

Following on from #2357, we're switching over the ranges so they include the end date. The non-inclusive end dates allows one range to finish on the day its sucecssor starts without overlapping.

This change makes the switch for MentorAtSchoolPeriod, it updates the range itself and adjusts the tests accordingly.

### Changes proposed in this pull request

- **Replace mentor_at_school_periods [) range with []**
- **Adjust overlap specs to make them pass**

Fixes DFE-Digital/register-ects-project-board#3416
