### PR TITLE
Create a future statement for clawback?

### DIFF
--- a/spec/forms/admin/finance/void_declaration_form_spec.rb
+++ b/spec/forms/admin/finance/void_declaration_form_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Admin::Finance::VoidDeclarationForm, type: :model do
     context "when voiding a paid declaration" do
       let(:declaration) { FactoryBot.create(:declaration, :paid) }
 
+      before do
+        FactoryBot.create(:statement,
+                          :open,
+                          :output_fee,
+                          active_lead_provider: declaration.training_period.active_lead_provider,
+                          deadline_date: 1.month.from_now)
+      end
+
       it { is_expected.to be_truthy }
 
       include_examples "does not call the void service"


### PR DESCRIPTION
### Context

Something is screwy if you run this spec in isolation.

The `contract_period` factory sets the base contract period year to `2021`

```ruby
    def next_available_output_fee_statement
      @next_available_output_fee_statement ||= Statements::Search
        .new(
          lead_provider_id: lead_provider.id,
          contract_period_years: contract_period.year,
          fee_type: "output",
          deadline_date: Date.current..,
          order: :deadline_date
        )
        .statements
        .first
    end
```

When run other specs advance the year, we don't see the problem.

### Changes proposed in this pull request

Add a `before` block to the spec to ensure the deadline is in the future.

### Guidance to review

Run on `main` first then on this branch:

`$ rspec ./spec/forms/admin/finance/void_declaration_form_spec.rb`
