### PR TITLE
Fix Puma 8 worker boot warnings

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -5,11 +5,14 @@ threads min_threads_count, max_threads_count
 if ENV["RAILS_ENV"] == "production"
   require "concurrent-ruby"
   worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
-  workers worker_count if worker_count > 1
-end
-
-on_worker_boot do
-  SemanticLogger.reopen if defined?(SemanticLogger)
+  if worker_count > 1
+    workers worker_count
+    # before_worker_boot only fires in cluster mode; registering it in single mode
+    # (dev/test) emits a Puma warning that the block will never execute.
+    before_worker_boot do
+      SemanticLogger.reopen if defined?(SemanticLogger)
+    end
+  end
 end
 
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"


### PR DESCRIPTION
### Context

When running rails server locally see this warning:
```
Use 'before_worker_boot', 'on_worker_boot' is deprecated and will be removed in v8
Warning: The code in the `before_worker_boot` block will not execute in the current Puma configuration. The `before_worker_boot` block only executes in Puma's cluster mode. To fix this, either remove the `before_worker_boot` call or increase Puma's worker count above zero. 
Warning: The code in the `before_worker_boot` block will not execute in the current Puma configuration. The `before_worker_boot` block only executes in Puma's cluster mode. To fix this, either remove the `before_worker_boot` call or increase Puma's worker count above zero. 
```

Locally we don't run in cluster mode, in production we do.

### Changes proposed in this pull request

Rename `on_worker_boot` to `before_worker_boot` and only register the hook when running in cluster mode.
Single-mode boots (dev/test) no longer emit deprecation or "block will never execute" warnings.

### Guidance to review
