### PR TITLE
[3870] Fix replacement schedule logic

### DIFF
--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -90,7 +90,7 @@ module Schedules
     def mentee_has_declared_training_with_previous_mentor?
       MentorshipPeriod
         .joins(:mentee, mentor: { training_periods: :declarations })
-        .where(ect_at_school_periods: { teacher_id: mentee.teacher_id })
+        .where(ect_at_school_periods: { teacher_id: mentee.teacher_id }) # all periods at _any_ school
         .where.not(mentor_at_school_period_id: period.id)
         .where.not(declarations: { payment_status: :voided })
         .where("declarations.declaration_date >= mentorship_periods.started_on")

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -85,15 +85,19 @@ module Schedules
       end
     end
 
-    def mentorship_periods_for_mentee_with_different_mentor
-      MentorAtSchoolPeriod
-        .joins(:mentorship_periods)
-        .merge(MentorshipPeriod.for_mentee(mentee.id))
-        .where.not(id: period.id)
-    end
-
     def previous_mentor_started_training?
-      mentorship_periods_for_mentee_with_different_mentor.joins(:declarations).exists?
+      MentorshipPeriod
+        .joins(:mentee)
+        .joins("INNER JOIN training_periods AS prev_tp
+                  ON prev_tp.mentor_at_school_period_id = mentorship_periods.mentor_at_school_period_id")
+        .joins("INNER JOIN declarations
+                  ON declarations.training_period_id = prev_tp.id")
+        .where(ect_at_school_periods: { teacher_id: mentee.teacher_id })
+        .where.not(mentorship_periods: { mentor_at_school_period_id: period.id })
+        .where.not(declarations: { payment_status: :voided })
+        .where("declarations.declaration_date >= mentorship_periods.started_on")
+        .where("declarations.declaration_date <= COALESCE(mentorship_periods.finished_on, CURRENT_DATE)")
+        .exists?
     end
 
     def replacement_schedule?

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -85,7 +85,9 @@ module Schedules
       end
     end
 
-    def previous_mentor_started_training?
+    # A non-voided declaration dated within the mentorship period signals that the
+    # previous mentor started training (i.e. they weren't only assigned)
+    def mentee_has_declared_training_with_previous_mentor?
       MentorshipPeriod
         .joins(:mentee, mentor: { training_periods: :declarations })
         .where(ect_at_school_periods: { teacher_id: mentee.teacher_id })
@@ -101,7 +103,7 @@ module Schedules
       return false unless mentee && mentee.provider_led_training_programme?
       return false if teacher.mentor_became_ineligible_for_funding_on.present?
 
-      previous_mentor_started_training?
+      mentee_has_declared_training_with_previous_mentor?
     end
 
     alias_method :extended_schedule?, :contract_period_reassignment_required?

--- a/app/services/schedules/find.rb
+++ b/app/services/schedules/find.rb
@@ -87,13 +87,9 @@ module Schedules
 
     def previous_mentor_started_training?
       MentorshipPeriod
-        .joins(:mentee)
-        .joins("INNER JOIN training_periods AS prev_tp
-                  ON prev_tp.mentor_at_school_period_id = mentorship_periods.mentor_at_school_period_id")
-        .joins("INNER JOIN declarations
-                  ON declarations.training_period_id = prev_tp.id")
+        .joins(:mentee, mentor: { training_periods: :declarations })
         .where(ect_at_school_periods: { teacher_id: mentee.teacher_id })
-        .where.not(mentorship_periods: { mentor_at_school_period_id: period.id })
+        .where.not(mentor_at_school_period_id: period.id)
         .where.not(declarations: { payment_status: :voided })
         .where("declarations.declaration_date >= mentorship_periods.started_on")
         .where("declarations.declaration_date <= COALESCE(mentorship_periods.finished_on, CURRENT_DATE)")

--- a/lib/tasks/product_review/3870.rake
+++ b/lib/tasks/product_review/3870.rake
@@ -1,0 +1,139 @@
+namespace :product_review do
+  desc "Set up replacement-schedule-across-schools scenario at Abbey Grove (#3870)"
+  task "3870" => :environment do
+    if Teacher.exists?(trn: "0000050")
+      puts "Scenario already set up — Rik Mayall (TRN 0000050) exists. Aborting."
+      next
+    end
+
+    abbey_grove = School.find_by!(urn: 1_759_427)
+    brookfield  = School.find_by!(urn: 2_976_163)
+
+    cp_2023 = ContractPeriod.find_by!(year: 2023)
+    cp_2024 = ContractPeriod.find_by!(year: 2024)
+
+    ambition       = LeadProvider.find_by!(name: "Ambition Institute")
+    artisan        = DeliveryPartner.find_by!(name: "Artisan Education Group")
+    golden_leaf    = AppropriateBodyPeriod.find_by!(name: "Golden Leaf Teaching School Hub")
+    south_yorks    = AppropriateBodyPeriod.find_by!(name: "South Yorkshire Studio Hub")
+
+    brookfield_partnership  = find_or_create_partnership!(school: brookfield,  lead_provider: ambition, delivery_partner: artisan, contract_period: cp_2023)
+    abbey_grove_partnership = find_or_create_partnership!(school: abbey_grove, lead_provider: ambition, delivery_partner: artisan, contract_period: cp_2024)
+
+    sched_2023 = Schedule.find_by!(contract_period_year: 2023, identifier: "ecf-standard-september")
+    sched_2024 = Schedule.find_by!(contract_period_year: 2024, identifier: "ecf-standard-september")
+
+    ApplicationRecord.transaction do
+      rik    = Teacher.create!(trn: "0000050", trs_first_name: "Rik",    trs_last_name: "Mayall",    trs_qts_awarded_on: Date.new(2021, 1, 1), trs_induction_status: "InProgress")
+      adrian = Teacher.create!(trn: "0000051", trs_first_name: "Adrian", trs_last_name: "Edmondson", trs_qts_awarded_on: Date.new(2021, 1, 1), trs_induction_status: "InProgress")
+      nigel  = Teacher.create!(trn: "0000052", trs_first_name: "Nigel",  trs_last_name: "Planer",    trs_qts_awarded_on: Date.new(2021, 1, 1), trs_induction_status: "InProgress")
+
+      # Brookfield (previous school): Adrian mentored Rik with declared training
+
+      adrian_at_brookfield = MentorAtSchoolPeriod.create!(
+        teacher: adrian,
+        school: brookfield,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 8, 31)
+      )
+
+      adrian_brookfield_training = TrainingPeriod.create!(
+        mentor_at_school_period: adrian_at_brookfield,
+        school_partnership: brookfield_partnership,
+        schedule: sched_2023,
+        training_programme: "provider_led",
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 8, 31)
+      )
+
+      rik_at_brookfield = ECTAtSchoolPeriod.create!(
+        teacher: rik,
+        school: brookfield,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 8, 31),
+        school_reported_appropriate_body: south_yorks
+      )
+
+      TrainingPeriod.create!(
+        ect_at_school_period: rik_at_brookfield,
+        school_partnership: brookfield_partnership,
+        schedule: sched_2023,
+        training_programme: "provider_led",
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 8, 31)
+      )
+
+      MentorshipPeriod.create!(
+        mentor: adrian_at_brookfield,
+        mentee: rik_at_brookfield,
+        started_on: Date.new(2023, 9, 1),
+        finished_on: Date.new(2024, 8, 31)
+      )
+
+      # The signal that "training started": a non-voided declaration whose date
+      # falls inside the previous mentorship.
+      Declaration.create!(
+        training_period: adrian_brookfield_training,
+        declaration_type: "started",
+        declaration_date: Date.new(2023, 12, 15),
+        evidence_type: "training-event-attended",
+        payment_status: :no_payment,
+        clawback_status: :no_clawback,
+        api_id: SecureRandom.uuid,
+        delivery_partner_when_created: artisan
+      )
+
+      # Abbey Grove (current school): Rik moved here, no current mentor
+
+      rik_at_abbey_grove = ECTAtSchoolPeriod.create!(
+        teacher: rik,
+        school: abbey_grove,
+        started_on: Date.new(2024, 9, 1),
+        finished_on: nil,
+        school_reported_appropriate_body: golden_leaf
+      )
+
+      TrainingPeriod.create!(
+        ect_at_school_period: rik_at_abbey_grove,
+        school_partnership: abbey_grove_partnership,
+        schedule: sched_2024,
+        training_programme: "provider_led",
+        started_on: Date.new(2024, 9, 1),
+        finished_on: nil
+      )
+
+      # Nigel is registered as a mentor at Abbey Grove with no training period yet
+      MentorAtSchoolPeriod.create!(
+        teacher: nigel,
+        school: abbey_grove,
+        started_on: Date.new(2025, 9, 1),
+        finished_on: nil
+      )
+    end
+
+    puts
+    puts "=" * 78
+    puts "  Replacement schedule across schools (#3870)"
+    puts "=" * 78
+    puts
+    puts "  State seeded by this task:"
+    puts "    - Rik Mayall: ECT at Abbey Grove (no current mentor)"
+    puts "    - Adrian Edmondson: prior closed mentorship of Rik at Brookfield, with"
+    puts "      a non-voided 'started' declaration during that mentorship"
+    puts "    - Nigel Planer: registered as a mentor at Abbey Grove, no training period"
+    puts "      and not yet linked to Rik"
+    puts
+    puts "  To verify:"
+    puts "    1. Sign in as Bob Belcher (Abbey Grove School)"
+    puts "    2. Open Rik's record and assign Nigel as his mentor"
+    puts "    3. Expect Nigel's new training period to be given a `replacement`"
+    puts "       schedule (would be `standard` without this PR)"
+    puts
+  end
+end
+
+def find_or_create_partnership!(school:, lead_provider:, delivery_partner:, contract_period:)
+  active_lead_provider = ActiveLeadProvider.find_or_create_by!(lead_provider:, contract_period_year: contract_period.year)
+  lpdp = LeadProviderDeliveryPartnership.find_or_create_by!(active_lead_provider:, delivery_partner:)
+  SchoolPartnership.find_or_create_by!(school:, lead_provider_delivery_partnership: lpdp)
+end

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -43,6 +43,17 @@ FactoryBot.define do
       end
     end
 
+    # Use when the declaration should count toward `replacement_schedule?`,
+    # which expects a declaration within the mentor's mentorship of the ECT.
+    trait :within_mentorship_period do
+      declaration_date do
+        mp = training_period&.mentor_at_school_period&.mentorship_periods&.order(:started_on)&.first
+        raise ArgumentError, "Cannot derive declaration_date: training_period must belong to a mentor with a mentorship_period" unless mp
+
+        mp.started_on + 1.day
+      end
+    end
+
     trait :voided_by_user do
       payment_status { :voided }
       voided_by_user { FactoryBot.create(:user) }

--- a/spec/services/ect_at_school_periods/switch_mentor_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_mentor_spec.rb
@@ -200,7 +200,7 @@ module ECTAtSchoolPeriods
             end
 
             context "when the previous mentor has started training" do
-              let!(:declaration) { FactoryBot.create(:declaration, training_period: mentor_training_period) }
+              let!(:declaration) { FactoryBot.create(:declaration, :within_mentorship_period, training_period: mentor_training_period) }
 
               it "assigns the mentor on a replacement schedule" do
                 switch_mentor

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -306,9 +306,21 @@ RSpec.describe Schedules::Find do
           end
 
           context "when the previous mentor has started training" do
-            let!(:declaration) { FactoryBot.create(:declaration, training_period: mentor_training_period) }
+            let!(:declaration) { FactoryBot.create(:declaration, :within_mentorship_period, training_period: mentor_training_period) }
 
             it_behaves_like "replacement schedule assigned"
+
+            context "when the previous mentor's declaration is dated outside the mentorship period" do
+              let!(:declaration) { FactoryBot.create(:declaration, training_period: mentor_training_period, declaration_date: 1.day.from_now) }
+
+              it_behaves_like "no replacement schedule assigned"
+            end
+
+            context "when the previous mentor's declaration is voided" do
+              let!(:declaration) { FactoryBot.create(:declaration, :voided_by_user, :within_mentorship_period, training_period: mentor_training_period) }
+
+              it_behaves_like "no replacement schedule assigned"
+            end
 
             context "when the mentor is ineligible for funding" do
               let(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
@@ -347,22 +359,69 @@ RSpec.describe Schedules::Find do
           end
 
           context "when the earliest previous mentor has started training" do
-            let!(:declaration) { FactoryBot.create(:declaration, training_period: first_mentor_training_period) }
+            let!(:declaration) { FactoryBot.create(:declaration, :within_mentorship_period, training_period: first_mentor_training_period) }
 
             it_behaves_like "replacement schedule assigned"
           end
 
           context "when the latest previous mentor has started training" do
-            let!(:declaration) { FactoryBot.create(:declaration, training_period: second_mentor_training_period) }
+            let!(:declaration) { FactoryBot.create(:declaration, :within_mentorship_period, training_period: second_mentor_training_period) }
 
             it_behaves_like "replacement schedule assigned"
           end
 
           context "when the new mentor is ineligible for funding" do
             let(:teacher) { FactoryBot.create(:teacher, :ineligible_for_mentor_funding) }
-            let!(:declaration) { FactoryBot.create(:declaration, training_period: second_mentor_training_period) }
+            let!(:declaration) { FactoryBot.create(:declaration, :within_mentorship_period, training_period: second_mentor_training_period) }
 
             it_behaves_like "no replacement schedule assigned"
+          end
+        end
+
+        context "when the previous mentor was at a different school" do
+          let(:previous_school) { FactoryBot.create(:school) }
+          let(:previous_school_start) { Date.new(year - 1, 9, 1) }
+          let(:previous_school_end) { Date.new(year - 1, 12, 31) }
+
+          let!(:mentee_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: previous_start_date, ect_at_school_period: mentee) }
+
+          let!(:mentee_at_previous_school) do
+            FactoryBot.create(:ect_at_school_period,
+                              school: previous_school,
+                              teacher: mentee.teacher,
+                              started_on: previous_school_start,
+                              finished_on: previous_school_end)
+          end
+
+          let(:previous_mentor) do
+            FactoryBot.create(:mentor_at_school_period,
+                              school: previous_school,
+                              started_on: previous_school_start,
+                              finished_on: previous_school_end)
+          end
+
+          let!(:previous_mentorship) do
+            FactoryBot.create(:mentorship_period,
+                              mentee: mentee_at_previous_school,
+                              mentor: previous_mentor,
+                              started_on: previous_school_start,
+                              finished_on: previous_school_end)
+          end
+
+          let!(:previous_mentor_training_period) do
+            FactoryBot.create(:training_period, :provider_led, :for_mentor,
+                              mentor_at_school_period: previous_mentor,
+                              started_on: previous_school_start,
+                              finished_on: previous_school_end)
+          end
+
+          context "when the previous mentor declared during the mentorship" do
+            let!(:declaration) do
+              FactoryBot.create(:declaration, :within_mentorship_period,
+                                training_period: previous_mentor_training_period)
+            end
+
+            it_behaves_like "replacement schedule assigned"
           end
         end
       end

--- a/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::LeadProviderStep do
                           mentee: ect_at_school_period,
                           mentor: previous_mentor)
 
-        FactoryBot.create(:declaration, training_period: previous_mentor_training_period)
+        FactoryBot.create(:declaration, :within_mentorship_period, training_period: previous_mentor_training_period)
       end
 
       it "assigns a replacement schedule to the mentor training period" do

--- a/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::ReviewMentorEligibilityStep 
                           mentee: ect_at_school_period,
                           mentor: previous_mentor)
 
-        FactoryBot.create(:declaration, training_period: previous_mentor_training_period)
+        FactoryBot.create(:declaration, :within_mentorship_period, training_period: previous_mentor_training_period)
       end
 
       it "assigns a replacement schedule to the mentor training period" do

--- a/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
@@ -251,7 +251,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-replacement-april")
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-replacement-september")
 
-        FactoryBot.create(:declaration, training_period: previous_mentor_training_period)
+        FactoryBot.create(:declaration, :within_mentorship_period, training_period: previous_mentor_training_period)
 
         store.ect_id = mentee.id
         store.lead_provider_id = lead_provider.id


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3870

### Changes proposed in this pull request

A new mentor should be assigned a `replacement` schedule (instead of a `standard` one) when they're taking over from a previous mentor who already started training this ECT, otherwise the new mentor would "start fresh" on a standard schedule and we'd double-count training milestones and funding.

As per the ticket description / comments, "started training" here has been clarified to mean: the previous mentor has at least one non-voided declaration whose `declaration_date` falls inside their mentorship period for this ECT. The date bounds matter because a mentor's training period can outlive (or precede) any individual mentorship — we only want declarations that landed while they were mentoring this mentee.

Two fixes in this PR to achieve this:
- The lookup now spans all of the mentee's `ECTAtSchoolPeriods`, not just their current one. Before this PR, if the ECT moved schools, the new mentor at school B could be given a fresh standard schedule, even though the mentor at school A had already declared training.
- Voided declarations are now excluded — they shouldn't count as evidence that training started.