### PR TITLE
Add lead provider name to logs

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -20,6 +20,7 @@ private
     super
     payload[:current_user_class] = current_lead_provider&.class&.name
     payload[:current_user_id] = current_lead_provider&.id
+    payload[:current_user_name] = current_lead_provider&.short_name
   end
 
 protected


### PR DESCRIPTION
It's a pain having to map between the `id` and the lead provider to find out who is making which requests; adding the LP short name to each log entry.

No easy way to test this that I can find but other request specs should cover it such that we know it won't blow up.
