### PR TITLE
[3874] Fix TRS name updates not bumping api_updated_at

### DIFF
--- a/app/models/concerns/declarative_updates.rb
+++ b/app/models/concerns/declarative_updates.rb
@@ -21,30 +21,34 @@ module DeclarativeUpdates
 
     def touch(target, when_changing: [], on_event: %i[update], timestamp_attribute: :updated_at, if: nil)
       condition = binding.local_variable_get(:if)
+      events = Array(on_event)
+      options = { target:, when_changing:, condition:, timestamp_attribute: }
 
-      after_commit(on: on_event) do
-        next if DeclarativeUpdates.skip?(:touch)
+      after_create { DeclarativeUpdates.perform_touch(self, **options) } if events.include?(:create)
+      after_update { DeclarativeUpdates.perform_touch(self, **options) } if events.include?(:update)
+      after_destroy { DeclarativeUpdates.perform_touch(self, **options) } if events.include?(:destroy)
+    end
+  end
 
-        should_touch_based_on_changes = destroyed? || when_changing.blank? || when_changing.any? do |attr|
-          saved_change_to_attribute?(attr)
-        end
+  def self.perform_touch(record, target:, when_changing:, condition:, timestamp_attribute:)
+    return if skip?(:touch)
 
-        should_touch_based_on_condition = condition.nil? || evaluate_condition(condition)
+    should_touch_based_on_changes = record.destroyed? || when_changing.blank? || when_changing.any? do |attr|
+      record.saved_change_to_attribute?(attr)
+    end
 
-        should_touch = should_touch_based_on_changes && should_touch_based_on_condition
+    should_touch_based_on_condition = condition.nil? || record.send(:evaluate_condition, condition)
 
-        next unless should_touch
+    return unless should_touch_based_on_changes && should_touch_based_on_condition
 
-        evaluated_target = instance_exec(&target)
+    evaluated_target = record.instance_exec(&target)
 
-        next unless evaluated_target
+    return unless evaluated_target
 
-        if evaluated_target.respond_to?(:update_all)
-          evaluated_target.update_all(timestamp_attribute => Time.zone.now)
-        else
-          evaluated_target.update_column(timestamp_attribute, Time.zone.now)
-        end
-      end
+    if evaluated_target.respond_to?(:update_all)
+      evaluated_target.update_all(timestamp_attribute => Time.zone.now)
+    else
+      evaluated_target.update_column(timestamp_attribute, Time.zone.now)
     end
   end
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -134,7 +134,8 @@ class Teacher < ApplicationRecord
   scope :not_failed, -> { where.not(trs_induction_status: %w[Failed FailedInWales]).or(induction_status_missing) }
   scope :not_passed, -> { where.not(trs_induction_status: "Passed").or(induction_status_missing) }
 
-  normalizes :corrected_name, with: -> { it.squish }
+  normalizes :trs_first_name, :trs_last_name, with: -> { it&.squish }
+  normalizes :corrected_name, with: -> { it&.squish }
 
   # Methods
   def eligible_for_funding?

--- a/app/services/teachers/refresh_trs_attributes.rb
+++ b/app/services/teachers/refresh_trs_attributes.rb
@@ -47,13 +47,11 @@ module Teachers
 
     # @return [Symbol]
     def update!
-      Teacher.transaction do
-        update_name!
-        update_trs_induction_status!
-        update_trs_attributes!
+      update_name!
+      update_trs_induction_status!
+      update_trs_attributes!
 
-        :teacher_updated
-      end
+      :teacher_updated
     end
 
     # @return [Symbol]

--- a/app/services/teachers/refresh_trs_attributes.rb
+++ b/app/services/teachers/refresh_trs_attributes.rb
@@ -47,11 +47,13 @@ module Teachers
 
     # @return [Symbol]
     def update!
-      update_name!
-      update_trs_induction_status!
-      update_trs_attributes!
+      Teacher.transaction do
+        update_name!
+        update_trs_induction_status!
+        update_trs_attributes!
 
-      :teacher_updated
+        :teacher_updated
+      end
     end
 
     # @return [Symbol]

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -54,6 +54,21 @@ describe Teacher do
     end
   end
 
+  describe "touch across multiple saves in one transaction", :with_touches do
+    it "bumps api_updated_at when a touched attribute changes in any save inside the transaction" do
+      teacher = FactoryBot.create(:teacher, trs_first_name: "Charlotte", trs_last_name: "Dunn")
+      teacher.update_columns(api_updated_at: 1.week.ago.round)
+      original_api_updated_at = teacher.reload.api_updated_at
+
+      Teacher.transaction do
+        teacher.update!(trs_first_name: "Charlie")
+        teacher.update!(trs_induction_status: "Passed")
+      end
+
+      expect(teacher.reload.api_updated_at).to be > original_api_updated_at
+    end
+  end
+
   describe "name normalisation" do
     it "squishes whitespace in trs_first_name and trs_last_name on assignment" do
       teacher = Teacher.new(trs_first_name: "  Charlotte  ", trs_last_name: "Dunn ")

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -38,6 +38,22 @@ describe Teacher do
                     timestamp_attribute: :api_unfunded_mentor_updated_at
   end
 
+  describe "touch rollback", :with_touches do
+    it "rolls back the api_updated_at touch when the surrounding transaction rolls back" do
+      teacher = FactoryBot.create(:teacher, trs_first_name: "Charlotte", trs_last_name: "Dunn")
+      original_api_updated_at = 1.week.ago.round
+      teacher.update_columns(api_updated_at: original_api_updated_at)
+
+      Teacher.transaction do
+        teacher.update!(trs_first_name: "Charlie")
+        raise ActiveRecord::Rollback
+      end
+
+      expect(teacher.reload.api_updated_at).to eq(original_api_updated_at)
+      expect(teacher.trs_first_name).to eq("Charlotte")
+    end
+  end
+
   describe "name normalisation" do
     it "squishes whitespace in trs_first_name and trs_last_name on assignment" do
       teacher = Teacher.new(trs_first_name: "  Charlotte  ", trs_last_name: "Dunn ")

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -38,6 +38,30 @@ describe Teacher do
                     timestamp_attribute: :api_unfunded_mentor_updated_at
   end
 
+  describe "name normalisation" do
+    it "squishes whitespace in trs_first_name and trs_last_name on assignment" do
+      teacher = Teacher.new(trs_first_name: "  Charlotte  ", trs_last_name: "Dunn ")
+
+      expect(teacher.trs_first_name).to eq("Charlotte")
+      expect(teacher.trs_last_name).to eq("Dunn")
+    end
+
+    it "treats a whitespace-only difference as no change" do
+      teacher = FactoryBot.create(:teacher, trs_first_name: "Charlotte", trs_last_name: "Dunn")
+
+      teacher.trs_last_name = "Dunn "
+
+      expect(teacher.changed?).to be(false)
+    end
+
+    it "leaves nil values untouched" do
+      teacher = Teacher.new(trs_first_name: nil, trs_last_name: nil)
+
+      expect(teacher.trs_first_name).to be_nil
+      expect(teacher.trs_last_name).to be_nil
+    end
+  end
+
   describe "associations" do
     it { is_expected.to have_many(:ect_at_school_periods) }
     it { is_expected.to have_many(:mentor_at_school_periods) }

--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe Teachers::Manage do
         end
       end
     end
+
+    context "when only whitespace differs" do
+      before { allow(RecordEventJob).to receive(:perform_later).and_return(true) }
+
+      it "does not record a name change event and does not bump api_updated_at", :with_touches do
+        original_api_updated_at = teacher.api_updated_at
+
+        service.update_name!(trs_first_name: "Barry", trs_last_name: "Allen ")
+
+        expect(RecordEventJob).not_to have_received(:perform_later)
+        expect(teacher.reload.api_updated_at).to eq(original_api_updated_at)
+        expect(teacher.trs_last_name).to eq("Allen")
+      end
+    end
   end
 
   describe "#update_trs_attributes!" do

--- a/spec/services/teachers/refresh_trs_attributes_spec.rb
+++ b/spec/services/teachers/refresh_trs_attributes_spec.rb
@@ -35,6 +35,18 @@ describe Teachers::RefreshTRSAttributes do
       end
     end
 
+    it "bumps api_updated_at and api_unfunded_mentor_updated_at when the TRS name changes", :with_touches do
+      teacher.update_columns(api_updated_at: 1.week.ago, api_unfunded_mentor_updated_at: 1.week.ago)
+      original_api_updated_at = teacher.reload.api_updated_at
+      original_api_unfunded_mentor_updated_at = teacher.api_unfunded_mentor_updated_at
+
+      service.refresh!
+      teacher.reload
+
+      expect(teacher.api_updated_at).to be > original_api_updated_at
+      expect(teacher.api_unfunded_mentor_updated_at).to be > original_api_unfunded_mentor_updated_at
+    end
+
     it "adds a teacher_name_updated_by_trs event" do
       expect(teacher.events).to be_empty
 


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3874

### Changes proposed in this pull request

* Normalise `trs_first_name` and `trs_last_name` with squish.

* `DeclarativeUpdates.touch` now uses `after_create`, `after_update` and `after_destroy` instead of `after_commit` so that we run touch on every save within a single transaction.

### Guidance to review
