### PR TITLE
[3896] Fix bug when `updated_at` is not updating when SIT details are updated on GET schools

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -28,7 +28,7 @@ class School < ApplicationRecord
   has_many :training_periods, through: :school_partnerships
   has_many :school_funding_eligibilities, foreign_key: :school_urn, primary_key: :urn, inverse_of: :school
 
-  touch -> { contract_period_metadata }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
+  touch -> { contract_period_metadata }, when_changing: %i[urn induction_tutor_name induction_tutor_email], timestamp_attribute: :api_updated_at
   touch -> { school_partnerships }, when_changing: %i[urn induction_tutor_name induction_tutor_email], timestamp_attribute: :api_updated_at
   touch -> { ect_teachers }, when_changing: %i[urn], timestamp_attribute: :api_updated_at
   touch -> { mentor_teachers }, when_changing: %i[urn], timestamp_attribute: :api_updated_at

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe School do
 
       before { Metadata::Handlers::School.new(instance).refresh_metadata! }
 
-      it_behaves_like "a declarative touch model", when_changing: %i[urn], timestamp_attribute: :api_updated_at
+      it_behaves_like "a declarative touch model", when_changing: %i[urn induction_tutor_name induction_tutor_email], timestamp_attribute: :api_updated_at
     end
 
     context "target school_partnerships" do


### PR DESCRIPTION
### Context

Ticket: [3896](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3896)

It was raised by a LP, that the `updated_at` value is not updating when SIT details are updated on GET schools.

### Changes proposed in this pull request

- Touch `contract_period_metadata.api_updated_at` when SIT details are updated as it's where `api_updated_at` value comes from in the school serializer.

### Guidance to review

Review app