### PR TITLE
PR labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+"API Release Note":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/views/api/release_notes/release_notes.yml"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Triage labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   label:
-    name: Triage labels
+    name: Apply labels
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6


### PR DESCRIPTION
### Context

Automatic labels on PRs was identified as beneficial for ensuring API release notes are published and maintained.

https://github.com/actions/labeler

### Changes proposed in this pull request

- Add Github's labeler workflow
- Add rule for tagging release notes with `API Release Note`

### Guidance to review

- Edit the release note YAML
- Could follow with `Devops`, `Documentation` and `Dependencies`