### PR TITLE
[3903] Remove mentor name link from ECT summary card

### DIFF
--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -108,7 +108,7 @@ module Schools
       def mentor_row
         {
           key: { text: "Mentor", classes: %w[mentor-key] },
-          value: { text: ect_mentor_details(ect_at_school_period) }
+          value: { text: ect_mentor_details(ect_at_school_period, link_to_mentor: false) }
         }
       end
 

--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -95,14 +95,13 @@ module ECTHelper
   end
 
   # @param ect [ECTAtSchoolPeriod]
-  def ect_mentor_details(ect)
+  def ect_mentor_details(ect, link_to_mentor: true)
     mentorship = ECTAtSchoolPeriods::Mentorship.new(ect)
 
-    if mentorship && mentorship.current_mentor.present?
-      govuk_link_to(mentorship.current_mentor_name, schools_mentor_path(mentorship.current_mentor))
-    else
-      link_to_assign_mentor(ect)
-    end
+    return link_to_assign_mentor(ect) if mentorship.current_mentor.blank?
+    return mentorship.current_mentor_name unless link_to_mentor
+
+    govuk_link_to(mentorship.current_mentor_name, schools_mentor_path(mentorship.current_mentor))
   end
 
   # @param ect [ECTAtSchoolPeriod]

--- a/spec/components/schools/ects/listing_card_component_spec.rb
+++ b/spec/components/schools/ects/listing_card_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :local_authority_ab, teacher:, school:, started_on:, finished_on: nil) }
   let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period:, started_on:) }
   let(:mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: nil) }
+  let(:mentor_name) { Teachers::Name.new(mentor.teacher).full_name }
   let(:valid_withdrawal_reason) { TrainingPeriod.withdrawal_reasons.keys.first }
   let(:valid_deferral_reason) { TrainingPeriod.deferral_reasons.keys.first }
 
@@ -20,6 +21,12 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
       expect(rendered_content).to have_selector(".govuk-summary-list__row", text: "Status")
       expect(rendered_content).to have_text("Registered")
     end
+
+    it "renders the mentor name without a link" do
+      expect(rendered_content).to have_selector(".govuk-summary-list__row", text: "Mentor")
+      expect(rendered_content).to have_text(mentor_name)
+      expect(rendered_content).not_to have_link(mentor_name)
+    end
   end
 
   context "when the ECT has no mentor assigned" do
@@ -29,6 +36,10 @@ RSpec.describe Schools::ECTs::ListingCardComponent, type: :component do
       expect(rendered_content).to have_selector(".govuk-summary-list__row", text: "Status")
       expect(rendered_content).to have_text("Action required")
       expect(rendered_content).to have_text("A mentor needs to be assigned to Naruto Uzumaki.")
+    end
+
+    it "renders the assign mentor link" do
+      expect(rendered_content).to have_link("Assign a mentor for this ECT")
     end
   end
 


### PR DESCRIPTION
### Context

Some schools have been changing the current mentor's details instead of assigning a new mentor to an ECT. This PR removes the mentor hyperlink from the ECT listing summary card to reduce that confusion.

### Changes

- Remove the mentor name link from the ECT listing summary card
- Keep the assign mentor link when an ECT has no mentor

| Before | After |
|--------|-------|
|<img width="1043" height="375" alt="image" src="https://github.com/user-attachments/assets/4d3b1a51-8820-4fde-a078-ff3c190045d0" />|<img width="1016" height="368" alt="image" src="https://github.com/user-attachments/assets/493937ea-035b-47c0-80de-df8fc485760f" />|