### PR TITLE
Label workflow rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,31 @@
 "API Release Note":
   - changed-files:
-      - any-glob-to-any-file:
-          - "app/views/api/release_notes/release_notes.yml"
+    - any-glob-to-any-file:
+      - "app/views/api/release_notes/release_notes.yml"
+
+Dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/dependabot.yml"
+      - "Gemfile"
+      - "package.json"
+
+Devops:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/*"
+      - ".github/actions/**/*"
+      - ".github/workflows/**/*"
+      - "config/terraform/**/*"
+
+Docker:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".devcontainer/**/*"
+      - "Dockerfile"
+
+Documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "documentation/**/*"
+      - "README.md"


### PR DESCRIPTION
### Context

The autolabeller works. Now we are adding our other labels which should flag non-code changes and keep dev PRs labelled like 🤖 dependebot's.

### Changes proposed in this pull request

Add rules for all the `D`s: `Dependencies`, `Devops`, `Docker`, and `Documentation`

### Guidance to review
