### PR TITLE
[3515] Prevent mentor_no_longer_being_mentor withdrawal reason for ECTs

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -78,6 +78,7 @@ class TrainingPeriod < ApplicationRecord
   validate :only_provider_led_mentor_training
   validates :withdrawn_at, presence: true, if: -> { withdrawal_reason.present? }
   validates :withdrawal_reason, presence: true, if: -> { withdrawn_at.present? }
+  validate :withdrawal_reason_valid_for_trainee_type
   validates :deferred_at, presence: true, if: -> { deferral_reason.present? }
   validates :deferral_reason, presence: true, if: -> { deferred_at.present? }
   validates :schedule, presence: { message: "Schedule is required for provider-led training periods" }, if: :provider_led_training_programme?
@@ -253,6 +254,13 @@ private
     return unless for_ect?
 
     errors.add(:schedule, "Only mentors can be assigned to replacement schedules") if schedule.replacement_schedule?
+  end
+
+  def withdrawal_reason_valid_for_trainee_type
+    return unless for_ect?
+    return unless mentor_no_longer_being_mentor_withdrawal_reason?
+
+    errors.add(:withdrawal_reason, "You cannot withdraw an ECT for this reason. The ECT is not a mentor.")
   end
 
   def school_consistency

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -2,6 +2,8 @@ class TrainingPeriod < ApplicationRecord
   include Interval
   include DeclarativeUpdates
 
+  MENTOR_ONLY_WITHDRAWAL_REASONS = %w[mentor_no_longer_being_mentor].freeze
+
   # Enums
   enum :training_programme,
        { provider_led: "provider_led",
@@ -258,7 +260,7 @@ private
 
   def withdrawal_reason_valid_for_trainee_type
     return unless for_ect?
-    return unless mentor_no_longer_being_mentor_withdrawal_reason?
+    return unless MENTOR_ONLY_WITHDRAWAL_REASONS.include?(withdrawal_reason)
 
     errors.add(:withdrawal_reason, "You cannot withdraw an ECT for this reason. The ECT is not a mentor.")
   end

--- a/app/services/api/teachers/withdraw.rb
+++ b/app/services/api/teachers/withdraw.rb
@@ -3,7 +3,7 @@ module API::Teachers
     include API::Concerns::Teachers::SharedAction
 
     WITHDRAWAL_REASONS = TrainingPeriod.withdrawal_reasons.values.map(&:dasherize).freeze
-    MENTOR_ONLY_WITHDRAWAL_REASONS = %w[mentor-no-longer-being-mentor].freeze
+    MENTOR_ONLY_WITHDRAWAL_REASONS = TrainingPeriod::MENTOR_ONLY_WITHDRAWAL_REASONS.map(&:dasherize).freeze
 
     attribute :reason
 

--- a/app/services/api/teachers/withdraw.rb
+++ b/app/services/api/teachers/withdraw.rb
@@ -3,6 +3,7 @@ module API::Teachers
     include API::Concerns::Teachers::SharedAction
 
     WITHDRAWAL_REASONS = TrainingPeriod.withdrawal_reasons.values.map(&:dasherize).freeze
+    MENTOR_ONLY_WITHDRAWAL_REASONS = %w[mentor-no-longer-being-mentor].freeze
 
     attribute :reason
 
@@ -14,6 +15,7 @@ module API::Teachers
     validate :not_already_withdrawn
     validate :training_period_has_started
     validate :training_for_at_least_one_day
+    validate :reason_valid_for_teacher_type
 
     def withdraw
       return false unless valid?
@@ -48,6 +50,14 @@ module API::Teachers
       return unless training_period&.started_on&.today?
 
       errors.add(:teacher_api_id, "You cannot defer or withdraw this participant today. You need to try again tomorrow as the training was recently changed for this participant.")
+    end
+
+    def reason_valid_for_teacher_type
+      return if errors.any?
+      return unless training_period&.for_ect?
+      return unless MENTOR_ONLY_WITHDRAWAL_REASONS.include?(reason)
+
+      errors.add(:reason, "You cannot withdraw an ECT for this reason. The ECT is not a mentor.")
     end
   end
 end

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,6 +21,45 @@
 #
 #     **bold** and _italic_ text
 
+- title: Prevent invalid withdrawal reason for early career teachers
+  date: 2026-05-08
+  tags:
+    - breaking-change
+  body: |
+    We’ve introduced a new validation on the `/api/v3/participants/{id}/withdraw` endpoint to prevent early career teachers (ECTs) from being withdrawn using an invalid withdrawal reason.
+
+    ## What’s changed
+
+    Lead providers can no longer withdraw an ECT using the withdrawal reason:
+
+    `mentor-no-longer-being-mentor`
+
+    This reason is only valid for mentors and does not apply to ECTs.
+
+    If you attempt to withdraw an ECT using this reason via `/api/v3/participants/{id}/withdraw`, the API will return the following validation error:
+
+    > You cannot withdraw an ECT for this reason. The ECT is not a mentor.
+
+    ## Why we’ve made this change
+
+    Previously, this withdrawal reason was available for ECTs despite not being applicable. This could lead to incorrect or confusing data being recorded.
+
+    This change improves data quality by:
+
+    - preventing invalid withdrawal reasons being used for ECTs
+    - making the API behaviour clearer and more consistent
+    - reducing follow‑up and correction work for lead providers
+
+    ## Who this applies to
+
+    This change only affects ECTs. Withdrawal behaviour for mentors is unchanged.
+
+    ## What you need to do
+
+    If your systems allow withdrawal reasons to be selected automatically or from a predefined list, ensure `mentor-no-longer-being-mentor` is not used when withdrawing ECTs.
+
+    You may also want to update any internal validation or user guidance that references ECT withdrawals.
+
 - title: Add working_pattern field for early career teachers
   date: 2026-05-07
   tags:
@@ -60,47 +99,6 @@
     No action is required. This is a non‑breaking, optional field.
 
     If your integration supports additional fields, you can start using `working_pattern` now.
-
-- title: Prevent invalid withdrawal reason for early career teachers
-  date: 2026-05-06
-  tags:
-    - sandbox-release
-    - production-release
-    - breaking-change
-  body: |
-    We’ve introduced a new validation on the `/api/v3/participants/{id}/withdraw` endpoint to prevent early career teachers (ECTs) from being withdrawn using an invalid withdrawal reason.
-
-    ## What’s changed
-
-    Lead providers can no longer withdraw an ECT using the withdrawal reason:
-
-    `mentor_no_longer_being_mentor`
-
-    This reason is only valid for mentors and does not apply to ECTs.
-
-    If you attempt to withdraw an ECT using this reason via `/api/v3/participants/{id}/withdraw`, the API will return the following validation error:
-
-    > You cannot withdraw an ECT for this reason. The ECT is not a mentor.
-
-    ## Why we’ve made this change
-
-    Previously, this withdrawal reason was available for ECTs despite not being applicable. This could lead to incorrect or confusing data being recorded.
-
-    This change improves data quality by:
-
-    - preventing invalid withdrawal reasons being used for ECTs
-    - making the API behaviour clearer and more consistent
-    - reducing follow‑up and correction work for lead providers
-
-    ## Who this applies to
-
-    This change only affects ECTs. Withdrawal behaviour for mentors is unchanged.
-
-    ## What you need to do
-
-    If your systems allow withdrawal reasons to be selected automatically or from a predefined list, ensure `mentor_no_longer_being_mentor` is not used when withdrawing ECTs.
-
-    You may also want to update any internal validation or user guidance that references ECT withdrawals.
 
 - title: Updates to schedule and cohort changes for deferred and withdrawn participants
   date: 2026-05-05

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -49,7 +49,7 @@
     ## Why we’ve made this change
 
     By exposing this data through the API, lead providers can:
-    
+
     - better understand whether an ECT is working part‑time or full‑time
     - tailor training and support more effectively
     - reduce manual follow‑up with schools
@@ -60,6 +60,47 @@
     No action is required. This is a non‑breaking, optional field.
 
     If your integration supports additional fields, you can start using `working_pattern` now.
+
+- title: Prevent invalid withdrawal reason for early career teachers
+  date: 2026-05-06
+  tags:
+    - sandbox-release
+    - production-release
+    - breaking-change
+  body: |
+    We’ve introduced a new validation on the `/api/v3/participants/{id}/withdraw` endpoint to prevent early career teachers (ECTs) from being withdrawn using an invalid withdrawal reason.
+
+    ## What’s changed
+
+    Lead providers can no longer withdraw an ECT using the withdrawal reason:
+
+    `mentor_no_longer_being_mentor`
+
+    This reason is only valid for mentors and does not apply to ECTs.
+
+    If you attempt to withdraw an ECT using this reason via `/api/v3/participants/{id}/withdraw`, the API will return the following validation error:
+
+    > You cannot withdraw an ECT for this reason. The ECT is not a mentor.
+
+    ## Why we’ve made this change
+
+    Previously, this withdrawal reason was available for ECTs despite not being applicable. This could lead to incorrect or confusing data being recorded.
+
+    This change improves data quality by:
+
+    - preventing invalid withdrawal reasons being used for ECTs
+    - making the API behaviour clearer and more consistent
+    - reducing follow‑up and correction work for lead providers
+
+    ## Who this applies to
+
+    This change only affects ECTs. Withdrawal behaviour for mentors is unchanged.
+
+    ## What you need to do
+
+    If your systems allow withdrawal reasons to be selected automatically or from a predefined list, ensure `mentor_no_longer_being_mentor` is not used when withdrawing ECTs.
+
+    You may also want to update any internal validation or user guidance that references ECT withdrawals.
 
 - title: Updates to schedule and cohort changes for deferred and withdrawn participants
   date: 2026-05-05

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -142,7 +142,11 @@ FactoryBot.define do
       started_on { period_start_date }
       finished_on { period_end_date  }
       withdrawn_at { Faker::Date.between(from: started_on, to: (period_end_date)) }
-      withdrawal_reason { TrainingPeriod.withdrawal_reasons.values.sample }
+      withdrawal_reason do
+        reasons = TrainingPeriod.withdrawal_reasons.values
+        reasons -= %w[mentor_no_longer_being_mentor] if ect_at_school_period.present?
+        reasons.sample
+      end
     end
 
     trait :deferred do

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -144,7 +144,7 @@ FactoryBot.define do
       withdrawn_at { Faker::Date.between(from: started_on, to: (period_end_date)) }
       withdrawal_reason do
         reasons = TrainingPeriod.withdrawal_reasons.values
-        reasons -= %w[mentor_no_longer_being_mentor] if ect_at_school_period.present?
+        reasons -= TrainingPeriod::MENTOR_ONLY_WITHDRAWAL_REASONS if ect_at_school_period.present?
         reasons.sample
       end
     end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -728,6 +728,64 @@ describe TrainingPeriod do
       end
     end
 
+    describe "withdrawal reason valid for trainee type" do
+      context "when training period is for an ECT" do
+        subject do
+          FactoryBot.build(
+            :training_period,
+            :for_ect,
+            ect_at_school_period:,
+            started_on: 3.months.ago,
+            finished_on: 1.month.ago,
+            withdrawn_at: 1.month.ago,
+            withdrawal_reason:
+          )
+        end
+
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 6.months.ago, finished_on: nil) }
+
+        context "when withdrawal_reason is mentor_no_longer_being_mentor" do
+          let(:withdrawal_reason) { :mentor_no_longer_being_mentor }
+
+          it "is invalid with the appropriate error" do
+            subject.valid?
+            expect(subject.errors[:withdrawal_reason]).to include("You cannot withdraw an ECT for this reason. The ECT is not a mentor.")
+          end
+        end
+
+        context "when withdrawal_reason is something other than mentor_no_longer_being_mentor" do
+          let(:withdrawal_reason) { :left_teaching_profession }
+
+          it "does not add the trainee-type error" do
+            subject.valid?
+            expect(subject.errors[:withdrawal_reason]).to be_empty
+          end
+        end
+      end
+
+      context "when training period is for a mentor" do
+        subject do
+          FactoryBot.build(
+            :training_period,
+            :for_mentor,
+            mentor_at_school_period:,
+            started_on: 3.months.ago,
+            finished_on: 1.month.ago,
+            withdrawn_at: 1.month.ago,
+            withdrawal_reason:
+          )
+        end
+
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 6.months.ago, finished_on: nil) }
+        let(:withdrawal_reason) { :mentor_no_longer_being_mentor }
+
+        it "does not add the trainee-type error" do
+          subject.valid?
+          expect(subject.errors[:withdrawal_reason]).to be_empty
+        end
+      end
+    end
+
     describe "school consistency" do
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
       let(:training_period) { FactoryBot.build(:training_period, ect_at_school_period:, school_partnership:, expression_of_interest:) }

--- a/spec/services/api/teachers/withdraw_spec.rb
+++ b/spec/services/api/teachers/withdraw_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
     )
   end
 
-  let(:reason) { described_class::WITHDRAWAL_REASONS.sample }
+  let(:reason) { (described_class::WITHDRAWAL_REASONS - described_class::MENTOR_ONLY_WITHDRAWAL_REASONS).sample }
 
   it_behaves_like "an API teacher shared action" do
     describe "validations" do
@@ -78,6 +78,25 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
             it { is_expected.to have_one_error_per_attribute }
           end
         end
+      end
+
+      context "for ect with mentor-no-longer-being-mentor reason" do
+        let(:at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.months.ago) }
+        let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: at_school_period, started_on: at_school_period.started_on) }
+        let(:teacher_type) { :ect }
+        let(:reason) { described_class::MENTOR_ONLY_WITHDRAWAL_REASONS.sample }
+
+        it { is_expected.to have_one_error_per_attribute }
+        it { is_expected.to have_error(:reason, "You cannot withdraw an ECT for this reason. The ECT is not a mentor.") }
+      end
+
+      context "for mentor with mentor-no-longer-being-mentor reason" do
+        let(:at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 2.months.ago) }
+        let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: at_school_period, started_on: at_school_period.started_on) }
+        let(:teacher_type) { :mentor }
+        let(:reason) { described_class::MENTOR_ONLY_WITHDRAWAL_REASONS.sample }
+
+        it { is_expected.to be_valid }
       end
     end
 

--- a/spec/services/teachers/withdraw_spec.rb
+++ b/spec/services/teachers/withdraw_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Teachers::Withdraw do
   let(:author) { Events::LeadProviderAPIAuthor.new(lead_provider:) }
   let(:lead_provider) { training_period.lead_provider }
-  let(:reason) { TrainingPeriod.withdrawal_reasons.values.map(&:dasherize).freeze.sample }
+  let(:reason) { (TrainingPeriod.withdrawal_reasons.values - TrainingPeriod::MENTOR_ONLY_WITHDRAWAL_REASONS).map(&:dasherize).sample }
   let(:teacher) { training_period.teacher }
 
   let(:service) do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3515

### Changes proposed in this pull request

* New validation in `API::Teachers::Withdraw`
* New validation in `TrainingPeriod` to reject the mentor-only withdrawal reason for ECTs
* Placeholder release note

### Guidance to review
