### PR TITLE
[3913] Remove mentor name links from ECT summaries

### DIFF
--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -108,7 +108,7 @@ module Schools
       def mentor_row
         {
           key: { text: "Mentor", classes: %w[mentor-key] },
-          value: { text: ect_mentor_details(ect_at_school_period, link_to_mentor: false) }
+          value: { text: ect_mentor_details(ect_at_school_period) }
         }
       end
 

--- a/app/components/schools/ects/listing_card_component.rb
+++ b/app/components/schools/ects/listing_card_component.rb
@@ -108,7 +108,7 @@ module Schools
       def mentor_row
         {
           key: { text: "Mentor", classes: %w[mentor-key] },
-          value: { text: ect_mentor_details(ect_at_school_period) }
+          value: { text: ect_mentor_name_or_assign_mentor_link(ect_at_school_period) }
         }
       end
 

--- a/app/components/schools/teacher_profile_summary_list_component.html.erb
+++ b/app/components/schools/teacher_profile_summary_list_component.html.erb
@@ -25,7 +25,7 @@
 
   <% list.with_row do |row| %>
     <% row.with_key { "Mentor" } %>
-    <% row.with_value { ect_mentor_details(@ect) } %>
+    <% row.with_value { ect_mentor_name_or_assign_mentor_link(@ect) } %>
     <% if current_mentor.present? %>
       <% row.with_action(
         text: "Change",

--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -95,7 +95,7 @@ module ECTHelper
   end
 
   # @param ect [ECTAtSchoolPeriod]
-  def ect_mentor_details(ect)
+  def ect_mentor_name_or_assign_mentor_link(ect)
     mentorship = ECTAtSchoolPeriods::Mentorship.new(ect)
 
     return link_to_assign_mentor(ect) if mentorship.current_mentor.blank?

--- a/app/helpers/ect_helper.rb
+++ b/app/helpers/ect_helper.rb
@@ -95,13 +95,12 @@ module ECTHelper
   end
 
   # @param ect [ECTAtSchoolPeriod]
-  def ect_mentor_details(ect, link_to_mentor: true)
+  def ect_mentor_details(ect)
     mentorship = ECTAtSchoolPeriods::Mentorship.new(ect)
 
     return link_to_assign_mentor(ect) if mentorship.current_mentor.blank?
-    return mentorship.current_mentor_name unless link_to_mentor
 
-    govuk_link_to(mentorship.current_mentor_name, schools_mentor_path(mentorship.current_mentor))
+    mentorship.current_mentor_name
   end
 
   # @param ect [ECTAtSchoolPeriod]

--- a/spec/components/schools/teacher_profile_summary_list_component_spec.rb
+++ b/spec/components/schools/teacher_profile_summary_list_component_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   subject { page }
 
   let(:school) { FactoryBot.create(:school) }
@@ -6,12 +8,15 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
   let(:mentor_teacher) { FactoryBot.create(:teacher, trn: "987654", trs_first_name: "Naruto", trs_last_name: "Ninetails") }
   let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: 3.years.ago) }
   let(:current_mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher: mentor_teacher, started_on: 3.years.ago) }
+  let(:current_mentor_name) { Teachers::Name.new(current_mentor.teacher).full_name }
   let(:mentee) do
     FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: mentee_teacher, started_on: Date.new(2021, 9, 1),
                                                        email: "foobarect@madeup.com", working_pattern: "full_time")
   end
 
   context "when the ECT has a mentor assigned" do
+    let(:mentor_row) { page.find(".govuk-summary-list__row", text: "Mentor") }
+
     before do
       FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: previous_mentor, started_on: 3.years.ago, finished_on: 2.years.ago - 1.day)
       FactoryBot.create(:mentorship_period, :ongoing, mentee:, mentor: current_mentor, started_on: 2.years.ago)
@@ -30,6 +35,15 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
     it { is_expected.to have_summary_list_row("School start date", value: "1 September 2021") }
     it { is_expected.to have_summary_list_row("Working pattern", value: "Full time") }
     it { is_expected.to have_summary_list_row("Status") }
+
+    it "renders the mentor name without a link" do
+      expect(mentor_row).to have_css(".govuk-summary-list__value", text: current_mentor_name)
+      expect(mentor_row).not_to have_link(current_mentor_name)
+    end
+
+    it "renders the change mentor link" do
+      expect(mentor_row).to have_link("Change", href: schools_ects_change_mentor_wizard_edit_path(mentee))
+    end
   end
 
   context "when latest started training is deferred" do
@@ -245,6 +259,10 @@ RSpec.describe Schools::TeacherProfileSummaryListComponent, type: :component do
       expect(page).to have_text("Action required")
       expect(page).to have_text("A mentor needs to be assigned to Kakarot SSJ.")
       expect(page).not_to have_text("Mentor required")
+    end
+
+    it "renders the assign mentor link" do
+      expect(page).to have_link("Assign a mentor for this ECT")
     end
   end
 

--- a/spec/helpers/ect_helper_spec.rb
+++ b/spec/helpers/ect_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ECTHelper, type: :helper do
   let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
 
   describe "#ect_mentor_details" do
-    subject { helper.ect_mentor_details(ect_at_school_period) }
+    subject(:mentor_details) { helper.ect_mentor_details(ect_at_school_period) }
 
     let(:default_link_text) { "Assign a mentor for this ECT" }
 
@@ -18,7 +18,8 @@ RSpec.describe ECTHelper, type: :helper do
         FactoryBot.create(:mentorship_period, :ongoing, mentee: ect_at_school_period, mentor: mentor_at_school_period, started_on:)
       end
 
-      it { is_expected.to have_link(latest_mentor_name(ect_at_school_period), href: schools_mentor_path(mentor_at_school_period)) }
+      it { is_expected.to eq(latest_mentor_name(ect_at_school_period)) }
+      it { is_expected.not_to have_link(latest_mentor_name(ect_at_school_period)) }
       it { is_expected.not_to have_link(default_link_text) }
     end
   end

--- a/spec/helpers/ect_helper_spec.rb
+++ b/spec/helpers/ect_helper_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ECTHelper, type: :helper do
   let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:, started_on:) }
   let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:) }
 
-  describe "#ect_mentor_details" do
-    subject(:mentor_details) { helper.ect_mentor_details(ect_at_school_period) }
+  describe "#ect_mentor_name_or_assign_mentor_link" do
+    subject(:mentor_details) { helper.ect_mentor_name_or_assign_mentor_link(ect_at_school_period) }
 
     let(:default_link_text) { "Assign a mentor for this ECT" }
 


### PR DESCRIPTION
### Summary

Following on from #2853, we also want to remove the links to the mentor from the ECT show page.


### Context

Some schools have been changing the current mentor's details instead of assigning a new mentor to an ECT. This PR removes the mentor hyperlink from the ECT show page to reduce that confusion.

| Before | After |
|--------|-------|
|<img width="732" height="469" alt="image" src="https://github.com/user-attachments/assets/4e874064-25c1-4e17-9be4-34f8b54bd04a" />|<img width="788" height="468" alt="image" src="https://github.com/user-attachments/assets/b07e9dbb-5fa9-424b-8167-42a40091e35b" />|
