### PR TITLE
Align admin timeline H1 with the other admin tabs

### DIFF
--- a/app/views/admin/teachers/timeline/show.html.erb
+++ b/app/views/admin/teachers/timeline/show.html.erb
@@ -1,6 +1,6 @@
 <%
   page_data(
-    title: smart_quotes(teacher_full_name(@teacher) + "'s timeline"),
+    title: teacher_full_name(@teacher),
     caption: teacher_trn(@teacher),
     caption_size: 'm',
     error: false,


### PR DESCRIPTION
### Summary

Align the timeline H1 with the other admin tabs.

| Before | After |
|--------|-------|
|<img width="1082" height="804" alt="image" src="https://github.com/user-attachments/assets/9eaae976-1653-4f74-9a1d-761015566a2d" />|<img width="1146" height="789" alt="image" src="https://github.com/user-attachments/assets/4d245b1a-b7c3-44ad-9773-03ae600fd34c" />|

