### PR TITLE
[3140] Block declarations in frozen contract periods for ineligible participants

### DIFF
--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -33,7 +33,7 @@ module API::Declarations
     validate :validate_only_started_or_completed_if_mentor
     validates :evidence_type, evidence_type: true, if: -> { errors.empty? }
     validate :teacher_not_withdrawn_before_declaration_date
-    validate :not_eligible_in_frozen_contract_period
+    validate :frozen_contract_period_for_ongoing_training_period
     validate :payment_statement_available
     validate :validate_milestone_exists
     validate :declaration_in_sequence
@@ -202,12 +202,12 @@ module API::Declarations
       errors.add(:contract_period_year, "You cannot submit or void declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.")
     end
 
-    def not_eligible_in_frozen_contract_period
+    def frozen_contract_period_for_ongoing_training_period
       return if errors[:contract_period_year].any?
       return unless teacher
 
       training_period_ongoing_today = training_periods.ongoing_today.first
-      return unless training_period_ongoing_today&.eligible_for_funding?
+      return unless training_period_ongoing_today
 
       current_contract_period = training_period_ongoing_today.contract_period
       return unless current_contract_period&.payments_frozen?

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -33,7 +33,7 @@ module API::Declarations
     validate :validate_only_started_or_completed_if_mentor
     validates :evidence_type, evidence_type: true, if: -> { errors.empty? }
     validate :teacher_not_withdrawn_before_declaration_date
-    validate :frozen_contract_period_for_ongoing_training_period
+    validate :contract_period_is_not_payments_frozen
     validate :payment_statement_available
     validate :validate_milestone_exists
     validate :declaration_in_sequence
@@ -202,7 +202,7 @@ module API::Declarations
       errors.add(:contract_period_year, "You cannot submit or void declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.")
     end
 
-    def frozen_contract_period_for_ongoing_training_period
+    def contract_period_is_not_payments_frozen
       return if errors[:contract_period_year].any?
       return unless teacher
 

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -216,7 +216,8 @@ RSpec.describe API::Declarations::Create, type: :model do
               contract_period.update!(payments_frozen_at: Time.zone.now)
             end
 
-            it { is_expected.to be_valid }
+            it { is_expected.to have_one_error_only }
+            it { is_expected.to have_error(:contract_period_year, "You cannot submit declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.") }
           end
 
           context "when teacher's latest ongoing training period is in a non-frozen contract period and participant is eligible for funding" do


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3140

### Changes proposed in this pull request

* Previous validation `not_eligible_in_frozen_contract_period` would be skipped if teacher is ineligible for funding therefore allowing frozen contract period
* Now we no longer skip the validation, and error when contract period is frozen
* Renamed validation to `frozen_contract_period_for_ongoing_training_period`

### Guidance to review
