### PR TITLE
Make contract period ranges inclusive end

### DIFF
--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -29,27 +29,11 @@ class ContractPeriod < ApplicationRecord
             :detailed_evidence_types_enabled,
             :uplift_fees_enabled, inclusion: { in: [true, false] }
 
-  def self.containing_date_end_exclusive(date)
+  def self.containing_date(date)
     find_by(*date_in_range(date))
   end
 
-  def self.containing_date_end_inclusive(date)
-    find_by(*date_in_range_inclusive_start_inclusive_end(date))
-  end
-
-  def self.containing_date(date)
-    containing_date_end_inclusive(date)
-  end
-
-  def self.current_end_exclusive
-    containing_date_end_exclusive(Time.zone.today)
-  end
-
-  def self.current_end_inclusive
-    containing_date_end_inclusive(Time.zone.today)
-  end
-
-  def self.current = current_end_inclusive
+  def self.current = containing_date(Date.current)
 
   def self.earliest_permitted_start_date
     return unless current
@@ -66,7 +50,7 @@ class ContractPeriod < ApplicationRecord
     current_contract_period = current
     return current_contract_period unless current_contract_period && start_date.is_a?(Date)
 
-    contract_period_from_start_date = containing_date_end_inclusive(start_date)
+    contract_period_from_start_date = containing_date(start_date)
     return current_contract_period if contract_period_from_start_date.nil?
     return current_contract_period if contract_period_from_start_date.year < current_contract_period.year
 

--- a/app/services/concerns/queries/range_queries.rb
+++ b/app/services/concerns/queries/range_queries.rb
@@ -3,22 +3,9 @@ module Queries
     extend ActiveSupport::Concern
 
     class_methods do
-      def date_in_range_inclusive_start_exclusive_end(date, range_column: "range")
+      def date_in_range(date, range_column: "range")
         [%("#{table_name}"."#{range_column}" @> date(?)), date]
       end
-
-      def date_in_range_inclusive_start_inclusive_end(date, range_column: "range")
-        [%(
-          daterange(
-            lower("#{table_name}"."#{range_column}"),
-            upper("#{table_name}"."#{range_column}"),
-            '[]'
-          ) @> date(?)
-        ).squish,
-         date]
-      end
-
-      alias_method :date_in_range, :date_in_range_inclusive_start_exclusive_end
 
       def containing_range(start, finish, range_column: "range")
         [%("#{table_name}"."#{range_column}" @> daterange(?, ?)), start, finish]

--- a/db/migrate/20260506131056_make_contract_period_ranges_inclusive_end.rb
+++ b/db/migrate/20260506131056_make_contract_period_ranges_inclusive_end.rb
@@ -1,0 +1,8 @@
+class MakeContractPeriodRangesInclusiveEnd < ActiveRecord::Migration[8.1]
+  def change
+    # rubocop:disable Rails/BulkChangeTable
+    remove_column :contract_periods, :range, :daterange
+    add_column :contract_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on, '[]')", stored: true
+    # rubocop:enable Rails/BulkChangeTable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_103015) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_131056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -179,7 +179,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_103015) do
     t.date "finished_on"
     t.boolean "mentor_funding_enabled", default: false, null: false
     t.datetime "payments_frozen_at"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
     t.date "started_on"
     t.datetime "updated_at", null: false
     t.boolean "uplift_fees_enabled", default: true, null: false

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -25,7 +25,7 @@ describe ContractPeriod do
       before { FactoryBot.create(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 2, 2)) }
 
       it "allows new records that do not overlap" do
-        non_overlapping = FactoryBot.build(:contract_period, started_on: Date.new(2024, 2, 2), finished_on: Date.new(2024, 3, 3))
+        non_overlapping = FactoryBot.build(:contract_period, started_on: Date.new(2024, 2, 3), finished_on: Date.new(2024, 3, 3))
         expect(non_overlapping).to be_valid
       end
 
@@ -33,30 +33,6 @@ describe ContractPeriod do
         overlapping = FactoryBot.build(:contract_period, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 3, 3))
         expect(overlapping).not_to be_valid
         expect(overlapping.errors.messages[:base]).to include(/Contract period overlaps/)
-      end
-    end
-  end
-
-  describe ".containing_date_end_exclusive" do
-    let!(:period) do
-      FactoryBot.create(:contract_period, started_on: Date.new(2024, 9, 1), finished_on: Date.new(2025, 8, 31))
-    end
-
-    it "returns the contract_period containing the given date" do
-      expect(ContractPeriod.containing_date_end_exclusive(Date.new(2025, 1, 1))).to eq(period)
-    end
-
-    it "returns nil when no period contains the date" do
-      expect(ContractPeriod.containing_date_end_exclusive(Date.new(2023, 1, 1))).to be_nil
-    end
-
-    context "when the date is on the boundary of a period" do
-      it "includes the start date in the period" do
-        expect(ContractPeriod.containing_date_end_exclusive(Date.new(2024, 9, 1))).to eq(period)
-      end
-
-      it "excludes the end date in the period" do
-        expect(ContractPeriod.containing_date_end_exclusive(Date.new(2025, 8, 31))).to be_nil
       end
     end
   end
@@ -82,38 +58,6 @@ describe ContractPeriod do
 
       it "includes the end date in the period" do
         expect(ContractPeriod.containing_date(Date.new(2025, 8, 31))).to eq(period)
-      end
-    end
-  end
-
-  describe ".current_end_exclusive" do
-    context "when there is a current contract period" do
-      let!(:period) do
-        FactoryBot.create(:contract_period, started_on: Date.new(2024, 6, 1), finished_on: Date.new(2025, 5, 31))
-      end
-
-      it "returns the current contract period" do
-        FactoryBot.create(:contract_period, started_on: Date.new(2023, 6, 1), finished_on: Date.new(2024, 5, 31))
-
-        travel_to Date.new(2024, 6, 1) do
-          expect(ContractPeriod.current_end_exclusive).to eq(period)
-        end
-      end
-
-      context "when we are on the last day of the contract period" do
-        it "returns nil" do
-          travel_to period.finished_on do
-            expect(ContractPeriod.current_end_exclusive).to be_nil
-          end
-        end
-      end
-    end
-
-    context "when there is no current contract period" do
-      it "returns nil" do
-        travel_to Date.new(2025, 6, 1) do
-          expect(ContractPeriod.current_end_exclusive).to be_nil
-        end
       end
     end
   end

--- a/spec/services/concerns/queries/range_queries_spec.rb
+++ b/spec/services/concerns/queries/range_queries_spec.rb
@@ -8,28 +8,12 @@ describe Queries::RangeQueries do
   let(:start) { Date.new(2001, 1, 1) }
   let(:finish) { Date.new(2001, 2, 2) }
 
-  describe ".date_in_range_inclusive_start_exclusive_end" do
-    subject { FakeRangeQueryClass.date_in_range_inclusive_start_exclusive_end(start) }
+  describe ".date_in_range" do
+    subject { FakeRangeQueryClass.date_in_range(start) }
 
     let(:clause) { %{"a_fake_table"."range" @> date(?)} }
 
     it { is_expected.to eql([clause, start]) }
-  end
-
-  describe ".date_in_range_inclusive_start_inclusive_end" do
-    subject { FakeRangeQueryClass.date_in_range_inclusive_start_inclusive_end(start) }
-
-    let(:clause) do
-      %(
-        daterange(
-          lower("a_fake_table"."range"),
-          upper("a_fake_table"."range"),
-          '[]'
-        ) @> date(?)
-      )
-    end
-
-    it { is_expected.to eql([clause.squish, start]) }
   end
 
   describe ".containing_range" do


### PR DESCRIPTION
### Context

This follows on from #2854 and #2834 and this time makes the ranges on the `contract_periods` table have an inclusive (`[]`) rather than an exlcusive (`[)`) one.

It's more intuitive for dates.

Fixes DFE-Digital/register-ects-project-board#3413

### Changes proposed in this pull request

- **Replace contract_periods `[)` range with `[]`**
- **Standardise on inclusive range for contract periods**
