### PR TITLE
[3918] Only show ECTs from current mentorship periods

### DIFF
--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -6,12 +6,15 @@ class MentorAtSchoolPeriod < ApplicationRecord
   belongs_to :school, inverse_of: :mentor_at_school_periods
   belongs_to :teacher, inverse_of: :mentor_at_school_periods
   has_many :mentorship_periods, inverse_of: :mentor, dependent: :destroy
+  has_many :current_or_future_mentorship_periods,
+           -> { current_or_future },
+           class_name: "MentorshipPeriod"
   has_many :training_periods, inverse_of: :mentor_at_school_period, dependent: :destroy
   has_many :declarations, through: :training_periods
   has_many :events
   has_many :current_or_future_ects,
            -> { current_or_future.induction_not_completed.includes(:teacher) },
-           through: :mentorship_periods,
+           through: :current_or_future_mentorship_periods,
            source: :mentee
   has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: "TrainingPeriod"
   has_one :earliest_training_period, -> { earliest_first }, class_name: "TrainingPeriod"

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -22,7 +22,7 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to have_many(:training_periods) }
     it { is_expected.to have_many(:declarations).through(:training_periods) }
     it { is_expected.to have_many(:events) }
-    it { is_expected.to have_many(:current_or_future_ects).through(:mentorship_periods).source(:mentee) }
+    it { is_expected.to have_many(:current_or_future_ects).through(:current_or_future_mentorship_periods).source(:mentee) }
   end
 
   describe "#current_or_future_ects" do
@@ -37,13 +37,24 @@ describe MentorAtSchoolPeriod do
     let(:finishing) { FactoryBot.create(:ect_at_school_period, school:, finished_on: 1.week.from_now) }
     let(:current)   { FactoryBot.create(:ect_at_school_period, school:, finished_on: nil) }
     let(:upcoming)  { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.week.from_now) }
-    let(:passed)    { FactoryBot.create(:ect_at_school_period, school:, teacher: passed_teacher) }
-    let(:failed)    { FactoryBot.create(:ect_at_school_period, school:, teacher: failed_teacher) }
+    let(:passed)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: passed_teacher) }
+    let(:failed)    { FactoryBot.create(:ect_at_school_period, :ongoing, school:, teacher: failed_teacher) }
+    let(:previously_mentored) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: 1.year.ago) }
 
     before do
       [finished, finishing, current, upcoming, passed, failed].each do |mentee|
-        FactoryBot.create(:mentorship_period, mentor:, mentee:)
+        FactoryBot.create(:mentorship_period,
+                          mentor:,
+                          mentee:,
+                          started_on: mentee.started_on,
+                          finished_on: mentee.finished_on)
       end
+
+      FactoryBot.create(:mentorship_period,
+                        mentor:,
+                        mentee: previously_mentored,
+                        started_on: previously_mentored.started_on,
+                        finished_on: 1.month.ago)
     end
 
     it { is_expected.to match_array [current, upcoming, finishing] }


### PR DESCRIPTION
## Summary

This PR fixes the mentor list showing ECTs from previous mentorship periods.

`current_or_future_ects` now filters through current or future mentorship periods, so an ECT only appears under a mentor when that mentorship period is current or upcoming.