### PR TITLE
[3612] Add validation rule to ensure `deadline_date` has passed for `payable` and `paid` statements

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -3,6 +3,7 @@ class Statement < ApplicationRecord
 
   VALID_FEE_TYPES = %w[output service].freeze
 
+  # Associations
   belongs_to :contract
   has_many :adjustments
   has_many :payment_declarations, inverse_of: :payment_statement, class_name: "Declaration"
@@ -11,24 +12,35 @@ class Statement < ApplicationRecord
   has_one :lead_provider, through: :active_lead_provider
   has_one :contract_period, through: :active_lead_provider
 
-  touch -> { self }, timestamp_attribute: :api_updated_at
+  # Enums
+  enum :status,
+       %w[open payable paid].index_by(&:itself),
+       validate: { message: "Choose a valid status" },
+       prefix: true
+  enum :fee_type,
+       %w[output service].index_by(&:itself),
+       validate: { message: "Fee type must be output or service" },
+       suffix: "fee"
 
   def self.maximum_year = Date.current.year + 5
 
+  # Validations
   validates :contract, presence: { message: "Contract is required" }
-  validates :fee_type,
-            presence: { message: "Enter a fee type" },
-            inclusion: { in: VALID_FEE_TYPES, message: "Fee type must be output or service" }
+  validates :fee_type, presence: { message: "Enter a fee type" }
+  validates :status, presence: { message: "Enter a status" }
   validates :month, numericality: { in: 1..12, only_integer: true, message: "Month must be a number between 1 and 12" }
   validates :year, numericality: { greater_than_or_equal_to: 2020, is_less_than_or_equal_to: :maximum_year, only_integer: true, message: "Year must be on or after 2020 and on or before #{maximum_year}" }
   validates :api_id, uniqueness: { case_sensitive: false, message: "API id already exists for another statement" }
   validate :unique_lead_provider_month_year
+  validates :deadline_date, presence: { message: "Deadline date must be specified" }
+  validate :deadline_date_in_the_past
 
+  # Scopes
   scope :with_fee_type, ->(fee_type) { where(fee_type:) }
   scope :with_status, ->(*status) { where(status:) }
   scope :with_statement_date, ->(year:, month:) { where(year:, month:) }
 
-  enum :fee_type, { service: "service", output: "output" }, suffix: "fee"
+  touch -> { self }, timestamp_attribute: :api_updated_at
 
   state_machine :status, initial: :open do
     state :open
@@ -80,5 +92,12 @@ private
     return unless existing
 
     errors.add(:base, "Statement with the same month and year already exists for this active lead provider")
+  end
+
+  def deadline_date_in_the_past
+    return unless payable? || paid?
+    return if deadline_date < Date.current
+
+    errors.add(:deadline_date, "Deadline date must be in the past")
   end
 end

--- a/app/services/api/declarations/create.rb
+++ b/app/services/api/declarations/create.rb
@@ -118,6 +118,7 @@ module API::Declarations
         lead_provider_id:,
         contract_period_years: contract_period.year,
         fee_type: "output",
+        status: "open",
         deadline_date: Time.zone.today..,
         order: :deadline_date
       ).statements.first

--- a/app/services/statements/mark_as_payable.rb
+++ b/app/services/statements/mark_as_payable.rb
@@ -5,7 +5,11 @@ module Statements
     attr_reader :statement
 
     def self.mark_all_eligible!
-      deadline_past_statements = Statement.where(status: :open).where(deadline_date: ...Date.current)
+      deadline_past_statements = Statements::Search.new(
+        status: "open",
+        deadline_date: ...Date.current,
+        order: :deadline_date
+      ).statements
 
       deadline_past_statements.find_each do |statement|
         new(statement).mark!

--- a/app/services/statements/search.rb
+++ b/app/services/statements/search.rb
@@ -1,6 +1,7 @@
 module Statements
   class Search
     class InvalidFeeTypeError < StandardError; end
+    class InvalidStatusError < StandardError; end
 
     include Queries::FilterIgnorable
 
@@ -11,6 +12,7 @@ module Statements
                    fee_type: "output",
                    statement_date: :ignore,
                    deadline_date: :ignore,
+                   status: :ignore,
                    order: :payment_date)
       @scope = Statement.distinct.includes(active_lead_provider: %i[lead_provider contract_period])
 
@@ -19,6 +21,7 @@ module Statements
       where_fee_type_is(fee_type)
       where_statement_date(statement_date)
       where_deadline_date(deadline_date)
+      where_status_is(status)
       set_order(order)
     end
 
@@ -61,6 +64,14 @@ module Statements
       return if deadline_date.blank?
 
       @scope = scope.where(deadline_date:)
+    end
+
+    def where_status_is(status)
+      return if ignore?(filter: status)
+
+      fail InvalidStatusError unless status.in?(Statement.statuses.keys)
+
+      @scope = scope.with_status(status)
     end
 
     def set_order(order)

--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory(:statement) do
     transient do
-      contract_period { FactoryBot.create(:contract_period) }
+      contract_period { FactoryBot.create(:contract_period, :current) }
       active_lead_provider { association(:active_lead_provider, contract_period:) }
 
       month_year_pair do
@@ -49,10 +49,12 @@ FactoryBot.define do
 
     trait :payable do
       status { :payable }
+      deadline_date { [Date.new(year, month, 1).prev_day, Date.yesterday].min }
     end
 
     trait :paid do
       status { :paid }
+      deadline_date { [Date.new(year, month, 1).prev_day, Date.yesterday].min }
     end
 
     trait :output_fee do
@@ -66,16 +68,10 @@ FactoryBot.define do
     trait :adjustable do
       open
       output_fee
-
-      deadline_date { Date.new(year, month, 1) }
-      payment_date { Date.new(year, month, 25) }
     end
 
     trait :paid_in_month do
       paid
-
-      deadline_date { Date.new(year, month, 1).prev_day }
-      payment_date  { Date.new(year, month, 25) }
 
       marked_as_paid_at do
         next_month = Date.new(year, month, 1).next_month

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -14,11 +14,16 @@ describe Statement do
 
     it { is_expected.to validate_presence_of(:contract).with_message("Contract is required") }
     it { is_expected.to validate_presence_of(:fee_type).with_message("Enter a fee type") }
-    it { is_expected.to allow_values("output", "service").for(:fee_type).with_message("Fee type must be output or service") }
+    it { is_expected.to validate_presence_of(:status).with_message("Enter a status") }
+    it { is_expected.to allow_values(*described_class.fee_types.keys).for(:fee_type).with_message("Fee type must be output or service") }
     it { is_expected.not_to allow_value(nil).for(:fee_type).with_message("Fee type must be output or service") }
     it { is_expected.to validate_numericality_of(:month).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(12).with_message("Month must be a number between 1 and 12") }
     it { is_expected.to validate_numericality_of(:year).only_integer.is_greater_than_or_equal_to(2020).with_message("Year must be on or after 2020 and on or before #{described_class.maximum_year}") }
     it { is_expected.to validate_uniqueness_of(:api_id).case_insensitive.with_message("API id already exists for another statement") }
+    it { is_expected.to allow_values(*described_class.statuses.keys).for(:status) }
+    it { is_expected.not_to allow_value(nil).for(:status).with_message("Choose a valid status") }
+    it { is_expected.to validate_inclusion_of(:fee_type).in_array(described_class.fee_types.keys).with_message("Fee type must be output or service") }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys).with_message("Choose a valid status") }
 
     describe "uniqueness of month and year for the same active lead provider" do
       let(:active_lead_provider) { contract.active_lead_provider }
@@ -35,8 +40,45 @@ describe Statement do
       it "is valid to create another statement with the same month and year for a different active lead provider" do
         other_active_lead_provider = FactoryBot.create(:active_lead_provider)
         other_contract = FactoryBot.create(:contract, active_lead_provider: other_active_lead_provider)
-        statement = described_class.new(contract: other_contract, month: 5, year: 2024)
+        statement = described_class.new(contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day)
+
         expect(statement).to be_valid
+      end
+    end
+
+    describe "deadline date in the past validation" do
+      subject { FactoryBot.build(:statement, deadline_date:) }
+
+      context "when statement is `open` status" do
+        let(:deadline_date) { 1.day.from_now.to_date }
+
+        it { is_expected.to be_valid }
+      end
+
+      Statement.statuses.except(:open).each_key do |status|
+        context "when statement is `#{status}` status" do
+          subject { FactoryBot.build(:statement, status.to_sym, deadline_date:) }
+
+          context "when `deadline_date` is in the future" do
+            let(:deadline_date) { 1.day.from_now.to_date }
+
+            it { is_expected.to have_one_error_only }
+            it { is_expected.to have_error(:deadline_date, "Deadline date must be in the past") }
+          end
+
+          context "when `deadline_date` is in the past" do
+            let(:deadline_date) { 1.day.ago.to_date }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when `deadline_date` is today" do
+            let(:deadline_date) { Date.current }
+
+            it { is_expected.to have_one_error_only }
+            it { is_expected.to have_error(:deadline_date, "Deadline date must be in the past") }
+          end
+        end
       end
     end
   end
@@ -99,6 +141,31 @@ describe Statement do
     subject { described_class.maximum_year }
 
     it { is_expected.to eq(Date.current.year + 5) }
+  end
+
+  describe "enums" do
+    it "has a `status` enum" do
+      expect(subject).to define_enum_for(:status)
+        .with_values({
+          open: "open",
+          payable: "payable",
+          paid: "paid",
+        })
+        .validating(allowing_nil: false)
+        .backed_by_column_of_type(:enum)
+        .with_prefix
+    end
+
+    it "has a `fee_type` enum" do
+      expect(subject).to define_enum_for(:fee_type)
+        .with_values({
+          output: "output",
+          service: "service"
+        })
+        .validating(allowing_nil: false)
+        .with_suffix("fee")
+        .backed_by_column_of_type(:enum)
+    end
   end
 
   describe "state transitions" do

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -194,6 +194,17 @@ RSpec.describe API::Declarations::Create, type: :model do
               it { is_expected.to have_error(:contract_period_year, "You cannot submit or void declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.") }
             end
           end
+
+          context "when payment statement is not open" do
+            let!(:payment_statement) { FactoryBot.create(:statement, :payable, active_lead_provider:) }
+
+            before do
+              teacher.update!("#{trainee_type}_first_became_eligible_for_training_at": 3.years.ago)
+            end
+
+            it { is_expected.to have_one_error_only }
+            it { is_expected.to have_error(:contract_period_year, "You cannot submit or void declarations for the #{contract_period.year} contract period. The funding contract for this contract period has ended. Get in touch if you need to discuss this with us.") }
+          end
         end
 
         describe "frozen contract period validations" do
@@ -629,7 +640,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 6.months.ago, finished_on: 2.weeks.from_now) }
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :active, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on, finished_on: at_school_period.finished_on) }
           let(:service) { instance_double(Declarations::Create) }
-          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:) }
+          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now) }
           let!(:mentorship_period) do
             if trainee_type == :ect
               mentor = FactoryBot.create(

--- a/spec/services/statements/search_spec.rb
+++ b/spec/services/statements/search_spec.rb
@@ -230,6 +230,54 @@ RSpec.describe Statements::Search do
           end
         end
       end
+
+      describe "by `status`" do
+        let!(:statement1) { FactoryBot.create(:statement, :open, year: 2025, month: 8) }
+        let!(:statement2) { FactoryBot.create(:statement, :payable, year: 2025, month: 4) }
+        let!(:statement3) { FactoryBot.create(:statement, :paid, year: 2025, month: 1) }
+
+        context "when `status`: 'open'" do
+          it "return only statements with status of open" do
+            search = described_class.new(status: "open")
+
+            expect(search.statements).to eq([statement1])
+          end
+        end
+
+        context "when `status`: 'payable'" do
+          it "return only statements with status of payable" do
+            search = described_class.new(status: "payable")
+
+            expect(search.statements).to eq([statement2])
+          end
+        end
+
+        context "when `status`: 'paid'" do
+          it "return only statements with status of paid" do
+            search = described_class.new(status: "paid")
+
+            expect(search.statements).to eq([statement3])
+          end
+        end
+
+        context "when `status`: :ignore" do
+          it "returns all statements" do
+            search = described_class.new(status: :ignore)
+
+            expect(search.statements).to contain_exactly(statement1, statement2, statement3)
+          end
+        end
+
+        it "does not filter by `status` if blank" do
+          search = described_class.new(status: " ")
+
+          expect(search.statements).to contain_exactly(statement1, statement2, statement3)
+        end
+
+        it "raises an error when searching by an invalid status" do
+          expect { described_class.new(status: "something_else") }.to raise_error(Statements::Search::InvalidStatusError)
+        end
+      end
     end
 
     describe "ordering" do


### PR DESCRIPTION
### Context

Ticket: [3612](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3612).

We have seed data in a bad shape at the moment, which means we have some payable statements where the deadline_date has not yet passed. This results in new declaration being attached to statements that are not in an open state. This should never be the case in production, but we should add validation rules and make the intention more explicit.

### Changes proposed in this pull request

1- Add a validation rule to ensure a statement cannot move to the `payable/paid` state unless the `deadline_date` is in the past.
2- Update the declarations Create service to filter output fee statements to only those that are open;
3- Make sure there are no time-related edge cases around marking statements as payable/the logic here still holds;
4- Make sure our seed data is all generating correctly and not falling foul of the new validation rule.
5- Existing data checked (sandbox/prod): there's no payable or paid statements records with deadline date in the future.

### Guidance to review

Review app