### PR TITLE
[3731] Change how we show uplift fee clawbacks

### DIFF
--- a/app/components/admin/statements/clawbacks_component.html.erb
+++ b/app/components/admin/statements/clawbacks_component.html.erb
@@ -13,12 +13,12 @@
         end
 
         table.with_body do |body|
-          declaration_type_outputs_with_clawbacks(calculator).each do |declaration_type_output|
+          rows(calculator).each do |clawback|
             body.with_row do |row|
-              row.with_cell { payment_type(calculator, declaration_type_output) }
-              row.with_cell { declaration_type_output.refundable_count.to_s }
-              row.with_cell(numeric: true) { number_to_pounds(-declaration_type_output.type_adjusted_fee_per_declaration) }
-              row.with_cell(numeric: true) { number_to_pounds(-declaration_type_output.total_refundable_amount) }
+              row.with_cell { clawback.payment_type }
+              row.with_cell { clawback.refundable_count.to_s }
+              row.with_cell(numeric: true) { number_to_pounds(-clawback.fee_per_declaration) }
+              row.with_cell(numeric: true) { number_to_pounds(-clawback.total_refundable_amount) }
             end
           end
         end
@@ -29,7 +29,7 @@
       Total
     </div>
     <div class="govuk-!-text-align-right govuk-heading-s">
-      <%= number_to_pounds(-calculator.outputs.total_refundable_amount) %>
+      <%= number_to_pounds(-total(calculator)) %>
     </div>
   </div>
 <% end %>

--- a/app/components/admin/statements/clawbacks_component.rb
+++ b/app/components/admin/statements/clawbacks_component.rb
@@ -9,10 +9,44 @@ module Admin
 
     private
 
-      def declaration_type_outputs_with_clawbacks(calculator)
-        calculator.outputs
+      Row = Data.define(:payment_type, :refundable_count, :fee_per_declaration, :total_refundable_amount)
+
+      def rows(calculator)
+        rows = calculator.outputs
           .declaration_type_outputs
           .filter { it.refundable_count.positive? }
+          .map do |output|
+            Row.new(
+              payment_type: payment_type(calculator, output),
+              refundable_count: output.refundable_count,
+              fee_per_declaration: output.type_adjusted_fee_per_declaration,
+              total_refundable_amount: output.total_refundable_amount
+            )
+          end
+
+        rows << uplift_row(calculator) if include_uplift?(calculator)
+        rows
+      end
+
+      def total(calculator)
+        total = calculator.outputs.total_refundable_amount
+        total += calculator.uplifts.total_refundable_amount if include_uplift?(calculator)
+        total
+      end
+
+      def include_uplift?(calculator)
+        contract.ecf_contract_type? &&
+          calculator.is_a?(PaymentCalculator::Banded) &&
+          calculator.uplifts.refundable_count.positive?
+      end
+
+      def uplift_row(calculator)
+        Row.new(
+          payment_type: "Uplift",
+          refundable_count: calculator.uplifts.refundable_count,
+          fee_per_declaration: calculator.uplifts.uplift_fee_per_declaration,
+          total_refundable_amount: calculator.uplifts.total_refundable_amount
+        )
       end
 
       def caption_text(calculator)

--- a/app/components/admin/statements/payment_overview/ecf_component.rb
+++ b/app/components/admin/statements/payment_overview/ecf_component.rb
@@ -19,7 +19,11 @@ module Admin
           raise ArgumentError, "Expected exactly 1 calculator for ECF contract type" unless calculators.one?
           raise ArgumentError, "Expected Banded calculator for ECF contract type" unless banded
 
-          @uplifts ||= banded.uplifts.total_net_amount
+          @uplifts ||= banded.uplifts.total_billable_amount
+        end
+
+        def clawbacks
+          @clawbacks ||= -(banded.outputs.total_refundable_amount + banded.uplifts.total_refundable_amount)
         end
       end
     end

--- a/app/components/admin/statements/uplift_fees_component.html.erb
+++ b/app/components/admin/statements/uplift_fees_component.html.erb
@@ -10,9 +10,9 @@
     end
     table.with_body do |body|
       body.with_row do |row|
-        row.with_cell(text: net_count)
+        row.with_cell(text: billable_count)
         row.with_cell(text: number_to_pounds(uplift_fee_per_declaration), numeric: true)
-        row.with_cell(text: number_to_pounds(total_net_amount), numeric: true)
+        row.with_cell(text: number_to_pounds(total_billable_amount), numeric: true)
       end
     end
   end %>
@@ -20,6 +20,6 @@
     Total
   </div>
   <div class="govuk-!-text-align-right govuk-heading-s">
-    <%= number_to_pounds(total_net_amount) %>
+    <%= number_to_pounds(total_billable_amount) %>
   </div>
 </div>

--- a/app/components/admin/statements/uplift_fees_component.rb
+++ b/app/components/admin/statements/uplift_fees_component.rb
@@ -3,9 +3,9 @@ module Admin
     class UpliftFeesComponent < ApplicationComponent
       delegate :number_to_pounds, to: :helpers
 
-      delegate :net_count,
+      delegate :billable_count,
                :uplift_fee_per_declaration,
-               :total_net_amount,
+               :total_billable_amount,
                to: :uplifts
 
       attr_accessor :statement

--- a/lib/tasks/product_review/3731.rake
+++ b/lib/tasks/product_review/3731.rake
@@ -1,0 +1,27 @@
+namespace :product_review do
+  desc "Add refundable uplift declarations to UCL's Oct 2024 statement so uplift clawbacks render (#3731)"
+  task "3731" => :environment do
+    ucl = LeadProvider.find_by!(name: "UCL Institute of Education")
+    contract_period = ContractPeriod.find_by!(year: 2024)
+    active_lead_provider = ActiveLeadProvider.find_by!(lead_provider: ucl, contract_period:)
+
+    statement = Statement
+      .joins(:contract)
+      .where(contracts: { active_lead_provider_id: active_lead_provider.id, contract_type: "ecf" })
+      .find_by!(month: 10, year: 2024, fee_type: "output")
+
+    refundable = Declaration
+      .where(clawback_statement: statement, declaration_type: "started")
+      .refundable
+
+    if refundable.empty?
+      puts "No refundable 'started' declarations on the October 2024 UCL statement — re-seed first (rails db:seed)."
+      next
+    end
+
+    targets = refundable.limit(3).to_a
+    targets.each { it.update!(pupil_premium_uplift: true) }
+
+    puts "Statement #{statement.id} updated."
+  end
+end

--- a/spec/components/admin/statements/clawbacks_component_spec.rb
+++ b/spec/components/admin/statements/clawbacks_component_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
     )
   end
 
+  let(:uplift_refundable_count) { 0 }
+  let(:uplift_fee_per_declaration) { 100 }
+  let(:banded_uplifts) do
+    instance_double(
+      PaymentCalculator::Banded::Uplifts,
+      refundable_count: uplift_refundable_count,
+      uplift_fee_per_declaration:,
+      total_refundable_amount: uplift_refundable_count * uplift_fee_per_declaration
+    )
+  end
+
   let(:flat_rate_declaration_type_outputs) do
     [
       instance_double(
@@ -82,6 +93,7 @@ RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
 
   before do
     allow(PaymentCalculator::Banded::Outputs).to receive(:new).and_return(banded_outputs)
+    allow(PaymentCalculator::Banded::Uplifts).to receive(:new).and_return(banded_uplifts)
     allow(PaymentCalculator::FlatRate::Outputs).to receive(:new).and_return(flat_rate_outputs)
     render_inline(component)
   end
@@ -109,6 +121,29 @@ RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
         ],
         total: "-£400.00"
       )
+    end
+
+    context "when there are refundable uplift fees" do
+      let(:uplift_refundable_count) { 2 }
+
+      it "appends an uplift row and includes it in the total" do
+        expect(page).to have_statement_table(
+          caption: "Clawbacks",
+          headings: [
+            "Payment type",
+            "Number of participants",
+            "Fee per participant",
+            "Payments"
+          ],
+          rows: [
+            ["Started (Band A)", "10", "-£15.00", "-£150.00"],
+            ["Started (Band B)", "10", "-£15.00", "-£150.00"],
+            ["Completed (Band A)", "5", "-£20.00", "-£100.00"],
+            ["Uplift", "2", "-£100.00", "-£200.00"]
+          ],
+          total: "-£600.00"
+        )
+      end
     end
   end
 
@@ -155,6 +190,28 @@ RSpec.describe Admin::Statements::ClawbacksComponent, type: :component do
         ],
         total: "-£230.00"
       )
+    end
+
+    context "when there are refundable uplift fees" do
+      let(:uplift_refundable_count) { 2 }
+
+      it "does not show an uplift row in ECT clawbacks" do
+        expect(page).to have_statement_table(
+          caption: "ECT clawbacks",
+          headings: [
+            "Payment type",
+            "Number of participants",
+            "Fee per participant",
+            "Payments"
+          ],
+          rows: [
+            ["Started (Band A)", "10", "-£15.00", "-£150.00"],
+            ["Started (Band B)", "10", "-£15.00", "-£150.00"],
+            ["Completed (Band A)", "5", "-£20.00", "-£100.00"]
+          ],
+          total: "-£400.00"
+        )
+      end
     end
   end
 

--- a/spec/components/admin/statements/payment_overview/ecf_component_spec.rb
+++ b/spec/components/admin/statements/payment_overview/ecf_component_spec.rb
@@ -22,14 +22,21 @@ RSpec.describe Admin::Statements::PaymentOverview::ECFComponent, type: :componen
   end
 
   let(:banded_outputs_double) { double(total_net_amount:, total_refundable_amount:, total_billable_amount:) }
-  let(:uplifts_double) { double(total_net_amount: total_uplifts_amount) }
+  let(:uplifts_double) do
+    double(
+      total_net_amount: total_billable_uplifts_amount - total_refundable_uplifts_amount,
+      total_billable_amount: total_billable_uplifts_amount,
+      total_refundable_amount: total_refundable_uplifts_amount
+    )
+  end
 
   let(:total_billable_amount) { 550 }
   let(:total_net_amount) { total_billable_amount - total_refundable_amount }
   let(:total_refundable_amount) { 150 }
   let(:total_manual_adjustments_amount) { 375 }
   let(:monthly_service_fee) { 1_000 }
-  let(:total_uplifts_amount) { 50 }
+  let(:total_billable_uplifts_amount) { 50 }
+  let(:total_refundable_uplifts_amount) { 0 }
 
   let(:contract) do
     FactoryBot.create(:contract, :for_ecf, active_lead_provider:, vat_rate: 0.20, banded_fee_structure:)
@@ -93,6 +100,29 @@ RSpec.describe Admin::Statements::PaymentOverview::ECFComponent, type: :componen
       it "VAT is zero and therefore not included in the total" do
         expect(page).to have_css("h2.govuk-heading-l", text: "£1,825.00")
         expect(page).to have_css("tr", text: /VAT£0\.00/)
+      end
+    end
+
+    context "when there are refundable uplift fees" do
+      let(:total_billable_uplifts_amount) { 200 }
+      let(:total_refundable_uplifts_amount) { 30 }
+
+      it "shows billable uplift fees in the Uplift fees row and adds refundable uplift fees to the Clawbacks row" do
+        expect(page).to have_statement_table(
+          selector: ".finance-panel__summary__total-payment-breakdown",
+          headings: [
+            "Payment type",
+            "Payment"
+          ],
+          rows: [
+            ["Output payment", "£550.00"],
+            ["Service fee", "£1,000.00"],
+            ["Uplift fees", "£200.00"],
+            ["Clawbacks", "-£180.00"],
+            ["Additional adjustments", "£375.00"],
+            ["VAT", "£389.00"],
+          ]
+        )
       end
     end
   end

--- a/spec/components/admin/statements/uplift_fees_component_spec.rb
+++ b/spec/components/admin/statements/uplift_fees_component_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe Admin::Statements::UpliftFeesComponent, type: :component do
   let(:contract) { FactoryBot.create(:contract, contract_type) }
   let(:statement) { FactoryBot.create(:statement, statement_type, contract:) }
 
-  let(:net_count) { 0 }
+  let(:billable_count) { 0 }
   let(:uplift_fee_per_declaration) { 100 }
-  let(:total_net_amount) { net_count * uplift_fee_per_declaration }
+  let(:total_billable_amount) { billable_count * uplift_fee_per_declaration }
 
   let(:uplifts) do
     instance_double(
       PaymentCalculator::Banded::Uplifts,
-      net_count:,
+      billable_count:,
       uplift_fee_per_declaration:,
-      total_net_amount:
+      total_billable_amount:
     )
   end
 
@@ -59,7 +59,7 @@ RSpec.describe Admin::Statements::UpliftFeesComponent, type: :component do
       end
 
       context "and declarations with uplift fees" do
-        let(:net_count) { 2 }
+        let(:billable_count) { 2 }
 
         it do
           expect(page).to have_statement_table(


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3731

### Changes proposed in this pull request

Don't count uplift clawbacks as part of billable uplifts, treat them separately instead

- Payment overview
  - Uplifts amount increases because we no longer include clawbacks here
  - Clawbacks amount increases (i.e. more negative) because we now include uplift clawbacks here
  - Same total, other rows unaffected
- Uplift fees
  - Number of participants increases because we no longer subtract clawbacks here (aligns with overview)
- Clawbacks table
  - Now includes a "Uplifts" row if there are uplift clawbacks (aligns with overview)
- All other sections are unchanged

| Before | After |
|--------|--------|
| <img width="1286" height="7880" alt="localhost_3000_admin_finance_statements_650" src="https://github.com/user-attachments/assets/8e7e60bb-1af2-4b26-9f8f-c12d48b68102" /> | <img width="1286" height="7954" alt="localhost_3000_admin_finance_statements_650 (1)" src="https://github.com/user-attachments/assets/cfe41f79-2c21-4682-9cef-768d012e6fc8" /> | 

### Guidance to review

I've run the product review rake task to make sure there's a statement showing uplift clawbacks on this review app: 
https://cpd-ec2-review-2874-web.test.teacherservices.cloud/admin/finance/statements/1304

When we're ready, we can also deploy this to migration to compare production vs this branch for a known problematic statement