### PR TITLE
Reduce authentication failure level in Sentry

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,7 +39,7 @@ class SessionsController < ApplicationController
   end
 
   def failure
-    Sentry.capture_message("[Authentication failure] #{params[:message]}")
+    Sentry.capture_message("[Authentication failure] #{params[:message]}", level: :info)
     session_manager.end_session!
   end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe "Sessions", type: :request do
 
       expect(Sentry)
         .to have_received(:capture_message).once
-        .with("[Authentication failure] csrf_detected")
+        .with("[Authentication failure] csrf_detected", level: :info)
     end
   end
 end


### PR DESCRIPTION
We're not planning on fixing these issues right now, so it felt sensible to specify the "level" in Sentry as `info` rather than `error`.