### PR TITLE
Preserving previous contract period on re-registration

### DIFF
--- a/app/services/contract_periods/for_mentor_registration.rb
+++ b/app/services/contract_periods/for_mentor_registration.rb
@@ -34,9 +34,7 @@ module ContractPeriods
     def previous_contract_period
       @previous_contract_period ||=
         @previous_training_period.contract_period ||
-        @previous_training_period.expression_of_interest&.contract_period ||
-        @previous_training_period.school_partnership&.active_lead_provider&.contract_period ||
-        @previous_training_period.schedule&.contract_period
+        @previous_training_period.expression_of_interest&.contract_period
     end
   end
 end

--- a/app/services/contract_periods/for_mentor_registration.rb
+++ b/app/services/contract_periods/for_mentor_registration.rb
@@ -1,0 +1,42 @@
+module ContractPeriods
+  class ForMentorRegistration
+    # NOTE: unlike ECTs, mentors in 2021/2022 contract periods are not migrated
+    # to 2024 on re-registration. Those mentors have a funding end date that
+    # prevents re-registration, so no reassignment logic is needed here.
+    class NoContractPeriodFoundForStartedOnDate < StandardError; end
+
+    def initialize(started_on:, previous_training_period: nil)
+      @started_on = started_on
+      @previous_training_period = previous_training_period
+    end
+
+    def call
+      return previous_contract_period if preserve_previous_contract_period?
+
+      ContractPeriod.for_registration_start_date(@started_on) ||
+        raise(
+          NoContractPeriodFoundForStartedOnDate,
+          "No contract period found for started_on=#{@started_on}"
+        )
+    end
+
+  private
+
+    def preserve_previous_contract_period?
+      return false unless @previous_training_period
+      return false unless @previous_training_period.provider_led_training_programme?
+      return false unless previous_contract_period
+      return false if previous_contract_period.payments_frozen?
+
+      ContractPeriod.for_registration_start_date(@started_on).present?
+    end
+
+    def previous_contract_period
+      @previous_contract_period ||=
+        @previous_training_period.contract_period ||
+        @previous_training_period.expression_of_interest&.contract_period ||
+        @previous_training_period.school_partnership&.active_lead_provider&.contract_period ||
+        @previous_training_period.schedule&.contract_period
+    end
+  end
+end

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -224,8 +224,10 @@ module Schools
 
     def previous_contract_period
       @previous_contract_period ||=
-        @previous_training_period.contract_period ||
-        @previous_training_period.expression_of_interest&.contract_period
+        previous_training_period.contract_period ||
+        previous_training_period.expression_of_interest&.contract_period ||
+        previous_training_period.school_partnership&.active_lead_provider&.contract_period ||
+        previous_training_period.schedule&.contract_period
     end
 
     def schedule

--- a/app/services/schools/register_ect.rb
+++ b/app/services/schools/register_ect.rb
@@ -224,10 +224,8 @@ module Schools
 
     def previous_contract_period
       @previous_contract_period ||=
-        previous_training_period.contract_period ||
-        previous_training_period.expression_of_interest&.contract_period ||
-        previous_training_period.school_partnership&.active_lead_provider&.contract_period ||
-        previous_training_period.schedule&.contract_period
+        @previous_training_period.contract_period ||
+        @previous_training_period.expression_of_interest&.contract_period
     end
 
     def schedule

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -84,6 +84,7 @@ module Schools
       earliest_matching_school_partnership if lead_provider.present?
     end
 
+    # Override TrainingPeriodSources default of ContractPeriod.current
     def contract_period
       resolved_contract_period
     end
@@ -91,15 +92,15 @@ module Schools
     def resolved_contract_period
       @resolved_contract_period ||= ContractPeriods::ForMentorRegistration.new(
         started_on: mentor_at_school_period.started_on,
-        previous_training_period:
+        previous_training_period: latest_mentor_training_period
       ).call
     end
 
-    def previous_training_period
-      @previous_training_period ||= TrainingPeriod
-                                      .for_mentor_trn(teacher.trn)
-                                      .order(started_on: :desc)
-                                      .first
+    def latest_mentor_training_period
+      @latest_mentor_training_period ||= TrainingPeriod
+                                           .for_mentor_trn(teacher.trn)
+                                           .order(started_on: :desc)
+                                           .first
     end
 
     def create_teacher!

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -72,7 +72,8 @@ module Schools
                                                                 school_partnership:,
                                                                 expression_of_interest:,
                                                                 mentee:,
-                                                                author: @author).call
+                                                                author: @author,
+                                                                contract_period: resolved_contract_period).call
     end
 
     def mentor_ineligible_for_funding?
@@ -81,6 +82,24 @@ module Schools
 
     def school_partnership
       earliest_matching_school_partnership if lead_provider.present?
+    end
+
+    def contract_period
+      resolved_contract_period
+    end
+
+    def resolved_contract_period
+      @resolved_contract_period ||= ContractPeriods::ForMentorRegistration.new(
+        started_on: mentor_at_school_period.started_on,
+        previous_training_period:
+      ).call
+    end
+
+    def previous_training_period
+      @previous_training_period ||= TrainingPeriod
+                                      .for_mentor_trn(teacher.trn)
+                                      .order(started_on: :desc)
+                                      .first
     end
 
     def create_teacher!

--- a/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Registering a mentor" do
     given_there_is_a_school_in_the_service
     and_the_school_is_in_a_partnership_with_a_lead_provider
     and_there_is_an_ect_with_no_mentor_registered_at_the_school
-    and_there_is_a_mentor_previously_registered_in_an_older_contract_period
+    and_there_is_a_mentor_previously_registered_at_another_school_in_an_older_contract_period
     and_i_sign_in_as_that_school_user
     and_i_am_on_the_schools_landing_page
 
@@ -65,7 +65,7 @@ private
     @ect_name = Teachers::Name.new(@ect.teacher).full_name
   end
 
-  def and_there_is_a_mentor_previously_registered_in_an_older_contract_period
+  def and_there_is_a_mentor_previously_registered_at_another_school_in_an_older_contract_period
     @contract_period_2024 = FactoryBot.create(:contract_period, :with_schedules, :previous)
     @another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)

--- a/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
@@ -1,0 +1,194 @@
+RSpec.describe "Registering a mentor" do
+  include_context "test TRS API returns a teacher"
+  include SchoolPartnershipHelpers
+
+  let(:trn) { "3002586" }
+
+  scenario "contract period is preserved when a mentor re-registers at a new school" do
+    given_there_is_a_school_in_the_service
+    and_the_school_is_in_a_partnership_with_a_lead_provider
+    and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    and_there_is_a_mentor_previously_registered_in_an_older_contract_period
+    and_i_sign_in_as_that_school_user
+    and_i_am_on_the_schools_landing_page
+
+    when_i_click_to_assign_a_mentor_to_the_ect
+    then_i_am_in_the_requirements_page
+
+    when_i_click_continue
+    then_i_should_be_taken_to_the_find_mentor_page
+
+    when_i_submit_the_find_mentor_form
+    then_i_should_be_taken_to_the_review_mentor_details_page
+
+    when_i_confirm_the_mentor_details
+    then_i_should_be_taken_to_the_email_address_page
+
+    when_i_enter_the_mentor_email_address
+    and_i_click_continue
+    then_i_should_be_taken_to_the_started_on_page
+    when_i_submit_the_started_on_form
+    then_i_should_be_taken_to_the_previous_training_period_details_page
+    when_i_submit_the_previous_training_period_details_form
+    then_i_should_be_taken_to_the_programme_choices_page
+    when_i_select_same_programme_choices
+    then_i_should_be_taken_to_the_check_answers_page
+
+    when_i_click_confirm_details
+    then_i_should_be_taken_to_the_confirmation_page
+    and_the_new_training_period_should_preserve_the_original_contract_period
+  end
+
+private
+
+  def given_there_is_a_school_in_the_service
+    @school = FactoryBot.create(:school, urn: "1234567")
+  end
+
+  def and_the_school_is_in_a_partnership_with_a_lead_provider
+    @contract_period_2025 = FactoryBot.create(:contract_period, :with_schedules, :current)
+    @school_partnership = make_partnership_for(@school, @contract_period_2025)
+    @lead_provider = @school_partnership.lead_provider_delivery_partnership.lead_provider
+  end
+
+  def and_there_is_an_ect_with_no_mentor_registered_at_the_school
+    @active_lead_provider = FactoryBot.create(:active_lead_provider,
+                                              lead_provider: @lead_provider,
+                                              contract_period: @contract_period_2025)
+    @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
+    FactoryBot.create(:training_period, :provider_led, :ongoing,
+                      ect_at_school_period: @ect,
+                      school_partnership: FactoryBot.create(:school_partnership,
+                                                            school: @school,
+                                                            lead_provider_delivery_partnership: FactoryBot.create(:lead_provider_delivery_partnership,
+                                                                                                                  active_lead_provider: @active_lead_provider)))
+    @ect_name = Teachers::Name.new(@ect.teacher).full_name
+  end
+
+  def and_there_is_a_mentor_previously_registered_in_an_older_contract_period
+    @contract_period_2024 = FactoryBot.create(:contract_period, :with_schedules, :previous)
+    @another_school = FactoryBot.create(:school, urn: "7654321")
+    @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
+
+    older_active_lead_provider = FactoryBot.create(:active_lead_provider,
+                                                   lead_provider: @lead_provider,
+                                                   contract_period: @contract_period_2024)
+
+    @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period,
+                                                          teacher: @teacher,
+                                                          school: @another_school,
+                                                          started_on: @contract_period_2024.started_on,
+                                                          finished_on: @contract_period_2024.started_on + 6.months)
+
+    FactoryBot.create(:training_period, :provider_led, :for_mentor, :with_only_expression_of_interest,
+                      mentor_at_school_period: @existing_mentor_at_school_period,
+                      started_on: @existing_mentor_at_school_period.started_on,
+                      expression_of_interest: older_active_lead_provider)
+  end
+
+  def and_i_sign_in_as_that_school_user
+    sign_in_as_school_user(school: @school)
+  end
+
+  def and_i_am_on_the_schools_landing_page
+    path = "/school/home/ects"
+    page.goto path
+    expect(page).to have_path(path)
+  end
+
+  def when_i_click_to_assign_a_mentor_to_the_ect
+    page.get_by_role("link", name: "Assign a mentor for this ECT").click
+  end
+
+  def then_i_am_in_the_requirements_page
+    expect(page.get_by_text("What you'll need to add a new mentor for #{@ect_name}")).to be_visible
+    expect(page.url).to end_with("/school/register-mentor/what-you-will-need?ect_id=#{@ect.id}")
+  end
+
+  def when_i_click_continue
+    page.get_by_role("link", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_find_mentor_page
+    expect(page).to have_path("/school/register-mentor/find-mentor")
+  end
+
+  def when_i_submit_the_find_mentor_form
+    page.get_by_label("trn").fill(trn)
+    page.get_by_label("day").fill("3")
+    page.get_by_label("month").fill("2")
+    page.get_by_label("year").fill("1977")
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_review_mentor_details_page
+    expect(page).to have_path("/school/register-mentor/review-mentor-details")
+  end
+
+  def when_i_confirm_the_mentor_details
+    page.get_by_label("Yes").check
+    page.get_by_role("button", name: "Confirm and continue").click
+  end
+
+  def then_i_should_be_taken_to_the_email_address_page
+    expect(page).to have_path("/school/register-mentor/email-address")
+  end
+
+  def when_i_enter_the_mentor_email_address
+    page.get_by_label("email").fill("kirk@springfield.com")
+  end
+
+  def and_i_click_continue
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_started_on_page
+    expect(page).to have_path("/school/register-mentor/started-on")
+  end
+
+  def when_i_submit_the_started_on_form
+    page.get_by_label("Day").fill("1")
+    page.get_by_label("Month").fill("6")
+    page.get_by_label("Year").fill("2025")
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_previous_training_period_details_page
+    expect(page).to have_path("/school/register-mentor/previous-training-period-details")
+  end
+
+  def when_i_submit_the_previous_training_period_details_form
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_programme_choices_page
+    expect(page).to have_path("/school/register-mentor/programme-choices")
+  end
+
+  def when_i_select_same_programme_choices
+    page.get_by_label("Yes").check
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_i_should_be_taken_to_the_check_answers_page
+    expect(page).to have_path("/school/register-mentor/check-answers")
+  end
+
+  def when_i_click_confirm_details
+    page.get_by_role("button", name: "Confirm details").click
+  end
+
+  def then_i_should_be_taken_to_the_confirmation_page
+    expect(page).to have_path("/school/register-mentor/confirmation")
+  end
+
+  def and_the_new_training_period_should_preserve_the_original_contract_period
+    new_mentor_at_school_period = @teacher.mentor_at_school_periods
+                                          .excluding(@existing_mentor_at_school_period)
+                                          .last
+    new_training_period = new_mentor_at_school_period&.training_periods&.first
+
+    expect(new_training_period).not_to be_nil
+    expect(new_training_period.schedule.contract_period).to eq(@contract_period_2024)
+  end
+end

--- a/spec/services/contract_periods/for_mentor_registration_spec.rb
+++ b/spec/services/contract_periods/for_mentor_registration_spec.rb
@@ -1,0 +1,207 @@
+RSpec.describe ContractPeriods::ForMentorRegistration do
+  subject(:resolver) do
+    described_class.new(
+      started_on:,
+      previous_training_period:
+    )
+  end
+
+  let(:previous_training_period) { nil }
+
+  let!(:contract_2024) do
+    FactoryBot.create(
+      :contract_period,
+      year: 2024,
+      started_on: Date.new(2024, 9, 1),
+      finished_on: Date.new(2025, 8, 31)
+    )
+  end
+
+  let!(:contract_2025) do
+    FactoryBot.create(
+      :contract_period,
+      year: 2025,
+      started_on: Date.new(2025, 9, 1),
+      finished_on: Date.new(2026, 8, 31)
+    )
+  end
+
+  describe "#call" do
+    context "when there is no previous training period" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      it "returns the registration contract period" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+
+    context "when there is a previous provider-led training period" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024,
+          expression_of_interest: nil,
+          school_partnership: nil,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      it "returns the previous training period's contract period" do
+        expect(resolver.call).to eq(contract_2024)
+      end
+    end
+
+    context "when the mentor was previously registered in the 2023 contract period" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+      let(:contract_2023) { FactoryBot.create(:contract_period, year: 2023) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2023,
+          expression_of_interest: nil,
+          school_partnership: nil,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      it "preserves the 2023 contract period" do
+        expect(resolver.call).to eq(contract_2023)
+      end
+    end
+
+    context "when the mentor was previously registered in a payments frozen contract period (2022)" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+      let(:frozen_contract) { FactoryBot.create(:contract_period, :with_payments_frozen, year: 2022) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: frozen_contract,
+          expression_of_interest: nil,
+          school_partnership: nil,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      it "falls back to the registration contract period if the previous period is frozen" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+
+    context "when there is a previous school-led training period" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024,
+          provider_led_training_programme?: false
+        )
+      end
+
+      it "returns the registration contract period" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+
+    context "when the previous provider-led training period used an EOI" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:active_lead_provider) do
+        instance_double(ActiveLeadProvider, contract_period: contract_2024)
+      end
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: nil,
+          expression_of_interest: active_lead_provider,
+          school_partnership: nil,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      it "returns the expression of interest contract period" do
+        expect(resolver.call).to eq(contract_2024)
+      end
+    end
+
+    context "when the previous provider-led training period used a school partnership" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:active_lead_provider) do
+        instance_double(ActiveLeadProvider, contract_period: contract_2024)
+      end
+
+      let(:school_partnership) do
+        instance_double(SchoolPartnership, active_lead_provider:)
+      end
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: nil,
+          expression_of_interest: nil,
+          school_partnership:,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      it "returns the school partnership contract period" do
+        expect(resolver.call).to eq(contract_2024)
+      end
+    end
+
+    context "when the previous provider-led training period when the contract period can only be derived from the schedule" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:schedule) do
+        instance_double(Schedule, contract_period: contract_2024)
+      end
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: nil,
+          expression_of_interest: nil,
+          school_partnership: nil,
+          schedule:,
+          provider_led_training_programme?: true
+        )
+      end
+
+      it "returns the schedule contract period" do
+        expect(resolver.call).to eq(contract_2024)
+      end
+    end
+
+    context "when the previous contract period is payments frozen" do
+      let(:started_on) { Date.new(2025, 9, 1) }
+
+      let(:previous_training_period) do
+        instance_double(
+          TrainingPeriod,
+          contract_period: contract_2024,
+          expression_of_interest: nil,
+          school_partnership: nil,
+          schedule: nil,
+          provider_led_training_programme?: true
+        )
+      end
+
+      before { allow(contract_2024).to receive(:payments_frozen?).and_return(true) }
+
+      it "returns the registration contract period" do
+        expect(resolver.call).to eq(contract_2025)
+      end
+    end
+  end
+end

--- a/spec/services/contract_periods/for_mentor_registration_spec.rb
+++ b/spec/services/contract_periods/for_mentor_registration_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe ContractPeriods::ForMentorRegistration do
           TrainingPeriod,
           contract_period: contract_2024,
           expression_of_interest: nil,
-          school_partnership: nil,
-          schedule: nil,
           provider_led_training_programme?: true
         )
       end
@@ -63,8 +61,6 @@ RSpec.describe ContractPeriods::ForMentorRegistration do
           TrainingPeriod,
           contract_period: contract_2023,
           expression_of_interest: nil,
-          school_partnership: nil,
-          schedule: nil,
           provider_led_training_programme?: true
         )
       end
@@ -83,13 +79,11 @@ RSpec.describe ContractPeriods::ForMentorRegistration do
           TrainingPeriod,
           contract_period: frozen_contract,
           expression_of_interest: nil,
-          school_partnership: nil,
-          schedule: nil,
           provider_led_training_programme?: true
         )
       end
 
-      it "falls back to the registration contract period if the previous period is frozen" do
+      it "falls back to the registration contract period" do
         expect(resolver.call).to eq(contract_2025)
       end
     end
@@ -122,63 +116,11 @@ RSpec.describe ContractPeriods::ForMentorRegistration do
           TrainingPeriod,
           contract_period: nil,
           expression_of_interest: active_lead_provider,
-          school_partnership: nil,
-          schedule: nil,
           provider_led_training_programme?: true
         )
       end
 
       it "returns the expression of interest contract period" do
-        expect(resolver.call).to eq(contract_2024)
-      end
-    end
-
-    context "when the previous provider-led training period used a school partnership" do
-      let(:started_on) { Date.new(2025, 9, 1) }
-
-      let(:active_lead_provider) do
-        instance_double(ActiveLeadProvider, contract_period: contract_2024)
-      end
-
-      let(:school_partnership) do
-        instance_double(SchoolPartnership, active_lead_provider:)
-      end
-
-      let(:previous_training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period: nil,
-          expression_of_interest: nil,
-          school_partnership:,
-          schedule: nil,
-          provider_led_training_programme?: true
-        )
-      end
-
-      it "returns the school partnership contract period" do
-        expect(resolver.call).to eq(contract_2024)
-      end
-    end
-
-    context "when the previous provider-led training period when the contract period can only be derived from the schedule" do
-      let(:started_on) { Date.new(2025, 9, 1) }
-
-      let(:schedule) do
-        instance_double(Schedule, contract_period: contract_2024)
-      end
-
-      let(:previous_training_period) do
-        instance_double(
-          TrainingPeriod,
-          contract_period: nil,
-          expression_of_interest: nil,
-          school_partnership: nil,
-          schedule:,
-          provider_led_training_programme?: true
-        )
-      end
-
-      it "returns the schedule contract period" do
         expect(resolver.call).to eq(contract_2024)
       end
     end
@@ -191,8 +133,6 @@ RSpec.describe ContractPeriods::ForMentorRegistration do
           TrainingPeriod,
           contract_period: contract_2024,
           expression_of_interest: nil,
-          school_partnership: nil,
-          schedule: nil,
           provider_led_training_programme?: true
         )
       end

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -98,7 +98,17 @@ RSpec.describe Schools::RegisterMentor do
 
         context "with MentorATSchoolPeriod records" do
           let!(:existing_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on: 2.years.ago) }
-          let!(:existing_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, mentor_at_school_period: existing_mentor_at_school_period, started_on: existing_mentor_at_school_period.started_on) }
+          let!(:existing_training_period) do
+            FactoryBot.create(
+              :training_period,
+              :provider_led,
+              :for_mentor,
+              :with_only_expression_of_interest,
+              mentor_at_school_period: existing_mentor_at_school_period,
+              started_on: existing_mentor_at_school_period.started_on,
+              expression_of_interest: active_lead_provider
+            )
+          end
           let(:mentor_at_school_period) { teacher.mentor_at_school_periods.excluding(existing_mentor_at_school_period).first }
 
           context "with :mentoring_at_new_school_only set to false" do


### PR DESCRIPTION
### Context
When a mentor is re-registered, new provider-led training periods were being created using the contract period derived from the new registration start date. This could move the mentor from their original contract period into the current one.

### Changes proposed in this pull request
- Add `ContractPeriods::ForMentorRegistration` to resolve the contract period for mentor registration
- Preserve the previous provider-led contract period where possible
- Derive the previous contract period from the training period, EOI, school partnership, or schedule
- Pass the resolved contract period into provider-led mentor training period creation
- Add feature and unit coverage for mentor re-registration preserving the original contract period

### Guidance to review
Alongside checking that the CP is preserved on re-registration - also sense check is that mentor behaviour intentionally differs from ECT reassignment logic. Mentors are not moved from closed 2021/2022 periods into 2024 here; instead, we preserve the previous non-frozen provider-led contract period when creating the new training period.