### PR TITLE
Display the training periods in the admin pages from newest to oldest

### DIFF
--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -2,11 +2,11 @@ module Admin
   module Teachers
     class TrainingSummaryComponent < ApplicationComponent
       class UnexpectedTrainingProgrammeError < StandardError; end
-      attr_reader :training_period, :index
+      attr_reader :training_period, :show_api_row
 
-      def initialize(training_period:, index: 0)
+      def initialize(training_period:, show_api_row: false)
         @training_period = training_period
-        @index = index
+        @show_api_row = show_api_row
       end
 
       def call
@@ -133,7 +133,7 @@ module Admin
       end
 
       def api_response_row
-        return unless show_api_row?
+        return unless show_api_row
 
         summary_row("API response", api_response_text)
       end
@@ -176,13 +176,9 @@ module Admin
       end
 
       def show_move_partnership_link?
-        @show_move_partnership_link ||= index.zero? &&
+        @show_move_partnership_link ||= show_api_row &&
           training_period.provider_led_training_programme? &&
           training_period.finished_on.nil?
-      end
-
-      def show_api_row?
-        index.zero?
       end
 
       def summary_row(label, value)

--- a/app/controllers/admin/teachers/trainings_controller.rb
+++ b/app/controllers/admin/teachers/trainings_controller.rb
@@ -8,7 +8,8 @@ module Admin
         @navigation_items = helpers.admin_teacher_navigation_items(@teacher, :training)
         @breadcrumbs = teacher_breadcrumbs
         @ect_at_school_periods = @teacher.ect_at_school_periods
-        @ect_training_periods = @teacher.ect_training_periods.includes(ect_at_school_period: :teacher).order(started_on: :desc).group_by(&:lead_provider_delivery_partnership)
+        @ect_training_periods = @teacher.ect_training_periods.includes(ect_at_school_period: :teacher).order(started_on: :desc)
+        @period_ids_to_show_api_row = @ect_training_periods.group_by(&:lead_provider_delivery_partnership).values.map { it.first.id }
         @mentor_training_periods = @teacher.mentor_training_periods.includes(mentor_at_school_period: :teacher).order(started_on: :desc)
       end
 

--- a/app/controllers/admin/teachers/trainings_controller.rb
+++ b/app/controllers/admin/teachers/trainings_controller.rb
@@ -8,9 +8,9 @@ module Admin
         @navigation_items = helpers.admin_teacher_navigation_items(@teacher, :training)
         @breadcrumbs = teacher_breadcrumbs
         @ect_at_school_periods = @teacher.ect_at_school_periods
-        @ect_training_periods = @teacher.ect_training_periods.includes(ect_at_school_period: :teacher).order(started_on: :desc)
+        @ect_training_periods = @teacher.ect_training_periods.includes(ect_at_school_period: :teacher).latest_first
         @period_ids_to_show_api_row = @ect_training_periods.group_by(&:lead_provider_delivery_partnership).values.map { it.first.id }
-        @mentor_training_periods = @teacher.mentor_training_periods.includes(mentor_at_school_period: :teacher).order(started_on: :desc)
+        @mentor_training_periods = @teacher.mentor_training_periods.includes(mentor_at_school_period: :teacher).latest_first
       end
 
     private

--- a/app/views/admin/teachers/trainings/show.html.erb
+++ b/app/views/admin/teachers/trainings/show.html.erb
@@ -11,17 +11,15 @@
 
 <% if @ect_at_school_periods.any? %>
   <h3 class="govuk-heading-s">ECT history</h3>
-  <% @ect_training_periods.each do |lpdp, training_periods| %>
-    <% training_periods.each_with_index do |training_period, index| %>
-      <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, index:) %>
-    <% end %>
+  <% @ect_training_periods.each do |training_period| %>
+    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @period_ids_to_show_api_row.include?(training_period.id)) %>
   <% end %>
 <% end %>
 
 <% if @mentor_training_periods.any? %>
   <h3 class="govuk-heading-s">Mentor history</h3>
   <% @mentor_training_periods.each_with_index do |training_period, index| %>
-    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, index:) %>
+    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: index.zero?) %>
   <% end %>
 <% end %>
 

--- a/spec/components/admin/teachers/training_summary_component_spec.rb
+++ b/spec/components/admin/teachers/training_summary_component_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
-  subject(:rendered) { render_inline(described_class.new(training_period:)) }
+  subject(:rendered) { render_inline(described_class.new(training_period:, show_api_row: true)) }
 
   describe "provider-led training periods" do
     let(:teacher) { metadata.teacher }
@@ -194,7 +194,7 @@ RSpec.describe Admin::Teachers::TrainingSummaryComponent, type: :component do
     end
 
     context "when the component is rendering a subsequent row" do
-      subject(:rendered) { render_inline(described_class.new(training_period:, index: 1)) }
+      subject(:rendered) { render_inline(described_class.new(training_period:, show_api_row: false)) }
 
       it "does not show the API data row" do
         expect(rendered_content).not_to have_css("dt", text: "API response")


### PR DESCRIPTION
### Context
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3727

The admin teacher training page should show training history from newest to oldest.

### Changes proposed in this pull request
  - fetch training periods without grouping so they can be displayed in the correct order
  - identify in the controller which training summaries should display the API row
  - replace the `index` argument in `TrainingSummaryComponent` with an explicit `show_api_row` flag

### Guidance to review
