### PR TITLE
Update Swagger schema to allow joining to be null in transfers.

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -3129,6 +3129,7 @@ components:
               example: '2021-05-31'
         joining:
           type: object
+          nullable: true
           required:
           - school_urn
           properties:

--- a/spec/swagger_schemas/models/participant_transfers/transfer.rb
+++ b/spec/swagger_schemas/models/participant_transfers/transfer.rb
@@ -65,6 +65,7 @@ PARTICIPANT_TRANSFERS_TRANSFER = {
     },
     joining: {
       type: :object,
+      nullable: true,
       required: %i[
         school_urn
       ],


### PR DESCRIPTION
### Context

Resolves: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2871

In a transfer joining is optional. However, in Swagger OpenAPI 3.0, a property may be optional and nullable, or optional but not nullable. Instead of omitting the joining property when there is none, we want to return this as null (to be in line with ECF1).

As such we need to update the Swagger schema for transfers to allow joining to be null.

### Changes proposed in this pull request

Updates the Swagger schema to allow joining to be null.

### Guidance to review

Simple change