### PR TITLE
Add validation to ASPs range and extract concern `at_school_period`

### DIFF
--- a/app/models/concerns/at_school_period.rb
+++ b/app/models/concerns/at_school_period.rb
@@ -31,7 +31,8 @@ module AtSchoolPeriod
     validates :teacher_id,
               presence: true
 
-    validate :covering_inner_periods
+    validate :covering_training_periods, if: -> { persisted? && training_periods.any? }
+    validate :covering_mentorship_periods, if: -> { persisted? && mentorship_periods.any? }
 
     # Scopes
     scope :for_school, ->(school_id) { where(school_id:) }
@@ -59,20 +60,18 @@ module AtSchoolPeriod
   end
 
   # Validations
-  def covering_inner_periods
-    return if started_on.blank?
-    return unless persisted?
+  def covering_training_periods
+    current_range = (started_on..finished_on)
+    return if training_periods.all? { current_range.cover?(it.range) }
 
-    inner_periods = mentorship_periods + training_periods
-    return if inner_periods.empty?
+    errors.add(:base, "Date range does not cover all the training periods")
+  end
 
-    starts = inner_periods.map(&:started_on)
-    ends = inner_periods.map(&:finished_on)
-    earliest_started_on = starts.min unless starts.any?(&:nil?)
-    latest_finished_on = ends.max unless ends.any?(&:nil?)
-    return if (started_on..finished_on).cover?(earliest_started_on..latest_finished_on)
+  def covering_mentorship_periods
+    current_range = (started_on..finished_on)
+    return if mentorship_periods.all? { current_range.cover?(it.range) }
 
-    errors.add(:base, "Date range does not cover all the inner periods")
+    errors.add(:base, "Date range does not cover all the mentorship periods")
   end
 
   # Methods

--- a/app/models/concerns/at_school_period.rb
+++ b/app/models/concerns/at_school_period.rb
@@ -62,14 +62,14 @@ module AtSchoolPeriod
   # Validations
   def covering_training_periods
     current_range = (started_on..finished_on)
-    return if training_periods.all? { current_range.cover?(it.range) }
+    return if training_periods.all? { current_range.cover?(it.started_on..it.finished_on) }
 
     errors.add(:base, "Date range does not cover all the training periods")
   end
 
   def covering_mentorship_periods
     current_range = (started_on..finished_on)
-    return if mentorship_periods.all? { current_range.cover?(it.range) }
+    return if mentorship_periods.all? { current_range.cover?(it.started_on..it.finished_on) }
 
     errors.add(:base, "Date range does not cover all the mentorship periods")
   end

--- a/app/models/concerns/at_school_period.rb
+++ b/app/models/concerns/at_school_period.rb
@@ -1,0 +1,83 @@
+module AtSchoolPeriod
+  extend ActiveSupport::Concern
+
+  included do
+    # Associations
+    has_many :events
+
+    has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: "TrainingPeriod"
+    has_one :earliest_training_period, -> { earliest_first }, class_name: "TrainingPeriod"
+    has_one :latest_training_period, -> { latest_first }, class_name: "TrainingPeriod"
+
+    # Callbacks
+    touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_updated_at
+    refresh_metadata -> { school }, on_event: %i[create destroy update]
+    refresh_metadata -> { teacher }, on_event: %i[create destroy update]
+
+    # Validations
+    validates :email,
+              notify_email: true,
+              allow_nil: true
+
+    validates :school_id,
+              presence: true
+
+    validates :started_on,
+              presence: true
+
+    validates :teacher_id,
+              presence: true
+
+    validate :covering_inner_periods
+
+    # Scopes
+    scope :for_school, ->(school_id) { where(school_id:) }
+    scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
+    scope :with_school, -> { includes(school: :gias_school) }
+    scope :with_teacher, -> { includes(:teacher) }
+
+    scope :with_partnerships_for_contract_period, ->(year) {
+      joins(training_periods: {
+        active_lead_provider: :contract_period
+      }).where(contract_periods: { year: })
+    }
+
+    scope :with_expressions_of_interest_for_contract_period, ->(year) {
+      joins(training_periods: {
+        expression_of_interest: :contract_period
+      })
+        .where(contract_periods: { year: })
+    }
+
+    scope :with_expressions_of_interest_for_lead_provider_and_contract_period, ->(year, lead_provider_id) {
+      with_expressions_of_interest_for_contract_period(year)
+        .where(expression_of_interest: { lead_provider_id: })
+    }
+  end
+
+  # Validations
+  def covering_inner_periods
+    inner_periods = mentorship_periods + training_periods
+    return if inner_periods.empty?
+
+    starts = inner_periods.map(&:started_on)
+    ends = inner_periods.map(&:finished_on)
+    earliest_started_on = starts.min unless starts.any?(&:nil?)
+    latest_finished_on = ends.max unless ends.any?(&:nil?)
+    return if (started_on..finished_on).cover?(earliest_started_on..latest_finished_on)
+
+    errors.add(:base, "Date range does not cover all the inner periods")
+  end
+
+  # Methods
+  def leaving_reported_for_school?(school)
+    leaving_today_or_in_future? && reported_leaving_by?(school)
+  end
+
+  def reported_leaving_by?(school)
+    reported_leaving_by_school_id.present? && reported_leaving_by_school_id == school&.id
+  end
+
+  delegate :provider_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
+  delegate :school_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
+end

--- a/app/models/concerns/at_school_period.rb
+++ b/app/models/concerns/at_school_period.rb
@@ -1,6 +1,9 @@
 module AtSchoolPeriod
   extend ActiveSupport::Concern
 
+  include Interval
+  include DeclarativeUpdates
+
   included do
     # Associations
     has_many :events
@@ -57,6 +60,9 @@ module AtSchoolPeriod
 
   # Validations
   def covering_inner_periods
+    return if started_on.blank?
+    return unless persisted?
+
     inner_periods = mentorship_periods + training_periods
     return if inner_periods.empty?
 

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -1,8 +1,6 @@
 class ECTAtSchoolPeriod < ApplicationRecord
   RECT_GO_LIVE_DATE = Date.new(2026, 4, 28).freeze
 
-  include Interval
-  include DeclarativeUpdates
   include AtSchoolPeriod
 
   # Associations

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -3,6 +3,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
   include Interval
   include DeclarativeUpdates
+  include AtSchoolPeriod
 
   # Associations
   belongs_to :school, inverse_of: :ect_at_school_periods
@@ -13,17 +14,9 @@ class ECTAtSchoolPeriod < ApplicationRecord
   has_many :mentors, through: :mentorship_periods, source: :mentor
   has_many :training_periods, inverse_of: :ect_at_school_period, dependent: :destroy
   has_many :mentor_at_school_periods, through: :teacher
-  has_many :events
-  has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: "TrainingPeriod"
-  has_one :earliest_training_period, -> { earliest_first }, class_name: "TrainingPeriod"
-  has_one :latest_training_period, -> { latest_first }, class_name: "TrainingPeriod"
+
   has_one :current_or_next_mentorship_period, -> { current_or_future.earliest_first }, class_name: "MentorshipPeriod"
   has_one :latest_mentorship_period, -> { latest_first }, class_name: "MentorshipPeriod"
-
-  touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_updated_at
-
-  refresh_metadata -> { school }, on_event: %i[create destroy update]
-  refresh_metadata -> { teacher }, on_event: %i[create destroy update]
 
   # Validations
   validate :appropriate_body_for_independent_school,
@@ -34,39 +27,9 @@ class ECTAtSchoolPeriod < ApplicationRecord
            if: -> { school&.state_funded? },
            on: :register_ect
 
-  validates :email,
-            notify_email: true,
-            allow_nil: true
-
-  validates :school_id,
-            presence: true
-
-  validates :started_on,
-            presence: true
-
-  validates :teacher_id,
-            presence: true
-
   validate :teacher_distinct_period
 
   # Scopes
-  scope :for_school, ->(school_id) { where(school_id:) }
-  scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
-  scope :with_partnerships_for_contract_period, ->(year) {
-    joins(training_periods: {
-      active_lead_provider: :contract_period
-    }).where(contract_periods: { year: })
-  }
-  scope :with_expressions_of_interest_for_contract_period, ->(year) {
-    joins(training_periods: {
-      expression_of_interest: :contract_period
-    })
-    .where(contract_periods: { year: })
-  }
-  scope :with_expressions_of_interest_for_lead_provider_and_contract_period, ->(year, lead_provider_id) {
-    with_expressions_of_interest_for_contract_period(year)
-    .where(expression_of_interest: { lead_provider_id: })
-  }
   scope :unclaimed_by_school_reported_appropriate_body, -> {
     current_or_future
       .where.not(school_reported_appropriate_body_id: nil)
@@ -124,19 +87,9 @@ class ECTAtSchoolPeriod < ApplicationRecord
     where.not(id: without_qts_award)
       .where.not(id: claimed_by_different_appropriate_body)
   }
-  scope :with_school, -> { includes(school: :gias_school) }
-  scope :with_teacher, -> { includes(:teacher) }
   scope :with_teacher_current_induction_period_appropriate_body, -> {
     includes(teacher: { current_or_next_induction_period: :appropriate_body_period })
   }
-
-  def reported_leaving_by?(school)
-    reported_leaving_by_school_id.present? && reported_leaving_by_school_id == school&.id
-  end
-
-  def leaving_reported_for_school?(school)
-    leaving_today_or_in_future? && reported_leaving_by?(school)
-  end
 
   def school_reported_appropriate_body_name = school_reported_appropriate_body&.name
 
@@ -177,8 +130,6 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
   delegate :trn, :trs_initial_teacher_training_provider_name, to: :teacher
   delegate :name, to: :school, prefix: true
-  delegate :provider_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
-  delegate :school_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
 
 private
 

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -1,6 +1,4 @@
 class MentorAtSchoolPeriod < ApplicationRecord
-  include Interval
-  include DeclarativeUpdates
   include AtSchoolPeriod
 
   # Associations

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -1,17 +1,18 @@
 class MentorAtSchoolPeriod < ApplicationRecord
   include Interval
   include DeclarativeUpdates
+  include AtSchoolPeriod
 
   # Associations
   belongs_to :school, inverse_of: :mentor_at_school_periods
   belongs_to :teacher, inverse_of: :mentor_at_school_periods
+
   has_many :mentorship_periods, inverse_of: :mentor, dependent: :destroy
   has_many :current_or_future_mentorship_periods,
            -> { current_or_future },
            class_name: "MentorshipPeriod"
   has_many :training_periods, inverse_of: :mentor_at_school_period, dependent: :destroy
   has_many :declarations, through: :training_periods
-  has_many :events
   has_many :lead_provider_metadata_for_mentees,
            class_name: "Metadata::TeacherLeadProvider",
            foreign_key: :ect_assigned_mentor_latest_school_period_id,
@@ -21,50 +22,13 @@ class MentorAtSchoolPeriod < ApplicationRecord
            -> { current_or_future.induction_not_completed.includes(:teacher) },
            through: :current_or_future_mentorship_periods,
            source: :mentee
-  has_one :current_or_next_training_period, -> { current_or_future.earliest_first }, class_name: "TrainingPeriod"
-  has_one :earliest_training_period, -> { earliest_first }, class_name: "TrainingPeriod"
-  has_one :latest_training_period, -> { latest_first }, class_name: "TrainingPeriod"
 
-  touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_updated_at
   touch -> { teacher }, on_event: %i[create destroy update], when_changing: %i[email], timestamp_attribute: :api_unfunded_mentor_updated_at, if: :latest_mentor_at_school_period?
 
-  refresh_metadata -> { school }, on_event: %i[create destroy update]
-  refresh_metadata -> { teacher }, on_event: %i[create destroy update]
-
   # Validations
-  validates :email,
-            notify_email: true,
-            allow_nil: true
-
-  validates :started_on,
-            presence: true
-
-  validates :school_id,
-            presence: true
-
-  validates :teacher_id,
-            presence: true
-
   validate :teacher_school_distinct_period
 
   # Scopes
-  scope :for_school, ->(school_id) { where(school_id:) }
-  scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
-  scope :with_partnerships_for_contract_period, ->(year) {
-    joins(training_periods: {
-      active_lead_provider: :contract_period
-    }).where(contract_periods: { year: })
-  }
-  scope :with_expressions_of_interest_for_contract_period, ->(year) {
-    joins(training_periods: {
-      expression_of_interest: :contract_period
-    })
-    .where(contract_periods: { year: })
-  }
-  scope :with_expressions_of_interest_for_lead_provider_and_contract_period, ->(year, lead_provider_id) {
-    with_expressions_of_interest_for_contract_period(year)
-    .where(expression_of_interest: { lead_provider_id: })
-  }
 
   # Instance methods
   def siblings
@@ -72,17 +36,6 @@ class MentorAtSchoolPeriod < ApplicationRecord
 
     teacher.mentor_at_school_periods.for_school(school_id).excluding(self)
   end
-
-  def reported_leaving_by?(school)
-    reported_leaving_by_school_id.present? && reported_leaving_by_school_id == school&.id
-  end
-
-  def leaving_reported_for_school?(school)
-    leaving_today_or_in_future? && reported_leaving_by?(school)
-  end
-
-  delegate :provider_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
-  delegate :school_led_training_programme?, to: :current_or_next_training_period, allow_nil: true
 
 private
 

--- a/app/services/ect_at_school_periods/finish.rb
+++ b/app/services/ect_at_school_periods/finish.rb
@@ -8,6 +8,7 @@ module ECTAtSchoolPeriods
       @author = author
       @reported_by_school_id = reported_by_school_id
       @record_event = record_event
+      @training_period = ect_at_school_period.current_or_next_training_period if unstarted_training_periods.none?
     end
 
     def finish!
@@ -24,6 +25,8 @@ module ECTAtSchoolPeriods
     end
 
   private
+
+    attr_reader :training_period
 
     def finish_ect_at_school_period!
       if ect_at_school_period.finished_on.present? && ect_at_school_period.finished_on <= finished_on
@@ -77,13 +80,6 @@ module ECTAtSchoolPeriods
       return if training_period.finished_on.present? && training_period.finished_on <= finished_on
 
       TrainingPeriods::Finish.ect_training(author:, training_period:, ect_at_school_period:, finished_on:, record_event: record_event?).finish!
-    end
-
-    # Prevent events being linked to unstarted training_periods (which will be deleted)
-    def training_period
-      return if unstarted_training_periods.present?
-
-      @training_period ||= ect_at_school_period.current_or_next_training_period
     end
 
     def destroy_unstarted_training_periods!

--- a/app/services/ect_at_school_periods/finish.rb
+++ b/app/services/ect_at_school_periods/finish.rb
@@ -14,6 +14,11 @@ module ECTAtSchoolPeriods
       ActiveRecord::Base.transaction do
         finish_mentorship_periods!
         finish_training_period!
+
+        # ect_at_school_period validation depends on inner periods.
+        # We need it to get updated with the latest inner period changes happening above.
+        ect_at_school_period.reload
+
         finish_ect_at_school_period!
       end
     end
@@ -21,8 +26,6 @@ module ECTAtSchoolPeriods
   private
 
     def finish_ect_at_school_period!
-      ect_at_school_period.reload
-
       if ect_at_school_period.finished_on.present? && ect_at_school_period.finished_on <= finished_on
         update_reporting_school!
         return

--- a/app/services/ect_at_school_periods/finish.rb
+++ b/app/services/ect_at_school_periods/finish.rb
@@ -12,15 +12,17 @@ module ECTAtSchoolPeriods
 
     def finish!
       ActiveRecord::Base.transaction do
-        finish_ect_at_school_period!
         finish_mentorship_periods!
         finish_training_period!
+        finish_ect_at_school_period!
       end
     end
 
   private
 
     def finish_ect_at_school_period!
+      ect_at_school_period.reload
+
       if ect_at_school_period.finished_on.present? && ect_at_school_period.finished_on <= finished_on
         update_reporting_school!
         return

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -36,8 +36,7 @@ module ECTAtSchoolPeriods
     end
 
     def to_provider_led
-      raise IncorrectTrainingProgrammeError if
-        @ect_at_school_period.provider_led_training_programme?
+      raise IncorrectTrainingProgrammeError if @ect_at_school_period.provider_led_training_programme?
 
       raise NoTrainingPeriodError if @lead_provider.blank?
 

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -36,7 +36,7 @@ private
     # We need it to get updated with the latest inner period changes happening above.
     period.reload
 
-    finish_mentor_at_school_period!(period.reload)
+    finish_mentor_at_school_period!(period)
     record_mentor_left_school_event!(period)
   end
 

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -65,7 +65,16 @@ private
     end
   end
 
+  def destroy_unstarted_training_periods!(period)
+    period.training_periods.started_on_or_after(finished_on).find_each do |training_period|
+      Event.where(training_period:).delete_all
+      training_period.destroy!
+    end
+  end
+
   def finish_training_periods!(period)
+    destroy_unstarted_training_periods!(period)
+
     period.training_periods.ongoing_on(finished_on).each do |training_period|
       TrainingPeriods::Finish.mentor_training(training_period:, mentor_at_school_period: period, finished_on:, author:).finish!
     end

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -31,6 +31,11 @@ private
   def finish!(period)
     finish_mentorship_periods!(period)
     finish_training_periods!(period)
+
+    # period validation depends on inner periods.
+    # We need it to get updated with the latest inner period changes happening above.
+    period.reload
+
     finish_mentor_at_school_period!(period.reload)
     record_mentor_left_school_event!(period)
   end

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -31,7 +31,7 @@ private
   def finish!(period)
     finish_mentorship_periods!(period)
     finish_training_periods!(period)
-    finish_mentor_at_school_period!(period)
+    finish_mentor_at_school_period!(period.reload)
     record_mentor_left_school_event!(period)
   end
 

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
                       started_on: "2021-01-01")
   end
 
-  let(:provider_led_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, school_partnership:) }
+  let(:provider_led_training_period) do
+    FactoryBot.create(:training_period, :provider_led, :ongoing, school_partnership:, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+  end
 
   context "when data is reported by the school" do
     before { render_inline(described_class.new(title: "Reported to us by your school", ect_at_school_period: school_led_ect_at_school_period, training_period: school_led_training_period, data_source: :school)) }

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       end
 
       # default end date to be a realistic end date
-      end_date { (started_on || start_date) + rand(6.months..1.year) }
+      end_date { (started_on || start_date) + rand(6.months...1.year) }
     end
 
     teacher { association :teacher, :with_realistic_name }

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       end
 
       # default end date to be a realistic end date
-      end_date { (started_on || start_date) + rand(6.months..1.year) }
+      end_date { (started_on || start_date) + rand(6.months...1.year) }
       api_mentor_training_record_id { SecureRandom.uuid }
       trn { APISeedData::Helpers::TRNGenerator.next }
       urn { Faker::Number.unique.number(digits: 6) }

--- a/spec/models/concerns/at_school_period_spec.rb
+++ b/spec/models/concerns/at_school_period_spec.rb
@@ -1,0 +1,396 @@
+describe AtSchoolPeriod do
+  describe "validations" do
+    subject { FactoryBot.build(:ect_at_school_period) }
+
+    it { is_expected.to validate_presence_of(:started_on) }
+    it { is_expected.to validate_presence_of(:school_id) }
+    it { is_expected.to validate_presence_of(:teacher_id) }
+
+    context "email" do
+      it { is_expected.to allow_value(nil).for(:email) }
+      it { is_expected.to allow_value("test@example.com").for(:email) }
+      it { is_expected.not_to allow_value("invalid_email").for(:email) }
+    end
+
+    describe "#covering_inner_periods" do
+      context "for an ECT at school period" do
+        let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+
+        context "with no inner periods" do
+          it "is valid" do
+            expect(ect).to be_valid
+          end
+        end
+
+        context "with training periods fully within range" do
+          before do
+            FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 6.months.ago, finished_on: 1.month.ago)
+          end
+
+          it "is valid" do
+            expect(ect.reload).to be_valid
+          end
+        end
+
+        context "with an ongoing training period when the ECT is ongoing" do
+          before do
+            FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, started_on: 6.months.ago)
+          end
+
+          it "is valid" do
+            expect(ect.reload).to be_valid
+          end
+        end
+
+        context "when the ECT start is moved after the training period start" do
+          before do
+            FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 6.months.ago, finished_on: 1.month.ago)
+          end
+
+          it "is invalid" do
+            ect.started_on = 3.months.ago
+            expect(ect).not_to be_valid
+            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+
+        context "when the ECT end date is moved before the training period end" do
+          let(:ect) { FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: 6.months.ago) }
+
+          before do
+            FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 2.years.ago, finished_on: 6.months.ago)
+          end
+
+          it "is invalid" do
+            ect.finished_on = 1.year.ago
+            expect(ect).not_to be_valid
+            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+
+        context "with an ongoing training period when the ECT is finished" do
+          let(:ect) { FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: 6.months.ago) }
+
+          before do
+            FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, started_on: 2.years.ago)
+          end
+
+          it "is invalid when setting finished_on while a training period is ongoing" do
+            ect.reload
+            ect.finished_on = 3.months.ago
+            expect(ect).not_to be_valid
+            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+
+        context "with mentorship periods fully within range" do
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+
+          before do
+            FactoryBot.create(:mentorship_period, mentee: ect, mentor:, started_on: 6.months.ago, finished_on: 1.month.ago)
+          end
+
+          it "is valid" do
+            expect(ect.reload).to be_valid
+          end
+        end
+
+        context "when the ECT start is moved after the mentorship period start" do
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+
+          before do
+            FactoryBot.create(:mentorship_period, mentee: ect, mentor:, started_on: 6.months.ago, finished_on: 1.month.ago)
+          end
+
+          it "is invalid" do
+            ect.started_on = 3.months.ago
+            expect(ect).not_to be_valid
+            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+
+        context "with multiple inner periods all within range" do
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+
+          before do
+            FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 9.months.ago, finished_on: 6.months.ago)
+            FactoryBot.create(:mentorship_period, mentee: ect, mentor:, started_on: 6.months.ago, finished_on: 3.months.ago)
+          end
+
+          it "is valid" do
+            expect(ect.reload).to be_valid
+          end
+        end
+
+        context "with multiple inner periods where one is outside range" do
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: ect.school) }
+
+          before do
+            FactoryBot.create(:training_period, ect_at_school_period: ect, started_on: 9.months.ago, finished_on: 6.months.ago)
+            FactoryBot.create(:mentorship_period, mentee: ect, mentor:, started_on: 6.months.ago, finished_on: 3.months.ago)
+          end
+
+          it "is invalid when the ECT start is moved past the earliest inner period" do
+            ect.started_on = 8.months.ago
+            expect(ect).not_to be_valid
+            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+      end
+
+      context "for a mentor at school period" do
+        let(:mentor) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 1.year.ago) }
+
+        context "with no inner periods" do
+          it "is valid" do
+            expect(mentor).to be_valid
+          end
+        end
+
+        context "with training periods fully within range" do
+          before do
+            FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period: mentor, started_on: 6.months.ago, finished_on: 1.month.ago)
+          end
+
+          it "is valid" do
+            expect(mentor.reload).to be_valid
+          end
+        end
+
+        context "when the mentor end date is moved earlier than the training period end" do
+          let(:mentor) { FactoryBot.create(:mentor_at_school_period, started_on: 2.years.ago, finished_on: 6.months.ago) }
+
+          before do
+            FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period: mentor, started_on: 2.years.ago, finished_on: 6.months.ago)
+          end
+
+          it "is invalid" do
+            mentor.finished_on = 1.year.ago
+            expect(mentor).not_to be_valid
+            expect(mentor.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+
+        context "with mentorship periods (where this mentor is mentoring) within range" do
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school: mentor.school) }
+
+          before do
+            FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: 6.months.ago, finished_on: 1.month.ago)
+          end
+
+          it "is valid" do
+            expect(mentor.reload).to be_valid
+          end
+        end
+
+        context "when the mentor start is moved after the mentorship period start" do
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school: mentor.school) }
+
+          before do
+            FactoryBot.create(:mentorship_period, mentor:, mentee: ect, started_on: 6.months.ago, finished_on: 3.months.ago)
+          end
+
+          it "is invalid" do
+            mentor.started_on = 4.months.ago
+            expect(mentor).not_to be_valid
+            expect(mentor.errors[:base]).to include("Date range does not cover all the inner periods")
+          end
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:teacher) { FactoryBot.create(:teacher) }
+    let!(:school) { period_1.school }
+    let!(:period_1) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: "2023-01-01", finished_on: "2023-06-01") }
+    let!(:period_2) { FactoryBot.create(:ect_at_school_period, :state_funded_school, teacher:, started_on: "2023-06-02", finished_on: "2023-12-11") }
+    let!(:period_3) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, teacher:, school:, started_on: "2023-12-12", finished_on: nil) }
+
+    describe ".for_school" do
+      let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: "2023-02-01", finished_on: "2023-07-01") }
+
+      it "returns only ect periods for the specified school" do
+        expect(ECTAtSchoolPeriod.for_school(period_1.school_id)).to match_array([period_1, period_3, teacher_2_period])
+      end
+    end
+
+    describe ".for_teacher" do
+      it "returns ect periods only for the specified teacher" do
+        expect(ECTAtSchoolPeriod.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".with_partnerships_for_contract_period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period, :for_ect, ect_at_school_period: period_2,
+                                                      started_on: period_2.started_on,
+                                                      finished_on: period_2.finished_on)
+      end
+
+      it "returns ect in training periods only for the specified contract period" do
+        expect(ECTAtSchoolPeriod.with_partnerships_for_contract_period(training_period.school_partnership.contract_period.id)).to match_array([period_2])
+      end
+    end
+
+    describe ".with_expressions_of_interest_for_contract_period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period,
+                          :with_only_expression_of_interest,
+                          :for_ect,
+                          ect_at_school_period: period_2,
+                          started_on: period_2.started_on,
+                          finished_on: period_2.finished_on)
+      end
+
+      it "returns ect in training periods only for the specified contract period" do
+        expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_contract_period(training_period.expression_of_interest.contract_period.id)).to match_array([period_2])
+      end
+    end
+
+    describe ".with_expressions_of_interest_for_lead_provider_and_contract_period" do
+      let!(:training_period) do
+        FactoryBot.create(:training_period,
+                          :with_only_expression_of_interest,
+                          :for_ect,
+                          ect_at_school_period: period_2,
+                          started_on: period_2.started_on,
+                          finished_on: period_2.finished_on)
+      end
+
+      it "returns ect in training periods only for the specified contract period and lead provider" do
+        expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_lead_provider_and_contract_period(training_period.expression_of_interest.contract_period.id, training_period.expression_of_interest.lead_provider_id)).to match_array([period_2])
+      end
+    end
+  end
+
+  describe "#reported_leaving_by?" do
+    context "via ECTAtSchoolPeriod" do
+      subject(:period) { FactoryBot.create(:ect_at_school_period, :ongoing, reported_leaving_by_school_id: reporter_id) }
+
+      let(:reporting_school) { FactoryBot.create(:school) }
+      let(:other_school) { FactoryBot.create(:school) }
+
+      context "when reported by the given school" do
+        let(:reporter_id) { reporting_school.id }
+
+        it "returns true" do
+          expect(period.reported_leaving_by?(reporting_school)).to be true
+        end
+      end
+
+      context "when reported by a different school" do
+        let(:reporter_id) { reporting_school.id }
+
+        it "returns false" do
+          expect(period.reported_leaving_by?(other_school)).to be false
+        end
+      end
+
+      context "when not reported" do
+        let(:reporter_id) { nil }
+
+        it "returns false" do
+          expect(period.reported_leaving_by?(reporting_school)).to be false
+        end
+      end
+    end
+
+    context "via MentorAtSchoolPeriod" do
+      subject(:period) { FactoryBot.create(:mentor_at_school_period, :ongoing, reported_leaving_by_school_id: reporter_id) }
+
+      let(:reporting_school) { FactoryBot.create(:school) }
+      let(:other_school) { FactoryBot.create(:school) }
+
+      context "when reported by the given school" do
+        let(:reporter_id) { reporting_school.id }
+
+        it "returns true" do
+          expect(period.reported_leaving_by?(reporting_school)).to be true
+        end
+      end
+
+      context "when not reported" do
+        let(:reporter_id) { nil }
+
+        it "returns false" do
+          expect(period.reported_leaving_by?(reporting_school)).to be false
+        end
+      end
+    end
+  end
+
+  describe "#leaving_reported_for_school?" do
+    let(:reporting_school) { FactoryBot.create(:school) }
+
+    context "via ECTAtSchoolPeriod" do
+      context "when leaving in the future and reported by the school" do
+        subject(:period) do
+          FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.day.from_now,
+                                                   reported_leaving_by_school_id: reporting_school.id)
+        end
+
+        it "returns true" do
+          expect(period.leaving_reported_for_school?(reporting_school)).to be true
+        end
+      end
+
+      context "when finished in the past" do
+        subject(:period) do
+          FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.day.ago,
+                                                   reported_leaving_by_school_id: reporting_school.id)
+        end
+
+        it "returns false" do
+          expect(period.leaving_reported_for_school?(reporting_school)).to be false
+        end
+      end
+
+      context "when not reported by the school" do
+        subject(:period) do
+          FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.day.from_now,
+                                                   reported_leaving_by_school_id: nil)
+        end
+
+        it "returns false" do
+          expect(period.leaving_reported_for_school?(reporting_school)).to be false
+        end
+      end
+
+      context "when reported by the school and finished_on is today" do
+        subject(:period) do
+          FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: Time.zone.today,
+                                                   reported_leaving_by_school_id: reporting_school.id)
+        end
+
+        it "returns true" do
+          expect(period.leaving_reported_for_school?(reporting_school)).to be true
+        end
+      end
+    end
+
+    context "via MentorAtSchoolPeriod" do
+      context "when leaving in the future and reported by the school" do
+        subject(:period) do
+          FactoryBot.create(:mentor_at_school_period, started_on: 1.year.ago, finished_on: 1.day.from_now,
+                                                      reported_leaving_by_school_id: reporting_school.id)
+        end
+
+        it "returns true" do
+          expect(period.leaving_reported_for_school?(reporting_school)).to be true
+        end
+      end
+
+      context "when finished in the past" do
+        subject(:period) do
+          FactoryBot.create(:mentor_at_school_period, started_on: 1.year.ago, finished_on: 1.day.ago,
+                                                      reported_leaving_by_school_id: reporting_school.id)
+        end
+
+        it "returns false" do
+          expect(period.leaving_reported_for_school?(reporting_school)).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/at_school_period_spec.rb
+++ b/spec/models/concerns/at_school_period_spec.rb
@@ -12,7 +12,7 @@ describe AtSchoolPeriod do
       it { is_expected.not_to allow_value("invalid_email").for(:email) }
     end
 
-    describe "#covering_inner_periods" do
+    describe "covering inner periods" do
       context "for an ECT at school period" do
         let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
 
@@ -50,7 +50,7 @@ describe AtSchoolPeriod do
           it "is invalid" do
             ect.started_on = 3.months.ago
             expect(ect).not_to be_valid
-            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(ect.errors[:base]).to include("Date range does not cover all the training periods")
           end
         end
 
@@ -64,7 +64,7 @@ describe AtSchoolPeriod do
           it "is invalid" do
             ect.finished_on = 1.year.ago
             expect(ect).not_to be_valid
-            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(ect.errors[:base]).to include("Date range does not cover all the training periods")
           end
         end
 
@@ -79,7 +79,7 @@ describe AtSchoolPeriod do
             ect.reload
             ect.finished_on = 3.months.ago
             expect(ect).not_to be_valid
-            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(ect.errors[:base]).to include("Date range does not cover all the training periods")
           end
         end
 
@@ -105,7 +105,7 @@ describe AtSchoolPeriod do
           it "is invalid" do
             ect.started_on = 3.months.ago
             expect(ect).not_to be_valid
-            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(ect.errors[:base]).to include("Date range does not cover all the mentorship periods")
           end
         end
 
@@ -133,7 +133,7 @@ describe AtSchoolPeriod do
           it "is invalid when the ECT start is moved past the earliest inner period" do
             ect.started_on = 8.months.ago
             expect(ect).not_to be_valid
-            expect(ect.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(ect.errors[:base]).to include("Date range does not cover all the training periods")
           end
         end
       end
@@ -167,7 +167,7 @@ describe AtSchoolPeriod do
           it "is invalid" do
             mentor.finished_on = 1.year.ago
             expect(mentor).not_to be_valid
-            expect(mentor.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(mentor.errors[:base]).to include("Date range does not cover all the training periods")
           end
         end
 
@@ -193,7 +193,7 @@ describe AtSchoolPeriod do
           it "is invalid" do
             mentor.started_on = 4.months.ago
             expect(mentor).not_to be_valid
-            expect(mentor.errors[:base]).to include("Date range does not cover all the inner periods")
+            expect(mentor.errors[:base]).to include("Date range does not cover all the mentorship periods")
           end
         end
       end

--- a/spec/models/concerns/at_school_period_spec.rb
+++ b/spec/models/concerns/at_school_period_spec.rb
@@ -262,6 +262,62 @@ describe AtSchoolPeriod do
         expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_lead_provider_and_contract_period(training_period.expression_of_interest.contract_period.id, training_period.expression_of_interest.lead_provider_id)).to match_array([period_2])
       end
     end
+
+    describe ".with_school" do
+      it "eager-loads the school and gias_school associations" do
+        ect = FactoryBot.create(:ect_at_school_period)
+        result = ECTAtSchoolPeriod.with_school.find(ect.id)
+        expect(result.association(:school).loaded?).to be true
+      end
+    end
+
+    describe ".with_teacher" do
+      it "eager-loads the teacher association" do
+        ect = FactoryBot.create(:ect_at_school_period)
+        result = ECTAtSchoolPeriod.with_teacher.find(ect.id)
+        expect(result.association(:teacher).loaded?).to be true
+      end
+    end
+  end
+
+  describe "#provider_led_training_programme?" do
+    context "when there is a current or next training period that is provider-led" do
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+
+      before { FactoryBot.create(:training_period, :ongoing, :provider_led, ect_at_school_period: ect, started_on: 6.months.ago) }
+
+      it "returns true" do
+        expect(ect.provider_led_training_programme?).to be true
+      end
+    end
+
+    context "when there is no current or next training period" do
+      subject { FactoryBot.build(:ect_at_school_period) }
+
+      it "returns nil" do
+        expect(subject.provider_led_training_programme?).to be_nil
+      end
+    end
+  end
+
+  describe "#school_led_training_programme?" do
+    context "when there is a current or next training period that is school-led" do
+      let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+
+      before { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period: ect, started_on: 6.months.ago) }
+
+      it "returns true" do
+        expect(ect.school_led_training_programme?).to be true
+      end
+    end
+
+    context "when there is no current or next training period" do
+      subject { FactoryBot.build(:ect_at_school_period) }
+
+      it "returns nil" do
+        expect(subject.school_led_training_programme?).to be_nil
+      end
+    end
   end
 
   describe "#reported_leaving_by?" do

--- a/spec/models/concerns/at_school_period_spec.rb
+++ b/spec/models/concerns/at_school_period_spec.rb
@@ -211,13 +211,13 @@ describe AtSchoolPeriod do
       let!(:teacher_2_period) { FactoryBot.create(:ect_at_school_period, :teaching_school_hub_ab, school:, started_on: "2023-02-01", finished_on: "2023-07-01") }
 
       it "returns only ect periods for the specified school" do
-        expect(ECTAtSchoolPeriod.for_school(period_1.school_id)).to match_array([period_1, period_3, teacher_2_period])
+        expect(ECTAtSchoolPeriod.for_school(period_1.school_id)).to contain_exactly(period_1, period_3, teacher_2_period)
       end
     end
 
     describe ".for_teacher" do
       it "returns ect periods only for the specified teacher" do
-        expect(ECTAtSchoolPeriod.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])
+        expect(ECTAtSchoolPeriod.for_teacher(teacher.id)).to contain_exactly(period_1, period_2, period_3)
       end
     end
 
@@ -229,7 +229,7 @@ describe AtSchoolPeriod do
       end
 
       it "returns ect in training periods only for the specified contract period" do
-        expect(ECTAtSchoolPeriod.with_partnerships_for_contract_period(training_period.school_partnership.contract_period.id)).to match_array([period_2])
+        expect(ECTAtSchoolPeriod.with_partnerships_for_contract_period(training_period.school_partnership.contract_period.id)).to contain_exactly(period_2)
       end
     end
 
@@ -244,7 +244,7 @@ describe AtSchoolPeriod do
       end
 
       it "returns ect in training periods only for the specified contract period" do
-        expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_contract_period(training_period.expression_of_interest.contract_period.id)).to match_array([period_2])
+        expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_contract_period(training_period.expression_of_interest.contract_period.id)).to contain_exactly(period_2)
       end
     end
 
@@ -259,7 +259,7 @@ describe AtSchoolPeriod do
       end
 
       it "returns ect in training periods only for the specified contract period and lead provider" do
-        expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_lead_provider_and_contract_period(training_period.expression_of_interest.contract_period.id, training_period.expression_of_interest.lead_provider_id)).to match_array([period_2])
+        expect(ECTAtSchoolPeriod.with_expressions_of_interest_for_lead_provider_and_contract_period(training_period.expression_of_interest.contract_period.id, training_period.expression_of_interest.lead_provider_id)).to contain_exactly(period_2)
       end
     end
 

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -44,7 +44,11 @@ describe SchoolPartnership do
       subject { instance.ongoing_training_periods }
 
       let(:instance) { FactoryBot.create(:school_partnership) }
-      let(:ongoing_training_period) { FactoryBot.create(:training_period, :ongoing, school_partnership: instance) }
+      let(:ongoing_training_period) do
+        FactoryBot.create(:training_period, :ongoing,
+                          school_partnership: instance,
+                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+      end
 
       before do
         # Different lead provider
@@ -52,7 +56,10 @@ describe SchoolPartnership do
         # Not on-going today
         ect_at_school_period = FactoryBot.create(:ect_at_school_period, school: instance.school, started_on: 1.year.ago, finished_on: 1.month.ago)
         FactoryBot.create(:training_period, school_partnership: instance, ect_at_school_period:, started_on: 5.months.ago, finished_on: 2.months.ago)
-        FactoryBot.create(:training_period, school_partnership: instance, started_on: 1.week.from_now, finished_on: nil)
+        FactoryBot.create(:training_period, :ongoing,
+                          school_partnership: instance,
+                          started_on: 1.week.from_now,
+                          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
       end
 
       it { is_expected.to contain_exactly(ongoing_training_period) }
@@ -67,16 +74,16 @@ describe SchoolPartnership do
 
     it do
       expect(subject).to validate_uniqueness_of(:school_id)
-        .scoped_to(:lead_provider_delivery_partnership_id)
-        .with_message("School and lead provider delivery partnership combination must be unique")
+                           .scoped_to(:lead_provider_delivery_partnership_id)
+                           .with_message("School and lead provider delivery partnership combination must be unique")
     end
   end
 
   describe "scopes" do
     describe ".earliest_first" do
-      let!(:school_partnership_first)  { FactoryBot.create(:school_partnership, created_at: 3.weeks.ago) }
+      let!(:school_partnership_first) { FactoryBot.create(:school_partnership, created_at: 3.weeks.ago) }
       let!(:school_partnership_second) { FactoryBot.create(:school_partnership, created_at: 2.weeks.ago) }
-      let!(:school_partnership_third)  { FactoryBot.create(:school_partnership, created_at: 1.week.ago) }
+      let!(:school_partnership_third) { FactoryBot.create(:school_partnership, created_at: 1.week.ago) }
 
       it "orders with earliest created records first" do
         expect(SchoolPartnership.earliest_first.to_a).to eq([

--- a/spec/requests/admin/finance/statements/statements_spec.rb
+++ b/spec/requests/admin/finance/statements/statements_spec.rb
@@ -168,10 +168,10 @@ RSpec.describe "Admin finance statements index", type: :request do
       let(:training_period) do
         FactoryBot.create(
           :training_period,
-          :for_ect,
           :ongoing,
           school_partnership:,
-          started_on: Date.new(2024, 10, 1)
+          started_on: Date.new(2024, 10, 1),
+          ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on: Date.new(2024, 10, 1))
         )
       end
       let!(:declaration) do

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe "Declarations endpoint", :with_metadata, openapi_spec: "v3/swagge
       :for_ect,
       :ongoing,
       :with_school_partnership,
-      school_partnership:
+      school_partnership:,
+      ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)
     )
   end
   let(:declaration) { FactoryBot.create(:declaration, training_period:) }

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -168,8 +168,8 @@ RSpec.describe "Declarations API", :with_metadata, :with_touches, type: :request
 
       before do
         # Close training periods for other lead providers.
-        resource.teacher.ect_at_school_periods.update!(finished_on: 1.month.from_now)
         resource.teacher.ect_training_periods.update!(finished_on: 1.month.from_now)
+        resource.teacher.ect_at_school_periods.reload.update!(finished_on: 1.month.from_now)
 
         # Create a training period with the new lead provider in the future.
         ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: 2.months.from_now, finished_on: nil, teacher: resource.teacher)

--- a/spec/requests/schools/ects/change_mentor_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_mentor_wizard_spec.rb
@@ -342,6 +342,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
                 .to change(TrainingPeriod, :count).by(1)
 
               ect_at_school_period.reload
+              other_mentor_at_school_period.reload
               new_training_period = TrainingPeriod.last
               expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
                 .to eq(other_mentor_at_school_period)
@@ -401,6 +402,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
                 .to change(TrainingPeriod, :count).by(1)
 
               ect_at_school_period.reload
+              other_mentor_at_school_period.reload
               new_training_period = TrainingPeriod.last
               expect(ect_at_school_period.current_or_next_mentorship_period.mentor)
                 .to eq(other_mentor_at_school_period)

--- a/spec/serializers/api/school_partnership_serializer_spec.rb
+++ b/spec/serializers/api/school_partnership_serializer_spec.rb
@@ -42,7 +42,14 @@ describe API::SchoolPartnershipSerializer, type: :serializer do
       end
 
       context "when there are `participants_currently_training`" do
-        before { FactoryBot.create_list(:training_period, 3, :ongoing, school_partnership: partnership) }
+        before do
+          3.times do
+            FactoryBot.create(:training_period,
+                              :ongoing,
+                              school_partnership: partnership,
+                              ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
+          end
+        end
 
         it { is_expected.to eq(3) }
       end

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -118,15 +118,18 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `contract_period_years`" do
+        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
         let(:contract_period1) { FactoryBot.create(:contract_period) }
         let(:contract_period2) { FactoryBot.create(:contract_period) }
         let(:contract_period3) { FactoryBot.create(:contract_period) }
         let(:school_partnership1) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period1)) }
         let(:school_partnership2) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period2)) }
         let(:school_partnership3) { FactoryBot.create(:school_partnership, active_lead_provider: FactoryBot.create(:active_lead_provider, contract_period: contract_period3)) }
-        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership1).teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, school_partnership: school_partnership2).teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership: school_partnership3).teacher }
+        let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_1, school_partnership: school_partnership1).teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, school_partnership: school_partnership2).teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership: school_partnership3).teacher }
 
         context "when `contract_period_years` param is omitted" do
           it "returns all teachers" do
@@ -208,10 +211,14 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `training_status`" do
+        let(:ect_at_school_period_1) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:ect_at_school_period_2) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+        let(:mentor_at_school_period_1) { FactoryBot.create(:mentor_at_school_period, :ongoing) }
+
         let(:school_partnership) { FactoryBot.create(:school_partnership) }
-        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, school_partnership:).teacher }
-        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, school_partnership:).teacher }
-        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, school_partnership:).teacher }
+        let!(:deferred_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, :deferred, ect_at_school_period: ect_at_school_period_1, school_partnership:).teacher }
+        let!(:withdrawn_teacher) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :withdrawn, mentor_at_school_period: mentor_at_school_period_1, school_partnership:).teacher }
+        let!(:active_teacher) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: ect_at_school_period_2, school_partnership:).teacher }
 
         context "when `training_status` param is omitted" do
           it "returns all teachers" do

--- a/spec/services/ect_at_school_periods/finish_spec.rb
+++ b/spec/services/ect_at_school_periods/finish_spec.rb
@@ -140,12 +140,11 @@ describe ECTAtSchoolPeriods::Finish do
         end
 
         it "uses MentorshipPeriods::Finish to close it" do
-          mentorships_finish = double("MentorshipPeriods::Finish", finish!: true)
-          allow(MentorshipPeriods::Finish).to receive(:new).with(any_args).and_return(mentorships_finish)
+          allow(MentorshipPeriods::Finish).to receive(:new).with(any_args).and_call_original
 
           subject.finish!
 
-          expect(mentorships_finish).to have_received(:finish!).once
+          expect(MentorshipPeriods::Finish).to have_received(:new).once
         end
       end
 
@@ -201,12 +200,11 @@ describe ECTAtSchoolPeriods::Finish do
         end
 
         it "uses TrainingPeriods::Finish to close it" do
-          training_periods_finish = double("TrainingPeriods::Finish", finish!: true)
-          allow(TrainingPeriods::Finish).to receive(:new).with(any_args).and_return(training_periods_finish)
+          allow(TrainingPeriods::Finish).to receive(:new).with(any_args).and_call_original
 
           subject.finish!
 
-          expect(training_periods_finish).to have_received(:finish!).once
+          expect(TrainingPeriods::Finish).to have_received(:new).once
         end
       end
 

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -224,9 +224,7 @@ module ECTAtSchoolPeriods
     end
 
     describe ".to_provider_led" do
-      let!(:contract_period) do
-        FactoryBot.create(:contract_period, :with_schedules, :current)
-      end
+      let!(:contract_period) { FactoryBot.create(:contract_period, :with_schedules, :current) }
       let(:lead_provider) { FactoryBot.create(:lead_provider) }
       let!(:active_lead_provider) do
         FactoryBot.create(
@@ -893,7 +891,7 @@ module ECTAtSchoolPeriods
               it "finds the active lead provider with the correct contract period" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
-                new_training_period = mentor_at_school_period.training_periods.last
+                new_training_period = mentor_at_school_period.reload.training_periods.last
                 expect(new_training_period.expression_of_interest).to eq(active_lead_provider)
               end
             end
@@ -936,7 +934,7 @@ module ECTAtSchoolPeriods
               it "finds the existing lead provider" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
-                new_training_period = mentor_at_school_period.training_periods.last
+                new_training_period = mentor_at_school_period.reload.training_periods.last
                 expect(new_training_period.school_partnership).to eq(school_partnership)
               end
             end
@@ -957,7 +955,7 @@ module ECTAtSchoolPeriods
               it "assigns a January schedule" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
-                new_training_period = mentor_at_school_period.training_periods.last
+                new_training_period = mentor_at_school_period.reload.training_periods.last
                 expect(new_training_period.schedule.identifier).to eq("ecf-standard-january")
                 expect(new_training_period.schedule.contract_period.year).to eq(2025)
               end
@@ -973,7 +971,7 @@ module ECTAtSchoolPeriods
               it "assigns a September schedule" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
-                new_training_period = mentor_at_school_period.training_periods.last
+                new_training_period = mentor_at_school_period.reload.training_periods.last
                 expect(new_training_period.schedule.identifier).to eq("ecf-standard-september")
                 expect(new_training_period.schedule.contract_period.year).to eq(2025)
               end
@@ -989,7 +987,7 @@ module ECTAtSchoolPeriods
               it "assigns an April schedule" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
-                new_training_period = mentor_at_school_period.training_periods.last
+                new_training_period = mentor_at_school_period.reload.training_periods.last
                 expect(new_training_period.schedule.identifier).to eq("ecf-standard-april")
                 expect(new_training_period.schedule.contract_period.year).to eq(2025)
               end
@@ -1009,7 +1007,7 @@ module ECTAtSchoolPeriods
             it "assigns a `finished_on` date for the training period" do
               SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
-              new_training_period = mentor_at_school_period.training_periods.last
+              new_training_period = mentor_at_school_period.reload.training_periods.last
               expect(new_training_period.finished_on).to eq(mentor_at_school_period.finished_on)
             end
           end

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -77,6 +77,35 @@ describe MentorAtSchoolPeriods::Finish do
       end
     end
 
+    context "when the training period has not started yet" do
+      let(:training_start_date) { finished_on + 2.weeks }
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_mentor,
+          mentor_at_school_period:,
+          started_on: training_start_date
+        )
+      end
+
+      it "deletes the training period" do
+        expect { subject.finish_periods_at_all_schools! }.to change(TrainingPeriod, :count).by(-1)
+      end
+
+      it "deletes any events associated with the training period" do
+        FactoryBot.create(:event, training_period:)
+        FactoryBot.create(:event, training_period:)
+        other_event = FactoryBot.create(:event)
+
+        expect(Event.where(training_period:).count).to eq(2)
+
+        subject.finish_periods_at_all_schools!
+
+        expect(Event.where(training_period:)).to be_empty
+        expect(Event.exists?(other_event.id)).to be true
+      end
+    end
+
     context "when the mentor's leaving date is earlier than the ECT's leaving date" do
       subject { MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: mentor_finished_on, author:, reported_by_school_id:) }
 

--- a/spec/services/mentor_at_school_periods/finish_spec.rb
+++ b/spec/services/mentor_at_school_periods/finish_spec.rb
@@ -155,30 +155,19 @@ describe MentorAtSchoolPeriods::Finish do
     end
 
     it "uses MentorshipPeriods::Finish to close mentorship periods" do
-      mentorships_finish = double("MentorshipPeriods::Finish", finish!: true)
-      allow(MentorshipPeriods::Finish).to receive(:new).with(
-        mentorship_period:,
-        finished_on:,
-        author:
-      ).and_return(mentorships_finish)
+      allow(MentorshipPeriods::Finish).to receive(:new).and_call_original
 
       subject.finish_periods_at_all_schools!
 
-      expect(mentorships_finish).to have_received(:finish!).once
+      expect(MentorshipPeriods::Finish).to have_received(:new).once
     end
 
     it "uses TrainingPeriods::Finish to close training periods" do
-      training_periods_finish = double("TrainingPeriods::Finish", finish!: true)
-      allow(TrainingPeriods::Finish).to receive(:mentor_training).with(
-        training_period:,
-        mentor_at_school_period:,
-        finished_on:,
-        author:
-      ).and_return(training_periods_finish)
+      allow(TrainingPeriods::Finish).to receive(:new).and_call_original
 
       subject.finish_periods_at_all_schools!
 
-      expect(training_periods_finish).to have_received(:finish!).once
+      expect(TrainingPeriods::Finish).to have_received(:new).once
     end
 
     context "when there are no ongoing mentor at school periods" do

--- a/spec/services/statements/declaration_selection_spec.rb
+++ b/spec/services/statements/declaration_selection_spec.rb
@@ -51,10 +51,11 @@ RSpec.describe Statements::DeclarationSelection do
       )
     )
   end
+  let(:started_on) { Date.new(2024, 10, 1) }
   let(:default_training_period_attrs) do
     {
       school_partnership:,
-      started_on: Date.new(2024, 10, 1)
+      started_on:,
     }
   end
 
@@ -88,7 +89,11 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:current_billable_later_declaration) do
@@ -99,7 +104,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.day,
           created_at: base_declaration_date + 1.day
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -118,7 +127,11 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:middle_declaration) do
@@ -129,7 +142,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.day,
           created_at: base_declaration_date + 1.day
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:later_declaration) do
@@ -140,7 +157,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 2.days,
           created_at: base_declaration_date + 2.days
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -156,21 +177,33 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:same_timestamp_declaration_two) do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:same_timestamp_declaration_three) do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -203,7 +236,11 @@ RSpec.describe Statements::DeclarationSelection do
           clawback_statement: statement,
           clawback_status: :awaiting_clawback
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -220,7 +257,11 @@ RSpec.describe Statements::DeclarationSelection do
           payment_statement: statement,
           payment_status: :voided
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -264,7 +305,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date,
           created_at: base_declaration_date
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:retained_billable_declaration) do
@@ -276,7 +321,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.day,
           created_at: base_declaration_date + 1.day
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:completed_billable_declaration) do
@@ -288,7 +337,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 2.days,
           created_at: base_declaration_date + 2.days
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:started_refundable_declaration) do
@@ -302,7 +355,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 3.days,
           created_at: base_declaration_date + 3.days
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:voided_declaration) do
@@ -314,7 +371,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 4.days,
           created_at: base_declaration_date + 4.days
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -352,7 +413,11 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -385,7 +450,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date,
           created_at: base_declaration_date
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:previous_billable_later_declaration) do
@@ -396,7 +465,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.hour,
           created_at: base_declaration_date + 1.hour
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:current_declaration) do
@@ -407,7 +480,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.day,
           created_at: base_declaration_date + 1.day
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -448,14 +525,22 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: qualifying_previous_statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:same_payment_date_declaration) do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: same_payment_date_statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:current_declaration) do
@@ -466,7 +551,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.day,
           created_at: base_declaration_date + 1.day
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 
@@ -527,7 +616,8 @@ RSpec.describe Statements::DeclarationSelection do
         :for_ect,
         :ongoing,
         school_partnership: other_school_partnership,
-        started_on: Date.new(2024, 10, 1)
+        started_on:,
+        ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:)
       )
     end
 
@@ -535,7 +625,11 @@ RSpec.describe Statements::DeclarationSelection do
       FactoryBot.create(
         :declaration,
         **default_declaration_attrs.merge(payment_statement: qualifying_previous_statement),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
     let!(:other_provider_declaration) do
@@ -553,7 +647,11 @@ RSpec.describe Statements::DeclarationSelection do
           declaration_date: base_declaration_date + 1.day,
           created_at: base_declaration_date + 1.day
         ),
-        training_period: FactoryBot.create(:training_period, :for_ect, :ongoing, **default_training_period_attrs)
+        training_period: FactoryBot.create(:training_period,
+                                           :for_ect,
+                                           :ongoing,
+                                           ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, started_on:),
+                                           **default_training_period_attrs)
       )
     end
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

- Validate the range of ASPs to cover the inner periods (training periods and mentorship periods)
- Extract `at_school_period` concern from `ect_at_school_period` and `mentor_at_school_period`

### Guidance to review
