### PR TITLE
[3377] Add validation rule to prevent mentors being moved to reduced schedules

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,26 +1,23 @@
 class Schedule < ApplicationRecord
-  REPLACEMENT_SCHEDULE_IDENTIFIERS = %w[
-    ecf-replacement-april
-    ecf-replacement-january
-    ecf-replacement-september
-  ].freeze
-
   enum :identifier,
-       {
-         "ecf-extended-april" => "ecf-extended-april",
-         "ecf-extended-january" => "ecf-extended-january",
-         "ecf-extended-september" => "ecf-extended-september",
-         "ecf-reduced-april" => "ecf-reduced-april",
-         "ecf-reduced-january" => "ecf-reduced-january",
-         "ecf-reduced-september" => "ecf-reduced-september",
-         "ecf-replacement-april" => "ecf-replacement-april",
-         "ecf-replacement-january" => "ecf-replacement-january",
-         "ecf-replacement-september" => "ecf-replacement-september",
-         "ecf-standard-april" => "ecf-standard-april",
-         "ecf-standard-january" => "ecf-standard-january",
-         "ecf-standard-september" => "ecf-standard-september"
-       },
+       %w[
+         ecf-extended-april
+         ecf-extended-january
+         ecf-extended-september
+         ecf-reduced-april
+         ecf-reduced-january
+         ecf-reduced-september
+         ecf-replacement-april
+         ecf-replacement-january
+         ecf-replacement-september
+         ecf-standard-april
+         ecf-standard-january
+         ecf-standard-september
+       ].index_by(&:itself),
        validate: { message: "Choose an identifier from the list" }
+
+  REPLACEMENT_SCHEDULE_IDENTIFIERS = identifiers.keys.grep(/replacement/).freeze
+  REDUCED_SCHEDULE_IDENTIFIERS = identifiers.keys.grep(/reduced/).freeze
 
   belongs_to :contract_period, inverse_of: :schedules, foreign_key: :contract_period_year
   has_many :milestones
@@ -39,8 +36,16 @@ class Schedule < ApplicationRecord
     where.not(identifier: REPLACEMENT_SCHEDULE_IDENTIFIERS)
   }
 
+  scope :excluding_reduced_schedules, -> {
+    where.not(identifier: REDUCED_SCHEDULE_IDENTIFIERS)
+  }
+
   def replacement_schedule?
     identifier.in?(REPLACEMENT_SCHEDULE_IDENTIFIERS)
+  end
+
+  def reduced_schedule?
+    identifier.in?(REDUCED_SCHEDULE_IDENTIFIERS)
   end
 
   def description

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -87,7 +87,8 @@ class TrainingPeriod < ApplicationRecord
   validates :finished_on, presence: true, if: -> { withdrawn_at.present? || deferred_at.present? }
   validate :contract_period_consistent_across_associations, if: :provider_led_training_programme?
   validate :schedule_absent_for_school_led, if: :school_led_training_programme?
-  validate :schedule_applicable_for_trainee
+  validate :schedule_applicable_for_ect
+  validate :schedule_applicable_for_mentor
   with_options if: -> { started_on&.future? } do
     validates :withdrawn_at, absence: true
     validates :withdrawal_reason, absence: true
@@ -251,11 +252,18 @@ private
     errors.add(:schedule, "Schedule must be absent for school-led training programmes")
   end
 
-  def schedule_applicable_for_trainee
+  def schedule_applicable_for_ect
     return if schedule.blank?
     return unless for_ect?
 
     errors.add(:schedule, "Only mentors can be assigned to replacement schedules") if schedule.replacement_schedule?
+  end
+
+  def schedule_applicable_for_mentor
+    return if schedule.blank?
+    return unless for_mentor?
+
+    errors.add(:schedule, "Only ECTs can be assigned to reduced schedules") if schedule.reduced_schedule?
   end
 
   def withdrawal_reason_valid_for_trainee_type

--- a/app/services/api/teachers/change_schedule.rb
+++ b/app/services/api/teachers/change_schedule.rb
@@ -12,7 +12,8 @@ module API::Teachers
     }, allow_blank: true
     validate :schedule_exists
     validate :change_to_different_schedule
-    validate :schedule_applicable_for_trainee
+    validate :schedule_applicable_for_ect
+    validate :schedule_applicable_for_mentor
     validate :school_partnership_exists_if_changing_contract_period
     validate :trainee_not_completed
     validate :lead_provider_is_currently_training_teacher
@@ -71,11 +72,18 @@ module API::Teachers
       errors.add(:schedule_identifier, "Selected schedule is already on the profile")
     end
 
-    def schedule_applicable_for_trainee
+    def schedule_applicable_for_ect
       return if errors[:schedule_identifier].any?
       return unless training_period&.for_ect?
 
       errors.add(:schedule_identifier, "Selected schedule is not valid for the teacher_type") if schedule.replacement_schedule?
+    end
+
+    def schedule_applicable_for_mentor
+      return if errors[:schedule_identifier].any?
+      return unless training_period&.for_mentor?
+
+      errors.add(:schedule_identifier, "Mentors cannot be placed on a reduced schedule. Assign them to a different schedule.") if schedule.reduced_schedule?
     end
 
     def school_partnership_exists_if_changing_contract_period

--- a/app/services/api_seed_data/participant_scenarios.rb
+++ b/app/services/api_seed_data/participant_scenarios.rb
@@ -80,7 +80,7 @@ module APISeedData
               started_on: start_date
             )
 
-            schedule = find_schedule(contract_period)
+            schedule = find_schedule(contract_period, type)
 
             FactoryBot.create(
               :training_period,
@@ -136,7 +136,7 @@ module APISeedData
               started_on: start_date
             )
 
-            schedule = find_schedule(contract_period)
+            schedule = find_schedule(contract_period, type)
 
             FactoryBot.create(
               :training_period,
@@ -183,7 +183,7 @@ module APISeedData
               started_on: start_date
             )
 
-            schedule = find_schedule(contract_period)
+            schedule = find_schedule(contract_period, :ect)
 
             FactoryBot.create(
               :training_period,
@@ -236,7 +236,7 @@ module APISeedData
               started_on: start_date
             )
 
-            schedule = find_schedule(contract_period)
+            schedule = find_schedule(contract_period, :ect)
 
             FactoryBot.create(
               :training_period,
@@ -303,7 +303,7 @@ module APISeedData
               school = school_partnership.school
               start_date = Date.new(contract_period_year, 9, 1)
               school_period = FactoryBot.create(:"#{type}_at_school_period", :ongoing, school:, started_on: start_date)
-              schedule = find_schedule(contract_period)
+              schedule = find_schedule(contract_period, type)
               teacher = school_period.teacher
 
               training_period = FactoryBot.create(
@@ -392,7 +392,7 @@ module APISeedData
 
               school_period = FactoryBot.create(:"#{type}_at_school_period", :ongoing, school:, started_on: start_date, finished_on: finished_date)
 
-              schedule = find_schedule(contract_period)
+              schedule = find_schedule(contract_period, type)
 
               FactoryBot.create(
                 :training_period,
@@ -459,7 +459,7 @@ module APISeedData
                 finished_on: finished_date
               )
 
-              schedule = find_schedule(contract_period)
+              schedule = find_schedule(contract_period, type)
 
               FactoryBot.create(
                 :training_period,
@@ -527,7 +527,7 @@ module APISeedData
                 finished_on: finished_date
               )
 
-              schedule = find_schedule(contract_period)
+              schedule = find_schedule(contract_period, type)
 
               FactoryBot.create(
                 :training_period,
@@ -597,7 +597,7 @@ module APISeedData
                 finished_on: finished_date
               )
 
-              schedule = find_schedule(contract_period)
+              schedule = find_schedule(contract_period, type)
 
               FactoryBot.create(
                 :training_period,
@@ -667,7 +667,7 @@ module APISeedData
                 finished_on: finished_date
               )
 
-              schedule = find_schedule(contract_period)
+              schedule = find_schedule(contract_period, type)
 
               FactoryBot.create(
                 :training_period,
@@ -702,7 +702,7 @@ module APISeedData
         .first
     end
 
-    def find_schedule(contract_period)
+    def find_schedule(contract_period, trainee_type)
       if Faker::Boolean.boolean(true_ratio: 0.8)
         return Schedule.find_by(
           contract_period:,
@@ -710,11 +710,19 @@ module APISeedData
         )
       end
 
-      Schedule
-        .excluding_replacement_schedules
-        .where(contract_period:)
-        .order(Arel.sql("RANDOM()"))
-        .first
+      if trainee_type == :mentor
+        Schedule
+          .excluding_reduced_schedules
+          .where(contract_period:)
+          .order(Arel.sql("RANDOM()"))
+          .first
+      else
+        Schedule
+          .excluding_replacement_schedules
+          .where(contract_period:)
+          .order(Arel.sql("RANDOM()"))
+          .first
+      end
     end
 
     def find_contract_period(year)

--- a/app/services/api_seed_data/teachers_with_change_schedule.rb
+++ b/app/services/api_seed_data/teachers_with_change_schedule.rb
@@ -143,6 +143,7 @@ module APISeedData
     def random_schedule(contract_period:, trainee_type:, excluding_schedule_identifier: nil)
       if trainee_type == :mentor
         Schedule
+          .excluding_reduced_schedules
           .where(contract_period:)
           .where.not(identifier: excluding_schedule_identifier)
           .order("RANDOM()")

--- a/app/services/api_seed_data/teachers_with_histories.rb
+++ b/app/services/api_seed_data/teachers_with_histories.rb
@@ -82,14 +82,12 @@ module APISeedData
                                end
       ect_mentor_traits = generate_ect_mentor_school_period_traits
       ect_specific_traits = generate_ect_specific_traits
-      schedule = find_schedule(school_partnership.contract_period)
 
       if rand_boolean(ECT_MENTOR_RATIO)
         create_ect_and_optional_mentor_training(
           teacher,
           school,
           school_period,
-          schedule,
           school_partnership,
           training_period_data,
           training_status_traits,
@@ -103,7 +101,6 @@ module APISeedData
           teacher,
           school,
           school_period,
-          schedule,
           school_partnership,
           training_period_data,
           training_status_traits,
@@ -121,7 +118,7 @@ module APISeedData
         .first
     end
 
-    def find_schedule(contract_period)
+    def find_schedule(contract_period, trainee_type)
       if rand_boolean(SCHEDULE_RATIO)
         return Schedule.find_by(
           contract_period:,
@@ -129,10 +126,17 @@ module APISeedData
         )
       end
 
-      schedules = Schedule
-        .excluding_replacement_schedules
-        .where(contract_period:)
-        .order(:id)
+      schedules = if trainee_type == :mentor
+                    Schedule
+                      .excluding_reduced_schedules
+                      .where(contract_period:)
+                      .order(:id)
+                  else
+                    Schedule
+                      .excluding_replacement_schedules
+                      .where(contract_period:)
+                      .order(:id)
+                  end
 
       # We cycle the schedules to avoid flaky tests that happen
       # with random schedules.
@@ -165,7 +169,6 @@ module APISeedData
       teacher,
       school,
       school_period,
-      schedule,
       school_partnership,
       training_period_data,
       training_period_traits,
@@ -178,6 +181,8 @@ module APISeedData
         school_period:,
         traits: ect_mentor_traits + ect_specific_traits
       )
+
+      schedule = find_schedule(school_partnership.contract_period, :ect)
 
       FactoryBot.create(
         :training_period,
@@ -201,6 +206,8 @@ module APISeedData
           traits: ect_mentor_traits
         )
 
+        schedule = find_schedule(school_partnership.contract_period, :mentor)
+
         FactoryBot.create(
           :training_period,
           *training_period_traits.compact,
@@ -218,7 +225,6 @@ module APISeedData
       teacher,
       school,
       school_period,
-      schedule,
       school_partnership,
       training_period_data,
       training_period_traits,
@@ -231,6 +237,8 @@ module APISeedData
         school_period:,
         traits: ect_mentor_traits
       )
+
+      schedule = find_schedule(school_partnership.contract_period, :mentor)
 
       FactoryBot.create(
         :training_period,
@@ -253,6 +261,8 @@ module APISeedData
           school_period:,
           traits: ect_mentor_traits + ect_specific_traits
         )
+
+        schedule = find_schedule(school_partnership.contract_period, :ect)
 
         FactoryBot.create(
           :training_period,

--- a/db/scripts/fix_mentors_training_period_schedules.rb
+++ b/db/scripts/fix_mentors_training_period_schedules.rb
@@ -1,0 +1,22 @@
+# This script finds training periods for mentors that are on a reduced schedule and updates them to the corresponding standard schedule.
+# This is necessary because mentors should not be on reduced schedules, which are only applicable for ECTs.
+
+SCHEDULE_MAPPINGS = {
+  "ecf-reduced-april": "ecf-standard-april",
+  "ecf-reduced-january": "ecf-standard-january",
+  "ecf-reduced-september": "ecf-standard-september"
+}.freeze
+
+TrainingPeriod.where.not(mentor_at_school_period_id: nil).where(schedule_id: Schedule.where(identifier: SCHEDULE_MAPPINGS.keys).select(:id)).find_each do |training_period|
+  # Double check: Only update training periods for mentors, not ECTs
+  next unless training_period.for_mentor?
+
+  new_schedule = Schedule.find_by!(
+    identifier: SCHEDULE_MAPPINGS[training_period.schedule.identifier.to_sym],
+    contract_period_year: training_period.schedule.contract_period_year
+  )
+
+  Rails.logger.debug "Updating TrainingPeriod ID: #{training_period.id} from Schedule: #{training_period.schedule.identifier} to Schedule: #{new_schedule.identifier}"
+
+  training_period.update!(schedule_id: new_schedule.id)
+end

--- a/spec/factories/schedule_factory.rb
+++ b/spec/factories/schedule_factory.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       identifier { "ecf-extended-september" }
     end
 
+    trait :reduced_schedule do
+      identifier { "ecf-reduced-september" }
+    end
+
     trait :with_milestones do
       after(:build) do |schedule|
         year = schedule.contract_period.year

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -37,6 +37,17 @@ describe Schedule do
         expect(subject).to contain_exactly(standard_schedule)
       end
     end
+
+    describe ".excluding_reduced_schedules" do
+      subject { Schedule.excluding_reduced_schedules }
+
+      let!(:reduced_schedule) { FactoryBot.create(:schedule, identifier: "ecf-reduced-april") }
+      let!(:standard_schedule) { FactoryBot.create(:schedule, identifier: "ecf-standard-april") }
+
+      it "returns only standard schedules" do
+        expect(subject).to contain_exactly(standard_schedule)
+      end
+    end
   end
 
   describe "#replacement_schedule?" do
@@ -48,6 +59,18 @@ describe Schedule do
     it "returns false for non-replacement schedules" do
       schedule = Schedule.new(identifier: "ecf-standard-april")
       expect(schedule).not_to be_replacement_schedule
+    end
+  end
+
+  describe "#reduced_schedule?" do
+    it "returns true for reduced schedules" do
+      schedule = Schedule.new(identifier: "ecf-reduced-april")
+      expect(schedule).to be_reduced_schedule
+    end
+
+    it "returns false for non-reduced schedules" do
+      schedule = Schedule.new(identifier: "ecf-standard-april")
+      expect(schedule).not_to be_reduced_schedule
     end
   end
 

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -705,7 +705,7 @@ describe TrainingPeriod do
       end
     end
 
-    describe "schedule applicable for trainee" do
+    describe "schedule applicable for ECTs" do
       it "adds an error when an ECT is assigned to a replacement schedule" do
         ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
         training_period = FactoryBot.build(:training_period, :for_ect, ect_at_school_period:, schedule: FactoryBot.create(:schedule, :replacement_schedule))
@@ -723,6 +723,29 @@ describe TrainingPeriod do
       it "does not add an error when an ECT is assigned to a non-replacement schedule" do
         ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
         training_period = FactoryBot.build(:training_period, :for_ect, ect_at_school_period:, schedule: FactoryBot.create(:schedule))
+        training_period.valid?
+        expect(training_period.errors[:schedule]).to be_empty
+      end
+    end
+
+    describe "schedule applicable for mentors" do
+      it "adds an error when a mentor is assigned to a reduced schedule" do
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
+        training_period = FactoryBot.build(:training_period, :for_mentor, mentor_at_school_period:, schedule: FactoryBot.create(:schedule, :reduced_schedule))
+        training_period.valid?
+        expect(training_period.errors[:schedule]).to include("Only ECTs can be assigned to reduced schedules")
+      end
+
+      it "does not add an error when an ECT is assigned to a reduced schedule" do
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
+        training_period = FactoryBot.build(:training_period, :for_ect, ect_at_school_period:, schedule: FactoryBot.create(:schedule, :reduced_schedule))
+        training_period.valid?
+        expect(training_period.errors[:schedule]).to be_empty
+      end
+
+      it "does not add an error when a mentor is assigned to a non-reduced schedule" do
+        mentor_at_school_period = FactoryBot.create(:mentor_at_school_period, started_on: Date.new(2024, 12, 25), finished_on: nil)
+        training_period = FactoryBot.build(:training_period, :for_mentor, mentor_at_school_period:, schedule: FactoryBot.create(:schedule))
         training_period.valid?
         expect(training_period.errors[:schedule]).to be_empty
       end

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
               it { is_expected.to have_one_error_per_attribute }
               it { is_expected.to have_error(:schedule_identifier, "Selected schedule is not valid for the teacher_type") }
             end
+          else
+            context "when a mentor attempts to change to a reduced schedule" do
+              let(:schedule_identifier) { "ecf-reduced-september" }
+              let!(:schedule) { FactoryBot.create(:schedule, identifier: schedule_identifier, contract_period:) }
+
+              it { is_expected.to have_one_error_per_attribute }
+              it { is_expected.to have_error(:schedule_identifier, "Mentors cannot be placed on a reduced schedule. Assign them to a different schedule.") }
+            end
           end
 
           context "when changing contract_period_year without a school partnership" do


### PR DESCRIPTION
### Context

Ticket: [3377](https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3377)

Mentors should not be placed on reduced schedules in any cohort. There are a single digit number of mentors on reduced schedules currently. We should prevent this in future.

### Changes proposed in this pull request

- Add validation rule to prevent mentors being moved to reduced schedules;
- Update the seeds accordingly;
- Add script to fix bad existing data;

### Guidance to review

[Review app](https://cpd-ec2-review-2882-web.test.teacherservices.cloud/admin)