### PR TITLE
[3947] Change AB on school view

### DIFF
--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -81,15 +81,11 @@ module Admin
       end
 
       def appropriate_body_name
-        if has_induction_periods_and_no_mentor_training_periods?
+        if induction.has_induction_periods?
           induction.latest_induction_period&.appropriate_body_name
         else
           school_period.school_reported_appropriate_body_name
         end
-      end
-
-      def has_induction_periods_and_no_mentor_training_periods?
-        school_period.teacher.mentor_training_periods.none? && induction.has_induction_periods?
       end
 
       def induction

--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -77,12 +77,14 @@ module Admin
       end
 
       def appropriate_body_text
-        if current_induction_period
-          current_induction_period.appropriate_body_period.name
-        elsif school_period.school_reported_appropriate_body_name.present?
-          school_period.school_reported_appropriate_body_name
+        appropriate_body_name.presence || "No appropriate body recorded"
+      end
+
+      def appropriate_body_name
+        if induction.has_induction_periods?
+          induction.latest_induction_period&.appropriate_body_name
         else
-          "No appropriate body recorded"
+          school_period.school_reported_appropriate_body_name
         end
       end
 

--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -81,15 +81,15 @@ module Admin
       end
 
       def appropriate_body_name
-        if induction.has_induction_periods?
+        if has_induction_periods_and_no_mentor_training_periods?
           induction.latest_induction_period&.appropriate_body_name
         else
           school_period.school_reported_appropriate_body_name
         end
       end
 
-      def current_induction_period
-        @current_induction_period ||= induction.current_induction_period
+      def has_induction_periods_and_no_mentor_training_periods?
+        school_period.teacher.mentor_training_periods.none? && induction.has_induction_periods?
       end
 
       def induction

--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -77,7 +77,11 @@ module Admin
       end
 
       def appropriate_body_text
-        school_period.school_reported_appropriate_body_name.presence || "No appropriate body recorded"
+        induction.current_induction_period.appropriate_body_period.name.presence || "No appropriate body recorded"
+      end
+
+      def induction
+        ::Teachers::Induction.new(school_period.teacher)
       end
 
       def mentorship_periods_for_ect

--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -77,7 +77,17 @@ module Admin
       end
 
       def appropriate_body_text
-        induction.current_induction_period.appropriate_body_period.name.presence || "No appropriate body recorded"
+        if current_induction_period
+          current_induction_period.appropriate_body_period.name
+        elsif school_period.school_reported_appropriate_body_name.present?
+          school_period.school_reported_appropriate_body_name
+        else
+          "No appropriate body recorded"
+        end
+      end
+
+      def current_induction_period
+        @current_induction_period ||= induction.current_induction_period
       end
 
       def induction

--- a/app/components/admin/teachers/school_summary_component.rb
+++ b/app/components/admin/teachers/school_summary_component.rb
@@ -82,7 +82,7 @@ module Admin
 
       def appropriate_body_name
         if induction.has_induction_periods?
-          induction.latest_induction_period&.appropriate_body_name
+          induction.latest_induction_period.appropriate_body_name
         else
           school_period.school_reported_appropriate_body_name
         end

--- a/app/components/schools/ect_induction_details_component.rb
+++ b/app/components/schools/ect_induction_details_component.rb
@@ -54,7 +54,7 @@ module Schools
 
     def appropriate_body_name
       if induction.has_induction_periods?
-        induction.latest_induction_period&.appropriate_body_name
+        induction.latest_induction_period.appropriate_body_name
       else
         @ect.school_reported_appropriate_body_name
       end

--- a/app/components/schools/ect_induction_details_component.rb
+++ b/app/components/schools/ect_induction_details_component.rb
@@ -37,7 +37,7 @@ module Schools
     end
 
     def induction_start_date
-      Teachers::Induction.new(@ect.teacher).induction_start_date&.to_fs(:govuk)
+      induction.induction_start_date&.to_fs(:govuk)
     end
 
     def induction_start_date_with_suffix(date)
@@ -49,7 +49,19 @@ module Schools
     end
 
     def appropriate_body_text
-      @ect.school_reported_appropriate_body_name.presence || "Not reported"
+      appropriate_body_name.presence || "Not reported"
+    end
+
+    def appropriate_body_name
+      if induction.has_induction_periods?
+        induction.latest_induction_period&.appropriate_body_name
+      else
+        @ect.school_reported_appropriate_body_name
+      end
+    end
+
+    def induction
+      @induction ||= Teachers::Induction.new(@ect.teacher)
     end
 
     def induction_start_date_not_reported_row

--- a/app/services/teachers/induction.rb
+++ b/app/services/teachers/induction.rb
@@ -11,6 +11,10 @@ module Teachers
       teacher.ongoing_induction_period
     end
 
+    def latest_induction_period
+      induction_periods.latest_first&.first
+    end
+
     def past_induction_periods
       @past_induction_periods ||= induction_periods.finished.latest_first
     end

--- a/spec/components/admin/teachers/school_summary_component_spec.rb
+++ b/spec/components/admin/teachers/school_summary_component_spec.rb
@@ -96,17 +96,6 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
           expect(rendered).to have_css("dt", text: "Appropriate body")
           expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
         end
-
-        context "when the teacher also has mentor training periods" do
-          let(:mentor_start_date) { school_period.started_on + 1.year }
-          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date) }
-          let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: mentor_start_date) }
-
-          it "shows the appropriate body from the school period, not the induction period" do
-            expect(rendered).to have_css("dt", text: "Appropriate body")
-            expect(rendered).to have_css("dd", text: "Appropriate Body Name")
-          end
-        end
       end
 
       context "when an ECT has more than one induction period" do
@@ -118,17 +107,6 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
         it "shows the appropriate body from the current induction period" do
           expect(rendered).to have_css("dt", text: "Appropriate body")
           expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
-        end
-
-        context "when the teacher also has mentor training periods" do
-          let(:mentor_start_date) { school_period.started_on + 1.year }
-          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date) }
-          let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: mentor_start_date) }
-
-          it "shows the appropriate body from the school period, not the induction period" do
-            expect(rendered).to have_css("dt", text: "Appropriate body")
-            expect(rendered).to have_css("dd", text: "Appropriate Body Name")
-          end
         end
       end
     end

--- a/spec/components/admin/teachers/school_summary_component_spec.rb
+++ b/spec/components/admin/teachers/school_summary_component_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
       }
     end
     let(:school_period) { FactoryBot.create(:ect_at_school_period, **school_period_attributes) }
+    let(:teacher) { school_period.teacher }
 
     context "card title" do
       it "links to the admin school overview" do
@@ -71,7 +72,7 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
     end
 
     context "Appropriate body row" do
-      context "when the ECT has no induction periods" do
+      context "when an ECT has no induction periods" do
         it "shows the appropriate body from the school period" do
           expect(rendered).to have_css("dt", text: "Appropriate body")
           expect(rendered).to have_css("dd", text: "Appropriate Body Name")
@@ -87,25 +88,47 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
         end
       end
 
-      context "when the ECT has one induction period" do
+      context "when an ECT has one induction period" do
         let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current Appropriate Body Name") }
-        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: school_period.teacher, appropriate_body_period: current_appropriate_body_period) }
+        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period) }
 
         it "shows the appropriate body from the induction period" do
           expect(rendered).to have_css("dt", text: "Appropriate body")
           expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
         end
+
+        context "when the teacher also has mentor training periods" do
+          let(:mentor_start_date) { school_period.started_on + 1.year }
+          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date) }
+          let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: mentor_start_date) }
+
+          it "shows the appropriate body from the school period, not the induction period" do
+            expect(rendered).to have_css("dt", text: "Appropriate body")
+            expect(rendered).to have_css("dd", text: "Appropriate Body Name")
+          end
+        end
       end
 
-      context "when the ECT has more than one induction period" do
+      context "when an ECT has more than one induction period" do
         let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current Appropriate Body Name") }
         let(:past_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Past Appropriate Body Name") }
-        let!(:past_induction_period) { FactoryBot.create(:induction_period, teacher: school_period.teacher, appropriate_body_period: past_appropriate_body_period) }
-        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: school_period.teacher, appropriate_body_period: current_appropriate_body_period, started_on: 7.days.ago) }
+        let!(:past_induction_period) { FactoryBot.create(:induction_period, teacher:, appropriate_body_period: past_appropriate_body_period) }
+        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period, started_on: 7.days.ago) }
 
         it "shows the appropriate body from the current induction period" do
           expect(rendered).to have_css("dt", text: "Appropriate body")
           expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
+        end
+
+        context "when the teacher also has mentor training periods" do
+          let(:mentor_start_date) { school_period.started_on + 1.year }
+          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: mentor_start_date) }
+          let!(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: mentor_start_date) }
+
+          it "shows the appropriate body from the school period, not the induction period" do
+            expect(rendered).to have_css("dt", text: "Appropriate body")
+            expect(rendered).to have_css("dd", text: "Appropriate Body Name")
+          end
         end
       end
     end

--- a/spec/components/admin/teachers/school_summary_component_spec.rb
+++ b/spec/components/admin/teachers/school_summary_component_spec.rb
@@ -71,17 +71,41 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
     end
 
     context "Appropriate body row" do
-      it "shows the school reported appropriate body" do
-        expect(rendered).to have_css("dt", text: "Appropriate body")
-        expect(rendered).to have_css("dd", text: "Appropriate Body Name")
+      context "when the ECT has no induction periods" do
+        it "shows the appropriate body from the school period" do
+          expect(rendered).to have_css("dt", text: "Appropriate body")
+          expect(rendered).to have_css("dd", text: "Appropriate Body Name")
+        end
+
+        context "when no appropriate body is recorded" do
+          let(:appropriate_body_period) { nil }
+
+          it "falls back to the placeholder text" do
+            expect(rendered).to have_css("dt", text: "Appropriate body")
+            expect(rendered).to have_css("dd", text: "No appropriate body recorded")
+          end
+        end
       end
 
-      context "when no appropriate body is recorded" do
-        let(:appropriate_body_period) { nil }
+      context "when the ECT has one induction period" do
+        let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current Appropriate Body Name") }
+        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: school_period.teacher, appropriate_body_period: current_appropriate_body_period) }
 
-        it "falls back to the placeholder text" do
+        it "shows the appropriate body from the induction period" do
           expect(rendered).to have_css("dt", text: "Appropriate body")
-          expect(rendered).to have_css("dd", text: "No appropriate body recorded")
+          expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
+        end
+      end
+
+      context "when the ECT has more than one induction period" do
+        let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current Appropriate Body Name") }
+        let(:past_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Past Appropriate Body Name") }
+        let!(:past_induction_period) { FactoryBot.create(:induction_period, teacher: school_period.teacher, appropriate_body_period: past_appropriate_body_period) }
+        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher: school_period.teacher, appropriate_body_period: current_appropriate_body_period, started_on: 7.days.ago) }
+
+        it "shows the appropriate body from the current induction period" do
+          expect(rendered).to have_css("dt", text: "Appropriate body")
+          expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
         end
       end
     end

--- a/spec/components/admin/teachers/school_summary_component_spec.rb
+++ b/spec/components/admin/teachers/school_summary_component_spec.rb
@@ -99,12 +99,12 @@ RSpec.describe Admin::Teachers::SchoolSummaryComponent, type: :component do
       end
 
       context "when an ECT has more than one induction period" do
-        let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current Appropriate Body Name") }
+        let(:latest_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current Appropriate Body Name") }
         let(:past_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Past Appropriate Body Name") }
         let!(:past_induction_period) { FactoryBot.create(:induction_period, teacher:, appropriate_body_period: past_appropriate_body_period) }
-        let!(:current_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period, started_on: 7.days.ago) }
+        let!(:latest_induction_period) { FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: latest_appropriate_body_period, started_on: 7.days.ago) }
 
-        it "shows the appropriate body from the current induction period" do
+        it "shows the appropriate body from the latest induction period" do
           expect(rendered).to have_css("dt", text: "Appropriate body")
           expect(rendered).to have_css("dd", text: "Current Appropriate Body Name")
         end

--- a/spec/components/schools/ect_induction_details_component_spec.rb
+++ b/spec/components/schools/ect_induction_details_component_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
                       started_on: Date.new(2023, 9, 1))
   end
 
+  let(:current_induction_period) { nil }
+  let(:past_induction_period) { nil }
+
   before do
+    past_induction_period
+    current_induction_period
     render_inline(described_class.new(ect))
   end
 
@@ -45,29 +50,64 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
     end
   end
 
-  context "when the appropriate body has not been reported" do
-    let(:ect) do
-      FactoryBot.create(:ect_at_school_period,
-                        teacher:,
-                        school_reported_appropriate_body: nil,
-                        started_on: Date.new(2023, 9, 1))
+  context "when the ECT has no induction periods" do
+    context "when the appropriate body has not been reported" do
+      let(:ect) do
+        FactoryBot.create(:ect_at_school_period,
+                          teacher:,
+                          school_reported_appropriate_body: nil,
+                          started_on: Date.new(2023, 9, 1))
+      end
+
+      it "renders not reported for the appropriate body" do
+        expect(page).to have_selector(".govuk-summary-list__key", text: "Appropriate body")
+        expect(page).to have_selector(".govuk-summary-list__value", text: "Not reported")
+      end
+
+      it "renders the induction start date fallback" do
+        expect(page).to have_selector(".govuk-summary-list__key", text: "Induction start date")
+        expect(page).to have_selector(".govuk-summary-list__value", text: "Yet to be reported by the appropriate body")
+      end
     end
 
-    it "renders not reported for the appropriate body" do
-      expect(page).to have_selector(".govuk-summary-list__key", text: "Appropriate body")
-      expect(page).to have_selector(".govuk-summary-list__value", text: "Not reported")
-    end
-
-    it "renders the induction start date fallback" do
-      expect(page).to have_selector(".govuk-summary-list__key", text: "Induction start date")
-      expect(page).to have_selector(".govuk-summary-list__value", text: "Yet to be reported by the appropriate body")
+    context "when the appropriate body is reported" do
+      it "renders the reported appropriate body" do
+        expect(page).to have_selector(".govuk-summary-list__key", text: "Appropriate body")
+        expect(page).to have_selector(".govuk-summary-list__value", text: "Alpha Teaching School Hub")
+        expect(page).not_to have_selector(".govuk-summary-list__value", text: "Not reported")
+      end
     end
   end
 
-  context "when the appropriate body is reported" do
-    it "renders the reported appropriate body" do
+  context "when the ECT has one induction period" do
+    let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current AB") }
+    let!(:current_induction_period) do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period, started_on: 1.week.ago)
+    end
+
+    it "renders the appropriate body from the induction period" do
       expect(page).to have_selector(".govuk-summary-list__key", text: "Appropriate body")
-      expect(page).to have_selector(".govuk-summary-list__value", text: "Alpha Teaching School Hub")
+      expect(page).to have_selector(".govuk-summary-list__value", text: "Current AB")
+      expect(page).not_to have_selector(".govuk-summary-list__value", text: "Alpha Teaching School Hub")
+      expect(page).not_to have_selector(".govuk-summary-list__value", text: "Not reported")
+    end
+  end
+
+  context "when the ECT has multiple induction periods" do
+    let(:past_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Past AB") }
+    let!(:past_induction_period) do
+      FactoryBot.create(:induction_period, teacher:, appropriate_body_period: past_appropriate_body_period)
+    end
+    let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current AB") }
+    let!(:current_induction_period) do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period, started_on: 1.week.ago)
+    end
+
+    it "renders the appropriate body from the latest induction period" do
+      expect(page).to have_selector(".govuk-summary-list__key", text: "Appropriate body")
+      expect(page).to have_selector(".govuk-summary-list__value", text: "Current AB")
+      expect(page).not_to have_selector(".govuk-summary-list__value", text: "Past AB")
+      expect(page).not_to have_selector(".govuk-summary-list__value", text: "Alpha Teaching School Hub")
       expect(page).not_to have_selector(".govuk-summary-list__value", text: "Not reported")
     end
   end

--- a/spec/components/schools/ect_induction_details_component_spec.rb
+++ b/spec/components/schools/ect_induction_details_component_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
                       started_on: Date.new(2023, 9, 1))
   end
 
-  let(:current_induction_period) { nil }
+  let(:latest_induction_period) { nil }
   let(:past_induction_period) { nil }
 
   before do
     past_induction_period
-    current_induction_period
+    latest_induction_period
     render_inline(described_class.new(ect))
   end
 
@@ -80,9 +80,9 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
   end
 
   context "when the ECT has one induction period" do
-    let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current AB") }
-    let!(:current_induction_period) do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period, started_on: 1.week.ago)
+    let(:latest_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current AB") }
+    let!(:latest_induction_period) do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: latest_appropriate_body_period, started_on: Date.new(2023, 9, 1))
     end
 
     it "renders the appropriate body from the induction period" do
@@ -91,16 +91,22 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
       expect(page).not_to have_selector(".govuk-summary-list__value", text: "Alpha Teaching School Hub")
       expect(page).not_to have_selector(".govuk-summary-list__value", text: "Not reported")
     end
+
+    it "renders the induction start date from the induction period, with a hint" do
+      expect(page).to have_selector(".govuk-summary-list__key", text: "Induction start date")
+      expect(page).to have_selector(".govuk-summary-list__value", text: "1 September 2023This has been reported by an appropriate body")
+      expect(page).not_to have_selector(".govuk-summary-list__value", text: "Yet to be reported by the appropriate body")
+    end
   end
 
   context "when the ECT has multiple induction periods" do
     let(:past_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Past AB") }
     let!(:past_induction_period) do
-      FactoryBot.create(:induction_period, teacher:, appropriate_body_period: past_appropriate_body_period)
+      FactoryBot.create(:induction_period, teacher:, appropriate_body_period: past_appropriate_body_period, started_on: Date.new(2023, 9, 1), finished_on: Date.new(2024, 7, 1))
     end
-    let(:current_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current AB") }
-    let!(:current_induction_period) do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: current_appropriate_body_period, started_on: 1.week.ago)
+    let(:latest_appropriate_body_period) { FactoryBot.create(:appropriate_body_period, name: "Current AB") }
+    let!(:latest_induction_period) do
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period: latest_appropriate_body_period, started_on: Date.new(2024, 9, 1))
     end
 
     it "renders the appropriate body from the latest induction period" do
@@ -109,6 +115,12 @@ RSpec.describe Schools::ECTInductionDetailsComponent, type: :component do
       expect(page).not_to have_selector(".govuk-summary-list__value", text: "Past AB")
       expect(page).not_to have_selector(".govuk-summary-list__value", text: "Alpha Teaching School Hub")
       expect(page).not_to have_selector(".govuk-summary-list__value", text: "Not reported")
+    end
+
+    it "renders the induction start date from the first induction period, with a hint" do
+      expect(page).to have_selector(".govuk-summary-list__key", text: "Induction start date")
+      expect(page).to have_selector(".govuk-summary-list__value", text: "1 September 2023This has been reported by an appropriate body")
+      expect(page).not_to have_selector(".govuk-summary-list__value", text: "Yet to be reported by the appropriate body")
     end
   end
 end

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -34,6 +34,41 @@ RSpec.describe Teachers::Induction do
     end
   end
 
+  describe "#latest_induction_period" do
+    context "with one ongoing period" do
+      before do
+        induction_period_unfinished
+      end
+
+      it "returns the current induction period" do
+        expect(service.latest_induction_period).to eq(induction_period_unfinished)
+      end
+    end
+
+    context "with one finished induction period" do
+      before { induction_period_finished_one_year_ago }
+
+      it "returns the finished induction period" do
+        expect(service.latest_induction_period).to eq(induction_period_finished_one_year_ago)
+      end
+    end
+
+    context "with multiple induction periods" do
+      before do
+        induction_period_unfinished
+        induction_period_finished_one_year_ago
+      end
+
+      it "returns the most recent induction period" do
+        expect(service.latest_induction_period).to eq(induction_period_unfinished)
+      end
+    end
+
+    context "without any induction periods" do
+      it { expect(service.latest_induction_period).to be_nil }
+    end
+  end
+
   describe "#past_induction_periods" do
     before do
       induction_period_unfinished

--- a/spec/services/teachers/induction_spec.rb
+++ b/spec/services/teachers/induction_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Teachers::Induction do
   end
 
   describe "#latest_induction_period" do
+    context "with no induction periods" do
+      it { expect(service.latest_induction_period).to be_nil }
+    end
+
     context "with one ongoing period" do
       before do
         induction_period_unfinished
@@ -62,10 +66,6 @@ RSpec.describe Teachers::Induction do
       it "returns the most recent induction period" do
         expect(service.latest_induction_period).to eq(induction_period_unfinished)
       end
-    end
-
-    context "without any induction periods" do
-      it { expect(service.latest_induction_period).to be_nil }
     end
   end
 

--- a/spec/views/schools/ects/show.html.erb_spec.rb
+++ b/spec/views/schools/ects/show.html.erb_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe "schools/ects/show.html.erb" do
 
   describe "Induction details" do
     before do
-      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:)
+      appropriate_body_period = FactoryBot.create(:appropriate_body_period, name: "Latest AB")
+      FactoryBot.create(:induction_period, :ongoing, teacher:, appropriate_body_period:, started_on: 1.week.ago.to_date)
       teacher.reload # Reload to pick up the new induction period
     end
 
@@ -124,12 +125,12 @@ RSpec.describe "schools/ects/show.html.erb" do
 
     it "shows appropriate body" do
       expect(subject).to have_css("dt.govuk-summary-list__key", text: "Appropriate body")
-      expect(subject).to have_css("dd.govuk-summary-list__value", text: "Requested AB")
+      expect(subject).to have_css("dd.govuk-summary-list__value", text: "Latest AB")
     end
 
     it "shows induction start date" do
       expect(subject).to have_css("dt.govuk-summary-list__key", text: "Induction start date")
-      expect(subject).to have_css("dd.govuk-summary-list__value", text: 1.year.ago.to_date.to_fs(:govuk))
+      expect(subject).to have_css("dd.govuk-summary-list__value", text: 1.week.ago.to_date.to_fs(:govuk))
     end
 
     context "when no induction start date is available" do


### PR DESCRIPTION
### Context
Currently, an ECT's appropriate body is recorded through the appropriate body period, which has a name attribute.  This is due to be refactored.  Until that point a mismatch can exist between an ECT's induction period and the appropriate body period.  Therefore, if an ECT has an induction period, we want to display the AB associated with that in the school summary page of the admin console, and the ECT induction summary for the schools.  If the ECT has more than one induction period, we take the details from the latest period.

If the teacher is both a Mentor and an ECT these details do not show up in components relative to the `mentor_at_school_period` so no changes are needed.

Admin view
<img width="961" height="731" alt="image" src="https://github.com/user-attachments/assets/a04e7523-465a-49c3-a0f3-a13658dc09dc" />

School view
<img width="678" height="917" alt="image" src="https://github.com/user-attachments/assets/83b84144-c828-4260-af3f-2928eccd4ac7" />


### Changes proposed in this pull request

### Guidance to review
Take an ECT with no induction periods and create an induction period with a different AB from the one reported.  You should see this present on the above screen now.  Find an ECT who has not had the AB reported.  Create a new induction period.  You should see the AB from the induction period is present.
