### PR TITLE
[3958] Make GIAS secure units eligible for funding

### DIFF
--- a/app/services/gias/types.rb
+++ b/app/services/gias/types.rb
@@ -60,7 +60,6 @@ module GIAS
     NOT_ELIGIBLE_TYPES = [
       "Other independent special school",
       "Other independent school",
-      "Secure units",
       "Offshore schools",
       "Service children's education",
       "Miscellaneous",


### PR DESCRIPTION
## Summary

- Update GIAS eligibility rules so `Secure units` are treated as eligible establishments.
- Secure units will be imported as eligible GIAS schools after the next GIAS sync.

## Production data check

Checked current production data:

- `GIAS::School.where(type_name: "Secure units").count` returned `0`
- `School.where(marked_as_eligible: true).count` returned `0`

So there are no current manual eligibility overrides to clean up in production.

## Follow up after nightly GIAS sync runs

The nightly GIAS sync runs with `auto_create_school: false`, so after the sync we should check whether secure units have been imported into `gias_schools` and create any missing local `schools` rows for open England eligible secure units.
