### PR TITLE
Make training period ranges have an inclusive end

### DIFF
--- a/app/services/api_seed_data/ect_participant_action_scenarios.rb
+++ b/app/services/api_seed_data/ect_participant_action_scenarios.rb
@@ -66,7 +66,7 @@ module APISeedData
 
         # Active training period at the same school but with a different lead provider
         school_partnership = school_partnerships(excluding_active_lead_provider: active_lead_provider, year: contract_period.year, school:).sample
-        training_time_period = { started_on: training_period_at_first_school.finished_on, finished_on: nil }
+        training_time_period = { started_on: training_period_at_first_school.finished_on.next_day, finished_on: nil }
         create_training_period(ect_at_school_period:, school_partnership:, training_time_period:)
 
         log_plant_info("Created participant started with another lead provider for #{school_partnership.active_lead_provider.lead_provider.name}")

--- a/app/services/api_seed_data/school_scenarios.rb
+++ b/app/services/api_seed_data/school_scenarios.rb
@@ -219,7 +219,7 @@ module APISeedData
           )
 
           # Training with original lead provider (finished)
-          add_training_period(
+          finished_training_period = add_training_period(
             school_period,
             programme_type: :provider_led,
             from: school_period.started_on,
@@ -231,7 +231,7 @@ module APISeedData
           add_training_period(
             school_period,
             programme_type: :provider_led,
-            from: school_period.started_on + 3.months,
+            from: finished_training_period.finished_on.next_day,
             with: other_lead_provider
           )
 
@@ -457,7 +457,7 @@ module APISeedData
             ect_at_school_period: school_period,
             school_partnership: school_partnership_other,
             schedule: schedule_2025,
-            started_on: first_training_end,
+            started_on: first_training_end.next_day,
             finished_on: second_training_end
           )
 

--- a/app/services/api_seed_data/teachers/school_transfers.rb
+++ b/app/services/api_seed_data/teachers/school_transfers.rb
@@ -58,9 +58,9 @@ module APISeedData
     def create_incomplete_transfer_scenario(from_lead_provider, to_lead_provider, type)
       teacher = select_random_teacher
       school_period1 = create_school_period(teacher, from: 3.years.ago, to: 1.week.ago, type:)
-      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
-      add_training_period(school_period1, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: from_lead_provider, transfer: true)
-      add_training_period(school_period1, from: 1.year.ago, to: 1.week.ago, programme_type: :provider_led, with: to_lead_provider, transfer: true)
+      training_period1 = add_training_period(school_period1, from: school_period1.started_on, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
+      training_period2 = add_training_period(school_period1, from: training_period1.finished_on.next_day, to: 1.year.ago, programme_type: :provider_led, with: from_lead_provider, transfer: true)
+      add_training_period(school_period1, from: training_period2.finished_on.next_day, to: school_period1.finished_on, programme_type: :provider_led, with: to_lead_provider, transfer: true)
 
       log_seed_info("1. Provider Led -> Unknown (incomplete): #{::Teachers::Name.new(teacher).full_name} (#{type})", indent: 4)
     end
@@ -69,10 +69,10 @@ module APISeedData
     def create_same_lp_transfer_scenario(from_lead_provider, to_lead_provider, type)
       teacher = select_random_teacher
       school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago, type:)
-      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
-      school_period2 = create_school_period(teacher, from: 2.years.ago, type:, transfer: true)
-      @training_period2 = add_training_period(school_period2, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: from_lead_provider, transfer: true)
-      add_training_period(school_period2, from: 1.year.ago, programme_type: :provider_led, with: to_lead_provider, transfer: true)
+      add_training_period(school_period1, from: school_period1.started_on, to: school_period1.finished_on, programme_type: :provider_led, with: from_lead_provider)
+      school_period2 = create_school_period(teacher, from: school_period1.finished_on.next_day, type:, transfer: true)
+      training_period2 = add_training_period(school_period2, from: school_period2.started_on, to: 1.year.ago, programme_type: :provider_led, with: from_lead_provider, transfer: true)
+      add_training_period(school_period2, from: training_period2.finished_on.next_day, programme_type: :provider_led, with: to_lead_provider, transfer: true)
 
       log_seed_info("2. Provider Led -> Provider Led (same LP): #{::Teachers::Name.new(teacher).full_name} (#{type})", indent: 4)
     end
@@ -81,11 +81,11 @@ module APISeedData
     def create_different_lp_transfer_scenario(from_lead_provider, to_lead_provider, type)
       teacher = select_random_teacher
       school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago, type:)
-      @training_period1 = add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
-      school_period2 = create_school_period(teacher, from: 2.years.ago, type:, transfer: true)
-      @training_period2 = add_training_period(school_period2, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: to_lead_provider, transfer: true)
+      add_training_period(school_period1, from: school_period1.started_on, to: school_period1.finished_on, programme_type: :provider_led, with: from_lead_provider)
+      school_period2 = create_school_period(teacher, from: school_period1.finished_on.next_day, type:, transfer: true)
+      training_period2 = add_training_period(school_period2, from: school_period2.started_on, to: 1.year.ago, programme_type: :provider_led, with: to_lead_provider, transfer: true)
       different_lead_provider = select_different_lead_provider(excluding_lead_providers: [from_lead_provider, to_lead_provider])
-      add_training_period(school_period2, from: 1.year.ago, programme_type: :provider_led, with: different_lead_provider)
+      add_training_period(school_period2, from: training_period2.finished_on.next_day, programme_type: :provider_led, with: different_lead_provider)
 
       log_seed_info("3. Provider Led -> Provider Led (different LP): #{::Teachers::Name.new(teacher).full_name} (#{type})", indent: 4)
     end
@@ -94,9 +94,9 @@ module APISeedData
     def create_provider_to_school_led_scenario(from_lead_provider)
       teacher = select_random_teacher
       school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago)
-      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: from_lead_provider)
-      school_period2 = create_school_period(teacher, from: 2.years.ago, transfer: true)
-      add_training_period(school_period2, from: 2.years.ago, programme_type: :school_led, transfer: true)
+      add_training_period(school_period1, from: school_period1.started_on, to: school_period1.finished_on, programme_type: :provider_led, with: from_lead_provider)
+      school_period2 = create_school_period(teacher, from: school_period1.finished_on.next_day, transfer: true)
+      add_training_period(school_period2, from: school_period2.started_on, programme_type: :school_led, transfer: true)
 
       log_seed_info("4. Provider Led -> School Led: #{::Teachers::Name.new(teacher).full_name} (ect)", indent: 4)
     end
@@ -105,9 +105,9 @@ module APISeedData
     def create_school_led_to_provider_scenario(from_lead_provider)
       teacher = select_random_teacher
       school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago)
-      add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :school_led)
-      school_period2 = create_school_period(teacher, from: 2.years.ago, transfer: true)
-      add_training_period(school_period2, from: 2.years.ago, programme_type: :provider_led, with: from_lead_provider, transfer: true)
+      add_training_period(school_period1, from: school_period1.started_on, to: school_period1.finished_on, programme_type: :school_led)
+      school_period2 = create_school_period(teacher, from: school_period1.finished_on.next_day, transfer: true)
+      add_training_period(school_period2, from: school_period2.started_on, programme_type: :provider_led, with: from_lead_provider, transfer: true)
 
       log_seed_info("5. School Led -> Provider Led: #{::Teachers::Name.new(teacher).full_name} (ect)", indent: 4)
     end

--- a/app/services/api_seed_data/teachers_with_change_schedule.rb
+++ b/app/services/api_seed_data/teachers_with_change_schedule.rb
@@ -96,7 +96,7 @@ module APISeedData
       create_training_period(
         trainee_type:,
         at_school_period:,
-        started_on: finished_on,
+        started_on: finished_on.next_day,
         finished_on: at_school_period.finished_on,
         schedule:,
         school_partnership:

--- a/app/services/declarations/mentor_completion.rb
+++ b/app/services/declarations/mentor_completion.rb
@@ -37,7 +37,7 @@ module Declarations
 
       TrainingPeriods::Create.provider_led(
         period:,
-        started_on: latest_training_period.finished_on,
+        started_on: latest_training_period.finished_on + 1.day,
         finished_on: period.finished_on,
         school_partnership: latest_training_period.school_partnership,
         expression_of_interest: nil,

--- a/app/services/ect_at_school_periods/change_lead_provider.rb
+++ b/app/services/ect_at_school_periods/change_lead_provider.rb
@@ -20,7 +20,7 @@ module ECTAtSchoolPeriods
       TrainingPeriods::Finish.ect_training(
         training_period:,
         ect_at_school_period:,
-        finished_on: Date.current,
+        finished_on: Date.yesterday,
         author:
       ).finish!
     end

--- a/app/services/ect_at_school_periods/switch_training.rb
+++ b/app/services/ect_at_school_periods/switch_training.rb
@@ -98,7 +98,7 @@ module ECTAtSchoolPeriods
       TrainingPeriods::Finish.ect_training(
         training_period: @training_period,
         ect_at_school_period: @ect_at_school_period,
-        finished_on: Date.current,
+        finished_on: Date.yesterday,
         author: @author
       ).finish!
     end

--- a/app/services/mentor_at_school_periods/change_lead_provider.rb
+++ b/app/services/mentor_at_school_periods/change_lead_provider.rb
@@ -14,7 +14,7 @@ module MentorAtSchoolPeriods
       TrainingPeriods::Finish.mentor_training(
         training_period:,
         mentor_at_school_period:,
-        finished_on: Date.current,
+        finished_on: Date.yesterday,
         author:
       ).finish!
     end

--- a/app/services/schools/assign_mentor.rb
+++ b/app/services/schools/assign_mentor.rb
@@ -67,9 +67,12 @@ module Schools
     end
 
     def previous_school_mentor_at_school_periods
-      finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(mentor.started_on)
-      scope = ::MentorAtSchoolPeriod.ongoing.or(finishes_in_the_future_scope)
-      mentor.teacher.mentor_at_school_periods.where.not(school: ect.school).merge(scope)
+      finishes_in_the_future_scope = ::MentorAtSchoolPeriod.finished_on_or_after(mentor.started_on.yesterday)
+      ongoing_or_finished_in_future_scope = ::MentorAtSchoolPeriod.ongoing.or(finishes_in_the_future_scope)
+      ::MentorAtSchoolPeriod
+        .where(teacher: mentor.teacher)
+        .where.not(school: ect.school)
+        .merge(ongoing_or_finished_in_future_scope)
     end
 
     def current_mentorship_period

--- a/app/services/schools/register_mentor.rb
+++ b/app/services/schools/register_mentor.rb
@@ -116,7 +116,11 @@ module Schools
     end
 
     def finish_periods_at_all_schools!
-      MentorAtSchoolPeriods::Finish.new(teacher:, finished_on: started_on, author:).finish_periods_at_all_schools!
+      MentorAtSchoolPeriods::Finish.new(
+        teacher:,
+        finished_on: started_on.yesterday,
+        author:
+      ).finish_periods_at_all_schools!
     end
 
     def mentoring_at_several_schools?

--- a/app/services/teachers/change_schedule.rb
+++ b/app/services/teachers/change_schedule.rb
@@ -61,7 +61,7 @@ module Teachers
     end
 
     def finish_training_period!
-      finished_on = [training_period.finished_on, Time.zone.today].compact.min
+      finished_on = [training_period.finished_on, Date.yesterday].compact.min
 
       if training_period.for_ect?
         TrainingPeriods::Finish.ect_training(

--- a/app/services/training_periods/change_partnership.rb
+++ b/app/services/training_periods/change_partnership.rb
@@ -42,14 +42,14 @@ module TrainingPeriods
         TrainingPeriods::Finish.ect_training(
           training_period:,
           ect_at_school_period: training_period.ect_at_school_period,
-          finished_on: Date.current,
+          finished_on: Date.yesterday,
           author:
         ).finish!
       else
         TrainingPeriods::Finish.mentor_training(
           training_period:,
           mentor_at_school_period: training_period.mentor_at_school_period,
-          finished_on: Date.current,
+          finished_on: Date.yesterday,
           author:
         ).finish!
       end

--- a/db/migrate/20260511090738_make_training_period_ranges_inclusive_end.rb
+++ b/db/migrate/20260511090738_make_training_period_ranges_inclusive_end.rb
@@ -1,0 +1,8 @@
+class MakeTrainingPeriodRangesInclusiveEnd < ActiveRecord::Migration[8.1]
+  def change
+    # rubocop:disable Rails/BulkChangeTable
+    remove_column :training_periods, :range, :daterange
+    add_column :training_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on, '[]')", stored: true
+    # rubocop:enable Rails/BulkChangeTable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -899,7 +899,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
     t.bigint "expression_of_interest_id"
     t.date "finished_on"
     t.bigint "mentor_at_school_period_id"
-    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on, '[]'::text)", stored: true
     t.bigint "schedule_id"
     t.bigint "school_partnership_id"
     t.date "started_on", null: false

--- a/db/seeds/support/school_transfer_helpers.rb
+++ b/db/seeds/support/school_transfer_helpers.rb
@@ -30,20 +30,27 @@ private
       raise ArgumentError, "Need either leaving_lead_provider or joining_lead_provider"
     end
 
-    school_period1 = create_school_period(teacher, from: 1.year.ago, to: 6.months.ago, type:)
-    school_period2 = create_school_period(teacher, from: 6.months.ago, type:, transfer: true)
+    school_period1_leave_date = 6.months.ago
+    school_period2_join_date = school_period1_leave_date + 1.day
+
+    school_period1 = create_school_period(teacher, from: 1.year.ago, to: school_period1_leave_date, type:)
+    school_period2 = create_school_period(teacher, from: school_period2_join_date, type:, transfer: true)
 
     if leaving_lead_provider && joining_lead_provider
-      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: 6.months.ago, with: leaving_lead_provider)
-      add_training_period(school_period2, programme_type: :provider_led, from: 6.months.ago, to: 3.months.ago, with: joining_lead_provider, transfer: true)
+      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: school_period1_leave_date, with: leaving_lead_provider)
+
+      leaving_lead_provider_finish_date = 3.months.ago
+      joining_lead_provider_start_date = leaving_lead_provider_finish_date + 1.day
+
+      add_training_period(school_period2, programme_type: :provider_led, from: school_period2_join_date, to: leaving_lead_provider_finish_date, with: joining_lead_provider, transfer: true)
       latest_lead_provider = FactoryBot.create(:lead_provider)
-      add_training_period(school_period2, programme_type: :provider_led, from: 3.months.ago, with: latest_lead_provider)
+      add_training_period(school_period2, programme_type: :provider_led, from: joining_lead_provider_start_date, with: latest_lead_provider)
     elsif leaving_lead_provider
-      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: 6.months.ago, with: leaving_lead_provider)
-      add_training_period(school_period2, programme_type: :school_led, from: 6.months.ago, to: 3.months.ago, transfer: true)
+      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: school_period1_leave_date, with: leaving_lead_provider)
+      add_training_period(school_period2, programme_type: :school_led, from: school_period2_join_date, to: 3.months.ago, transfer: true)
     elsif joining_lead_provider
-      add_training_period(school_period1, programme_type: :school_led, from: 1.year.ago, to: 6.months.ago)
-      add_training_period(school_period2, programme_type: :provider_led, from: 6.months.ago, to: 3.months.ago, with: joining_lead_provider, transfer: true)
+      add_training_period(school_period1, programme_type: :school_led, from: 1.year.ago, to: school_period1_leave_date)
+      add_training_period(school_period2, programme_type: :provider_led, from: school_period2_join_date, to: 3.months.ago, with: joining_lead_provider, transfer: true)
     end
   end
 

--- a/db/seeds/support/school_transfer_helpers.rb
+++ b/db/seeds/support/school_transfer_helpers.rb
@@ -3,26 +3,26 @@ private
 
   def build_ignored_transfer_for_finished_school_period(teacher:, lead_provider:, type: :ect)
     school_period1 = create_school_period(teacher, from: 1.year.ago, to: 1.week.ago, type:)
-    add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago.tomorrow, to: 9.months.ago, with: lead_provider)
-    add_training_period(school_period1, programme_type: :provider_led, from: 9.months.ago.tomorrow, to: 3.months.ago, with: lead_provider)
-    add_training_period(school_period1, programme_type: :school_led, from: 3.months.ago.tomorrow, to: 1.week.ago)
+    add_training_period(school_period1, programme_type: :provider_led, from: school_period1.started_on, to: 9.months.ago, with: lead_provider)
+    add_training_period(school_period1, programme_type: :provider_led, from: 9.months.ago.next_day, to: 3.months.ago, with: lead_provider)
+    add_training_period(school_period1, programme_type: :school_led, from: 3.months.ago.next_day, to: school_period1.finished_on)
   end
 
   def build_unknown_transfer_for_finished_school_period(teacher:, lead_provider:, type: :ect)
     school_period1 = create_school_period(teacher, from: 1.year.ago, to: 1.week.ago, type:)
     original_lead_provider = FactoryBot.create(:lead_provider)
-    add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago.tomorrow, to: 9.months.ago, with: original_lead_provider)
-    add_training_period(school_period1, programme_type: :provider_led, from: 9.months.ago.tomorrow, to: 3.months.ago, with: original_lead_provider, transfer: true)
-    add_training_period(school_period1, programme_type: :provider_led, from: 3.months.ago.tomorrow, to: 1.week.ago, with: lead_provider, transfer: true)
+    training_period1 = add_training_period(school_period1, programme_type: :provider_led, from: school_period1.started_on, to: 9.months.ago, with: original_lead_provider)
+    training_period2 = add_training_period(school_period1, programme_type: :provider_led, from: training_period1.finished_on.next_day, to: 3.months.ago, with: original_lead_provider, transfer: true)
+    add_training_period(school_period1, programme_type: :provider_led, from: training_period2.finished_on.next_day, to: school_period1.finished_on, with: lead_provider, transfer: true)
   end
 
   def build_new_school_transfer(teacher:, lead_provider:, type: :ect)
     school_period1 = create_school_period(teacher, from: 1.year.ago, to: 6.months.ago, type:)
-    add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: 6.months.ago, with: lead_provider)
-    school_period2 = create_school_period(teacher, from: 6.months.ago.tomorrow, type:, transfer: true)
-    add_training_period(school_period2, programme_type: :provider_led, from: 6.months.ago.tomorrow, to: 3.months.ago, with: lead_provider, transfer: true)
+    add_training_period(school_period1, programme_type: :provider_led, from: school_period1.started_on, to: school_period1.finished_on, with: lead_provider)
+    school_period2 = create_school_period(teacher, from: school_period1.finished_on.next_day, type:, transfer: true)
+    training_period1 = add_training_period(school_period2, programme_type: :provider_led, from: school_period2.started_on, to: 3.months.ago, with: lead_provider, transfer: true)
     latest_lead_provider = FactoryBot.create(:lead_provider)
-    add_training_period(school_period2, programme_type: :provider_led, from: 3.months.ago.tomorrow, with: latest_lead_provider, transfer: true)
+    add_training_period(school_period2, programme_type: :provider_led, from: training_period1.finished_on.next_day, with: latest_lead_provider, transfer: true)
   end
 
   def build_new_provider_transfer(teacher:, leaving_lead_provider: nil, joining_lead_provider: nil, type: :ect)
@@ -31,22 +31,22 @@ private
     end
 
     school_period1_leave_date = 6.months.ago
-    school_period2_join_date = school_period1_leave_date + 1.day
+    school_period2_join_date = school_period1_leave_date.next_day
 
-    school_period1 = create_school_period(teacher, from: 1.year.ago, to: school_period1_leave_date, type:)
+    school_period1 = create_school_period(teacher, from: 1.year.ago, to: school_period1_leave_date.prev_day, type:)
     school_period2 = create_school_period(teacher, from: school_period2_join_date, type:, transfer: true)
 
     if leaving_lead_provider && joining_lead_provider
-      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: school_period1_leave_date, with: leaving_lead_provider)
+      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: school_period1_leave_date.prev_day, with: leaving_lead_provider)
 
       leaving_lead_provider_finish_date = 3.months.ago
-      joining_lead_provider_start_date = leaving_lead_provider_finish_date + 1.day
+      joining_lead_provider_start_date = leaving_lead_provider_finish_date.next_day
 
       add_training_period(school_period2, programme_type: :provider_led, from: school_period2_join_date, to: leaving_lead_provider_finish_date, with: joining_lead_provider, transfer: true)
       latest_lead_provider = FactoryBot.create(:lead_provider)
       add_training_period(school_period2, programme_type: :provider_led, from: joining_lead_provider_start_date, with: latest_lead_provider)
     elsif leaving_lead_provider
-      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: school_period1_leave_date, with: leaving_lead_provider)
+      add_training_period(school_period1, programme_type: :provider_led, from: 1.year.ago, to: school_period1_leave_date.prev_day, with: leaving_lead_provider)
       add_training_period(school_period2, programme_type: :school_led, from: school_period2_join_date, to: 3.months.ago, transfer: true)
     elsif joining_lead_provider
       add_training_period(school_period1, programme_type: :school_led, from: 1.year.ago, to: school_period1_leave_date)
@@ -56,15 +56,15 @@ private
 
   def build_ignored_transfer(teacher:, lead_provider:, type: :ect)
     school_period1 = create_school_period(teacher, from: 1.year.ago, to: 6.months.ago, type:)
-    add_training_period(school_period1, programme_type: :school_led, from: 1.year.ago, to: 6.months.ago)
-    school_period2 = create_school_period(teacher, from: 6.months.ago, type:, transfer: true)
-    add_training_period(school_period2, programme_type: :school_led, from: 6.months.ago, to: 1.week.ago, transfer: true)
-    add_training_period(school_period2, programme_type: :provider_led, from: 1.week.ago, with: lead_provider, transfer: true)
+    add_training_period(school_period1, programme_type: :school_led, from: school_period1.started_on, to: school_period1.finished_on)
+    school_period2 = create_school_period(teacher, from: school_period1.finished_on.next_day, type:, transfer: true)
+    training_period1 = add_training_period(school_period2, programme_type: :school_led, from: school_period2.started_on, to: 1.week.ago, transfer: true)
+    add_training_period(school_period2, programme_type: :provider_led, from: training_period1.finished_on.next_day, with: lead_provider, transfer: true)
   end
 
   def create_school_period(teacher, from:, to: nil, type: :ect, transfer: false)
     if transfer
-      from = from.tomorrow
+      from = from.next_day
     end
 
     FactoryBot.create(
@@ -83,7 +83,7 @@ private
            end
 
     if transfer
-      from = from.tomorrow
+      from = from.next_day
     end
 
     case programme_type

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
           type: "Provider-led",
           lead_provider: @lead_provider,
           start: @ect_at_school_period.started_on,
-          end: Date.current
+          end: Date.yesterday
         }
       )
     end
@@ -107,7 +107,7 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
           type: "Provider-led",
           lead_provider: @lead_provider,
           start: @ect_at_school_period.started_on,
-          end: Date.current
+          end: Date.yesterday
         }
       )
     end
@@ -165,7 +165,7 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
           type: "Provider-led",
           lead_provider: @lead_provider,
           start: @ect_at_school_period.started_on,
-          end: Date.current
+          end: Date.yesterday
         }
       )
     end

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_for_ects_in_closed_contract_periods_spec.rb
@@ -212,7 +212,7 @@ private
 
   def and_the_old_training_period_has_been_finished_but_left_in_the_original_contract_period
     @provider_led_training_period.reload
-    expect(@provider_led_training_period.finished_on).to eq(Date.current)
+    expect(@provider_led_training_period.finished_on).to eq(Date.yesterday)
     expect(@provider_led_training_period.contract_period.year).to eq(2021)
   end
 

--- a/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
           school: @school,
           type: "School-led",
           start: @ect_at_school_period.started_on,
-          end: Date.current
+          end: Date.yesterday
         }
       )
     end
@@ -111,7 +111,7 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
           school: @school,
           type: "School-led",
           start: @ect_at_school_period.started_on,
-          end: Date.current
+          end: Date.yesterday
         }
       )
     end
@@ -171,7 +171,7 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
           school: @school,
           type: "School-led",
           start: @ect_at_school_period.started_on,
-          end: Date.current
+          end: Date.yesterday
         }
       )
     end

--- a/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Changing to school-led training before the ECTs reported leaving
       when_i_visit_the_admin_teacher_training_page
       then_i_see_the_correct_training_periods(
         { school: @school, type: "School-led", start: Date.current, end: @leaving_date },
-        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.current }
+        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.yesterday }
       )
     end
   end
@@ -76,7 +76,7 @@ RSpec.describe "Changing to school-led training before the ECTs reported leaving
       then_i_see_the_correct_training_periods(
         { school: @another_school, type: "School-led", start: @joining_date, end: nil },
         { school: @school, type: "School-led", start: Date.current, end: @joining_date.yesterday },
-        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.current }
+        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.yesterday }
       )
     end
   end
@@ -116,7 +116,7 @@ RSpec.describe "Changing to school-led training before the ECTs reported leaving
       then_i_see_the_correct_training_periods(
         { school: @another_school, type: "School-led", start: @joining_date, end: nil },
         { school: @school, type: "School-led", start: Date.current, end: @joining_date.yesterday },
-        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.current }
+        { school: @school, type: "Provider-led", lead_provider: @lead_provider, start: @ect_at_school_period.started_on, end: Date.yesterday }
       )
     end
   end

--- a/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
@@ -220,7 +220,7 @@ private
 
   def and_the_school_led_training_period_has_been_finished
     @school_led_training_period.reload
-    expect(@school_led_training_period.finished_on).to eq(Date.current)
+    expect(@school_led_training_period.finished_on).to eq(Date.yesterday)
   end
 
   def and_the_provider_led_training_period_has_been_left_in_the_original_contract_period

--- a/spec/features/schools/ects/change/training_programme_spec.rb
+++ b/spec/features/schools/ects/change/training_programme_spec.rb
@@ -85,7 +85,7 @@ private
     @ect = FactoryBot.create(
       :ect_at_school_period,
       :ongoing,
-      started_on: 1.day.ago,
+      started_on: 2.months.ago,
       teacher: @teacher,
       school: @school,
       email: "ect@example.com"

--- a/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
@@ -235,8 +235,8 @@ private
   end
 
   def and_all_the_dates_are_correct
-    expect(@existing_mentor_at_school_period.reload.finished_on).to eq @new_mentor_start_date
-    expect(@existing_mentorship.reload.finished_on).to eq @new_mentor_start_date
+    expect(@existing_mentor_at_school_period.reload.finished_on).to eq @new_mentor_start_date.yesterday
+    expect(@existing_mentorship.reload.finished_on).to eq @new_mentor_start_date.yesterday
     expect(@new_mentor_at_school_period.started_on).to eq @new_mentor_start_date
     expect(@new_mentorship.started_on).to eq @new_mentor_start_date
   end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -39,7 +39,7 @@ describe ECTAtSchoolPeriod do
 
       context "when there is a current period and a future period" do
         let!(:training_period) { FactoryBot.create(:training_period, started_on: 1.year.ago, finished_on: 2.weeks.from_now, ect_at_school_period:) }
-        let!(:future_training_period) { FactoryBot.create(:training_period, started_on: 2.weeks.from_now, finished_on: nil, ect_at_school_period:) }
+        let!(:future_training_period) { FactoryBot.create(:training_period, started_on: 2.weeks.from_now.next_day, finished_on: nil, ect_at_school_period:) }
 
         it "returns the current ect_at_school_period" do
           expect(ect_at_school_period.current_or_next_training_period).to eql(training_period)

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -76,7 +76,7 @@ describe MentorAtSchoolPeriod do
 
     context "when there is a current period and a future period" do
       let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 1.year.ago, finished_on: 2.weeks.from_now, mentor_at_school_period:) }
-      let!(:future_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 2.weeks.from_now, finished_on: nil, mentor_at_school_period:) }
+      let!(:future_training_period) { FactoryBot.create(:training_period, :for_mentor, started_on: 2.weeks.from_now.next_day, finished_on: nil, mentor_at_school_period:) }
 
       it "returns the current mentor_at_school_period" do
         expect(mentor_at_school_period.current_or_next_training_period).to eql(training_period)

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -1156,7 +1156,7 @@ describe TrainingPeriod do
       FactoryBot.create(
         :training_period,
         ect_at_school_period:,
-        started_on: "2022-06-01",
+        started_on: "2022-06-02",
         finished_on: "2023-01-01"
       )
     end

--- a/spec/requests/admin/teachers/training_partnerships_spec.rb
+++ b/spec/requests/admin/teachers/training_partnerships_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Admin::Teachers::TrainingPartnerships", type: :request do
       expect(flash[:alert]).to eq("Partnership updated")
 
       training_period.reload
-      expect(training_period.finished_on).to eq(Date.current)
+      expect(training_period.finished_on).to eq(Date.yesterday)
 
       replacement = TrainingPeriod.order(:created_at).last
       expect(replacement.school_partnership).to eq(other_school_partnership)

--- a/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
@@ -191,7 +191,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
           post(path_for_step("check-answers"))
 
-          expect(training_period.reload.finished_on).to eq(Date.current)
+          expect(training_period.reload.finished_on).to eq(Date.yesterday)
           new_training_period = mentor_at_school_period.training_periods.ongoing.first
           expect(new_training_period.expression_of_interest.lead_provider).to eq(lead_provider)
 

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                 :ongoing,
                 "#{trainee_type}_at_school_period": at_school_period,
                 school_partnership: frozen_school_partnership,
-                started_on: training_period.finished_on
+                started_on: training_period.finished_on + 1.day
               )
             end
 
@@ -341,7 +341,7 @@ RSpec.describe API::Declarations::Create, type: :model do
                 :ongoing,
                 "#{trainee_type}_at_school_period": at_school_period,
                 school_partnership: training_period.school_partnership,
-                started_on: 2.months.ago
+                started_on: 2.months.ago + 1.day
               )
             end
 

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
       following_on_from_training_period.update!(finished_on: previous_finished_on)
       school_period = following_on_from_training_period.at_school_period
 
-      FactoryBot.create(:training_period, trait, :ongoing, school_partnership:, started_on: previous_finished_on, "#{trainee}_at_school_period": school_period)
+      FactoryBot.create(:training_period, trait, :ongoing, school_partnership:, started_on: previous_finished_on + 1.day, "#{trainee}_at_school_period": school_period)
     else
       teacher ||= FactoryBot.create(:teacher)
       school_period = FactoryBot.create(:"#{trainee}_at_school_period", :ongoing, teacher:)

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
 
           context "when there are future training periods (for the same teacher)" do
             before do
-              FactoryBot.create(:training_period, :"for_#{trainee_type}", started_on: training_period.finished_on, finished_on: at_school_period.finished_on, "#{trainee_type}_at_school_period": at_school_period)
+              FactoryBot.create(:training_period, :"for_#{trainee_type}", started_on: training_period.finished_on + 1.day, finished_on: at_school_period.finished_on, "#{trainee_type}_at_school_period": at_school_period)
             end
 
             it { is_expected.to have_one_error_per_attribute }

--- a/spec/services/api/teachers/resume_spec.rb
+++ b/spec/services/api/teachers/resume_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe API::Teachers::Resume, type: :model do
             it { is_expected.to have_error(:teacher_api_id, "This participant cannot be resumed because they are already active with another provider.") }
 
             context "when resuming after the other active/ongoing training period has finished" do
-              before { travel_to 3.months.from_now }
+              before { travel_to 4.months.from_now }
 
               it { is_expected.to be_valid }
             end

--- a/spec/services/api/teachers/school_transfers/history_spec.rb
+++ b/spec/services/api/teachers/school_transfers/history_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe API::Teachers::SchoolTransfers::History do
       before do
         school_period1 = create_school_period(teacher, from: 3.years.ago, to: 1.week.ago)
         add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: lead_provider1)
-        add_training_period(school_period1, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1, transfer: true)
-        add_training_period(school_period1, from: 1.year.ago, to: 1.week.ago, programme_type: :school_led, transfer: true)
+        add_training_period(school_period1, from: 2.years.ago + 1.day, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1, transfer: true)
+        add_training_period(school_period1, from: 1.year.ago + 1.day, to: 1.week.ago, programme_type: :school_led, transfer: true)
       end
 
       it "returns no transfers for lead provider #1" do
@@ -68,8 +68,8 @@ RSpec.describe API::Teachers::SchoolTransfers::History do
       before do
         school_period1 = create_school_period(teacher, from: 3.years.ago, to: 1.week.ago)
         add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: lead_provider1)
-        add_training_period(school_period1, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1)
-        @training_period3 = add_training_period(school_period1, from: 1.year.ago, to: 1.week.ago, programme_type: :provider_led, with: lead_provider2)
+        add_training_period(school_period1, from: 2.years.ago + 1.day, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1)
+        @training_period3 = add_training_period(school_period1, from: 1.year.ago + 1.day, to: 1.week.ago, programme_type: :provider_led, with: lead_provider2)
       end
 
       it "returns no transfers for lead provider #1" do
@@ -109,8 +109,8 @@ RSpec.describe API::Teachers::SchoolTransfers::History do
       before do
         school_period1 = create_school_period(teacher, from: 3.years.ago, to: 1.week.ago)
         add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: lead_provider1)
-        add_training_period(school_period1, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1)
-        @training_period3 = add_training_period(school_period1, from: 1.year.ago, to: 1.week.ago, programme_type: :provider_led, with: lead_provider2)
+        add_training_period(school_period1, from: 2.years.ago + 1.day, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1)
+        @training_period3 = add_training_period(school_period1, from: 1.year.ago + 1.day, to: 1.week.ago, programme_type: :provider_led, with: lead_provider2)
         record_completed_induction(teacher, school_period1)
       end
 
@@ -144,9 +144,9 @@ RSpec.describe API::Teachers::SchoolTransfers::History do
       before do
         school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago)
         @training_period1 = add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: lead_provider1)
-        school_period2 = create_school_period(teacher, from: 2.years.ago, transfer: true)
-        @training_period2 = add_training_period(school_period2, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1, transfer: true)
-        add_training_period(school_period2, from: 1.year.ago, programme_type: :provider_led, with: lead_provider2)
+        school_period2 = create_school_period(teacher, from: 2.years.ago + 1.day, transfer: true)
+        @training_period2 = add_training_period(school_period2, from: 2.years.ago + 1.day, to: 1.year.ago, programme_type: :provider_led, with: lead_provider1, transfer: true)
+        add_training_period(school_period2, from: 1.year.ago + 1.day, programme_type: :provider_led, with: lead_provider2)
       end
 
       it "returns a new_school transfer for lead provider #1" do
@@ -188,9 +188,9 @@ RSpec.describe API::Teachers::SchoolTransfers::History do
       before do
         school_period1 = create_school_period(teacher, from: 3.years.ago, to: 2.years.ago)
         @training_period1 = add_training_period(school_period1, from: 3.years.ago, to: 2.years.ago, programme_type: :provider_led, with: lead_provider1)
-        school_period2 = create_school_period(teacher, from: 2.years.ago, transfer: true)
-        @training_period2 = add_training_period(school_period2, from: 2.years.ago, to: 1.year.ago, programme_type: :provider_led, with: lead_provider2, transfer: true)
-        add_training_period(school_period2, from: 1.year.ago, programme_type: :provider_led, with: lead_provider3)
+        school_period2 = create_school_period(teacher, from: 2.years.ago + 1.day, transfer: true)
+        @training_period2 = add_training_period(school_period2, from: 2.years.ago + 1.day, to: 1.year.ago, programme_type: :provider_led, with: lead_provider2, transfer: true)
+        add_training_period(school_period2, from: 1.year.ago + 1.day, programme_type: :provider_led, with: lead_provider3)
       end
 
       it "returns a new_provider transfer for lead provider #1" do

--- a/spec/services/declarations/mentor_completion_spec.rb
+++ b/spec/services/declarations/mentor_completion_spec.rb
@@ -131,12 +131,12 @@ RSpec.describe Declarations::MentorCompletion, :with_metadata do
         context "when there is no training period ongoing today for the lead provider" do
           before { training_period.update!(finished_on: 1.day.ago) }
 
-          it "creates a new training period, starting the day the previous one finished" do
+          it "creates a new training period, starting the day after the previous one finished" do
             expect { service.perform }.to change(TrainingPeriod, :count).by(1)
 
             new_training_period = TrainingPeriod.last
             expect(new_training_period.mentor_at_school_period).to eq(mentor_at_school_period)
-            expect(new_training_period.started_on).to eq(training_period.finished_on)
+            expect(new_training_period.started_on).to eq(training_period.finished_on + 1.day)
             expect(new_training_period.school_partnership).to eq(training_period.school_partnership)
             expect(new_training_period.schedule).to eq(training_period.schedule)
             expect(new_training_period.expression_of_interest).to be_nil

--- a/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_spec.rb
@@ -81,7 +81,7 @@ module ECTAtSchoolPeriods
           change_lead_provider
 
           expect { training_period.reload }.not_to raise_error
-          expect(training_period.finished_on).to eq(Date.current)
+          expect(training_period.finished_on).to eq(Date.yesterday)
         end
 
         it "creates a new training period with the new lead provider" do

--- a/spec/services/ect_at_school_periods/current_training_spec.rb
+++ b/spec/services/ect_at_school_periods/current_training_spec.rb
@@ -18,7 +18,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training) }
     end
@@ -81,7 +81,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner) }
     end
@@ -106,7 +106,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.delivery_partner.name) }
     end
@@ -131,7 +131,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period:, period_start_date: old_training.finished_on + 1.day) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider) }
     end
@@ -156,7 +156,7 @@ describe ECTAtSchoolPeriods::CurrentTraining do
 
     context "when the ect has an ongoing training period at the school" do
       let!(:old_training) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:) }
-      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, period_start_date: old_training.finished_on, ect_at_school_period:) }
+      let!(:ongoing_training) { FactoryBot.create(:training_period, :ongoing, :for_ect, period_start_date: old_training.finished_on + 1.day, ect_at_school_period:) }
 
       it { is_expected.to eq(ongoing_training.school_partnership.lead_provider_delivery_partnership.active_lead_provider.lead_provider.name) }
     end

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -46,7 +46,7 @@ module ECTAtSchoolPeriods
             SwitchTraining.to_school_led(ect_at_school_period, author:)
 
             expect { training_period.reload }.not_to raise_error
-            expect(training_period.finished_on).to eq(Date.current)
+            expect(training_period.finished_on).to eq(Date.yesterday)
           end
 
           it "creates a new school-led training period" do
@@ -269,7 +269,7 @@ module ECTAtSchoolPeriods
             SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
             expect { training_period.reload }.not_to raise_error
-            expect(training_period.finished_on).to eq(Date.current)
+            expect(training_period.finished_on).to eq(Date.yesterday)
           end
 
           it "creates a new provider-led training period with that partnership" do
@@ -304,7 +304,7 @@ module ECTAtSchoolPeriods
             SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
             expect { training_period.reload }.not_to raise_error
-            expect(training_period.finished_on).to eq(Date.current)
+            expect(training_period.finished_on).to eq(Date.yesterday)
           end
 
           it "creates a new provider-led training period with an expression of interest" do
@@ -504,7 +504,7 @@ module ECTAtSchoolPeriods
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
                 expect { training_period.reload }.not_to raise_error
-                expect(training_period.finished_on).to eq(Date.current)
+                expect(training_period.finished_on).to eq(Date.yesterday)
               end
 
               it "retains the previous schedule and contract period" do
@@ -536,7 +536,7 @@ module ECTAtSchoolPeriods
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
                 expect { training_period.reload }.not_to raise_error
-                expect(training_period.finished_on).to eq(Date.current)
+                expect(training_period.finished_on).to eq(Date.yesterday)
               end
 
               it "moves to the successor contract period with an extended schedule" do
@@ -596,7 +596,7 @@ module ECTAtSchoolPeriods
               SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
               expect { training_period.reload }.not_to raise_error
-              expect(training_period.finished_on).to eq(Date.current)
+              expect(training_period.finished_on).to eq(Date.yesterday)
             end
 
             it "retains the schedule from the open contract period" do
@@ -651,7 +651,7 @@ module ECTAtSchoolPeriods
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
                 expect { training_period.reload }.not_to raise_error
-                expect(training_period.finished_on).to eq(Date.current)
+                expect(training_period.finished_on).to eq(Date.yesterday)
               end
 
               it "retains the previous schedule and contract period" do
@@ -683,7 +683,7 @@ module ECTAtSchoolPeriods
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
                 expect { training_period.reload }.not_to raise_error
-                expect(training_period.finished_on).to eq(Date.current)
+                expect(training_period.finished_on).to eq(Date.yesterday)
               end
 
               it "moves to the successor contract period with an extended schedule" do
@@ -739,7 +739,7 @@ module ECTAtSchoolPeriods
               SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
 
               expect { training_period.reload }.not_to raise_error
-              expect(training_period.finished_on).to eq(Date.current)
+              expect(training_period.finished_on).to eq(Date.yesterday)
             end
 
             it "retains the schedule from the open contract period" do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1364,7 +1364,7 @@ RSpec.describe Events::Record do
       let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 25)) }
       let(:original_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
       let(:original_schedule) { original_training_period.schedule }
-      let(:new_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: Date.new(2025, 7, 20), finished_on: Date.new(2025, 7, 25)) }
+      let(:new_training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on: Date.new(2025, 7, 21), finished_on: Date.new(2025, 7, 25)) }
       let(:course_identifier) { "ecf-induction" }
 
       it "queues a RecordEventJob with the correct values" do
@@ -1390,7 +1390,7 @@ RSpec.describe Events::Record do
       let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 25)) }
       let(:original_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: Date.new(2024, 9, 10), finished_on: Date.new(2025, 7, 20)) }
       let(:original_schedule) { original_training_period.schedule }
-      let(:new_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 7, 20), finished_on: Date.new(2025, 7, 25)) }
+      let(:new_training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 7, 21), finished_on: Date.new(2025, 7, 25)) }
       let(:course_identifier) { "ecf-mentor" }
 
       it "queues a RecordEventJob with the correct values" do

--- a/spec/services/mentor_at_school_periods/change_lead_provider_spec.rb
+++ b/spec/services/mentor_at_school_periods/change_lead_provider_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe MentorAtSchoolPeriods::ChangeLeadProvider, type: :service do
           it "closes existing training periods and opens a new training period" do
             subject
 
-            expect(training_period.reload.finished_on).to eq(Time.zone.today)
+            expect(training_period.reload.finished_on).to eq(Date.yesterday)
           end
         end
 

--- a/spec/services/schools/register_mentor_spec.rb
+++ b/spec/services/schools/register_mentor_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Schools::RegisterMentor do
               expect(mentor_at_school_period.started_on).to eq(started_on)
 
               expect(existing_mentor_at_school_period.reload.teacher_id).to eq(teacher.id)
-              expect(existing_mentor_at_school_period.finished_on).to eq(mentor_at_school_period.started_on)
+              expect(existing_mentor_at_school_period.finished_on).to eq(mentor_at_school_period.started_on.prev_day)
             end
 
             it "creates a new training period and finishes the old period" do

--- a/spec/services/teachers/change_schedule_spec.rb
+++ b/spec/services/teachers/change_schedule_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Teachers::ChangeSchedule do
         it "ends the current training period and creates a new training period starting today with the new schedule/partnership/contract period" do
           expect { service.change_schedule }.to change(TrainingPeriod, :count).from(1).to(2)
 
-          expect(training_period.reload.finished_on).to eq(Time.zone.today)
+          expect(training_period.reload.finished_on).to eq(Date.yesterday)
 
           new_training_period = TrainingPeriod.except(training_period).last
 
@@ -54,7 +54,7 @@ RSpec.describe Teachers::ChangeSchedule do
           it "sets the newly created training period finished_on to nil" do
             expect { service.change_schedule }.to change(TrainingPeriod, :count).from(1).to(2)
 
-            expect(training_period.reload.finished_on).to eq(Time.zone.today)
+            expect(training_period.reload.finished_on).to eq(Date.yesterday)
 
             new_training_period = TrainingPeriod.except(training_period).last
             expect(new_training_period.finished_on).to be_nil
@@ -68,7 +68,7 @@ RSpec.describe Teachers::ChangeSchedule do
           it "retains the original finished_on for the newly created training period" do
             expect { service.change_schedule }.to change(TrainingPeriod, :count).from(1).to(2)
 
-            expect(training_period.reload.finished_on).to eq(Time.zone.today)
+            expect(training_period.reload.finished_on).to eq(Date.yesterday)
 
             new_training_period = TrainingPeriod.except(training_period).last
             expect(new_training_period.finished_on).to eq(training_period_finished_on)
@@ -82,7 +82,7 @@ RSpec.describe Teachers::ChangeSchedule do
           it "retains the original finished_on for the newly created training period" do
             expect { service.change_schedule }.to change(TrainingPeriod, :count).from(1).to(2)
 
-            expect(training_period.reload.finished_on).to eq(Time.zone.today)
+            expect(training_period.reload.finished_on).to eq(Date.yesterday)
 
             new_training_period = TrainingPeriod.except(training_period).last
             expect(new_training_period.finished_on).to eq(school_period_finished_on)

--- a/spec/services/training_periods/change_partnership_spec.rb
+++ b/spec/services/training_periods/change_partnership_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TrainingPeriods::ChangePartnership do
           .to change(TrainingPeriod, :count).by(1)
           .and change { Event.where(event_type: "teacher_finishes_training_period").count }.by(1)
           .and change { Event.where(event_type: "training_period_assigned_to_school_partnership").count }.by(1)
-        expect(training_period.reload.finished_on).to eq(today)
+        expect(training_period.reload.finished_on).to eq(today.prev_day)
         replacement = TrainingPeriod.where(ect_at_school_period: ect_period).where.not(id: training_period.id).order(created_at: :desc).first
         expect(replacement.school_partnership).to eq(other_school_partnership)
         expect(replacement.expression_of_interest).to be_nil


### PR DESCRIPTION
### Context

This follows on from #2357, #2834 and #2854,  where we convert ranges from `[)` ranges to `[]`.

Here we're doing `training_periods`.

The `[)` range allows a new period to begin on the day the previous one finishes.

This can cause a bit of confusion, because the ranges `2025-01-03..2025-02-03` and `2025-02-03..2025-03-03` can coexist, but where was the trainee on `2025-02-03`?

Using `[]` means the later period must start on the day following the closure of the previous one at the earliest.

### What's changed

The main changes here are:

* updating the functionality so when we open a 'replacement' period today, the previous one finishes yesterday
* fixing the specs so they're not building test scenarios with 'overlapping' periods