### PR TITLE
[3898] Redirect users to access denied page on error fetching roles

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,13 +19,13 @@ class SessionsController < ApplicationController
     end
   rescue Sessions::Users::Builder::UnknownOrganisation,
          Sessions::Users::Builder::UnknownPersonaType,
-         Sessions::Users::Builder::UnknownProvider,
-         DfESignIn::APIClient::AccessLevelNotFound,
-         DfESignIn::APIClient::UsersNotFound,
-         DfESignIn::APIClient::OrganisationNotFound,
-         DfESignIn::APIClient::RolesNotFound
+         Sessions::Users::Builder::UnknownProvider
 
-    session[:invalid_user_organisation_name] = user_builder.organisation_name if user_builder&.organisation_name
+    session[:invalid_user_organisation_name] = user_builder.organisation_name if user_builder.organisation_name
+    redirect_to access_denied_path
+  rescue DfESignIn::APIClient::NotFoundError => e
+    Sentry.capture_exception(e)
+
     redirect_to access_denied_path
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,9 +19,10 @@ class SessionsController < ApplicationController
     end
   rescue Sessions::Users::Builder::UnknownOrganisation,
          Sessions::Users::Builder::UnknownPersonaType,
-         Sessions::Users::Builder::UnknownProvider
+         Sessions::Users::Builder::UnknownProvider,
+         DfESignIn::APIClient::AccessLevelNotFound
 
-    session[:invalid_user_organisation_name] = user_builder.organisation_name
+    session[:invalid_user_organisation_name] = user_builder.organisation_name if user_builder&.organisation_name
     redirect_to access_denied_path
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,7 +24,7 @@ class SessionsController < ApplicationController
     session[:invalid_user_organisation_name] = user_builder.organisation_name
     redirect_to access_denied_path
   rescue DfESignIn::APIClient::NotFoundError => e
-    Sentry.capture_exception(e)
+    Sentry.capture_message(e.message, level: :info)
 
     redirect_to access_denied_path
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < ApplicationController
          Sessions::Users::Builder::UnknownPersonaType,
          Sessions::Users::Builder::UnknownProvider
 
-    session[:invalid_user_organisation_name] = user_builder.organisation_name if user_builder.organisation_name
+    session[:invalid_user_organisation_name] = user_builder.organisation_name
     redirect_to access_denied_path
   rescue DfESignIn::APIClient::NotFoundError => e
     Sentry.capture_exception(e)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,9 +21,9 @@ class SessionsController < ApplicationController
          Sessions::Users::Builder::UnknownPersonaType,
          Sessions::Users::Builder::UnknownProvider,
          DfESignIn::APIClient::AccessLevelNotFound,
-         DfESignIn::APIClient::UserNotFound,
+         DfESignIn::APIClient::UsersNotFound,
          DfESignIn::APIClient::OrganisationNotFound,
-         DfESignIn::APIClient::RoleNotFound
+         DfESignIn::APIClient::RolesNotFound
 
     session[:invalid_user_organisation_name] = user_builder.organisation_name if user_builder&.organisation_name
     redirect_to access_denied_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,10 @@ class SessionsController < ApplicationController
   rescue Sessions::Users::Builder::UnknownOrganisation,
          Sessions::Users::Builder::UnknownPersonaType,
          Sessions::Users::Builder::UnknownProvider,
-         DfESignIn::APIClient::AccessLevelNotFound
+         DfESignIn::APIClient::AccessLevelNotFound,
+         DfESignIn::APIClient::UserNotFound,
+         DfESignIn::APIClient::OrganisationNotFound,
+         DfESignIn::APIClient::RoleNotFound
 
     session[:invalid_user_organisation_name] = user_builder.organisation_name if user_builder&.organisation_name
     redirect_to access_denied_path

--- a/lib/dfe_sign_in/api_client.rb
+++ b/lib/dfe_sign_in/api_client.rb
@@ -8,8 +8,8 @@ module DfESignIn
     class DfESignInDisabled < StandardError; end
     class OrganisationNotFound < StandardError; end
     class AccessLevelNotFound < StandardError; end
-    class RoleNotFound < StandardError; end
-    class UserNotFound < StandardError; end
+    class RolesNotFound < StandardError; end
+    class UsersNotFound < StandardError; end
 
     attr_reader :connection
 
@@ -61,7 +61,7 @@ module DfESignIn
       if response.success?
         response.body
       else
-        raise UserNotFound, "Could not retrieve user: #{response.status} #{response.body}"
+        raise UsersNotFound, "Could not retrieve users: #{response.status} #{response.body}"
       end
     end
 
@@ -75,7 +75,7 @@ module DfESignIn
       if response.success?
         response.body
       else
-        raise RoleNotFound, "Could not retrieve role: #{response.status} #{response.body}"
+        raise RolesNotFound, "Could not retrieve roles: #{response.status} #{response.body}"
       end
     end
 

--- a/lib/dfe_sign_in/api_client.rb
+++ b/lib/dfe_sign_in/api_client.rb
@@ -6,7 +6,10 @@ module DfESignIn
   #
   class APIClient
     class DfESignInDisabled < StandardError; end
+    class OrganisationNotFound < StandardError; end
     class AccessLevelNotFound < StandardError; end
+    class RoleNotFound < StandardError; end
+    class UserNotFound < StandardError; end
 
     attr_reader :connection
 
@@ -31,7 +34,7 @@ module DfESignIn
       if response.success?
         Organisation.from_response_body(response.body)
       else
-        raise "API request failed: #{response.status} #{response.body}"
+        raise OrganisationNotFound, "Could not retrieve organisations: #{response.status} #{response.body}"
       end
     end
 
@@ -44,7 +47,7 @@ module DfESignIn
       if response.success?
         AccessLevel.from_response_body(response.body)
       else
-        raise AccessLevelNotFound, "API request failed: #{response.status} #{response.body}"
+        raise AccessLevelNotFound, "Could not retrieve access level: #{response.status} #{response.body}"
       end
     end
 
@@ -58,7 +61,7 @@ module DfESignIn
       if response.success?
         response.body
       else
-        raise "API request failed: #{response.status} #{response.body}"
+        raise UserNotFound, "Could not retrieve user: #{response.status} #{response.body}"
       end
     end
 
@@ -72,7 +75,7 @@ module DfESignIn
       if response.success?
         response.body
       else
-        raise "API request failed: #{response.status} #{response.body}"
+        raise RoleNotFound, "Could not retrieve role: #{response.status} #{response.body}"
       end
     end
 

--- a/lib/dfe_sign_in/api_client.rb
+++ b/lib/dfe_sign_in/api_client.rb
@@ -6,6 +6,7 @@ module DfESignIn
   #
   class APIClient
     class DfESignInDisabled < StandardError; end
+    class AccessLevelNotFound < StandardError; end
 
     attr_reader :connection
 
@@ -43,7 +44,7 @@ module DfESignIn
       if response.success?
         AccessLevel.from_response_body(response.body)
       else
-        raise "API request failed: #{response.status} #{response.body}"
+        raise AccessLevelNotFound, "API request failed: #{response.status} #{response.body}"
       end
     end
 

--- a/lib/dfe_sign_in/api_client.rb
+++ b/lib/dfe_sign_in/api_client.rb
@@ -5,11 +5,21 @@ module DfESignIn
   # - roles: service's roles
   #
   class APIClient
+    class ResponseError < StandardError
+      attr_reader :response
+
+      delegate :status, :body, to: :response
+
+      def initialize(response:)
+        @response = response
+        super("DfE Sign In API request failed with status #{response.status}: #{response.body}")
+      end
+    end
+
     class DfESignInDisabled < StandardError; end
-    class OrganisationNotFound < StandardError; end
-    class AccessLevelNotFound < StandardError; end
-    class RolesNotFound < StandardError; end
-    class UsersNotFound < StandardError; end
+    class ForbiddenError < ResponseError; end
+    class NotFoundError < ResponseError; end
+    class InternalServerError < ResponseError; end
 
     attr_reader :connection
 
@@ -31,11 +41,9 @@ module DfESignIn
 
       response = @connection.get(path)
 
-      if response.success?
-        Organisation.from_response_body(response.body)
-      else
-        raise OrganisationNotFound, "Could not retrieve organisations: #{response.status} #{response.body}"
-      end
+      raise_error_for_response!(response)
+
+      Organisation.from_response_body(response.body)
     end
 
     # @see https://github.com/DFE-Digital/login.dfe.public-api#get-user-access-to-service
@@ -44,11 +52,9 @@ module DfESignIn
 
       response = @connection.get(path)
 
-      if response.success?
-        AccessLevel.from_response_body(response.body)
-      else
-        raise AccessLevelNotFound, "Could not retrieve access level: #{response.status} #{response.body}"
-      end
+      raise_error_for_response!(response)
+
+      AccessLevel.from_response_body(response.body)
     end
 
     # TODO: wrap with Data object
@@ -58,11 +64,9 @@ module DfESignIn
 
       response = @connection.get(path)
 
-      if response.success?
-        response.body
-      else
-        raise UsersNotFound, "Could not retrieve users: #{response.status} #{response.body}"
-      end
+      raise_error_for_response!(response)
+
+      response.body
     end
 
     # TODO: integrate with DfESignIn::AccessLevel::Role
@@ -72,14 +76,29 @@ module DfESignIn
 
       response = @connection.get(path)
 
-      if response.success?
-        response.body
-      else
-        raise RolesNotFound, "Could not retrieve roles: #{response.status} #{response.body}"
-      end
+      raise_error_for_response!(response)
+
+      response.body
     end
 
   private
+
+    def raise_error_for_response!(response)
+      return if response.success?
+
+      klass = error_class(response.status)
+
+      raise klass.new(response:)
+    end
+
+    def error_class(status)
+      case status
+      when 403 then ForbiddenError
+      when 404 then NotFoundError
+      when 500 then InternalServerError
+      else ResponseError
+      end
+    end
 
     def jwt
       @jwt ||= JWT.encode({ iss: client_id, aud: audience }, secret, "HS256")

--- a/spec/lib/dfe_sign_in/api_client_spec.rb
+++ b/spec/lib/dfe_sign_in/api_client_spec.rb
@@ -1,3 +1,54 @@
+RSpec.shared_examples "DfE Sign In endpoint with error handling" do
+  context "when the API returns a successful response" do
+    let(:status) { 200 }
+    let(:success) { true }
+
+    it "does not raise an error" do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  context "when the API returns a 403" do
+    let(:status) { 403 }
+    let(:success) { false }
+    let(:response_body) { "Forbidden" }
+
+    it "raises a ForbiddenError" do
+      expect { subject }.to raise_error(DfESignIn::APIClient::ForbiddenError)
+    end
+  end
+
+  context "when the API returns a 404" do
+    let(:status) { 404 }
+    let(:success) { false }
+    let(:response_body) { "Not Found" }
+
+    it "raises a NotFoundError" do
+      expect { subject }.to raise_error(DfESignIn::APIClient::NotFoundError)
+    end
+  end
+
+  context "when the API returns a 500" do
+    let(:status) { 500 }
+    let(:success) { false }
+    let(:response_body) { "Server Error" }
+
+    it "raises an InternalServerError" do
+      expect { subject }.to raise_error(DfESignIn::APIClient::InternalServerError)
+    end
+  end
+
+  context "when the API returns an unexpected error code" do
+    let(:status) { 418 }
+    let(:success) { false }
+    let(:response_body) { "I'm a teapot" }
+
+    it "raises a generic ResponseError" do
+      expect { subject }.to raise_error(DfESignIn::APIClient::ResponseError)
+    end
+  end
+end
+
 describe DfESignIn::APIClient do
   let(:fake_base_url) { "https://api.very-nice-website.org/" }
   let(:test_client_id) { "SomeService" }
@@ -5,7 +56,10 @@ describe DfESignIn::APIClient do
   let(:fake_api_secret) { "ABC123" }
 
   let(:connection) { client.instance_variable_get(:@connection) }
-  let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
+
+  let(:success) { true }
+  let(:status) { 200 }
+  let(:response) { instance_double(Faraday::Response, success?: success, status:, body: response_body) }
 
   before do
     stub_const("ENV", {
@@ -64,6 +118,8 @@ describe DfESignIn::APIClient do
   end
 
   describe "#organisations" do
+    subject { client.organisations(user_id:) }
+
     let(:response_body) do
       [
         {
@@ -109,37 +165,28 @@ describe DfESignIn::APIClient do
     let(:connection) { client.instance_variable_get(:@connection) }
     let(:user_id) { "b41b3462-62f8-4b43-8d4b-407f7f115056" }
     let(:expected_path) { %(/users/#{user_id}/organisations) }
-    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
 
     before do
       allow(connection).to receive(:get).with(expected_path).and_return(response)
     end
 
+    include_examples "DfE Sign In endpoint with error handling"
+
     # GET https://environment-url/users/{user-id}/organisations
     it "calls the organisations endpoint" do
-      client.organisations(user_id:)
+      subject
 
       expect(connection).to have_received(:get).with(expected_path)
     end
 
     it "returns an array of DfESignIn::Organisation" do
-      output = client.organisations(user_id:)
-
-      expect(output).to all(be_a(DfESignIn::Organisation))
-    end
-
-    context "when the response is unsuccessful" do
-      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
-
-      it "raises an OrganisationNotFound error" do
-        expect {
-          client.organisations(user_id:)
-        }.to raise_error(DfESignIn::APIClient::OrganisationNotFound, "Could not retrieve organisations: 500 Internal Server Error")
-      end
+      expect(subject).to all(be_a(DfESignIn::Organisation))
     end
   end
 
   describe "#access_levels" do
+    subject { client.access_levels(organisation_id:, user_id:, service_id:) }
+
     let(:user_id) { "55555555-9999-8888-7777-111111111111" }
     let(:organisation_id) { "55555555-4444-3333-2222-111111111111" }
     let(:service_id) { "55555555-4444-3333-9999-888888888888" }
@@ -170,47 +217,40 @@ describe DfESignIn::APIClient do
     let(:client) { DfESignIn::APIClient.new }
     let(:connection) { client.instance_variable_get(:@connection) }
     let(:expected_path) { %(services/#{service_id}/organisations/#{organisation_id}/users/#{user_id}) }
-    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
 
     before do
       allow(connection).to receive(:get).with(expected_path).and_return(response)
     end
 
+    include_examples "DfE Sign In endpoint with error handling"
+
     # GET https://environment-url/users/{user-id}/organisations
     it "calls the access levels endpoint" do
-      client.access_levels(service_id:, organisation_id:, user_id:)
+      subject
 
       expect(connection).to have_received(:get).with(expected_path)
     end
 
     it "returns a DfESignIn::AccessLevel" do
-      access_level = client.access_levels(service_id:, organisation_id:, user_id:)
+      access_level = subject
 
       expect(access_level).to be_a(DfESignIn::AccessLevel)
       expect(access_level.roles).to all(be_a(DfESignIn::AccessLevel::Role))
     end
 
     it "correctly sets the access level values" do
-      access_level = client.access_levels(service_id:, organisation_id:, user_id:)
+      access_level = subject
 
       expect(access_level.user_id).to eql(user_id)
       expect(access_level.organisation_id).to eql(organisation_id)
       expect(access_level.service_id).to eql(service_id)
       expect(access_level.roles.map(&:name)).to include("Register ECTs")
     end
-
-    context "when the response is unsuccessful" do
-      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
-
-      it "raises an AccessLevelNotFound error" do
-        expect {
-          client.access_levels(service_id:, organisation_id:, user_id:)
-        }.to raise_error(DfESignIn::APIClient::AccessLevelNotFound, "Could not retrieve access level: 500 Internal Server Error")
-      end
-    end
   end
 
   describe "#users" do
+    subject { client.users }
+
     let(:response_body) do
       {
         "users": [
@@ -276,36 +316,27 @@ describe DfESignIn::APIClient do
     let(:client) { DfESignIn::APIClient.new }
     let(:connection) { client.instance_variable_get(:@connection) }
     let(:expected_path) { %(/users) }
-    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
 
     before do
       allow(connection).to receive(:get).with(expected_path).and_return(response)
     end
 
+    include_examples "DfE Sign In endpoint with error handling"
+
     it "calls the users endpoint" do
-      client.users
+      subject
 
       expect(connection).to have_received(:get).with(expected_path)
     end
 
     it "returns the response body" do
-      output = client.users
-
-      expect(output).to eql(response_body)
-    end
-
-    context "when the response is unsuccessful" do
-      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
-
-      it "raises a UsersNotFound error" do
-        expect {
-          client.users
-        }.to raise_error(DfESignIn::APIClient::UsersNotFound, "Could not retrieve users: 500 Internal Server Error")
-      end
+      expect(subject).to eql(response_body)
     end
   end
 
   describe "#roles" do
+    subject { client.roles(service_id:) }
+
     let(:response_body) do
       [
         {
@@ -325,32 +356,21 @@ describe DfESignIn::APIClient do
     let(:connection) { client.instance_variable_get(:@connection) }
     let(:service_id) { "55555555-4444-3333-9999-888888888888" }
     let(:expected_path) { %(/services/#{service_id}/roles) }
-    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
 
     before do
       allow(connection).to receive(:get).with(expected_path).and_return(response)
     end
 
+    include_examples "DfE Sign In endpoint with error handling"
+
     it "calls the roles endpoint" do
-      client.roles(service_id:)
+      subject
 
       expect(connection).to have_received(:get).with(expected_path)
     end
 
     it "returns an array of roles" do
-      output = client.roles(service_id:)
-
-      expect(output).to all(include("name", "code", "status"))
-    end
-
-    context "when the response is unsuccessful" do
-      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
-
-      it "raises a RolesNotFound error" do
-        expect {
-          client.roles(service_id:)
-        }.to raise_error(DfESignIn::APIClient::RolesNotFound, "Could not retrieve roles: 500 Internal Server Error")
-      end
+      expect(subject).to all(include("name", "code", "status"))
     end
   end
 end

--- a/spec/lib/dfe_sign_in/api_client_spec.rb
+++ b/spec/lib/dfe_sign_in/api_client_spec.rb
@@ -127,6 +127,16 @@ describe DfESignIn::APIClient do
 
       expect(output).to all(be_a(DfESignIn::Organisation))
     end
+
+    context "when the response is unsuccessful" do
+      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
+
+      it "raises an OrganisationNotFound error" do
+        expect {
+          client.organisations(user_id:)
+        }.to raise_error(DfESignIn::APIClient::OrganisationNotFound, "Could not retrieve organisations: 500 Internal Server Error")
+      end
+    end
   end
 
   describe "#access_levels" do
@@ -187,6 +197,160 @@ describe DfESignIn::APIClient do
       expect(access_level.organisation_id).to eql(organisation_id)
       expect(access_level.service_id).to eql(service_id)
       expect(access_level.roles.map(&:name)).to include("Register ECTs")
+    end
+
+    context "when the response is unsuccessful" do
+      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
+
+      it "raises an AccessLevelNotFound error" do
+        expect {
+          client.access_levels(service_id:, organisation_id:, user_id:)
+        }.to raise_error(DfESignIn::APIClient::AccessLevelNotFound, "Could not retrieve access level: 500 Internal Server Error")
+      end
+    end
+  end
+
+  describe "#users" do
+    let(:response_body) do
+      {
+        "users": [
+          {
+            "approvedAt" => "2019-06-19T15:09:58.683Z",
+            "updatedAt" => "2019-06-19T15:09:58.683Z",
+            "organisation": {
+              "id" => "13F20E54-79EA-4146-8E39-18197576F023",
+              "name" => "Department for Education",
+              "Category" => "002",
+              "Type": nil,
+              "URN": nil,
+              "UID": nil,
+              "UKPRN": nil,
+              "EstablishmentNumber" => "001",
+              "Status": 1,
+              "ClosedOn": nil,
+              "Address": nil,
+              "phaseOfEducation": nil,
+              "statutoryLowAge": nil,
+              "statutoryHighAge": nil,
+              "telephone": nil,
+              "regionCode": nil,
+              "legacyId" => "1031237",
+              "companyRegistrationNumber" => "1234567",
+              "ProviderProfileID" => "",
+              "UPIN" => "",
+              "PIMSProviderType" => "Central Government Department",
+              "PIMSStatus" => "",
+              "DistrictAdministrativeName" => "",
+              "OpenedOn" => "2007-09-01T00:00:00.0000000Z",
+              "SourceSystem" => "",
+              "ProviderTypeName" => "Government Body",
+              "GIASProviderType" => "",
+              "PIMSProviderTypeCode" => "",
+              "createdAt" => "2019-02-20T14:27:59.020Z",
+              "updatedAt" => "2019-02-20T14:28:38.223Z"
+            },
+            "roles": [
+              {
+                "id" => "FA3DDF63-6D48-41BB-8706-1048B24D4744",
+                "name" => "Test Service - Example role",
+                "code" => "TEST",
+                "numericId" => "12345",
+                "status": 1
+              }
+            ],
+            "roleName" => "Approver",
+            "roleId": 10_000,
+            "userId" => "21D62132-6570-4E63-9DCB-137CC35E7543",
+            "userStatus": 1,
+            "email" => "foo@example.com",
+            "familyName" => "Johnson",
+            "givenName" => "Roger"
+          }
+        ],
+        "numberOfRecords": 1,
+        "page": 1,
+        "numberOfPages": 1
+      }
+    end
+
+    let(:client) { DfESignIn::APIClient.new }
+    let(:connection) { client.instance_variable_get(:@connection) }
+    let(:expected_path) { %(/users) }
+    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
+
+    before do
+      allow(connection).to receive(:get).with(expected_path).and_return(response)
+    end
+
+    it "calls the users endpoint" do
+      client.users
+
+      expect(connection).to have_received(:get).with(expected_path)
+    end
+
+    it "returns the response body" do
+      output = client.users
+
+      expect(output).to eql(response_body)
+    end
+
+    context "when the response is unsuccessful" do
+      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
+
+      it "raises a UserNotFound error" do
+        expect {
+          client.users
+        }.to raise_error(DfESignIn::APIClient::UserNotFound, "Could not retrieve user: 500 Internal Server Error")
+      end
+    end
+  end
+
+  describe "#roles" do
+    let(:response_body) do
+      [
+        {
+          "name" => "Role 1 Name",
+          "code" => "Role1Code",
+          "status" => "Active"
+        },
+        {
+          "name" => "Role 2 Name",
+          "code" => "Role2Code",
+          "status" => "Inactive"
+        }
+      ]
+    end
+
+    let(:client) { DfESignIn::APIClient.new }
+    let(:connection) { client.instance_variable_get(:@connection) }
+    let(:service_id) { "55555555-4444-3333-9999-888888888888" }
+    let(:expected_path) { %(/services/#{service_id}/roles) }
+    let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
+
+    before do
+      allow(connection).to receive(:get).with(expected_path).and_return(response)
+    end
+
+    it "calls the roles endpoint" do
+      client.roles(service_id:)
+
+      expect(connection).to have_received(:get).with(expected_path)
+    end
+
+    it "returns an array of roles" do
+      output = client.roles(service_id:)
+
+      expect(output).to all(include("name", "code", "status"))
+    end
+
+    context "when the response is unsuccessful" do
+      let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
+
+      it "raises a RoleNotFound error" do
+        expect {
+          client.roles(service_id:)
+        }.to raise_error(DfESignIn::APIClient::RoleNotFound, "Could not retrieve role: 500 Internal Server Error")
+      end
     end
   end
 end

--- a/spec/lib/dfe_sign_in/api_client_spec.rb
+++ b/spec/lib/dfe_sign_in/api_client_spec.rb
@@ -297,10 +297,10 @@ describe DfESignIn::APIClient do
     context "when the response is unsuccessful" do
       let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
 
-      it "raises a UserNotFound error" do
+      it "raises a UsersNotFound error" do
         expect {
           client.users
-        }.to raise_error(DfESignIn::APIClient::UserNotFound, "Could not retrieve user: 500 Internal Server Error")
+        }.to raise_error(DfESignIn::APIClient::UsersNotFound, "Could not retrieve users: 500 Internal Server Error")
       end
     end
   end
@@ -346,10 +346,10 @@ describe DfESignIn::APIClient do
     context "when the response is unsuccessful" do
       let(:response) { instance_double(Faraday::Response, success?: false, status: 500, body: "Internal Server Error") }
 
-      it "raises a RoleNotFound error" do
+      it "raises a RolesNotFound error" do
         expect {
           client.roles(service_id:)
-        }.to raise_error(DfESignIn::APIClient::RoleNotFound, "Could not retrieve role: 500 Internal Server Error")
+        }.to raise_error(DfESignIn::APIClient::RolesNotFound, "Could not retrieve roles: 500 Internal Server Error")
       end
     end
   end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -85,50 +85,55 @@ RSpec.describe "Sessions", type: :request do
       end
     end
 
-    [
-      DfESignIn::APIClient::OrganisationNotFound,
-      DfESignIn::APIClient::AccessLevelNotFound,
-      DfESignIn::APIClient::UsersNotFound,
-      DfESignIn::APIClient::RolesNotFound
-    ].each do |error_class|
-      context "when the DfE SignIn API returns no access level" do
-        let(:params) do
-          {
-            email:,
-            name:,
-            dfe_sign_in_organisation_id:,
-            dfe_sign_in_user_id:,
-            dfe_sign_in_roles: %w[SchoolUser],
-          }
-        end
+    context "when the DfE SignIn API cannot find any Access Levels" do
+      let(:params) do
+        {
+          email:,
+          name:,
+          dfe_sign_in_organisation_id:,
+          dfe_sign_in_user_id:,
+          dfe_sign_in_roles: %w[SchoolUser],
+        }
+      end
 
-        let(:user_builder) { instance_double(Sessions::Users::Builder) }
+      let(:user_builder) { instance_double(Sessions::Users::Builder) }
 
-        before do
-          FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
+      before do
+        FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
 
-          allow(Sessions::Users::Builder).to receive(:new).and_return(user_builder)
-          allow(user_builder).to receive(:organisation_name).and_return(nil)
-          allow(user_builder).to receive(:session_user).and_raise(Sessions::Users::Builder::UnknownOrganisation, dfe_sign_in_organisation_id)
+        response = instance_double(
+          Faraday::Response,
+          status: 404,
+          body: "DfE Sign In API request failed"
+        )
 
-          allow(client).to receive(:access_levels).and_raise(error_class, "Error message")
+        allow(client).to receive(:access_levels).and_raise(DfESignIn::APIClient::NotFoundError.new(response:))
 
-          mock_dfe_sign_in_provider!(uid: dfe_sign_in_user_id,
-                                     email:,
-                                     first_name:,
-                                     last_name:,
-                                     organisation_id: dfe_sign_in_organisation_id,
-                                     organisation_name: nil)
-        end
+        mock_dfe_sign_in_provider!(uid: dfe_sign_in_user_id,
+                                   email:,
+                                   first_name:,
+                                   last_name:,
+                                   organisation_id: dfe_sign_in_organisation_id,
+                                   organisation_name: nil)
+      end
 
-        after do
-          stop_mocking_dfe_sign_in_provider!
-        end
+      after do
+        stop_mocking_dfe_sign_in_provider!
+      end
 
-        it "redirects to the access denied page" do
-          post("/auth/dfe/callback")
-          expect(response).to redirect_to(access_denied_path)
-        end
+      it "redirects to the access denied page" do
+        post("/auth/dfe/callback")
+        expect(response).to redirect_to(access_denied_path)
+      end
+
+      it "logs an exception in Sentry" do
+        allow(Sentry).to receive(:capture_exception)
+
+        post("/auth/dfe/callback")
+
+        expect(Sentry)
+          .to have_received(:capture_exception).once
+          .with(an_instance_of(DfESignIn::APIClient::NotFoundError))
       end
     end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -125,13 +125,13 @@ RSpec.describe "Sessions", type: :request do
       end
 
       it "logs an exception in Sentry" do
-        allow(Sentry).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_message)
 
         post("/auth/dfe/callback")
 
         expect(Sentry)
-          .to have_received(:capture_exception).once
-          .with(an_instance_of(DfESignIn::APIClient::NotFoundError))
+          .to have_received(:capture_message).once
+          .with("DfE Sign In API request failed with status 404: DfE Sign In API request failed", { level: :info })
       end
     end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe "Sessions", type: :request do
     [
       DfESignIn::APIClient::OrganisationNotFound,
       DfESignIn::APIClient::AccessLevelNotFound,
-      DfESignIn::APIClient::UserNotFound,
-      DfESignIn::APIClient::RoleNotFound
+      DfESignIn::APIClient::UsersNotFound,
+      DfESignIn::APIClient::RolesNotFound
     ].each do |error_class|
       context "when the DfE SignIn API returns no access level" do
         let(:params) do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -85,46 +85,50 @@ RSpec.describe "Sessions", type: :request do
       end
     end
 
-    context "when the DfE SignIn API returns no access level" do
-      let(:params) do
-        {
-          email:,
-          name:,
-          dfe_sign_in_organisation_id:,
-          dfe_sign_in_user_id:,
-          dfe_sign_in_roles: %w[AppropriateBodyUser],
-        }
-      end
+    [
+      DfESignIn::APIClient::OrganisationNotFound,
+      DfESignIn::APIClient::AccessLevelNotFound,
+      DfESignIn::APIClient::UserNotFound,
+      DfESignIn::APIClient::RoleNotFound
+    ].each do |error_class|
+      context "when the DfE SignIn API returns no access level" do
+        let(:params) do
+          {
+            email:,
+            name:,
+            dfe_sign_in_organisation_id:,
+            dfe_sign_in_user_id:,
+            dfe_sign_in_roles: %w[SchoolUser],
+          }
+        end
 
-      let(:user_builder) { instance_double(Sessions::Users::Builder) }
+        let(:user_builder) { instance_double(Sessions::Users::Builder) }
 
-      before do
-        FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
+        before do
+          FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
 
-        allow(Sessions::Users::Builder).to receive(:new).and_return(user_builder)
-        allow(user_builder).to receive(:organisation_name).and_return(nil)
-        allow(user_builder).to receive(:session_user).and_raise(Sessions::Users::Builder::UnknownOrganisation, dfe_sign_in_organisation_id)
+          allow(Sessions::Users::Builder).to receive(:new).and_return(user_builder)
+          allow(user_builder).to receive(:organisation_name).and_return(nil)
+          allow(user_builder).to receive(:session_user).and_raise(Sessions::Users::Builder::UnknownOrganisation, dfe_sign_in_organisation_id)
 
-        allow(client).to receive(:access_levels).and_raise(
-          DfESignIn::APIClient::AccessLevelNotFound,
-          "API request failed: 404 RuntimeError"
-        )
+          allow(client).to receive(:access_levels).and_raise(error_class, "Error message")
 
-        mock_dfe_sign_in_provider!(uid: dfe_sign_in_user_id,
-                                   email:,
-                                   first_name:,
-                                   last_name:,
-                                   organisation_id: dfe_sign_in_organisation_id,
-                                   organisation_name: nil)
-      end
+          mock_dfe_sign_in_provider!(uid: dfe_sign_in_user_id,
+                                     email:,
+                                     first_name:,
+                                     last_name:,
+                                     organisation_id: dfe_sign_in_organisation_id,
+                                     organisation_name: nil)
+        end
 
-      after do
-        stop_mocking_dfe_sign_in_provider!
-      end
+        after do
+          stop_mocking_dfe_sign_in_provider!
+        end
 
-      it "redirects to the access denied page" do
-        post("/auth/dfe/callback")
-        expect(response).to redirect_to(access_denied_path)
+        it "redirects to the access denied page" do
+          post("/auth/dfe/callback")
+          expect(response).to redirect_to(access_denied_path)
+        end
       end
     end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -96,8 +96,6 @@ RSpec.describe "Sessions", type: :request do
         }
       end
 
-      let(:user_builder) { instance_double(Sessions::Users::Builder) }
-
       before do
         FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -41,11 +41,91 @@ RSpec.describe "Sessions", type: :request do
     let(:dfe_sign_in_organisation_id) { Faker::Internet.uuid }
     let(:dfe_sign_in_user_id) { Faker::Internet.uuid }
     let(:school_urn) { "123456" }
+    let(:client) { DfESignIn::FakeAPIClient.new(role_codes: params[:dfe_sign_in_roles]) }
 
     before do
-      allow(DfESignIn::APIClient).to receive(:new).and_return(
-        DfESignIn::FakeAPIClient.new(role_codes: params[:dfe_sign_in_roles])
-      )
+      allow(DfESignIn::APIClient).to receive(:new).and_return(client)
+    end
+
+    context "when the organisation is not recognised" do
+      let(:params) do
+        {
+          email:,
+          name:,
+          dfe_sign_in_organisation_id:,
+          dfe_sign_in_user_id:,
+          dfe_sign_in_roles: %w[AppropriateBodyUser],
+        }
+      end
+
+      let(:user_builder) { instance_double(Sessions::Users::Builder) }
+
+      before do
+        FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
+
+        allow(Sessions::Users::Builder).to receive(:new).and_return(user_builder)
+        allow(user_builder).to receive(:organisation_name).and_return(dfe_sign_in_organisation_name)
+        allow(user_builder).to receive(:session_user).and_raise(Sessions::Users::Builder::UnknownOrganisation, dfe_sign_in_organisation_id)
+
+        mock_dfe_sign_in_provider!(uid: dfe_sign_in_user_id,
+                                   email:,
+                                   first_name:,
+                                   last_name:,
+                                   organisation_id: dfe_sign_in_organisation_id,
+                                   organisation_name: dfe_sign_in_organisation_name)
+      end
+
+      after do
+        stop_mocking_dfe_sign_in_provider!
+      end
+
+      it "redirects to the access denied page" do
+        post("/auth/dfe/callback")
+        expect(response).to redirect_to(access_denied_path)
+      end
+    end
+
+    context "when the DfE SignIn API returns no access level" do
+      let(:params) do
+        {
+          email:,
+          name:,
+          dfe_sign_in_organisation_id:,
+          dfe_sign_in_user_id:,
+          dfe_sign_in_roles: %w[AppropriateBodyUser],
+        }
+      end
+
+      let(:user_builder) { instance_double(Sessions::Users::Builder) }
+
+      before do
+        FactoryBot.create(:appropriate_body_period, dfe_sign_in_organisation_id:)
+
+        allow(Sessions::Users::Builder).to receive(:new).and_return(user_builder)
+        allow(user_builder).to receive(:organisation_name).and_return(nil)
+        allow(user_builder).to receive(:session_user).and_raise(Sessions::Users::Builder::UnknownOrganisation, dfe_sign_in_organisation_id)
+
+        allow(client).to receive(:access_levels).and_raise(
+          DfESignIn::APIClient::AccessLevelNotFound,
+          "API request failed: 404 RuntimeError"
+        )
+
+        mock_dfe_sign_in_provider!(uid: dfe_sign_in_user_id,
+                                   email:,
+                                   first_name:,
+                                   last_name:,
+                                   organisation_id: dfe_sign_in_organisation_id,
+                                   organisation_name: nil)
+      end
+
+      after do
+        stop_mocking_dfe_sign_in_provider!
+      end
+
+      it "redirects to the access denied page" do
+        post("/auth/dfe/callback")
+        expect(response).to redirect_to(access_denied_path)
+      end
     end
 
     context "when using an appropriate body user" do


### PR DESCRIPTION
Test redirection and errors

### Context
Errors in [Sentry](https://dfe-teacher-services.sentry.io/issues/7446855386/?project=4508369974788096&query=is%3Aunresolved&referrer=issue-stream)

When a user has not been assigned to an organisation in DfE Sign In the endpoint we use to fetch roles can return errors, as per the [documentation](https://github.com/DFE-Digital/login.dfe.public-api#get-user-access-to-service).

Currently we do not catch this error, and so a generic `RuntimeError` is raised and the user is redirected to the standard 500 error page.  Instead we want to redirect the user to the access denied page, so they know there's a problem with their account/access.  

