### PR TITLE
Admin users can search by training record IDs

### DIFF
--- a/app/services/admin/teachers/search.rb
+++ b/app/services/admin/teachers/search.rb
@@ -40,10 +40,16 @@ module Admin
         trns = query_string.scan(/\b\d{7}\b/)
         return scope.where(trn: trns) if trns.any?
 
-        full_text_scope = full_text_matches(scope)
-        return full_text_scope unless api_participant_id_query?
+        api_ids = query_string.scan(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i)
+        return api_id_matches(scope, api_ids) if api_ids.any?
 
-        full_text_scope.or(api_participant_id_matches(scope))
+        full_text_matches(scope)
+      end
+
+      def api_id_matches(scope, ids)
+        scope.where(api_id: ids)
+          .or(scope.where(api_ect_training_record_id: ids))
+          .or(scope.where(api_mentor_training_record_id: ids))
       end
 
       def full_text_matches(scope)
@@ -57,16 +63,6 @@ module Admin
 
       def normalized_full_text_query
         @normalized_full_text_query ||= query_string.scan(/[[:alnum:]]+/).join(" ")
-      end
-
-      def api_participant_id_query?
-        query_string.match?(/\A(?=.*[\d-])[a-f0-9-]{8,}\z/i)
-      end
-
-      def api_participant_id_matches(scope)
-        escaped_query = ActiveRecord::Base.sanitize_sql_like(query_string)
-
-        scope.where("CAST(teachers.api_id AS text) ILIKE ?", "%#{escaped_query}%")
       end
 
       def filter_teachers_by_role(scope)

--- a/app/views/admin/teachers/index.html.erb
+++ b/app/views/admin/teachers/index.html.erb
@@ -5,7 +5,7 @@
         :q,
         value: params[:q],
         label: { text: "Search for teacher", size: "s" },
-        hint: { text: "Name, TRN or API participant ID" },
+        hint: { text: "Name, TRN, API participant ID, or API training record ID" },
         form_group: { class: "app-teachers-filters__search" }
       ) %>
 
@@ -65,4 +65,3 @@
 <%= govuk_button_link_to("Import a record from TRS", new_admin_import_ect_find_path, secondary: true) %>
 
 <%= render Shared::PaginationSummaryComponent.new(pagy: @pagy, record_name: "teachers") %>
-

--- a/spec/requests/admin/teachers/index_spec.rb
+++ b/spec/requests/admin/teachers/index_spec.rb
@@ -91,7 +91,33 @@ RSpec.describe "Admin teachers index", type: :request do
           let!(:other_teacher_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher: other_teacher, contract_period: other_teacher_contract_period) }
 
           it "filters teachers by API participant ID" do
-            get "/admin/teachers", params: { q: "4266141740" }
+            get "/admin/teachers", params: { q: "123e4567-e89b-12d3-a456-426614174000" }
+
+            expect(response.status).to eq(200)
+            expect(response.body).to include(teacher.trn)
+            expect(response.body).not_to include(other_teacher.trn)
+          end
+        end
+
+        context "when searching by API ECT training record ID" do
+          let!(:teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "123e4567-e89b-12d3-a456-576614174000") }
+          let!(:other_teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+          it "filters teachers by API ECT training record ID" do
+            get "/admin/teachers", params: { q: "123e4567-e89b-12d3-a456-576614174000" }
+
+            expect(response.status).to eq(200)
+            expect(response.body).to include(teacher.trn)
+            expect(response.body).not_to include(other_teacher.trn)
+          end
+        end
+
+        context "when searching by API mentor training record ID" do
+          let!(:teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "123e4567-e89b-12d3-a456-576614174000") }
+          let!(:other_teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+          it "filters teachers by API mentor training record ID" do
+            get "/admin/teachers", params: { q: "123e4567-e89b-12d3-a456-576614174000" }
 
             expect(response.status).to eq(200)
             expect(response.body).to include(teacher.trn)

--- a/spec/services/admin/teachers/search_spec.rb
+++ b/spec/services/admin/teachers/search_spec.rb
@@ -1,17 +1,18 @@
 RSpec.describe Admin::Teachers::Search do
-  subject { described_class.new(query_string:, role:, contract_period:) }
+  subject(:search) { described_class.new(query_string:, role:, contract_period:) }
 
   let(:query_string) { nil }
   let(:role) { nil }
   let(:contract_period) { nil }
 
   describe "#teacher_scope" do
+    subject(:teacher_scope) { search.teacher_scope }
+
     context "when the query is blank" do
       let!(:teacher) { FactoryBot.create(:teacher) }
+      let!(:other_teacher) { FactoryBot.create(:teacher) }
 
-      it "returns all teachers" do
-        expect(subject.teacher_scope).to include(teacher)
-      end
+      it { is_expected.to contain_exactly(teacher, other_teacher) }
     end
 
     context "when it is an exact 7 digit TRN" do
@@ -19,9 +20,7 @@ RSpec.describe Admin::Teachers::Search do
       let!(:teacher) { FactoryBot.create(:teacher, trn: "1234567") }
       let!(:other_teacher) { FactoryBot.create(:teacher, trn: "7654321", trs_first_name: "1234567", trs_last_name: "Teacher") }
 
-      it "matches by TRN only" do
-        expect(subject.teacher_scope).to contain_exactly(teacher)
-      end
+      it { is_expected.to contain_exactly(teacher) }
     end
 
     context "when it contains a full TRN with extra text" do
@@ -29,9 +28,23 @@ RSpec.describe Admin::Teachers::Search do
       let!(:teacher) { FactoryBot.create(:teacher, trn: "1234567") }
       let!(:other_teacher) { FactoryBot.create(:teacher, trs_first_name: "TRN", trs_last_name: "Teacher") }
 
-      it "matches by TRN" do
-        expect(subject.teacher_scope).to contain_exactly(teacher)
-      end
+      it { is_expected.to contain_exactly(teacher) }
+    end
+
+    context "when it is an exact API participant ID" do
+      let(:query_string) { "123e4567-e89b-12d3-a456-426614174000" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_id: "123e4567-e89b-12d3-a456-426614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to contain_exactly(teacher) }
+    end
+
+    context "when it contains a full API participant ID with extra text" do
+      let(:query_string) { "API ID 123e4567-e89b-12d3-a456-426614174000" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_id: "123e4567-e89b-12d3-a456-426614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to contain_exactly(teacher) }
     end
 
     context "when it is a partial API participant ID" do
@@ -39,9 +52,65 @@ RSpec.describe Admin::Teachers::Search do
       let!(:teacher) { FactoryBot.create(:teacher, api_id: "123e4567-e89b-12d3-a456-426614174000") }
       let!(:other_teacher) { FactoryBot.create(:teacher, api_id: "999e4567-e89b-12d3-a456-426614174999") }
 
-      it "matches the API participant ID" do
-        expect(subject.teacher_scope).to contain_exactly(teacher)
-      end
+      it { is_expected.to be_empty }
+    end
+
+    context "when it is an exact API ECT training record ID" do
+      let(:query_string) { "523e4567-e89b-12d3-a456-426614174000" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "523e4567-e89b-12d3-a456-426614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to contain_exactly(teacher) }
+    end
+
+    context "when it contains a full API ECT training record ID with extra text" do
+      let(:query_string) { "something: 523e4567-e89b-12d3-a456-426614174000" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "523e4567-e89b-12d3-a456-426614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to contain_exactly(teacher) }
+    end
+
+    context "when it is a partial API ECT training record ID" do
+      let(:query_string) { "5766141740" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "123e4567-e89b-12d3-a456-576614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when it is an exact API mentor training record ID" do
+      let(:query_string) { "823e4567-e89b-12d3-a456-426614174000" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "823e4567-e89b-12d3-a456-426614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to contain_exactly(teacher) }
+    end
+
+    context "when it contains a full API mentor training record ID with extra text" do
+      let(:query_string) { "id:823e4567-e89b-12d3-a456-426614174000" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "823e4567-e89b-12d3-a456-426614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to contain_exactly(teacher) }
+    end
+
+    context "when it is a partial API mentor training record ID" do
+      let(:query_string) { "5766141740" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "123e4567-e89b-12d3-a456-576614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when it contains multiple API IDs" do
+      let(:query_string) { "123e4567-e89b-12d3-a456-576614174000 something a9285449-7b0e-47f4-b054-2d09c24c7de5 999e4567-e89b-12d3-a456-426614174999" }
+      let!(:teacher) { FactoryBot.create(:teacher, api_id: "123e4567-e89b-12d3-a456-576614174000") }
+      let!(:other_teacher) { FactoryBot.create(:teacher, api_ect_training_record_id: "999e4567-e89b-12d3-a456-426614174999") }
+      let!(:another_teacher) { FactoryBot.create(:teacher, api_mentor_training_record_id: "a9285449-7b0e-47f4-b054-2d09c24c7de5") }
+      let!(:missing_teacher) { FactoryBot.create(:teacher) }
+
+      it { is_expected.to contain_exactly(teacher, other_teacher, another_teacher) }
     end
 
     context "when the query is a plain name" do
@@ -49,17 +118,13 @@ RSpec.describe Admin::Teachers::Search do
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki", api_id: "123e4567-e89b-12d3-a456-426614174000") }
       let!(:other_teacher) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha", api_id: "999e4567-e89b-12d3-a456-426614174999") }
 
-      it "does not fall back to API participant ID matching" do
-        expect(subject.teacher_scope).to contain_exactly(teacher)
-      end
+      it { is_expected.to contain_exactly(teacher) }
     end
 
     context "when the query only contains tsquery punctuation" do
       let(:query_string) { "<?'" }
 
-      it "returns no teachers" do
-        expect(subject.teacher_scope).to be_empty
-      end
+      it { is_expected.to be_empty }
     end
 
     context "when filtering ECT rows by contract period across the whole dataset" do
@@ -123,7 +188,7 @@ RSpec.describe Admin::Teachers::Search do
       end
 
       it "matches teachers by the latest role periods, latest training period and contract period" do
-        expect(subject.teacher_scope).to contain_exactly(matching_teacher)
+        expect(teacher_scope).to contain_exactly(matching_teacher)
       end
     end
 
@@ -189,7 +254,7 @@ RSpec.describe Admin::Teachers::Search do
       end
 
       it "matches mentors by the latest role periods, latest training period and contract period" do
-        expect(subject.teacher_scope).to contain_exactly(matching_teacher)
+        expect(teacher_scope).to contain_exactly(matching_teacher)
       end
     end
   end


### PR DESCRIPTION
Now we're live, there has been feedback from Users that it would be useful if they could search for Teachers by their training record ID too.

Currently we only search by participant ID, but this _casts_ that net a bit more widely.

Now, we partially match against a teacher's `api_ect_training_record_id` and their `api_mentor_training_record_id` too.
