### PR TITLE
Ensure ECTs can transfer the day a previous 2-day school period ended

### DIFF
--- a/app/services/ect_at_school_periods/finish.rb
+++ b/app/services/ect_at_school_periods/finish.rb
@@ -29,13 +29,15 @@ module ECTAtSchoolPeriods
     attr_reader :training_period
 
     def finish_ect_at_school_period!
-      if ect_at_school_period.finished_on.present? && ect_at_school_period.finished_on <= finished_on
-        update_reporting_school!
-        return
+      if reported_by_school_id
+        ect_at_school_period.reported_leaving_by_school_id = reported_by_school_id
       end
 
-      ect_at_school_period.update!(finish_attrs)
+      if ect_at_school_period.finished_on.blank? || ect_at_school_period.finished_on.after?(finished_on)
+        ect_at_school_period.finished_on = finished_on
+      end
 
+      ect_at_school_period.save!
       record_teacher_left_school_as_ect_event!
     end
 
@@ -48,12 +50,6 @@ module ECTAtSchoolPeriods
         happened_at: finished_on,
         **event_params
       )
-    end
-
-    def update_reporting_school!
-      return unless reported_by_school_id
-
-      ect_at_school_period.update!(reported_leaving_by_school_id: reported_by_school_id)
     end
 
     def finish_mentorship_periods!
@@ -106,12 +102,6 @@ module ECTAtSchoolPeriods
         school: ect_at_school_period.school,
         training_period:
       }
-    end
-
-    def finish_attrs
-      { finished_on: }.tap do |attrs|
-        attrs[:reported_leaving_by_school_id] = reported_by_school_id if reported_by_school_id
-      end
     end
 
     def record_event?

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -773,13 +773,13 @@ RSpec.describe Schools::RegisterECT do
       end
     end
 
-    context "when ECT is transferring from another school on the same date as the previously reported leaving date" do
+    context "when ECT is transferring from another school on the same date " \
+            "as the previously reported leaving date" do
       let(:training_programme) { "school_led" }
       let(:lead_provider) { nil }
       let(:other_school) { FactoryBot.create(:school) }
       let!(:teacher) { FactoryBot.create(:teacher, trn:) }
       let(:started_on) { Date.new(2026, 3, 18) }
-      let(:expected_finished_on) { started_on.yesterday }
 
       let!(:existing_period) do
         FactoryBot.create(
@@ -793,12 +793,73 @@ RSpec.describe Schools::RegisterECT do
       end
 
       it "updates the previous period to end the day before the new start date" do
-        service.register!
-
-        expect(existing_period.reload.finished_on).to eq(expected_finished_on)
+        expect { service.register! }
+          .to change { existing_period.reload.finished_on }
+          .from(started_on)
+          .to(started_on.yesterday)
 
         new_period = teacher.ect_at_school_periods.find_by!(school:)
         expect(new_period.started_on).to eq(started_on)
+      end
+    end
+
+    context "when ECT is transferring from another school on the same date " \
+            "as the previously reported leaving date when the previous period " \
+            "finishes the day after it started" do
+      let(:training_programme) { "school_led" }
+      let(:lead_provider) { nil }
+      let(:other_school) { FactoryBot.create(:school) }
+      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:started_on) { Date.new(2025, 8, 1) }
+
+      let!(:existing_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          teacher:,
+          school: other_school,
+          started_on: started_on.yesterday,
+          finished_on: started_on,
+          reported_leaving_by_school_id: other_school.id
+        )
+      end
+
+      it "updates the previous period to end the day before the new start date" do
+        expect { service.register! }
+          .to change { existing_period.reload.finished_on }
+          .from(started_on)
+          .to(started_on.yesterday)
+
+        new_period = teacher.ect_at_school_periods.find_by!(school:)
+        expect(new_period.started_on).to eq(started_on)
+      end
+    end
+
+    context "when ECT is transferring from another school on the same date " \
+            "as the previously reported leaving date when the previous period " \
+            "finishes the same day it started" do
+      let(:training_programme) { "school_led" }
+      let(:lead_provider) { nil }
+      let(:other_school) { FactoryBot.create(:school) }
+      let!(:teacher) { FactoryBot.create(:teacher, trn:) }
+      let(:started_on) { Date.new(2025, 8, 1) }
+
+      let!(:existing_period) do
+        FactoryBot.create(
+          :ect_at_school_period,
+          teacher:,
+          school: other_school,
+          started_on:,
+          finished_on: started_on,
+          reported_leaving_by_school_id: other_school.id
+        )
+      end
+
+      # TODO: we want to handle this more gracefully (i.e communicate to Users)
+      # that they need to choose a different start date
+      it "raises an error" do
+        expect { service.register! }
+          .to raise_error(ActiveRecord::RecordInvalid)
+          .with_message(/The end date must be later than the start date/)
       end
     end
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3972

### Changes proposed in this pull request

Before, we ran into issues when Users tried to register a new ECT the same day
a 2-day `ECTAtSchoolPeriod` ended at another school.

If the teacher has an `ECTAtSchoolPeriod` at another school that started on or
before the registration date and is either:

- ongoing (i.e has no `finished_on`), or
- has a `finished_on` on or after the registration date

then we "finish" that `ECTAtSchoolPeriod` on the day before the registration
date. This means the ECT can be registered on the given registration date
without any of the periods overlapping.

However we ran into [issues] for these short school periods. Since we try to
"finish" the period the day before the registration date, that meant we tried to
change the previous period so it started and finished on the same day.

Once upon a time (pre https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2357), that would have been a problem. But now that
represents a period with a duration of 1 day.

To make it possible, though, we need to update the validations and database
constraints to reflect that.

This updates the inteval validation to allow `finished_on` to be the same as
`started_on`, and changes the database constraint to allow period lengths that
**are at least zero**.

Now, ECTs can be transfered without running into errors in these scenarios.

---

Note: it might seem strange that a teacher could be at a school for a single
day. It is strange! These are mostly a result of migration, where we have some
"stub" records from the economy migrator.

[issues]: https://dfe-teacher-services.sentry.io/issues/7462387892

### Guidance to review
