### PR TITLE
[3559] Show training API responses per lead provider

### DIFF
--- a/app/controllers/admin/teachers/trainings_controller.rb
+++ b/app/controllers/admin/teachers/trainings_controller.rb
@@ -24,8 +24,7 @@ module Admin
           training_periods
             .select(&:provider_led_training_programme?)
             .group_by { |training_period| lead_provider_id_for(training_period) }
-            .values
-            .map { it.first.id }
+            .map { |_lead_provider_id, training_periods| training_periods.first.id }
         end
       end
 

--- a/app/controllers/admin/teachers/trainings_controller.rb
+++ b/app/controllers/admin/teachers/trainings_controller.rb
@@ -8,12 +8,32 @@ module Admin
         @navigation_items = helpers.admin_teacher_navigation_items(@teacher, :training)
         @breadcrumbs = teacher_breadcrumbs
         @ect_at_school_periods = @teacher.ect_at_school_periods
-        @ect_training_periods = @teacher.ect_training_periods.includes(ect_at_school_period: :teacher).latest_first
-        @period_ids_to_show_api_row = @ect_training_periods.group_by(&:lead_provider_delivery_partnership).values.map { it.first.id }
-        @mentor_training_periods = @teacher.mentor_training_periods.includes(mentor_at_school_period: :teacher).latest_first
+        @ect_training_periods = @teacher.ect_training_periods
+          .includes(:active_lead_provider, :expression_of_interest, ect_at_school_period: :teacher)
+          .latest_first
+        @mentor_training_periods = @teacher.mentor_training_periods
+          .includes(:active_lead_provider, :expression_of_interest, mentor_at_school_period: :teacher)
+          .latest_first
+        @training_period_ids_with_api_response = training_period_ids_with_api_response
       end
 
     private
+
+      def training_period_ids_with_api_response
+        [@ect_training_periods, @mentor_training_periods].flat_map do |training_periods|
+          training_periods
+            .select(&:provider_led_training_programme?)
+            .group_by { |training_period| lead_provider_id_for(training_period) }
+            .except(nil)
+            .values
+            .map { it.first.id }
+        end
+      end
+
+      def lead_provider_id_for(training_period)
+        training_period.active_lead_provider&.lead_provider_id ||
+          training_period.expression_of_interest&.lead_provider_id
+      end
 
       def teacher_breadcrumbs
         {

--- a/app/controllers/admin/teachers/trainings_controller.rb
+++ b/app/controllers/admin/teachers/trainings_controller.rb
@@ -14,12 +14,12 @@ module Admin
         @mentor_training_periods = @teacher.mentor_training_periods
           .includes(:active_lead_provider, :expression_of_interest, mentor_at_school_period: :teacher)
           .latest_first
-        @training_period_ids_with_api_response = training_period_ids_with_api_response
+        @latest_training_period_ids_with_api_response = latest_training_period_ids_with_api_response
       end
 
     private
 
-      def training_period_ids_with_api_response
+      def latest_training_period_ids_with_api_response
         [@ect_training_periods, @mentor_training_periods].flat_map do |training_periods|
           training_periods
             .select(&:provider_led_training_programme?)

--- a/app/controllers/admin/teachers/trainings_controller.rb
+++ b/app/controllers/admin/teachers/trainings_controller.rb
@@ -24,7 +24,6 @@ module Admin
           training_periods
             .select(&:provider_led_training_programme?)
             .group_by { |training_period| lead_provider_id_for(training_period) }
-            .except(nil)
             .values
             .map { it.first.id }
         end

--- a/app/views/admin/teachers/trainings/show.html.erb
+++ b/app/views/admin/teachers/trainings/show.html.erb
@@ -12,14 +12,14 @@
 <% if @ect_at_school_periods.any? %>
   <h3 class="govuk-heading-s">ECT history</h3>
   <% @ect_training_periods.each do |training_period| %>
-    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @period_ids_to_show_api_row.include?(training_period.id)) %>
+    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @training_period_ids_with_api_response.include?(training_period.id)) %>
   <% end %>
 <% end %>
 
 <% if @mentor_training_periods.any? %>
   <h3 class="govuk-heading-s">Mentor history</h3>
-  <% @mentor_training_periods.each_with_index do |training_period, index| %>
-    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: index.zero?) %>
+  <% @mentor_training_periods.each do |training_period| %>
+    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @training_period_ids_with_api_response.include?(training_period.id)) %>
   <% end %>
 <% end %>
 

--- a/app/views/admin/teachers/trainings/show.html.erb
+++ b/app/views/admin/teachers/trainings/show.html.erb
@@ -12,14 +12,14 @@
 <% if @ect_at_school_periods.any? %>
   <h3 class="govuk-heading-s">ECT history</h3>
   <% @ect_training_periods.each do |training_period| %>
-    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @training_period_ids_with_api_response.include?(training_period.id)) %>
+    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @latest_training_period_ids_with_api_response.include?(training_period.id)) %>
   <% end %>
 <% end %>
 
 <% if @mentor_training_periods.any? %>
   <h3 class="govuk-heading-s">Mentor history</h3>
   <% @mentor_training_periods.each do |training_period| %>
-    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @training_period_ids_with_api_response.include?(training_period.id)) %>
+    <%= render Admin::Teachers::TrainingSummaryComponent.new(training_period:, show_api_row: @latest_training_period_ids_with_api_response.include?(training_period.id)) %>
   <% end %>
 <% end %>
 

--- a/spec/requests/admin/teachers/trainings_spec.rb
+++ b/spec/requests/admin/teachers/trainings_spec.rb
@@ -98,6 +98,52 @@ RSpec.describe "Admin::Teachers::Training", type: :request do
         end
       end
 
+      context "with multiple mentor training periods" do
+        let(:teacher) { FactoryBot.create(:teacher) }
+        let(:older_started_on) { Date.new(2023, 6, 1) }
+        let(:middle_started_on) { Date.new(2024, 6, 1) }
+        let(:newer_started_on) { Date.new(2025, 6, 1) }
+        let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: older_started_on, finished_on: nil) }
+
+        before do
+          lead_provider = FactoryBot.create(:lead_provider)
+          latest_lead_provider = FactoryBot.create(:lead_provider)
+          older_active_lp = FactoryBot.create(:active_lead_provider, lead_provider:)
+          newer_active_lp = FactoryBot.create(:active_lead_provider, lead_provider:)
+          latest_active_lp = FactoryBot.create(:active_lead_provider, lead_provider: latest_lead_provider)
+
+          FactoryBot.create(:training_period,
+                            :for_mentor,
+                            :with_active_lead_provider,
+                            active_lead_provider: older_active_lp,
+                            mentor_at_school_period:,
+                            started_on: older_started_on,
+                            finished_on: middle_started_on - 1.day)
+
+          FactoryBot.create(:training_period,
+                            :for_mentor,
+                            :with_active_lead_provider,
+                            active_lead_provider: newer_active_lp,
+                            mentor_at_school_period:,
+                            started_on: middle_started_on,
+                            finished_on: newer_started_on - 1.day)
+
+          FactoryBot.create(:training_period,
+                            :for_mentor,
+                            :with_active_lead_provider,
+                            active_lead_provider: latest_active_lp,
+                            mentor_at_school_period:,
+                            started_on: newer_started_on,
+                            finished_on: nil)
+        end
+
+        it "shows an API response for the latest mentor period under each lead provider" do
+          get admin_teacher_training_path(teacher)
+
+          expect(response.body).to include("API response").twice
+        end
+      end
+
       context "when the teacher has no training periods" do
         let(:teacher) { FactoryBot.create(:teacher) }
 
@@ -128,10 +174,9 @@ RSpec.describe "Admin::Teachers::Training", type: :request do
           expect(response.body.index(newer_started_on.to_fs(:govuk))).to be < body.index(older_started_on.to_fs(:govuk))
         end
 
-        it "shows an API response for each period with a different partnership" do
+        it "shows an API response for each period with a different lead provider" do
           get admin_teacher_training_path(teacher)
 
-          expect(SchoolPartnership.count).to eq(2)
           expect(response.body).to include("API response").twice
         end
 
@@ -157,6 +202,39 @@ RSpec.describe "Admin::Teachers::Training", type: :request do
             expect(response.body).to include("API response").once
             expect(response.body.index("API response")).to be < response.body.index(older_started_on.to_fs(:govuk))
           end
+        end
+      end
+
+      context "with multiple ECT training periods under the same lead provider" do
+        let(:teacher) { FactoryBot.create(:teacher) }
+        let(:older_started_on) { 2.years.ago.to_date }
+        let(:newer_started_on) { 1.year.ago.to_date }
+        let(:ect_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: older_started_on, finished_on: nil) }
+
+        before do
+          lead_provider = FactoryBot.create(:lead_provider)
+          older_active_lp = FactoryBot.create(:active_lead_provider, lead_provider:)
+          newer_active_lp = FactoryBot.create(:active_lead_provider, lead_provider:)
+
+          FactoryBot.create(:training_period,
+                            :with_active_lead_provider,
+                            active_lead_provider: older_active_lp,
+                            ect_at_school_period: ect_period,
+                            started_on: older_started_on,
+                            finished_on: newer_started_on - 1.day)
+
+          FactoryBot.create(:training_period,
+                            :with_active_lead_provider,
+                            active_lead_provider: newer_active_lp,
+                            ect_at_school_period: ect_period,
+                            started_on: newer_started_on,
+                            finished_on: nil)
+        end
+
+        it "only shows an API response for the latest period under that lead provider" do
+          get admin_teacher_training_path(teacher)
+
+          expect(response.body).to include("API response").once
         end
       end
     end


### PR DESCRIPTION
### Context

Fixes the teacher training history API response rows so they show on the latest training period per lead provider, separately for ECT and mentor histories.

### Changes proposed in this pull request

- Group API response rows by lead provider instead of partnership
- Apply the same API response row logic to mentor training periods.

### Guidance to review

Log in as an admin user and find a teacher with multiple training periods across different lead providers.

Check the Training tab. The API response row should show on the latest card for each lead provider, and not on older cards for the same lead provider.