### PR TITLE
Fix flaky `API::Declarations::Create` spec

### DIFF
--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -1,24 +1,23 @@
 FactoryBot.define do
   factory(:statement) do
     transient do
-      contract_period { FactoryBot.create(:contract_period, :current) }
+      contract_period { create(:contract_period, :current) }
       active_lead_provider { association(:active_lead_provider, contract_period:) }
 
       month_year_pair do
-        # Statements start in November of the contract year and run to August 3 years ahead
-        # e.g. for 2021 cohort: November 2021 through to August 2024
-        contract_year = contract.active_lead_provider.contract_period.year
-        start_date = Date.new(contract_year, 11, 1)
+        contract_year = active_lead_provider.contract_period.year
+        last_year, last_month =
+          Statement
+            .joins(contract: :active_lead_provider)
+            .where(contract: { active_lead_provider: })
+            .order(year: :desc, month: :desc)
+            .pick(:year, :month)
 
-        # Offset by the number of existing statements for this active_lead_provider
-        # so each factory call produces a unique month/year pair
-        existing_count = Statement
-          .joins(:contract)
-          .where(contracts: { active_lead_provider_id: active_lead_provider.id })
-          .count
+        # Advance 1 month from any existing statement, or default to November
+        # of the contract year if there are no statements yet.
+        date = Date.new(last_year || contract_year, last_month || 10, 1) >> 1
 
-        month = start_date >> existing_count
-        { year: month.year, month: month.month }
+        { year: date.year, month: date.month }
       end
     end
 
@@ -30,18 +29,6 @@ FactoryBot.define do
     deadline_date { Date.new(year, month, 1).prev_day }
     payment_date { Date.new(year, month, 25) }
     output_fee
-
-    initialize_with do
-      Statement
-        .joins(:contract)
-        .where(contracts: { active_lead_provider_id: active_lead_provider.id })
-        .find_or_initialize_by(
-          month:,
-          year:
-        ) do |statement|
-          statement.contract = contract
-        end
-    end
 
     trait :open do
       status { :open }


### PR DESCRIPTION
### Context

[Link to example failed run](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/25563024893/job/75039261911?pr=2879)

The tests around creating a declaration and asserting on the underlying `Create` service call can be flaky. The flakyness comes from asserting that the underlying `Create` service is called with a particular `payment_statement`; when the test is failing the statement is `nil`.

### Changes proposed in this pull request

- Fix flaky `API::Declarations::Create` spec

Remove `initialize_with` from the `Statement` factory so we hit a uniqueness violation error if we see this again in the future, which should more directly point to the underlying issue.

Improve the `month_year_pair` behaviour so that it should never generate a pairing that already exists. This could happen previously as we were just offsetting on the `Statement#count`; other statements created with a specific `month` or `year` would disrupt the offset/uniqueness.

### Guidance to review

I haven't been able to replicate it, but I'm fairly confident this is arising due to the way the `Statement` factory both populates `year` and `month` on a sequence based on the `Statement#count` and how it also runs a `find_or_initialize_by` (presumably to avoid issues with the unique index on `month` and `year`).

What I think happens is a `Statement` already exists with the `month` and `year` that are picked by `month_year_pair` when we come to create the statement for our test. The `initialize_with` is then returning an existing statement and so the `deadline_date` we explicitly pass in as `1.month.from_now` gets ignored, resulting in the `Statement::Search` in the `Create` service returning `nil`. Here's an example of how the `initialize_with` can cause unexpected state:

```
statement1 = FactoryBot.create(:statement, deadline_date: 1.day.ago)
statement2 = FactoryBot.create(:statement, year: statement1.year, month.statement1.month, deadline_date: 1.day.from_now)

statement2.deadline_date
=> 1.day.ago
```

That being said, I haven't been able to pin down where the rogue `Statement` is leaking from.