### PR TITLE
Avoid loading `Teacher` model in API ID backfill migration

### DIFF
--- a/db/migrate/20250911134739_backfill_teachers_api_ids.rb
+++ b/db/migrate/20250911134739_backfill_teachers_api_ids.rb
@@ -1,13 +1,16 @@
 class BackfillTeachersAPIIds < ActiveRecord::Migration[8.0]
   def up
-    Teacher.find_each do |teacher|
-      updates = {}
-      updates[:api_user_id] = teacher.ecf_user_id if teacher.ecf_user_id.present?
-      updates[:api_ect_profile_id] = teacher.ecf_ect_profile_id if teacher.ecf_ect_profile_id.present?
-      updates[:api_mentor_profile_id] = teacher.ecf_mentor_profile_id if teacher.ecf_mentor_profile_id.present?
-
-      teacher.update!(updates) if updates.any?
-    end
+    execute <<~SQL
+      UPDATE teachers
+      SET
+        api_user_id = COALESCE(ecf_user_id, api_user_id),
+        api_ect_profile_id = COALESCE(ecf_ect_profile_id, api_ect_profile_id),
+        api_mentor_profile_id = COALESCE(ecf_mentor_profile_id, api_mentor_profile_id),
+        updated_at = CURRENT_TIMESTAMP
+      WHERE ecf_user_id IS NOT NULL
+        OR ecf_ect_profile_id IS NOT NULL
+        OR ecf_mentor_profile_id IS NOT NULL
+    SQL
   end
 
   def down = nil


### PR DESCRIPTION
### Summary

The [`20250911134739_backfill_teachers_api_ids` migration](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/db/migrate/20250911134739_backfill_teachers_api_ids.rb#L3) references the `Teacher` model.

Since that migration was added, [`Teacher` has gained a `migration_mode` enum](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/app/models/teacher.rb#L15) backed by the `teachers.migration_mode` column. That column is only introduced later in the migration sequence, via [`20260106142812_consolidate_migration_mode_fields`](https://github.com/DFE-Digital/register-early-career-teachers-public/blob/main/db/migrate/20260106142812_consolidate_migration_mode_fields.rb).

When review apps create a fresh database and replay migrations from scratch, the older API ID backfill migration runs before `teachers.migration_mode` exists. Loading the current `Teacher` model at that point raises:

`Undeclared attribute type for enum 'migration_mode' in Teacher`

This fixes the issue by replacing the model based backfill with raw SQL, so the historical migration no longer depends on the current model definition.