### PR TITLE
Clear the wizard store before visiting the update SIT details page

### DIFF
--- a/app/controllers/schools/induction_tutor/update_induction_tutor_wizard_controller.rb
+++ b/app/controllers/schools/induction_tutor/update_induction_tutor_wizard_controller.rb
@@ -2,6 +2,16 @@ module Schools
   module InductionTutor
     class UpdateInductionTutorWizardController < SchoolsController
       include InductionTutorable
+
+      before_action :reset_wizard
+
+    private
+
+      def reset_wizard
+        return if request.referer.to_s.include?("/school/induction-tutor/update-induction-tutor/")
+
+        store.reset if current_step == :edit
+      end
     end
   end
 end

--- a/spec/requests/schools/induction_tutor/update_induction_tutor_wizard_spec.rb
+++ b/spec/requests/schools/induction_tutor/update_induction_tutor_wizard_spec.rb
@@ -41,6 +41,23 @@ describe "Schools::InductionTutor::UpdateInductionTutorWizardController" do
           expect(response).to have_http_status(:ok)
         end
       end
+
+      it "prefills from the current school on a fresh journey" do
+        other_school = FactoryBot.create(
+          :school,
+          :with_induction_tutor,
+          induction_tutor_name: "Second School Tutor",
+          induction_tutor_email: "second.school.tutor@example.com"
+        )
+
+        post path_for_step("edit"), params: { edit: { induction_tutor_name: "First School Tutor", induction_tutor_email: } }
+
+        sign_in_as(:school_user, school: other_school)
+        get path_for_step("edit")
+
+        expect(response.body).to include("Second School Tutor")
+        expect(response.body).to include("second.school.tutor@example.com")
+      end
     end
 
     context "when visiting an invalid step" do


### PR DESCRIPTION
### Context
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3720

The update induction tutor wizard keeps submitted form data in the session and when an admin impersonates a different school, the form shows induction tutor details from the previous school.

### Changes proposed in this pull request
- Add a `reset_wizard` method to clear the wizard store when visiting the update induction tutor page

### Guidance to review

1. Sign in as an admin and impersonate a school
2. Change the SIT details at the school
3. Impersonate a different school
4. Go to change the SIT details at the second school
5. See the details from the second school are being pre-filled