### PR TITLE
[3934] Add finance contract period show page

### DIFF
--- a/app/controllers/admin/finance/contract_periods_controller.rb
+++ b/app/controllers/admin/finance/contract_periods_controller.rb
@@ -10,5 +10,21 @@ module Admin::Finance
       page = params[:page].presence
       @pagy, @contract_periods = pagy(ContractPeriod.most_recent_first, page:)
     end
+
+    def show
+      @contract_period = ContractPeriod
+        .includes(:active_lead_providers, :schedules)
+        .find(params[:id])
+
+      @editable = !@contract_period.started_on_or_before_today?
+      @has_lead_providers = @contract_period.active_lead_providers.any?
+      @has_schedules = @contract_period.schedules.any?
+
+      @breadcrumbs = {
+        "Finance" => admin_finance_path,
+        "Contract periods" => admin_contract_periods_path,
+        @contract_period.year.to_s => nil,
+      }
+    end
   end
 end

--- a/app/views/admin/finance/contract_periods/index.html.erb
+++ b/app/views/admin/finance/contract_periods/index.html.erb
@@ -7,7 +7,7 @@
     govuk_table(
       head: ["Year", "Started on", "Finished on"],
       rows: @contract_periods.map { |cp| [
-        cp.year.to_s,
+        govuk_link_to(cp.year.to_s, admin_contract_period_path(cp)),
         cp.started_on.to_fs(:govuk),
         cp.finished_on.to_fs(:govuk),
       ] }

--- a/app/views/admin/finance/contract_periods/show.html.erb
+++ b/app/views/admin/finance/contract_periods/show.html.erb
@@ -1,0 +1,69 @@
+<% page_data(title: "Contract period #{@contract_period.year}", breadcrumbs: @breadcrumbs) %>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Year")
+      row.with_value(text: @contract_period.year)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Started on")
+      row.with_value(text: @contract_period.started_on.to_fs(:govuk))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Finished on")
+      row.with_value(text: @contract_period.finished_on.to_fs(:govuk))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Enabled")
+      row.with_value(text: @contract_period.enabled? ? "Yes" : "No")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Mentor funding enabled")
+      row.with_value(text: @contract_period.mentor_funding_enabled? ? "Yes" : "No")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Detailed evidence types enabled")
+      row.with_value(text: @contract_period.detailed_evidence_types_enabled? ? "Yes" : "No")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Uplift fees enabled")
+      row.with_value(text: @contract_period.uplift_fees_enabled? ? "Yes" : "No")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Payments frozen")
+      row.with_value(text: @contract_period.payments_frozen? ? @contract_period.payments_frozen_at.to_fs(:govuk) : "No")
+    end
+  end
+%>
+
+<%= govuk_button_link_to("Edit contract period", "#", disabled: !@editable) %>
+
+<h2 class="govuk-heading-m">Set up</h2>
+
+<%= govuk_task_list do |list| %>
+  <% list.with_item(title: "Lead providers", href: (@editable ? "#" : nil)) do |item| %>
+    <% if @has_lead_providers %>
+      <% item.with_status(text: "Completed") %>
+    <% else %>
+      <% item.with_status do %>
+        <%= govuk_tag(text: "Incomplete", colour: "blue") %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% list.with_item(title: "Schedules", href: (@has_schedules ? "#" : nil)) do |item| %>
+    <% if @has_schedules %>
+      <% item.with_status(text: "Completed") %>
+    <% else %>
+      <% item.with_status(text: "Cannot start yet", cannot_start_yet: true) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -108,7 +108,7 @@ namespace :admin do
         resource :search_declarations, only: :show, path: "search-declarations"
 
         constraints -> { Rails.application.config.enable_finance_contract_periods } do
-          resources :contract_periods, only: %i[index], path: "contract-periods"
+          resources :contract_periods, only: %i[index show], path: "contract-periods"
         end
       end
     end

--- a/spec/requests/admin/finance/contract_periods_spec.rb
+++ b/spec/requests/admin/finance/contract_periods_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe "Admin finance contract periods", type: :request do
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+
+  describe "GET /admin/finance/contract-periods" do
+    it "redirects to sign in path when not signed in" do
+      get "/admin/finance/contract-periods"
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get "/admin/finance/contract-periods"
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a non-finance DfE user" do
+      include_context "sign in as DfE user"
+
+      it "requires authorisation with the finance access error message" do
+        get "/admin/finance/contract-periods"
+
+        expect(response.status).to eq(401)
+
+        expect(response.body).to include(
+          "This is to access financial information for Register early career teachers. To gain access, contact the product team."
+        )
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "displays the contract periods index page" do
+        get "/admin/finance/contract-periods"
+
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe "GET /admin/finance/contract-periods/:id" do
+    it "redirects to sign in path when not signed in" do
+      get "/admin/finance/contract-periods/#{contract_period.id}"
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get "/admin/finance/contract-periods/#{contract_period.id}"
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a non-finance DfE user" do
+      include_context "sign in as DfE user"
+
+      it "requires authorisation with the finance access error message" do
+        get "/admin/finance/contract-periods/#{contract_period.id}"
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "displays the contract period show page" do
+        get "/admin/finance/contract-periods/#{contract_period.id}"
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("Contract period #{contract_period.year}")
+      end
+    end
+  end
+end

--- a/spec/views/admin/finance/contract_periods/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/contract_periods/show.html.erb_spec.rb
@@ -1,0 +1,162 @@
+RSpec.describe "admin/finance/contract_periods/show.html.erb" do
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+
+  before do
+    assign(:contract_period, contract_period)
+    assign(:editable, !contract_period.started_on_or_before_today?)
+    assign(:has_lead_providers, contract_period.active_lead_providers.any?)
+    assign(:has_schedules, contract_period.schedules.any?)
+    assign(:breadcrumbs, {
+      "Finance" => admin_finance_path,
+      "Contract periods" => admin_contract_periods_path,
+      contract_period.year.to_s => nil,
+    })
+  end
+
+  it "has the page title 'Contract period <year>'" do
+    render
+
+    expect(view.content_for(:page_title)).to eq("Contract period #{contract_period.year}")
+  end
+
+  it "renders the breadcrumbs" do
+    render
+
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to include(contract_period.year.to_s)
+  end
+
+  it "renders a summary list with the contract period attributes" do
+    render
+
+    expect(rendered).to have_css(".govuk-summary-list")
+    expect(rendered).to have_content("Year")
+    expect(rendered).to have_content(contract_period.year.to_s)
+    expect(rendered).to have_content("Started on")
+    expect(rendered).to have_content(contract_period.started_on.to_fs(:govuk))
+    expect(rendered).to have_content("Finished on")
+    expect(rendered).to have_content(contract_period.finished_on.to_fs(:govuk))
+    expect(rendered).to have_content("Mentor funding enabled")
+    expect(rendered).to have_content("Detailed evidence types enabled")
+    expect(rendered).to have_content("Uplift fees enabled")
+    expect(rendered).to have_content("Payments frozen")
+  end
+
+  it "renders a task list" do
+    render
+
+    expect(rendered).to have_css(".govuk-task-list")
+    expect(rendered).to have_content("Lead providers")
+    expect(rendered).to have_content("Schedules")
+  end
+
+  describe "edit button" do
+    context "when the contract period has not yet started" do
+      let(:contract_period) do
+        FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+      end
+
+      it "renders an enabled edit button" do
+        render
+
+        expect(rendered).to have_link("Edit contract period")
+      end
+    end
+
+    context "when the contract period has already started" do
+      let(:contract_period) do
+        FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
+      end
+
+      it "renders the edit button in a disabled state" do
+        render
+
+        expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Edit contract period")
+      end
+    end
+  end
+
+  describe "lead providers task" do
+    context "when the contract period has not yet started and has no active lead providers" do
+      let(:contract_period) do
+        FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+      end
+
+      it "shows the task as incomplete with a blue tag and selectable" do
+        render
+
+        expect(rendered).to have_link("Lead providers")
+        within(".govuk-task-list") do
+          expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "Incomplete")
+        end
+      end
+    end
+
+    context "when the contract period has not yet started and has active lead providers" do
+      let(:contract_period) do
+        FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+      end
+
+      before do
+        FactoryBot.create(:active_lead_provider, contract_period:)
+      end
+
+      it "shows the task as completed and selectable" do
+        render
+
+        expect(rendered).to have_link("Lead providers")
+        within(".govuk-task-list") do
+          expect(rendered).to have_content("Completed")
+        end
+      end
+    end
+
+    context "when the contract period has started and has active lead providers" do
+      let(:contract_period) do
+        FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
+      end
+
+      before do
+        FactoryBot.create(:active_lead_provider, contract_period:)
+      end
+
+      it "shows the task as completed but not selectable" do
+        render
+
+        expect(rendered).not_to have_link("Lead providers")
+        within(".govuk-task-list") do
+          expect(rendered).to have_content("Lead providers")
+          expect(rendered).to have_content("Completed")
+        end
+      end
+    end
+  end
+
+  describe "schedules task" do
+    context "when the contract period has no schedules" do
+      it "shows the task as cannot start yet" do
+        render
+
+        expect(rendered).not_to have_link("Schedules")
+        within(".govuk-task-list") do
+          expect(rendered).to have_content("Schedules")
+          expect(rendered).to have_css(".govuk-task-list__status--cannot-start-yet", text: "Cannot start yet")
+        end
+      end
+    end
+
+    context "when the contract period has schedules" do
+      let(:contract_period) { FactoryBot.create(:contract_period, :with_schedules) }
+
+      it "shows the task as completed and links to it" do
+        render
+
+        expect(rendered).to have_link("Schedules")
+        within(".govuk-task-list") do
+          expect(rendered).to have_content("Completed")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3934
Branching off: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2902

### Changes proposed in this pull request

* Finance contract period show page
* Showing lead providers and schedules as task list
* Edit button enabled only if editable

### Guidance to review

* Sign in as DfE admin finance user
