### PR TITLE
Fix flaky `Teachers::Manage` spec

### DIFF
--- a/spec/services/teachers/manage_spec.rb
+++ b/spec/services/teachers/manage_spec.rb
@@ -41,10 +41,8 @@ RSpec.describe Teachers::Manage do
   end
 
   describe ".new" do
-    subject(:service) { described_class.new(author:, teacher:, appropriate_body_period:) }
-
     it "is private" do
-      expect { service }.to raise_error(NoMethodError, /private method 'new' called/)
+      expect(described_class.private_methods).to include(:new)
     end
   end
 


### PR DESCRIPTION
The test to ensure the `:new` method is private fails consistently when running the whole test suite locally.

I haven't been able to figure out how/why it fails, but reworking the test to check `private_methods` directly instead of asserting an error is raised when calling `new` seems to resolve the flakyness for me.
