### PR TITLE
[3952] Scope unfunded mentor email to the requesting lead provider - Part 2

### DIFF
--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -12,6 +12,11 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :mentor_at_school_period, dependent: :destroy
   has_many :declarations, through: :training_periods
   has_many :events
+  has_many :mentor_lead_provider_metadata,
+           class_name: "Metadata::TeacherLeadProvider",
+           foreign_key: :ect_assigned_mentor_latest_school_period_id,
+           dependent: :nullify,
+           inverse_of: :ect_assigned_mentor_latest_school_period
   has_many :current_or_future_ects,
            -> { current_or_future.induction_not_completed.includes(:teacher) },
            through: :current_or_future_mentorship_periods,

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -12,7 +12,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   has_many :training_periods, inverse_of: :mentor_at_school_period, dependent: :destroy
   has_many :declarations, through: :training_periods
   has_many :events
-  has_many :mentor_lead_provider_metadata,
+  has_many :lead_provider_metadata_for_mentees,
            class_name: "Metadata::TeacherLeadProvider",
            foreign_key: :ect_assigned_mentor_latest_school_period_id,
            dependent: :nullify,

--- a/app/models/metadata/teacher_lead_provider.rb
+++ b/app/models/metadata/teacher_lead_provider.rb
@@ -13,7 +13,7 @@ module Metadata
     belongs_to :latest_mentor_contract_period, optional: true, class_name: "ContractPeriod", foreign_key: :latest_mentor_contract_period_year
     belongs_to :ect_assigned_mentor_latest_school_period, optional: true, class_name: "MentorAtSchoolPeriod"
 
-    touch -> { teacher }, on_event: :update, timestamp_attribute: :api_updated_at, when_changing: %i[api_mentor_id]
+    touch -> { teacher }, on_event: :update, timestamp_attribute: :api_updated_at, when_changing: %i[ect_assigned_mentor_latest_school_period_id]
 
     validates :teacher, presence: true
     validates :lead_provider, presence: true

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -27,6 +27,11 @@ class Teacher < ApplicationRecord
   has_many :induction_extensions, inverse_of: :teacher
   has_many :teacher_id_changes, inverse_of: :teacher, dependent: :destroy
   has_many :lead_provider_metadata, class_name: "Metadata::TeacherLeadProvider", dependent: :destroy
+  has_many :mentor_lead_provider_metadata,
+           class_name: "Metadata::TeacherLeadProvider",
+           foreign_key: :api_mentor_id,
+           primary_key: :api_id,
+           inverse_of: false
   has_many :induction_periods
   has_many :appropriate_body_periods, through: :induction_periods
   has_many :events

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -27,7 +27,7 @@ class Teacher < ApplicationRecord
   has_many :induction_extensions, inverse_of: :teacher
   has_many :teacher_id_changes, inverse_of: :teacher, dependent: :destroy
   has_many :lead_provider_metadata, class_name: "Metadata::TeacherLeadProvider", dependent: :destroy
-  has_many :mentor_lead_provider_metadata, through: :mentor_at_school_periods
+  has_many :lead_provider_metadata_for_mentees, through: :mentor_at_school_periods
   has_many :induction_periods
   has_many :appropriate_body_periods, through: :induction_periods
   has_many :events

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -27,11 +27,7 @@ class Teacher < ApplicationRecord
   has_many :induction_extensions, inverse_of: :teacher
   has_many :teacher_id_changes, inverse_of: :teacher, dependent: :destroy
   has_many :lead_provider_metadata, class_name: "Metadata::TeacherLeadProvider", dependent: :destroy
-  has_many :mentor_lead_provider_metadata,
-           class_name: "Metadata::TeacherLeadProvider",
-           foreign_key: :api_mentor_id,
-           primary_key: :api_id,
-           inverse_of: false
+  has_many :mentor_lead_provider_metadata, through: :mentor_at_school_periods
   has_many :induction_periods
   has_many :appropriate_body_periods, through: :induction_periods
   has_many :events

--- a/app/serializers/api/teacher_serializer.rb
+++ b/app/serializers/api/teacher_serializer.rb
@@ -25,7 +25,7 @@ class API::TeacherSerializer < Blueprinter::Base
       end
       field(:email) { |(training_period, _, _)| training_period.email }
       field(:mentor_id) do |(training_period, _, metadata)|
-        metadata.api_mentor_id if training_period.for_ect?
+        metadata.ect_assigned_mentor_latest_school_period&.teacher&.api_id if training_period.for_ect?
       end
       field(:school_urn) { |(training_period, _, _)| training_period.school_partnership.school.urn.to_s }
       field(:participant_type) { |(training_period, _, _)| training_period.for_ect? ? "ect" : "mentor" }

--- a/app/serializers/api/teachers/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/teachers/unfunded_mentor_serializer.rb
@@ -3,8 +3,14 @@ class API::Teachers::UnfundedMentorSerializer < Blueprinter::Base
     exclude :id
 
     field(:full_name) { |teacher| Teachers::Name.new(teacher).full_name }
-    field(:email) do |teacher, _options|
-      teacher.latest_mentor_at_school_period.email
+    field(:email) do |teacher, options|
+      lead_provider_id = options[:lead_provider_id]
+
+      teacher.mentor_lead_provider_metadata
+        .select { |m| m.lead_provider_id == lead_provider_id }
+        .max_by { |m| m.latest_mentor_at_school_period.started_on }
+        .latest_mentor_at_school_period
+        .email
     end
     field(:trn, name: :teacher_reference_number)
     field :created_at

--- a/app/serializers/api/teachers/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/teachers/unfunded_mentor_serializer.rb
@@ -6,7 +6,7 @@ class API::Teachers::UnfundedMentorSerializer < Blueprinter::Base
     field(:email) do |teacher, options|
       lead_provider_id = options[:lead_provider_id]
 
-      teacher.mentor_lead_provider_metadata
+      teacher.lead_provider_metadata_for_mentees
         .select { |m| m.lead_provider_id == lead_provider_id }
         .max_by { |m| m.ect_assigned_mentor_latest_school_period.started_on }
         .ect_assigned_mentor_latest_school_period

--- a/app/serializers/api/teachers/unfunded_mentor_serializer.rb
+++ b/app/serializers/api/teachers/unfunded_mentor_serializer.rb
@@ -8,8 +8,8 @@ class API::Teachers::UnfundedMentorSerializer < Blueprinter::Base
 
       teacher.mentor_lead_provider_metadata
         .select { |m| m.lead_provider_id == lead_provider_id }
-        .max_by { |m| m.latest_mentor_at_school_period.started_on }
-        .latest_mentor_at_school_period
+        .max_by { |m| m.ect_assigned_mentor_latest_school_period.started_on }
+        .ect_assigned_mentor_latest_school_period
         .email
     end
     field(:trn, name: :teacher_reference_number)

--- a/app/services/api/teachers/query.rb
+++ b/app/services/api/teachers/query.rb
@@ -69,7 +69,8 @@ module API::Teachers
               mentor_at_school_period: [],
               schedule: [],
             },
-            latest_mentor_contract_period: []
+            latest_mentor_contract_period: [],
+            ect_assigned_mentor_latest_school_period: :teacher
           }
         )
     end

--- a/app/services/api/teachers/unfunded_mentors/query.rb
+++ b/app/services/api/teachers/unfunded_mentors/query.rb
@@ -37,7 +37,7 @@ module API::Teachers::UnfundedMentors
     def preload_associations(results)
       results
         .strict_loading
-        .includes(mentor_lead_provider_metadata: :ect_assigned_mentor_latest_school_period)
+        .includes(lead_provider_metadata_for_mentees: :ect_assigned_mentor_latest_school_period)
     end
 
     def where_lead_provider_is(lead_provider_id)

--- a/app/services/api/teachers/unfunded_mentors/query.rb
+++ b/app/services/api/teachers/unfunded_mentors/query.rb
@@ -41,10 +41,10 @@ module API::Teachers::UnfundedMentors
     end
 
     def where_lead_provider_is(lead_provider_id)
-      mentor_ids_associated_with_teachers_for_the_lead_provider = Metadata::TeacherLeadProvider
+      mentor_teacher_ids_for_the_lead_provider = Metadata::TeacherLeadProvider
+        .joins(ect_assigned_mentor_latest_school_period: :teacher)
         .where(lead_provider_id:)
-        .where.not(api_mentor_id: nil)
-        .select(:api_mentor_id)
+        .select(MentorAtSchoolPeriod.arel_table[:teacher_id])
 
       teacher_ids_trained_by_the_lead_provider = Metadata::TeacherLeadProvider
         .where(lead_provider_id:)
@@ -55,7 +55,7 @@ module API::Teachers::UnfundedMentors
         .select(:teacher_id)
 
       @scope = scope
-        .where(api_id: mentor_ids_associated_with_teachers_for_the_lead_provider)
+        .where(id: mentor_teacher_ids_for_the_lead_provider)
         .where.not(id: teacher_ids_trained_by_the_lead_provider)
     end
 

--- a/app/services/api/teachers/unfunded_mentors/query.rb
+++ b/app/services/api/teachers/unfunded_mentors/query.rb
@@ -37,7 +37,7 @@ module API::Teachers::UnfundedMentors
     def preload_associations(results)
       results
         .strict_loading
-        .includes(mentor_lead_provider_metadata: :latest_mentor_at_school_period)
+        .includes(mentor_lead_provider_metadata: :ect_assigned_mentor_latest_school_period)
     end
 
     def where_lead_provider_is(lead_provider_id)

--- a/app/services/api/teachers/unfunded_mentors/query.rb
+++ b/app/services/api/teachers/unfunded_mentors/query.rb
@@ -37,9 +37,7 @@ module API::Teachers::UnfundedMentors
     def preload_associations(results)
       results
         .strict_loading
-        .includes(
-          :latest_mentor_at_school_period
-        )
+        .includes(mentor_lead_provider_metadata: :latest_mentor_at_school_period)
     end
 
     def where_lead_provider_is(lead_provider_id)

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -27,8 +27,8 @@ module Metadata::Handlers
         latest_mentor_training_period = latest_mentor_training_period_by_lead_provider(teacher:)[lead_provider_id]
         latest_ect_contract_period = latest_ect_training_period&.contract_period
         latest_mentor_contract_period = latest_mentor_training_period&.contract_period
-        latest_mentorship_period = latest_ect_training_period&.at_school_period&.latest_mentorship_period
-        ect_assigned_mentor_latest_school_period_id = latest_mentorship_period.mentor_at_school_period_id if latest_mentorship_period&.ongoing_today?
+        ect_assigned_mentor_latest_school_period_id =
+          latest_ongoing_mentor_at_school_period_id(latest_ect_training_period&.ect_at_school_period_id)
         involved_in_school_transfer = school_transfers_exist_for(teacher.ect_at_school_periods, lead_provider_id) ||
           school_transfers_exist_for(teacher.mentor_at_school_periods, lead_provider_id)
 
@@ -60,6 +60,16 @@ module Metadata::Handlers
         .select("DISTINCT ON (lead_provider_id) training_periods.*")
         .order("lead_provider_id, training_periods.started_on DESC")
         .index_by { it.lead_provider&.id }
+    end
+
+    def latest_ongoing_mentor_at_school_period_id(ect_at_school_period_id)
+      return nil if ect_at_school_period_id.nil?
+
+      MentorshipPeriod
+        .where(ect_at_school_period_id:)
+        .ongoing_today
+        .latest_first
+        .pick(:mentor_at_school_period_id)
     end
 
     def latest_mentor_training_period_by_lead_provider(teacher:)

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -28,8 +28,7 @@ module Metadata::Handlers
         latest_ect_contract_period = latest_ect_training_period&.contract_period
         latest_mentor_contract_period = latest_mentor_training_period&.contract_period
         latest_mentorship_period = latest_ect_training_period&.at_school_period&.latest_mentorship_period
-        ect_assigned_mentor_latest_school_period = latest_mentorship_period.mentor if latest_mentorship_period&.ongoing_today?
-        api_mentor_id = ect_assigned_mentor_latest_school_period&.teacher&.api_id
+        ect_assigned_mentor_latest_school_period_id = latest_mentorship_period.mentor_at_school_period_id if latest_mentorship_period&.ongoing_today?
         involved_in_school_transfer = school_transfers_exist_for(teacher.ect_at_school_periods, lead_provider_id) ||
           school_transfers_exist_for(teacher.mentor_at_school_periods, lead_provider_id)
 
@@ -40,8 +39,7 @@ module Metadata::Handlers
           latest_mentor_training_period_id: latest_mentor_training_period&.id,
           latest_ect_contract_period_year: latest_ect_contract_period&.year,
           latest_mentor_contract_period_year: latest_mentor_contract_period&.year,
-          ect_assigned_mentor_latest_school_period_id: ect_assigned_mentor_latest_school_period&.id,
-          api_mentor_id:,
+          ect_assigned_mentor_latest_school_period_id:,
           involved_in_school_transfer:
         }
 

--- a/lib/remove_teacher.rb
+++ b/lib/remove_teacher.rb
@@ -25,9 +25,7 @@ class RemoveTeacher
 
   # @return [Array<Symbol>]
   def has_many_associations
-    Teacher.reflect_on_all_associations(:has_many)
-      .reject { |r| r.options[:primary_key].present? }
-      .map(&:name).sort
+    Teacher.reflect_on_all_associations(:has_many).map(&:name).sort
   end
 
 private

--- a/lib/remove_teacher.rb
+++ b/lib/remove_teacher.rb
@@ -25,7 +25,9 @@ class RemoveTeacher
 
   # @return [Array<Symbol>]
   def has_many_associations
-    Teacher.reflect_on_all_associations(:has_many).map(&:name).sort
+    Teacher.reflect_on_all_associations(:has_many)
+      .reject { |r| r.options[:primary_key].present? }
+      .map(&:name).sort
   end
 
 private

--- a/spec/lib/remove_teacher_spec.rb
+++ b/spec/lib/remove_teacher_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RemoveTeacher, :aggregate_failures do
       lead_provider_metadata
       mentor_at_school_periods
       mentor_declarations
+      mentor_lead_provider_metadata
       mentor_training_periods
       teacher_id_changes
     ])

--- a/spec/lib/remove_teacher_spec.rb
+++ b/spec/lib/remove_teacher_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe RemoveTeacher, :aggregate_failures do
       induction_extensions
       induction_periods
       lead_provider_metadata
+      lead_provider_metadata_for_mentees
       mentor_at_school_periods
       mentor_declarations
-      mentor_lead_provider_metadata
       mentor_training_periods
       teacher_id_changes
     ])

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -23,6 +23,7 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to have_many(:declarations).through(:training_periods) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:current_or_future_ects).through(:current_or_future_mentorship_periods).source(:mentee) }
+    it { is_expected.to have_many(:mentor_lead_provider_metadata).class_name("Metadata::TeacherLeadProvider").with_foreign_key(:ect_assigned_mentor_latest_school_period_id).dependent(:nullify).inverse_of(:ect_assigned_mentor_latest_school_period) }
   end
 
   describe "#current_or_future_ects" do

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -23,7 +23,7 @@ describe MentorAtSchoolPeriod do
     it { is_expected.to have_many(:declarations).through(:training_periods) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:current_or_future_ects).through(:current_or_future_mentorship_periods).source(:mentee) }
-    it { is_expected.to have_many(:mentor_lead_provider_metadata).class_name("Metadata::TeacherLeadProvider").with_foreign_key(:ect_assigned_mentor_latest_school_period_id).dependent(:nullify).inverse_of(:ect_assigned_mentor_latest_school_period) }
+    it { is_expected.to have_many(:lead_provider_metadata_for_mentees).class_name("Metadata::TeacherLeadProvider").with_foreign_key(:ect_assigned_mentor_latest_school_period_id).dependent(:nullify).inverse_of(:ect_assigned_mentor_latest_school_period) }
   end
 
   describe "#current_or_future_ects" do

--- a/spec/models/metadata/teacher_lead_provider_spec.rb
+++ b/spec/models/metadata/teacher_lead_provider_spec.rb
@@ -59,6 +59,6 @@ describe Metadata::TeacherLeadProvider do
       Metadata::TeacherLeadProvider.bypass_update_restrictions { example.run }
     end
 
-    it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[api_mentor_id], timestamp_attribute: :api_updated_at
+    it_behaves_like "a declarative touch model", on_event: %i[update], when_changing: %i[ect_assigned_mentor_latest_school_period_id], timestamp_attribute: :api_updated_at
   end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -106,6 +106,7 @@ describe Teacher do
     it { is_expected.to have_many(:ect_declarations).through(:ect_training_periods).source(:declarations) }
     it { is_expected.to have_many(:teacher_id_changes) }
     it { is_expected.to have_many(:lead_provider_metadata).class_name("Metadata::TeacherLeadProvider") }
+    it { is_expected.to have_many(:mentor_lead_provider_metadata).through(:mentor_at_school_periods) }
     it { is_expected.to have_one(:started_induction_period).class_name("InductionPeriod") }
     it { is_expected.to have_one(:finished_induction_period).class_name("InductionPeriod") }
     it { is_expected.to have_one(:earliest_ect_at_school_period).class_name("ECTAtSchoolPeriod") }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -106,7 +106,7 @@ describe Teacher do
     it { is_expected.to have_many(:ect_declarations).through(:ect_training_periods).source(:declarations) }
     it { is_expected.to have_many(:teacher_id_changes) }
     it { is_expected.to have_many(:lead_provider_metadata).class_name("Metadata::TeacherLeadProvider") }
-    it { is_expected.to have_many(:mentor_lead_provider_metadata).through(:mentor_at_school_periods) }
+    it { is_expected.to have_many(:lead_provider_metadata_for_mentees).through(:mentor_at_school_periods) }
     it { is_expected.to have_one(:started_induction_period).class_name("InductionPeriod") }
     it { is_expected.to have_one(:finished_induction_period).class_name("InductionPeriod") }
     it { is_expected.to have_one(:earliest_ect_at_school_period).class_name("ECTAtSchoolPeriod") }

--- a/spec/serializers/api/teachers/unfunded_mentor_serializer_spec.rb
+++ b/spec/serializers/api/teachers/unfunded_mentor_serializer_spec.rb
@@ -1,4 +1,6 @@
 describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
+  include MentorshipPeriodHelpers
+
   subject(:response) do
     options = { lead_provider_id: lead_provider.id }
     JSON.parse(described_class.render(unfunded_mentor_teacher, **options))
@@ -14,11 +16,21 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
       api_unfunded_mentor_updated_at:
     )
   end
+  let!(:school_partnership_for_lead_provider) do
+    FactoryBot.create(:school_partnership, :for_year, lead_provider:)
+  end
 
   before do
-    # Create mentor at school periods for the unfunded mentor teacher
-    FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: unfunded_mentor_teacher, started_on: 6.months.ago, email: "test1@test.com")
-    FactoryBot.create(:mentor_at_school_period, teacher: unfunded_mentor_teacher, started_on: 1.year.ago, finished_on: 6.months.ago, email: "test2@test.com")
+    create_mentorship_period_for(
+      mentee_school_partnership: school_partnership_for_lead_provider,
+      mentor: unfunded_mentor_teacher,
+      create_mentor_training_period: false,
+      refresh_metadata: true
+    )
+    unfunded_mentor_teacher
+      .mentor_at_school_periods
+      .find_by(school: school_partnership_for_lead_provider.school)
+      .update!(email: "lead-provider-school@example.com")
   end
 
   describe "core attributes" do
@@ -32,9 +44,7 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
     subject(:attributes) { response["attributes"] }
 
     it "serializes correctly" do
-      expect(attributes["email"]).to be_present
-      expect(attributes["email"]).to eq(unfunded_mentor_teacher.latest_mentor_at_school_period.email)
-      expect(attributes["email"]).to eq("test1@test.com")
+      expect(attributes["email"]).to eq("lead-provider-school@example.com")
       expect(attributes["teacher_reference_number"]).to be_present
       expect(attributes["teacher_reference_number"]).to eq(unfunded_mentor_teacher.trn)
       expect(attributes["created_at"]).to be_present
@@ -60,6 +70,41 @@ describe API::Teachers::UnfundedMentorSerializer, type: :serializer do
 
         it { is_expected.to eq([unfunded_mentor_teacher.trs_first_name, unfunded_mentor_teacher.trs_last_name].join(" ")) }
       end
+    end
+  end
+
+  describe "`email` per lead provider" do
+    let!(:other_lead_provider) { FactoryBot.create(:lead_provider) }
+    let!(:school_partnership_for_other_lead_provider) do
+      FactoryBot.create(
+        :school_partnership,
+        :for_year,
+        lead_provider: other_lead_provider,
+        year: school_partnership_for_lead_provider.lead_provider_delivery_partnership.active_lead_provider.contract_period_year
+      )
+    end
+
+    before do
+      create_mentorship_period_for(
+        mentee_school_partnership: school_partnership_for_other_lead_provider,
+        mentor: unfunded_mentor_teacher,
+        create_mentor_training_period: false,
+        refresh_metadata: true
+      )
+      unfunded_mentor_teacher
+        .mentor_at_school_periods
+        .find_by(school: school_partnership_for_other_lead_provider.school)
+        .update!(email: "other-lead-provider-school@example.com")
+    end
+
+    it "returns the email from the school where the mentor mentors an ECT trained by the requesting lead provider" do
+      response = JSON.parse(described_class.render(unfunded_mentor_teacher, lead_provider_id: lead_provider.id))
+      expect(response.dig("attributes", "email")).to eq("lead-provider-school@example.com")
+    end
+
+    it "returns a different email when the same mentor is requested by another lead provider" do
+      response = JSON.parse(described_class.render(unfunded_mentor_teacher, lead_provider_id: other_lead_provider.id))
+      expect(response.dig("attributes", "email")).to eq("other-lead-provider-school@example.com")
     end
   end
 end

--- a/spec/services/api/teachers/unfunded_mentors/query_spec.rb
+++ b/spec/services/api/teachers/unfunded_mentors/query_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
 
   describe "preloading relationships" do
     shared_examples "preloaded associations" do
-      it { expect(result.association(:latest_mentor_at_school_period)).to be_loaded }
+      it { expect(result.association(:mentor_lead_provider_metadata)).to be_loaded }
     end
 
     describe "#unfunded_mentors" do

--- a/spec/services/api/teachers/unfunded_mentors/query_spec.rb
+++ b/spec/services/api/teachers/unfunded_mentors/query_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe API::Teachers::UnfundedMentors::Query, :with_metadata do
 
   describe "preloading relationships" do
     shared_examples "preloaded associations" do
-      it { expect(result.association(:mentor_lead_provider_metadata)).to be_loaded }
+      it { expect(result.association(:lead_provider_metadata_for_mentees)).to be_loaded }
     end
 
     describe "#unfunded_mentors" do

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe Metadata::Handlers::Teacher do
             latest_ect_contract_period: ect_training_period1.contract_period,
             latest_mentor_training_period: mentor_training_period1,
             latest_mentor_contract_period: mentor_training_period1.contract_period,
-            api_mentor_id: nil,
             ect_assigned_mentor_latest_school_period: nil
           )
 
@@ -126,7 +125,6 @@ RSpec.describe Metadata::Handlers::Teacher do
             latest_ect_contract_period: ect_training_period2.contract_period,
             latest_mentor_training_period: mentor_training_period2,
             latest_mentor_contract_period: mentor_training_period2.contract_period,
-            api_mentor_id: nil,
             ect_assigned_mentor_latest_school_period: nil
           )
         end
@@ -204,7 +202,6 @@ RSpec.describe Metadata::Handlers::Teacher do
             latest_ect_contract_period: ect_training_period2.contract_period,
             latest_mentor_training_period: mentor_training_period2,
             latest_mentor_contract_period: mentor_training_period2.contract_period,
-            api_mentor_id: nil,
             ect_assigned_mentor_latest_school_period: nil
           )
         end
@@ -240,14 +237,13 @@ RSpec.describe Metadata::Handlers::Teacher do
             latest_ect_contract_period: ect_training_period1.contract_period,
             latest_mentor_training_period: nil,
             latest_mentor_contract_period: nil,
-            api_mentor_id: nil,
             ect_assigned_mentor_latest_school_period: nil
           )
         end
       end
 
       context "teacher without any training periods" do
-        it "creates metadata with nil latest training periods and api_mentor_id" do
+        it "creates metadata with nil latest training periods and ect_assigned_mentor_latest_school_period" do
           refresh_metadata
 
           metadata = Metadata::TeacherLeadProvider.where(lead_provider: lead_provider1).sole
@@ -258,7 +254,6 @@ RSpec.describe Metadata::Handlers::Teacher do
             latest_ect_contract_period: nil,
             latest_mentor_training_period: nil,
             latest_mentor_contract_period: nil,
-            api_mentor_id: nil,
             ect_assigned_mentor_latest_school_period: nil
           )
         end
@@ -323,14 +318,13 @@ RSpec.describe Metadata::Handlers::Teacher do
           )
         end
 
-        it "creates metadata with the correct/latest api_mentor_id and ect_assigned_mentor_latest_school_period" do
+        it "creates metadata with the correct/latest ect_assigned_mentor_latest_school_period" do
           refresh_metadata
 
           metadata = Metadata::TeacherLeadProvider.where(teacher: teacher1, lead_provider: lead_provider1).sole
           expect(metadata).to have_attributes(
             teacher: teacher1,
             lead_provider: lead_provider1,
-            api_mentor_id: latest_mentorship_period.mentor.teacher.api_id,
             ect_assigned_mentor_latest_school_period: latest_mentorship_period.mentor
           )
         end
@@ -374,7 +368,7 @@ RSpec.describe Metadata::Handlers::Teacher do
           )
         end
 
-        it "creates metadata with nil `api_mentor_id`" do
+        it "creates metadata with nil `ect_assigned_mentor_latest_school_period`" do
           refresh_metadata
 
           metadata = Metadata::TeacherLeadProvider.where(teacher: teacher1, lead_provider: lead_provider1).sole
@@ -385,7 +379,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             latest_ect_contract_period: ect_training_period.contract_period,
             latest_mentor_training_period: nil,
             latest_mentor_contract_period: nil,
-            api_mentor_id: nil
+            ect_assigned_mentor_latest_school_period: nil
           )
         end
 
@@ -427,7 +421,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             )
           end
 
-          it "creates metadata with the correct/latest api_mentor_id" do
+          it "creates metadata with the correct/latest ect_assigned_mentor_latest_school_period" do
             refresh_metadata
 
             metadata = Metadata::TeacherLeadProvider.where(teacher: teacher1, lead_provider: lead_provider1).sole
@@ -438,7 +432,7 @@ RSpec.describe Metadata::Handlers::Teacher do
               latest_ect_contract_period: ect_training_period.contract_period,
               latest_mentor_training_period: nil,
               latest_mentor_contract_period: nil,
-              api_mentor_id: latest_mentorship_period.mentor.teacher.api_id
+              ect_assigned_mentor_latest_school_period: latest_mentorship_period.mentor
             )
           end
         end
@@ -485,7 +479,6 @@ RSpec.describe Metadata::Handlers::Teacher do
           latest_mentor_training_period_id: nil,
           latest_ect_contract_period_year: nil,
           latest_mentor_contract_period_year: nil,
-          api_mentor_id: nil,
           involved_in_school_transfer: false
         )
       end


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3952

Split into 3 PRs:

PR 1 (merged): https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2891
- Added `ect_assigned_mentor_latest_school_period_id` column on `Metadata::TeacherLeadProvider`, populated via the metadata refresh.

PR 2 (this PR):
- Switches `GET /api/v3/unfunded-mentors` to read the email via the new metadata column, so each lead provider sees the email from the school where the mentor is mentoring *their* ECT.
- Removes every remaining reference to `api_mentor_id` in app code so PR 3's column drop can ship safely.

PR 3: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2914
- Drops the `api_mentor_id` column from the metadata table.

### Changes proposed in this pull request

- `UnfundedMentorSerializer` — `email` field filters `teacher.mentor_lead_provider_metadata` by the requesting `lead_provider_id`, picks the row with the most recent `ect_assigned_mentor_latest_school_period.started_on`, and returns that period's email. `max_by` is retained for correctness when a mentor mentors ECTs at different schools for the same LP.
- `UnfundedMentors::Query` — preload chain set to `mentor_lead_provider_metadata: :ect_assigned_mentor_latest_school_period`, keeping the endpoint N+1-free under `strict_loading`. `where_lead_provider_is` filter switched from `api_mentor_id` to a join through `ect_assigned_mentor_latest_school_period → teacher`.
- `Teacher` — adds `has_many :mentor_lead_provider_metadata, through: :mentor_at_school_periods`.
- `MentorAtSchoolPeriod` — adds the inverse `has_many :mentor_lead_provider_metadata` with `dependent: :nullify`, so destroying a MASP nullifies the metadata back-reference rather than dangling.
- `API::TeacherSerializer` — `mentor_id` field now reads `metadata.ect_assigned_mentor_latest_school_period&.teacher&.api_id`. `API::Teachers::Query` preload extended to load that chain.
- `Metadata::TeacherLeadProvider` — `touch` on `api_updated_at` now fires when `ect_assigned_mentor_latest_school_period_id` changes (instead of `api_mentor_id`).
- `Metadata::Handlers::Teacher` — stops computing/stamping `api_mentor_id`; uses `latest_mentorship_period.mentor_at_school_period_id` directly so the includes simplify back to `:latest_mentorship_period`.
- Restored cross-LP behaviour tests in the serializer spec (two LPs receive two different emails for the same shared mentor); dropped `api_mentor_id` assertions from the handler spec.

### Guidance to review

PR 3 depends on this. Merge order: PR 2 → PR 3 (so the app stops referencing `api_mentor_id` before the column is dropped).