### PR TITLE
[3952] Scope unfunded mentor email to the requesting lead provider - Part 3

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -187,7 +187,6 @@
   - latest_ect_contract_period_year
   - latest_mentor_contract_period_year
   - involved_in_school_transfer
-  - api_mentor_id
   - ect_assigned_mentor_latest_school_period_id
   - created_at
   - updated_at

--- a/db/migrate/20260513163242_remove_api_mentor_id_from_metadata_teachers_lead_providers.rb
+++ b/db/migrate/20260513163242_remove_api_mentor_id_from_metadata_teachers_lead_providers.rb
@@ -1,0 +1,5 @@
+class RemoveAPIMentorIdFromMetadataTeachersLeadProviders < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :metadata_teachers_lead_providers, :api_mentor_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -520,7 +520,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
   end
 
   create_table "metadata_teachers_lead_providers", force: :cascade do |t|
-    t.uuid "api_mentor_id"
     t.datetime "created_at", null: false
     t.bigint "ect_assigned_mentor_latest_school_period_id"
     t.boolean "involved_in_school_transfer"

--- a/documentation/domain-model.md
+++ b/documentation/domain-model.md
@@ -372,33 +372,6 @@ erDiagram
     string name
     datetime updated_at
   }
-  Declaration {
-    integer id
-    uuid api_id
-    datetime api_updated_at
-    integer clawback_statement_id
-    enum clawback_status
-    datetime created_at
-    datetime declaration_date
-    enum declaration_type
-    integer delivery_partner_when_created_id
-    enum evidence_type
-    integer mentorship_period_id
-    integer payment_statement_id
-    enum payment_status
-    boolean pupil_premium_uplift
-    boolean sparsity_uplift
-    integer training_period_id
-    datetime updated_at
-    datetime voided_by_user_at
-    integer voided_by_user_id
-  }
-  Declaration }o--|| TrainingPeriod : belongs_to
-  Declaration }o--|| User : belongs_to
-  Declaration }o--|| MentorshipPeriod : belongs_to
-  Declaration }o--|| DeliveryPartner : belongs_to
-  Declaration }o--|| Statement : belongs_to
-  Declaration }o--|| Statement : belongs_to
   ContractPeriod {
     integer year
     datetime created_at
@@ -468,6 +441,33 @@ erDiagram
     datetime updated_at
     integer zendesk_id
   }
+  Declaration {
+    integer id
+    uuid api_id
+    datetime api_updated_at
+    integer clawback_statement_id
+    enum clawback_status
+    datetime created_at
+    datetime declaration_date
+    enum declaration_type
+    integer delivery_partner_when_created_id
+    enum evidence_type
+    integer mentorship_period_id
+    integer payment_statement_id
+    enum payment_status
+    boolean pupil_premium_uplift
+    boolean sparsity_uplift
+    integer training_period_id
+    datetime updated_at
+    datetime voided_by_user_at
+    integer voided_by_user_id
+  }
+  Declaration }o--|| TrainingPeriod : belongs_to
+  Declaration }o--|| User : belongs_to
+  Declaration }o--|| MentorshipPeriod : belongs_to
+  Declaration }o--|| DeliveryPartner : belongs_to
+  Declaration }o--|| Statement : belongs_to
+  Declaration }o--|| Statement : belongs_to
   Metadata_TeacherLeadProvider {
     integer id
     uuid api_mentor_id


### PR DESCRIPTION
### Context

Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3952

Split into 3 PRs:

PR 1 (merged): https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2891
- Added `ect_assigned_mentor_latest_school_period_id` column on `Metadata::TeacherLeadProvider`, populated via the metadata refresh.

PR 2: https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2912
- Switched the read paths to use the new metadata column and removed every remaining reference to `api_mentor_id` from app code.

PR 3 (this PR):
- Physically drops the now-unused `api_mentor_id` column from the metadata table.

### Changes proposed in this pull request

- Migration — `remove_column :metadata_teachers_lead_providers, :api_mentor_id`.
- `db/schema.rb` — column line removed.
- `config/analytics_blocklist.yml` — `api_mentor_id` entry removed.

### Guidance to review

Depends on PR 2 being merged and deployed first; all app code references must be live on the new column before the migration drops the old one.