### PR TITLE
Add ActiveLeadProvider::SeedFromPrevious service

### DIFF
--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -114,8 +114,8 @@ private
         year: new_year,
         # Statements run on a fixed monthly cycle: the deadline is the last day
         # of the preceding month, and payment is made on the 25th of the month.
-        deadline_date: Date.new(new_year, previous_statement.month, 1).prev_day,
-        payment_date: Date.new(new_year, previous_statement.month, 25),
+        deadline_date: previous_statement.deadline_date.years_since(year_offset),
+        payment_date: previous_statement.payment_date.years_since(year_offset),
         fee_type: previous_statement.fee_type,
         status: :open
       )

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -1,0 +1,124 @@
+# Seeds a newly-created active lead provider with a copy of its previous
+# contract period's setup: delivery partnerships, plus a single new contract
+# (inc. fee structures, bands and statements) — based on the previous contract
+# that owned the latest statement, and carrying every previous statement
+# rolled forward to the new period's year.
+#
+# It Errors if it cannot do this.
+class ActiveLeadProviders::SeedFromPrevious
+  class PreviousActiveLeadProviderError < StandardError; end
+  class AlreadyPopulatedError < StandardError; end
+
+  attr_reader :active_lead_provider
+
+  delegate :lead_provider, to: :active_lead_provider
+  delegate :contract_period, to: :active_lead_provider, prefix: :current
+  delegate :lead_provider_delivery_partnerships, :contracts, :statements,
+           to: :previous_activation, prefix: :previous
+
+  def initialize(active_lead_provider:)
+    raise ArgumentError, "active_lead_provider is required" if active_lead_provider.blank?
+
+    @active_lead_provider = active_lead_provider
+  end
+
+  def call
+    raise PreviousActiveLeadProviderError, "no previous active_lead_provider found for #{active_lead_provider.id}" if previous_activation.blank?
+    if previous_activation_empty?
+      raise PreviousActiveLeadProviderError,
+            "active_lead_provider for #{active_lead_provider.id} is missing previous delivery partnerships, contracts or statements"
+    end
+    raise AlreadyPopulatedError, "active_lead_provider #{active_lead_provider.id} already has data" if active_lead_provider_populated?
+
+    # This is a large graph, so let's make all or nothing...
+    ActiveRecord::Base.transaction do
+      create_new_delivery_partnerships
+      create_new_contract
+    end
+  end
+
+  def previous_activation
+    @previous_activation ||= previous_contract_period&.active_lead_providers&.find_by(lead_provider:)
+  end
+
+  def previous_contract_period
+    return if current_contract_period.blank?
+
+    @previous_contract_period ||= ContractPeriod.find_by(year: current_contract_period.year - 1)
+  end
+
+  def previous_latest_contract
+    @previous_latest_contract ||= previous_statements.order(year: :desc, month: :desc).first.contract
+  end
+
+private
+
+  def previous_activation_empty?
+    previous_lead_provider_delivery_partnerships.empty? ||
+      previous_contracts.empty? || previous_statements.empty?
+  end
+
+  def active_lead_provider_populated?
+    active_lead_provider.lead_provider_delivery_partnerships.any? ||
+      active_lead_provider.contracts.any?
+  end
+
+  def create_new_delivery_partnerships
+    previous_lead_provider_delivery_partnerships.each do |previous_partnership|
+      active_lead_provider.lead_provider_delivery_partnerships.create!(delivery_partner: previous_partnership.delivery_partner)
+    end
+  end
+
+  def create_new_contract
+    # Bands and fee structures validate by querying the database for their
+    # already-persisted siblings (see create_banded_fee_structure), so the graph
+    # has to be created as it's built — assembling it in memory and saving once
+    # would run those validations before the siblings exist.
+    previous_contract = previous_latest_contract
+
+    active_lead_provider.contracts.create!(
+      contract_type: previous_contract.contract_type,
+      ecf_contract_version: previous_contract.ecf_contract_version,
+      ecf_mentor_contract_version: previous_contract.ecf_mentor_contract_version,
+      banded_fee_structure: create_banded_fee_structure(previous_contract.banded_fee_structure),
+      flat_rate_fee_structure: create_flat_rate_fee_structure(previous_contract.flat_rate_fee_structure),
+      statements: build_new_statements,
+      vat_rate: previous_contract.vat_rate
+    )
+  end
+
+  def create_banded_fee_structure(previous_fee_structure)
+    return unless previous_fee_structure
+
+    # Band's band_consistency_across_active_lead_provider calls .reload on its parent
+    # banded_fee_structure, so the parent must be inserted before any newly created band validates.
+    previous_fee_structure.dup.tap do |new_fee_structure|
+      new_fee_structure.save!
+      previous_fee_structure.bands.each { |band| new_fee_structure.bands << band.dup }
+    end
+  end
+
+  def create_flat_rate_fee_structure(previous_fee_structure)
+    return unless previous_fee_structure
+
+    previous_fee_structure.dup.tap(&:save!)
+  end
+
+  def build_new_statements
+    year_offset = current_contract_period.year - previous_contract_period.year
+
+    previous_statements.map do |previous_statement|
+      new_year = previous_statement.year + year_offset
+      Statement.new(
+        month: previous_statement.month,
+        year: new_year,
+        # Statements run on a fixed monthly cycle: the deadline is the last day
+        # of the preceding month, and payment is made on the 25th of the month.
+        deadline_date: Date.new(new_year, previous_statement.month, 1).prev_day,
+        payment_date: Date.new(new_year, previous_statement.month, 25),
+        fee_type: previous_statement.fee_type,
+        status: :open
+      )
+    end
+  end
+end

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -37,6 +37,8 @@ class ActiveLeadProviders::SeedFromPrevious
     end
   end
 
+private
+
   def previous_activation
     @previous_activation ||= previous_contract_period&.active_lead_providers&.find_by(lead_provider:)
   end
@@ -50,8 +52,6 @@ class ActiveLeadProviders::SeedFromPrevious
   def previous_latest_contract
     @previous_latest_contract ||= previous_statements.order(year: :desc, month: :desc).first.contract
   end
-
-private
 
   def previous_activation_empty?
     previous_lead_provider_delivery_partnerships.empty? ||

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -112,8 +112,6 @@ private
       Statement.new(
         month: previous_statement.month,
         year: new_year,
-        # Statements run on a fixed monthly cycle: the deadline is the last day
-        # of the preceding month, and payment is made on the 25th of the month.
         deadline_date: previous_statement.deadline_date.years_since(year_offset),
         payment_date: previous_statement.payment_date.years_since(year_offset),
         fee_type: previous_statement.fee_type,

--- a/spec/services/active_lead_providers/seed_from_previous_spec.rb
+++ b/spec/services/active_lead_providers/seed_from_previous_spec.rb
@@ -1,0 +1,210 @@
+RSpec.describe ActiveLeadProviders::SeedFromPrevious do
+  subject(:service) { described_class.new(active_lead_provider: teach_first_activation_2026) }
+
+  # given a new contract_period...
+  let!(:contract_period_2026) { FactoryBot.create(:contract_period, :with_schedules, year: 2026, mentor_funding_enabled: true) }
+  # and an old contract_period...
+  let!(:contract_period_2025) { FactoryBot.create(:contract_period, :with_schedules, year: 2025) }
+
+  # given a lead provider, active in both periods...
+  let(:teach_first) { FactoryBot.create(:lead_provider, name: "Teach First") }
+  let(:teach_first_activation_2026) { FactoryBot.create(:active_lead_provider, lead_provider: teach_first, contract_period: contract_period_2026) }
+  let!(:teach_first_activation_2025) { FactoryBot.create(:active_lead_provider, lead_provider: teach_first, contract_period: contract_period_2025) }
+
+  describe "finding the appropriate previous contract_period and active_lead_provider" do
+    # We don't want to find earlier contract_periods..
+    let!(:contract_period_2024) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
+    let!(:contract_period_2023) { FactoryBot.create(:contract_period, :with_schedules, year: 2023) }
+
+    # We don't want to find earlier activations..
+    let!(:teach_first_activation_2024) { FactoryBot.create(:active_lead_provider, lead_provider: teach_first, contract_period: contract_period_2024) }
+
+    # We don't want to find other lead_providers..
+    let(:ambition_institute) { FactoryBot.create(:lead_provider, name: "Ambition Institute") }
+    let!(:ambition_insitute_activation_2025) { FactoryBot.create(:active_lead_provider, lead_provider: ambition_institute, contract_period: contract_period_2025) }
+    let!(:ambition_insitute_activation_2024) { FactoryBot.create(:active_lead_provider, lead_provider: ambition_institute, contract_period: contract_period_2024) }
+
+    it "finds the correct previous_contract_period" do
+      expect(service.previous_contract_period).to eq contract_period_2025
+    end
+
+    it "finds the same lead provider's activation relationship from the relevant previous_contract_period" do
+      expect(service.previous_activation).to eq teach_first_activation_2025
+    end
+  end
+
+  describe "building subordinates from the previous activation's subordinate records" do
+    before do
+      create_subordinate_records(teach_first_activation_2025)
+      service.call
+    end
+
+    describe "delivery_partnerships" do
+      let(:previous_partnerships) { teach_first_activation_2025.lead_provider_delivery_partnerships }
+      let(:new_partnerships) { teach_first_activation_2026.lead_provider_delivery_partnerships }
+
+      it "builds new delivery partnerships mirroring the previous ones" do
+        expect(new_partnerships.size).to eq previous_partnerships.size
+        expect(new_partnerships.map(&:delivery_partner))
+          .to match_array(previous_partnerships.map(&:delivery_partner))
+      end
+    end
+
+    describe "contracts" do
+      let(:previous_contract) { teach_first_activation_2025.contracts.first }
+      let(:new_contract) { teach_first_activation_2026.contracts.first }
+
+      it "builds a single new contract based on the latest previous one" do
+        expect(teach_first_activation_2026.contracts.size).to eq 1
+        expect(new_contract.lead_provider).to eq teach_first
+        expect(new_contract.contract_type).to eq "ittecf_ectp"
+      end
+
+      describe "statements" do
+        let(:previous_statements) { previous_contract.statements }
+        let(:new_statements) { new_contract.statements }
+
+        it "builds open statements for the new contract period, mirroring the previous ones" do
+          expect(new_statements.size).to eq previous_statements.size
+          expect(new_statements.map(&:status).uniq).to eq %w[open]
+          expect(new_statements.map { |s| [s.month, s.year] })
+            .to match_array(previous_statements.map { |s| [s.month, s.year + 1] })
+        end
+      end
+
+      describe "contract fee structures" do
+        it "builds a new banded_fee_structure for the new contract, based on the previous" do
+          fee_attributes = %i[recruitment_target setup_fee uplift_fee_per_declaration monthly_service_fee]
+          expect(new_contract.banded_fee_structure.slice(*fee_attributes))
+            .to eq(previous_contract.banded_fee_structure.slice(*fee_attributes))
+          expect(new_contract.banded_fee_structure).not_to eq(previous_contract.banded_fee_structure)
+        end
+
+        it "builds bands for the new banded_fee_structure" do
+          band_attributes = %i[min_declarations max_declarations fee_per_declaration output_fee_ratio service_fee_ratio]
+          expect(new_contract.banded_fee_structure.bands.map { |b| b.slice(*band_attributes) })
+            .to match_array(previous_contract.banded_fee_structure.bands.map { |b| b.slice(*band_attributes) })
+          expect(new_contract.banded_fee_structure.bands).not_to include(*previous_contract.banded_fee_structure.bands)
+        end
+
+        it "builds a new flat_rate_fee_structure for the new contract, based on the previous" do
+          flat_rate_attributes = %i[recruitment_target fee_per_declaration]
+          expect(new_contract.flat_rate_fee_structure.slice(*flat_rate_attributes))
+            .to eq(previous_contract.flat_rate_fee_structure.slice(*flat_rate_attributes))
+          expect(new_contract.flat_rate_fee_structure).not_to eq(previous_contract.flat_rate_fee_structure)
+        end
+      end
+    end
+  end
+
+  context "when the previous activation has multiple contracts" do
+    let!(:earlier_contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: teach_first_activation_2025, vat_rate: 0.10) }
+    let!(:latest_contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: teach_first_activation_2025, vat_rate: 0.20) }
+
+    before do
+      FactoryBot.create_list(:lead_provider_delivery_partnership, 3, active_lead_provider: teach_first_activation_2025)
+      FactoryBot.create(:statement, :paid, active_lead_provider: teach_first_activation_2025, contract: earlier_contract, month: 11, year: 2025)
+      FactoryBot.create(:statement, :paid, active_lead_provider: teach_first_activation_2025, contract: latest_contract, month: 8, year: 2028)
+      service.call
+    end
+
+    it "builds a single new contract based on the contract owning the latest statement, rolling every previous statement onto it" do
+      new_contracts = teach_first_activation_2026.contracts
+      expect(new_contracts.size).to eq 1
+      expect(new_contracts.first.vat_rate).to eq 0.20
+      expect(new_contracts.first.statements.map { |s| [s.month, s.year] })
+        .to contain_exactly([11, 2026], [8, 2029])
+    end
+  end
+
+  context "when no active_lead_provider is given" do
+    it "raises an ArgumentError" do
+      expect { described_class.new(active_lead_provider: nil) }
+        .to raise_error(ArgumentError, /active_lead_provider is required/)
+    end
+  end
+
+  context "when there is no previous activation for the lead provider" do
+    before { teach_first_activation_2025.destroy! }
+
+    it "raises an error" do
+      expect { service.call }
+        .to raise_error(described_class::PreviousActiveLeadProviderError, /no previous active_lead_provider/)
+    end
+  end
+
+  context "when the previous activation has no subordinate data" do
+    it "raises an error" do
+      expect { service.call }
+        .to raise_error(described_class::PreviousActiveLeadProviderError, /active_lead_provider for \d+ is missing previous delivery partnerships, contracts or statements/)
+    end
+  end
+
+  context "when the previous activation is only partially populated" do
+    let(:missing_data_error_message) { /active_lead_provider for \d+ is missing previous delivery partnerships, contracts or statements/ }
+
+    context "with delivery partnerships but no contracts or statements" do
+      before { FactoryBot.create_list(:lead_provider_delivery_partnership, 3, active_lead_provider: teach_first_activation_2025) }
+
+      it "raises an error" do
+        expect { service.call }.to raise_error(described_class::PreviousActiveLeadProviderError, missing_data_error_message)
+      end
+    end
+
+    context "with a contract but no partnerships or statements" do
+      before { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: teach_first_activation_2025) }
+
+      it "raises an error" do
+        expect { service.call }.to raise_error(described_class::PreviousActiveLeadProviderError, missing_data_error_message)
+      end
+    end
+
+    context "with partnerships and a contract but no statements" do
+      before do
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 3, active_lead_provider: teach_first_activation_2025)
+        FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: teach_first_activation_2025)
+      end
+
+      it "raises an error" do
+        expect { service.call }.to raise_error(described_class::PreviousActiveLeadProviderError, missing_data_error_message)
+      end
+    end
+
+    context "with a contract and statements but no partnerships" do
+      before do
+        contract = FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: teach_first_activation_2025)
+        FactoryBot.create(:statement, :paid, active_lead_provider: teach_first_activation_2025, contract:, month: 11, year: 2025)
+      end
+
+      it "raises an error" do
+        expect { service.call }.to raise_error(described_class::PreviousActiveLeadProviderError, missing_data_error_message)
+      end
+    end
+  end
+
+  context "when the active lead provider already has data" do
+    before do
+      create_subordinate_records(teach_first_activation_2025)
+      FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: teach_first_activation_2026)
+    end
+
+    it "raises an error rather than duplicating data" do
+      expect { service.call }
+        .to raise_error(described_class::AlreadyPopulatedError, /active_lead_provider \d+ already has data/)
+    end
+  end
+
+private
+
+  def create_subordinate_records(active_lead_provider)
+    FactoryBot.create_list(:lead_provider_delivery_partnership, 3, active_lead_provider:)
+    contract = FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:)
+    contract_year = active_lead_provider.contract_period.year
+    date = Date.new(contract_year, 11, 1)
+    # Statements span November of contract_year through August three years later
+    while date <= Date.new(contract_year + 3, 8, 1)
+      FactoryBot.create(:statement, :paid, active_lead_provider:, contract:, month: date.month, year: date.year)
+      date = date.next_month
+    end
+  end
+end

--- a/spec/services/active_lead_providers/seed_from_previous_spec.rb
+++ b/spec/services/active_lead_providers/seed_from_previous_spec.rb
@@ -11,28 +11,6 @@ RSpec.describe ActiveLeadProviders::SeedFromPrevious do
   let(:teach_first_activation_2026) { FactoryBot.create(:active_lead_provider, lead_provider: teach_first, contract_period: contract_period_2026) }
   let!(:teach_first_activation_2025) { FactoryBot.create(:active_lead_provider, lead_provider: teach_first, contract_period: contract_period_2025) }
 
-  describe "finding the appropriate previous contract_period and active_lead_provider" do
-    # We don't want to find earlier contract_periods..
-    let!(:contract_period_2024) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
-    let!(:contract_period_2023) { FactoryBot.create(:contract_period, :with_schedules, year: 2023) }
-
-    # We don't want to find earlier activations..
-    let!(:teach_first_activation_2024) { FactoryBot.create(:active_lead_provider, lead_provider: teach_first, contract_period: contract_period_2024) }
-
-    # We don't want to find other lead_providers..
-    let(:ambition_institute) { FactoryBot.create(:lead_provider, name: "Ambition Institute") }
-    let!(:ambition_insitute_activation_2025) { FactoryBot.create(:active_lead_provider, lead_provider: ambition_institute, contract_period: contract_period_2025) }
-    let!(:ambition_insitute_activation_2024) { FactoryBot.create(:active_lead_provider, lead_provider: ambition_institute, contract_period: contract_period_2024) }
-
-    it "finds the correct previous_contract_period" do
-      expect(service.previous_contract_period).to eq contract_period_2025
-    end
-
-    it "finds the same lead provider's activation relationship from the relevant previous_contract_period" do
-      expect(service.previous_activation).to eq teach_first_activation_2025
-    end
-  end
-
   describe "building subordinates from the previous activation's subordinate records" do
     before do
       create_subordinate_records(teach_first_activation_2025)


### PR DESCRIPTION
### Context

resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3938

### Changes proposed in this pull request

Service to seed an ActiveLeadProvider from the previous contract_period's relevant ActiveLeadProvider.

### Guidance to review
