### PR TITLE
Widen training card so JSON is less cramped

### DIFF
--- a/app/assets/stylesheets/admin/teachers.scss
+++ b/app/assets/stylesheets/admin/teachers.scss
@@ -8,13 +8,6 @@
   font-size: 0.8em;
 }
 
-.govuk-summary-list__value .app-code--full-width {
-  display: block;
-  width: 100%;
-  padding: 1em;
-  box-sizing: border-box;
-}
-
 .app-teachers-filters {
   @include govuk-media-query($from: tablet) {
     align-items: flex-end;

--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -14,7 +14,7 @@ module Admin
           if show_move_partnership_link?
             card.with_action { helpers.govuk_link_to("Move to a different partnership", move_partnership_path) }
           end
-          card.with_summary_list do |list|
+          card.with_summary_list(actions: false) do |list|
             rows.each do |row|
               list.with_row do |r|
                 r.with_key(text: row[:key][:text]) if row[:key].present?

--- a/app/components/admin/teachers/training_summary_component.rb
+++ b/app/components/admin/teachers/training_summary_component.rb
@@ -140,7 +140,7 @@ module Admin
 
       def api_response_text
         govuk_details(summary_text: "See this participant as they appear over the API for #{lead_provider&.name}") do
-          content_tag(:pre, class: "app-code app-code--full-width") do
+          content_tag(:pre, class: "app-code") do
             content_tag(:code, formatted_teacher)
           end
         end


### PR DESCRIPTION
This summary list has no actions so we can disable the actions column which [allows the content to stretch right across](https://govuk-components.x-govuk.org/components/summary-list/#summary-lists-without-actions).

| Before | After |
| ------ | ------ |
| <img width="1361" height="982" alt="Screenshot From 2026-05-14 18-44-31" src="https://github.com/user-attachments/assets/a09d8a2d-ed4a-452d-afe6-b5b66d4eb592" /> | <img width="1361" height="982" alt="Screenshot From 2026-05-14 18-44-17" src="https://github.com/user-attachments/assets/b4a78294-6eec-44e1-a03d-251a53bc70ac" /> |