### PR TITLE
[3843] Block registrations between 1st and 15th June

### DIFF
--- a/app/controllers/concerns/schools/registration_window_redirectable.rb
+++ b/app/controllers/concerns/schools/registration_window_redirectable.rb
@@ -1,0 +1,15 @@
+module Schools
+  module RegistrationWindowRedirectable
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :redirect_if_registration_window_closed
+    end
+
+  private
+
+    def redirect_if_registration_window_closed
+      redirect_to schools_registration_window_closed_path if RegistrationWindow.closed?
+    end
+  end
+end

--- a/app/controllers/schools/ects/change_training_programme_wizard_controller.rb
+++ b/app/controllers/schools/ects/change_training_programme_wizard_controller.rb
@@ -1,6 +1,7 @@
 module Schools
   module ECTs
     class ChangeTrainingProgrammeWizardController < SchoolsController
+      include Schools::RegistrationWindowRedirectable
       include Schools::InductionRedirectable
 
       include Wizardable

--- a/app/controllers/schools/register_ect_wizard_controller.rb
+++ b/app/controllers/schools/register_ect_wizard_controller.rb
@@ -1,5 +1,6 @@
 module Schools
   class RegisterECTWizardController < SchoolsController
+    include Schools::RegistrationWindowRedirectable
     include Schools::InductionRedirectable
     include WizardStoreRescuable
 

--- a/app/controllers/schools/register_mentor_wizard_controller.rb
+++ b/app/controllers/schools/register_mentor_wizard_controller.rb
@@ -1,5 +1,6 @@
 module Schools
   class RegisterMentorWizardController < SchoolsController
+    include Schools::RegistrationWindowRedirectable
     include Schools::InductionRedirectable
     include WizardStoreRescuable
 

--- a/app/controllers/schools/registration_window_closed_controller.rb
+++ b/app/controllers/schools/registration_window_closed_controller.rb
@@ -1,0 +1,7 @@
+module Schools
+  class RegistrationWindowClosedController < SchoolsController
+    def show
+      @reopens_on = RegistrationWindow.reopens_on.strftime("%-d %B")
+    end
+  end
+end

--- a/app/models/schools/registration_window.rb
+++ b/app/models/schools/registration_window.rb
@@ -1,0 +1,13 @@
+module Schools
+  class RegistrationWindow
+    CLOSED_PERIOD = Date.new(2026, 6, 1)..Date.new(2026, 6, 14)
+
+    def self.closed?
+      CLOSED_PERIOD.cover?(Date.current)
+    end
+
+    def self.reopens_on
+      CLOSED_PERIOD.end + 1.day
+    end
+  end
+end

--- a/app/views/schools/registration_window_closed/show.html.erb
+++ b/app/views/schools/registration_window_closed/show.html.erb
@@ -1,0 +1,17 @@
+<% page_data(
+     title: "You cannot register early career teachers (ECTs) or mentors until #{@reopens_on}"
+   ) %>
+
+<p class="govuk-body">Until <%= @reopens_on %> you cannot:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>register new early career teachers (ECTs) and mentors</li>
+  <li>change ECT training programmes</li>
+</ul>
+
+<p class="govuk-body">If you want to register an ECT who's already started their induction you should:</p>
+<ol class="govuk-list govuk-list--number">
+  <li>Contact the ECT's lead provider so that they can set up the ECT's training programme.</li>
+  <li>Register the ECT in this service when registration opens.</li>
+</ol>
+
+<p class="govuk-body"><%= govuk_link_to("Back to ECTs", schools_ects_home_path) %></p>

--- a/app/views/schools/registration_window_closed/show.html.erb
+++ b/app/views/schools/registration_window_closed/show.html.erb
@@ -3,15 +3,21 @@
    ) %>
 
 <p class="govuk-body">Until <%= @reopens_on %> you cannot:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>register new early career teachers (ECTs) and mentors</li>
-  <li>change ECT training programmes</li>
-</ul>
+<%= govuk_list(
+  [
+    "register new early career teachers (ECTs) and mentors",
+    "change ECT training programmes"
+  ],
+  type: :bullet
+) %>
 
 <p class="govuk-body">If you want to register an ECT who’s already started their induction you should:</p>
-<ol class="govuk-list govuk-list--number">
-  <li>Contact the ECT’s lead provider so that they can set up the ECT's training programme.</li>
-  <li>Register the ECT in this service when registration opens.</li>
-</ol>
+<%= govuk_list(
+  [
+    "Contact the ECT’s lead provider so that they can set up the ECT's training programme.",
+    "Register the ECT in this service when registration opens."
+  ],
+  type: :number
+) %>
 
 <p class="govuk-body"><%= govuk_link_to("Back to ECTs", schools_ects_home_path) %></p>

--- a/app/views/schools/registration_window_closed/show.html.erb
+++ b/app/views/schools/registration_window_closed/show.html.erb
@@ -8,9 +8,9 @@
   <li>change ECT training programmes</li>
 </ul>
 
-<p class="govuk-body">If you want to register an ECT who's already started their induction you should:</p>
+<p class="govuk-body">If you want to register an ECT who’s already started their induction you should:</p>
 <ol class="govuk-list govuk-list--number">
-  <li>Contact the ECT's lead provider so that they can set up the ECT's training programme.</li>
+  <li>Contact the ECT’s lead provider so that they can set up the ECT's training programme.</li>
   <li>Register the ECT in this service when registration opens.</li>
 </ol>
 

--- a/config/routes/school.rb
+++ b/config/routes/school.rb
@@ -1,6 +1,10 @@
 namespace :schools, path: :school do
   get "/access-denied", to: "access#show", as: :access_denied
 
+  get "/registration-window-closed",
+      to: "registration_window_closed#show",
+      as: :registration_window_closed
+
   get "/home/ects", to: "ects#index", as: :ects_home
   resources :ects, only: %i[index show] do
     resource :mentorship, only: %i[new create] do

--- a/spec/models/schools/registration_window_spec.rb
+++ b/spec/models/schools/registration_window_spec.rb
@@ -1,0 +1,52 @@
+describe Schools::RegistrationWindow do
+  let(:first_day_of_closure) { Date.new(2026, 6, 1) }
+  let(:last_day_of_closure) { Date.new(2026, 6, 14) }
+
+  describe ".closed?" do
+    subject { described_class.closed? }
+
+    before { travel_to date }
+
+    context "on the day before the closed period" do
+      let(:date) { first_day_of_closure - 1.day }
+
+      it { is_expected.to be false }
+    end
+
+    context "on the first day of the closed period" do
+      let(:date) { first_day_of_closure }
+
+      it { is_expected.to be true }
+    end
+
+    context "on the day after the closed period begins" do
+      let(:date) { first_day_of_closure + 1.day }
+
+      it { is_expected.to be true }
+    end
+
+    context "on the last day of the closed period" do
+      let(:date) { last_day_of_closure }
+
+      it { is_expected.to be true }
+    end
+
+    context "on the day after the closed period" do
+      let(:date) { last_day_of_closure + 1.day }
+
+      it { is_expected.to be false }
+    end
+
+    context "in a different year" do
+      let(:date) { first_day_of_closure + 1.year }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".reopens_on" do
+    subject { described_class.reopens_on }
+
+    it { is_expected.to eq last_day_of_closure + 1.day }
+  end
+end

--- a/spec/models/schools/registration_window_spec.rb
+++ b/spec/models/schools/registration_window_spec.rb
@@ -1,46 +1,46 @@
 describe Schools::RegistrationWindow do
+  subject { described_class }
+
   let(:first_day_of_closure) { Date.new(2026, 6, 1) }
   let(:last_day_of_closure) { Date.new(2026, 6, 14) }
 
   describe ".closed?" do
-    subject { described_class.closed? }
-
     before { travel_to date }
 
     context "on the day before the closed period" do
       let(:date) { first_day_of_closure - 1.day }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_closed }
     end
 
     context "on the first day of the closed period" do
       let(:date) { first_day_of_closure }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_closed }
     end
 
     context "on the day after the closed period begins" do
       let(:date) { first_day_of_closure + 1.day }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_closed }
     end
 
     context "on the last day of the closed period" do
       let(:date) { last_day_of_closure }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_closed }
     end
 
     context "on the day after the closed period" do
       let(:date) { last_day_of_closure + 1.day }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_closed }
     end
 
     context "in a different year" do
       let(:date) { first_day_of_closure + 1.year }
 
-      it { is_expected.to be false }
+      it { is_expected.not_to be_closed }
     end
   end
 

--- a/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
@@ -29,6 +29,7 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
     subject { get path_for_step("edit") }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when not signed in" do
       it "redirects to the root page" do

--- a/spec/requests/schools/register_ect_wizard_spec.rb
+++ b/spec/requests/schools/register_ect_wizard_spec.rb
@@ -7,6 +7,7 @@ describe "Schools::RegisterECTWizardController" do
     subject { get path_for_step("what-you-will-need") }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
   end
 
   describe "POST #create" do

--- a/spec/requests/schools/register_mentor_wizard_spec.rb
+++ b/spec/requests/schools/register_mentor_wizard_spec.rb
@@ -7,6 +7,7 @@ describe "Schools::RegisterMentorWizardController" do
     subject { get path_for_step("what-you-will-need") }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
   end
 
   describe "POST #create" do

--- a/spec/requests/schools/registration_window_closed_spec.rb
+++ b/spec/requests/schools/registration_window_closed_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe "Schools::RegistrationWindowClosedController" do
+  let(:school) { FactoryBot.create(:school) }
+
+  describe "GET #show" do
+    subject(:show) { get schools_registration_window_closed_path }
+
+    context "when not signed in" do
+      it "redirects to the root page" do
+        show
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed in as a school user" do
+      before do
+        sign_in_as(:school_user, school:)
+        show
+      end
+
+      it "returns a successful response" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/registration_window_redirect.rb
+++ b/spec/support/shared_examples/registration_window_redirect.rb
@@ -1,0 +1,30 @@
+RSpec.shared_examples "a route blocked when the registration window is closed" do
+  around do |example|
+    travel_back
+    travel_to(date)
+    example.run
+  ensure
+    travel_back
+  end
+
+  before do
+    sign_in_as(:school_user, school:)
+    subject
+  end
+
+  context "when the registration window is closed" do
+    let(:date) { Schools::RegistrationWindow::CLOSED_PERIOD.begin }
+
+    it "redirects to the registration window closed page" do
+      expect(response).to redirect_to(schools_registration_window_closed_path)
+    end
+  end
+
+  context "when the registration window is open" do
+    let(:date) { Schools::RegistrationWindow.reopens_on }
+
+    it "does not redirect to the registration window closed page" do
+      expect(response).not_to redirect_to(schools_registration_window_closed_path)
+    end
+  end
+end

--- a/spec/support/shared_examples/registration_window_redirect.rb
+++ b/spec/support/shared_examples/registration_window_redirect.rb
@@ -1,10 +1,7 @@
 RSpec.shared_examples "a route blocked when the registration window is closed" do
   around do |example|
-    travel_back
     travel_to(date)
     example.run
-  ensure
-    travel_back
   end
 
   before do

--- a/spec/views/schools/registration_window_closed/show.html.erb_spec.rb
+++ b/spec/views/schools/registration_window_closed/show.html.erb_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "schools/registration_window_closed/show" do
+  before do
+    assign(:reopens_on, "15 June")
+    render
+  end
+
+  it "sets the page title with the reopening date" do
+    expect(sanitize(view.content_for(:page_title))).to eql(
+      "You cannot register early career teachers (ECTs) or mentors until 15 June"
+    )
+  end
+
+  it "shows the reopening date in the body" do
+    expect(rendered).to have_content("Until 15 June you cannot:")
+  end
+
+  it "includes a back link to the ECT list" do
+    expect(rendered).to have_link("Back to ECTs", href: schools_ects_home_path)
+  end
+end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3843

### Changes proposed in this pull request

- Introduce a `RegistrationWindow` class that defines a period during which registration is closed
- Add a concern to the appropriate controllers that redirects to an information page if the current date is within that window

### Guidance to review

> [!CAUTION]
> ~**Remove the second commit d0e3fc4f480f4f9c3eca7b7d570c1568ddc7020c before merging.** It's only there to make this easily testable on a review app, piggybacking on the existing method for testing API responses with a special header. It is not part of the work, doesn't need to be reviewed, and should not be merged!~

☝️  removed