### PR TITLE
Fix Pagy error when navigating back to delivery partners index from lead provider partnerships page

### DIFF
--- a/app/controllers/admin/delivery_partners/delivery_partnerships_controller.rb
+++ b/app/controllers/admin/delivery_partners/delivery_partnerships_controller.rb
@@ -42,7 +42,8 @@ module Admin
       rescue Admin::DeliveryPartners::AddLeadProviders::NoLeadProvidersSelectedError => e
         redirect_to new_admin_delivery_partner_delivery_partnership_path(
           params[:delivery_partner_id],
-          backlink_params.merge(year: params[:year])
+          params[:year],
+          backlink_params
         ), notice: e.message
       rescue Admin::DeliveryPartners::AddLeadProviders::ValidationError => e
         redirect_to admin_delivery_partner_path(

--- a/app/controllers/admin/delivery_partners/delivery_partnerships_controller.rb
+++ b/app/controllers/admin/delivery_partners/delivery_partnerships_controller.rb
@@ -11,7 +11,7 @@ module Admin
         @contract_period = ContractPeriod.find_by(year: @year)
 
         if @contract_period.blank?
-          redirect_to admin_delivery_partner_path(@delivery_partner, page: params[:page], q: params[:q]),
+          redirect_to admin_delivery_partner_path(@delivery_partner, backlink_params),
                       alert: "Contract period for year #{@year} not found"
           return
         end
@@ -35,14 +35,26 @@ module Admin
           author: current_user
         ).call
 
-        redirect_to admin_delivery_partner_path(params[:delivery_partner_id], page: params[:page], q: params[:q]),
-                    alert: "Lead provider partners updated"
+        redirect_to admin_delivery_partner_path(
+          params[:delivery_partner_id],
+          backlink_params
+        ), alert: "Lead provider partners updated"
       rescue Admin::DeliveryPartners::AddLeadProviders::NoLeadProvidersSelectedError => e
-        redirect_to new_admin_delivery_partner_delivery_partnership_path(params[:delivery_partner_id], params[:year], page: params[:page], q: params[:q]),
-                    notice: e.message
+        redirect_to new_admin_delivery_partner_delivery_partnership_path(
+          params[:delivery_partner_id],
+          backlink_params.merge(year: params[:year])
+        ), notice: e.message
       rescue Admin::DeliveryPartners::AddLeadProviders::ValidationError => e
-        redirect_to admin_delivery_partner_path(params[:delivery_partner_id], page: params[:page], q: params[:q]),
-                    notice: e.message
+        redirect_to admin_delivery_partner_path(
+          params[:delivery_partner_id],
+          backlink_params
+        ), notice: e.message
+      end
+
+    private
+
+      def backlink_params
+        params.permit(:page, :q).compact_blank
       end
     end
   end

--- a/app/controllers/admin/delivery_partners/delivery_partnerships_controller.rb
+++ b/app/controllers/admin/delivery_partners/delivery_partnerships_controller.rb
@@ -11,7 +11,7 @@ module Admin
         @contract_period = ContractPeriod.find_by(year: @year)
 
         if @contract_period.blank?
-          redirect_to admin_delivery_partner_path(@delivery_partner, backlink_params),
+          redirect_to admin_delivery_partner_path(@delivery_partner, index_params),
                       alert: "Contract period for year #{@year} not found"
           return
         end
@@ -37,24 +37,24 @@ module Admin
 
         redirect_to admin_delivery_partner_path(
           params[:delivery_partner_id],
-          backlink_params
+          index_params
         ), alert: "Lead provider partners updated"
       rescue Admin::DeliveryPartners::AddLeadProviders::NoLeadProvidersSelectedError => e
         redirect_to new_admin_delivery_partner_delivery_partnership_path(
           params[:delivery_partner_id],
           params[:year],
-          backlink_params
+          index_params
         ), notice: e.message
       rescue Admin::DeliveryPartners::AddLeadProviders::ValidationError => e
         redirect_to admin_delivery_partner_path(
           params[:delivery_partner_id],
-          backlink_params
+          index_params
         ), notice: e.message
       end
 
     private
 
-      def backlink_params
+      def index_params
         params.permit(:page, :q).compact_blank
       end
     end

--- a/spec/features/admin/organisations/delivery_partners_spec.rb
+++ b/spec/features/admin/organisations/delivery_partners_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe "Admin organisations delivery partners" do
     then_i_should_see_a_form_error
   end
 
+  scenario "returning to delivery partners index does not include empty page params" do
+    given_i_am_logged_in_as_an_admin
+    and_delivery_partners_exist
+    and_a_known_delivery_partner_exists
+    and_a_contract_period_exists
+    and_an_active_lead_provider_exists
+
+    when_i_click_organisations_on_the_top_menu
+    when_i_click_delivery_partners_link
+    then_i_should_see_the_admin_delivery_partners_page
+
+    and_i_view_a_delivery_partner
+    and_i_add_a_lead_provider_partnership
+    and_i_click_the_delivery_partners_breadcrumb
+
+    then_i_should_be_on_the_delivery_partners_index_without_empty_page_params
+  end
+
   def given_i_am_logged_in_as_an_admin
     sign_in_as_dfe_user(role: :admin)
   end
@@ -59,6 +77,19 @@ RSpec.describe "Admin organisations delivery partners" do
 
   def and_a_delivery_partner_exists_with_name(name)
     FactoryBot.create(:delivery_partner, name:)
+  end
+
+  def and_a_known_delivery_partner_exists
+    @known_delivery_partner = FactoryBot.create(:delivery_partner, name: "Known Delivery Partner")
+  end
+
+  def and_a_contract_period_exists
+    @contract_period = FactoryBot.create(:contract_period, :current)
+  end
+
+  def and_an_active_lead_provider_exists
+    @lead_provider = FactoryBot.create(:lead_provider)
+    FactoryBot.create(:active_lead_provider, lead_provider: @lead_provider, contract_period: @contract_period)
   end
 
   def when_i_click_organisations_on_the_top_menu
@@ -138,5 +169,25 @@ RSpec.describe "Admin organisations delivery partners" do
 
   def then_i_should_see_a_form_error
     expect(page.locator(".govuk-error-summary")).to be_visible
+  end
+
+  def and_i_view_a_delivery_partner
+    page.get_by_role("link", name: @known_delivery_partner.name).click
+  end
+
+  def and_i_add_a_lead_provider_partnership
+    page.get_by_role("link", name: "Add").first.click
+    page.get_by_label(@lead_provider.name).check
+    page.get_by_role("button", name: "Confirm").click
+  end
+
+  def and_i_click_the_delivery_partners_breadcrumb
+    page.get_by_role("link", name: "Delivery partners").click
+  end
+
+  def then_i_should_be_on_the_delivery_partners_index_without_empty_page_params
+    expect(page.url).not_to include("page=")
+    expect(page.url).not_to include("q=")
+    expect(page.get_by_role("heading", name: "Delivery partners")).to be_visible
   end
 end


### PR DESCRIPTION
[Ticket ](https://github.com/DFE-Digital/register-early-career-teachers-public/issues/2917)



### Context
Navigating back to the delivery partners index using breadcrumbs after adding a lead provider partnership is erroring.

### Changes proposed in this pull request
- Use compact_blank on backlink params in DeliveryPartnershipsController
- Add feature spec to assert no empty page params in redirect URL

### Guidance to review
Log in as an admin user
Navigate to Organisations → Delivery partners
Click on a delivery partner
Click "Add" next to a contract period year
Select a lead provider and click Confirm
Click the "Delivery partners" breadcrumb
Verify you land on the delivery partners index without a 500 error and the URL does not contain page= or q=