### PR TITLE
Fix issue with `mentor_id` being `nil`

### DIFF
--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -57,10 +57,7 @@ module Metadata::Handlers
 
     def latest_ect_training_period_by_lead_provider(teacher:)
       @latest_ect_training_period_by_lead_provider ||= TrainingPeriod
-        .includes(
-          { ect_at_school_period: { latest_mentorship_period: { mentor: :teacher } } },
-          lead_provider_delivery_partnership: { active_lead_provider: :lead_provider }
-        )
+        .includes(:ect_at_school_period, lead_provider_delivery_partnership: { active_lead_provider: :lead_provider })
         .where(ect_at_school_period: { teacher: })
         .select("DISTINCT ON (lead_provider_id) training_periods.*")
         .order("lead_provider_id, training_periods.started_on DESC")


### PR DESCRIPTION
We added an `includes` on the `has_one` for the
`latest_mentorship_period`, however that association also has a default `latest_first` ordering.

When not eager-loaded, the default ordering is ran and we are correctly returning the `latest_mentorship_period`. When we `includes` this association, however, Rails joins on all `MentorshipPeriod` records and the ordering is lost.

We should be able to fix this by ensuring the `has_one` only ever returns the latest (and not all, ordered by latest), but for now we can revert to fix the issue.