### PR TITLE
Show current school for future leavers in admin teacher overview

### DIFF
--- a/app/presenters/admin/teacher_presenter.rb
+++ b/app/presenters/admin/teacher_presenter.rb
@@ -45,8 +45,8 @@ module Admin
 
     def current_schools
       @current_schools ||= begin
-        ect_schools = teacher.ect_at_school_periods.ongoing.includes(school: :gias_school).map(&:school)
-        mentor_schools = teacher.mentor_at_school_periods.ongoing.includes(school: :gias_school).map(&:school)
+        ect_schools = teacher.ect_at_school_periods.ongoing_today.includes(school: :gias_school).map(&:school)
+        mentor_schools = teacher.mentor_at_school_periods.ongoing_today.includes(school: :gias_school).map(&:school)
         (ect_schools + mentor_schools).compact.uniq(&:id)
       end
     end

--- a/spec/presenters/admin/teacher_presenter_spec.rb
+++ b/spec/presenters/admin/teacher_presenter_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe Admin::TeacherPresenter do
       end
     end
 
+    context "when the teacher has an ECT period finishing today" do
+      before { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 1.month.ago, finished_on: Time.zone.today) }
+
+      it "includes the school" do
+        expect(presenter.current_schools).to include(school)
+      end
+    end
+
+    context "when the teacher has an ECT period that finished yesterday" do
+      before { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 1.month.ago, finished_on: 1.day.ago) }
+
+      it "does not include the school" do
+        expect(presenter.current_schools).not_to include(school)
+      end
+    end
+
     context "when there are no ongoing periods" do
       it "is empty" do
         expect(presenter.current_schools).to be_empty

--- a/spec/presenters/admin/teacher_presenter_spec.rb
+++ b/spec/presenters/admin/teacher_presenter_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe Admin::TeacherPresenter do
       end
     end
 
+    context "when the teacher has an ECT period with a future leaving date" do
+      before { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 1.month.ago, finished_on: 1.week.from_now) }
+
+      it "includes the school until the leaving date has passed" do
+        expect(presenter.current_schools).to include(school)
+      end
+    end
+
+    context "when the teacher has a mentor period with a future leaving date" do
+      before { FactoryBot.create(:mentor_at_school_period, teacher:, school:, started_on: 1.month.ago, finished_on: 1.week.from_now) }
+
+      it "includes the school until the leaving date has passed" do
+        expect(presenter.current_schools).to include(school)
+      end
+    end
+
     context "when there are no ongoing periods" do
       it "is empty" do
         expect(presenter.current_schools).to be_empty


### PR DESCRIPTION
### Context
Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3328

When a teacher has a future leaving date, the admin teacher overview page shows "not currently registered at a school" instead of the teacher's current school.

### Changes proposed in this pull request

- Use the `ongoing_today` scope when building `current_schools` for ECT and mentor periods

### Guidance to review

- check the admin teacher overview shows the school name when a teacher has a future leaving date
- check the school name disappears only once the leaving date has passed