### PR TITLE
[3939] Add schedule index for a contract period

### DIFF
--- a/app/controllers/admin/finance/schedules_controller.rb
+++ b/app/controllers/admin/finance/schedules_controller.rb
@@ -2,6 +2,12 @@ module Admin::Finance
   class SchedulesController < Admin::Finance::BaseController
     before_action :set_contract_period
     def index
+      @breadcrumbs = {
+        "Finance" => admin_finance_path,
+        "Contract periods" => admin_contract_periods_path,
+        @contract_period.year.to_s => admin_contract_period_path(@contract_period),
+        "Schedules" => nil
+      }
     end
 
   private

--- a/app/controllers/admin/finance/schedules_controller.rb
+++ b/app/controllers/admin/finance/schedules_controller.rb
@@ -1,6 +1,12 @@
 module Admin::Finance
   class SchedulesController < Admin::Finance::BaseController
+    before_action :set_contract_period
     def index
+    end
+
+  private
+
+    def set_contract_period
       @contract_period = ContractPeriod.find(params[:contract_period_id])
     end
   end

--- a/app/controllers/admin/finance/schedules_controller.rb
+++ b/app/controllers/admin/finance/schedules_controller.rb
@@ -1,0 +1,7 @@
+module Admin::Finance
+  class SchedulesController < Admin::Finance::BaseController
+    def index
+      @contract_period = ContractPeriod.find(params[:contract_period_id])
+    end
+  end
+end

--- a/app/helpers/admin/schedules_helper.rb
+++ b/app/helpers/admin/schedules_helper.rb
@@ -2,4 +2,8 @@ module Admin::SchedulesHelper
   def schedule_name(identifier)
     identifier.delete_prefix("ecf-").titleize
   end
+
+  def sort_schedules(contract_period)
+    contract_period.schedules.sort_by { |s| ::Schedule.identifiers.keys.index(s.identifier) }
+  end
 end

--- a/app/helpers/admin/schedules_helper.rb
+++ b/app/helpers/admin/schedules_helper.rb
@@ -1,0 +1,24 @@
+module Admin::SchedulesHelper
+  SCHEDULE_MAPPINGS = {
+    # standard
+    "ecf-standard-april" => "Standard April",
+    "ecf-standard-january" => "Standard January",
+    "ecf-standard-september" => "Standard September",
+    # extended
+    "ecf-extended-april" => "Extended April",
+    "ecf-extended-january" => "Extended January",
+    "ecf-extended-september" => "Extended September",
+    # reduced
+    "ecf-reduced-april" => "Reduced April",
+    "ecf-reduced-january" => "Reduced January",
+    "ecf-reduced-september" => "Reduced September",
+    # replacement
+    "ecf-replacement-april" => "Replacement April",
+    "ecf-replacement-january" => "Replacement January",
+    "ecf-replacement-september" => "Replacement September",
+  }.freeze
+
+  def schedule_name(identifier)
+    SCHEDULE_MAPPINGS.fetch(identifier, identifier.humanize)
+  end
+end

--- a/app/helpers/admin/schedules_helper.rb
+++ b/app/helpers/admin/schedules_helper.rb
@@ -1,24 +1,5 @@
 module Admin::SchedulesHelper
-  SCHEDULE_MAPPINGS = {
-    # standard
-    "ecf-standard-april" => "Standard April",
-    "ecf-standard-january" => "Standard January",
-    "ecf-standard-september" => "Standard September",
-    # extended
-    "ecf-extended-april" => "Extended April",
-    "ecf-extended-january" => "Extended January",
-    "ecf-extended-september" => "Extended September",
-    # reduced
-    "ecf-reduced-april" => "Reduced April",
-    "ecf-reduced-january" => "Reduced January",
-    "ecf-reduced-september" => "Reduced September",
-    # replacement
-    "ecf-replacement-april" => "Replacement April",
-    "ecf-replacement-january" => "Replacement January",
-    "ecf-replacement-september" => "Replacement September",
-  }.freeze
-
   def schedule_name(identifier)
-    SCHEDULE_MAPPINGS.fetch(identifier, identifier.humanize)
+    identifier.delete_prefix("ecf-").titleize
   end
 end

--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -65,6 +65,10 @@ class ContractPeriod < ApplicationRecord
     payments_frozen_at.present? && payments_frozen_at <= Time.zone.now
   end
 
+  def all_schedules?
+    schedules.count.eql?(Schedule.identifiers.size)
+  end
+
 private
 
   def siblings

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,18 +1,18 @@
 class Schedule < ApplicationRecord
   enum :identifier,
        %w[
-         ecf-extended-april
-         ecf-extended-january
-         ecf-extended-september
-         ecf-reduced-april
-         ecf-reduced-january
-         ecf-reduced-september
-         ecf-replacement-april
-         ecf-replacement-january
-         ecf-replacement-september
-         ecf-standard-april
          ecf-standard-january
+         ecf-standard-april
          ecf-standard-september
+         ecf-extended-january
+         ecf-extended-april
+         ecf-extended-september
+         ecf-reduced-january
+         ecf-reduced-april
+         ecf-reduced-september
+         ecf-replacement-january
+         ecf-replacement-april
+         ecf-replacement-september
        ].index_by(&:itself),
        validate: { message: "Choose an identifier from the list" }
 

--- a/app/views/admin/finance/contract_periods/show.html.erb
+++ b/app/views/admin/finance/contract_periods/show.html.erb
@@ -59,7 +59,7 @@
     <% end %>
   <% end %>
 
-  <% list.with_item(title: "Schedules", href: (@has_schedules ? "#" : nil)) do |item| %>
+  <% list.with_item(title: "Schedules", href: (@has_schedules ? admin_contract_period_schedules_path(@contract_period) : nil)) do |item| %>
     <% if @has_schedules %>
       <% item.with_status(text: "Completed") %>
     <% else %>

--- a/app/views/admin/finance/schedules/index.html.erb
+++ b/app/views/admin/finance/schedules/index.html.erb
@@ -25,9 +25,6 @@
 <% end %>
 
 <%=
-  disabled =
-    @contract_period.schedules.count.eql?(Schedule.identifiers.size) ||
-    @contract_period.started_on_or_before_today?
-
-  govuk_button_to("Add schedule", "#", disabled:)
+govuk_button_to("Add schedule", "#",
+  disabled: (@contract_period.all_schedules? || @contract_period.started_on_or_before_today?))
 %>

--- a/app/views/admin/finance/schedules/index.html.erb
+++ b/app/views/admin/finance/schedules/index.html.erb
@@ -3,7 +3,7 @@
     title: "Schedules",
     caption: @contract_period.year,
     caption_size: "l",
-    breadcrumbs: ["Contract periods", @contract_period.year]
+    breadcrumbs: @breadcrumbs
   )
 %>
 

--- a/app/views/admin/finance/schedules/index.html.erb
+++ b/app/views/admin/finance/schedules/index.html.erb
@@ -15,7 +15,7 @@
   <%=
     govuk_table(
       head: ["Schedule"],
-      rows: @contract_period.schedules.map do |schedule|
+      rows: @contract_period.schedules.sort_by { |s| Schedule.identifiers.keys.index(s.identifier) }.map do |schedule|
         [
           govuk_link_to(schedule_name(schedule.identifier), "#"),
         ]

--- a/app/views/admin/finance/schedules/index.html.erb
+++ b/app/views/admin/finance/schedules/index.html.erb
@@ -1,0 +1,33 @@
+<%
+  page_data(
+    title: "Schedules",
+    caption: @contract_period.year,
+    caption_size: "l",
+    breadcrumbs: ["Contract periods", @contract_period.year]
+  )
+%>
+
+<p class="govuk-body">Manage schedules for the <%= @contract_period.year %> contract period.</p>
+
+<% if @contract_period.schedules.none? %>
+  <p class="govuk-body">This contract period currently has no schedules.</p>
+<% else %>
+  <%=
+    govuk_table(
+      head: ["Schedule"],
+      rows: @contract_period.schedules.map do |schedule|
+        [
+          govuk_link_to(schedule_name(schedule.identifier), "#"),
+        ]
+      end
+    )
+  %>
+<% end %>
+
+<%=
+  disabled =
+    @contract_period.schedules.count.eql?(Schedule.identifiers.size) ||
+    @contract_period.started_on_or_before_today?
+
+  govuk_button_to("Add schedule", "#", disabled:)
+%>

--- a/app/views/admin/finance/schedules/index.html.erb
+++ b/app/views/admin/finance/schedules/index.html.erb
@@ -15,7 +15,7 @@
   <%=
     govuk_table(
       head: ["Schedule"],
-      rows: @contract_period.schedules.sort_by { |s| Schedule.identifiers.keys.index(s.identifier) }.map do |schedule|
+      rows: sort_schedules(@contract_period).map do |schedule|
         [
           govuk_link_to(schedule_name(schedule.identifier), "#"),
         ]

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -108,7 +108,9 @@ namespace :admin do
         resource :search_declarations, only: :show, path: "search-declarations"
 
         constraints -> { Rails.application.config.enable_finance_contract_periods } do
-          resources :contract_periods, only: %i[index show], path: "contract-periods"
+          resources :contract_periods, only: %i[index show], path: "contract-periods" do
+            resources :schedules, only: %i[index], path: "schedules"
+          end
         end
       end
     end

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -2780,18 +2780,18 @@ components:
                   type: string
                   required: true
                   enum:
-                  - ecf-extended-april
-                  - ecf-extended-january
-                  - ecf-extended-september
-                  - ecf-reduced-april
-                  - ecf-reduced-january
-                  - ecf-reduced-september
-                  - ecf-replacement-april
-                  - ecf-replacement-january
-                  - ecf-replacement-september
-                  - ecf-standard-april
                   - ecf-standard-january
+                  - ecf-standard-april
                   - ecf-standard-september
+                  - ecf-extended-january
+                  - ecf-extended-april
+                  - ecf-extended-september
+                  - ecf-reduced-january
+                  - ecf-reduced-april
+                  - ecf-reduced-september
+                  - ecf-replacement-january
+                  - ecf-replacement-april
+                  - ecf-replacement-september
                   example: ecf-extended-september
                 course_identifier:
                   description: The type of course the participant is enrolled in
@@ -2920,18 +2920,18 @@ components:
           description: The schedule of the participant
           type: string
           enum:
-          - ecf-extended-april
-          - ecf-extended-january
-          - ecf-extended-september
-          - ecf-reduced-april
-          - ecf-reduced-january
-          - ecf-reduced-september
-          - ecf-replacement-april
-          - ecf-replacement-january
-          - ecf-replacement-september
-          - ecf-standard-april
           - ecf-standard-january
+          - ecf-standard-april
           - ecf-standard-september
+          - ecf-extended-january
+          - ecf-extended-april
+          - ecf-extended-september
+          - ecf-reduced-january
+          - ecf-reduced-april
+          - ecf-reduced-september
+          - ecf-replacement-january
+          - ecf-replacement-april
+          - ecf-replacement-september
           example: ecf-standard-january
         delivery_partner_id:
           description: Unique ID of the delivery partner associated with the participant

--- a/spec/helpers/admin/schedules_helper_spec.rb
+++ b/spec/helpers/admin/schedules_helper_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Admin::SchedulesHelper, type: :helper do
+  describe "#schedule_name" do
+    it "humanises the identifier" do
+      expect(helper.schedule_name("ecf-standard-september")).to eq("Standard September")
+      expect(helper.schedule_name("ecf-extended-january")).to eq("Extended January")
+      expect(helper.schedule_name("ecf-replacement-april")).to eq("Replacement April")
+    end
+  end
+
+  describe "#sort_schedules" do
+    let(:contract_period) { FactoryBot.create(:contract_period) }
+
+    before do
+      FactoryBot.create(:schedule, identifier: "ecf-reduced-april", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-standard-april", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-standard-september", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-reduced-january", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-standard-january", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-reduced-september", contract_period:)
+    end
+
+    it "orders a contract period's schedules" do
+      expect(helper.sort_schedules(contract_period).map(&:identifier)).to eq(%w[
+        ecf-standard-january
+        ecf-standard-april
+        ecf-standard-september
+        ecf-reduced-january
+        ecf-reduced-april
+        ecf-reduced-september
+      ])
+    end
+  end
+end

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -242,4 +242,29 @@ describe ContractPeriod do
       it { is_expected.to be_payments_frozen }
     end
   end
+
+  describe "#all_schedules?" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+    let(:schedule_identifiers) { Schedule.identifiers.values }
+
+    context "when all possible schedules have been allocated to the contract period" do
+      before do
+        schedule_identifiers.each do |identifier|
+          FactoryBot.create(:schedule, identifier:, contract_period:)
+        end
+      end
+
+      it { expect(contract_period).to be_all_schedules }
+    end
+
+    context "when only some schedules have been allocated to the contract period" do
+      before do
+        schedule_identifiers.take(2).each do |identifier|
+          FactoryBot.create(:schedule, identifier:, contract_period:)
+        end
+      end
+
+      it { expect(contract_period).not_to be_all_schedules }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,11 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
+  # Opening registration contract periods
+  config.before(:each, :enable_finance_contract_periods) do
+    allow(Rails.application.config).to receive(:enable_finance_contract_periods).and_return(true)
+  end
+
   config.before do
     # RIAB: new data model
     allow(Rails.application.config).to receive(:enable_teaching_school_hubs).and_return(true)

--- a/spec/requests/admin/finance/schedules_spec.rb
+++ b/spec/requests/admin/finance/schedules_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe "Admin finance schedules", :enable_finance_contract_periods do
+  let(:contract_period) { FactoryBot.create(:contract_period) }
+
+  describe "GET /admin/finance/contract-periods/:id/schedules" do
+    context "when not authenticated" do
+      it "redirects to sign in page" do
+        get "/admin/finance/contract-periods/#{contract_period.id}/schedules"
+        expect(response).to redirect_to(sign_in_path)
+      end
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get "/admin/finance/contract-periods/#{contract_period.id}/schedules"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authenticated as a non-finance DfE user" do
+      include_context "sign in as DfE user"
+
+      it "requires authorisation with finance privileges" do
+        get "/admin/finance/contract-periods/#{contract_period.id}/schedules"
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include("To gain access, contact the product team.")
+      end
+    end
+
+    context "when authenticated as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      before do
+        FactoryBot.create(:schedule, identifier: "ecf-standard-january", contract_period:)
+        FactoryBot.create(:schedule, identifier: "ecf-standard-april", contract_period:)
+        FactoryBot.create(:schedule, identifier: "ecf-extended-january")
+        get "/admin/finance/contract-periods/#{contract_period.id}/schedules"
+      end
+
+      context "and the contract period is closed" do
+        let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+
+        it "displays the schedules index page" do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("Manage schedules for the 2025 contract period.")
+        end
+
+        it "displays the schedules for the contract period" do
+          expect(response.body).to include("Standard January")
+          expect(response.body).to include("Standard April")
+          expect(response.body).not_to include("Extended January")
+        end
+
+        it "has a disabled button" do
+          expect(response.body).to include("Add schedule")
+          expect(response.body).to include('data-module="govuk-button" disabled="disabled"')
+        end
+      end
+
+      context "and the contract period is not yet open" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+
+        it "has an enabled button" do
+          expect(response.body).to include("Add schedule")
+          expect(response.body).not_to include('data-module="govuk-button" disabled="disabled"')
+        end
+      end
+    end
+  end
+end

--- a/spec/views/admin/finance/schedules/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/schedules/index.html.erb_spec.rb
@@ -68,15 +68,19 @@ RSpec.describe "admin/finance/schedules/index.html.erb" do
 
   context "when the contract period has schedules" do
     before do
-      FactoryBot.create(:schedule, identifier: "ecf-standard-january", contract_period:)
       FactoryBot.create(:schedule, identifier: "ecf-reduced-april", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-standard-april", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-standard-january", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-extended-september", contract_period:)
     end
 
-    it "lists their names" do
+    it "lists their names by type then month chronologically" do
       render
       expect(rendered).not_to have_text("This contract period currently has no schedules.")
       expect(rendered).to have_text("Standard January")
+      expect(rendered).to have_text("Standard April")
       expect(rendered).to have_text("Reduced April")
+      expect(rendered).to have_text("Extended September")
     end
   end
 end

--- a/spec/views/admin/finance/schedules/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/schedules/index.html.erb_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe "admin/finance/schedules/index.html.erb" do
+  before do
+    assign(:contract_period, contract_period)
+  end
+
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, :previous)
+  end
+
+  it "has intro text" do
+    render
+    expect(rendered).to have_text(/Manage schedules for the \d{4} contract period./)
+  end
+
+  context "when a contract period is closed" do
+    it "has a disabled add schedule button" do
+      render
+      expect(rendered).to have_button("Add schedule", disabled: true)
+    end
+  end
+
+  context "when the current contract period has all possible schedules" do
+    let(:contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+
+    before do
+      Schedule.identifiers { |identifier| FactoryBot.create(:schedule, identifier:, contract_period:) }
+    end
+
+    it "has a disabled add schedule button" do
+      render
+      expect(rendered).to have_button("Add schedule", disabled: true)
+    end
+  end
+
+  context "when a contract period is opened" do
+    let(:contract_period) do
+      FactoryBot.create(:contract_period, :next)
+    end
+
+    it "has no schedules yet" do
+      render
+      expect(rendered).to have_text("This contract period currently has no schedules.")
+    end
+
+    it "has an active add a schedule button" do
+      render
+      expect(rendered).to have_button("Add schedule", disabled: false)
+    end
+  end
+
+  context "when the contract period has schedules" do
+    before do
+      FactoryBot.create(:schedule, identifier: "ecf-standard-january", contract_period:)
+      FactoryBot.create(:schedule, identifier: "ecf-reduced-april", contract_period:)
+    end
+
+    it "lists their names" do
+      render
+      expect(rendered).not_to have_text("This contract period currently has no schedules.")
+      expect(rendered).to have_text("Standard January")
+      expect(rendered).to have_text("Reduced April")
+    end
+  end
+end

--- a/spec/views/admin/finance/schedules/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/schedules/index.html.erb_spec.rb
@@ -1,9 +1,25 @@
 RSpec.describe "admin/finance/schedules/index.html.erb" do
   before do
     assign(:contract_period, contract_period)
+
+    assign(:breadcrumbs, {
+      "Finance" => admin_finance_path,
+      "Contract periods" => admin_contract_periods_path,
+      contract_period.year.to_s => admin_contract_period_path(contract_period),
+      "Schedules" => nil
+    })
   end
 
   let(:contract_period) { FactoryBot.create(:contract_period, :previous) }
+
+  it "renders breadcrumbs" do
+    render
+
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link(contract_period.year.to_s, href: admin_contract_period_path(contract_period))
+    expect(view.content_for(:backlink_or_breadcrumb)).to include("Schedules")
+  end
 
   it "has intro text" do
     render

--- a/spec/views/admin/finance/schedules/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/schedules/index.html.erb_spec.rb
@@ -3,29 +3,36 @@ RSpec.describe "admin/finance/schedules/index.html.erb" do
     assign(:contract_period, contract_period)
   end
 
-  let(:contract_period) do
-    FactoryBot.create(:contract_period, :previous)
-  end
+  let(:contract_period) { FactoryBot.create(:contract_period, :previous) }
 
   it "has intro text" do
     render
     expect(rendered).to have_text(/Manage schedules for the \d{4} contract period./)
   end
 
-  context "when a contract period is closed" do
+  context "when a contract period is closed to amendments" do
     it "has a disabled add schedule button" do
       render
       expect(rendered).to have_button("Add schedule", disabled: true)
+    end
+  end
+
+  context "when a contract period is open to amendments" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+
+    it "has an enabled add a schedule button" do
+      render
+      expect(rendered).to have_button("Add schedule", disabled: false)
     end
   end
 
   context "when the current contract period has all possible schedules" do
-    let(:contract_period) do
-      FactoryBot.create(:contract_period, :current)
-    end
+    let(:contract_period) { FactoryBot.create(:contract_period, :next) }
 
     before do
-      Schedule.identifiers { |identifier| FactoryBot.create(:schedule, identifier:, contract_period:) }
+      Schedule.identifiers.each_value do |identifier|
+        FactoryBot.create(:schedule, identifier:, contract_period:)
+      end
     end
 
     it "has a disabled add schedule button" do
@@ -34,19 +41,12 @@ RSpec.describe "admin/finance/schedules/index.html.erb" do
     end
   end
 
-  context "when a contract period is opened" do
-    let(:contract_period) do
-      FactoryBot.create(:contract_period, :next)
-    end
+  context "when a new contract period is opened" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :next) }
 
-    it "has no schedules yet" do
+    it "has no schedules" do
       render
       expect(rendered).to have_text("This contract period currently has no schedules.")
-    end
-
-    it "has an active add a schedule button" do
-      render
-      expect(rendered).to have_button("Add schedule", disabled: false)
     end
   end
 


### PR DESCRIPTION
### Context

[Epic](https://github.com/DFE-Digital/register-ects-project-board/issues/3927) opening registration journey

Closes https://github.com/DFE-Digital/register-ects-project-board/issues/3939

We are not including milestones on this page yet, just a simple list of schedules

### Changes proposed in this pull request

- [x] controller and view with supporting helper
- [x] request and view spec
- [x] inject feature flag config into request specs
- [x] link from the contract period page task list

### Guidance to review

<img width="2528" height="2972" alt="cpd-ec2-review-2935-web test teacherservices cloud_admin_finance_contract-periods_2026_schedules (1)" src="https://github.com/user-attachments/assets/7df04a55-02c0-4185-9cd9-90ce9861d7e1" />


```
Admin finance schedules
  GET /admin/finance/contract-periods/:id/schedules
    when authenticated as a non-finance DfE user
      requires authorisation with finance privileges
    with an authenticated non-DfE user
      requires authorisation
    when authenticated as a finance DfE user
      and the contract period is not yet open
        has an enabled button
      and the contract period is closed
        has a disabled button
        displays the schedules index page
        displays the schedules for the contract period
    when not authenticated
      redirects to sign in page
```

```
admin/finance/schedules/index.html.erb
  renders breadcrumbs
  has intro text
  when the current contract period has all possible schedules
    has a disabled add schedule button
  when the contract period has schedules
    lists their names
  when a contract period is open to amendments
    has an enabled add a schedule button
  when a new contract period is opened
    has no schedules
  when a contract period is closed to amendments
    has a disabled add schedule button
```
