### PR TITLE
[3942] Add admin statements index for contract period and lead provider

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
@@ -10,7 +10,7 @@ module Admin::Finance::ActiveLeadProviders
       @breadcrumbs = {
         "Finance" => admin_finance_path,
         "Contract periods" => admin_contract_periods_path,
-        contract_period.year.to_s => admin_contract_period_path(contract_period),
+        @active_lead_provider.contract_period_year.to_s => admin_contract_period_path(contract_period),
         @active_lead_provider.lead_provider_name => admin_contract_period_active_lead_providers_path(contract_period),
       }
       @pagy, @statements = pagy(@active_lead_provider.statements.order(year: :asc, month: :asc))

--- a/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
@@ -1,0 +1,25 @@
+module Admin::Finance::ActiveLeadProviders
+  class StatementsController < Admin::Finance::BaseController
+    layout "full"
+
+    before_action :set_active_lead_provider
+
+    def index
+      @breadcrumbs = {
+        "Finance" => admin_finance_path,
+        "Contract periods" => admin_contract_periods_path,
+        @active_lead_provider.contract_period_year.to_s => admin_contract_period_path(@active_lead_provider.contract_period),
+        @active_lead_provider.lead_provider_name => nil,
+      }
+      @pagy, @statements = pagy(@active_lead_provider.statements.order(year: :asc, month: :asc))
+    end
+
+  private
+
+    def set_active_lead_provider
+      @active_lead_provider = ActiveLeadProvider
+        .includes(:contract_period, :lead_provider)
+        .find(params[:active_lead_provider_id])
+    end
+  end
+end

--- a/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers/statements_controller.rb
@@ -5,11 +5,13 @@ module Admin::Finance::ActiveLeadProviders
     before_action :set_active_lead_provider
 
     def index
+      contract_period = @active_lead_provider.contract_period
+
       @breadcrumbs = {
         "Finance" => admin_finance_path,
         "Contract periods" => admin_contract_periods_path,
-        @active_lead_provider.contract_period_year.to_s => admin_contract_period_path(@active_lead_provider.contract_period),
-        @active_lead_provider.lead_provider_name => nil,
+        contract_period.year.to_s => admin_contract_period_path(contract_period),
+        @active_lead_provider.lead_provider_name => admin_contract_period_active_lead_providers_path(contract_period),
       }
       @pagy, @statements = pagy(@active_lead_provider.statements.order(year: :asc, month: :asc))
     end

--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -24,7 +24,7 @@ module Admin::Finance
     end
 
     def create
-      @active_lead_provider = ActiveLeadProviders::Create.new(
+      @active_lead_provider = ::ActiveLeadProviders::Create.new(
         author: current_user,
         contract_period: @contract_period,
         lead_provider_id: active_lead_provider_params[:lead_provider_id]
@@ -37,8 +37,8 @@ module Admin::Finance
         @available_lead_providers = available_lead_providers
         render :new, status: :unprocessable_entity
       end
-    rescue ActiveLeadProviders::SeedFromPrevious::PreviousActiveLeadProviderError,
-           ActiveLeadProviders::SeedFromPrevious::AlreadyPopulatedError => e
+    rescue ::ActiveLeadProviders::SeedFromPrevious::PreviousActiveLeadProviderError,
+           ::ActiveLeadProviders::SeedFromPrevious::AlreadyPopulatedError => e
       flash[:error] = "Cannot seed: #{e.message}"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
     end
@@ -46,10 +46,10 @@ module Admin::Finance
     def destroy
       active_lead_provider = @contract_period.active_lead_providers.find(params[:id])
       lead_provider_name = active_lead_provider.lead_provider.name
-      ActiveLeadProviders::CascadeDelete.new(active_lead_provider:, author: current_user).call
+      ::ActiveLeadProviders::CascadeDelete.new(active_lead_provider:, author: current_user).call
       flash[:notice] = "#{lead_provider_name} removed"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
-    rescue ActiveLeadProviders::CascadeDelete::CascadeDeleteError => e
+    rescue ::ActiveLeadProviders::CascadeDelete::CascadeDeleteError => e
       flash[:error] = "Cannot remove #{lead_provider_name}: #{e.message}"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
     end

--- a/app/models/active_lead_provider.rb
+++ b/app/models/active_lead_provider.rb
@@ -29,4 +29,6 @@ class ActiveLeadProvider < ApplicationRecord
       .without_existing_partnership_for(delivery_partner, contract_period)
       .with_lead_provider_ordered_by_name
   }
+
+  delegate :name, to: :lead_provider, prefix: true
 end

--- a/app/views/admin/finance/active_lead_providers/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/index.html.erb
@@ -31,8 +31,7 @@
             <%= govuk_link_to(pluralize(alp.contracts.size, "contract"), "#", visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% row.with_cell do %>
-            <%# TODO: link to admin statements page once it exists %>
-            <%= govuk_link_to(pluralize(alp.statements.size, "statement"), "#", visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
+            <%= govuk_link_to(pluralize(alp.statements.size, "statement"), admin_active_lead_provider_statements_path(alp), visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% row.with_cell do %>
             <%# TODO: link to admin delivery partners page once it exists %>

--- a/app/views/admin/finance/active_lead_providers/statements/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/statements/index.html.erb
@@ -1,0 +1,35 @@
+<% page_data(title: "Statements", breadcrumbs: @breadcrumbs) %>
+
+<p class="govuk-body">
+  Statements for <%= @active_lead_provider.lead_provider_name %> in the <%= @active_lead_provider.contract_period_year %> contract period.
+</p>
+
+<% if @statements.none? %>
+  <p class="govuk-body">No statements found</p>
+<% else %>
+  <%=
+    govuk_table(
+      head: ["Month", "Fee type", "Deadline date", "Payment date", "Status"],
+      rows: @statements.map { |statement|
+        status_colour = { "open" => "blue", "payable" => "yellow", "paid" => "green" }.fetch(statement.status)
+        status_text = statement.output_fee? && statement.paid? ? "Authorised for payment" : statement.status.capitalize
+
+        [
+          govuk_link_to(
+            Statements::Period.for(statement),
+            "#",
+            visually_hidden_suffix: "statement for #{@active_lead_provider.lead_provider_name}"
+          ),
+          statement.fee_type.humanize,
+          statement.deadline_date.to_fs(:govuk),
+          statement.payment_date.to_fs(:govuk),
+          govuk_tag(text: status_text, colour: status_colour),
+        ]
+      }
+    )
+  %>
+<% end %>
+
+<%= render Shared::PaginationSummaryComponent.new(pagy: @pagy, record_name: "statements") %>
+
+<%= govuk_button_link_to("Add statement", "#", disabled: @active_lead_provider.contract_period.started_on_or_before_today?) %>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -112,6 +112,10 @@ namespace :admin do
             resources :schedules, only: %i[index], path: "schedules"
             resources :active_lead_providers, only: %i[index new create destroy], path: "active-lead-providers"
           end
+
+          resources :active_lead_providers, only: %i[], path: "active-lead-providers" do
+            resources :statements, only: %i[index], controller: "active_lead_providers/statements"
+          end
         end
       end
     end

--- a/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Admin finance active lead provider statements", type: :request d
         expect(response.status).to eq(200)
         expect(response.body).to include("Lead Provider 1")
         expect(response.body).to include(Statements::Period.for(statement))
+        expect(response.body).to include(admin_contract_period_active_lead_providers_path(contract_period))
       end
     end
   end

--- a/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
@@ -2,139 +2,33 @@ RSpec.describe "Admin finance active lead provider statements", type: :request d
   let(:contract_period) { FactoryBot.create(:contract_period, :current) }
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Lead Provider 1") }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
-
-  let!(:output_statement) do
-    FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: contract_period.year)
-  end
-
-  let!(:service_statement) do
-    FactoryBot.create(:statement, :paid, :service_fee, active_lead_provider:, month: 1, year: contract_period.year.next)
-  end
-
+  let!(:statement) { FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: contract_period.year) }
   let(:path) { admin_active_lead_provider_statements_path(active_lead_provider) }
 
-  before do
-    allow(Rails.application.config).to receive(:enable_finance_contract_periods).and_return(env_var_value)
-  end
-
   describe "GET /admin/finance/active-lead-providers/:active_lead_provider_id/statements" do
-    context "when enabled" do
-      let(:env_var_value) { true }
+    it "redirects to sign in path when not signed in" do
+      get path
+      expect(response).to redirect_to(sign_in_path)
+    end
 
-      it "redirects to sign in path when not signed in" do
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
         get path
-        expect(response).to redirect_to(sign_in_path)
-      end
-
-      context "with an authenticated non-DfE user" do
-        include_context "sign in as non-DfE user"
-
-        it "requires authorisation" do
-          get path
-          expect(response.status).to eq(401)
-        end
-      end
-
-      context "when signed in as a non-finance DfE user" do
-        include_context "sign in as DfE user"
-
-        it "requires authorisation" do
-          get path
-          expect(response.status).to eq(401)
-        end
-      end
-
-      context "when signed in as a finance DfE user" do
-        include_context "sign in as finance DfE user"
-
-        it "displays the statements in a single table for the active lead provider" do
-          get path
-
-          expect(response.status).to eq(200)
-          expect(response.body).to include("Lead Provider 1")
-          expect(response.body).to include("Month")
-          expect(response.body).to include("Fee type")
-          expect(response.body).to include("Status")
-          expect(response.body).to include("Deadline date")
-          expect(response.body).to include("Payment date")
-        end
-
-        it "includes both output and service fee statements" do
-          get path
-
-          expect(response.body).to include(Statements::Period.for(output_statement))
-          expect(response.body).to include(Statements::Period.for(service_statement))
-          expect(response.body).to include("Output")
-          expect(response.body).to include("Service")
-        end
-
-        it "shows the status as a tag" do
-          get path
-
-          expect(response.body).to include("Open")
-          expect(response.body).to include("Paid")
-        end
-
-        describe "the Add statement button" do
-          context "when the contract period has started" do
-            let(:contract_period) { FactoryBot.create(:contract_period, :current) }
-
-            it "renders the button in a disabled state" do
-              get path
-
-              expect(response.body).to include("Add statement")
-              expect(response.body).to include('aria-disabled="true"')
-            end
-          end
-
-          context "when the contract period has not started" do
-            let(:contract_period) { FactoryBot.create(:contract_period, :next) }
-
-            it "renders the button enabled" do
-              get path
-
-              expect(response.body).to include("Add statement")
-              expect(response.body).not_to include('aria-disabled="true"')
-            end
-          end
-        end
-
-        context "when there are no statements" do
-          let(:other_lead_provider) { FactoryBot.create(:lead_provider, name: "No statements LP") }
-          let(:other_active_lead_provider) do
-            FactoryBot.create(:active_lead_provider, contract_period:, lead_provider: other_lead_provider)
-          end
-          let(:path) { admin_active_lead_provider_statements_path(other_active_lead_provider) }
-
-          it "shows an empty message" do
-            get path
-
-            expect(response.status).to eq(200)
-            expect(response.body).to include("No statements found")
-          end
-        end
+        expect(response.status).to eq(401)
       end
     end
 
-    context "when disabled" do
+    context "when signed in as a finance DfE user" do
       include_context "sign in as finance DfE user"
 
-      context "implicitly" do
-        let(:env_var_value) { nil }
+      it "displays the active lead provider's statements" do
+        get path
 
-        it "returns 404 not found" do
-          get path
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "explicitly" do
-        let(:env_var_value) { false }
-
-        it "returns 404 not found" do
-          get path
-          expect(response.status).to eq(404)
-        end
+        expect(response.status).to eq(200)
+        expect(response.body).to include("Lead Provider 1")
+        expect(response.body).to include(Statements::Period.for(statement))
       end
     end
   end

--- a/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers/statements_spec.rb
@@ -1,0 +1,141 @@
+RSpec.describe "Admin finance active lead provider statements", type: :request do
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Lead Provider 1") }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+
+  let!(:output_statement) do
+    FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: contract_period.year)
+  end
+
+  let!(:service_statement) do
+    FactoryBot.create(:statement, :paid, :service_fee, active_lead_provider:, month: 1, year: contract_period.year.next)
+  end
+
+  let(:path) { admin_active_lead_provider_statements_path(active_lead_provider) }
+
+  before do
+    allow(Rails.application.config).to receive(:enable_finance_contract_periods).and_return(env_var_value)
+  end
+
+  describe "GET /admin/finance/active-lead-providers/:active_lead_provider_id/statements" do
+    context "when enabled" do
+      let(:env_var_value) { true }
+
+      it "redirects to sign in path when not signed in" do
+        get path
+        expect(response).to redirect_to(sign_in_path)
+      end
+
+      context "with an authenticated non-DfE user" do
+        include_context "sign in as non-DfE user"
+
+        it "requires authorisation" do
+          get path
+          expect(response.status).to eq(401)
+        end
+      end
+
+      context "when signed in as a non-finance DfE user" do
+        include_context "sign in as DfE user"
+
+        it "requires authorisation" do
+          get path
+          expect(response.status).to eq(401)
+        end
+      end
+
+      context "when signed in as a finance DfE user" do
+        include_context "sign in as finance DfE user"
+
+        it "displays the statements in a single table for the active lead provider" do
+          get path
+
+          expect(response.status).to eq(200)
+          expect(response.body).to include("Lead Provider 1")
+          expect(response.body).to include("Month")
+          expect(response.body).to include("Fee type")
+          expect(response.body).to include("Status")
+          expect(response.body).to include("Deadline date")
+          expect(response.body).to include("Payment date")
+        end
+
+        it "includes both output and service fee statements" do
+          get path
+
+          expect(response.body).to include(Statements::Period.for(output_statement))
+          expect(response.body).to include(Statements::Period.for(service_statement))
+          expect(response.body).to include("Output")
+          expect(response.body).to include("Service")
+        end
+
+        it "shows the status as a tag" do
+          get path
+
+          expect(response.body).to include("Open")
+          expect(response.body).to include("Paid")
+        end
+
+        describe "the Add statement button" do
+          context "when the contract period has started" do
+            let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+            it "renders the button in a disabled state" do
+              get path
+
+              expect(response.body).to include("Add statement")
+              expect(response.body).to include('aria-disabled="true"')
+            end
+          end
+
+          context "when the contract period has not started" do
+            let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+
+            it "renders the button enabled" do
+              get path
+
+              expect(response.body).to include("Add statement")
+              expect(response.body).not_to include('aria-disabled="true"')
+            end
+          end
+        end
+
+        context "when there are no statements" do
+          let(:other_lead_provider) { FactoryBot.create(:lead_provider, name: "No statements LP") }
+          let(:other_active_lead_provider) do
+            FactoryBot.create(:active_lead_provider, contract_period:, lead_provider: other_lead_provider)
+          end
+          let(:path) { admin_active_lead_provider_statements_path(other_active_lead_provider) }
+
+          it "shows an empty message" do
+            get path
+
+            expect(response.status).to eq(200)
+            expect(response.body).to include("No statements found")
+          end
+        end
+      end
+    end
+
+    context "when disabled" do
+      include_context "sign in as finance DfE user"
+
+      context "implicitly" do
+        let(:env_var_value) { nil }
+
+        it "returns 404 not found" do
+          get path
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "explicitly" do
+        let(:env_var_value) { false }
+
+        it "returns 404 not found" do
+          get path
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+end

--- a/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
     active_lead_providers.each do |alp|
       expect(rendered).to have_css("tr", text: alp.lead_provider.name)
       expect(rendered).to have_css("tr", text: pluralize(alp.contracts.count, "contract"))
-      expect(rendered).to have_css("tr", text: pluralize(alp.statements.count, "statement"))
+      expect(rendered).to have_link(pluralize(alp.statements.count, "statement"), href: admin_active_lead_provider_statements_path(alp))
       expect(rendered).to have_css("tr", text: pluralize(alp.delivery_partners.count, "delivery partner"))
     end
 
@@ -66,7 +66,7 @@ RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
       active_lead_providers.each do |alp|
         name = alp.lead_provider.name
         expect(rendered).to have_link("#{pluralize(alp.contracts.count, 'contract')} for #{name}")
-        expect(rendered).to have_link("#{pluralize(alp.statements.count, 'statement')} for #{name}")
+        expect(rendered).to have_link("#{pluralize(alp.statements.count, 'statement')} for #{name}", href: admin_active_lead_provider_statements_path(alp))
         expect(rendered).to have_link("#{pluralize(alp.delivery_partners.count, 'delivery partner')} for #{name}")
       end
     end

--- a/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "admin/finance/active_lead_providers/statements/index.html.erb" d
       "Finance" => admin_finance_path,
       "Contract periods" => admin_contract_periods_path,
       contract_period.year.to_s => admin_contract_period_path(contract_period),
-      lead_provider.name => nil,
+      lead_provider.name => admin_contract_period_active_lead_providers_path(contract_period),
     })
   end
 
@@ -33,7 +33,7 @@ RSpec.describe "admin/finance/active_lead_providers/statements/index.html.erb" d
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link(contract_period.year.to_s, href: admin_contract_period_path(contract_period))
-    expect(view.content_for(:backlink_or_breadcrumb)).to include(lead_provider.name)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link(lead_provider.name, href: admin_contract_period_active_lead_providers_path(contract_period))
 
     expect(rendered).to have_content("Statements for #{lead_provider.name} in the #{contract_period.year} contract period.")
 

--- a/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
@@ -26,90 +26,47 @@ RSpec.describe "admin/finance/active_lead_providers/statements/index.html.erb" d
     })
   end
 
-  it "has the page title 'Statements'" do
+  it "renders the title, breadcrumbs, description, statements table in order, and an enabled add button" do
     render
 
     expect(view.content_for(:page_title)).to eq("Statements")
-  end
-
-  it "renders the breadcrumbs" do
-    render
-
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link(contract_period.year.to_s, href: admin_contract_period_path(contract_period))
     expect(view.content_for(:backlink_or_breadcrumb)).to include(lead_provider.name)
-  end
-
-  it "describes what the user is looking at" do
-    render
 
     expect(rendered).to have_content("Statements for #{lead_provider.name} in the #{contract_period.year} contract period.")
-  end
-
-  it "renders a single table with the expected columns" do
-    render
 
     expect(rendered).to have_css(".govuk-table", count: 1)
     ["Month", "Fee type", "Deadline date", "Payment date", "Status"].each do |header|
       expect(rendered).to have_css(".govuk-table__header", text: header)
     end
-  end
 
-  it "renders a row per statement with a stubbed month link, fee type, dates and status tag" do
-    render
-
-    expect(rendered).to have_css(".govuk-table > .govuk-table__body > tr", count: 2)
-
+    rows = Capybara.string(rendered).all(".govuk-table > .govuk-table__body > tr")
+    expect(rows.count).to eq(2)
+    expect(rows[0].text).to include("November 2099")
+    expect(rows[1].text).to include("December 2099")
     expect(rendered).to have_link("November 2099", href: "#")
-    expect(rendered).to have_link("December 2099", href: "#")
-
     expect(rendered).to have_content("Output")
     expect(rendered).to have_content("Service")
-
     expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "Open")
     expect(rendered).to have_css(".govuk-tag.govuk-tag--green", text: "Paid")
-
     expect(rendered).to have_content(november_statement.deadline_date.to_fs(:govuk))
     expect(rendered).to have_content(december_statement.payment_date.to_fs(:govuk))
+
+    expect(rendered).to have_link("Add statement", href: "#")
+    expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add statement")
   end
 
-  it "renders statements in the order they are given (year/month ascending)" do
-    render
-
-    body = Capybara.string(rendered)
-    rows = body.all(".govuk-table > .govuk-table__body > tr").map(&:text)
-
-    expect(rows[0]).to include("November 2099")
-    expect(rows[1]).to include("December 2099")
-  end
-
-  describe "the Add statement button" do
-    context "when the contract period has not yet started" do
-      it "renders an enabled button stubbed to '#'" do
-        render
-
-        expect(rendered).to have_link("Add statement", href: "#")
-        expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add statement")
-      end
+  context "when the contract period has already started" do
+    let(:contract_period) do
+      FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
     end
 
-    context "when the contract period has already started" do
-      let(:contract_period) do
-        FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
-      end
-      let(:november_statement) do
-        FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: 2020)
-      end
-      let(:december_statement) do
-        FactoryBot.create(:statement, :paid, :service_fee, active_lead_provider:, month: 12, year: 2020)
-      end
+    it "renders the add button in a disabled state" do
+      render
 
-      it "renders the button in a disabled state" do
-        render
-
-        expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Add statement")
-      end
+      expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Add statement")
     end
   end
 

--- a/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/statements/index.html.erb_spec.rb
@@ -1,0 +1,126 @@
+RSpec.describe "admin/finance/active_lead_providers/statements/index.html.erb" do
+  let(:contract_period) do
+    FactoryBot.create(:contract_period, year: 2099, started_on: Date.new(2099, 6, 1), finished_on: Date.new(2100, 5, 31))
+  end
+  let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Lead Provider 1") }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+
+  let(:november_statement) do
+    FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: 2099)
+  end
+  let(:december_statement) do
+    FactoryBot.create(:statement, :paid, :service_fee, active_lead_provider:, month: 12, year: 2099)
+  end
+  let(:raw_statements) { [november_statement, december_statement] }
+  let(:pagy) { Pagy.new(count: raw_statements.count, limit: 10, page: 1) }
+
+  before do
+    assign(:active_lead_provider, active_lead_provider)
+    assign(:statements, raw_statements)
+    assign(:pagy, pagy)
+    assign(:breadcrumbs, {
+      "Finance" => admin_finance_path,
+      "Contract periods" => admin_contract_periods_path,
+      contract_period.year.to_s => admin_contract_period_path(contract_period),
+      lead_provider.name => nil,
+    })
+  end
+
+  it "has the page title 'Statements'" do
+    render
+
+    expect(view.content_for(:page_title)).to eq("Statements")
+  end
+
+  it "renders the breadcrumbs" do
+    render
+
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link(contract_period.year.to_s, href: admin_contract_period_path(contract_period))
+    expect(view.content_for(:backlink_or_breadcrumb)).to include(lead_provider.name)
+  end
+
+  it "describes what the user is looking at" do
+    render
+
+    expect(rendered).to have_content("Statements for #{lead_provider.name} in the #{contract_period.year} contract period.")
+  end
+
+  it "renders a single table with the expected columns" do
+    render
+
+    expect(rendered).to have_css(".govuk-table", count: 1)
+    ["Month", "Fee type", "Deadline date", "Payment date", "Status"].each do |header|
+      expect(rendered).to have_css(".govuk-table__header", text: header)
+    end
+  end
+
+  it "renders a row per statement with a stubbed month link, fee type, dates and status tag" do
+    render
+
+    expect(rendered).to have_css(".govuk-table > .govuk-table__body > tr", count: 2)
+
+    expect(rendered).to have_link("November 2099", href: "#")
+    expect(rendered).to have_link("December 2099", href: "#")
+
+    expect(rendered).to have_content("Output")
+    expect(rendered).to have_content("Service")
+
+    expect(rendered).to have_css(".govuk-tag.govuk-tag--blue", text: "Open")
+    expect(rendered).to have_css(".govuk-tag.govuk-tag--green", text: "Paid")
+
+    expect(rendered).to have_content(november_statement.deadline_date.to_fs(:govuk))
+    expect(rendered).to have_content(december_statement.payment_date.to_fs(:govuk))
+  end
+
+  it "renders statements in the order they are given (year/month ascending)" do
+    render
+
+    body = Capybara.string(rendered)
+    rows = body.all(".govuk-table > .govuk-table__body > tr").map(&:text)
+
+    expect(rows[0]).to include("November 2099")
+    expect(rows[1]).to include("December 2099")
+  end
+
+  describe "the Add statement button" do
+    context "when the contract period has not yet started" do
+      it "renders an enabled button stubbed to '#'" do
+        render
+
+        expect(rendered).to have_link("Add statement", href: "#")
+        expect(rendered).not_to have_selector("a[aria-disabled='true']", text: "Add statement")
+      end
+    end
+
+    context "when the contract period has already started" do
+      let(:contract_period) do
+        FactoryBot.create(:contract_period, year: 2020, started_on: Date.new(2020, 6, 1), finished_on: Date.new(2021, 5, 31))
+      end
+      let(:november_statement) do
+        FactoryBot.create(:statement, :open, :output_fee, active_lead_provider:, month: 11, year: 2020)
+      end
+      let(:december_statement) do
+        FactoryBot.create(:statement, :paid, :service_fee, active_lead_provider:, month: 12, year: 2020)
+      end
+
+      it "renders the button in a disabled state" do
+        render
+
+        expect(rendered).to have_selector("a[disabled], a[aria-disabled='true']", text: "Add statement")
+      end
+    end
+  end
+
+  context "when there are no statements" do
+    let(:raw_statements) { [] }
+
+    it "displays a message informing me there are no statements" do
+      render
+
+      expect(rendered).to have_content("No statements found")
+      expect(rendered).not_to have_css(".govuk-table")
+    end
+  end
+end


### PR DESCRIPTION
### Context

resolves https://github.com/DFE-Digital/register-ects-project-board/issues/3942

### Changes proposed in this pull request

* Statements index page listing all statements for contract period and lead provider

<img width="1259" height="1260" alt="Screenshot 2026-05-22 at 11 27 51" src="https://github.com/user-attachments/assets/448d9d67-cb99-4e0f-a14a-b6db335f4162" />

### Guidance to review

* Simple relatively standard Rails controller with index action.
* Implements link from ActiveLeadProviders#index to statements.
* Introduces namespace collisions that require namespace modifications to ActiveLeadProvidersController
