### PR TITLE
Add ActiveLeadProvidersController

### DIFF
--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -46,6 +46,9 @@ module Admin::Finance
       ActiveLeadProviders::CascadeDelete.new(active_lead_provider:).call
       flash[:notice] = "#{lead_provider_name} removed"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
+    rescue ActiveLeadProviders::CascadeDelete::CascadeDeleteError => e
+      flash[:error] = "Cannot remove #{lead_provider_name}: #{e.message}"
+      redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
     end
 
   private

--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -24,10 +24,12 @@ module Admin::Finance
     end
 
     def create
-      @active_lead_provider = @contract_period.active_lead_providers.build(active_lead_provider_params)
+      @active_lead_provider = ActiveLeadProviders::Create.new(
+        contract_period: @contract_period,
+        lead_provider_id: active_lead_provider_params[:lead_provider_id]
+      ).call
 
-      if @active_lead_provider.save
-        ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider: @active_lead_provider).call
+      if @active_lead_provider.persisted?
         flash[:notice] = "#{@active_lead_provider.lead_provider.name} added"
         redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
       else

--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -46,7 +46,7 @@ module Admin::Finance
     def destroy
       active_lead_provider = @contract_period.active_lead_providers.find(params[:id])
       lead_provider_name = active_lead_provider.lead_provider.name
-      ActiveLeadProviders::CascadeDelete.new(active_lead_provider:).call
+      ActiveLeadProviders::CascadeDelete.new(active_lead_provider:, author: current_user).call
       flash[:notice] = "#{lead_provider_name} removed"
       redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
     rescue ActiveLeadProviders::CascadeDelete::CascadeDeleteError => e

--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -25,6 +25,7 @@ module Admin::Finance
 
     def create
       @active_lead_provider = ActiveLeadProviders::Create.new(
+        author: current_user,
         contract_period: @contract_period,
         lead_provider_id: active_lead_provider_params[:lead_provider_id]
       ).call

--- a/app/controllers/admin/finance/active_lead_providers_controller.rb
+++ b/app/controllers/admin/finance/active_lead_providers_controller.rb
@@ -1,0 +1,78 @@
+module Admin::Finance
+  class ActiveLeadProvidersController < Admin::Finance::BaseController
+    layout "full"
+
+    before_action :set_contract_period
+    before_action :reject_if_contract_period_started, only: %i[new create destroy]
+
+    def index
+      @breadcrumbs = {
+        "Finance" => admin_finance_path,
+        "Contract periods" => admin_contract_periods_path,
+        @contract_period.year.to_s => admin_contract_period_path(@contract_period),
+      }
+      @editable = editable?
+      @active_lead_providers = @contract_period
+        .active_lead_providers
+        .with_lead_provider_ordered_by_name
+        .includes(:contracts, :statements, :delivery_partners)
+    end
+
+    def new
+      @active_lead_provider = @contract_period.active_lead_providers.build
+      @available_lead_providers = available_lead_providers
+    end
+
+    def create
+      @active_lead_provider = @contract_period.active_lead_providers.build(active_lead_provider_params)
+
+      if @active_lead_provider.save
+        ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider: @active_lead_provider).call
+        flash[:notice] = "#{@active_lead_provider.lead_provider.name} added"
+        redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
+      else
+        @available_lead_providers = available_lead_providers
+        render :new, status: :unprocessable_entity
+      end
+    rescue ActiveLeadProviders::SeedFromPrevious::PreviousActiveLeadProviderError,
+           ActiveLeadProviders::SeedFromPrevious::AlreadyPopulatedError => e
+      flash[:error] = "Cannot seed: #{e.message}"
+      redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
+    end
+
+    def destroy
+      active_lead_provider = @contract_period.active_lead_providers.find(params[:id])
+      lead_provider_name = active_lead_provider.lead_provider.name
+      ActiveLeadProviders::CascadeDelete.new(active_lead_provider:).call
+      flash[:notice] = "#{lead_provider_name} removed"
+      redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
+    end
+
+  private
+
+    def set_contract_period
+      @contract_period = ContractPeriod.find(params[:contract_period_id])
+    end
+
+    def reject_if_contract_period_started
+      return if editable?
+
+      flash[:error] = "Active lead providers cannot be changed once the contract period has started"
+      redirect_to admin_contract_period_active_lead_providers_path(@contract_period)
+    end
+
+    def available_lead_providers
+      LeadProvider
+        .where.not(id: @contract_period.active_lead_providers.select(:lead_provider_id))
+        .alphabetical
+    end
+
+    def active_lead_provider_params
+      params.expect(active_lead_provider: [:lead_provider_id])
+    end
+
+    def editable?
+      !@contract_period.started_on_or_before_today?
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   EVENT_TYPES = %w[
+    active_lead_provider_created
     bulk_upload_completed
     bulk_upload_started
     delivery_partner_created

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   EVENT_TYPES = %w[
     active_lead_provider_created
+    active_lead_provider_deleted
     bulk_upload_completed
     bulk_upload_started
     delivery_partner_created

--- a/app/services/active_lead_providers/cascade_delete.rb
+++ b/app/services/active_lead_providers/cascade_delete.rb
@@ -1,9 +1,12 @@
 module ActiveLeadProviders
   class CascadeDelete
-    # Defensive nullification/deletion below assumes the active lead provider has
-    # not yet been used: active lead providers should not be deleted once their
-    # contract period has started. Without this defence the FK constraints would
-    # block deletion if any usage data ever existed.
+    # Active lead providers should only be deleted before their contract period
+    # has started, i.e. while still unused. If any usage data references this
+    # active lead provider we refuse to delete it and raise CascadeDeleteError for
+    # the controller to handle. The destruction below can then safely assume there
+    # is no usage data depending on the records it removes.
+
+    class CascadeDeleteError < StandardError; end
 
     attr_reader :active_lead_provider
 
@@ -12,21 +15,35 @@ module ActiveLeadProviders
     end
 
     def call
+      reject_if_in_use!
+
       ActiveRecord::Base.transaction do
         destroy_statements!
         destroy_contracts_and_fee_structures!
         destroy_lead_provider_delivery_partnerships!
-        nullify_expressions_of_interest!
         active_lead_provider.destroy!
       end
     end
 
   private
 
+    def reject_if_in_use!
+      raise CascadeDeleteError, "Declarations are present" if declarations.exists?
+      raise CascadeDeleteError, "Training periods are present" if training_periods.exists?
+      raise CascadeDeleteError, "Expressions of interest are present" if active_lead_provider.expressions_of_interest.exists?
+    end
+
+    def declarations
+      statement_ids = active_lead_provider.statements.ids
+      Declaration.where(payment_statement_id: statement_ids).or(Declaration.where(clawback_statement_id: statement_ids))
+    end
+
+    def training_periods
+      TrainingPeriod.where(school_partnership_id: active_lead_provider.school_partnerships.ids)
+    end
+
     def destroy_statements!
       statement_ids = active_lead_provider.statements.ids
-      Declaration.where(payment_statement_id: statement_ids).update_all(payment_statement_id: nil)
-      Declaration.where(clawback_statement_id: statement_ids).update_all(clawback_statement_id: nil)
       Statement::Adjustment.where(statement_id: statement_ids).delete_all
       Statement.where(id: statement_ids).destroy_all
     end
@@ -47,13 +64,8 @@ module ActiveLeadProviders
     def destroy_lead_provider_delivery_partnerships!
       lpdp_ids = active_lead_provider.lead_provider_delivery_partnerships.ids
       school_partnership_ids = SchoolPartnership.where(lead_provider_delivery_partnership_id: lpdp_ids).ids
-      TrainingPeriod.where(school_partnership_id: school_partnership_ids).update_all(school_partnership_id: nil)
       SchoolPartnership.where(id: school_partnership_ids).destroy_all
       LeadProviderDeliveryPartnership.where(id: lpdp_ids).destroy_all
-    end
-
-    def nullify_expressions_of_interest!
-      active_lead_provider.expressions_of_interest.update_all(expression_of_interest_id: nil)
     end
   end
 end

--- a/app/services/active_lead_providers/cascade_delete.rb
+++ b/app/services/active_lead_providers/cascade_delete.rb
@@ -1,0 +1,59 @@
+module ActiveLeadProviders
+  class CascadeDelete
+    # Defensive nullification/deletion below assumes the active lead provider has
+    # not yet been used: active lead providers should not be deleted once their
+    # contract period has started. Without this defence the FK constraints would
+    # block deletion if any usage data ever existed.
+
+    attr_reader :active_lead_provider
+
+    def initialize(active_lead_provider:)
+      @active_lead_provider = active_lead_provider
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        destroy_statements!
+        destroy_contracts_and_fee_structures!
+        destroy_lead_provider_delivery_partnerships!
+        nullify_expressions_of_interest!
+        active_lead_provider.destroy!
+      end
+    end
+
+  private
+
+    def destroy_statements!
+      statement_ids = active_lead_provider.statements.ids
+      Declaration.where(payment_statement_id: statement_ids).update_all(payment_statement_id: nil)
+      Declaration.where(clawback_statement_id: statement_ids).update_all(clawback_statement_id: nil)
+      Statement::Adjustment.where(statement_id: statement_ids).delete_all
+      Statement.where(id: statement_ids).destroy_all
+    end
+
+    def destroy_contracts_and_fee_structures!
+      # Contracts hold the FK to both fee structures, so the contract must be
+      # destroyed before the fee structures it references. Fee structures are not
+      # shared between contracts (uniqueness validation on Contract enforces this).
+      active_lead_provider.contracts.find_each do |contract|
+        flat_rate_fee_structure = contract.flat_rate_fee_structure
+        banded_fee_structure = contract.banded_fee_structure
+        contract.destroy!
+        flat_rate_fee_structure&.destroy!
+        banded_fee_structure&.destroy!
+      end
+    end
+
+    def destroy_lead_provider_delivery_partnerships!
+      lpdp_ids = active_lead_provider.lead_provider_delivery_partnerships.ids
+      school_partnership_ids = SchoolPartnership.where(lead_provider_delivery_partnership_id: lpdp_ids).ids
+      TrainingPeriod.where(school_partnership_id: school_partnership_ids).update_all(school_partnership_id: nil)
+      SchoolPartnership.where(id: school_partnership_ids).destroy_all
+      LeadProviderDeliveryPartnership.where(id: lpdp_ids).destroy_all
+    end
+
+    def nullify_expressions_of_interest!
+      active_lead_provider.expressions_of_interest.update_all(expression_of_interest_id: nil)
+    end
+  end
+end

--- a/app/services/active_lead_providers/cascade_delete.rb
+++ b/app/services/active_lead_providers/cascade_delete.rb
@@ -8,10 +8,13 @@ module ActiveLeadProviders
 
     class CascadeDeleteError < StandardError; end
 
-    attr_reader :active_lead_provider
+    attr_reader :active_lead_provider, :author
 
-    def initialize(active_lead_provider:)
+    delegate :lead_provider, :contract_period, to: :active_lead_provider
+
+    def initialize(active_lead_provider:, author:)
       @active_lead_provider = active_lead_provider
+      @author = author
     end
 
     def call
@@ -23,6 +26,8 @@ module ActiveLeadProviders
         destroy_lead_provider_delivery_partnerships!
         active_lead_provider.destroy!
       end
+
+      Events::Record.record_active_lead_provider_deleted_event!(author:, lead_provider:, contract_period:)
     end
 
   private

--- a/app/services/active_lead_providers/create.rb
+++ b/app/services/active_lead_providers/create.rb
@@ -5,7 +5,8 @@
 class ActiveLeadProviders::Create
   attr_reader :active_lead_provider
 
-  def initialize(contract_period:, lead_provider_id:)
+  def initialize(author:, contract_period:, lead_provider_id:)
+    @author = author
     @contract_period = contract_period
     @lead_provider_id = lead_provider_id
   end
@@ -13,12 +14,15 @@ class ActiveLeadProviders::Create
   def call
     @active_lead_provider = contract_period.active_lead_providers.build(lead_provider_id:)
 
-    ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:).call if active_lead_provider.save
+    if active_lead_provider.save
+      Events::Record.record_active_lead_provider_created_event!(author:, active_lead_provider:)
+      ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:).call
+    end
 
     active_lead_provider
   end
 
 private
 
-  attr_reader :contract_period, :lead_provider_id
+  attr_reader :author, :contract_period, :lead_provider_id
 end

--- a/app/services/active_lead_providers/create.rb
+++ b/app/services/active_lead_providers/create.rb
@@ -1,0 +1,24 @@
+# Builds an active lead provider for a contract period and, once saved, seeds it
+# from the previous contract period (see SeedFromPrevious). Returns the active
+# lead provider so callers can inspect validation errors when it isn't persisted;
+# SeedFromPrevious errors are allowed to propagate.
+class ActiveLeadProviders::Create
+  attr_reader :active_lead_provider
+
+  def initialize(contract_period:, lead_provider_id:)
+    @contract_period = contract_period
+    @lead_provider_id = lead_provider_id
+  end
+
+  def call
+    @active_lead_provider = contract_period.active_lead_providers.build(lead_provider_id:)
+
+    ActiveLeadProviders::SeedFromPrevious.new(active_lead_provider:).call if active_lead_provider.save
+
+    active_lead_provider
+  end
+
+private
+
+  attr_reader :contract_period, :lead_provider_id
+end

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -12,6 +12,7 @@ class ActiveLeadProviders::SeedFromPrevious
   attr_reader :active_lead_provider
 
   delegate :lead_provider, to: :active_lead_provider
+  delegate :name, to: :lead_provider, prefix: true
   delegate :contract_period, to: :active_lead_provider, prefix: :current
   delegate :lead_provider_delivery_partnerships, :contracts, :statements,
            to: :previous_activation, prefix: :previous
@@ -23,12 +24,12 @@ class ActiveLeadProviders::SeedFromPrevious
   end
 
   def call
-    raise PreviousActiveLeadProviderError, "no previous active_lead_provider found for #{active_lead_provider.id}" if previous_activation.blank?
+    raise PreviousActiveLeadProviderError, "No previous activation found in #{previous_contract_period.year} for #{lead_provider_name}" if previous_activation.blank?
     if previous_activation_empty?
       raise PreviousActiveLeadProviderError,
-            "active_lead_provider for #{active_lead_provider.id} is missing previous delivery partnerships, contracts or statements"
+            "Key info for #{lead_provider_name} is missing previous delivery partnerships, contracts or statements."
     end
-    raise AlreadyPopulatedError, "active_lead_provider #{active_lead_provider.id} already has data" if active_lead_provider_populated?
+    raise AlreadyPopulatedError, "#{lead_provider_name} already has data for #{current_contract_period.year}" if active_lead_provider_populated?
 
     # This is a large graph, so let's make all or nothing...
     ActiveRecord::Base.transaction do

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -920,6 +920,17 @@ module Events
       ).record_event!
     end
 
+    # Active Lead Provider Events
+
+    def self.record_active_lead_provider_created_event!(author:, active_lead_provider:, happened_at: Time.zone.now)
+      event_type = :active_lead_provider_created
+      lead_provider = active_lead_provider.lead_provider
+      contract_period = active_lead_provider.contract_period
+      heading = "#{lead_provider.name} added for #{contract_period.year}"
+
+      new(event_type:, author:, heading:, active_lead_provider:, lead_provider:, happened_at:).record_event!
+    end
+
     # Delivery Partner Events
 
     def self.record_delivery_partner_created_event!(author:, delivery_partner:, happened_at: Time.zone.now)

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -931,6 +931,15 @@ module Events
       new(event_type:, author:, heading:, active_lead_provider:, lead_provider:, happened_at:).record_event!
     end
 
+    # The active lead provider is destroyed before this fires, so we record the
+    # surviving lead provider rather than a relationship to the deleted record.
+    def self.record_active_lead_provider_deleted_event!(author:, lead_provider:, contract_period:, happened_at: Time.zone.now)
+      event_type = :active_lead_provider_deleted
+      heading = "#{lead_provider.name} removed for #{contract_period.year}"
+
+      new(event_type:, author:, heading:, lead_provider:, happened_at:).record_event!
+    end
+
     # Delivery Partner Events
 
     def self.record_delivery_partner_created_event!(author:, delivery_partner:, happened_at: Time.zone.now)

--- a/app/views/admin/finance/active_lead_providers/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/index.html.erb
@@ -28,15 +28,15 @@
           <% row.with_cell(text: alp.lead_provider.name) %>
           <% row.with_cell do %>
             <%# TODO: link to admin contracts page once it exists %>
-            <%= govuk_link_to(pluralize(alp.contracts.size, "contract"), "#") %>
+            <%= govuk_link_to(pluralize(alp.contracts.size, "contract"), "#", visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% row.with_cell do %>
             <%# TODO: link to admin statements page once it exists %>
-            <%= govuk_link_to(pluralize(alp.statements.size, "statement"), "#") %>
+            <%= govuk_link_to(pluralize(alp.statements.size, "statement"), "#", visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% row.with_cell do %>
             <%# TODO: link to admin delivery partners page once it exists %>
-            <%= govuk_link_to(pluralize(alp.delivery_partners.size, "delivery partner"), "#") %>
+            <%= govuk_link_to(pluralize(alp.delivery_partners.size, "delivery partner"), "#", visually_hidden_suffix: "for #{alp.lead_provider.name}") %>
           <% end %>
           <% if @editable %>
             <% row.with_cell do %>
@@ -44,6 +44,7 @@
                     admin_contract_period_active_lead_provider_path(@contract_period, alp),
                     method: :delete,
                     secondary: true,
+                    visually_hidden_suffix: alp.lead_provider.name,
                     class: "govuk-!-margin-bottom-0" %>
             <% end %>
           <% end %>

--- a/app/views/admin/finance/active_lead_providers/index.html.erb
+++ b/app/views/admin/finance/active_lead_providers/index.html.erb
@@ -1,0 +1,61 @@
+<% page_data(title: "Lead providers for #{@contract_period.year}", breadcrumbs: @breadcrumbs) %>
+
+<p class="govuk-body">
+  These lead providers are active for the <%= @contract_period.year %> contract period
+  (<%= @contract_period.started_on.to_fs(:govuk) %> to <%= @contract_period.finished_on.to_fs(:govuk) %>).
+</p>
+
+<% unless @editable %>
+  <p class="govuk-hint">This contract period has started, so active lead providers are no longer editable.</p>
+<% end %>
+
+<% if @active_lead_providers.none? %>
+  <p class='govuk-body'>No active lead providers for <%= @contract_period.year %></p>
+<% else %>
+  <%= govuk_table do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Lead provider") %>
+        <% row.with_cell(text: "Contracts") %>
+        <% row.with_cell(text: "Statements") %>
+        <% row.with_cell(text: "Delivery partners") %>
+        <% row.with_cell(text: "") if @editable %>
+      <% end %>
+    <% end %>
+    <% table.with_body do |body| %>
+      <% @active_lead_providers.each do |alp| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: alp.lead_provider.name) %>
+          <% row.with_cell do %>
+            <%# TODO: link to admin contracts page once it exists %>
+            <%= govuk_link_to(pluralize(alp.contracts.size, "contract"), "#") %>
+          <% end %>
+          <% row.with_cell do %>
+            <%# TODO: link to admin statements page once it exists %>
+            <%= govuk_link_to(pluralize(alp.statements.size, "statement"), "#") %>
+          <% end %>
+          <% row.with_cell do %>
+            <%# TODO: link to admin delivery partners page once it exists %>
+            <%= govuk_link_to(pluralize(alp.delivery_partners.size, "delivery partner"), "#") %>
+          <% end %>
+          <% if @editable %>
+            <% row.with_cell do %>
+              <%= govuk_button_to "Remove",
+                    admin_contract_period_active_lead_provider_path(@contract_period, alp),
+                    method: :delete,
+                    secondary: true,
+                    class: "govuk-!-margin-bottom-0" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% if @editable %>
+  <div class="govuk-!-text-align-right">
+    <%= govuk_button_link_to "Add a lead provider",
+          new_admin_contract_period_active_lead_provider_path(@contract_period) %>
+  </div>
+<% end %>

--- a/app/views/admin/finance/active_lead_providers/new.html.erb
+++ b/app/views/admin/finance/active_lead_providers/new.html.erb
@@ -1,0 +1,21 @@
+<% page_data(
+     title: "Add a lead provider for #{@contract_period.year}",
+     backlink_href: admin_contract_period_active_lead_providers_path(@contract_period),
+   ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @active_lead_provider, url: admin_contract_period_active_lead_providers_path(@contract_period)) do |f| %>
+      <%= content_for(:error_summary) { f.govuk_error_summary } %>
+
+      <%= f.govuk_collection_radio_buttons :lead_provider_id,
+            @available_lead_providers,
+            :id,
+            :name,
+            legend: { text: "Lead provider" },
+            hint: { text: "Only lead providers not active for #{@contract_period.year} are shown." } %>
+
+      <%= f.govuk_submit "Add lead provider" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/finance/contract_periods/show.html.erb
+++ b/app/views/admin/finance/contract_periods/show.html.erb
@@ -49,7 +49,7 @@
 <h2 class="govuk-heading-m">Set up</h2>
 
 <%= govuk_task_list do |list| %>
-  <% list.with_item(title: "Lead providers", href: (@editable ? "#" : nil)) do |item| %>
+  <% list.with_item(title: "Lead providers", href: admin_contract_period_active_lead_providers_path(@contract_period)) do |item| %>
     <% if @has_lead_providers %>
       <% item.with_status(text: "Completed") %>
     <% else %>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -110,6 +110,7 @@ namespace :admin do
         constraints -> { Rails.application.config.enable_finance_contract_periods } do
           resources :contract_periods, only: %i[index show], path: "contract-periods" do
             resources :schedules, only: %i[index], path: "schedules"
+            resources :active_lead_providers, only: %i[index new create destroy], path: "active-lead-providers"
           end
         end
       end

--- a/spec/requests/admin/finance/active_lead_providers_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers_spec.rb
@@ -1,0 +1,185 @@
+RSpec.describe "Admin active lead providers", type: :request do
+  let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+  let(:index_path) { admin_contract_period_active_lead_providers_path(contract_period) }
+  let(:started_error) { "Active lead providers cannot be changed once the contract period has started" }
+
+  describe "GET /admin/contract-periods/:contract_period_id/active-lead-providers" do
+    it "redirects to sign in path when not signed in" do
+      get index_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get index_path
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "displays the active lead providers index page" do
+        get index_path
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe "GET /admin/contract-periods/:contract_period_id/active-lead-providers/new" do
+    let(:new_path) { new_admin_contract_period_active_lead_provider_path(contract_period) }
+
+    it "redirects to sign in path when not signed in" do
+      get new_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        get new_path
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "displays the new active lead provider page" do
+        get new_path
+        expect(response.status).to eq(200)
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "redirects to the index with an alert" do
+          get new_path
+          expect(response).to redirect_to(index_path)
+          expect(flash[:error]).to eq(started_error)
+        end
+      end
+    end
+  end
+
+  describe "POST /admin/contract-periods/:contract_period_id/active-lead-providers" do
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:params) { { active_lead_provider: { lead_provider_id: lead_provider.id } } }
+
+    it "redirects to sign in path when not signed in" do
+      post(index_path, params:)
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        post(index_path, params:)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      let(:previous_contract_period) { FactoryBot.create(:contract_period, :current) }
+      let(:previous_activation) { FactoryBot.create(:active_lead_provider, contract_period: previous_contract_period, lead_provider:) }
+      let(:previous_contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: previous_activation) }
+      let!(:previous_delivery_partnerships) do
+        FactoryBot.create_list(:lead_provider_delivery_partnership, 2, active_lead_provider: previous_activation)
+      end
+
+      let!(:previous_statement) do
+        FactoryBot.create(:statement, :paid, active_lead_provider: previous_activation, contract: previous_contract, month: 11, year: previous_contract_period.year)
+      end
+
+      it "creates an active lead provider seeded from the previous period, and redirects to the index" do
+        expect { post index_path, params: }.to change(ActiveLeadProvider, :count).by(1)
+
+        active_lead_provider = ActiveLeadProvider.last
+        expect(active_lead_provider).to have_attributes(contract_period_year: contract_period.year, lead_provider_id: lead_provider.id)
+        expect(active_lead_provider.lead_provider_delivery_partnerships.map(&:delivery_partner))
+          .to match_array(previous_activation.lead_provider_delivery_partnerships.map(&:delivery_partner))
+        expect(active_lead_provider.contracts.size).to eq(1)
+        expect(active_lead_provider.contracts.first.statements.map { |s| [s.month, s.year] })
+          .to contain_exactly([11, contract_period.year])
+        expect(response).to redirect_to(admin_contract_period_active_lead_providers_path(contract_period))
+      end
+
+      context "when the lead provider is missing" do
+        let(:params) { { active_lead_provider: { lead_provider_id: "" } } }
+
+        it "does not create an active lead provider and re-renders new" do
+          expect { post index_path, params: }.not_to(change(ActiveLeadProvider, :count))
+
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "when the lead provider already has an active lead provider for the contract period" do
+        before { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
+
+        it "does not create a duplicate and re-renders new" do
+          expect { post index_path, params: }.not_to(change(ActiveLeadProvider, :count))
+
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "does not create an active lead provider and redirects to the index with an alert" do
+          expect { post index_path, params: }.not_to(change(ActiveLeadProvider, :count))
+
+          expect(response).to redirect_to(index_path)
+          expect(flash[:error]).to eq(started_error)
+        end
+      end
+    end
+  end
+
+  describe "DELETE /admin/contract-periods/:contract_period_id/active-lead-providers/:id" do
+    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+    let(:destroy_path) { admin_contract_period_active_lead_provider_path(contract_period, active_lead_provider) }
+
+    it "redirects to sign in path when not signed in" do
+      delete destroy_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    context "with an authenticated non-DfE user" do
+      include_context "sign in as non-DfE user"
+
+      it "requires authorisation" do
+        delete destroy_path
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when signed in as a finance DfE user" do
+      include_context "sign in as finance DfE user"
+
+      it "destroys the active lead provider and redirects to the index" do
+        expect { delete destroy_path }.to change(ActiveLeadProvider, :count).by(-1)
+
+        expect(response).to redirect_to(admin_contract_period_active_lead_providers_path(contract_period))
+      end
+
+      context "when the contract period has started" do
+        let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+        it "does not destroy the active lead provider and redirects to the index with an alert" do
+          expect { delete destroy_path }.not_to(change(ActiveLeadProvider, :count))
+
+          expect(response).to redirect_to(index_path)
+          expect(flash[:error]).to eq(started_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/admin/finance/active_lead_providers_spec.rb
+++ b/spec/requests/admin/finance/active_lead_providers_spec.rb
@@ -180,6 +180,17 @@ RSpec.describe "Admin active lead providers", type: :request do
           expect(flash[:error]).to eq(started_error)
         end
       end
+
+      context "when the active lead provider has data that cannot be deleted" do
+        before { FactoryBot.create(:training_period, :with_active_lead_provider, active_lead_provider:) }
+
+        it "does not destroy the active lead provider and redirects to the index with an alert" do
+          expect { delete destroy_path }.not_to(change(ActiveLeadProvider, :count))
+
+          expect(response).to redirect_to(index_path)
+          expect(flash[:error]).to eq("Cannot remove #{active_lead_provider.lead_provider.name}: Training periods are present")
+        end
+      end
     end
   end
 end

--- a/spec/services/active_lead_providers/cascade_delete_spec.rb
+++ b/spec/services/active_lead_providers/cascade_delete_spec.rb
@@ -1,5 +1,5 @@
 describe ActiveLeadProviders::CascadeDelete do
-  subject(:service) { described_class.new(active_lead_provider:) }
+  subject(:service) { described_class.new(active_lead_provider:, author:) }
 
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
   let!(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:) }
@@ -9,12 +9,18 @@ describe ActiveLeadProviders::CascadeDelete do
   let!(:lead_provider_delivery_partnership) do
     FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
   end
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
 
-  it "destroys the active lead provider with its contracts, fee structures, bands, statements, and partnerships, leaving delivery partners intact" do
+  before { allow(Events::Record).to receive(:record_active_lead_provider_deleted_event!) }
+
+  it "destroys the active lead provider with its contracts, fee structures, bands, statements, and partnerships, leaving delivery partners intact, and records the deleted event" do
     flat_rate_fee_structure_id = flat_rate_fee_structure.id
     banded_fee_structure_id = banded_fee_structure.id
     band_ids = banded_fee_structure.bands.pluck(:id)
     delivery_partner = lead_provider_delivery_partnership.delivery_partner
+    lead_provider = active_lead_provider.lead_provider
+    contract_period = active_lead_provider.contract_period
 
     service.call
 
@@ -26,6 +32,7 @@ describe ActiveLeadProviders::CascadeDelete do
     expect(Statement).not_to exist(statement.id)
     expect(LeadProviderDeliveryPartnership).not_to exist(lead_provider_delivery_partnership.id)
     expect(DeliveryPartner).to exist(delivery_partner.id)
+    expect(Events::Record).to have_received(:record_active_lead_provider_deleted_event!).with(author:, lead_provider:, contract_period:)
   end
 
   it "wraps the deletions in a transaction" do
@@ -36,6 +43,7 @@ describe ActiveLeadProviders::CascadeDelete do
     expect(Contract).to exist(contract.id)
     expect(Statement).to exist(statement.id)
     expect(LeadProviderDeliveryPartnership).to exist(lead_provider_delivery_partnership.id)
+    expect(Events::Record).not_to have_received(:record_active_lead_provider_deleted_event!)
   end
 
   describe "raising an exception when usage data is present" do

--- a/spec/services/active_lead_providers/cascade_delete_spec.rb
+++ b/spec/services/active_lead_providers/cascade_delete_spec.rb
@@ -37,4 +37,27 @@ describe ActiveLeadProviders::CascadeDelete do
     expect(Statement).to exist(statement.id)
     expect(LeadProviderDeliveryPartnership).to exist(lead_provider_delivery_partnership.id)
   end
+
+  describe "raising an exception when usage data is present" do
+    it "raises when a declaration references one of its statements, destroying nothing" do
+      FactoryBot.create(:declaration, active_lead_provider:, payment_statement: statement)
+
+      expect { service.call }.to raise_error(described_class::CascadeDeleteError, "Declarations are present")
+      expect(ActiveLeadProvider).to exist(active_lead_provider.id)
+    end
+
+    it "raises when a training period references one of its school partnerships, destroying nothing" do
+      FactoryBot.create(:training_period, :with_active_lead_provider, active_lead_provider:)
+
+      expect { service.call }.to raise_error(described_class::CascadeDeleteError, "Training periods are present")
+      expect(ActiveLeadProvider).to exist(active_lead_provider.id)
+    end
+
+    it "raises when an expression of interest references it, destroying nothing" do
+      FactoryBot.create(:training_period, :with_only_expression_of_interest, expression_of_interest: active_lead_provider)
+
+      expect { service.call }.to raise_error(described_class::CascadeDeleteError, "Expressions of interest are present")
+      expect(ActiveLeadProvider).to exist(active_lead_provider.id)
+    end
+  end
 end

--- a/spec/services/active_lead_providers/cascade_delete_spec.rb
+++ b/spec/services/active_lead_providers/cascade_delete_spec.rb
@@ -1,0 +1,40 @@
+describe ActiveLeadProviders::CascadeDelete do
+  subject(:service) { described_class.new(active_lead_provider:) }
+
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let!(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:) }
+  let(:flat_rate_fee_structure) { contract.flat_rate_fee_structure }
+  let(:banded_fee_structure) { contract.banded_fee_structure }
+  let!(:statement) { FactoryBot.create(:statement, contract:, active_lead_provider:) }
+  let!(:lead_provider_delivery_partnership) do
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
+  end
+
+  it "destroys the active lead provider with its contracts, fee structures, bands, statements, and partnerships, leaving delivery partners intact" do
+    flat_rate_fee_structure_id = flat_rate_fee_structure.id
+    banded_fee_structure_id = banded_fee_structure.id
+    band_ids = banded_fee_structure.bands.pluck(:id)
+    delivery_partner = lead_provider_delivery_partnership.delivery_partner
+
+    service.call
+
+    expect(ActiveLeadProvider).not_to exist(active_lead_provider.id)
+    expect(Contract).not_to exist(contract.id)
+    expect(Contract::FlatRateFeeStructure).not_to exist(flat_rate_fee_structure_id)
+    expect(Contract::BandedFeeStructure).not_to exist(banded_fee_structure_id)
+    expect(Contract::BandedFeeStructure::Band.where(id: band_ids)).not_to exist
+    expect(Statement).not_to exist(statement.id)
+    expect(LeadProviderDeliveryPartnership).not_to exist(lead_provider_delivery_partnership.id)
+    expect(DeliveryPartner).to exist(delivery_partner.id)
+  end
+
+  it "wraps the deletions in a transaction" do
+    allow(active_lead_provider).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+
+    expect { service.call }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    expect(ActiveLeadProvider).to exist(active_lead_provider.id)
+    expect(Contract).to exist(contract.id)
+    expect(Statement).to exist(statement.id)
+    expect(LeadProviderDeliveryPartnership).to exist(lead_provider_delivery_partnership.id)
+  end
+end

--- a/spec/services/active_lead_providers/create_spec.rb
+++ b/spec/services/active_lead_providers/create_spec.rb
@@ -1,0 +1,36 @@
+describe ActiveLeadProviders::Create do
+  subject(:service) { described_class.new(contract_period:, lead_provider_id:) }
+
+  let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:seed) { instance_double(ActiveLeadProviders::SeedFromPrevious, call: true) }
+
+  before { allow(ActiveLeadProviders::SeedFromPrevious).to receive(:new).and_return(seed) }
+
+  context "with a valid lead provider" do
+    let(:lead_provider_id) { lead_provider.id }
+
+    it "builds and saves the active lead provider, then seeds it from the previous period" do
+      result = nil
+      expect { result = service.call }.to change(ActiveLeadProvider, :count).by(1)
+
+      expect(result).to be_persisted
+      expect(result).to have_attributes(contract_period_year: contract_period.year, lead_provider_id: lead_provider.id)
+      expect(ActiveLeadProviders::SeedFromPrevious).to have_received(:new).with(active_lead_provider: result)
+      expect(seed).to have_received(:call)
+    end
+  end
+
+  context "with an invalid lead provider" do
+    let(:lead_provider_id) { nil }
+
+    it "does not save or seed, and returns the unpersisted record carrying its errors" do
+      result = nil
+      expect { result = service.call }.not_to change(ActiveLeadProvider, :count)
+
+      expect(result).not_to be_persisted
+      expect(result.errors[:lead_provider_id]).to include("Choose a lead provider")
+      expect(ActiveLeadProviders::SeedFromPrevious).not_to have_received(:new)
+    end
+  end
+end

--- a/spec/services/active_lead_providers/create_spec.rb
+++ b/spec/services/active_lead_providers/create_spec.rb
@@ -1,21 +1,27 @@
 describe ActiveLeadProviders::Create do
-  subject(:service) { described_class.new(contract_period:, lead_provider_id:) }
+  subject(:service) { described_class.new(author:, contract_period:, lead_provider_id:) }
 
   let(:contract_period) { FactoryBot.create(:contract_period, :next) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:user) { FactoryBot.create(:user, :admin) }
+  let(:author) { Sessions::Users::DfEPersona.new(email: user.email) }
   let(:seed) { instance_double(ActiveLeadProviders::SeedFromPrevious, call: true) }
 
-  before { allow(ActiveLeadProviders::SeedFromPrevious).to receive(:new).and_return(seed) }
+  before do
+    allow(ActiveLeadProviders::SeedFromPrevious).to receive(:new).and_return(seed)
+    allow(Events::Record).to receive(:record_active_lead_provider_created_event!)
+  end
 
   context "with a valid lead provider" do
     let(:lead_provider_id) { lead_provider.id }
 
-    it "builds and saves the active lead provider, then seeds it from the previous period" do
+    it "builds and saves the active lead provider, records the created event, then seeds it from the previous period" do
       result = nil
       expect { result = service.call }.to change(ActiveLeadProvider, :count).by(1)
 
       expect(result).to be_persisted
       expect(result).to have_attributes(contract_period_year: contract_period.year, lead_provider_id: lead_provider.id)
+      expect(Events::Record).to have_received(:record_active_lead_provider_created_event!).with(author:, active_lead_provider: result)
       expect(ActiveLeadProviders::SeedFromPrevious).to have_received(:new).with(active_lead_provider: result)
       expect(seed).to have_received(:call)
     end
@@ -24,12 +30,13 @@ describe ActiveLeadProviders::Create do
   context "with an invalid lead provider" do
     let(:lead_provider_id) { nil }
 
-    it "does not save or seed, and returns the unpersisted record carrying its errors" do
+    it "does not save, record an event, or seed, and returns the unpersisted record carrying its errors" do
       result = nil
       expect { result = service.call }.not_to change(ActiveLeadProvider, :count)
 
       expect(result).not_to be_persisted
       expect(result.errors[:lead_provider_id]).to include("Choose a lead provider")
+      expect(Events::Record).not_to have_received(:record_active_lead_provider_created_event!)
       expect(ActiveLeadProviders::SeedFromPrevious).not_to have_received(:new)
     end
   end

--- a/spec/services/active_lead_providers/seed_from_previous_spec.rb
+++ b/spec/services/active_lead_providers/seed_from_previous_spec.rb
@@ -107,19 +107,19 @@ RSpec.describe ActiveLeadProviders::SeedFromPrevious do
 
     it "raises an error" do
       expect { service.call }
-        .to raise_error(described_class::PreviousActiveLeadProviderError, /no previous active_lead_provider/)
+        .to raise_error(described_class::PreviousActiveLeadProviderError, /No previous activation found in 2025 for Teach First/)
     end
   end
 
   context "when the previous activation has no subordinate data" do
     it "raises an error" do
       expect { service.call }
-        .to raise_error(described_class::PreviousActiveLeadProviderError, /active_lead_provider for \d+ is missing previous delivery partnerships, contracts or statements/)
+        .to raise_error(described_class::PreviousActiveLeadProviderError, /Key info for Teach First is missing previous delivery partnerships, contracts or statements/)
     end
   end
 
   context "when the previous activation is only partially populated" do
-    let(:missing_data_error_message) { /active_lead_provider for \d+ is missing previous delivery partnerships, contracts or statements/ }
+    let(:missing_data_error_message) { /Key info for Teach First is missing previous delivery partnerships, contracts or statements/ }
 
     context "with delivery partnerships but no contracts or statements" do
       before { FactoryBot.create_list(:lead_provider_delivery_partnership, 3, active_lead_provider: teach_first_activation_2025) }
@@ -168,7 +168,7 @@ RSpec.describe ActiveLeadProviders::SeedFromPrevious do
 
     it "raises an error rather than duplicating data" do
       expect { service.call }
-        .to raise_error(described_class::AlreadyPopulatedError, /active_lead_provider \d+ already has data/)
+        .to raise_error(described_class::AlreadyPopulatedError, /Teach First already has data for 2026/)
     end
   end
 

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1814,6 +1814,25 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_active_lead_provider_deleted_event!" do
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        Events::Record.record_active_lead_provider_deleted_event!(author:, lead_provider:, contract_period:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          lead_provider:,
+          heading: "#{lead_provider.name} removed for #{contract_period.year}",
+          event_type: :active_lead_provider_deleted,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe "#record_teacher_schedule_assigned_to_training_period!" do
     include_context "safe_schedules"
 

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1793,6 +1793,27 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_active_lead_provider_created_event!" do
+    let(:lead_provider) { FactoryBot.create(:lead_provider) }
+    let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+    let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time do
+        Events::Record.record_active_lead_provider_created_event!(author:, active_lead_provider:)
+
+        expect(RecordEventJob).to have_received(:perform_later).with(
+          active_lead_provider:,
+          lead_provider:,
+          heading: "#{lead_provider.name} added for #{contract_period.year}",
+          event_type: :active_lead_provider_created,
+          happened_at: Time.zone.now,
+          **author_params
+        )
+      end
+    end
+  end
+
   describe "#record_teacher_schedule_assigned_to_training_period!" do
     include_context "safe_schedules"
 

--- a/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
+  let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+  let(:active_lead_providers) { FactoryBot.create_list(:active_lead_provider, 3, contract_period:) }
+  let(:add_button_text) { "Add a lead provider" }
+  let(:started_hint) { "This contract period has started, so active lead providers are no longer editable." }
+
+  before do
+    assign(:contract_period, contract_period)
+    assign(:active_lead_providers, active_lead_providers)
+    assign(:editable, !contract_period.started_on_or_before_today?)
+    assign(:breadcrumbs, {
+      "Finance" => admin_finance_path,
+      "Contract periods" => admin_contract_periods_path,
+      contract_period.year.to_s => admin_contract_period_path(contract_period),
+    })
+  end
+
+  it "renders the title, breadcrumbs, table, counts, delete and add buttons, and no started hint" do
+    render
+
+    expect(view.content_for(:page_title)).to eq("Lead providers for #{contract_period.year}")
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Finance", href: admin_finance_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Contract periods", href: admin_contract_periods_path)
+    expect(view.content_for(:backlink_or_breadcrumb)).to have_link(contract_period.year.to_s, href: admin_contract_period_path(contract_period))
+
+    expect(rendered).to have_css("p.govuk-body", normalize_ws: true, text: "These lead providers are active for the #{contract_period.year} contract period (#{contract_period.started_on.to_fs(:govuk)} to #{contract_period.finished_on.to_fs(:govuk)}).")
+
+    expect(rendered).to have_css(".govuk-table", count: 1)
+    expect(rendered).to have_css(".govuk-table__head th", text: "Lead provider")
+    expect(rendered).to have_css(".govuk-table__head th", text: "Contracts")
+    expect(rendered).to have_css(".govuk-table__head th", text: "Statements")
+    expect(rendered).to have_css(".govuk-table__head th", text: "Delivery partners")
+
+    expect(rendered).to have_css(".govuk-table__body > tr", count: 3)
+    active_lead_providers.each do |alp|
+      expect(rendered).to have_css("tr", text: alp.lead_provider.name)
+      expect(rendered).to have_css("tr", text: pluralize(alp.contracts.count, "contract"))
+      expect(rendered).to have_css("tr", text: pluralize(alp.statements.count, "statement"))
+      expect(rendered).to have_css("tr", text: pluralize(alp.delivery_partners.count, "delivery partner"))
+    end
+
+    expect(rendered).to have_css(".govuk-button--secondary", count: 3, text: "Remove")
+    active_lead_providers.each do |alp|
+      expect(rendered).to have_css(
+        "form[action='#{admin_contract_period_active_lead_provider_path(contract_period, alp)}']"
+      )
+    end
+
+    expect(rendered).to have_link(add_button_text, href: new_admin_contract_period_active_lead_provider_path(contract_period))
+
+    expect(rendered).not_to have_content(started_hint)
+  end
+
+  context "when the contract period has started" do
+    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+
+    it "shows the started hint, hides delete and add buttons, and still renders the counts as links" do
+      render
+
+      expect(rendered).to have_css(".govuk-hint", text: started_hint)
+
+      expect(rendered).not_to have_css(".govuk-button--secondary", text: "Remove")
+      expect(rendered).not_to have_link(add_button_text)
+
+      active_lead_providers.each do |alp|
+        expect(rendered).to have_link(pluralize(alp.contracts.count, "contract"))
+        expect(rendered).to have_link(pluralize(alp.statements.count, "statement"))
+        expect(rendered).to have_link(pluralize(alp.delivery_partners.count, "delivery partner"))
+      end
+    end
+  end
+
+  context "when there are no active lead providers" do
+    let(:active_lead_providers) { [] }
+
+    it "displays an empty state message" do
+      render
+
+      expect(rendered).to have_content("No active lead providers for #{contract_period.year}")
+    end
+  end
+end

--- a/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
+++ b/spec/views/admin/finance/active_lead_providers/index.html.erb_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
       expect(rendered).to have_css(
         "form[action='#{admin_contract_period_active_lead_provider_path(contract_period, alp)}']"
       )
+      expect(rendered).to have_button("Remove #{alp.lead_provider.name}")
     end
 
     expect(rendered).to have_link(add_button_text, href: new_admin_contract_period_active_lead_provider_path(contract_period))
@@ -63,9 +64,10 @@ RSpec.describe "admin/finance/active_lead_providers/index.html.erb" do
       expect(rendered).not_to have_link(add_button_text)
 
       active_lead_providers.each do |alp|
-        expect(rendered).to have_link(pluralize(alp.contracts.count, "contract"))
-        expect(rendered).to have_link(pluralize(alp.statements.count, "statement"))
-        expect(rendered).to have_link(pluralize(alp.delivery_partners.count, "delivery partner"))
+        name = alp.lead_provider.name
+        expect(rendered).to have_link("#{pluralize(alp.contracts.count, 'contract')} for #{name}")
+        expect(rendered).to have_link("#{pluralize(alp.statements.count, 'statement')} for #{name}")
+        expect(rendered).to have_link("#{pluralize(alp.delivery_partners.count, 'delivery partner')} for #{name}")
       end
     end
   end

--- a/spec/views/admin/finance/contract_periods/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/contract_periods/show.html.erb_spec.rb
@@ -121,12 +121,11 @@ RSpec.describe "admin/finance/contract_periods/show.html.erb" do
         FactoryBot.create(:active_lead_provider, contract_period:)
       end
 
-      it "shows the task as completed but not selectable" do
+      it "shows the task as completed and selectable" do
         render
 
-        expect(rendered).not_to have_link("Lead providers")
+        expect(rendered).to have_link("Lead providers")
         within(".govuk-task-list") do
-          expect(rendered).to have_content("Lead providers")
           expect(rendered).to have_content("Completed")
         end
       end


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3935
and resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3971

### Changes proposed in this pull request

#### Fully populated

<img width="1517" height="1047" alt="Screenshot 2026-05-20 at 11 38 42" src="https://github.com/user-attachments/assets/40b25105-2cbc-41ff-85f9-c8daefeb1315" />

Notes: 
* Use a secondary CTA to keep the page from being to "shouty".

**Note: The older images below are missing the index copy, e.g. These lead providers are active for the 2026 contract period (1 June 2026 to 31 May 2027).**



#### Blank slate

Given we have just created a Contract Period, when we navigate to the list of ActiveLeadProvider's, it will be empty.
Notes: 
* Right aligned CTA button.


<img width="1111" height="842" alt="Screenshot 2026-05-19 at 13 19 25" src="https://github.com/user-attachments/assets/0181b56e-d5be-4285-b454-3517f462e8de" />


#### Adding an activation

When we click the add button, we only need to select the Lead Provider we want to Activate.

Notes: 
* Since there is a single field, is there any value in the "Lead Provider" label?
* Radio buttons work better than the blank typeahead for the small number of Lead Providers available.


<img width="1118" height="1083" alt="Screenshot 2026-05-19 at 13 19 35" src="https://github.com/user-attachments/assets/824ab926-3522-477f-9e35-c9b79428f19a" />


#### Confirming addition

When we activate a Lead Provider, we call the SeedFromPrevious service to seed Contracts, Statements and Delivery Partners.

Notes: 
* We expect to have maybe 5 - 10 ActiveLeadProviders in the table. Having a column for Contracts, Statements and Delivery Partners limits the vertical sprawl.
* We provide a full text description rather than a number to provide a more affordant clickable area (i.e. "1 contract" as the link rather than "1").
* We use a secondary button for the _remove_ button as to be less "shouty" this really becomes apparent when there are a handful of rows.

<img width="1121" height="1102" alt="Screenshot 2026-05-19 at 13 19 42" src="https://github.com/user-attachments/assets/0d408bb6-c00c-4eca-aca3-dcf79a6a4f77" />



#### Multiple activations

This will be the standard state of the screen.

Notes: 
* As activations are added, the simple tabular structure allows us to see the activation we have just added without scrolling.
* We use a secondary button for the _remove_ button as to be less "shouty" this really becomes apparent when there are a handful of rows. (again)

<img width="1121" height="1108" alt="Screenshot 2026-05-19 at 13 19 59" src="https://github.com/user-attachments/assets/d908bef6-3cc7-4b72-95dd-3127fa219acb" />



#### Remove activation 

Removing an activation happens prior to the ContractPeriod.

Notes: 
* I think this is the correct confirmation style, the Contract Period hasn't started, so this isn't an OMG type action?

<img width="1122" height="1081" alt="Screenshot 2026-05-19 at 13 20 11" src="https://github.com/user-attachments/assets/0d6561b1-64f9-497a-bc09-2deac21a3e0a" />


#### Locked because ContractPeriod has started

After a Contract Period has started the page is no longer editable.

Notes: 
* Small `govuk-hint` text indicating why the ActiveLeadProvider list is not editable.

<img width="1122" height="1029" alt="Screenshot 2026-05-19 at 13 23 32" src="https://github.com/user-attachments/assets/0a5ffb7a-ce73-4ec4-a5d5-d0f0c12975b9" />


#### Issue with seeding

We allow the ActiveLeadProvider to be created, but show the error.

Notes: 
* Have changed the error wording in the **SeedFromPrevious** service to better suit being surfaced the UI - concretely we refer to the year and lead provider name rather than the object id.
* We don't get too excited about surfacing service error messages as this is for internal (admin) users.
 
<img width="1122" height="1094" alt="Screenshot 2026-05-19 at 16 18 01" src="https://github.com/user-attachments/assets/339e43ba-9f5c-4d04-83b2-44695d749f6b" />


### Guidance to review

This is pretty much a standard Rails controller with the following idiosyncrasies:
- Instead of relying on `dependent: :destroy` relationships to cascade deletes we use an explicit CascadeDelete service.
- We call a SeedFromPrevious service to "seed" after we create the ActiveLeadProvider activation. While the SeedFromPrevious creates subordinates in a transaction (so will rollback all if any fail), the ActiveLeadProvider is created outwith the transaction - so we can still have the ActiveLeadProvider; this is useful if we do not have a previous Activation from which to seed.
- In our index we include the subordinates to avoid an N+1 situation, for the number of activations we have this is potentially overkill.
- We add dead (`"#"`) links to the contracts, statements, and delivery partners (lead provider delivery partners) in lieu of those controllers.
- See additional notes associated with the UI screens.

#### Acceptance criteria

✅  We link to this step from the contract period page task list.
✅ We have a short description of what the form is for (ask for copy).
✅ When ActiveLeadProvider records exist for the contract period already we should add a heading, delete button (placeholder) and a task list for them as per the UI.
✅ We should NOT allow deleting active lead providers on contract periods that have started/are open, so disable the button (but we can still display the task list).
✅ We should display a list of lead providers that can be added to the contract period - this should only include lead providers not already added and those that were active in the previous contract period.
✅ On adding a new lead provider we should create the ActiveLeadProvider, run it through the service to generate the data for the contract period and refresh the page.
