### PR TITLE
Show teachers with future start dates in admin partnerships summary

### DIFF
--- a/app/components/admin/schools/partnerships_summary_component.rb
+++ b/app/components/admin/schools/partnerships_summary_component.rb
@@ -44,7 +44,7 @@ module Admin
 
       def teachers_for(training_periods, period_type)
         training_periods
-          .select { |period| period.started_on <= Time.zone.today && period.ongoing_today? }
+          .select(&:ongoing_today?)
           .filter_map { |period| period.public_send(period_type)&.teacher }
           .uniq
           .sort_by { |teacher| teacher_full_name(teacher) }

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -166,7 +166,6 @@ future_contract_period = ContractPeriod.for_registration_start_date(future_start
 ambition_artisan_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: ambition_institute)
 ambition_artisan_2023 = ActiveLeadProvider.find_by!(contract_period: cp_2023, lead_provider: ambition_institute)
 teach_first_grain_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: teach_first)
-teach_first_grain_2025 = ActiveLeadProvider.find_by!(contract_period: cp_2025, lead_provider: teach_first)
 
 teach_first_grain_future = ActiveLeadProvider.find_by!(
   contract_period: future_contract_period,

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -160,10 +160,18 @@ cp_2023 = ContractPeriod.find_by!(year: 2023)
 cp_2024 = ContractPeriod.find_by!(year: 2024)
 cp_2025 = ContractPeriod.find_by!(year: 2025)
 
+future_start_date = 2.weeks.from_now.to_date
+future_contract_period = ContractPeriod.for_registration_start_date(future_start_date)
+
 ambition_artisan_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: ambition_institute)
 ambition_artisan_2023 = ActiveLeadProvider.find_by!(contract_period: cp_2023, lead_provider: ambition_institute)
 teach_first_grain_2022 = ActiveLeadProvider.find_by!(contract_period: cp_2022, lead_provider: teach_first)
 teach_first_grain_2025 = ActiveLeadProvider.find_by!(contract_period: cp_2025, lead_provider: teach_first)
+
+teach_first_grain_future = ActiveLeadProvider.find_by!(
+  contract_period: future_contract_period,
+  lead_provider: teach_first
+)
 
 # Abbey Grove — Ambition / Artisan
 ambition_artisan_abbey_grove_2022 = find_or_create_school_partnership!(
@@ -201,6 +209,13 @@ teach_first_grain_abbey_grove_2025 = find_or_create_school_partnership!(
   lead_provider: teach_first,
   delivery_partner: grain_teaching_school_hub,
   contract_period: cp_2025
+)
+
+teach_first_grain_abbey_grove_future = find_or_create_school_partnership!(
+  school: abbey_grove_school,
+  lead_provider: teach_first,
+  delivery_partner: grain_teaching_school_hub,
+  contract_period: future_contract_period
 )
 
 # Ackley Bridge — Ambition / Artisan
@@ -847,13 +862,13 @@ FactoryBot.create(:training_period,
                   expression_of_interest: ambition_artisan_2023,
                   training_programme: "provider_led").tap { |tp| describe_training_period(tp) }
 
-print_seed_info("Peter Davison (ECT)", indent: 2, colour: ECT_COLOUR)
+print_seed_info("Peter Davison (ECT - future start date)", indent: 2, colour: ECT_COLOUR)
 
 peter_davison_at_abbey_grove_school = FactoryBot.create(:ect_at_school_period,
                                                         teacher: peter_davison,
                                                         school: abbey_grove_school,
                                                         email: "pd@tardis.bbc",
-                                                        started_on: 2.weeks.from_now,
+                                                        started_on: future_start_date,
                                                         finished_on: nil,
                                                         school_reported_appropriate_body: south_yorkshire_studio_hub).tap { |sp| describe_ect_at_school_period(sp) }
 
@@ -861,11 +876,31 @@ FactoryBot.create(:training_period,
                   :for_ect,
                   :with_schedule,
                   ect_at_school_period: peter_davison_at_abbey_grove_school,
-                  started_on: 2.weeks.from_now,
+                  started_on: future_start_date,
                   finished_on: nil,
-                  school_partnership: teach_first_grain_abbey_grove_2025,
+                  school_partnership: teach_first_grain_abbey_grove_future,
                   training_programme: "provider_led",
-                  expression_of_interest: teach_first_grain_2025).tap { |tp| describe_training_period(tp) }
+                  expression_of_interest: teach_first_grain_future).tap { |tp| describe_training_period(tp) }
+
+print_seed_info("Kenneth Williams (mentor - future start date)", indent: 2, colour: MENTOR_COLOUR)
+
+kenneth_williams = Teacher.find_by!(trn: "0000040")
+
+kenneth_williams_mentoring_at_abbey_grove = FactoryBot.create(:mentor_at_school_period,
+                                                              teacher: kenneth_williams,
+                                                              school: abbey_grove_school,
+                                                              email: "kenneth.williams@carry-on.com",
+                                                              started_on: future_start_date,
+                                                              finished_on: nil).tap { |sp| describe_mentor_at_school_period(sp) }
+
+FactoryBot.create(:training_period,
+                  :for_mentor,
+                  :with_schedule,
+                  mentor_at_school_period: kenneth_williams_mentoring_at_abbey_grove,
+                  started_on: future_start_date,
+                  finished_on: nil,
+                  school_partnership: teach_first_grain_abbey_grove_future,
+                  training_programme: "provider_led").tap { |tp| describe_training_period(tp) }
 
 print_seed_info("Naruto Uzumaki (ECT, invalid LP)", indent: 2, colour: ECT_COLOUR)
 

--- a/spec/components/admin/schools/partnerships_summary_component_spec.rb
+++ b/spec/components/admin/schools/partnerships_summary_component_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
 
       it "does not show ECTs with a future start date whose training period is unconfirmed" do
         unconfirmed_ect_period = FactoryBot.create(:ect_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil)
-        FactoryBot.create(:training_period, :for_ect, ect_at_school_period: unconfirmed_ect_period, school_partnership: nil)
+        FactoryBot.create(:training_period, :with_only_expression_of_interest, :for_ect, ect_at_school_period: unconfirmed_ect_period)
 
         unconfirmed_name = Teachers::Name.new(unconfirmed_ect_period.teacher).full_name
         expect(rendered).not_to have_link(unconfirmed_name, href: admin_teacher_path(unconfirmed_ect_period.teacher))

--- a/spec/components/admin/schools/partnerships_summary_component_spec.rb
+++ b/spec/components/admin/schools/partnerships_summary_component_spec.rb
@@ -90,6 +90,8 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
     let!(:ect_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
     let!(:mentor_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
     let!(:finished_ect_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: 2.years.ago, finished_on: 1.year.ago) }
+    let!(:finished_mentor_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: 2.years.ago, finished_on: 1.year.ago) }
+    let!(:future_ect_period) { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil) }
     let!(:future_mentor_period) { FactoryBot.create(:mentor_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil) }
 
     let!(:ect_training_period) do
@@ -112,6 +114,20 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
       FactoryBot.create(:training_period,
                         :for_ect,
                         ect_at_school_period: finished_ect_period,
+                        school_partnership: partnership_with_teachers)
+    end
+
+    let!(:finished_mentor_training_period) do
+      FactoryBot.create(:training_period,
+                        :for_mentor,
+                        mentor_at_school_period: finished_mentor_period,
+                        school_partnership: partnership_with_teachers)
+    end
+
+    let!(:future_ect_training_period) do
+      FactoryBot.create(:training_period,
+                        :for_ect,
+                        ect_at_school_period: future_ect_period,
                         school_partnership: partnership_with_teachers)
     end
 
@@ -150,12 +166,42 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
         expect(a_index).to be < z_index
       end
 
-      it "only shows current ECTs and mentors" do
+      it "does not show finished ECTs" do
         finished_name = Teachers::Name.new(finished_ect_period.teacher).full_name
-        future_name = Teachers::Name.new(future_mentor_period.teacher).full_name
-
         expect(rendered).not_to have_link(finished_name, href: admin_teacher_path(finished_ect_period.teacher))
-        expect(rendered).not_to have_link(future_name, href: admin_teacher_path(future_mentor_period.teacher))
+      end
+
+      it "does not show finished mentors" do
+        finished_name = Teachers::Name.new(finished_mentor_period.teacher).full_name
+        expect(rendered).not_to have_link(finished_name, href: admin_teacher_path(finished_mentor_period.teacher))
+      end
+
+      it "shows ongoing ECTs" do
+        ongoing_name = Teachers::Name.new(ect_period.teacher).full_name
+        expect(rendered).to have_link(ongoing_name, href: admin_teacher_path(ect_period.teacher))
+      end
+
+      it "shows ongoing mentors" do
+        ongoing_name = Teachers::Name.new(mentor_period.teacher).full_name
+        expect(rendered).to have_link(ongoing_name, href: admin_teacher_path(mentor_period.teacher))
+      end
+
+      it "shows ECTs with a future start date" do
+        future_ect_name = Teachers::Name.new(future_ect_period.teacher).full_name
+        expect(rendered).to have_link(future_ect_name, href: admin_teacher_path(future_ect_period.teacher))
+      end
+
+      it "shows mentors with a future start date" do
+        future_mentor_name = Teachers::Name.new(future_mentor_period.teacher).full_name
+        expect(rendered).to have_link(future_mentor_name, href: admin_teacher_path(future_mentor_period.teacher))
+      end
+
+      it "does not show ECTs with a future start date whose training period is unconfirmed" do
+        unconfirmed_ect_period = FactoryBot.create(:ect_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil)
+        FactoryBot.create(:training_period, :for_ect, ect_at_school_period: unconfirmed_ect_period, school_partnership: nil)
+
+        unconfirmed_name = Teachers::Name.new(unconfirmed_ect_period.teacher).full_name
+        expect(rendered).not_to have_link(unconfirmed_name, href: admin_teacher_path(unconfirmed_ect_period.teacher))
       end
 
       it "shows fallbacks when no teachers are linked" do

--- a/spec/components/admin/schools/partnerships_summary_component_spec.rb
+++ b/spec/components/admin/schools/partnerships_summary_component_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
         body = rendered.to_html
         newer = body.index("#{current_year} partnerships")
         older = body.index("#{previous_year} partnerships")
+
         expect(newer).not_to be_nil
         expect(older).not_to be_nil
         expect(newer).to be < older
@@ -138,15 +139,25 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
                         school_partnership: partnership_with_teachers)
     end
 
-    describe "teacher rows" do
-      it "lists linked ECTs with links" do
-        expect(rendered).to have_link(Teachers::Name.new(ect_period.teacher).full_name, href: admin_teacher_path(ect_period.teacher))
+    let(:alpha_partnership_card) do
+      rendered.css(".govuk-summary-card").find do |card|
+        card.text.include?("Alpha Provider and Delta Partner")
       end
+    end
 
-      it "lists linked mentors with links" do
-        expect(rendered).to have_link(Teachers::Name.new(mentor_period.teacher).full_name, href: admin_teacher_path(mentor_period.teacher))
+    let(:ect_row) do
+      alpha_partnership_card.css(".govuk-summary-list__row").find do |row|
+        row.css(".govuk-summary-list__key").text.include?("ECTs")
       end
+    end
 
+    let(:mentor_row) do
+      alpha_partnership_card.css(".govuk-summary-list__row").find do |row|
+        row.css(".govuk-summary-list__key").text.include?("Mentors")
+      end
+    end
+
+    describe "alphabetical ordering" do
       it "lists teachers alphabetically" do
         z_teacher = FactoryBot.create(:teacher, corrected_name: "Z Teacher")
         a_teacher = FactoryBot.create(:teacher, corrected_name: "A Teacher")
@@ -157,7 +168,7 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
         FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: z_period, school_partnership: partnership_with_teachers)
         FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: a_period, school_partnership: partnership_with_teachers)
 
-        body = rendered.to_html
+        body = mentor_row.to_html
         a_index = body.index("A Teacher")
         z_index = body.index("Z Teacher")
 
@@ -165,51 +176,66 @@ RSpec.describe Admin::Schools::PartnershipsSummaryComponent, type: :component do
         expect(z_index).not_to be_nil
         expect(a_index).to be < z_index
       end
+    end
 
-      it "does not show finished ECTs" do
-        finished_name = Teachers::Name.new(finished_ect_period.teacher).full_name
-        expect(rendered).not_to have_link(finished_name, href: admin_teacher_path(finished_ect_period.teacher))
-      end
-
-      it "does not show finished mentors" do
-        finished_name = Teachers::Name.new(finished_mentor_period.teacher).full_name
-        expect(rendered).not_to have_link(finished_name, href: admin_teacher_path(finished_mentor_period.teacher))
-      end
-
+    context "with ECTs linked to a partnership" do
       it "shows ongoing ECTs" do
         ongoing_name = Teachers::Name.new(ect_period.teacher).full_name
-        expect(rendered).to have_link(ongoing_name, href: admin_teacher_path(ect_period.teacher))
-      end
-
-      it "shows ongoing mentors" do
-        ongoing_name = Teachers::Name.new(mentor_period.teacher).full_name
-        expect(rendered).to have_link(ongoing_name, href: admin_teacher_path(mentor_period.teacher))
+        expect(ect_row).to have_link(ongoing_name, href: admin_teacher_path(ect_period.teacher))
       end
 
       it "shows ECTs with a future start date" do
         future_ect_name = Teachers::Name.new(future_ect_period.teacher).full_name
-        expect(rendered).to have_link(future_ect_name, href: admin_teacher_path(future_ect_period.teacher))
+        expect(ect_row).to have_link(future_ect_name, href: admin_teacher_path(future_ect_period.teacher))
+      end
+
+      it "does not show finished ECTs" do
+        finished_name = Teachers::Name.new(finished_ect_period.teacher).full_name
+        expect(ect_row).not_to have_link(finished_name, href: admin_teacher_path(finished_ect_period.teacher))
+      end
+
+      it "does not show ECTs whose training period is unconfirmed" do
+        unconfirmed_ect_period = FactoryBot.create(:ect_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil)
+
+        FactoryBot.create(:training_period,
+                          :with_only_expression_of_interest,
+                          :for_ect,
+                          ect_at_school_period: unconfirmed_ect_period)
+
+        unconfirmed_name = Teachers::Name.new(unconfirmed_ect_period.teacher).full_name
+
+        expect(ect_row).not_to have_link(
+          unconfirmed_name,
+          href: admin_teacher_path(unconfirmed_ect_period.teacher)
+        )
+      end
+    end
+
+    context "with mentors linked to a partnership" do
+      it "shows ongoing mentors" do
+        ongoing_name = Teachers::Name.new(mentor_period.teacher).full_name
+        expect(mentor_row).to have_link(ongoing_name, href: admin_teacher_path(mentor_period.teacher))
       end
 
       it "shows mentors with a future start date" do
         future_mentor_name = Teachers::Name.new(future_mentor_period.teacher).full_name
-        expect(rendered).to have_link(future_mentor_name, href: admin_teacher_path(future_mentor_period.teacher))
+        expect(mentor_row).to have_link(future_mentor_name, href: admin_teacher_path(future_mentor_period.teacher))
       end
 
-      it "does not show ECTs with a future start date whose training period is unconfirmed" do
-        unconfirmed_ect_period = FactoryBot.create(:ect_at_school_period, school:, started_on: 1.month.from_now, finished_on: nil)
-        FactoryBot.create(:training_period, :with_only_expression_of_interest, :for_ect, ect_at_school_period: unconfirmed_ect_period)
-
-        unconfirmed_name = Teachers::Name.new(unconfirmed_ect_period.teacher).full_name
-        expect(rendered).not_to have_link(unconfirmed_name, href: admin_teacher_path(unconfirmed_ect_period.teacher))
+      it "does not show finished mentors" do
+        finished_name = Teachers::Name.new(finished_mentor_period.teacher).full_name
+        expect(mentor_row).not_to have_link(finished_name, href: admin_teacher_path(finished_mentor_period.teacher))
       end
+    end
 
+    describe "fallback when no teachers are linked" do
       it "shows fallbacks when no teachers are linked" do
-        partnership_card = rendered.css(".govuk-summary-card").find do |card|
+        beta_partnership_card = rendered.css(".govuk-summary-card").find do |card|
           card.text.include?("Beta Provider and Gamma Partner")
         end
-        expect(partnership_card).to have_css(".govuk-summary-list__row", text: /ECTs.*None assigned/)
-        expect(partnership_card).to have_css(".govuk-summary-list__row", text: /Mentors.*None assigned/)
+
+        expect(beta_partnership_card).to have_css(".govuk-summary-list__row", text: /ECTs.*None assigned/)
+        expect(beta_partnership_card).to have_css(".govuk-summary-list__row", text: /Mentors.*None assigned/)
       end
     end
   end


### PR DESCRIPTION
### Context
The partnerships summary component was filtering training periods using started_on <= Time.zone.today, which excluded teachers registered with a future start date. This PR removes that guard so that current & future TPs are included. 

### Changes proposed in this pull request
- `PartnershipsSummaryComponent#teachers_for` —> remove started_on guard
- Specs —> added future-start ECT and mentor coverage & unconfirmed future-start coverage
- Seeds —> add Peter Davison (ECT) and Kenneth Williams (mentor) at Abbey Grove with future start dates via `future_contract_period`

### Guidance to review
1. Sign in as admin
2. Navigate to Abbey Grove (`/admin/schools/1759427/partnerships`)
3. Under **2026 partnerships** → Teach First and Grain Teaching School Hub, verify Peter Davison appears under ECTs and Kenneth Williams appears under Mentors
