### PR TITLE
Fix overlapping training periods

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -52,7 +52,9 @@ module Interval
   def period_dates_validation
     return if incomplete?
 
-    errors.add(:finished_on, "The end date must be later than the start date (#{started_on.to_fs(:govuk)})") if invalid_date_order?
+    if invalid_date_order?
+      errors.add(:finished_on, "The end date must be later than the start date (#{started_on.to_fs(:govuk)})")
+    end
   end
 
   def overlap_validation(name:)
@@ -82,7 +84,7 @@ module Interval
   def valid_date_order?
     return true if incomplete?
 
-    started_on < finished_on
+    started_on <= finished_on
   end
 
   def leaving_today_or_in_future?

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -80,6 +80,15 @@ class InductionPeriod < ApplicationRecord
 
 private
 
+  # Overriden from `app/models/concerns/interval.rb` since the range has not yet
+  # been migrated to inclusive ends.
+  # TODO: remove this override once the range is migrated.
+  def valid_date_order?
+    return true if incomplete?
+
+    started_on < finished_on
+  end
+
   # Ensure admin users inserting new induction periods include end dates.
   def end_date_admin_only
     return unless inserting_induction_period? && finished_on.blank?

--- a/db/migrate/20260519161732_change_period_length_check_constraints.rb
+++ b/db/migrate/20260519161732_change_period_length_check_constraints.rb
@@ -2,44 +2,44 @@ class ChangePeriodLengthCheckConstraints < ActiveRecord::Migration[8.1]
   def up
     # ECTAtSchoolPeriods
     remove_check_constraint :ect_at_school_periods, name: "period_length_greater_than_zero", if_exists: true
-    add_check_constraint :ect_at_school_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+    add_check_constraint :ect_at_school_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_not_exists: true, validate: true
 
     # MentorAtSchoolPeriods
     remove_check_constraint :mentor_at_school_periods, name: "period_length_greater_than_zero", if_exists: true
-    add_check_constraint :mentor_at_school_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+    add_check_constraint :mentor_at_school_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_not_exists: true, validate: true
 
     # TrainingPeriods
     remove_check_constraint :training_periods, name: "period_length_greater_than_zero", if_exists: true
-    add_check_constraint :training_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+    add_check_constraint :training_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_not_exists: true, validate: true
 
     # MentorshipPeriods
     remove_check_constraint :mentorship_periods, name: "period_length_greater_than_zero", if_exists: true
-    add_check_constraint :mentorship_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+    add_check_constraint :mentorship_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_not_exists: true, validate: true
 
     # ContractPeriods
     remove_check_constraint :contract_periods, name: "period_length_greater_than_zero", if_exists: true
-    add_check_constraint :contract_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+    add_check_constraint :contract_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_not_exists: true, validate: true
   end
 
   def down
     # ECTAtSchoolPeriods
     remove_check_constraint :ect_at_school_periods, name: "finished_on_not_before_started_on", if_exists: true
-    add_check_constraint :ect_at_school_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+    add_check_constraint :ect_at_school_periods, "finished_on > started_on", name: "period_length_greater_than_zero", if_not_exists: true, validate: true
 
     # MentorAtSchoolPeriods
     remove_check_constraint :mentor_at_school_periods, name: "finished_on_not_before_started_on", if_exists: true
-    add_check_constraint :mentor_at_school_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+    add_check_constraint :mentor_at_school_periods, "finished_on > started_on", name: "period_length_greater_than_zero", if_not_exists: true, validate: true
 
     # TrainingPeriods
     remove_check_constraint :training_periods, name: "finished_on_not_before_started_on", if_exists: true
-    add_check_constraint :training_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+    add_check_constraint :training_periods, "finished_on > started_on", name: "period_length_greater_than_zero", if_not_exists: true, validate: true
 
     # MentorshipPeriods
     remove_check_constraint :mentorship_periods, name: "finished_on_not_before_started_on", if_exists: true
-    add_check_constraint :mentorship_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+    add_check_constraint :mentorship_periods, "finished_on > started_on", name: "period_length_greater_than_zero", if_not_exists: true, validate: true
 
     # ContractPeriods
     remove_check_constraint :contract_periods, name: "finished_on_not_before_started_on", if_exists: true
-    add_check_constraint :contract_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+    add_check_constraint :contract_periods, "finished_on > started_on", name: "period_length_greater_than_zero", if_not_exists: true, validate: true
   end
 end

--- a/db/migrate/20260519161732_change_period_length_check_constraints.rb
+++ b/db/migrate/20260519161732_change_period_length_check_constraints.rb
@@ -1,0 +1,45 @@
+class ChangePeriodLengthCheckConstraints < ActiveRecord::Migration[8.1]
+  def up
+    # ECTAtSchoolPeriods
+    remove_check_constraint :ect_at_school_periods, name: "period_length_greater_than_zero", if_exists: true
+    add_check_constraint :ect_at_school_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+
+    # MentorAtSchoolPeriods
+    remove_check_constraint :mentor_at_school_periods, name: "period_length_greater_than_zero", if_exists: true
+    add_check_constraint :mentor_at_school_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+
+    # TrainingPeriods
+    remove_check_constraint :training_periods, name: "period_length_greater_than_zero", if_exists: true
+    add_check_constraint :training_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+
+    # MentorshipPeriods
+    remove_check_constraint :mentorship_periods, name: "period_length_greater_than_zero", if_exists: true
+    add_check_constraint :mentorship_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+
+    # ContractPeriods
+    remove_check_constraint :contract_periods, name: "period_length_greater_than_zero", if_exists: true
+    add_check_constraint :contract_periods, "finished_on >= started_on", name: "finished_on_not_before_started_on", if_exists: true, validate: true
+  end
+
+  def down
+    # ECTAtSchoolPeriods
+    remove_check_constraint :ect_at_school_periods, name: "finished_on_not_before_started_on", if_exists: true
+    add_check_constraint :ect_at_school_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+
+    # MentorAtSchoolPeriods
+    remove_check_constraint :mentor_at_school_periods, name: "finished_on_not_before_started_on", if_exists: true
+    add_check_constraint :mentor_at_school_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+
+    # TrainingPeriods
+    remove_check_constraint :training_periods, name: "finished_on_not_before_started_on", if_exists: true
+    add_check_constraint :training_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+
+    # MentorshipPeriods
+    remove_check_constraint :mentorship_periods, name: "finished_on_not_before_started_on", if_exists: true
+    add_check_constraint :mentorship_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+
+    # ContractPeriods
+    remove_check_constraint :contract_periods, name: "finished_on_not_before_started_on", if_exists: true
+    add_check_constraint :contract_periods, "finished_on >= started_on", name: "period_length_greater_than_zero", if_exists: true, validate: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_161732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -184,7 +184,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
     t.datetime "updated_at", null: false
     t.boolean "uplift_fees_enabled", default: true, null: false
     t.index ["year"], name: "index_contract_periods_on_year", unique: true
-    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
+    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
   end
 
   create_table "contracts", force: :cascade do |t|
@@ -281,7 +281,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
     t.index ["school_reported_appropriate_body_id"], name: "idx_on_school_reported_appropriate_body_id_01f5ffc90a"
     t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
-    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
+    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
   end
 
   create_table "events", force: :cascade do |t|
@@ -461,7 +461,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
     t.index ["teacher_id"], name: "index_mentor_at_school_periods_on_teacher_id"
-    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
+    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
   end
 
   create_table "mentorship_periods", force: :cascade do |t|
@@ -479,7 +479,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
     t.index ["mentor_at_school_period_id", "ect_at_school_period_id", "started_on"], name: "idx_on_mentor_at_school_period_id_ect_at_school_per_d69dffeecc", unique: true
     t.index ["mentor_at_school_period_id"], name: "index_mentorship_periods_on_mentor_at_school_period_id"
-    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
+    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
   end
 
   create_table "metadata_delivery_partners_lead_providers", force: :cascade do |t|
@@ -921,7 +921,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_105345) do
     t.index ["schedule_id"], name: "index_training_periods_on_schedule_id"
     t.index ["school_partnership_id", "ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "provider_partnership_trainings", unique: true
     t.index ["school_partnership_id"], name: "index_training_periods_on_school_partnership_id"
-    t.check_constraint "finished_on > started_on", name: "period_length_greater_than_zero"
+    t.check_constraint "finished_on >= started_on", name: "finished_on_not_before_started_on"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/scripts/fix_overlapping_training_periods.rb
+++ b/db/scripts/fix_overlapping_training_periods.rb
@@ -1,0 +1,45 @@
+# These records are now invalid since changing the inclusivity of
+# training period ranges
+#
+# Here, the query joins training periods to themselves using the teacher_id
+# and gets earlier/later pairs by joining one record's started_on to the other
+# record's finished_on
+#
+# Note, we're adding the 'type' field so we don't join ECT training periods to
+# mentor training periods
+#
+# For each one of the results we want to push the finshed_on date one day earlier
+
+query = <<~SQL
+  with
+    ect_data as (
+      select easp.teacher_id, 'ect' as type, tp.id, tp.started_on, tp.finished_on
+      from training_periods tp
+      inner join ect_at_school_periods easp on tp.ect_at_school_period_id = easp.id
+    ),
+    mentor_data as (
+      select masp.teacher_id, 'mentor' as type, tp.id, tp.started_on, tp.finished_on
+      from training_periods tp
+      inner join mentor_at_school_periods masp on tp.ect_at_school_period_id = masp.id
+    ),
+    all_data as (
+      select * from ect_data
+      union
+      select * from mentor_data
+    )
+  select earlier.id
+  from all_data earlier
+  inner join all_data later
+    on earlier.teacher_id = later.teacher_id
+    and earlier.finished_on = later.started_on
+    and earlier.type = later.type
+SQL
+
+result = ActiveRecord::Base.connection.execute(query)
+training_periods_to_adjust = result.field_values("id")
+
+TrainingPeriod.transaction do
+  TrainingPeriod.where(id: training_periods_to_adjust).find_each do |training_period|
+    training_period.update!(finished_on: training_period.finished_on.prev_day)
+  end
+end

--- a/db/scripts/fix_overlapping_training_periods.rb
+++ b/db/scripts/fix_overlapping_training_periods.rb
@@ -8,7 +8,7 @@
 # Note, we're adding the 'type' field so we don't join ECT training periods to
 # mentor training periods
 #
-# For each one of the results we want to push the finshed_on date one day earlier
+# For each one of the results we want to push the finished_on date one day earlier
 
 query = <<~SQL
   with
@@ -20,7 +20,7 @@ query = <<~SQL
     mentor_data as (
       select masp.teacher_id, 'mentor' as type, tp.id, tp.started_on, tp.finished_on
       from training_periods tp
-      inner join mentor_at_school_periods masp on tp.ect_at_school_period_id = masp.id
+      inner join mentor_at_school_periods masp on tp.mentor_at_school_period_id = masp.id
     ),
     all_data as (
       select * from ect_data

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -7,14 +7,27 @@ describe Interval do
 
   describe "validations" do
     context "period dates" do
+      subject { DummyMentor.new(started_on:, finished_on:) }
+
       context "when finished_on is earlier than started_on" do
-        subject { DummyMentor.new(started_on: Date.yesterday, finished_on: 2.days.ago) }
+        let(:started_on) { Date.current }
+        let(:finished_on) { Date.yesterday }
 
-        before { subject.valid? }
+        it { is_expected.to have_error(:finished_on, "The end date must be later than the start date (#{started_on.to_fs(:govuk)})") }
+      end
 
-        it "adds an error" do
-          expect(subject.errors.messages).to include(finished_on: ["The end date must be later than the start date (#{Date.yesterday.to_fs(:govuk)})"])
-        end
+      context "when finished_on is the same as started_on" do
+        let(:started_on) { Date.current }
+        let(:finished_on) { Date.current }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when finished_on is later than started_on" do
+        let(:started_on) { Date.current }
+        let(:finished_on) { Date.tomorrow }
+
+        it { is_expected.to be_valid }
       end
     end
 

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -148,10 +148,10 @@ describe ContractPeriod do
   end
 
   describe "check constraints" do
-    subject { FactoryBot.build(:contract_period, started_on: Date.current, finished_on: Date.current) }
+    subject { FactoryBot.build(:contract_period, started_on: Date.current, finished_on: Date.yesterday) }
 
-    it "prevents 0 day periods from being written to the database" do
-      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    it "prevents periods with a duration less than 1 day from being written to the database" do
+      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::DataException/)
     end
   end
 

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -403,13 +403,13 @@ describe ECTAtSchoolPeriod do
   end
 
   describe "check constraints" do
-    subject { FactoryBot.build(:ect_at_school_period, school:, teacher:, started_on: Date.current, finished_on: Date.current) }
+    subject { FactoryBot.build(:ect_at_school_period, school:, teacher:, started_on: Date.current, finished_on: Date.yesterday) }
 
     let(:school) { FactoryBot.create(:school) }
     let(:teacher) { FactoryBot.create(:teacher) }
 
-    it "prevents 0 day periods from being written to the database" do
-      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    it "prevents periods with a duration less than 1 day from being written to the database" do
+      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::DataException/)
     end
   end
 

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe InductionPeriod do
     end
 
     describe "check constraints" do
-      subject { FactoryBot.build(:induction_period, teacher:, appropriate_body_period:, started_on: Date.current, finished_on: Date.current) }
+      subject { FactoryBot.build(:induction_period, teacher:, appropriate_body_period:, started_on: Date.current, finished_on: Date.yesterday) }
 
       let(:teacher) { FactoryBot.create(:teacher) }
       let(:appropriate_body_period) { FactoryBot.create(:appropriate_body_period) }
 
-      it "prevents 0 day periods from being written to the database" do
-        expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+      it "prevents periods with a duration less than 1 day from being written to the database" do
+        expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::DataException/)
       end
     end
 

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -251,13 +251,13 @@ describe MentorAtSchoolPeriod do
   end
 
   describe "check constraints" do
-    subject { FactoryBot.build(:mentor_at_school_period, school:, teacher:, started_on: Date.current, finished_on: Date.current) }
+    subject { FactoryBot.build(:mentor_at_school_period, school:, teacher:, started_on: Date.current, finished_on: Date.yesterday) }
 
     let(:school) { FactoryBot.create(:school) }
     let(:teacher) { FactoryBot.create(:teacher) }
 
-    it "prevents 0 day periods from being written to the database" do
-      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    it "prevents periods with a duration less than 1 day from being written to the database" do
+      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::DataException/)
     end
   end
 

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -423,13 +423,13 @@ describe MentorshipPeriod do
   end
 
   describe "check constraints" do
-    subject { FactoryBot.build(:mentorship_period, mentee:, mentor:, started_on: Date.current, finished_on: Date.current) }
+    subject { FactoryBot.build(:mentorship_period, mentee:, mentor:, started_on: Date.current, finished_on: Date.yesterday) }
 
     let(:mentee) { FactoryBot.create(:ect_at_school_period) }
     let(:mentor) { FactoryBot.create(:mentor_at_school_period) }
 
-    it "prevents 0 day periods from being written to the database" do
-      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    it "prevents periods with a duration less than 1 day from being written to the database" do
+      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::DataException/)
     end
   end
 

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -851,12 +851,12 @@ describe TrainingPeriod do
   end
 
   describe "check constraints" do
-    subject { FactoryBot.build(:training_period, ect_at_school_period:, started_on: Date.current, finished_on: Date.current) }
+    subject { FactoryBot.build(:training_period, ect_at_school_period:, started_on: Date.current, finished_on: Date.yesterday) }
 
     let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period) }
 
-    it "prevents 0 day periods from being written to the database" do
-      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    it "prevents periods with a duration less than 1 day from being written to the database" do
+      expect { subject.save(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::DataException/)
     end
   end
 


### PR DESCRIPTION
Since changing the training period range inclusivity, these training periods are now invalid. They should finish the day before the next one starts, not on the same day.

This script nudges their `finished_on` back by one day.

As we're now allowing periods that start and finish on the same day, the validation has been updated to reflect that.