### PR TITLE
Schools can assign induction tutor details to the upcoming contract period

### DIFF
--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -34,12 +34,11 @@ class ContractPeriod < ApplicationRecord
   end
 
   def self.current = containing_date(Date.current)
+  def self.upcoming = closest_to(Date.current).starting_tomorrow_or_after.first
+  def self.current_or_upcoming = current.presence || upcoming
 
-  def self.upcoming
-    closest_to(Date.current)
-      .merge(current_or_future)
-      .excluding(current)
-      .first
+  def self.current_or_upcoming!
+    current_or_upcoming || raise(StandardError, "No current or upcoming contract period")
   end
 
   def self.earliest_permitted_start_date

--- a/app/models/contract_period.rb
+++ b/app/models/contract_period.rb
@@ -35,6 +35,13 @@ class ContractPeriod < ApplicationRecord
 
   def self.current = containing_date(Date.current)
 
+  def self.upcoming
+    closest_to(Date.current)
+      .merge(current_or_future)
+      .excluding(current)
+      .first
+  end
+
   def self.earliest_permitted_start_date
     return unless current
 

--- a/app/services/schools/induction_tutor_details.rb
+++ b/app/services/schools/induction_tutor_details.rb
@@ -1,6 +1,7 @@
 module Schools
   class InductionTutorDetails
     include Rails.application.routes.url_helpers
+
     attr_reader :user
 
     def initialize(user)
@@ -11,8 +12,9 @@ module Schools
       return unless user&.school_user?
       return if user.dfe_user_impersonating_school_user?
       return unless school
+      return unless closest_contract_period
 
-      last_updated_year.blank? || last_updated_year < ContractPeriod.current.year
+      last_updated_year.blank? || last_updated_year < closest_contract_period.year
     end
 
     def wizard_path
@@ -25,12 +27,11 @@ module Schools
 
   private
 
-    def school
-      @school ||= @user&.school
-    end
+    def school = @school ||= @user&.school
+    def last_updated_year = school.induction_tutor_last_nominated_in&.year
 
-    def last_updated_year
-      school.induction_tutor_last_nominated_in&.year
+    def closest_contract_period
+      @closest_contract_period ||= ContractPeriod.current_or_upcoming
     end
   end
 end

--- a/app/wizards/schools/induction_tutor/check_answers_step.rb
+++ b/app/wizards/schools/induction_tutor/check_answers_step.rb
@@ -12,7 +12,7 @@ module Schools
           school.update!(
             induction_tutor_name: store.induction_tutor_name,
             induction_tutor_email: store.induction_tutor_email,
-            induction_tutor_last_nominated_in: current_contract_period
+            induction_tutor_last_nominated_in: closest_contract_period
           )
           true
         end
@@ -35,7 +35,7 @@ module Schools
           old_name: school.induction_tutor_name,
           new_name: store.induction_tutor_name,
           new_email: store.induction_tutor_email,
-          contract_period_year: current_contract_period.year,
+          contract_period_year: closest_contract_period.year,
           author:
         )
       end

--- a/app/wizards/schools/induction_tutor/confirm_existing_induction_tutor_wizard/edit_step.rb
+++ b/app/wizards/schools/induction_tutor/confirm_existing_induction_tutor_wizard/edit_step.rb
@@ -2,8 +2,6 @@ module Schools
   module InductionTutor
     module ConfirmExistingInductionTutorWizard
       class EditStep < InductionTutor::Step
-        delegate :school, :author, :valid_step?, :current_contract_period, to: :wizard
-
         attribute :are_these_details_correct, :boolean
         attribute :induction_tutor_name, :string
         attribute :induction_tutor_email, :string
@@ -42,7 +40,7 @@ module Schools
             store.are_these_details_correct = are_these_details_correct
 
             ActiveRecord::Base.transaction do
-              school.update!(induction_tutor_last_nominated_in: current_contract_period)
+              school.update!(induction_tutor_last_nominated_in: closest_contract_period)
 
               record_confirmation_event!
             end
@@ -72,7 +70,7 @@ module Schools
             school:,
             name: school.induction_tutor_name,
             email: school.induction_tutor_email,
-            contract_period_year: current_contract_period.year,
+            contract_period_year: closest_contract_period.year,
             author:
           )
         end

--- a/app/wizards/schools/induction_tutor/edit_step.rb
+++ b/app/wizards/schools/induction_tutor/edit_step.rb
@@ -1,8 +1,6 @@
 module Schools
   module InductionTutor
     class EditStep < InductionTutor::Step
-      delegate :school, :author, :valid_step?, :current_contract_period, to: :wizard
-
       attribute :induction_tutor_name, :string
       attribute :induction_tutor_email, :string
 

--- a/app/wizards/schools/induction_tutor/step.rb
+++ b/app/wizards/schools/induction_tutor/step.rb
@@ -1,7 +1,7 @@
 module Schools
   module InductionTutor
     class Step < ApplicationWizardStep
-      delegate :school, :author, :valid_step?, :current_contract_period, to: :wizard
+      delegate :school, :author, :valid_step?, :closest_contract_period, to: :wizard
 
       def self.permitted_params = []
 

--- a/app/wizards/schools/induction_tutor/wizard.rb
+++ b/app/wizards/schools/induction_tutor/wizard.rb
@@ -16,9 +16,7 @@ module Schools
         @school ||= School.find(school_id)
       end
 
-      def current_contract_period
-        ContractPeriod.current
-      end
+      def closest_contract_period = ContractPeriod.current_or_upcoming!
 
       def send_confirmation_email?
         raise NotImplementedError, "#{self.class} must implement #send_confirmation_email?"

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -94,6 +94,57 @@ describe ContractPeriod do
     end
   end
 
+  describe ".upcoming" do
+    subject(:upcoming) { described_class.upcoming }
+
+    context "when there are no contract periods" do
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is only an upcoming contract period" do
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      it { is_expected.to eq(upcoming_contract_period) }
+    end
+
+    context "when there is only a current contract period" do
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there are current and upcoming contract periods" do
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      it { is_expected.to eq(upcoming_contract_period) }
+    end
+
+    context "when there is a closer previous contract period" do
+      let!(:previous_contract_period) do
+        FactoryBot.create(:contract_period, :previous)
+      end
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      before { travel_to current_contract_period.started_on }
+
+      it { is_expected.to eq(upcoming_contract_period) }
+    end
+  end
+
   describe ".earliest_permitted_start_date" do
     context "when there are contract periods" do
       let!(:oldest) do

--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -145,6 +145,79 @@ describe ContractPeriod do
     end
   end
 
+  describe ".current_or_upcoming" do
+    subject(:current_or_upcoming) { described_class.current_or_upcoming }
+
+    context "when there are no contract periods" do
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is only an upcoming contract period" do
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      it { is_expected.to eq(upcoming_contract_period) }
+    end
+
+    context "when there is only a current contract period" do
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+
+      it { is_expected.to eq(current_contract_period) }
+    end
+
+    context "when there are current and upcoming contract periods" do
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      it { is_expected.to eq(current_contract_period) }
+    end
+  end
+
+  describe ".current_or_upcoming!" do
+    subject(:current_or_upcoming) { ContractPeriod.current_or_upcoming! }
+
+    context "when there are no contract periods" do
+      it "raises an error" do
+        expect { current_or_upcoming }.to raise_error("No current or upcoming contract period")
+      end
+    end
+
+    context "when there is only an upcoming contract period" do
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      it { is_expected.to eq(upcoming_contract_period) }
+    end
+
+    context "when there is only a current contract period" do
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+
+      it { is_expected.to eq(current_contract_period) }
+    end
+
+    context "when there are current and upcoming contract periods" do
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current)
+      end
+
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(:contract_period, :next)
+      end
+
+      it { is_expected.to eq(current_contract_period) }
+    end
+  end
+
   describe ".earliest_permitted_start_date" do
     context "when there are contract periods" do
       let!(:oldest) do

--- a/spec/services/schools/induction_tutor_details_spec.rb
+++ b/spec/services/schools/induction_tutor_details_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Schools::InductionTutorDetails do
-  subject(:service) do
-    described_class.new(user)
-  end
+  subject(:service) { described_class.new(user) }
 
   let(:school) { FactoryBot.create(:school) }
   let(:user) { FactoryBot.create(:school_user, school_urn: school.urn) }
@@ -10,17 +8,13 @@ RSpec.describe Schools::InductionTutorDetails do
     context "when there is no user" do
       let(:user) { nil }
 
-      it "returns false" do
-        expect(service).not_to be_update_required
-      end
+      it { is_expected.not_to be_update_required }
     end
 
     context "when the user is not a school user" do
       let(:user) { FactoryBot.create(:dfe_user) }
 
-      it "returns false" do
-        expect(service).not_to be_update_required
-      end
+      it { is_expected.not_to be_update_required }
     end
 
     context "when the user is a school user impersonated by a DfE user" do
@@ -30,65 +24,62 @@ RSpec.describe Schools::InductionTutorDetails do
         FactoryBot.build(:dfe_user_impersonating_school_user, email: school_user.email, school_urn: school.urn)
       end
 
-      it "returns false" do
-        expect(service).not_to be_update_required
-      end
+      it { is_expected.not_to be_update_required }
+    end
+
+    context "when there is no current or upcoming contract period" do
+      it { is_expected.not_to be_update_required }
     end
 
     context "when the induction tutor details are not set for the school" do
+      let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
       let(:school) { FactoryBot.create(:school, :without_induction_tutor) }
 
-      it "returns true" do
-        expect(service).to be_update_required
-      end
+      it { is_expected.to be_update_required }
     end
 
     context "when the induction tutor details have never been confirmed" do
+      let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
       let(:school) { FactoryBot.create(:school, :with_unconfirmed_induction_tutor) }
 
-      it "returns true" do
-        expect(service).to be_update_required
-      end
+      it { is_expected.to be_update_required }
     end
 
     context "when the induction tutor details were last confirmed before the current contract year" do
-      before do
-        FactoryBot.create(:contract_period, :current)
-        previous_contract_period = FactoryBot.create(:contract_period, :previous)
-
-        school.update!(induction_tutor_last_nominated_in: previous_contract_period,
-                       induction_tutor_name: "Alastair Sim",
-                       induction_tutor_email: "alastair.sim@st-trinians.org.uk")
+      let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
+      let!(:previous_contract_period) { FactoryBot.create(:contract_period, :previous) }
+      let(:school) do
+        FactoryBot.create(
+          :school,
+          :with_induction_tutor,
+          induction_tutor_last_nominated_in: previous_contract_period
+        )
       end
 
-      it "returns true" do
-        expect(service).to be_update_required
-      end
+      it { is_expected.to be_update_required }
     end
 
     context "when the induction tutor details were last confirmed in the current contract year" do
-      before do
-        current_contract_period = FactoryBot.create(:contract_period, :current)
-        school.update!(induction_tutor_last_nominated_in: current_contract_period,
-                       induction_tutor_name: "Alastair Sim",
-                       induction_tutor_email: "alastair.sim@st-trinians.org.uk")
+      let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
+      let(:school) do
+        FactoryBot.create(
+          :school,
+          :with_induction_tutor,
+          induction_tutor_last_nominated_in: current_contract_period
+        )
       end
 
-      it "returns false" do
-        expect(service).not_to be_update_required
-      end
+      it { is_expected.not_to be_update_required }
     end
 
     context "when it is the last day of the current contract period" do
-      let(:school) { FactoryBot.create(:school, :with_unconfirmed_induction_tutor) }
-      let(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
-
-      before do
-        previous_contract_period = FactoryBot.create(:contract_period, :previous)
-
-        school.update!(induction_tutor_last_nominated_in: previous_contract_period,
-                       induction_tutor_name: "Alastair Sim",
-                       induction_tutor_email: "alastair.sim@st-trinians.org.uk")
+      let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
+      let(:school) do
+        FactoryBot.create(
+          :school,
+          :with_induction_tutor,
+          induction_tutor_last_nominated_in: current_contract_period
+        )
       end
 
       around do |example|
@@ -97,27 +88,66 @@ RSpec.describe Schools::InductionTutorDetails do
         end
       end
 
-      it "returns true" do
-        expect(service).to be_update_required
+      it { is_expected.not_to be_update_required }
+    end
+
+    context "when the current contract period has finished but the upcoming contract period has not started" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 2.months.ago,
+          finished_on: Date.yesterday
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: Date.tomorrow,
+          finished_on: 2.months.from_now
+        )
+      end
+
+      context "and the induction tutor details were last confirmed in the current contract period year" do
+        let(:school) do
+          FactoryBot.create(
+            :school,
+            :with_induction_tutor,
+            induction_tutor_last_nominated_in: current_contract_period
+          )
+        end
+
+        it { is_expected.to be_update_required }
+      end
+
+      context "and the induction tutor details were last confirmed in the upcoming contract period year" do
+        let(:school) do
+          FactoryBot.create(
+            :school,
+            :with_induction_tutor,
+            induction_tutor_last_nominated_in: upcoming_contract_period
+          )
+        end
+
+        it { is_expected.not_to be_update_required }
       end
     end
   end
 
   describe "#wizard_path" do
+    subject(:wizard_path) { service.wizard_path }
+
     context "when the school has an unconfirmed induction tutor" do
       let(:school) { FactoryBot.create(:school, :with_unconfirmed_induction_tutor) }
 
-      it "returns the confirm existing induction tutor wizard path" do
-        expect(service.wizard_path).to eq("/school/induction-tutor/confirm-existing-induction-tutor/edit")
-      end
+      it { is_expected.to eq("/school/induction-tutor/confirm-existing-induction-tutor/edit") }
     end
 
     context "when the school does not have an induction tutor nominted" do
       let(:school) { FactoryBot.create(:school, :without_induction_tutor) }
 
-      it "returns the new induction tutor wizard path" do
-        expect(service.wizard_path).to eq("/school/induction-tutor/new-induction-tutor/edit")
-      end
+      it { is_expected.to eq("/school/induction-tutor/new-induction-tutor/edit") }
     end
   end
 end

--- a/spec/support/shared_examples/induction_redirect.rb
+++ b/spec/support/shared_examples/induction_redirect.rb
@@ -1,200 +1,44 @@
 RSpec.shared_examples "an induction redirectable route" do
   context "induction redirection" do
-    let!(:current_contract_period) do
-      FactoryBot.create(:contract_period, :current)
-    end
-    let(:year_induction_tutor_nominated_in) { current_contract_period.year }
+    let(:school) { FactoryBot.create(:school) }
+    let(:wizard_path) { "/some-path" }
 
-    let!(:school) do
-      FactoryBot.create(:school, :without_induction_tutor,
-                        induction_tutor_last_nominated_in:,
-                        induction_tutor_name:,
-                        induction_tutor_email:)
-    end
-    let!(:induction_tutor_last_nominated_in) do
-      FactoryBot.create(:contract_period, year: year_induction_tutor_nominated_in)
-    end
-    let(:induction_tutor_name) { Faker::Name.name }
-    let(:induction_tutor_email) { Faker::Internet.email }
-
-    context "when signed in as a school user" do
-      before { sign_in_as(:school_user, school:) }
-
-      context "when the school's induction tutor has never been confirmed" do
-        let(:induction_tutor_last_nominated_in) { nil }
-
-        it_behaves_like "redirects to confirmation wizard"
-      end
-
-      context "when the school's induction tutor is not set" do
-        let(:induction_tutor_last_nominated_in) { nil }
-        let(:induction_tutor_name) { nil }
-        let(:induction_tutor_email) { nil }
-
-        it_behaves_like "redirects to new wizard"
-      end
-
-      context "when the school's induction tutor needs to update information" do
-        let(:year_induction_tutor_nominated_in) do
-          current_contract_period.year - 1
-        end
-
-        context "when we are in the current contract period" do
-          it_behaves_like "redirects to confirmation wizard"
-        end
-
-        context "when we are between contract periods" do
-          let!(:current_contract_period) do
-            FactoryBot.create(:contract_period, :current)
-          end
-          let!(:upcoming_contract_period) do
-            FactoryBot.create(
-              :contract_period,
-              :next,
-              started_on: current_contract_period.finished_on + 1.week,
-              finished_on: current_contract_period.finished_on + 1.year
-            )
-          end
-
-          before do
-            travel_to current_contract_period.finished_on + 1.day
-            # We need to sign in again after time travel
-            sign_in_as(:school_user, school:)
-          end
-
-          it_behaves_like "redirects to confirmation wizard"
-        end
-      end
-
-      context "when the school's induction tutor does not need to update information" do
-        it_behaves_like "does not redirect to wizard"
-      end
+    before do
+      induction_tutor_details = instance_double(
+        Schools::InductionTutorDetails,
+        update_required?: induction_tutor_details_need_updating,
+        wizard_path:
+      )
+      allow(Schools::InductionTutorDetails)
+        .to receive(:new)
+        .and_return(induction_tutor_details)
+      sign_in_as(:school_user, school:)
     end
 
-    context "when signed in as a dfe user" do
-      let(:user) { FactoryBot.create(:user, :admin) }
+    context "when the induction tutor details need updating" do
+      let(:induction_tutor_details_need_updating) { true }
 
-      before { sign_in_as(:dfe_user, user:) }
-
-      context "when the school's induction tutor has never been confirmed" do
-        let(:induction_tutor_last_nominated_in) { nil }
-
-        it_behaves_like "does not redirect to wizard"
-      end
-
-      context "when the school's induction tutor is not set" do
-        let(:induction_tutor_last_nominated_in) { nil }
-        let(:induction_tutor_name) { nil }
-        let(:induction_tutor_email) { nil }
-
-        it_behaves_like "does not redirect to wizard"
-      end
-
-      context "when the school's induction tutor needs to update information" do
-        let(:year_induction_tutor_nominated_in) do
-          current_contract_period.year - 1
-        end
-
-        context "when we are in the current contract period" do
-          it_behaves_like "does not redirect to wizard"
-        end
-
-        context "when we are between contract periods" do
-          let!(:current_contract_period) do
-            FactoryBot.create(:contract_period, :current)
-          end
-          let!(:upcoming_contract_period) do
-            FactoryBot.create(
-              :contract_period,
-              :next,
-              started_on: current_contract_period.finished_on + 1.week,
-              finished_on: current_contract_period.finished_on + 1.year
-            )
-          end
-
-          before do
-            travel_to current_contract_period.finished_on + 1.day
-            # We need to sign in again after time travel
-            sign_in_as(:dfe_user, user:)
-          end
-
-          it_behaves_like "does not redirect to wizard"
-        end
-      end
+      it_behaves_like "redirects to the wizard path"
     end
 
-    context "when signed in as an appropriate body" do
-      let(:appropriate_body) { FactoryBot.create(:appropriate_body_period) }
+    context "when the induction tutor details are up to date" do
+      let(:induction_tutor_details_need_updating) { false }
 
-      before { sign_in_as(:appropriate_body_user, appropriate_body:) }
-
-      context "when the school's induction tutor has never been confirmed" do
-        let(:induction_tutor_last_nominated_in) { nil }
-
-        it_behaves_like "does not redirect to wizard"
-      end
-
-      context "when the school's induction tutor is not set" do
-        let(:induction_tutor_last_nominated_in) { nil }
-        let(:induction_tutor_name) { nil }
-        let(:induction_tutor_email) { nil }
-
-        it_behaves_like "does not redirect to wizard"
-      end
-
-      context "when the school's induction tutor needs to update information" do
-        let(:year_induction_tutor_nominated_in) do
-          current_contract_period.year - 1
-        end
-
-        context "when we are in the current contract period" do
-          it_behaves_like "does not redirect to wizard"
-        end
-
-        context "when we are between contract periods" do
-          let!(:current_contract_period) do
-            FactoryBot.create(:contract_period, :current)
-          end
-          let!(:upcoming_contract_period) do
-            FactoryBot.create(
-              :contract_period,
-              :next,
-              started_on: current_contract_period.finished_on + 1.week,
-              finished_on: current_contract_period.finished_on + 1.year
-            )
-          end
-
-          before do
-            travel_to current_contract_period.finished_on + 1.day
-            # We need to sign in again after time travel
-            sign_in_as(:appropriate_body_user, appropriate_body:)
-          end
-
-          it_behaves_like "does not redirect to wizard"
-        end
-      end
+      it_behaves_like "does not redirect to the wizard path"
     end
   end
 end
 
-RSpec.shared_examples "redirects to confirmation wizard" do
-  it "redirects to the wizard" do
+RSpec.shared_examples "redirects to the wizard path" do
+  it "redirects to the wizard path" do
     subject
-    expect(response).to redirect_to(schools_induction_tutor_confirm_existing_induction_tutor_wizard_edit_path)
+    expect(response).to redirect_to(wizard_path)
   end
 end
 
-RSpec.shared_examples "redirects to new wizard" do
-  it "redirects to the wizard" do
+RSpec.shared_examples "does not redirect to the wizard path" do
+  it "does not redirect to the wizard path" do
     subject
-    expect(response).to redirect_to(schools_induction_tutor_new_induction_tutor_wizard_edit_path)
-  end
-end
-
-RSpec.shared_examples "does not redirect to wizard" do
-  it "does not redirect to either wizard" do
-    subject
-    expect(response).not_to redirect_to(schools_induction_tutor_confirm_existing_induction_tutor_wizard_edit_path)
-    expect(response).not_to redirect_to(schools_induction_tutor_new_induction_tutor_wizard_edit_path)
+    expect(response).not_to redirect_to(wizard_path)
   end
 end

--- a/spec/support/shared_examples/induction_redirect.rb
+++ b/spec/support/shared_examples/induction_redirect.rb
@@ -1,7 +1,9 @@
 RSpec.shared_examples "an induction redirectable route" do
   context "induction redirection" do
-    let(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
-    let(:year) { current_contract_period.year }
+    let!(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+    let(:year_induction_tutor_nominated_in) { current_contract_period.year }
 
     let!(:school) do
       FactoryBot.create(:school, :without_induction_tutor,
@@ -9,8 +11,9 @@ RSpec.shared_examples "an induction redirectable route" do
                         induction_tutor_name:,
                         induction_tutor_email:)
     end
-
-    let!(:induction_tutor_last_nominated_in) { FactoryBot.create(:contract_period, year:) }
+    let!(:induction_tutor_last_nominated_in) do
+      FactoryBot.create(:contract_period, year: year_induction_tutor_nominated_in)
+    end
     let(:induction_tutor_name) { Faker::Name.name }
     let(:induction_tutor_email) { Faker::Internet.email }
 
@@ -32,11 +35,35 @@ RSpec.shared_examples "an induction redirectable route" do
       end
 
       context "when the school's induction tutor needs to update information" do
-        let(:year) { current_contract_period.year - 1 }
+        let(:year_induction_tutor_nominated_in) do
+          current_contract_period.year - 1
+        end
 
-        before { current_contract_period }
+        context "when we are in the current contract period" do
+          it_behaves_like "redirects to confirmation wizard"
+        end
 
-        it_behaves_like "redirects to confirmation wizard"
+        context "when we are between contract periods" do
+          let!(:current_contract_period) do
+            FactoryBot.create(:contract_period, :current)
+          end
+          let!(:upcoming_contract_period) do
+            FactoryBot.create(
+              :contract_period,
+              :next,
+              started_on: current_contract_period.finished_on + 1.week,
+              finished_on: current_contract_period.finished_on + 1.year
+            )
+          end
+
+          before do
+            travel_to current_contract_period.finished_on + 1.day
+            # We need to sign in again after time travel
+            sign_in_as(:school_user, school:)
+          end
+
+          it_behaves_like "redirects to confirmation wizard"
+        end
       end
 
       context "when the school's induction tutor does not need to update information" do
@@ -64,11 +91,35 @@ RSpec.shared_examples "an induction redirectable route" do
       end
 
       context "when the school's induction tutor needs to update information" do
-        let(:year) { current_contract_period.year - 1 }
+        let(:year_induction_tutor_nominated_in) do
+          current_contract_period.year - 1
+        end
 
-        before { current_contract_period }
+        context "when we are in the current contract period" do
+          it_behaves_like "does not redirect to wizard"
+        end
 
-        it_behaves_like "does not redirect to wizard"
+        context "when we are between contract periods" do
+          let!(:current_contract_period) do
+            FactoryBot.create(:contract_period, :current)
+          end
+          let!(:upcoming_contract_period) do
+            FactoryBot.create(
+              :contract_period,
+              :next,
+              started_on: current_contract_period.finished_on + 1.week,
+              finished_on: current_contract_period.finished_on + 1.year
+            )
+          end
+
+          before do
+            travel_to current_contract_period.finished_on + 1.day
+            # We need to sign in again after time travel
+            sign_in_as(:dfe_user, user:)
+          end
+
+          it_behaves_like "does not redirect to wizard"
+        end
       end
     end
 
@@ -92,11 +143,35 @@ RSpec.shared_examples "an induction redirectable route" do
       end
 
       context "when the school's induction tutor needs to update information" do
-        let(:year) { current_contract_period.year - 1 }
+        let(:year_induction_tutor_nominated_in) do
+          current_contract_period.year - 1
+        end
 
-        before { current_contract_period }
+        context "when we are in the current contract period" do
+          it_behaves_like "does not redirect to wizard"
+        end
 
-        it_behaves_like "does not redirect to wizard"
+        context "when we are between contract periods" do
+          let!(:current_contract_period) do
+            FactoryBot.create(:contract_period, :current)
+          end
+          let!(:upcoming_contract_period) do
+            FactoryBot.create(
+              :contract_period,
+              :next,
+              started_on: current_contract_period.finished_on + 1.week,
+              finished_on: current_contract_period.finished_on + 1.year
+            )
+          end
+
+          before do
+            travel_to current_contract_period.finished_on + 1.day
+            # We need to sign in again after time travel
+            sign_in_as(:appropriate_body_user, appropriate_body:)
+          end
+
+          it_behaves_like "does not redirect to wizard"
+        end
       end
     end
   end

--- a/spec/wizards/schools/induction_tutor/confirm_existing_induction_tutor_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/induction_tutor/confirm_existing_induction_tutor_wizard/edit_step_spec.rb
@@ -161,29 +161,122 @@ describe Schools::InductionTutor::ConfirmExistingInductionTutorWizard::EditStep 
 
   describe "#save!" do
     context "when the user has confirmed the details are correct" do
-      it "updates the school's induction_tutor_last_nominated_in" do
-        current_step.save!
-        expect(school.reload.induction_tutor_last_nominated_in).to eq(current_contract_period)
-      end
-
       it "stores the confirmation" do
         expect { current_step.save! }.to change(store, :are_these_details_correct).to(true)
       end
 
-      it "records a confirmation event" do
-        freeze_time
-
-        expect(Events::Record)
-          .to receive(:record_school_induction_tutor_confirmed_event!)
-          .with(
-            author:,
-            school:,
-            name: induction_tutor_name,
-            email: induction_tutor_email,
-            contract_period_year: current_contract_period.year
+      context "when the current contract period is ongoing today" do
+        let!(:previous_contract_period) do
+          FactoryBot.create(
+            :contract_period,
+            :previous,
+            started_on: 2.months.ago,
+            finished_on: 1.month.ago.prev_day
           )
+        end
+        let!(:current_contract_period) do
+          FactoryBot.create(
+            :contract_period,
+            :current,
+            started_on: 1.month.ago,
+            finished_on: 1.month.from_now
+          )
+        end
+        let!(:upcoming_contract_period) do
+          FactoryBot.create(
+            :contract_period,
+            :next,
+            started_on: 2.months.from_now,
+            finished_on: 6.months.from_now
+          )
+        end
+        let(:school) do
+          FactoryBot.create(
+            :school,
+            :with_induction_tutor,
+            induction_tutor_last_nominated_in: previous_contract_period
+          )
+        end
 
-        current_step.save!
+        it "updates the school's induction_tutor_last_nominated_in" do
+          expect { current_step.save! }
+            .to change { school.reload.induction_tutor_last_nominated_in }
+            .from(previous_contract_period)
+            .to(current_contract_period)
+        end
+
+        it "records a confirmation event" do
+          freeze_time
+
+          expect(Events::Record)
+            .to receive(:record_school_induction_tutor_confirmed_event!)
+            .with(
+              author:,
+              school:,
+              name: induction_tutor_name,
+              email: induction_tutor_email,
+              contract_period_year: current_contract_period.year
+            )
+
+          current_step.save!
+        end
+      end
+
+      context "when the current contract period has finished" do
+        let!(:previous_contract_period) do
+          FactoryBot.create(
+            :contract_period,
+            :previous,
+            started_on: 2.months.ago,
+            finished_on: 1.month.ago.prev_day
+          )
+        end
+        let!(:current_contract_period) do
+          FactoryBot.create(
+            :contract_period,
+            :current,
+            started_on: 1.month.ago,
+            finished_on: 1.day.ago
+          )
+        end
+        let!(:upcoming_contract_period) do
+          FactoryBot.create(
+            :contract_period,
+            :next,
+            started_on: 2.months.from_now,
+            finished_on: 6.months.from_now
+          )
+        end
+        let(:school) do
+          FactoryBot.create(
+            :school,
+            :with_induction_tutor,
+            induction_tutor_last_nominated_in: previous_contract_period
+          )
+        end
+
+        it "updates the school's induction_tutor_last_nominated_in" do
+          expect { current_step.save! }
+            .to change { school.reload.induction_tutor_last_nominated_in }
+            .from(previous_contract_period)
+            .to(upcoming_contract_period)
+        end
+
+        it "records a confirmation event" do
+          freeze_time
+
+          expect(Events::Record)
+            .to receive(:record_school_induction_tutor_confirmed_event!)
+            .with(
+              author:,
+              school:,
+              name: induction_tutor_name,
+              email: induction_tutor_email,
+              contract_period_year: upcoming_contract_period.year
+            )
+
+          current_step.save!
+        end
       end
     end
 

--- a/spec/wizards/schools/induction_tutor/new_induction_tutor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/induction_tutor/new_induction_tutor_wizard/check_answers_step_spec.rb
@@ -13,7 +13,7 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
 
   let(:store)  { FactoryBot.build(:session_repository, induction_tutor_email:, induction_tutor_name:) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { FactoryBot.create(:school, :without_induction_tutor) }
   let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
   let(:induction_tutor_email) { Faker::Internet.email }
@@ -34,34 +34,102 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
   end
 
   describe "#save!" do
-    it "updates the school's induction tutor details and sets induction_tutor_last_nominated_in" do
+    context "when the current contract period is ongoing today" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 1.month.ago,
+          finished_on: 1.month.from_now
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: 2.months.from_now,
+          finished_on: 6.months.from_now
+        )
+      end
+
+      it "assigns the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_last_nominated_in }
+          .from(nil)
+          .to(current_contract_period)
+      end
+
+      it "records an event" do
+        freeze_time
+
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: current_contract_period.year
+          )
+
+        current_step.save!
+      end
+    end
+
+    context "when the current contract period has finished" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 1.month.ago,
+          finished_on: 1.day.ago
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: 2.months.from_now,
+          finished_on: 6.months.from_now
+        )
+      end
+
+      it "assigns the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_last_nominated_in }
+          .from(nil)
+          .to(upcoming_contract_period)
+      end
+
+      it "records an event" do
+        freeze_time
+
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: upcoming_contract_period.year
+          )
+
+        current_step.save!
+      end
+    end
+
+    it "updates the school's induction tutor details" do
       current_step.save!
 
       school.reload
       expect(school.induction_tutor_email).to eq(induction_tutor_email)
       expect(school.induction_tutor_name).to eq(induction_tutor_name)
-      expect(school.induction_tutor_last_nominated_in).to eq(current_contract_period)
     end
 
     it "is truthy" do
       expect(current_step.save!).to be_truthy
-    end
-
-    it "records an event" do
-      freeze_time
-
-      expect(Events::Record)
-        .to receive(:record_school_induction_tutor_updated_event!)
-        .with(
-          author:,
-          school:,
-          old_name: school.induction_tutor_name,
-          new_name: induction_tutor_name,
-          new_email: induction_tutor_email,
-          contract_period_year: current_contract_period.year
-        )
-
-      current_step.save!
     end
 
     it "sends a confirmation email" do

--- a/spec/wizards/schools/induction_tutor/update_induction_tutor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/induction_tutor/update_induction_tutor_wizard/check_answers_step_spec.rb
@@ -13,7 +13,7 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
 
   let(:store)  { FactoryBot.build(:session_repository, induction_tutor_email:, induction_tutor_name:) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
-  let(:school) { FactoryBot.create(:school) }
+  let(:school) { FactoryBot.create(:school, :with_unconfirmed_induction_tutor) }
   let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
   let(:induction_tutor_email) { Faker::Internet.email }
@@ -34,34 +34,102 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
   end
 
   describe "#save!" do
-    it "updates the school's induction tutor details and sets induction_tutor_last_nominated_in" do
+    context "when the current contract period is ongoing today" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 1.month.ago,
+          finished_on: 1.month.from_now
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: 2.months.from_now,
+          finished_on: 6.months.from_now
+        )
+      end
+
+      it "assigns the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_last_nominated_in }
+          .from(nil)
+          .to(current_contract_period)
+      end
+
+      it "records an event" do
+        freeze_time
+
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: current_contract_period.year
+          )
+
+        current_step.save!
+      end
+    end
+
+    context "when the current contract period has finished" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 1.month.ago,
+          finished_on: 1.day.ago
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: 2.months.from_now,
+          finished_on: 6.months.from_now
+        )
+      end
+
+      it "assigns the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_last_nominated_in }
+          .from(nil)
+          .to(upcoming_contract_period)
+      end
+
+      it "records an event" do
+        freeze_time
+
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: upcoming_contract_period.year
+          )
+
+        current_step.save!
+      end
+    end
+
+    it "updates the school's induction tutor details" do
       current_step.save!
 
       school.reload
       expect(school.induction_tutor_email).to eq(induction_tutor_email)
       expect(school.induction_tutor_name).to eq(induction_tutor_name)
-      expect(school.induction_tutor_last_nominated_in).to eq(current_contract_period)
     end
 
     it "is truthy" do
       expect(current_step.save!).to be_truthy
-    end
-
-    it "records an event" do
-      freeze_time
-
-      expect(Events::Record)
-        .to receive(:record_school_induction_tutor_updated_event!)
-        .with(
-          author:,
-          school:,
-          old_name: school.induction_tutor_name,
-          new_name: induction_tutor_name,
-          new_email: induction_tutor_email,
-          contract_period_year: current_contract_period.year
-        )
-
-      current_step.save!
     end
 
     it "sends a confirmation email" do


### PR DESCRIPTION
### Context

Driven by https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2922

### Changes proposed in this pull request

Before, we only ever cared about the current contract period.

In https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2922, the comparison between the last updated year for a school's
induction tutor details and `ContractPeriod.current` raised errors when there
was no "current" contract period (i.e in the gap).

Between the end of the 2025 contract period and the start of the 2026 contract
period, we still need users to be able to access the service (although lots of
functionality is restricted).

This reworks the induction tutor details checks so that they look to the future
in the absence of a "current" contract period.

Now, users are prompted to assign induction tutor details for the "upcoming"
contract period when there is no "current" contract period (i.e in "the gap").

This seemed pragmatic, since we would have asked schools to submit this
information as soon as the next contract period opened. This gives schools an
opportunity to fulfil that obligation sooner.

Crucially, no errors are raised either. If there is neither a current or an
upcoming contract period, then no update to induction tutor details is required.
The user is able to access the service, but registration is blocked.

### Guidance to review

We might want to wait for #2772 to land and temporarily edit the CP dates (as in #2922) to review this
