### PR TITLE
[3923] Add paid and clawed back events to declarations

### DIFF
--- a/app/helpers/declaration_helper.rb
+++ b/app/helpers/declaration_helper.rb
@@ -21,10 +21,12 @@ module DeclarationHelper
 
   DECLARATION_EVENT_STATE_NAMES = {
     "teacher_declaration_created" => "Submitted",
+    "teacher_declaration_eligible" => "Eligible",
+    "teacher_declaration_payable" => "Payable",
+    "teacher_declaration_paid" => "Paid",
     "teacher_declaration_voided" => "Voided",
     "teacher_declaration_awaiting_clawback" => "Awaiting clawback",
-    "teacher_declaration_payable" => "Payable",
-    "teacher_declaration_eligible" => "Eligible",
+    "teacher_declaration_clawed_back" => "Clawed back",
   }.freeze
 
   def declaration_state_tag(declaration)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -65,13 +65,15 @@ class Event < ApplicationRecord
     teacher_declaration_awaiting_clawback
     teacher_declaration_created
     teacher_declaration_eligible
+    teacher_declaration_payable
+    teacher_declaration_paid
+    teacher_declaration_clawed_back
     mentor_completion_status_change
     training_period_assigned_to_school_partnership
     dfe_user_created
     dfe_user_updated
     statement_authorised_for_payment
     statement_marked_payable
-    teacher_declaration_payable
     contract_period_added
     contract_period_updated
   ].freeze

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1029,7 +1029,7 @@ module Events
       event_type = :teacher_declaration_clawed_back
       teacher_name = Teachers::Name.new(teacher).full_name
       declaration_type = declaration.declaration_type
-      heading = "#{teacher_name}'s #{declaration_type} declaration was clawed_back"
+      heading = "#{teacher_name}'s #{declaration_type} declaration was clawed back"
 
       new(event_type:, author:, heading:, teacher:, training_period:, declaration:, happened_at:).record_event!
     end

--- a/app/services/events/record.rb
+++ b/app/services/events/record.rb
@@ -1016,6 +1016,24 @@ module Events
       new(event_type:, author:, heading:, teacher:, training_period:, declaration:, happened_at:).record_event!
     end
 
+    def self.record_teacher_declaration_paid!(author:, teacher:, training_period:, declaration:, happened_at: Time.current)
+      event_type = :teacher_declaration_paid
+      teacher_name = Teachers::Name.new(teacher).full_name
+      declaration_type = declaration.declaration_type
+      heading = "#{teacher_name}'s #{declaration_type} declaration was paid"
+
+      new(event_type:, author:, heading:, teacher:, training_period:, declaration:, happened_at:).record_event!
+    end
+
+    def self.record_teacher_declaration_clawed_back!(author:, teacher:, training_period:, declaration:, happened_at: Time.current)
+      event_type = :teacher_declaration_clawed_back
+      teacher_name = Teachers::Name.new(teacher).full_name
+      declaration_type = declaration.declaration_type
+      heading = "#{teacher_name}'s #{declaration_type} declaration was clawed_back"
+
+      new(event_type:, author:, heading:, teacher:, training_period:, declaration:, happened_at:).record_event!
+    end
+
     # Contract periods Events
 
     def self.record_contract_period_added_event!(author:, contract_period:)

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -152,7 +152,7 @@ FactoryBot.define do
         declaration.clawback_status = clawback_status
 
         if Declaration::BILLABLE_PAYMENT_STATUSES.include?(payment_status) && !evaluator.payment_statement
-          statement_trait = payment_status == "eligable" ? :open : payment_status.to_sym
+          statement_trait = payment_status == "eligible" ? :open : payment_status.to_sym
           declaration.payment_statement = FactoryBot.create(:statement, statement_trait, active_lead_provider:)
         else
           declaration.payment_statement = evaluator.payment_statement
@@ -219,7 +219,7 @@ FactoryBot.define do
         declaration.clawback_status = clawback_status
 
         if Declaration::BILLABLE_PAYMENT_STATUSES.include?(payment_status) && !evaluator.payment_statement
-          statement_trait = payment_status == "eligable" ? :open : payment_status.to_sym
+          statement_trait = payment_status == "eligible" ? :open : payment_status.to_sym
           declaration.payment_statement = FactoryBot.create(:statement, statement_trait, active_lead_provider:)
         else
           declaration.payment_statement = evaluator.payment_statement

--- a/spec/factories/declaration_factory.rb
+++ b/spec/factories/declaration_factory.rb
@@ -107,14 +107,21 @@ FactoryBot.define do
         active_lead_provider { nil }
         started_on { declaration_date }
         declaration_type { "started" }
+        payment_status { "no_payment" }
+        payment_statement { nil }
+        clawback_status { "no_clawback" }
+        clawback_statement { nil }
       end
 
       after(:build) do |declaration, evaluator|
-        school_partnership = evaluator.school_partnership
+        school_partnership = evaluator.school_partnership || create(:school_partnership)
         declaration.declaration_type = evaluator.declaration_type
+        payment_status = evaluator.payment_status
+        clawback_status = evaluator.clawback_status
 
         teacher = create(:teacher)
         school = school_partnership.school
+        active_lead_provider = school_partnership.active_lead_provider
 
         ect_at_school_period =
           create(
@@ -141,6 +148,22 @@ FactoryBot.define do
         declaration.training_period = training_period
         milestone = training_period.schedule.milestones.find { |m| m.declaration_type == declaration.declaration_type }
         declaration.declaration_date = milestone.start_date + 1.day
+        declaration.payment_status = payment_status
+        declaration.clawback_status = clawback_status
+
+        if Declaration::BILLABLE_PAYMENT_STATUSES.include?(payment_status) && !evaluator.payment_statement
+          statement_trait = payment_status == "eligable" ? :open : payment_status.to_sym
+          declaration.payment_statement = FactoryBot.create(:statement, statement_trait, active_lead_provider:)
+        else
+          declaration.payment_statement = evaluator.payment_statement
+        end
+
+        if Declaration::REFUNDABLE_CLAWBACK_STATUSES.include?(clawback_status) && !evaluator.clawback_statement
+          statement_trait = clawback_status == "awaiting_clawback" ? :payable : :paid
+          declaration.clawback_statement = FactoryBot.create(:statement, statement_trait, active_lead_provider:)
+        else
+          declaration.clawback_statement = evaluator.clawback_statement
+        end
       end
     end
 
@@ -151,14 +174,22 @@ FactoryBot.define do
         active_lead_provider { nil }
         started_on { declaration_date }
         declaration_type { "started" }
+        payment_status { "no_payment" }
+        payment_statement { nil }
+        clawback_status { "no_clawback" }
+        clawback_statement { nil }
       end
 
       after(:build) do |declaration, evaluator|
         school_partnership = evaluator.school_partnership
         declaration.declaration_type = evaluator.declaration_type
+        evaluator.payment_status
+        payment_status = evaluator.payment_status
+        clawback_status = evaluator.clawback_status
 
         teacher = create(:teacher)
         school = school_partnership.school
+        active_lead_provider = school_partnership.active_lead_provider
 
         mentor_at_school_period = create(
           :mentor_at_school_period,
@@ -184,6 +215,22 @@ FactoryBot.define do
         declaration.training_period = training_period
         milestone = training_period.schedule.milestones.find { |m| m.declaration_type == declaration.declaration_type }
         declaration.declaration_date = milestone.start_date + 1.day
+        declaration.payment_status = payment_status
+        declaration.clawback_status = clawback_status
+
+        if Declaration::BILLABLE_PAYMENT_STATUSES.include?(payment_status) && !evaluator.payment_statement
+          statement_trait = payment_status == "eligable" ? :open : payment_status.to_sym
+          declaration.payment_statement = FactoryBot.create(:statement, statement_trait, active_lead_provider:)
+        else
+          declaration.payment_statement = evaluator.payment_statement
+        end
+
+        if Declaration::REFUNDABLE_CLAWBACK_STATUSES.include?(clawback_status) && !evaluator.clawback_statement
+          statement_trait = clawback_status == "awaiting_clawback" ? :payable : :paid
+          declaration.clawback_statement = FactoryBot.create(:statement, statement_trait, active_lead_provider:)
+        else
+          declaration.clawback_statement = evaluator.clawback_statement
+        end
       end
     end
   end

--- a/spec/helpers/declaration_helper_spec.rb
+++ b/spec/helpers/declaration_helper_spec.rb
@@ -94,10 +94,22 @@ RSpec.describe DeclarationHelper, type: :helper do
       it { is_expected.to eq("Payable") }
     end
 
+    context "when the event type is 'teacher_declaration_paid'" do
+      let(:event_type) { "teacher_declaration_paid" }
+
+      it { is_expected.to eq("Paid") }
+    end
+
     context "when the event type is 'teacher_declaration_eligible'" do
       let(:event_type) { "teacher_declaration_eligible" }
 
       it { is_expected.to eq("Eligible") }
+    end
+
+    context "when the event type is 'teacher_declaration_clawed_back'" do
+      let(:event_type) { "teacher_declaration_clawed_back" }
+
+      it { is_expected.to eq("Clawed back") }
     end
 
     context "when the event type is not recognised" do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -2358,6 +2358,68 @@ RSpec.describe Events::Record do
     end
   end
 
+  describe ".record_teacher_declaration_paid" do
+    let(:declaration) do
+      FactoryBot.create(:declaration, :with_ect, payment_status: "paid")
+    end
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time
+
+      training_period = declaration.training_period
+      teacher = training_period.ect_at_school_period.teacher
+      teacher_full_name = "#{teacher.trs_first_name} #{teacher.trs_last_name}"
+
+      Events::Record.record_teacher_declaration_paid!(
+        author:,
+        teacher:,
+        training_period:,
+        declaration:
+      )
+
+      expect(RecordEventJob).to have_received(:perform_later).with(
+        event_type: :teacher_declaration_paid,
+        heading: "#{teacher_full_name}'s started declaration was paid",
+        teacher:,
+        training_period:,
+        declaration:,
+        happened_at: Time.current,
+        **author_params
+      )
+    end
+  end
+
+  describe ".record_teacher_declaration_clawed_back" do
+    let(:declaration) do
+      FactoryBot.create(:declaration, :with_ect, payment_status: "paid", clawback_status: "clawed_back")
+    end
+
+    it "queues a RecordEventJob with the correct values" do
+      freeze_time
+
+      training_period = declaration.training_period
+      teacher = training_period.ect_at_school_period.teacher
+      teacher_full_name = "#{teacher.trs_first_name} #{teacher.trs_last_name}"
+
+      Events::Record.record_teacher_declaration_clawed_back!(
+        author:,
+        teacher:,
+        training_period:,
+        declaration:
+      )
+
+      expect(RecordEventJob).to have_received(:perform_later).with(
+        event_type: :teacher_declaration_clawed_back,
+        heading: "#{teacher_full_name}'s started declaration was clawed_back",
+        teacher:,
+        training_period:,
+        declaration:,
+        happened_at: Time.current,
+        **author_params
+      )
+    end
+  end
+
   describe ".record_school_user_signs_in_event!" do
     let(:school) { FactoryBot.create(:school) }
     let(:school_user) do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -2410,7 +2410,7 @@ RSpec.describe Events::Record do
 
       expect(RecordEventJob).to have_received(:perform_later).with(
         event_type: :teacher_declaration_clawed_back,
-        heading: "#{teacher_full_name}'s started declaration was clawed_back",
+        heading: "#{teacher_full_name}'s started declaration was clawed back",
         teacher:,
         training_period:,
         declaration:,


### PR DESCRIPTION
### Context
We have imported declarations and statements from ECF1.  However their state history is drawn from the events table, and it is missing.

### Changes proposed in this pull request
In order to back fill the missing events for declarations imported from ECF1 we need to create two events: a declaration is paid and a  declaration is clawed back.

https://github.com/DFE-Digital/register-ects-project-board/issues/3923

A later PR will add a rake task which will backfill all statements and declarations which are marked as paid, but are missing the events.

This is also a pre-requisite of: https://github.com/DFE-Digital/register-ects-project-board/issues/3397

That will require a service class which will mark each declaration as paid/clawed back, as well as creating the events.  It will be pretty similar to the rake task's code obviously.

### Guidance to review
At this stage there is not much to product review.
