### PR TITLE
Use GIAS contact email in the API when the school induction tutor email is not set

### DIFF
--- a/app/serializers/api/school_partnership_serializer.rb
+++ b/app/serializers/api/school_partnership_serializer.rb
@@ -27,7 +27,7 @@ class API::SchoolPartnershipSerializer < Blueprinter::Base
     end
 
     field :induction_tutor_email do |partnership, _options|
-      partnership.school.induction_tutor_email
+      Schools::InductionTutorEmail.new(school: partnership.school).email_or_gias_contact
     end
 
     field(:participants_currently_training) do |partnership, _options|

--- a/app/serializers/api/school_serializer.rb
+++ b/app/serializers/api/school_serializer.rb
@@ -24,7 +24,7 @@ class API::SchoolSerializer < Blueprinter::Base
       data[:school].induction_tutor_name if data[:expression_of_interest_or_school_partnership]
     end
     field :induction_tutor_email do |data|
-      data[:school].induction_tutor_email if data[:expression_of_interest_or_school_partnership]
+      Schools::InductionTutorEmail.new(school: data[:school]).email_or_gias_contact if data[:expression_of_interest_or_school_partnership]
     end
     field :created_at do |data|
       data[:school].created_at

--- a/app/services/schools/induction_tutor_email.rb
+++ b/app/services/schools/induction_tutor_email.rb
@@ -1,0 +1,17 @@
+module Schools
+  class InductionTutorEmail
+    attr_reader :school
+
+    def initialize(school:)
+      @school = school
+    end
+
+    def email
+      school.induction_tutor_email
+    end
+
+    def email_or_gias_contact
+      email.presence || school.gias_school.primary_contact_email.presence || school.gias_school.secondary_contact_email
+    end
+  end
+end

--- a/spec/serializers/api/school_partnership_serializer_spec.rb
+++ b/spec/serializers/api/school_partnership_serializer_spec.rb
@@ -3,6 +3,8 @@ describe API::SchoolPartnershipSerializer, type: :serializer do
     JSON.parse(described_class.render(partnership))
   end
 
+  let(:gias_school) { FactoryBot.create(:gias_school, primary_contact_email:) }
+  let(:primary_contact_email) { "head@school.example.com" }
   let(:school) { FactoryBot.create(:school, :with_induction_tutor) }
   let!(:partnership) { FactoryBot.create(:school_partnership, created_at:, api_updated_at:, school:) }
   let(:delivery_partner) { partnership.delivery_partner }
@@ -32,6 +34,21 @@ describe API::SchoolPartnershipSerializer, type: :serializer do
       expect(attributes["induction_tutor_email"]).to eq(school.induction_tutor_email)
       expect(attributes["created_at"]).to eq(created_at.utc.rfc3339)
       expect(attributes["updated_at"]).to eq(api_updated_at.utc.rfc3339)
+    end
+
+    context "when the induction tutor is not present on the school" do
+      let(:school) do
+        FactoryBot.create(:school,
+                          gias_school:,
+                          induction_tutor_name: nil,
+                          induction_tutor_email: nil,
+                          induction_tutor_last_nominated_in: nil)
+      end
+
+      it "uses the GIAS contact email" do
+        expect(attributes["induction_tutor_name"]).to be_nil
+        expect(attributes["induction_tutor_email"]).to eq(primary_contact_email)
+      end
     end
 
     describe "participants_currently_training" do

--- a/spec/serializers/api/school_serializer_spec.rb
+++ b/spec/serializers/api/school_serializer_spec.rb
@@ -6,6 +6,8 @@ describe API::SchoolSerializer, type: :serializer do
 
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:contract_period) { FactoryBot.create(:contract_period) }
+  let(:gias_school) { FactoryBot.create(:gias_school, primary_contact_email:) }
+  let(:primary_contact_email) { "head@school.example.com" }
   let(:school) { FactoryBot.create(:school, :with_induction_tutor, created_at:) }
   let!(:contract_period_metadata) { FactoryBot.create(:school_contract_period_metadata, school:, contract_period:, api_updated_at:) }
   let!(:lead_provider_contract_period_metadata) do
@@ -50,6 +52,22 @@ describe API::SchoolSerializer, type: :serializer do
       expect(attributes["induction_tutor_email"]).to eq(school.induction_tutor_email)
       expect(attributes["created_at"]).to eq(school.created_at.utc.rfc3339)
       expect(attributes["updated_at"]).to eq(contract_period_metadata.api_updated_at.utc.rfc3339)
+    end
+
+    context "when the induction tutor is not present on the school" do
+      let(:school) do
+        FactoryBot.create(:school,
+                          gias_school:,
+                          induction_tutor_name: nil,
+                          induction_tutor_email: nil,
+                          induction_tutor_last_nominated_in: nil,
+                          created_at:)
+      end
+
+      it "uses the GIAS contact email" do
+        expect(attributes["induction_tutor_name"]).to be_nil
+        expect(attributes["induction_tutor_email"]).to eq(primary_contact_email)
+      end
     end
   end
 end

--- a/spec/services/schools/induction_tutor_email_spec.rb
+++ b/spec/services/schools/induction_tutor_email_spec.rb
@@ -1,0 +1,57 @@
+describe Schools::InductionTutorEmail do
+  subject(:service) { described_class.new(school:) }
+
+  let(:school) { FactoryBot.create(:school, gias_school:, induction_tutor_email:, induction_tutor_name:, induction_tutor_last_nominated_in: nil) }
+  let(:gias_school) { FactoryBot.create(:gias_school, primary_contact_email:, secondary_contact_email:) }
+
+  let(:induction_tutor_name) { "Griff Walnut" }
+  let(:induction_tutor_email) { "griff@example.com" }
+  let(:primary_contact_email) { "head@example.com" }
+  let(:secondary_contact_email) { "bernard@example.com" }
+
+  describe "#email" do
+    it "returns the school induction tutor email" do
+      expect(service.email).to eq(induction_tutor_email)
+    end
+
+    context "when the school induction tutor email is not set" do
+      let(:induction_tutor_email) { nil }
+      let(:induction_tutor_name) { nil }
+
+      it "returns nil" do
+        expect(service.email).to be_nil
+      end
+    end
+  end
+
+  describe "#email_or_gias_contact" do
+    it "returns the school induction tutor email" do
+      expect(service.email_or_gias_contact).to eq(induction_tutor_email)
+    end
+
+    context "when the school induction tutor email is not set" do
+      let(:induction_tutor_email) { nil }
+      let(:induction_tutor_name) { nil }
+
+      it "returns the primary GIAS contact" do
+        expect(service.email_or_gias_contact).to eq(primary_contact_email)
+      end
+
+      context "when the primary GIAS contact is not set" do
+        let(:primary_contact_email) { nil }
+
+        it "returns the secondary GIAS contact" do
+          expect(service.email_or_gias_contact).to eq(secondary_contact_email)
+        end
+
+        context "when the secondary GIAS contact is not set" do
+          let(:secondary_contact_email) { nil }
+
+          it "returns nil" do
+            expect(service.email_or_gias_contact).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

In the school and school partnerships API endpoints, use the GIAS primary or secondary contact email for the induction tutor email returned in the API response when the induction tutor email has not been set on the School.

### Changes proposed in this pull request

Adds a service `Schools::InductionTutorEmail` with the above logic
Updates the school and school partnership serializers to use the new service for the induction tutor email value

### Guidance to review
