### PR TITLE
Add contract to fee structure tables (part 1)

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -319,6 +319,7 @@
   - fee_per_declaration
   - created_at
   - updated_at
+  - contract_id
   :contract_banded_fee_structures:
   - id
   - recruitment_target
@@ -327,6 +328,7 @@
   - setup_fee
   - created_at
   - updated_at
+  - contract_id
   :contract_banded_fee_structure_bands:
   - id
   - banded_fee_structure_id

--- a/db/migrate/20260521133546_add_contract_id_to_fee_structures.rb
+++ b/db/migrate/20260521133546_add_contract_id_to_fee_structures.rb
@@ -1,0 +1,6 @@
+class AddContractIdToFeeStructures < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :contract_banded_fee_structures, :contract, foreign_key: true
+    add_reference :contract_flat_rate_fee_structures, :contract, foreign_key: true
+  end
+end

--- a/db/migrate/20260521133546_add_contract_id_to_fee_structures.rb
+++ b/db/migrate/20260521133546_add_contract_id_to_fee_structures.rb
@@ -1,6 +1,9 @@
 class AddContractIdToFeeStructures < ActiveRecord::Migration[8.1]
   def change
-    add_reference :contract_banded_fee_structures, :contract, foreign_key: true
-    add_reference :contract_flat_rate_fee_structures, :contract, foreign_key: true
+    add_reference :contract_banded_fee_structures, :contract, null: true, foreign_key: true
+    add_reference :contract_flat_rate_fee_structures, :contract, null: true, foreign_key: true
+
+    add_index :contract_banded_fee_structures, :contract_id, unique: true, where: "contract_id IS NOT NULL", name: "index_banded_fee_structures_on_contract_id_unique_not_null"
+    add_index :contract_flat_rate_fee_structures, :contract_id, unique: true, where: "contract_id IS NOT NULL", name: "index_flat_rate_fee_structures_on_contract_id_unique_not_null"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -164,6 +164,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_133546) do
     t.decimal "setup_fee", precision: 12, scale: 2, null: false
     t.datetime "updated_at", null: false
     t.decimal "uplift_fee_per_declaration", precision: 12, scale: 2, null: false
+    t.index ["contract_id"], name: "index_banded_fee_structures_on_contract_id_unique_not_null", unique: true, where: "(contract_id IS NOT NULL)"
     t.index ["contract_id"], name: "index_contract_banded_fee_structures_on_contract_id"
   end
 
@@ -174,6 +175,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_133546) do
     t.integer "recruitment_target", null: false
     t.datetime "updated_at", null: false
     t.index ["contract_id"], name: "index_contract_flat_rate_fee_structures_on_contract_id"
+    t.index ["contract_id"], name: "index_flat_rate_fee_structures_on_contract_id_unique_not_null", unique: true, where: "(contract_id IS NOT NULL)"
   end
 
   create_table "contract_periods", primary_key: "year", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_161732) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_133546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -157,19 +157,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_161732) do
   end
 
   create_table "contract_banded_fee_structures", force: :cascade do |t|
+    t.bigint "contract_id"
     t.datetime "created_at", null: false
     t.decimal "monthly_service_fee", precision: 12, scale: 2
     t.integer "recruitment_target", null: false
     t.decimal "setup_fee", precision: 12, scale: 2, null: false
     t.datetime "updated_at", null: false
     t.decimal "uplift_fee_per_declaration", precision: 12, scale: 2, null: false
+    t.index ["contract_id"], name: "index_contract_banded_fee_structures_on_contract_id"
   end
 
   create_table "contract_flat_rate_fee_structures", force: :cascade do |t|
+    t.bigint "contract_id"
     t.datetime "created_at", null: false
     t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
     t.integer "recruitment_target", null: false
     t.datetime "updated_at", null: false
+    t.index ["contract_id"], name: "index_contract_flat_rate_fee_structures_on_contract_id"
   end
 
   create_table "contract_periods", primary_key: "year", id: :serial, force: :cascade do |t|
@@ -940,6 +944,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_161732) do
   add_foreign_key "appropriate_bodies", "dfe_sign_in_organisations"
   add_foreign_key "appropriate_body_periods", "appropriate_bodies"
   add_foreign_key "contract_banded_fee_structure_bands", "contract_banded_fee_structures", column: "banded_fee_structure_id", on_delete: :cascade
+  add_foreign_key "contract_banded_fee_structures", "contracts"
+  add_foreign_key "contract_flat_rate_fee_structures", "contracts"
   add_foreign_key "contracts", "active_lead_providers"
   add_foreign_key "contracts", "contract_banded_fee_structures", column: "banded_fee_structure_id"
   add_foreign_key "contracts", "contract_flat_rate_fee_structures", column: "flat_rate_fee_structure_id"

--- a/db/scripts/populate_contract_id_on_fee_structures.rb
+++ b/db/scripts/populate_contract_id_on_fee_structures.rb
@@ -1,0 +1,8 @@
+# Populate contract_id value on fee structures so we can reverse the relationship
+#
+# $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/move_contract_id_to_fee_structures.rb
+
+Contract.find_each do |contract|
+  contract.banded_fee_structure&.update!(contract_id: contract.id)
+  contract.flat_rate_fee_structure&.update!(contract_id: contract.id)
+end

--- a/db/scripts/populate_contract_id_on_fee_structures.rb
+++ b/db/scripts/populate_contract_id_on_fee_structures.rb
@@ -2,6 +2,20 @@
 #
 # $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/populate_contract_id_on_fee_structures.rb
 
+shared_banded = Contract
+  .where.not(banded_fee_structure_id: nil)
+  .group(:banded_fee_structure_id)
+  .having("COUNT(*) > 1")
+  .exists?
+
+shared_flat_rate = Contract
+  .where.not(flat_rate_fee_structure_id: nil)
+  .group(:flat_rate_fee_structure_id)
+  .having("COUNT(*) > 1")
+  .exists?
+
+raise "Fee structures are shared between contracts!" if shared_banded || shared_flat_rate
+
 Contract.find_each do |contract|
   contract.banded_fee_structure&.update!(contract_id: contract.id)
   contract.flat_rate_fee_structure&.update!(contract_id: contract.id)

--- a/db/scripts/populate_contract_id_on_fee_structures.rb
+++ b/db/scripts/populate_contract_id_on_fee_structures.rb
@@ -1,6 +1,6 @@
 # Populate contract_id value on fee structures so we can reverse the relationship
 #
-# $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/move_contract_id_to_fee_structures.rb
+# $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/populate_contract_id_on_fee_structures.rb
 
 Contract.find_each do |contract|
   contract.banded_fee_structure&.update!(contract_id: contract.id)


### PR DESCRIPTION
### Context

Now more is known about the shapes of the contracts and fee structures, it makes sense to reverse the relationship between them so that the `banded_fee_structure` and `flat_rate_fee_structure`  tables `belong_to` a `Contract` and a `Contract` `has_one` `banded_fee_structure` and/or `flat_rate_fee_structure` instead of the reverse.

This is the first step towards this which adds the `contract_id` to the fee structure tables and a script to populate that once the migration has been run.

### Changes proposed in this pull request

- DB change to add the `contract_id` to `contract_banded_fee_structures` and `contract_flat_rate_fee_structures` tables
- A script that can be run once deployed to populate the `contract_id` value

### Guidance to review
