### PR TITLE
#2959 - validate ongoing training periods are fully covered by its ASP

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -207,7 +207,7 @@ private
   end
 
   def enveloped_by_trainee_at_school_period
-    return if finished_on.blank?
+    return if at_school_period.blank? || started_on.blank?
     return if (at_school_period_started_on..at_school_period_finished_on).cover?(started_on..finished_on)
 
     errors.add(:base, "Date range is not contained by the period the trainee is at the school")

--- a/app/services/api_seed_data/participant_scenarios.rb
+++ b/app/services/api_seed_data/participant_scenarios.rb
@@ -76,6 +76,7 @@ module APISeedData
 
             school_period = FactoryBot.create(
               :"#{type}_at_school_period",
+              :ongoing,
               school:,
               started_on: start_date
             )
@@ -132,6 +133,7 @@ module APISeedData
 
             school_period = FactoryBot.create(
               :"#{type}_at_school_period",
+              :ongoing,
               school:,
               started_on: start_date
             )
@@ -450,13 +452,12 @@ module APISeedData
 
               school = school_partnership.school
               start_date = Time.zone.today + rand(1..6).months
-              finished_date = start_date + rand(6..12).months
 
               school_period = FactoryBot.create(
                 :"#{type}_at_school_period",
+                :ongoing,
                 school:,
-                started_on: start_date,
-                finished_on: finished_date
+                started_on: start_date
               )
 
               schedule = find_schedule(contract_period, type)

--- a/app/services/api_seed_data/school_scenarios.rb
+++ b/app/services/api_seed_data/school_scenarios.rb
@@ -490,12 +490,12 @@ module APISeedData
 
           # Create an ECT training with this lead provider
           ect_teacher = FactoryBot.create(:teacher)
-          ect_school_period = FactoryBot.create(:ect_at_school_period, teacher: ect_teacher, school:, started_on: start_date)
+          ect_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, teacher: ect_teacher, school:, started_on: start_date)
           add_training_period(ect_school_period, programme_type: :provider_led, from: start_date, with: lead_provider)
 
           # Create a mentor training with this lead provider
           mentor_teacher = FactoryBot.create(:teacher)
-          mentor_school_period = FactoryBot.create(:mentor_at_school_period, teacher: mentor_teacher, school:, started_on: start_date)
+          mentor_school_period = FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: mentor_teacher, school:, started_on: start_date)
           add_training_period(mentor_school_period, programme_type: :provider_led, from: start_date, with: lead_provider)
 
           log_seed_info("Created school with ECT and mentor training with #{lead_provider.name}", colour: Colourize::COLOURS.keys.sample)

--- a/spec/components/admin/schools/teachers_table_component_spec.rb
+++ b/spec/components/admin/schools/teachers_table_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::Schools::TeachersTableComponent, type: :component do
     end
 
     let!(:ect_and_mentor) do
-      ect_at_school_period = FactoryBot.create(:ect_at_school_period, school:, started_on: Date.new(2024, 7, 1))
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: Date.new(2024, 7, 1))
       school_partnership = FactoryBot.create(:school_partnership, :for_year, school:, year: 2024)
       FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, school_partnership:)
 

--- a/spec/components/admin/statements/declaration_component_spec.rb
+++ b/spec/components/admin/statements/declaration_component_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Admin::Statements::DeclarationComponent, type: :component do
   let(:statement_trait) { :output_fee }
   let(:statement) { FactoryBot.create(:statement, :payable, statement_trait, active_lead_provider:, contract:) }
 
-  let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :with_active_lead_provider, active_lead_provider:) }
+  let(:ect_training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, :with_active_lead_provider, active_lead_provider:, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
   let!(:ect_declaration) { FactoryBot.create(:declaration, :voided, training_period: ect_training_period, payment_statement: statement) }
-  let(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_active_lead_provider, active_lead_provider:) }
+  let(:mentor_training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_active_lead_provider, active_lead_provider:, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)) }
   let!(:mentor_declaration) { FactoryBot.create(:declaration, :voided, training_period: mentor_training_period, payment_statement: statement) }
 
   let(:started_flatrate) do

--- a/spec/components/schools/summary_card_component_spec.rb
+++ b/spec/components/schools/summary_card_component_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Schools::SummaryCardComponent, type: :component do
 
   context "when data is reported by the appropriate body" do
     let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school_reported_appropriate_body:) }
-    let(:training_period) { FactoryBot.create(:training_period, :ongoing, :school_led) }
+    let(:training_period) { FactoryBot.create(:training_period, :ongoing, :school_led, ect_at_school_period:) }
 
     before do
       FactoryBot.create(:induction_period, teacher: ect_at_school_period.teacher, started_on: "2023-01-01")

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -119,6 +119,21 @@ FactoryBot.define do
 
     trait :ongoing do
       finished_on { nil }
+
+      # An ongoing training period is only valid when its parent at-school period
+      # is also ongoing (otherwise the TP extends past the parent). If the parent
+      # was implicitly created with a finished_on date, make it ongoing so the
+      # envelope validation stays satisfied.
+      after(:build) do |tp|
+        asp = tp.at_school_period
+        next if asp.blank? || asp.finished_on.blank?
+
+        if asp.persisted?
+          asp.update_columns(finished_on: nil)
+        else
+          asp.finished_on = nil
+        end
+      end
     end
 
     trait :for_ect do

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -55,10 +55,10 @@ FactoryBot.define do
 
     trait :with_school_partnership do
       transient do
-        teacher_period { ect_at_school_period.presence || mentor_at_school_period }
+        at_school_period { ect_at_school_period.presence || mentor_at_school_period }
       end
 
-      school_partnership { association :school_partnership, school: teacher_period&.school || FactoryBot.create(:school) }
+      school_partnership { association :school_partnership, school: at_school_period&.school || FactoryBot.create(:school) }
     end
 
     trait :with_active_lead_provider do
@@ -70,7 +70,7 @@ FactoryBot.define do
         association :school_partnership,
                     :with_active_lead_provider,
                     active_lead_provider:,
-                    school: teacher_period&.school || FactoryBot.create(:school)
+                    school: at_school_period&.school || FactoryBot.create(:school)
       end
     end
 

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -119,21 +119,6 @@ FactoryBot.define do
 
     trait :ongoing do
       finished_on { nil }
-
-      # An ongoing training period is only valid when its parent at-school period
-      # is also ongoing (otherwise the TP extends past the parent). If the parent
-      # was implicitly created with a finished_on date, make it ongoing so the
-      # envelope validation stays satisfied.
-      after(:build) do |tp|
-        asp = tp.at_school_period
-        next if asp.blank? || asp.finished_on.blank?
-
-        if asp.persisted?
-          asp.update_columns(finished_on: nil)
-        else
-          asp.finished_on = nil
-        end
-      end
     end
 
     trait :for_ect do

--- a/spec/lib/schools/validation/period_boundary_spec.rb
+++ b/spec/lib/schools/validation/period_boundary_spec.rb
@@ -520,13 +520,13 @@ RSpec.describe Schools::Validation::PeriodBoundary do
   end
 
   context "when validating an ECT at school period" do
-    let(:input_period) { FactoryBot.create(:ect_at_school_period, started_on: input_period_started_on) }
+    let(:input_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: input_period_started_on) }
 
     it_behaves_like "period boundary validations"
   end
 
   context "when validating a mentor at school period" do
-    let(:input_period) { FactoryBot.create(:mentor_at_school_period, started_on: input_period_started_on) }
+    let(:input_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: input_period_started_on) }
 
     it_behaves_like "period boundary validations"
   end

--- a/spec/migration_fixes/real_examples/teacher_34082_spec.rb
+++ b/spec/migration_fixes/real_examples/teacher_34082_spec.rb
@@ -51,16 +51,16 @@ describe "Real data check for teacher 34082" do
         attributes: {}
       },
       {
-        object_type: "TrainingPeriod",
-        object_id: 136_520,
+        object_type: "ECTAtSchoolPeriod",
+        object_id: 10_404,
         action: "update",
         attributes: {
           finished_on: nil,
         }
       },
       {
-        object_type: "ECTAtSchoolPeriod",
-        object_id: 10_404,
+        object_type: "TrainingPeriod",
+        object_id: 136_520,
         action: "update",
         attributes: {
           finished_on: nil,

--- a/spec/models/concerns/at_school_period_spec.rb
+++ b/spec/models/concerns/at_school_period_spec.rb
@@ -68,8 +68,8 @@ describe AtSchoolPeriod do
           end
         end
 
-        context "with an ongoing training period when the ECT is finished" do
-          let(:ect) { FactoryBot.create(:ect_at_school_period, started_on: 2.years.ago, finished_on: 6.months.ago) }
+        context "when finishing an ECT that has an ongoing training period" do
+          let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.years.ago) }
 
           before do
             FactoryBot.create(:training_period, :ongoing, ect_at_school_period: ect, started_on: 2.years.ago)

--- a/spec/models/school_partnership_spec.rb
+++ b/spec/models/school_partnership_spec.rb
@@ -52,7 +52,7 @@ describe SchoolPartnership do
 
       before do
         # Different lead provider
-        FactoryBot.create(:training_period, :ongoing, :with_school_partnership)
+        FactoryBot.create(:training_period, :ongoing, :with_school_partnership, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing))
         # Not on-going today
         ect_at_school_period = FactoryBot.create(:ect_at_school_period, school: instance.school, started_on: 1.year.ago, finished_on: 1.month.ago)
         FactoryBot.create(:training_period, school_partnership: instance, ect_at_school_period:, started_on: 5.months.ago, finished_on: 2.months.ago)

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe School do
 
     context "target ect_teachers" do
       let(:school_partnership) { FactoryBot.create(:school_partnership, school: instance) }
-      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: instance) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: instance) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period:) }
 
       let(:target) { instance.ect_teachers }
@@ -40,7 +40,7 @@ RSpec.describe School do
 
     context "target mentor_teachers" do
       let!(:school_partnership) { FactoryBot.create(:school_partnership, school: instance) }
-      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school: instance) }
+      let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school: instance) }
       let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:) }
 
       let(:target) { instance.mentor_teachers }
@@ -442,7 +442,7 @@ RSpec.describe School do
         end
 
         context "and has an ongoing ect training period" do
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
 
           before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
@@ -450,7 +450,7 @@ RSpec.describe School do
         end
 
         context "and has an ongoing mentor training period" do
-          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
+          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
 
           before { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:) }
 
@@ -467,7 +467,7 @@ RSpec.describe School do
 
         context "and training is at another school" do
           let(:other_school) { FactoryBot.create(:school, :state_funded) }
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school: other_school) }
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: other_school) }
 
           before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
@@ -477,7 +477,7 @@ RSpec.describe School do
 
       context "and section 41 is approved" do
         let(:school) { FactoryBot.create(:school, :independent, :section_41) }
-        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+        let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
 
         before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
@@ -487,7 +487,7 @@ RSpec.describe School do
 
     context "when the school is state-funded" do
       let(:school) { FactoryBot.create(:school, :state_funded) }
-      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+      let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
 
       before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
@@ -508,7 +508,7 @@ RSpec.describe School do
         end
 
         context "with an ongoing ect training period" do
-          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+          let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
 
           before { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
@@ -516,7 +516,7 @@ RSpec.describe School do
         end
 
         context "with an ongoing mentor training period" do
-          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
+          let!(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
 
           before { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:) }
 

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -52,7 +52,7 @@ describe TrainingPeriod do
   end
 
   describe "declarative touch" do
-    let(:instance) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
+    let(:instance) { FactoryBot.create(:training_period, :for_ect) }
 
     context "target teacher" do
       let(:target) { instance.teacher }
@@ -355,6 +355,36 @@ describe TrainingPeriod do
       end
     end
 
+    describe "enveloped by trainee at school period" do
+      let(:envelope_error) { "Date range is not contained by the period the trainee is at the school" }
+
+      context "ongoing training period inside an ongoing at school period" do
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.year.ago) }
+
+        it "is valid when the training period starts on or after the at school period" do
+          training_period = FactoryBot.build(:training_period, :ongoing, :for_ect, ect_at_school_period:, started_on: 6.months.ago)
+          training_period.valid?
+          expect(training_period.errors[:base]).not_to include(envelope_error)
+        end
+
+        it "is invalid when the training period starts before the at school period" do
+          training_period = FactoryBot.build(:training_period, :ongoing, :for_ect, ect_at_school_period:, started_on: 2.years.ago)
+          training_period.valid?
+          expect(training_period.errors[:base]).to include(envelope_error)
+        end
+      end
+
+      context "ongoing training period inside a finished at school period" do
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 1.year.ago, finished_on: 1.month.ago) }
+
+        it "is invalid because the training period extends past the at school period" do
+          training_period = FactoryBot.build(:training_period, :for_ect, ect_at_school_period:, started_on: 6.months.ago, finished_on: nil)
+          training_period.valid?
+          expect(training_period.errors[:base]).to include(envelope_error)
+        end
+      end
+    end
+
     describe "concurrent ongoing periods" do
       subject(:save_concurrent_ongoing_period!) do
         concurrent_ongoing_period.save!
@@ -406,11 +436,11 @@ describe TrainingPeriod do
         let(:concurrent_ongoing_period) do
           FactoryBot.build(
             :training_period,
-            :ongoing,
             :for_ect,
             :provider_led,
             ect_at_school_period:,
-            started_on: ect_at_school_period.finished_on
+            started_on: ect_at_school_period.finished_on,
+            finished_on: nil
           )
         end
 

--- a/spec/requests/schools/access_spec.rb
+++ b/spec/requests/schools/access_spec.rb
@@ -74,7 +74,7 @@ describe "Schools access guard" do
       let(:school) { gias_school.school }
 
       before do
-        ect_at_school_period = FactoryBot.create(:ect_at_school_period, school:)
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, :ongoing, school:)
         FactoryBot.create(:training_period, :ongoing, ect_at_school_period:)
         sign_in_as(:school_user, method: :dfe_sign_in, school:)
       end

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "ECT summary" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, school:, started_on: 2.years.ago) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: 2.years.ago) }
   let(:school) { FactoryBot.create(:school) }
 
   describe "GET #index" do

--- a/spec/requests/schools/ects_spec.rb
+++ b/spec/requests/schools/ects_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "ECT summary" do
-  let(:ect) { FactoryBot.create(:ect_at_school_period, school:) }
+  let(:ect) { FactoryBot.create(:ect_at_school_period, school:, started_on: 2.years.ago) }
   let(:school) { FactoryBot.create(:school) }
 
   describe "GET #index" do
@@ -105,6 +105,8 @@ RSpec.describe "ECT summary" do
 
       context "when accessing future ECT period at current school" do
         let(:teacher) { ect.teacher }
+        let!(:training_period) { nil }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 6.months.from_now) }
         let!(:future_period) { FactoryBot.create(:ect_at_school_period, teacher:, school:, started_on: 1.year.from_now) }
 
         before do
@@ -121,6 +123,8 @@ RSpec.describe "ECT summary" do
       context "when accessing future ECT period from different school" do
         let(:other_school) { FactoryBot.create(:school) }
         let(:teacher) { ect.teacher }
+        let!(:training_period) { nil }
+        let(:ect) { FactoryBot.create(:ect_at_school_period, school:, started_on: 1.year.ago, finished_on: 6.months.from_now) }
         let!(:future_period) { FactoryBot.create(:ect_at_school_period, teacher:, school: other_school, started_on: 1.year.from_now) }
 
         before do

--- a/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
@@ -9,6 +9,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
       :ongoing,
       teacher:,
       school:,
+      started_on:,
       email: "mentor@example.com"
     )
   end

--- a/spec/requests/schools/register_ect_wizard_spec.rb
+++ b/spec/requests/schools/register_ect_wizard_spec.rb
@@ -21,7 +21,7 @@ describe "Schools::RegisterECTWizardController" do
   describe "section 41 approval lost" do
     let(:gias_school) { FactoryBot.create(:gias_school, :independent_school_type, :not_section_41) }
     let(:school) { FactoryBot.create(:school, urn: gias_school.urn, gias_school:) }
-    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
+    let!(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:) }
     let!(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
     before { sign_in_as(:school_user, method: :dfe_sign_in, school:) }

--- a/spec/services/admin/teachers/rows_spec.rb
+++ b/spec/services/admin/teachers/rows_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Admin::Teachers::Rows do
     context "when a teacher has a later ect role period" do
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Naruto", trs_last_name: "Uzumaki") }
       let!(:older_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher:, started_on: Date.new(2025, 1, 1)) }
+      let!(:latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
@@ -152,7 +152,7 @@ RSpec.describe Admin::Teachers::Rows do
     context "when a teacher has a later mentor role period" do
       let!(:teacher) { FactoryBot.create(:teacher, trs_first_name: "Kakashi", trs_last_name: "Hatake") }
       let!(:older_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher:, started_on: Date.new(2025, 1, 1)) }
+      let!(:latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)

--- a/spec/services/admin/teachers/search_spec.rb
+++ b/spec/services/admin/teachers/search_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Admin::Teachers::Search do
       let!(:non_matching_teacher) { FactoryBot.create(:teacher, trs_first_name: "Sasuke", trs_last_name: "Uchiha") }
       let!(:matching_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: matching_teacher, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 7, 31)) }
       let!(:non_matching_old_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: non_matching_teacher, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:non_matching_latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
+      let!(:non_matching_latest_ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)
@@ -199,7 +199,7 @@ RSpec.describe Admin::Teachers::Search do
       let!(:non_matching_teacher) { FactoryBot.create(:teacher, trs_first_name: "Might", trs_last_name: "Guy") }
       let!(:matching_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: matching_teacher, started_on: Date.new(2025, 1, 1), finished_on: Date.new(2025, 7, 31)) }
       let!(:non_matching_old_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: non_matching_teacher, started_on: Date.new(2024, 1, 1), finished_on: Date.new(2024, 7, 31)) }
-      let!(:non_matching_latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
+      let!(:non_matching_latest_mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, teacher: non_matching_teacher, started_on: Date.new(2025, 1, 1)) }
 
       before do
         contract_period_2024 = FactoryBot.create(:contract_period, year: 2024)

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -243,6 +243,7 @@ RSpec.describe API::Declarations::Create, type: :model do
           context "when teacher's latest ongoing training period is in a frozen contract period but declaration targets non-frozen" do
             let(:declaration_date) { Faker::Date.between(from: training_period.started_on, to: training_period.finished_on).rfc3339 }
 
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 6.months.ago) }
             let!(:training_period) do
               FactoryBot.create(
                 :training_period,
@@ -322,6 +323,8 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         describe "training period selection" do
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 6.months.ago) }
+
           context "when multiple training periods exist for the same lead provider" do
             let!(:training_period) do
               FactoryBot.create(
@@ -630,7 +633,8 @@ RSpec.describe API::Declarations::Create, type: :model do
         let(:teacher_type) { trainee_type }
 
         context "when invalid" do
-          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
+          let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
           let(:teacher_api_id) { SecureRandom.uuid }
 
           it { expect(instance.create).to be(false) }

--- a/spec/services/api/declarations/query_spec.rb
+++ b/spec/services/api/declarations/query_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe API::Declarations::Query, :with_metadata do
 
     describe "filtering" do
       describe "by `lead_provider_id`" do
-        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
         let(:lead_provider_id) { training_period.lead_provider.id }
 
         let!(:declaration1) { FactoryBot.create(:declaration, training_period:) }

--- a/spec/services/api/schools/query_spec.rb
+++ b/spec/services/api/schools/query_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe API::Schools::Query, :with_metadata do
         let!(:school1) { FactoryBot.create(:school, :eligible) }
         let!(:school2) { FactoryBot.create(:school, :eligible) }
 
-        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_ect) }
+        let!(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_ect, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
         let!(:school3) { training_period.school_partnership.school }
 
         let(:updated_since) { 1.day.ago }

--- a/spec/services/api/teachers/change_schedule_spec.rb
+++ b/spec/services/api/teachers/change_schedule_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe API::Teachers::ChangeSchedule, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.change_schedule).to be(false) }

--- a/spec/services/api/teachers/defer_spec.rb
+++ b/spec/services/api/teachers/defer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
     describe "validations" do
       API::Concerns::Teachers::SharedAction::TEACHER_TYPES.each do |trainee_type|
         context "for #{trainee_type}" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 2.months.ago) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
           let(:teacher_type) { trainee_type }
 
@@ -59,7 +59,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
           end
 
           context "when training not started yet" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 3.months.from_now) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "You cannot defer #/teacher_api_id. This is because they have not been training with you for at least one day.") }
@@ -95,7 +95,7 @@ RSpec.describe API::Teachers::Defer, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.defer).to be(false) }

--- a/spec/services/api/teachers/query_spec.rb
+++ b/spec/services/api/teachers/query_spec.rb
@@ -86,10 +86,10 @@ RSpec.describe API::Teachers::Query, :with_metadata do
 
     describe "filtering" do
       describe "by `lead_provider`" do
-        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
         let!(:teacher1) { training_period.teacher }
-        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
-        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
+        let!(:teacher2) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let!(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
 
         context "when `lead_provider` param is omitted" do
           it "returns all teachers" do
@@ -177,9 +177,9 @@ RSpec.describe API::Teachers::Query, :with_metadata do
       end
 
       describe "by `api_from_teacher_id`" do
-        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
-        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher }
-        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
+        let(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+        let(:teacher2) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher }
+        let(:teacher3) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
         let!(:teacher_id_change1) { FactoryBot.create(:teacher_id_change, teacher: teacher1, api_from_teacher_id: teacher2.api_id) }
         let!(:teacher_id_change2) { FactoryBot.create(:teacher_id_change, teacher: teacher2, api_from_teacher_id: teacher3.api_id) }
         let!(:teacher_id_change3) { FactoryBot.create(:teacher_id_change, teacher: teacher3, api_from_teacher_id: teacher1.api_id) }
@@ -313,8 +313,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     describe "ordering" do
-      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing).teacher }
-      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher } }
+      let!(:teacher1) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher }
+      let!(:teacher2) { travel_to(1.day.ago) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher } }
 
       describe "default order" do
         it "returns teachers ordered by created_at, in ascending order" do
@@ -363,8 +363,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     it "raises an error if the teacher is not in the filtered query" do
-      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).teacher
-      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher
       lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
 
       query = described_class.new(lead_provider_id:)
@@ -392,8 +392,8 @@ RSpec.describe API::Teachers::Query, :with_metadata do
     end
 
     it "raises an error if the teacher is not in the filtered query" do
-      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing).teacher
-      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing).teacher
+      teacher1 = FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)).teacher
+      teacher2 = FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)).teacher
       lead_provider_id = teacher1.lead_provider_metadata.first.lead_provider_id
 
       query = described_class.new(lead_provider_id:)

--- a/spec/services/api/teachers/resume_spec.rb
+++ b/spec/services/api/teachers/resume_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe API::Teachers::Resume, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.resume).to be(false) }

--- a/spec/services/api/teachers/withdraw_spec.rb
+++ b/spec/services/api/teachers/withdraw_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
     describe "validations" do
       API::Concerns::Teachers::SharedAction::TEACHER_TYPES.each do |trainee_type|
         context "for #{trainee_type}" do
-          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 2.months.ago) }
+          let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
           let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
           let(:teacher_type) { trainee_type }
 
@@ -52,7 +52,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
           end
 
           context "when training not started yet" do
-            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 3.months.from_now) }
+            let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 3.months.from_now) }
 
             it { is_expected.to have_one_error_per_attribute }
             it { is_expected.to have_error(:teacher_api_id, "You cannot withdraw #/teacher_api_id. This is because they have not been training with you for at least one day.") }
@@ -81,7 +81,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
       end
 
       context "for ect with mentor-no-longer-being-mentor reason" do
-        let(:at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: 2.months.ago) }
+        let(:at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.months.ago) }
         let!(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: at_school_period, started_on: at_school_period.started_on) }
         let(:teacher_type) { :ect }
         let(:reason) { described_class::MENTOR_ONLY_WITHDRAWAL_REASONS.sample }
@@ -91,7 +91,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
       end
 
       context "for mentor with mentor-no-longer-being-mentor reason" do
-        let(:at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: 2.months.ago) }
+        let(:at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: 2.months.ago) }
         let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: at_school_period, started_on: at_school_period.started_on) }
         let(:teacher_type) { :mentor }
         let(:reason) { described_class::MENTOR_ONLY_WITHDRAWAL_REASONS.sample }
@@ -125,7 +125,7 @@ RSpec.describe API::Teachers::Withdraw, type: :model do
           let(:teacher_type) { trainee_type }
 
           context "when invalid" do
-            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing) }
+            let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
             let(:teacher_api_id) { SecureRandom.uuid }
 
             it { expect(instance.withdraw).to be(false) }

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
     end
 
     context "when training period has started and not finished" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing) }
+      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:) }
 
       it { is_expected.to eq(:active) }
       it { expect(service).to be_active }

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
     subject { service.status }
 
     context "when training period set to start in the future" do
-      let(:training_period) { FactoryBot.create(:training_period, :not_started_yet) }
+      let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 1.week.from_now) }
+      let(:training_period) { FactoryBot.create(:training_period, :not_started_yet, ect_at_school_period:) }
 
       it { is_expected.to eq(:joining) }
     end

--- a/spec/services/ect_at_school_periods/switch_mentor_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_mentor_spec.rb
@@ -188,7 +188,7 @@ module ECTAtSchoolPeriods
 
             let!(:current_mentorship) { FactoryBot.create(:mentorship_period, started_on: 2.weeks.ago, finished_on: 1.day.ago, mentee: ect_at_school_period, mentor: previous_mentor) }
             let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school: ect_at_school_period.school, started_on: 1.month.ago, finished_on: 1.day.ago) }
-            let(:mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on: 2.weeks.ago, mentor_at_school_period: previous_mentor) }
+            let(:mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: 2.weeks.ago, finished_on: 1.day.ago, mentor_at_school_period: previous_mentor) }
 
             context "when the previous mentor had not started training" do
               it "assigns a standard schedule to the new training period" do

--- a/spec/services/events/record_spec.rb
+++ b/spec/services/events/record_spec.rb
@@ -1183,7 +1183,7 @@ RSpec.describe Events::Record do
     end
 
     context "when ECT training" do
-      let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing) }
+      let(:training_period) { FactoryBot.create(:training_period, :for_ect, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing)) }
       let(:course_identifier) { "ecf-induction" }
 
       it "queues a RecordEventJob with the correct values" do
@@ -1206,7 +1206,7 @@ RSpec.describe Events::Record do
     end
 
     context "when Mentor training" do
-      let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing) }
+      let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period: FactoryBot.create(:mentor_at_school_period, :ongoing)) }
       let(:course_identifier) { "ecf-mentor" }
 
       it "queues a RecordEventJob with the correct values" do
@@ -1850,6 +1850,7 @@ RSpec.describe Events::Record do
       let(:ect_at_school_period) do
         FactoryBot.create(
           :ect_at_school_period,
+          :ongoing,
           teacher:,
           school:,
           started_on:
@@ -1882,6 +1883,7 @@ RSpec.describe Events::Record do
       let(:mentor_at_school_period) do
         FactoryBot.create(
           :mentor_at_school_period,
+          :ongoing,
           teacher:,
           school:,
           started_on:

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -440,6 +440,7 @@ RSpec.describe Schedules::Find do
       before { travel_to provider_led_start_date }
 
       context "when the ECT started training in the 2021 contract period" do
+        let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, :with_training_period, teacher:, school:, started_on: Date.new(2021, 7, 1)) }
         let(:contract_period_2021) { FactoryBot.create(:contract_period, :with_schedules, :with_payments_frozen, year: 2021) }
         let(:old_active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period: contract_period_2021) }
         let!(:old_training_period) do

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Schedules::Find do
       let(:provider_led_start_date) { Date.new(year, 12, 1) }
       let(:previous_start_date) { Date.new(year, 7, 1) }
 
-      let(:mentee) { FactoryBot.create(:ect_at_school_period, school:, started_on: previous_start_date, finished_on: 1.day.ago) }
+      let(:mentee) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on: previous_start_date) }
       let(:schedule) { FactoryBot.create(:schedule, contract_period: previous_contract_period, identifier: "ecf-standard-september") }
 
       before do
@@ -293,7 +293,7 @@ RSpec.describe Schedules::Find do
           let!(:mentee_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: previous_start_date, ect_at_school_period: mentee) }
           let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on: previous_start_date, finished_on: 1.day.ago) }
           let!(:mentorship_period) { FactoryBot.create(:mentorship_period, started_on: previous_start_date, finished_on: 1.day.ago, mentee:, mentor: previous_mentor) }
-          let!(:mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on: previous_start_date, mentor_at_school_period: previous_mentor) }
+          let!(:mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: previous_start_date, finished_on: 1.day.ago, mentor_at_school_period: previous_mentor) }
 
           context "when the previous mentor has not started training" do
             it_behaves_like "no replacement schedule assigned"
@@ -330,8 +330,8 @@ RSpec.describe Schedules::Find do
 
             context "when the previous mentor has both ect and mentor periods" do
               before do
-                FactoryBot.create(:ect_at_school_period, started_on: previous_start_date - 1.year, teacher: previous_mentor.teacher, school:)
-                FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: previous_start_date - 1.year, ect_at_school_period: previous_mentor.teacher.ect_at_school_periods.last, school_partnership:)
+                previous_mentor_ect_period = FactoryBot.create(:ect_at_school_period, started_on: previous_start_date - 1.year, finished_on: previous_start_date - 1.day, teacher: previous_mentor.teacher, school:)
+                FactoryBot.create(:training_period, :provider_led, started_on: previous_start_date - 1.year, finished_on: previous_start_date - 1.day, ect_at_school_period: previous_mentor_ect_period, school_partnership:)
               end
 
               it_behaves_like "replacement schedule assigned"
@@ -345,8 +345,8 @@ RSpec.describe Schedules::Find do
 
           let(:first_mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on: first_date, finished_on: second_date) }
           let(:second_mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on: first_date, finished_on: 1.day.ago) }
-          let!(:first_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on: first_date, mentor_at_school_period: first_mentor) }
-          let!(:second_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on: second_date, mentor_at_school_period: second_mentor) }
+          let!(:first_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: first_date, finished_on: second_date, mentor_at_school_period: first_mentor) }
+          let!(:second_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: second_date, finished_on: 1.day.ago, mentor_at_school_period: second_mentor) }
 
           before do
             FactoryBot.create(:training_period, :provider_led, :ongoing, started_on: first_date, ect_at_school_period: mentee)

--- a/spec/services/schools/access_blocker_spec.rb
+++ b/spec/services/schools/access_blocker_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Schools::AccessBlocker do
       let(:school_urn) { school.urn }
 
       before do
-        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, school:))
+        FactoryBot.create(:training_period, :ongoing, ect_at_school_period: FactoryBot.create(:ect_at_school_period, :ongoing, school:))
       end
 
       it "does not block access" do

--- a/spec/support/shared_examples/api_teacher_shared_action_support.rb
+++ b/spec/support/shared_examples/api_teacher_shared_action_support.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "an API teacher shared action", :with_metadata do
 
     API::Concerns::Teachers::SharedAction::TEACHER_TYPES.each do |trainee_type|
       context "for #{trainee_type}" do
-        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", started_on: 2.months.ago) }
+        let(:at_school_period) { FactoryBot.create(:"#{trainee_type}_at_school_period", :ongoing, started_on: 2.months.ago) }
         let!(:training_period) { FactoryBot.create(:training_period, :"for_#{trainee_type}", :ongoing, "#{trainee_type}_at_school_period": at_school_period, started_on: at_school_period.started_on) }
         let(:teacher_type) { trainee_type }
 

--- a/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/lead_provider_step_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::LeadProviderStep do
 
     context "when the mentee has previously started training with another mentor" do
       let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school:, started_on:, finished_on: started_on + 2.months) }
-      let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on:, mentor_at_school_period: previous_mentor) }
+      let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on:, finished_on: started_on + 2.months, mentor_at_school_period: previous_mentor) }
       let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on: Date.current) }
 
       before do

--- a/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
+++ b/spec/wizards/schools/assign_existing_mentor_wizard/review_mentor_eligibility_step_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Schools::AssignExistingMentorWizard::ReviewMentorEligibilityStep 
 
     context "when the mentee has previously started training with another mentor" do
       let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school: ect_at_school_period.school, started_on: 1.month.ago, finished_on: 1.day.ago) }
-      let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on: 2.days.ago, mentor_at_school_period: previous_mentor) }
+      let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: 2.days.ago, finished_on: 1.day.ago, mentor_at_school_period: previous_mentor) }
 
       before do
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-replacement-january")

--- a/spec/wizards/schools/ects/change_training_programme_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/ects/change_training_programme_wizard/lead_provider_step_spec.rb
@@ -98,7 +98,7 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::LeadProviderStep do
   end
 
   describe "#lead_providers_for_select" do
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:, started_on:) }
+    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:) }
     let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year:) }
     let!(:other_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year:) }
     let!(:future_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: year + 1) }

--- a/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
   subject(:step) { described_class.new(wizard:, leaving_on:) }
 
   let(:wizard) { instance_double(Schools::ECTs::TeacherLeavingWizard::Wizard, store:, ect_at_school_period:) }
-  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, started_on: Date.new(2025, 1, 1)) }
+  let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, started_on: Date.new(2025, 1, 1)) }
   let(:teacher_name) { Teachers::Name.new(ect_at_school_period.teacher).full_name }
   let(:store) { FactoryBot.build(:session_repository, form_key: :teacher_leaving_wizard) }
   let(:leaving_on) { { "day" => "1", "month" => "3", "year" => "2025" } }

--- a/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/teacher_leaving_wizard/edit_step_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Schools::ECTs::TeacherLeavingWizard::EditStep do
     end
 
     context "when the date clashes with the latest training period" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2024, 12, 31)) }
+      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         allow(Schools::Validation::PeriodBoundary)

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/confirmation_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/confirmation_step_spec.rb
@@ -12,7 +12,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::ConfirmationStep, type: :mo
   end
   let(:store) { FactoryBot.build(:session_repository) }
   let(:school) { FactoryBot.create(:school) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
   let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, mentor_at_school_period:, started_on: Time.zone.today) }
 
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
@@ -15,7 +15,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
   let(:school) { FactoryBot.create(:school) }
   let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_school_partnership, mentor_at_school_period:, started_on: Time.zone.today) }
+  let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_school_partnership, mentor_at_school_period:, started_on: mentor_at_school_period.started_on) }
 
   let(:params) { { lead_provider_id: lead_provider.id } }
 

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
@@ -13,7 +13,7 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
   let(:store) { FactoryBot.build(:session_repository) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, school:) }
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let!(:training_period) { FactoryBot.create(:training_period, :for_mentor, :ongoing, :with_school_partnership, mentor_at_school_period:, started_on: mentor_at_school_period.started_on) }
 

--- a/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::EditStep do
     end
 
     context "when the date clashes with the latest training period" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:, started_on: Date.new(2024, 12, 31)) }
+      let(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period:, started_on: Date.new(2025, 1, 1)) }
 
       before do
         allow(Schools::Validation::PeriodBoundary)

--- a/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/teacher_leaving_wizard/edit_step_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Schools::Mentors::TeacherLeavingWizard::EditStep do
   subject(:step) { described_class.new(wizard:, leaving_on:) }
 
   let(:wizard) { instance_double(Schools::Mentors::TeacherLeavingWizard::Wizard, store:, mentor_at_school_period:) }
-  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, started_on: Date.new(2025, 1, 1)) }
+  let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, :ongoing, started_on: Date.new(2025, 1, 1)) }
   let(:teacher_name) { Teachers::Name.new(mentor_at_school_period.teacher).full_name }
   let(:store) { FactoryBot.build(:session_repository, form_key: :teacher_leaving_wizard) }
   let(:leaving_on) { { "day" => "1", "month" => "3", "year" => "2025" } }

--- a/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/start_date_step_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Schools::RegisterECTWizard::StartDateStep, type: :model do
     end
 
     context "when the date clashes with the latest training period" do
-      let(:training_period) { FactoryBot.create(:training_period, :ongoing, ect_at_school_period: previous_period, started_on: Date.new(2024, 12, 31)) }
+      let(:training_period) { FactoryBot.create(:training_period, ect_at_school_period: previous_period, started_on: Date.new(2024, 12, 31), finished_on: Date.new(2025, 3, 31)) }
 
       let(:previous_period) do
         FactoryBot.create(:ect_at_school_period,

--- a/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
+++ b/spec/wizards/schools/register_mentor_wizard/registration_store_spec.rb
@@ -244,7 +244,7 @@ describe Schools::RegisterMentorWizard::RegistrationStore do
       let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:, lead_provider:) }
       let!(:previous_mentorship_period) { FactoryBot.create(:mentorship_period, started_on: 2.weeks.ago, finished_on: 1.day.ago, mentee:, mentor: previous_mentor) }
       let(:previous_mentor) { FactoryBot.create(:mentor_at_school_period, school: mentee.school, started_on: 1.month.ago, finished_on: 1.day.ago) }
-      let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, :for_mentor, started_on: 2.weeks.ago, mentor_at_school_period: previous_mentor) }
+      let(:previous_mentor_training_period) { FactoryBot.create(:training_period, :provider_led, :for_mentor, started_on: 2.weeks.ago, finished_on: 1.day.ago, mentor_at_school_period: previous_mentor) }
 
       before do
         FactoryBot.create(:schedule, contract_period:, identifier: "ecf-replacement-january")

--- a/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
+++ b/spec/wizards/schools/register_mentor_wizard/shared_examples/started_on_step.rb
@@ -144,7 +144,7 @@ RSpec.shared_examples "a started on step" do |current_step:|
       end
 
       context "when the date clashes with the latest training period" do
-        let(:training_period) { FactoryBot.create(:training_period, :ongoing, :for_mentor, mentor_at_school_period: previous_period, started_on: Date.new(2024, 12, 31)) }
+        let(:training_period) { FactoryBot.create(:training_period, :for_mentor, mentor_at_school_period: previous_period, started_on: Date.new(2024, 12, 31), finished_on: Date.new(2025, 3, 31)) }
 
         let(:previous_period) do
           FactoryBot.create(:mentor_at_school_period,


### PR DESCRIPTION
### Context
Issue [#2959](https://github.com/DFE-Digital/register-early-career-teachers-public/issues/2959).

`TrainingPeriod#enveloped_by_trainee_at_school_period` don't validate for ongoing training periods, so if its parent `ECTAtSchoolPeriod` / `MentorAtSchoolPeriod` was already finished (or started later) it is accepted as valid even though it logically extended past the parent. 

There is a mirror rule on the parent (`AtSchoolPeriod#covering_training_periods`) that already validates this.
This ticket is to close the gap for the child period therefore making the validation symetric and preventing potential exceptions thrown in production.

### Changes proposed in this pull request
  - remove the skip on TrainingPeriod
  - adjust specs to create ongoing parents when the child is ongoing.