### PR TITLE
Take into account future `MentorshipPeriod`s in API responses

### DIFF
--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -28,7 +28,7 @@ module Metadata::Handlers
         latest_ect_contract_period = latest_ect_training_period&.contract_period
         latest_mentor_contract_period = latest_mentor_training_period&.contract_period
         ect_assigned_mentor_latest_school_period_id =
-          latest_ongoing_mentor_at_school_period_id(latest_ect_training_period&.ect_at_school_period_id)
+          latest_ongoing_mentor_at_school_period_id(latest_ect_training_period&.ect_at_school_period)
         involved_in_school_transfer = school_transfers_exist_for(teacher.ect_at_school_periods, lead_provider_id) ||
           school_transfers_exist_for(teacher.mentor_at_school_periods, lead_provider_id)
 
@@ -62,13 +62,13 @@ module Metadata::Handlers
         .index_by { it.lead_provider&.id }
     end
 
-    def latest_ongoing_mentor_at_school_period_id(ect_at_school_period_id)
-      return nil if ect_at_school_period_id.nil?
+    def latest_ongoing_mentor_at_school_period_id(ect_at_school_period)
+      return nil if ect_at_school_period.nil?
 
-      MentorshipPeriod
-        .where(ect_at_school_period_id:)
-        .ongoing_today
-        .latest_first
+      ect_at_school_period
+        .mentorship_periods
+        .current_or_future
+        .earliest_first
         .pick(:mentor_at_school_period_id)
     end
 

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -287,15 +287,6 @@ RSpec.describe Metadata::Handlers::Teacher do
             school_partnership: school_partnership1
           )
         end
-        let!(:latest_mentorship_period) do
-          FactoryBot.create(
-            :mentorship_period,
-            mentee: ect_at_school_period,
-            mentor: mentor_at_school_period,
-            started_on: ect_training_period1.started_on + 1.month,
-            finished_on: nil
-          )
-        end
 
         before do
           # Previous mentorship period.
@@ -303,8 +294,8 @@ RSpec.describe Metadata::Handlers::Teacher do
             :mentorship_period,
             mentee: ect_at_school_period,
             mentor: mentor_at_school_period,
-            started_on: latest_mentorship_period.started_on - 1.month,
-            finished_on: latest_mentorship_period.started_on
+            started_on: ect_at_school_period.started_on + 1.month,
+            finished_on: ect_at_school_period.started_on + 2.months
           )
 
           # Previous ECT training period.
@@ -318,15 +309,42 @@ RSpec.describe Metadata::Handlers::Teacher do
           )
         end
 
-        it "creates metadata with the correct/latest ect_assigned_mentor_latest_school_period" do
-          refresh_metadata
+        context "when there is a mentorship period starting in the future" do
+          let!(:future_mentorship_period) do
+            FactoryBot.create(
+              :mentorship_period,
+              mentee: ect_at_school_period,
+              mentor: mentor_at_school_period,
+              started_on: 1.month.from_now,
+              finished_on: nil
+            )
+          end
 
-          metadata = Metadata::TeacherLeadProvider.where(teacher: teacher1, lead_provider: lead_provider1).sole
-          expect(metadata).to have_attributes(
-            teacher: teacher1,
-            lead_provider: lead_provider1,
-            ect_assigned_mentor_latest_school_period: latest_mentorship_period.mentor
-          )
+          it "assigns the mentor from the future mentorship period to ect_assigned_mentor_latest_school_period" do
+            refresh_metadata
+
+            metadata = Metadata::TeacherLeadProvider.find_by!(teacher: teacher1, lead_provider: lead_provider1)
+            expect(metadata.ect_assigned_mentor_latest_school_period).to eq(future_mentorship_period.mentor)
+          end
+
+          context "when there is also an ongoing mentorship period" do
+            let!(:ongoing_mentorship_period) do
+              FactoryBot.create(
+                :mentorship_period,
+                mentee: ect_at_school_period,
+                mentor: mentor_at_school_period,
+                started_on: 1.month.ago,
+                finished_on: future_mentorship_period.started_on.prev_day
+              )
+            end
+
+            it "assigns the mentor from the ongoing mentorship period to ect_assigned_mentor_latest_school_period" do
+              refresh_metadata
+
+              metadata = Metadata::TeacherLeadProvider.find_by!(teacher: teacher1, lead_provider: lead_provider1)
+              expect(metadata.ect_assigned_mentor_latest_school_period).to eq(ongoing_mentorship_period.mentor)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
### Context

At the moment, if an ECT is going to be mentored in the future the `mentor_id` in the `TeacherSerializer` is returning `null`. Instead, we want to return the `mentor_id` based on the future mentorship period in this scenario.

Similarly, in the unfunded mentor API response we surface the email relative to the latest, ongoing `MentorshipPeriod` for an ECT with the lead provider. We want to also include future `MentorshipPeriod`s here as well.

### Changes proposed in this pull request

- Take into account future `MentorshipPeriod`s in API responses