### PR TITLE
Prefix page titles with Error:

### DIFF
--- a/app/views/schools/ects/change_email_address_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_email_address_wizard/edit.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
     title: "Change email address for #{@wizard.teacher_full_name}",
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_ect_path(@wizard.ect_at_school_period)
 ) %>
 

--- a/app/views/schools/ects/change_lead_provider_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_lead_provider_wizard/edit.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Change lead provider for #{@wizard.teacher_full_name}",
+  error: @wizard.current_step.errors.present?,
   backlink_href: schools_ect_path(@wizard.ect_at_school_period)
 ) %>
 

--- a/app/views/schools/ects/change_mentor_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/edit.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
     title: "Who will mentor #{@wizard.teacher_full_name}?",
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_ect_path(@wizard.ect_at_school_period)
 ) %>
 

--- a/app/views/schools/ects/change_mentor_wizard/lead_provider.html.erb
+++ b/app/views/schools/ects/change_mentor_wizard/lead_provider.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
     title: "Which lead provider would you like to contact your school about training #{@wizard.current_step.new_mentor_name}?",
+    error: @wizard.current_step.errors.present?,
     backlink_href: @wizard.previous_step_path
   ) %>
 

--- a/app/views/schools/ects/change_name_wizard/edit.html.erb
+++ b/app/views/schools/ects/change_name_wizard/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_data(
     title: "Change name for #{@wizard.teacher_full_name}",
-    error: @wizard.ect_at_school_period.errors.present?,
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_ect_path(@ect_at_school_period),
 ) %>
 

--- a/app/views/schools/ects/change_training_programme_wizard/lead_provider.html.erb
+++ b/app/views/schools/ects/change_training_programme_wizard/lead_provider.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
   title: "Which lead provider will be training #{@wizard.teacher_full_name}?",
+  error: @wizard.current_step.errors.present?,
   backlink_href: @wizard.previous_step_path
 ) %>
 

--- a/app/views/schools/induction_tutor/update_induction_tutor_wizard/edit.html.erb
+++ b/app/views/schools/induction_tutor/update_induction_tutor_wizard/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_data(
     title: "Change induction tutor",
-    error: @wizard.school.errors.present?,
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_induction_tutor_path
 ) %>
 

--- a/app/views/schools/mentors/change_email_address_wizard/edit.html.erb
+++ b/app/views/schools/mentors/change_email_address_wizard/edit.html.erb
@@ -1,5 +1,6 @@
 <% page_data(
     title: "Change email address for #{@wizard.teacher_full_name}",
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_mentor_path(@wizard.mentor_at_school_period)
 ) %>
 

--- a/app/views/schools/mentors/change_lead_provider_wizard/edit.html.erb
+++ b/app/views/schools/mentors/change_lead_provider_wizard/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_data(
     title: "Change lead provider for #{@wizard.teacher_full_name}",
-    error: @mentor_at_school_period.errors.present?,
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_mentor_path(@mentor_at_school_period)
 ) %>
 

--- a/app/views/schools/mentors/change_name_wizard/edit.html.erb
+++ b/app/views/schools/mentors/change_name_wizard/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_data(
     title: "Change name for #{@wizard.teacher_full_name}",
-    error: @mentor_at_school_period.errors.present?,
+    error: @wizard.current_step.errors.present?,
     backlink_href: schools_mentor_path(@mentor_at_school_period),
 ) %>
 

--- a/spec/features/schools/ects/change/email_address_spec.rb
+++ b/spec/features/schools/ects/change/email_address_spec.rb
@@ -21,6 +21,21 @@ describe "School user can change ECTs email address" do
     then_i_see_the_confirmation_message
   end
 
+  context "when an invalid email address is submitted" do
+    it "re-renders the form with an error prefix in the page title" do
+      given_there_is_a_school
+      and_there_is_an_ect
+      and_i_am_logged_in_as_a_school_user
+
+      when_i_visit_the_ect_page
+      then_i_can_change_the_email_address
+
+      when_i_enter_an_invalid_email_address
+      and_i_continue
+      then_the_page_title_has_an_error_prefix
+    end
+  end
+
 private
 
   def given_there_is_a_school
@@ -94,5 +109,13 @@ private
     expect(success_panel).to have_text(
       "You’ve changed John Doe’s email address to new@example.com"
     )
+  end
+
+  def when_i_enter_an_invalid_email_address
+    page.get_by_label("Email address").fill("not-an-email")
+  end
+
+  def then_the_page_title_has_an_error_prefix
+    expect(page.title).to start_with("Error:")
   end
 end

--- a/spec/features/schools/ects/change/lead_provider_spec.rb
+++ b/spec/features/schools/ects/change/lead_provider_spec.rb
@@ -52,6 +52,24 @@ describe "School user can change ECT's lead provider" do
     then_i_see_the_confirmation_message
   end
 
+  context "when no lead provider is selected" do
+    it "re-renders the form with an error prefix in the page title" do
+      given_there_is_a_school
+      and_there_is_an_ect(started_on: 1.week.ago)
+      and_there_is_a_contract_period
+      and_there_is_an_active_lead_provider
+      with_provider_led_training
+      and_there_is_another_active_lead_provider
+      and_i_am_logged_in_as_a_school_user
+
+      when_i_visit_the_ect_page
+      then_i_can_change_the_assigned_lead_provider
+
+      when_i_continue_without_selecting_a_lead_provider
+      then_the_page_title_has_an_error_prefix
+    end
+  end
+
 private
 
   def given_there_is_a_school
@@ -204,5 +222,13 @@ private
     expect(success_panel).to have_text(
       "You’ve chosen #{@selected_lead_provider_name} as the new lead provider for John Doe"
     )
+  end
+
+  def when_i_continue_without_selecting_a_lead_provider
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_the_page_title_has_an_error_prefix
+    expect(page.title).to start_with("Error:")
   end
 end

--- a/spec/features/schools/ects/change/mentor_spec.rb
+++ b/spec/features/schools/ects/change/mentor_spec.rb
@@ -90,6 +90,9 @@ describe "School user can change early career teachers mentor" do
       then_i_change_lead_provider
       and_i_see_the_change_lead_provider_form
 
+      when_i_continue_without_selecting_a_lead_provider
+      then_the_lead_provider_page_title_has_an_error_prefix
+
       when_i_choose_a_lead_provider
       and_i_click_continue
       then_i_am_asked_to_check_and_confirm_the_change
@@ -149,7 +152,7 @@ describe "School user can change early career teachers mentor" do
       then_i_can_change_the_assigned_mentor
 
       when_i_continue_without_selecting_a_mentor
-      then_the_page_title_has_an_error_prefix
+      then_the_change_mentor_page_title_has_an_error_prefix
     end
   end
 
@@ -308,11 +311,9 @@ private
   end
 
   def then_i_change_lead_provider
-    change_provider_link_text = <<~TXT.squish
-      #{@provider_led_training_period.lead_provider.name} will not be providing
-      mentor training to Jane Smith
-    TXT
-    page.get_by_role("link", name: change_provider_link_text).click
+    page
+      .get_by_role("link", name: /will not be providing mentor training to Jane Smith/)
+      .click
   end
 
   def and_i_see_the_change_lead_provider_form
@@ -354,7 +355,21 @@ private
     page.get_by_role("button", name: "Continue").click
   end
 
-  def then_the_page_title_has_an_error_prefix
+  def then_the_change_mentor_page_title_has_an_error_prefix
     expect(page.title).to start_with("Error:")
+  end
+
+  def when_i_continue_without_selecting_a_lead_provider
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_the_lead_provider_page_title_has_an_error_prefix
+    expect(page.title).to start_with("Error:")
+
+    expect(page.locator("h1")).to have_text(
+      "Which lead provider would you like to contact your school about training Jane Smith?"
+    )
+
+    expect(page.locator(".govuk-error-summary")).to be_visible
   end
 end

--- a/spec/features/schools/ects/change/mentor_spec.rb
+++ b/spec/features/schools/ects/change/mentor_spec.rb
@@ -139,6 +139,20 @@ describe "School user can change early career teachers mentor" do
     end
   end
 
+  context "when no mentor is selected" do
+    it "re-renders the form with an error prefix in the page title" do
+      and_the_mentee_is_on_school_led_training
+      and_the_mentee_has_an_assigned_mentor
+      and_there_is_another_registered_mentor
+
+      when_i_visit_the_early_career_teacher_show_page
+      then_i_can_change_the_assigned_mentor
+
+      when_i_continue_without_selecting_a_mentor
+      then_the_page_title_has_an_error_prefix
+    end
+  end
+
 private
 
   def given_there_is_a_school
@@ -334,5 +348,13 @@ private
   def then_i_am_taken_back_to_the_early_career_teacher_show_page
     heading = page.locator("h1")
     expect(heading).to have_text("John Doe")
+  end
+
+  def when_i_continue_without_selecting_a_mentor
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_the_page_title_has_an_error_prefix
+    expect(page.title).to start_with("Error:")
   end
 end

--- a/spec/features/schools/ects/change/name_spec.rb
+++ b/spec/features/schools/ects/change/name_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "Changing an ECT's name" do
   scenario "invalid long name" do
     when_i_change_the_name_to(Faker::Lorem.characters(number: 71))
     and_i_click_the_continue_button
+    then_the_page_title_should_have_an_error_prefix
     expect(page.get_by_role("link", name: "Corrected name must be 70 characters or less")).to be_visible
     then_i_should_be_taken_to_the_edit_page
   end
@@ -71,6 +72,7 @@ RSpec.describe "Changing an ECT's name" do
   scenario "invalid blank name" do
     when_i_change_the_name_to("")
     and_i_click_the_continue_button
+    then_the_page_title_should_have_an_error_prefix
     expect(page.get_by_role("link", name: "Enter the correct full name")).to be_visible
     then_i_should_be_taken_to_the_edit_page
   end
@@ -78,6 +80,7 @@ RSpec.describe "Changing an ECT's name" do
   scenario "invalid same name" do
     when_i_change_the_name_to("Miriam Margolyes")
     and_i_click_the_continue_button
+    then_the_page_title_should_have_an_error_prefix
     expect(page.get_by_role("link", name: "The name must be different from the current name")).to be_visible
     then_i_should_be_taken_to_the_edit_page
   end
@@ -148,5 +151,10 @@ RSpec.describe "Changing an ECT's name" do
 
   def and_the_name_field_should_be(name)
     expect(page.locator("#edit-name-field").input_value).to eq(name)
+  end
+
+  def then_the_page_title_should_have_an_error_prefix
+    expect(page.title).to start_with("Error:")
+    then_i_should_see_the_change_name_page
   end
 end

--- a/spec/features/schools/ects/change/training_programme_spec.rb
+++ b/spec/features/schools/ects/change/training_programme_spec.rb
@@ -62,6 +62,11 @@ describe "School user can change ECTs training programme" do
     and_i_can_change_the_training_programme_to_provider_led
 
     when_i_change_the_training_programme
+    then_i_see_the_lead_provider_selection_page
+
+    when_i_continue_without_selecting_a_lead_provider
+    then_the_lead_provider_page_title_has_an_error_prefix
+
     and_i_choose_the_lead_provider
     and_i_continue
     then_i_am_asked_to_check_and_confirm_the_change
@@ -204,5 +209,20 @@ private
     expect(success_panel).to have_text(
       "You’ve changed John Doe’s training programme to school-led"
     )
+  end
+
+  def then_i_see_the_lead_provider_selection_page
+    heading = page.locator("h1", hasText: "Which lead provider will be training John Doe?")
+    expect(heading).to be_visible
+  end
+
+  def when_i_continue_without_selecting_a_lead_provider
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def then_the_lead_provider_page_title_has_an_error_prefix
+    expect(page.title).to start_with("Error:")
+    then_i_see_the_lead_provider_selection_page
+    expect(page.locator(".govuk-error-summary")).to be_visible
   end
 end

--- a/spec/features/schools/induction_tutor/update_induction_tutor_spec.rb
+++ b/spec/features/schools/induction_tutor/update_induction_tutor_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Assigning a new induction tutor" do
 
     when_i_enter_invalid_details_for_the_induction_tutor
     and_i_click_continue
+    then_the_page_title_should_have_an_error_prefix
     then_i_should_see_error_messages_indicating_what_i_need_to_fix
 
     when_i_enter_valid_details_for_the_induction_tutor
@@ -82,5 +83,11 @@ RSpec.describe "Assigning a new induction tutor" do
 
   def base_page
     "/school/induction-tutor/update-induction-tutor"
+  end
+
+  def then_the_page_title_should_have_an_error_prefix
+    expect(page.title).to start_with("Error:")
+    expect(page.locator("h1")).to have_text("Change induction tutor")
+    expect(page.locator(".govuk-error-summary")).to be_visible
   end
 end

--- a/spec/features/schools/mentors/change/email_address_spec.rb
+++ b/spec/features/schools/mentors/change/email_address_spec.rb
@@ -21,6 +21,21 @@ describe "School user can change mentor's email address" do
     then_i_see_the_confirmation_message
   end
 
+  context "when an invalid email address is submitted" do
+    it "re-renders the form with an error prefix in the page title" do
+      given_there_is_a_school
+      and_there_is_a_mentor
+      and_i_am_logged_in_as_a_school_user
+
+      when_i_visit_the_mentor_page
+      then_i_can_change_the_email_address
+
+      when_i_enter_an_invalid_email_address
+      and_i_continue
+      then_the_page_title_has_an_error_prefix
+    end
+  end
+
 private
 
   def given_there_is_a_school
@@ -94,5 +109,13 @@ private
     expect(success_panel).to have_text(
       "You’ve changed the mentor’s email address to new@example.com"
     )
+  end
+
+  def when_i_enter_an_invalid_email_address
+    page.get_by_label("Email address").fill("not-an-email")
+  end
+
+  def then_the_page_title_has_an_error_prefix
+    expect(page.title).to start_with("Error:")
   end
 end

--- a/spec/features/schools/mentors/change/lead_provider_spec.rb
+++ b/spec/features/schools/mentors/change/lead_provider_spec.rb
@@ -19,6 +19,10 @@ describe "School user can change a mentor's lead provider" do
       and_i_see_the_change_lead_provider_form
       and_the_current_lead_provider_is_not_an_option
 
+      when_i_continue
+      then_the_page_title_should_have_an_error_prefix
+      and_i_see_the_change_lead_provider_form
+
       when_i_choose_a_lead_provider
       and_i_continue
       then_i_am_asked_to_check_and_confirm_the_change
@@ -150,6 +154,11 @@ private
   def and_i_see_the_change_lead_provider_form
     heading = page.locator("h1")
     expect(heading).to have_text("Change lead provider for John Doe")
+  end
+
+  def then_the_page_title_should_have_an_error_prefix
+    expect(page.title).to start_with("Error:")
+    expect(page.locator(".govuk-error-summary")).to be_visible
   end
 
   def and_the_current_lead_provider_is_not_an_option

--- a/spec/features/schools/mentors/change/name_spec.rb
+++ b/spec/features/schools/mentors/change/name_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Changing an mentor's name" do
+RSpec.describe "Changing a mentor's name" do
   let!(:mentor_at_school_period) do
     FactoryBot.create(:mentor_at_school_period, :ongoing, school:, teacher:)
   end
@@ -34,7 +34,7 @@ RSpec.describe "Changing an mentor's name" do
     then_i_should_be_taken_to_the_check_answers_page
     and_i_click_the_back_link
     then_i_should_see_the_change_name_page
-    then_the_form_should_should_show("Professor Sprout")
+    then_the_form_should_show("Professor Sprout")
     when_i_change_the_name_to("Sister Mildred")
     and_i_click_the_continue_button
     and_i_click_the_confirmation_button
@@ -54,6 +54,7 @@ RSpec.describe "Changing an mentor's name" do
   scenario "invalid long name" do
     when_i_change_the_name_to(Faker::Lorem.characters(number: 71))
     and_i_click_the_continue_button
+    then_the_page_title_should_have_an_error_prefix
     expect(page.get_by_role("link", name: "Corrected name must be 70 characters or less")).to be_visible
     then_i_should_be_taken_to_the_edit_page
   end
@@ -61,6 +62,7 @@ RSpec.describe "Changing an mentor's name" do
   scenario "invalid blank name" do
     when_i_change_the_name_to("")
     and_i_click_the_continue_button
+    then_the_page_title_should_have_an_error_prefix
     expect(page.get_by_role("link", name: "Enter the correct full name")).to be_visible
     then_i_should_be_taken_to_the_edit_page
   end
@@ -68,6 +70,7 @@ RSpec.describe "Changing an mentor's name" do
   scenario "invalid same name" do
     when_i_change_the_name_to("Miriam Margolyes")
     and_i_click_the_continue_button
+    then_the_page_title_should_have_an_error_prefix
     expect(page.get_by_role("link", name: "The name must be different from the current name")).to be_visible
     then_i_should_be_taken_to_the_edit_page
   end
@@ -137,5 +140,11 @@ RSpec.describe "Changing an mentor's name" do
     expect(page.locator("#edit-name-field").input_value).to eq(name)
   end
 
-  alias_method :then_the_form_should_should_show, :then_the_form_should_be_reset
+  def then_the_page_title_should_have_an_error_prefix
+    expect(page.title).to start_with("Error:")
+    then_i_should_see_the_change_name_page
+    expect(page.locator(".govuk-error-summary")).to be_visible
+  end
+
+  alias_method :then_the_form_should_show, :then_the_form_should_be_reset
 end


### PR DESCRIPTION
### Context
When validation errors are shown during change journeys for ECTs, mentors and SITs, the page title was not consistently prefixed with Error: as required by the GOV.UK Design System. Some wizards had it correctly, others were missing it.

### Changes proposed in this pull request

Added error: @wizard.current_step.errors.present? to the page_data call in four change wizard edit views that were missing it:

schools/ects/change_email_address_wizard/edit
schools/ects/change_lead_provider_wizard/edit
schools/ects/change_mentor_wizard/edit
schools/mentors/change_email_address_wizard/edit

and

schools/mentors/change_name_wizard/edit
schools/ects/change_name_wizard/edit
schools/mentors/change_lead_provider_wizard/edit
schools/induction_tutor/update_induction_tutor_wizard/edit
schools/ects/change_mentor_wizard/lead_provider
schools/ects/change_training_programme_wizard/lead_provider

Also added validation-failure scenarios to the corresponding feature specs asserting that the page title starts with Error: when the form is re-rendered with errors.

### Guidance to review
Can check the four edited views on the review app by submitting each form without valid input and inspecting the browser tab title.