### PR TITLE
Metadata feature flag for open registration journey testing

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
   config.dfe_sign_in_enabled = true
   config.enable_api = true
   config.enable_test_guidance = false
-  config.enable_finance_contract_periods = true
+  config.enable_finance_contract_periods = false
   config.active_job.queue_adapter = :test
 
   # Custom config

--- a/spec/requests/admin/finance/contract_periods/active_lead_providers_spec.rb
+++ b/spec/requests/admin/finance/contract_periods/active_lead_providers_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Admin active lead providers", type: :request do
+RSpec.describe "Admin active lead providers", :enable_finance_contract_periods, type: :request do
   let(:contract_period) { FactoryBot.create(:contract_period, :next) }
   let(:index_path) { admin_contract_period_active_lead_providers_path(contract_period) }
   let(:started_error) { "Active lead providers cannot be changed once the contract period has started" }
@@ -14,7 +14,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
       it "requires authorisation" do
         get index_path
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -23,7 +23,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
       it "displays the active lead providers index page" do
         get index_path
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:success)
       end
     end
   end
@@ -41,7 +41,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
       it "requires authorisation" do
         get new_path
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
       it "displays the new active lead provider page" do
         get new_path
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:success)
       end
 
       context "when the contract period has started" do
@@ -79,7 +79,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
       it "requires authorisation" do
         post(index_path, params:)
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -115,8 +115,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
         it "does not create an active lead provider and re-renders new" do
           expect { post index_path, params: }.not_to(change(ActiveLeadProvider, :count))
-
-          expect(response.status).to eq(422)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
 
@@ -125,8 +124,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
         it "does not create a duplicate and re-renders new" do
           expect { post index_path, params: }.not_to(change(ActiveLeadProvider, :count))
-
-          expect(response.status).to eq(422)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
 
@@ -157,7 +155,7 @@ RSpec.describe "Admin active lead providers", type: :request do
 
       it "requires authorisation" do
         delete destroy_path
-        expect(response.status).to eq(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 

--- a/spec/requests/admin/finance/contract_periods/contract_periods_spec.rb
+++ b/spec/requests/admin/finance/contract_periods/contract_periods_spec.rb
@@ -1,14 +1,17 @@
 RSpec.describe "Admin finance contract periods", type: :request do
   let(:contract_period) { FactoryBot.create(:contract_period) }
 
-  before do
-    allow(Rails.application.config).to receive(:enable_finance_contract_periods).and_return(env_var_value)
-  end
-
   describe "GET /admin/finance/contract-periods" do
-    context "when enabled" do
-      let(:env_var_value) { true }
+    context "when disabled" do
+      include_context "sign in as finance DfE user"
 
+      it "returns 404 not found" do
+        get "/admin/finance/contract-periods"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when enabled", :enable_finance_contract_periods do
       it "redirects to sign in path when not signed in" do
         get "/admin/finance/contract-periods"
         expect(response).to redirect_to(sign_in_path)
@@ -19,7 +22,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "requires authorisation" do
           get "/admin/finance/contract-periods"
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -28,9 +31,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "requires authorisation with the finance access error message" do
           get "/admin/finance/contract-periods"
-
-          expect(response.status).to eq(401)
-
+          expect(response).to have_http_status(:unauthorized)
           expect(response.body).to include(
             "This is to access financial information for Register early career teachers. To gain access, contact the product team."
           )
@@ -42,43 +43,23 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "displays the contract periods index page" do
           get "/admin/finance/contract-periods"
-
-          expect(response.status).to eq(200)
-        end
-      end
-    end
-
-    context "when disabled" do
-      include_context "sign in as finance DfE user"
-
-      context "implicitly" do
-        let(:env_var_value) { nil }
-
-        it "returns 404 not found" do
-          get "/admin/finance/contract-periods"
-
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "explicitly" do
-        let(:env_var_value) { false }
-
-        it "returns 404 not found" do
-          get "/admin/finance/contract-periods"
-
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:success)
         end
       end
     end
   end
 
   describe "GET /admin/finance/contract-periods/:id" do
-    let(:contract_period) { FactoryBot.create(:contract_period) }
+    context "when disabled" do
+      include_context "sign in as finance DfE user"
 
-    context "when enabled" do
-      let(:env_var_value) { true }
+      it "returns 404 not found" do
+        get "/admin/finance/contract-periods/#{contract_period.id}"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
 
+    context "when enabled", :enable_finance_contract_periods do
       it "redirects to sign in path when not signed in" do
         get "/admin/finance/contract-periods/#{contract_period.id}"
         expect(response).to redirect_to(sign_in_path)
@@ -89,7 +70,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "requires authorisation" do
           get "/admin/finance/contract-periods/#{contract_period.id}"
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -98,7 +79,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "requires authorisation with the finance access error message" do
           get "/admin/finance/contract-periods/#{contract_period.id}"
-          expect(response.status).to eq(401)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
@@ -107,33 +88,8 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "displays the contract period show page" do
           get "/admin/finance/contract-periods/#{contract_period.id}"
-
-          expect(response.status).to eq(200)
+          expect(response).to have_http_status(:success)
           expect(response.body).to include("Contract period #{contract_period.year}")
-        end
-      end
-    end
-
-    context "when disabled" do
-      include_context "sign in as finance DfE user"
-
-      context "implicitly" do
-        let(:env_var_value) { nil }
-
-        it "returns 404 not found" do
-          get "/admin/finance/contract-periods/#{contract_period.id}"
-
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "explicitly" do
-        let(:env_var_value) { false }
-
-        it "returns 404 not found" do
-          get "/admin/finance/contract-periods/#{contract_period.id}"
-
-          expect(response.status).to eq(404)
         end
       end
     end
@@ -142,9 +98,25 @@ RSpec.describe "Admin finance contract periods", type: :request do
   describe "POST /admin/finance/contract-periods" do
     include_context "sign in as finance DfE user"
 
-    context "when enabled" do
-      let(:env_var_value) { true }
+    context "when disabled" do
+      let(:params) do
+        {
+          contract_period: {
+            "year" => 2026,
+            detailed_evidence_types_enabled: true,
+            mentor_funding_enabled: true,
+            uplift_fees_enabled: false,
+          }
+        }
+      end
 
+      it "returns 404 not found" do
+        post(admin_contract_periods_path, params:)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when enabled", :enable_finance_contract_periods do
       context "with valid parameters" do
         # An existing contract period is required by the service
         # which creates schedules and milestones based on the most recent contract period
@@ -157,7 +129,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         let(:started_on) { 1.month.from_now }
         let(:finished_on) { 12.months.from_now }
-        let(:valid_params) do
+        let(:params) do
           {
             contract_period: {
               "year" => 2026,
@@ -175,12 +147,11 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "creates a new contract period" do
-          expect { post admin_contract_periods_path, params: valid_params }.to change(ContractPeriod, :count).by(1)
+          expect { post(admin_contract_periods_path, params:) }.to change(ContractPeriod, :count).by(1)
         end
 
         it "redirects to the contract periods page with success message" do
-          post admin_contract_periods_path, params: valid_params
-
+          post(admin_contract_periods_path, params:)
           expect(response).to redirect_to(admin_contract_periods_path)
           expect(flash[:alert]).to eq("2026 Contract period added")
         end
@@ -188,7 +159,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
         it "records a 'contract period created' event" do
           allow(Events::Record).to receive(:record_contract_period_added_event!).once.and_call_original
 
-          post admin_contract_periods_path, params: valid_params
+          post(admin_contract_periods_path, params:)
 
           expect(Events::Record).to have_received(:record_contract_period_added_event!)
           .once
@@ -203,7 +174,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "creates the contract period with correct attributes" do
-          post admin_contract_periods_path, params: valid_params
+          post(admin_contract_periods_path, params:)
 
           contract_period = ContractPeriod.last
           expect(contract_period.year).to eq(2026)
@@ -218,7 +189,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
       context "with invalid parameters" do
         let(:started_on) { nil }
         let(:finished_on) { 3.months.from_now }
-        let(:invalid_params) do
+        let(:params) do
           {
             contract_period: {
               "year" => 2026,
@@ -236,20 +207,17 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "does not create a new contract period" do
-          expect {
-            post admin_contract_periods_path,
-                 params: invalid_params
-          }.not_to change(ContractPeriod, :count)
+          expect { post(admin_contract_periods_path, params:) }.not_to change(ContractPeriod, :count)
         end
 
         it "renders the new template with unprocessable_content status" do
-          post admin_contract_periods_path, params: invalid_params
+          post(admin_contract_periods_path, params:)
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include("Enter a start date")
         end
 
         it "shows validation errors" do
-          post admin_contract_periods_path, params: invalid_params
+          post(admin_contract_periods_path, params:)
           expect(response.body).to include("Enter a start date")
         end
       end
@@ -262,12 +230,19 @@ RSpec.describe "Admin finance contract periods", type: :request do
                             finished_on: 3.months.from_now)
         end
 
-        let(:overlapping_params) do
+        let(:started_on) { 4.months.ago }
+        let(:finished_on) { 1.month.from_now }
+
+        let(:params) do
           {
             contract_period: {
               "year" => 2027,
-              started_on: 4.months.ago,
-              finished_on: 1.month.from_now,
+              "started_on(3i)" => started_on.day,
+              "started_on(2i)" => started_on.month,
+              "started_on(1i)" => started_on.year,
+              "finished_on(3i)" => finished_on.day,
+              "finished_on(2i)" => finished_on.month,
+              "finished_on(1i)" => finished_on.year,
               detailed_evidence_types_enabled: true,
               mentor_funding_enabled: true,
               uplift_fees_enabled: false,
@@ -276,19 +251,17 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "does not create a new contract period" do
-          expect {
-            post admin_contract_periods_path, params: overlapping_params
-          }.not_to change(ContractPeriod, :count)
+          expect { post(admin_contract_periods_path, params:) }.not_to change(ContractPeriod, :count)
         end
 
         it "renders the new template with unprocessable_content status" do
-          post admin_contract_periods_path, params: overlapping_params
+          post(admin_contract_periods_path, params:)
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include("Start date cannot overlap another Contract period")
         end
 
         it "shows validation errors" do
-          post admin_contract_periods_path, params: overlapping_params
+          post(admin_contract_periods_path, params:)
           expect(response.body).to include("Start date cannot overlap another Contract period")
         end
       end
@@ -314,9 +287,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "does not create a new contract period" do
-          expect {
-            post admin_contract_periods_path, params:
-          }.not_to change(ContractPeriod, :count)
+          expect { post(admin_contract_periods_path, params:) }.not_to change(ContractPeriod, :count)
         end
 
         it "returns unprocessable_content status" do
@@ -332,52 +303,9 @@ RSpec.describe "Admin finance contract periods", type: :request do
       end
     end
 
-    context "when disabled" do
-      let(:started_on) { 6.months.from_now }
-      let(:finished_on) { 3.months.from_now }
-      let(:params) do
-        {
-          contract_period: {
-            "year" => 2026,
-            "started_on(3i)" => started_on.day,
-            "started_on(2i)" => started_on.month,
-            "started_on(1i)" => started_on.year,
-            "finished_on(3i)" => finished_on.day,
-            "finished_on(2i)" => finished_on.month,
-            "finished_on(1i)" => finished_on.year,
-            detailed_evidence_types_enabled: true,
-            mentor_funding_enabled: true,
-            uplift_fees_enabled: false,
-          }
-        }
-      end
-
-      context "implicitly" do
-        let(:env_var_value) { nil }
-
-        it "returns 404 not found" do
-          post(admin_contract_periods_path, params:)
-
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "explicitly" do
-        let(:env_var_value) { false }
-
-        it "returns 404 not found" do
-          post(admin_contract_periods_path, params:)
-
-          expect(response.status).to eq(404)
-        end
-      end
-    end
-
-    context "when seeding from previous" do
-      let(:env_var_value) { true }
-
+    context "when seeding from previous", :enable_finance_contract_periods do
       context "with invalid params" do
-        let(:invalid_params) do
+        let(:params) do
           {
             contract_period: {
               "year" => 2027,
@@ -395,13 +323,11 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "does not create a new contract period" do
-          expect {
-            post admin_contract_periods_path, params: invalid_params
-          }.not_to change(ContractPeriod, :count)
+          expect { post(admin_contract_periods_path, params:) }.not_to change(ContractPeriod, :count)
         end
 
         it "renders the new template with unprocessable_content status" do
-          post admin_contract_periods_path, params: invalid_params
+          post(admin_contract_periods_path, params:)
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include("Cannot seed contract period")
         end
@@ -412,9 +338,14 @@ RSpec.describe "Admin finance contract periods", type: :request do
   describe "GET /admin/finance/contract-periods/new" do
     include_context "sign in as finance DfE user"
 
-    context "when enabled" do
-      let(:env_var_value) { true }
+    context "when disabled" do
+      it "returns 404 not found" do
+        get new_admin_contract_period_path
+        expect(response).to have_http_status(:not_found)
+      end
+    end
 
+    context "when enabled", :enable_finance_contract_periods do
       it "renders the new template" do
         get new_admin_contract_period_path
         expect(response).to have_http_status(:success)
@@ -431,28 +362,6 @@ RSpec.describe "Admin finance contract periods", type: :request do
         expect(response.body).to include("Uplift fees enabled")
       end
     end
-
-    context "when disabled" do
-      context "implicitly" do
-        let(:env_var_value) { nil }
-
-        it "returns 404 not found" do
-          get new_admin_contract_period_path
-
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "explicitly" do
-        let(:env_var_value) { false }
-
-        it "returns 404 not found" do
-          get new_admin_contract_period_path
-
-          expect(response.status).to eq(404)
-        end
-      end
-    end
   end
 
   describe "GET /admin/finance/contract-periods/:id/edit" do
@@ -460,35 +369,18 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
     let(:contract_period) { FactoryBot.create(:contract_period, :next) }
 
-    context "when enabled" do
-      let(:env_var_value) { true }
-
-      it "returns success" do
+    context "when disabled" do
+      it "returns 404 not found" do
         get edit_admin_contract_period_path(contract_period)
-        expect(response).to be_successful
-        expect(CGI.unescapeHTML(response.body)).to include("Edit #{contract_period.year} Contract period")
+        expect(response).to have_http_status(:not_found)
       end
     end
 
-    context "when disabled" do
-      context "implicitly" do
-        let(:env_var_value) { nil }
-
-        it "returns 404 not found" do
-          get edit_admin_contract_period_path(contract_period)
-
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "explicitly" do
-        let(:env_var_value) { false }
-
-        it "returns 404 not found" do
-          get edit_admin_contract_period_path(contract_period)
-
-          expect(response.status).to eq(404)
-        end
+    context "when enabled", :enable_finance_contract_periods do
+      it "returns success" do
+        get edit_admin_contract_period_path(contract_period)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Edit #{contract_period.year} Contract period")
       end
     end
   end
@@ -496,18 +388,22 @@ RSpec.describe "Admin finance contract periods", type: :request do
   describe "PATCH /admin/finance/contract-periods/:id" do
     include_context "sign in as finance DfE user"
 
-    let!(:contract_period) { FactoryBot.create(:contract_period, year: Date.current.year + 2) }
+    let!(:contract_period) do
+      FactoryBot.create(:contract_period, year: Date.current.next_year(2).year)
+    end
 
-    context "when enabled" do
-      let(:env_var_value) { true }
-
+    context "when enabled", :enable_finance_contract_periods do
       context "with valid parameters" do
-        let(:valid_params) do
+        let(:params) do
           {
             contract_period: {
               "year" => contract_period.year,
-              started_on: Date.new(contract_period.started_on.year, 1, 1),
-              finished_on: Date.new(contract_period.finished_on.year, 12, 31),
+              "started_on(3i)" => "1",
+              "started_on(2i)" => "1",
+              "started_on(1i)" => contract_period.started_on.year.to_s,
+              "finished_on(3i)" => "31",
+              "finished_on(2i)" => "12",
+              "finished_on(1i)" => contract_period.finished_on.year.to_s,
               detailed_evidence_types_enabled: true,
               mentor_funding_enabled: true,
               uplift_fees_enabled: false,
@@ -516,7 +412,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
         end
 
         it "updates the contract period" do
-          patch admin_contract_period_path(contract_period.id), params: valid_params
+          patch(admin_contract_period_path(contract_period.id), params:)
 
           expect(response).to redirect_to(admin_contract_periods_path)
           expect(flash[:alert]).to eq("#{contract_period.year} Contract period updated")
@@ -532,10 +428,10 @@ RSpec.describe "Admin finance contract periods", type: :request do
         it "records a contract period updated event" do
           allow(Events::Record).to receive(:record_contract_period_updated_event!).once.and_call_original
 
-          contract_period.assign_attributes(valid_params[:contract_period])
+          contract_period.assign_attributes(params[:contract_period])
           expected_modifications = contract_period.changes
 
-          patch admin_contract_period_path(contract_period.id), params: valid_params
+          patch(admin_contract_period_path(contract_period.id), params:)
 
           expect(Events::Record).to have_received(:record_contract_period_updated_event!).once.with(
             hash_including(
@@ -552,7 +448,7 @@ RSpec.describe "Admin finance contract periods", type: :request do
       context "with invalid parameters" do
         let(:started_on) { nil }
         let(:finished_on) { 3.months.from_now }
-        let(:invalid_params) do
+        let(:params) do
           {
             contract_period: {
               "year" => 2026,
@@ -571,18 +467,18 @@ RSpec.describe "Admin finance contract periods", type: :request do
 
         it "does not update the contract period" do
           expect {
-            patch admin_contract_period_path(contract_period.id), params: invalid_params
+            patch(admin_contract_period_path(contract_period.id), params:)
           }.not_to(change { contract_period.reload.attributes })
         end
 
         it "renders the edit template with unprocessable_content status" do
-          patch admin_contract_period_path(contract_period.id), params: invalid_params
+          patch(admin_contract_period_path(contract_period.id), params:)
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include("Enter a start date")
         end
 
         it "shows validation errors" do
-          patch admin_contract_period_path(contract_period.id), params: invalid_params
+          patch(admin_contract_period_path(contract_period.id), params:)
           expect(response.body).to include("Enter a start date")
         end
       end

--- a/spec/requests/admin/finance/contract_periods/schedules_spec.rb
+++ b/spec/requests/admin/finance/contract_periods/schedules_spec.rb
@@ -1,7 +1,16 @@
-RSpec.describe "Admin finance schedules", :enable_finance_contract_periods do
+RSpec.describe "Admin finance schedules", type: :request do
   let(:contract_period) { FactoryBot.create(:contract_period) }
 
-  describe "GET /admin/finance/contract-periods/:id/schedules" do
+  context "when disabled" do
+    include_context "sign in as finance DfE user"
+
+    it "returns 404 not found" do
+      get "/admin/finance/contract-periods/#{contract_period.id}/schedules"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /admin/finance/contract-periods/:id/schedules", :enable_finance_contract_periods do
     context "when not authenticated" do
       it "redirects to sign in page" do
         get "/admin/finance/contract-periods/#{contract_period.id}/schedules"

--- a/spec/views/admin/finance/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/show.html.erb_spec.rb
@@ -1,19 +1,29 @@
 RSpec.describe "admin/finance/show.html.erb" do
-  it "has a link to the statements page" do
+  it "links to the statements page" do
     render
 
     expect(rendered).to have_link("Statements", href: admin_finance_statements_path)
   end
 
-  it "has a link to the search declarations page" do
+  it "links to the search declarations page" do
     render
 
     expect(rendered).to have_link("Search declarations", href: admin_search_declarations_path)
   end
 
-  it "has a link to the contract periods page" do
-    render
+  context "with finance contract periods enabled", :enable_finance_contract_periods do
+    it "links to the contract periods page" do
+      render
 
-    expect(rendered).to have_link("Contract periods", href: admin_contract_periods_path)
+      expect(rendered).to have_link("Contract periods", href: admin_contract_periods_path)
+    end
+  end
+
+  context "with finance contract periods disabled" do
+    it "does not link to the contract periods page" do
+      render
+
+      expect(rendered).not_to have_link("Contract periods", href: admin_contract_periods_path)
+    end
   end
 end


### PR DESCRIPTION
### Context

New routes under `/admin/finance/contract-periods` will remain disabled until the feature is complete; activated with `ENABLE_FINANCE_CONTRACT_PERIODS`

### Changes proposed in this pull request

Unify test coverage using a metadata tag

### Guidance to review
