### PR TITLE
[3923] Create Rake task to populate events from ECF1 data

### DIFF
--- a/db/seeds/declarations.rb
+++ b/db/seeds/declarations.rb
@@ -176,6 +176,7 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
   milestones.each do |declaration_type|
     # Create billable declarations
     n = Random.rand(25)
+    print_seed_info("Creating #{n} ECT #{declaration_type} declarations", indent: 6)
     pupil_premium_uplift = assign_uplift(declaration_type, uplift_count)
     FactoryBot.create_list(:declaration, n, :with_ect,
                            payment_status: "payable",
@@ -199,6 +200,7 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
 
     # Create refunded declarations
     n = Random.rand(25)
+    print_seed_info("Creating #{n} mentor #{declaration_type} declarations", indent: 6)
     FactoryBot.create_list(:declaration, n, :with_ect, :clawed_back,
                            declaration_type:,
                            school_partnership:,

--- a/db/seeds/declarations.rb
+++ b/db/seeds/declarations.rb
@@ -114,7 +114,7 @@ end
 
 august_statement_2024 = FactoryBot.create(:statement,
                                           :adjustable,
-                                          :payable,
+                                          :paid,
                                           month: 8,
                                           year: 2024,
                                           deadline_date: Date.new(2024, 7, 31),
@@ -126,7 +126,7 @@ end
 
 october_statement_2024 = FactoryBot.create(:statement,
                                            :adjustable,
-                                           :payable,
+                                           :paid,
                                            month: 10,
                                            year: 2024,
                                            deadline_date: Date.new(2024, 9, 30),
@@ -138,7 +138,7 @@ end
 
 august_statement_2025 = FactoryBot.create(:statement,
                                           :adjustable,
-                                          :payable,
+                                          :paid,
                                           month: 8,
                                           year: 2025,
                                           deadline_date: Date.new(2025, 7, 31),
@@ -150,7 +150,7 @@ end
 
 october_statement_2025 = FactoryBot.create(:statement,
                                            :adjustable,
-                                           :payable,
+                                           :paid,
                                            month: 10,
                                            year: 2025,
                                            deadline_date: Date.new(2025, 9, 30),
@@ -199,9 +199,7 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
 
     # Create refunded declarations
     n = Random.rand(25)
-    FactoryBot.create_list(:declaration, n, :with_ect,
-                           payment_status: "payable",
-                           clawback_status: "awaiting_clawback",
+    FactoryBot.create_list(:declaration, n, :with_ect, :clawed_back,
                            declaration_type:,
                            school_partnership:,
                            payment_statement: august_statement,
@@ -222,9 +220,7 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
     add_to_results(results, year, declaration_type, :mentors, 1)
 
     # Create refunded declarations for mentors
-    FactoryBot.create(:declaration, :with_mentor,
-                      payment_status: "payable",
-                      clawback_status: "awaiting_clawback",
+    FactoryBot.create(:declaration, :with_mentor, :clawed_back,
                       declaration_type:,
                       school_partnership:,
                       payment_statement: august_statement,

--- a/lib/backfill/record_declaration_event.rb
+++ b/lib/backfill/record_declaration_event.rb
@@ -1,0 +1,76 @@
+module Backfill
+  class RecordDeclarationEvent
+    VALID_STATUSES = %i[paid clawed_back].freeze
+
+    attr_reader :declaration, :status, :statement
+
+    def initialize(declaration:, status:, statement:)
+      @declaration = declaration
+      @status = status
+      @statement = statement
+
+      validate_status
+    end
+
+    def process
+      if event_exists?
+        puts("- #{declaration.id} #{formatted_status} event already exists")
+        return false
+      end
+
+      unless statement.status_paid?
+        puts("- #{declaration.id} #{formatted_status} event cannot be created because statement is not paid")
+        return false
+      end
+
+      Event.create!(
+        event_type:,
+        heading:,
+        happened_at:,
+        declaration:,
+        teacher:,
+        training_period: declaration.training_period,
+        author_name: "System",
+        author_type: "system"
+      )
+
+      true
+    end
+
+  private
+
+    def validate_status
+      return if VALID_STATUSES.include?(status)
+
+      raise ArgumentError, "Unknown declaration event status: #{status.inspect}"
+    end
+
+    def heading
+      "#{teacher_name}'s #{declaration.declaration_type} declaration was #{formatted_status}"
+    end
+
+    def event_exists?
+      declaration.events.exists?(event_type:)
+    end
+
+    def event_type
+      "teacher_declaration_#{status}"
+    end
+
+    def happened_at
+      statement.payment_date
+    end
+
+    def formatted_status
+      status.to_s.humanize.downcase
+    end
+
+    def teacher_name
+      Teachers::Name.new(teacher).full_name
+    end
+
+    def teacher
+      @teacher ||= declaration.teacher
+    end
+  end
+end

--- a/lib/backfill/record_declaration_event.rb
+++ b/lib/backfill/record_declaration_event.rb
@@ -13,15 +13,7 @@ module Backfill
     end
 
     def process
-      if event_exists?
-        puts("- #{declaration.id} #{formatted_status} event already exists")
-        return false
-      end
-
-      unless statement.status_paid?
-        puts("- #{declaration.id} #{formatted_status} event cannot be created because statement is not paid")
-        return false
-      end
+      return false if event_exists?
 
       Event.create!(
         event_type:,

--- a/lib/backfill/record_statement_payment_events.rb
+++ b/lib/backfill/record_statement_payment_events.rb
@@ -15,25 +15,30 @@ module Backfill
     end
 
     def process
-      counts = DECLARATION_TYPES.index_with { 0 }
+      processed = DECLARATION_TYPES.index_with { 0 }
+      updated = DECLARATION_TYPES.index_with { 0 }
 
       ActiveRecord::Base.transaction do
         paid_declarations.find_each do |declaration|
+          processed[declaration_type(declaration)] += 1
+
           next unless declaration_event_created?(declaration, statement, :paid)
 
-          counts[declaration_type(declaration)] += 1
+          updated[declaration_type(declaration)] += 1
         end
 
         clawed_back_declarations.find_each do |declaration|
+          processed[:clawed_back] += 1
+
           next unless declaration_event_created?(declaration, declaration.clawback_statement, :clawed_back)
 
-          counts[:clawed_back] += 1
+          updated[:clawed_back] += 1
         end
 
-        record_statement_authorized_for_payment_event!
+        record_statement_authorised_for_payment_event!
       end
 
-      counts
+      format_output(processed, updated)
     end
 
   private
@@ -53,8 +58,8 @@ module Backfill
       ).process
     end
 
-    def record_statement_authorized_for_payment_event!
-      if statement_authorized_event_exists?
+    def record_statement_authorised_for_payment_event!
+      if statement_authorised_event_exists?
         puts("Statement: #{statement.id} Authorised for payment event already exists")
         return
       end
@@ -76,7 +81,7 @@ module Backfill
       puts("Statement: #{statement.id} Authorised for payment event created")
     end
 
-    def statement_authorized_event_exists?
+    def statement_authorised_event_exists?
       Event.where(
         event_type: "statement_authorised_for_payment",
         statement:
@@ -92,6 +97,12 @@ module Backfill
         .clawback_declarations
         .clawback_status_clawed_back
         .includes(:clawback_statement)
+    end
+
+    def format_output(processed, updated)
+      DECLARATION_TYPES.index_with do |type|
+        "#{updated[type]} / #{processed[type]}"
+      end
     end
   end
 end

--- a/lib/backfill/record_statement_payment_events.rb
+++ b/lib/backfill/record_statement_payment_events.rb
@@ -1,0 +1,101 @@
+module Backfill
+  class RecordStatementPaymentEvents
+    attr_reader :statement
+
+    DECLARATION_TYPES = %i[
+      started
+      retained
+      extended
+      completed
+      clawed_back
+    ].freeze
+
+    def initialize(statement)
+      @statement = statement
+    end
+
+    def process
+      counts = DECLARATION_TYPES.index_with { 0 }
+
+      ActiveRecord::Base.transaction do
+        paid_declarations.find_each do |declaration|
+          created = record_declaration_event(declaration, statement, :paid)
+
+          next unless created
+
+          counts[declaration_type(declaration)] += 1
+        end
+
+        clawed_back_declarations.find_each do |declaration|
+          created = record_declaration_event(declaration, declaration.clawback_statement, :clawed_back)
+
+          next unless created
+
+          counts[:clawed_back] += 1
+        end
+
+        record_statement_authorized_for_payment_event!
+      end
+
+      counts
+    end
+
+  private
+
+    delegate :active_lead_provider, to: :statement
+    delegate :lead_provider, to: :active_lead_provider
+
+    def declaration_type(declaration)
+      declaration.declaration_type.split("-").first.to_sym
+    end
+
+    def record_declaration_event(declaration, statement, status)
+      RecordDeclarationEvent.new(
+        declaration:,
+        status:,
+        statement:
+      ).process
+    end
+
+    def record_statement_authorized_for_payment_event!
+      if statement_authorized_event_exists?
+        puts("Statement: #{statement.id} Authorised for payment event already exists")
+        return
+      end
+
+      Event.create!(
+        event_type: "statement_authorised_for_payment",
+        heading: "Statement authorised for payment",
+        happened_at: statement.payment_date,
+        statement:,
+        lead_provider:,
+        active_lead_provider:,
+        metadata: {
+          contract_period_year: active_lead_provider.contract_period_year
+        },
+        author_name: "System",
+        author_type: "system"
+      )
+
+      puts("Statement: #{statement.id} Authorised for payment event created")
+    end
+
+    def statement_authorized_event_exists?
+      Event.where(
+        event_type: "statement_authorised_for_payment",
+        statement:
+      ).exists?
+    end
+
+    def paid_declarations
+      statement.payment_declarations.payment_status_paid
+    end
+
+    def clawed_back_declarations
+      statement
+        .clawback_declarations
+        .clawback_status_clawed_back
+        .includes(:clawback_statement)
+    end
+  end
+end

--- a/lib/backfill/record_statement_payment_events.rb
+++ b/lib/backfill/record_statement_payment_events.rb
@@ -19,17 +19,13 @@ module Backfill
 
       ActiveRecord::Base.transaction do
         paid_declarations.find_each do |declaration|
-          created = record_declaration_event(declaration, statement, :paid)
-
-          next unless created
+          next unless declaration_event_created?(declaration, statement, :paid)
 
           counts[declaration_type(declaration)] += 1
         end
 
         clawed_back_declarations.find_each do |declaration|
-          created = record_declaration_event(declaration, declaration.clawback_statement, :clawed_back)
-
-          next unless created
+          next unless declaration_event_created?(declaration, declaration.clawback_statement, :clawed_back)
 
           counts[:clawed_back] += 1
         end
@@ -49,7 +45,7 @@ module Backfill
       declaration.declaration_type.split("-").first.to_sym
     end
 
-    def record_declaration_event(declaration, statement, status)
+    def declaration_event_created?(declaration, statement, status)
       RecordDeclarationEvent.new(
         declaration:,
         status:,

--- a/lib/backfill/record_statement_payment_events.rb
+++ b/lib/backfill/record_statement_payment_events.rb
@@ -15,26 +15,50 @@ module Backfill
     end
 
     def process
+      unless statement.status_paid?
+        puts("- #{statement.id} event cannot be created because statement is not paid")
+        return {}
+      end
+
+      unless statement.output_fee?
+        puts("- #{statement.id} event cannot be created for service statements")
+        return {}
+      end
+
       processed = DECLARATION_TYPES.index_with { 0 }
       updated = DECLARATION_TYPES.index_with { 0 }
 
+      paid_declarations.find_in_batches(batch_size: 500) do |declarations|
+        ActiveRecord::Base.transaction do
+          declarations.each do |declaration|
+            type = declaration_type(declaration)
+
+            processed[type] += 1
+
+            next unless declaration_event_created?(declaration, statement, :paid)
+
+            updated[type] += 1
+          end
+        end
+      end
+
+      clawed_back_declarations.find_in_batches(batch_size: 500) do |declarations|
+        ActiveRecord::Base.transaction do
+          declarations.each do |declaration|
+            processed[:clawed_back] += 1
+
+            next unless declaration_event_created?(
+              declaration,
+              declaration.clawback_statement,
+              :clawed_back
+            )
+
+            updated[:clawed_back] += 1
+          end
+        end
+      end
+
       ActiveRecord::Base.transaction do
-        paid_declarations.find_each do |declaration|
-          processed[declaration_type(declaration)] += 1
-
-          next unless declaration_event_created?(declaration, statement, :paid)
-
-          updated[declaration_type(declaration)] += 1
-        end
-
-        clawed_back_declarations.find_each do |declaration|
-          processed[:clawed_back] += 1
-
-          next unless declaration_event_created?(declaration, declaration.clawback_statement, :clawed_back)
-
-          updated[:clawed_back] += 1
-        end
-
         record_statement_authorised_for_payment_event!
       end
 
@@ -67,7 +91,7 @@ module Backfill
       Event.create!(
         event_type: "statement_authorised_for_payment",
         heading: "Statement authorised for payment",
-        happened_at: statement.payment_date,
+        happened_at:,
         statement:,
         lead_provider:,
         active_lead_provider:,
@@ -79,6 +103,10 @@ module Backfill
       )
 
       puts("Statement: #{statement.id} Authorised for payment event created")
+    end
+
+    def happened_at
+      statement.marked_as_paid_at || statement.payment_date
     end
 
     def statement_authorised_event_exists?
@@ -101,7 +129,7 @@ module Backfill
 
     def format_output(processed, updated)
       DECLARATION_TYPES.index_with do |type|
-        "#{updated[type]} / #{processed[type]}"
+        "#{updated[type]}/#{processed[type]}"
       end
     end
   end

--- a/lib/tasks/populate_payment_events.rake
+++ b/lib/tasks/populate_payment_events.rake
@@ -1,0 +1,46 @@
+namespace :bulk do
+  desc "Generate payment events for ECF1 declarations"
+  task populate_payment_events: :environment do
+    paid_statements = Statement.status_paid
+    results = {}
+
+    Rails.logger.silence do
+      paid_statements.find_in_batches(batch_size: 100) do |statements|
+        statements.each do |statement|
+          results[statement.id] = { id: statement.id, month: " #{statement.month}".rjust(2), year: statement.year, error: "" }
+
+          puts("Processing statement #{statement.id} for #{statement.month}/#{statement.year}")
+
+          counts = Backfill::RecordStatementPaymentEvents.new(statement).process
+
+          results[statement.id].merge!(counts)
+
+          format_counts = Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type|
+            "#{type.to_s.humanize}: #{counts[type]}"
+          }.join(", ")
+
+          puts(
+            "Processed statement #{statement.id}: " \
+            "#{format_counts}"
+          )
+        rescue StandardError => e
+          puts(
+            "Failed processing statement #{statement.id}: #{e.class} #{e.message}"
+          )
+
+          results[statement.id][:error] = "#{e.class} #{e.message}"
+        end
+      end
+    end
+
+    puts("Results:")
+
+    puts(
+      results.values.map { |result|
+        "Statement ID: #{result[:id]}, Month: #{result[:month]}, Year: #{result[:year]}, " \
+        "#{Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type| "#{type.to_s.humanize}: #{result[type]}" }.join(', ')}" \
+        ", Error: #{result[:error]}"
+      }.join("\n")
+    )
+  end
+end

--- a/lib/tasks/populate_payment_events.rake
+++ b/lib/tasks/populate_payment_events.rake
@@ -2,27 +2,23 @@ namespace :bulk do
   desc "Generate payment events for ECF1 declarations"
   task populate_payment_events: :environment do
     paid_statements = Statement.status_paid
-    results = {}
 
     Rails.logger.silence do
-      paid_statements.find_in_batches(batch_size: 100) do |statements|
-        statements.each do |statement|
-          results[statement.id] = { id: statement.id, month: " #{statement.month}".rjust(2), year: statement.year, error: "" }
+      paid_statements.find_in_batches(batch_size: 100).with_index do |statements, index|
+        puts(
+          "------------------------------------------------------------------------------\n" \
+          "Starting batch #{index + 1} " \
+          "(statement ids #{statements.first.id} - #{statements.last.id})"
+        )
 
-          puts("Processing statement #{statement.id} for #{statement.month}/#{statement.year}")
+        results = {}
+
+        statements.each do |statement|
+          results[statement.id] = { id: statement.id, month: statement.month, year: statement.year, error: "" }
 
           counts = Backfill::RecordStatementPaymentEvents.new(statement).process
 
           results[statement.id].merge!(counts)
-
-          format_counts = Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type|
-            "#{type.to_s.humanize}: #{counts[type]}"
-          }.join(", ")
-
-          puts(
-            "Processed statement #{statement.id}: " \
-            "#{format_counts}"
-          )
         rescue StandardError => e
           puts(
             "Failed processing statement #{statement.id}: #{e.class} #{e.message}"
@@ -30,17 +26,20 @@ namespace :bulk do
 
           results[statement.id][:error] = "#{e.class} #{e.message}"
         end
+
+        puts(
+          "------------------------------------------------------------------------------\n" \
+          "Results:"
+        )
+
+        puts(
+          results.values.map { |result|
+            "Statement ID: #{result[:id]}, Month: #{sprintf('%02d', result[:month])}, Year: #{result[:year]}, " \
+            "#{Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type| "#{type.to_s.humanize}: #{result[type].to_s.rjust(3)}" }.join(', ')}" \
+            ", Error: #{result[:error]}"
+          }.join("\n")
+        )
       end
     end
-
-    puts("Results:")
-
-    puts(
-      results.values.map { |result|
-        "Statement ID: #{result[:id]}, Month: #{result[:month]}, Year: #{result[:year]}, " \
-        "#{Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type| "#{type.to_s.humanize}: #{result[type]}" }.join(', ')}" \
-        ", Error: #{result[:error]}"
-      }.join("\n")
-    )
   end
 end

--- a/lib/tasks/populate_payment_events.rake
+++ b/lib/tasks/populate_payment_events.rake
@@ -1,10 +1,20 @@
 namespace :bulk do
   desc "Generate payment events for ECF1 declarations"
-  task populate_payment_events: :environment do
-    paid_statements = Statement.status_paid
+  task :populate_payment_events, %i[year month] => :environment do |_task, args|
+    year = args[:year]&.to_s&.to_i
+    month = args[:month]&.to_s&.to_i
+
+    raise ArgumentError, "Year is required" if year.blank?
+    raise ArgumentError, "Month must be between 1 and 12" if month.present? && !month.between?(1, 12)
+
+    paid_statements = Statement.output_fee.status_paid.where(year:)
+
+    paid_statements = paid_statements.where(month:) if month.present?
+
+    puts "Found #{paid_statements.count} paid output fee statements for year #{year}#{month.present? ? ", month #{month}" : ''}"
 
     Rails.logger.silence do
-      paid_statements.find_in_batches(batch_size: 100).with_index do |statements, index|
+      paid_statements.find_in_batches(batch_size: 20).with_index do |statements, index|
         puts(
           "------------------------------------------------------------------------------\n" \
           "Starting batch #{index + 1} " \
@@ -34,9 +44,16 @@ namespace :bulk do
 
         puts(
           results.values.map { |result|
-            "Statement ID: #{result[:id]}, Month: #{sprintf('%02d', result[:month])}, Year: #{result[:year]}, " \
-            "#{Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type| "#{type.to_s.humanize}: #{result[type].to_s.rjust(3)}" }.join(', ')}" \
-            ", Error: #{result[:error]}"
+            declaration_results =
+              Backfill::RecordStatementPaymentEvents::DECLARATION_TYPES.map { |type|
+                "#{type.to_s.humanize}: #{result[type].to_s.rjust(7)}"
+              }.join(", ")
+
+            "Statement ID: #{result[:id]}, " \
+              "Month: #{sprintf('%02d', result[:month])}, " \
+              "Year: #{result[:year]}, " \
+              "#{declaration_results}, " \
+              "Error: #{result[:error]}"
           }.join("\n")
         )
       end

--- a/spec/lib/backfill/record_declaration_event_spec.rb
+++ b/spec/lib/backfill/record_declaration_event_spec.rb
@@ -69,17 +69,6 @@ RSpec.describe Backfill::RecordDeclarationEvent do
       it { is_expected.to be_falsy }
     end
 
-    context "when the statement is not paid" do
-      let(:statement) { FactoryBot.create(:statement) }
-
-      it "does not create the event" do
-        expect { process }
-          .not_to change(Event, :count)
-      end
-
-      it { is_expected.to be_falsy }
-    end
-
     context "when the declaration is a clawback declaration" do
       let!(:declaration) do
         FactoryBot.create(

--- a/spec/lib/backfill/record_declaration_event_spec.rb
+++ b/spec/lib/backfill/record_declaration_event_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe Backfill::RecordDeclarationEvent do
+  subject(:process) do
+    described_class.new(
+      declaration:,
+      status:,
+      statement:
+    ).process
+  end
+
+  # Silence puts statements
+  before do
+    allow($stdout).to receive(:puts)
+  end
+
+  let(:year) { 2024 }
+
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :with_active_lead_provider, :for_year, year:) }
+  let(:active_lead_provider) { school_partnership.active_lead_provider }
+  let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:) }
+
+  let(:status) { :paid }
+
+  let(:statement) do
+    FactoryBot.create(:statement,
+                      :adjustable,
+                      :paid,
+                      month: 9,
+                      year:,
+                      deadline_date: Date.new(year, 8, 31),
+                      payment_date: Date.new(year, 9, 30),
+                      active_lead_provider:,
+                      contract:)
+  end
+
+  let!(:declaration) do
+    FactoryBot.create(
+      :declaration,
+      :with_ect,
+      payment_status: "paid",
+      school_partnership:,
+      payment_statement: statement
+    )
+  end
+
+  describe "#process" do
+    context "when the event does not already exist" do
+      it "creates the declaration event" do
+        expect { process }
+          .to change(Event, :count).by(1)
+
+        event = Event.last
+
+        expect(event.event_type).to eq("teacher_declaration_paid")
+        expect(event.declaration).to eq(declaration)
+        expect(event.teacher).to eq(declaration.teacher)
+        expect(event.training_period).to eq(declaration.training_period)
+        expect(event.happened_at).to eq(statement.payment_date.in_time_zone)
+
+        expect(event.author_name).to eq("System")
+        expect(event.author_type).to eq("system")
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the event already exists" do
+      before do
+        FactoryBot.create(
+          :event,
+          event_type: "teacher_declaration_paid",
+          declaration:
+        )
+      end
+
+      it "does not create another event" do
+        expect { process }
+          .not_to change(Event, :count)
+      end
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when the statement is not paid" do
+      let(:statement) do
+        FactoryBot.create(:statement,
+                          :adjustable,
+                          month: 9,
+                          year:,
+                          deadline_date: Date.new(year, 8, 31),
+                          payment_date: Date.new(year, 9, 30),
+                          active_lead_provider:,
+                          contract:)
+      end
+
+      it "does not create the event" do
+        expect { process }
+          .not_to change(Event, :count)
+      end
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when the declaration is a clawback declaration" do
+      let(:status) { :clawed_back }
+
+      it "creates a clawed back event" do
+        process
+
+        expect(Event.last.event_type)
+          .to eq("teacher_declaration_clawed_back")
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "with an invalid status" do
+      let(:status) { :foo }
+
+      it "raises an error" do
+        expect { process }
+          .to raise_error(
+            ArgumentError,
+            "Unknown declaration event status: :foo"
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/backfill/record_declaration_event_spec.rb
+++ b/spec/lib/backfill/record_declaration_event_spec.rb
@@ -12,25 +12,14 @@ RSpec.describe Backfill::RecordDeclarationEvent do
     allow($stdout).to receive(:puts)
   end
 
-  let(:year) { 2024 }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year:, active_lead_provider:) }
+  let(:active_lead_provider) { statement.active_lead_provider }
+  let(:contract) { statement.contract }
+  let(:year) { statement.contract_period.year }
 
-  let(:school_partnership) { FactoryBot.create(:school_partnership, :with_active_lead_provider, :for_year, year:) }
-  let(:active_lead_provider) { school_partnership.active_lead_provider }
-  let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:) }
+  let(:statement) { FactoryBot.create(:statement, :paid) }
 
   let(:status) { :paid }
-
-  let(:statement) do
-    FactoryBot.create(:statement,
-                      :adjustable,
-                      :paid,
-                      month: 9,
-                      year:,
-                      deadline_date: Date.new(year, 8, 31),
-                      payment_date: Date.new(year, 9, 30),
-                      active_lead_provider:,
-                      contract:)
-  end
 
   let!(:declaration) do
     FactoryBot.create(
@@ -81,16 +70,7 @@ RSpec.describe Backfill::RecordDeclarationEvent do
     end
 
     context "when the statement is not paid" do
-      let(:statement) do
-        FactoryBot.create(:statement,
-                          :adjustable,
-                          month: 9,
-                          year:,
-                          deadline_date: Date.new(year, 8, 31),
-                          payment_date: Date.new(year, 9, 30),
-                          active_lead_provider:,
-                          contract:)
-      end
+      let(:statement) { FactoryBot.create(:statement) }
 
       it "does not create the event" do
         expect { process }

--- a/spec/lib/backfill/record_declaration_event_spec.rb
+++ b/spec/lib/backfill/record_declaration_event_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe Backfill::RecordDeclarationEvent do
     end
 
     context "when the declaration is a clawback declaration" do
+      let!(:declaration) do
+        FactoryBot.create(
+          :declaration,
+          :with_ect,
+          payment_status: "paid",
+          clawback_status: "clawed_back",
+          school_partnership:,
+          payment_statement: statement
+        )
+      end
+
       let(:status) { :clawed_back }
 
       it "creates a clawed back event" do

--- a/spec/lib/backfill/record_statement_payment_events_spec.rb
+++ b/spec/lib/backfill/record_statement_payment_events_spec.rb
@@ -1,37 +1,14 @@
 RSpec.describe Backfill::RecordStatementPaymentEvents do
   subject { described_class.new(statement).process }
 
-  let(:school_partnership) { FactoryBot.create(:school_partnership, :with_active_lead_provider, :for_year, year:) }
-  let(:active_lead_provider) { school_partnership.active_lead_provider }
-  let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year:, active_lead_provider:) }
+  let(:active_lead_provider) { statement.active_lead_provider }
+  let(:contract) { statement.contract }
+  let(:year) { statement.contract_period.year }
 
-  let!(:payment_statement) do
-    FactoryBot.create(:statement,
-                      :adjustable,
-                      :paid,
-                      month: 8,
-                      year:,
-                      deadline_date: Date.new(year, 7, 31),
-                      payment_date: Date.new(year, 8, 31),
-                      active_lead_provider:,
-                      contract:)
-  end
+  let!(:statement) { FactoryBot.create(:statement, :paid) }
 
-  let!(:statement) do
-    FactoryBot.create(:statement,
-                      :adjustable,
-                      :paid,
-                      month: 9,
-                      year:,
-                      deadline_date: Date.new(year, 8, 31),
-                      payment_date: Date.new(year, 9, 30),
-                      active_lead_provider:,
-                      contract:)
-  end
-
-  let(:uplift_count) { 0 }
-  let(:year) { 2024 }
-  let(:milestones) { %w[started retained-1 retained-2 retained-3 retained-4 extended-1 extended-2 extended-3 completed] }
+  let(:milestones) { %w[started retained-1 retained-2 extended-1 completed] }
   let(:paid_declarations) { [] }
   let(:clawed_back_declarations) { [] }
   let(:voided_declarations) { [] }
@@ -39,14 +16,13 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
   before do
     allow($stdout).to receive(:puts)
 
-    milestones.each do |declaration_type|
-      pupil_premium_uplift = assign_uplift(declaration_type, uplift_count)
+    previous_statement = FactoryBot.create(:statement, :paid, active_lead_provider:, contract:)
 
+    milestones.each do |declaration_type|
       paid_declarations << FactoryBot.create_list(:declaration, 2, :with_ect,
                                                   declaration_type:,
                                                   payment_status: "paid",
                                                   school_partnership:,
-                                                  pupil_premium_uplift:,
                                                   payment_statement: statement)
 
       voided_declarations << FactoryBot.create(:declaration, :with_ect,
@@ -60,7 +36,7 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
                                                          payment_status: "paid",
                                                          clawback_status: "clawed_back",
                                                          school_partnership:,
-                                                         payment_statement:,
+                                                         payment_statement: previous_statement,
                                                          clawback_statement: statement)
 
       next unless %w[started completed].include?(declaration_type)
@@ -76,7 +52,7 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
                                                     payment_status: "paid",
                                                     clawback_status: "clawed_back",
                                                     school_partnership:,
-                                                    payment_statement:,
+                                                    payment_statement: previous_statement,
                                                     clawback_statement: statement)
     end
 
@@ -86,6 +62,18 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
   end
 
   describe "#process" do
+    it "returns counts of created declaration events by type" do
+      result = subject
+
+      expect(result).to include(
+        started: 3,
+        retained: 4,
+        extended: 2,
+        completed: 3,
+        clawed_back: 12
+      )
+    end
+
     it "records paid events for each paid declaration on the statement" do
       allow(Backfill::RecordDeclarationEvent).to receive(:new).and_call_original
 
@@ -98,18 +86,6 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
           status: :paid
         )
       end
-    end
-
-    it "returns counts of created declaration events by type" do
-      result = subject
-
-      expect(result).to include(
-        started: 3,
-        retained: 8,
-        extended: 6,
-        completed: 3,
-        clawed_back: 20
-      )
     end
 
     it "records clawed back events for clawed back declarations on the statement" do
@@ -179,13 +155,5 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
           )
       end
     end
-  end
-
-  def assign_uplift(declaration_type, uplift_count)
-    return false unless declaration_type == "started"
-
-    uplift = uplift_count < 2 ? true : [true, false].sample
-    uplift_count + 1 if uplift
-    uplift
   end
 end

--- a/spec/lib/backfill/record_statement_payment_events_spec.rb
+++ b/spec/lib/backfill/record_statement_payment_events_spec.rb
@@ -62,18 +62,6 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
   end
 
   describe "#process" do
-    it "returns counts of created declaration events by type" do
-      result = subject
-
-      expect(result).to include(
-        started: 3,
-        retained: 4,
-        extended: 2,
-        completed: 3,
-        clawed_back: 12
-      )
-    end
-
     it "records paid events for each paid declaration on the statement" do
       allow(Backfill::RecordDeclarationEvent).to receive(:new).and_call_original
 
@@ -138,6 +126,42 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
         .to include(
           "contract_period_year" => active_lead_provider.contract_period_year
         )
+    end
+
+    it "returns counts of processed declarations out of the total by type" do
+      result = subject
+
+      expect(result).to include(
+        started: "3/3",
+        retained: "4/4",
+        extended: "2/2",
+        completed: "3/3",
+        clawed_back: "12/12"
+      )
+    end
+
+    context "when some declarations already have events recorded" do
+      before do
+        paid_declarations.first(2).each do |declaration|
+          FactoryBot.create(:event, event_type: "teacher_declaration_paid", declaration:)
+        end
+
+        clawed_back_declarations.first(2).each do |declaration|
+          FactoryBot.create(:event, event_type: "teacher_declaration_clawed_back", declaration:)
+        end
+      end
+
+      it "returns counts of those processed out of the total count" do
+        result = subject
+
+        expect(result).to include(
+          started: "1/3",
+          retained: "4/4",
+          extended: "2/2",
+          completed: "3/3",
+          clawed_back: "10/12"
+        )
+      end
     end
 
     context "when a statement authorised for payment event already exists for the statement" do

--- a/spec/lib/backfill/record_statement_payment_events_spec.rb
+++ b/spec/lib/backfill/record_statement_payment_events_spec.rb
@@ -1,0 +1,191 @@
+RSpec.describe Backfill::RecordStatementPaymentEvents do
+  subject { described_class.new(statement).process }
+
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :with_active_lead_provider, :for_year, year:) }
+  let(:active_lead_provider) { school_partnership.active_lead_provider }
+  let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:) }
+
+  let!(:payment_statement) do
+    FactoryBot.create(:statement,
+                      :adjustable,
+                      :paid,
+                      month: 8,
+                      year:,
+                      deadline_date: Date.new(year, 7, 31),
+                      payment_date: Date.new(year, 8, 31),
+                      active_lead_provider:,
+                      contract:)
+  end
+
+  let!(:statement) do
+    FactoryBot.create(:statement,
+                      :adjustable,
+                      :paid,
+                      month: 9,
+                      year:,
+                      deadline_date: Date.new(year, 8, 31),
+                      payment_date: Date.new(year, 9, 30),
+                      active_lead_provider:,
+                      contract:)
+  end
+
+  let(:uplift_count) { 0 }
+  let(:year) { 2024 }
+  let(:milestones) { %w[started retained-1 retained-2 retained-3 retained-4 extended-1 extended-2 extended-3 completed] }
+  let(:paid_declarations) { [] }
+  let(:clawed_back_declarations) { [] }
+  let(:voided_declarations) { [] }
+
+  before do
+    allow($stdout).to receive(:puts)
+
+    milestones.each do |declaration_type|
+      pupil_premium_uplift = assign_uplift(declaration_type, uplift_count)
+
+      paid_declarations << FactoryBot.create_list(:declaration, 2, :with_ect,
+                                                  declaration_type:,
+                                                  payment_status: "paid",
+                                                  school_partnership:,
+                                                  pupil_premium_uplift:,
+                                                  payment_statement: statement)
+
+      voided_declarations << FactoryBot.create(:declaration, :with_ect,
+                                               declaration_type:,
+                                               payment_status: "voided",
+                                               school_partnership:,
+                                               payment_statement: statement)
+
+      clawed_back_declarations << FactoryBot.create_list(:declaration, 2, :with_ect,
+                                                         declaration_type:,
+                                                         payment_status: "paid",
+                                                         clawback_status: "clawed_back",
+                                                         school_partnership:,
+                                                         payment_statement:,
+                                                         clawback_statement: statement)
+
+      next unless %w[started completed].include?(declaration_type)
+
+      paid_declarations << FactoryBot.create(:declaration, :with_mentor,
+                                             declaration_type:,
+                                             payment_status: "paid",
+                                             school_partnership:,
+                                             payment_statement: statement)
+
+      clawed_back_declarations << FactoryBot.create(:declaration, :with_mentor,
+                                                    declaration_type:,
+                                                    payment_status: "paid",
+                                                    clawback_status: "clawed_back",
+                                                    school_partnership:,
+                                                    payment_statement:,
+                                                    clawback_statement: statement)
+    end
+
+    paid_declarations.flatten!
+    clawed_back_declarations.flatten!
+    voided_declarations.flatten!
+  end
+
+  describe "#process" do
+    it "records paid events for each paid declaration on the statement" do
+      allow(Backfill::RecordDeclarationEvent).to receive(:new).and_call_original
+
+      subject
+
+      paid_declarations.each do |declaration|
+        expect(Backfill::RecordDeclarationEvent).to have_received(:new).with(
+          declaration:,
+          statement:,
+          status: :paid
+        )
+      end
+    end
+
+    it "returns counts of created declaration events by type" do
+      result = subject
+
+      expect(result).to include(
+        started: 3,
+        retained: 8,
+        extended: 6,
+        completed: 3,
+        clawed_back: 20
+      )
+    end
+
+    it "records clawed back events for clawed back declarations on the statement" do
+      allow(Backfill::RecordDeclarationEvent).to receive(:new).and_call_original
+
+      subject
+
+      clawed_back_declarations.each do |declaration|
+        expect(Backfill::RecordDeclarationEvent).to have_received(:new).with(
+          declaration:,
+          statement:,
+          status: :clawed_back
+        )
+      end
+    end
+
+    it "does not record paid events for voided declarations on the statement" do
+      allow(Backfill::RecordDeclarationEvent).to receive(:new).and_call_original
+
+      subject
+
+      voided_declarations.each do |declaration|
+        expect(Backfill::RecordDeclarationEvent).not_to have_received(:new).with(
+          declaration:,
+          statement: anything,
+          status: anything
+        )
+      end
+    end
+
+    it "creates a statement authorised for payment event" do
+      expect { subject }
+        .to change(
+          Event.where(event_type: "statement_authorised_for_payment"),
+          :count
+        ).by(1)
+
+      event = Event.find_by!(
+        event_type: "statement_authorised_for_payment",
+        statement:
+      )
+
+      expect(event.happened_at).to eq(statement.payment_date.in_time_zone)
+      expect(event.lead_provider).to eq(active_lead_provider.lead_provider)
+      expect(event.active_lead_provider).to eq(active_lead_provider)
+      expect(event.author_name).to eq("System")
+      expect(event.author_type).to eq("system")
+
+      expect(event.metadata)
+        .to include(
+          "contract_period_year" => active_lead_provider.contract_period_year
+        )
+    end
+
+    context "when a statement authorised for payment event already exists for the statement" do
+      it "does not create a duplicate statement authorised event" do
+        FactoryBot.create(
+          :event,
+          event_type: "statement_authorised_for_payment",
+          statement:
+        )
+
+        expect { subject }
+          .not_to change(
+            Event.where(event_type: "statement_authorised_for_payment"),
+            :count
+          )
+      end
+    end
+  end
+
+  def assign_uplift(declaration_type, uplift_count)
+    return false unless declaration_type == "started"
+
+    uplift = uplift_count < 2 ? true : [true, false].sample
+    uplift_count + 1 if uplift
+    uplift
+  end
+end

--- a/spec/lib/backfill/record_statement_payment_events_spec.rb
+++ b/spec/lib/backfill/record_statement_payment_events_spec.rb
@@ -164,6 +164,36 @@ RSpec.describe Backfill::RecordStatementPaymentEvents do
       end
     end
 
+    context "when the statement is not paid" do
+      let(:statement) { FactoryBot.create(:statement) }
+
+      it "does not create any events" do
+        expect { subject }
+          .not_to change(Event, :count)
+      end
+
+      it "does not return any results" do
+        result = subject
+
+        expect(result).to eq({})
+      end
+    end
+
+    context "when the statement is not an output fee statement" do
+      let(:statement) { FactoryBot.create(:statement, :service_fee) }
+
+      it "does not create any events" do
+        expect { subject }
+          .not_to change(Event, :count)
+      end
+
+      it "does not return any results" do
+        result = subject
+
+        expect(result).to eq({})
+      end
+    end
+
     context "when a statement authorised for payment event already exists for the statement" do
       it "does not create a duplicate statement authorised event" do
         FactoryBot.create(


### PR DESCRIPTION
### Context

In the admin console, for each declaration we show a state history which relies on events.  Unfortunately all the historical ECF1 declarations did not have events created for them, so we need to backfill the data.

### Changes proposed in this pull request

My initial idea was to use the built in methods that record events.  But since each of these triggers a background job that just runs one create statement this could easily overload the job processing processes and be difficult to clear down.
Therefore this task runs in batches, locking each statement and its declaration and creating the events directly.

### Guidance to review
Product Review testing for 2024:
<img width="1109" height="351" alt="image" src="https://github.com/user-attachments/assets/b8b9b0d2-c0a8-4f52-9d93-c270b1af2392" />

For 2025
<img width="1081" height="269" alt="image" src="https://github.com/user-attachments/assets/8e990e08-a6d7-4d20-b73d-d30f362ef1e2" />


In order to review this, I have run the task on all the statements.  We should expect only the Aug/Oct statements from 2024 and 2025 to have declarations processed.  There may be too many declarations to check individually, but we can spot check.  The task itself outputs the total number of declarations of each type per statement processed which should tally against the statement view.
