### PR TITLE
[3546] Fix ECT email field screen reader label

### DIFF
--- a/app/views/schools/register_ect_wizard/_email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/_email_address.html.erb
@@ -8,19 +8,15 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%=
-    f.govuk_email_field(
-      :email,
-      label: { text: "What is #{@ect.full_name}’s email address?",
-               tag: 'h1',
-               size: 'l' }
-    ) do %>
-    <p class="govuk-body">We ask for an email so we can share their details if needed for training.</p>
+  <h1 class="govuk-heading-l">What is <%= @ect.full_name %>’s email address?</h1>
 
-    <p class="govuk-body">Make sure you use an email the ECT can access. You can update it later if they haven’t got a school email set up yet.</p>
+  <p class="govuk-body">We ask for an email so we can share their details if needed for training.</p>
 
-    <p class="govuk-body">Do not use a generic email like headteacher@school.com</p>
-  <% end %>
+  <p class="govuk-body">Make sure you use an email the ECT can access. You can update it later if they haven’t got a school email set up yet.</p>
+
+  <p class="govuk-body">Do not use a generic email like headteacher@school.com</p>
+
+  <%= f.govuk_email_field(:email, label: { text: "Email address", hidden: true }) %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/schools/register_ect_wizard/_email_address.html.erb
+++ b/app/views/schools/register_ect_wizard/_email_address.html.erb
@@ -16,7 +16,7 @@
 
   <p class="govuk-body">Do not use a generic email like headteacher@school.com</p>
 
-  <%= f.govuk_email_field(:email, label: { text: "Email address", hidden: true }) %>
+  <%= f.govuk_email_field(:email, label: { text: "Email address" }) %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/schools/register_mentor_wizard/_email_address.html.erb
+++ b/app/views/schools/register_mentor_wizard/_email_address.html.erb
@@ -12,7 +12,7 @@
 <%= form_with(model: @wizard.current_step, url: @wizard.current_step_path) do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
-  <%= f.govuk_email_field(:email, label: { text: "Email address", hidden: true, class: 'govuk-!-margin-bottom-4' }) %>
+  <%= f.govuk_email_field(:email, label: { text: "Email address" }) %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/moving_school_backdated_start_date_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "Moving School - backdated start spec" do
   end
 
   def when_i_enter_the_ect_email_address
-    page.get_by_label("What is Kirk Van Houten’s email address?").fill("example@example.com")
+    page.get_by_label("Email address").fill("example@example.com")
   end
 
   def when_i_select_full_time

--- a/spec/features/schools/ects/register/happy_path_spec.rb
+++ b/spec/features/schools/ects/register/happy_path_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "Registering an ECT" do
   end
 
   def when_i_enter_the_ect_email_address
-    page.get_by_label("What is Kirk Van Damme’s email address?").fill("example@example.com")
+    page.get_by_label("Email address").fill("example@example.com")
   end
 
   def then_i_should_be_taken_to_the_training_programme_page
@@ -321,7 +321,7 @@ RSpec.describe "Registering an ECT" do
   end
 
   def when_i_enter_a_new_ect_email_address
-    page.get_by_label("What is Kirk Van Houten’s email address?").fill("new@example.com")
+    page.get_by_label("Email address").fill("new@example.com")
   end
 
   def and_i_should_see_the_new_email

--- a/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
+++ b/spec/views/schools/register_mentor_wizard/shared_examples/email_view.rb
@@ -51,4 +51,11 @@ RSpec.shared_examples "an email address step view" do |current_step:, back_path:
     expect(rendered).to have_button("Continue")
     expect(rendered).to have_selector("form[action='#{send(continue_path)}']")
   end
+
+  it "includes a visible email address label" do
+    render
+
+    expect(rendered).to have_css("label.govuk-label", text: "Email address")
+    expect(rendered).not_to have_css("label.govuk-visually-hidden", text: "Email address")
+  end
 end


### PR DESCRIPTION
## Fix ECT email field accessibility label

Separate the page heading and guidance copy from the email field label in the ECT registration flow.

Previously, the email field reused the full page question as its label and rendered guidance copy inside the field block. This meant screen readers could announce duplicated and unnecessary content when focusing on the input.

**This change:**
- adds an explicit `<h1>` for the page heading
- moves the guidance content outside the field block
- changes the input label to `Email address`
- hides the label visually while keeping it available to screen readers

This matches the mentor registration flow and improves accessibility for screen reader users.