### PR TITLE
Update release_notes.yml

### DIFF
--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,7 +21,18 @@
 #
 #     **bold** and _italic_ text
 
-- title: Update to the induction_tutor_email attribute on GET partnerships and GET schools endpoints
+  title: Added schedules and contract data for the 2026 to 2027 intake to the test (sandbox) environment 
+  date: 2026-05-27
+  tags:
+    - data-update
+    - sandbox-release
+  body: |
+    We’ve added the schedules and contract data for the 2026 to 2027 intake of early career teachers (ECTs) and mentors to the test (sandbox) environment.
+
+    Lead providers can use the seed data we’ve created. This will allow full end-to-end process testing and ensure smooth integration with POST participant-declarations, POST Partnership endpoints and all GET endpoints.
+
+
+  title: Update to the induction_tutor_email attribute on GET partnerships and GET schools endpoints
   date: 2026-05-26
   tags:
     - sandbox-release

--- a/app/views/api/release_notes/release_notes.yml
+++ b/app/views/api/release_notes/release_notes.yml
@@ -21,7 +21,7 @@
 #
 #     **bold** and _italic_ text
 
-  title: Added schedules and contract data for the 2026 to 2027 intake to the test (sandbox) environment 
+- title: Added schedules and contract data for the 2026 to 2027 intake to the test (sandbox) environment 
   date: 2026-05-27
   tags:
     - data-update
@@ -32,7 +32,7 @@
     Lead providers can use the seed data we’ve created. This will allow full end-to-end process testing and ensure smooth integration with POST participant-declarations, POST Partnership endpoints and all GET endpoints.
 
 
-  title: Update to the induction_tutor_email attribute on GET partnerships and GET schools endpoints
+- title: Update to the induction_tutor_email attribute on GET partnerships and GET schools endpoints
   date: 2026-05-26
   tags:
     - sandbox-release


### PR DESCRIPTION
4007-release note added seed data to sandbox

### Context
Add entry to release notes for addition of schedules and contracts seed data for 2026 to 2027 intake to the sandbox environment

### Changes proposed in this pull request
Add entry to release_notes.yml

### Guidance to review
Visual/sense check in review app.

I've followed the general style of previous and similar entries.