### PR TITLE
Prevent LPs creating partnerships against future contract periods

### DIFF
--- a/app/services/api/school_partnerships/create.rb
+++ b/app/services/api/school_partnerships/create.rb
@@ -13,6 +13,7 @@ module API::SchoolPartnerships
     validates :lead_provider_id, presence: { message: "Enter a '#/lead_provider_id'." }
     validates :delivery_partner_api_id, presence: { message: "Enter a '#/delivery_partner_api_id'." }
     validate :contract_period_exists
+    validate :contract_period_started
     validate :contract_period_enabled
     validate :lead_provider_exists
     validate :school_exists
@@ -60,6 +61,12 @@ module API::SchoolPartnerships
       return if errors[:contract_period_year].any?
 
       errors.add(:contract_period_year, "You cannot create this partnership as the contract period is closed.") unless contract_period&.enabled?
+    end
+
+    def contract_period_started
+      return if errors[:contract_period_year].any?
+
+      errors.add(:contract_period_year, "You cannot create a partnership for a future contract period.") unless contract_period&.started_on_or_before_today?
     end
 
     def lead_provider_exists

--- a/db/seeds/contract_periods.rb
+++ b/db/seeds/contract_periods.rb
@@ -32,7 +32,7 @@ end
     detailed_evidence_types_enabled: true,
     uplift_fees_enabled: false },
   { year: 2026,
-    enabled: false,
+    enabled: true,
     mentor_funding_enabled: true,
     detailed_evidence_types_enabled: true,
     uplift_fees_enabled: false }

--- a/spec/requests/api/docs/v3/schools_spec.rb
+++ b/spec/requests/api/docs/v3/schools_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Schools endpoint", :with_metadata, openapi_spec: "v3/swagger.yam
   let(:resource) { FactoryBot.create(:school, :eligible, :with_induction_tutor) }
   let!(:school_partnership) { FactoryBot.create(:school_partnership, school: resource, lead_provider_delivery_partnership:) }
   let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
-  let(:contract_period) { lead_provider_delivery_partnership.contract_period }
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school: resource) }
   let!(:training_period) { FactoryBot.create(:training_period, :provider_led, :ongoing, ect_at_school_period:, school_partnership:) }
   let(:"filter[cohort]") { contract_period.year }

--- a/spec/requests/api/v3/partnerships_spec.rb
+++ b/spec/requests/api/v3/partnerships_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe "Partnerships API", :with_touches, type: :request do
   let(:serializer) { API::SchoolPartnershipSerializer }
   let(:serializer_options) { { lead_provider: } }
   let(:query) { API::SchoolPartnerships::Query }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
   let(:lead_provider) { active_lead_provider.lead_provider }
 
   def create_resource(active_lead_provider:)

--- a/spec/services/api/school_partnerships/create_spec.rb
+++ b/spec/services/api/school_partnerships/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
     )
   end
 
-  let(:contract_period) { FactoryBot.create(:contract_period) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
   let(:contract_period_year) { contract_period.year }
 
   let(:school) { FactoryBot.create(:school, :eligible) }
@@ -43,11 +43,20 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
     end
 
     context "when the contract period year is not enabled" do
-      before { contract_period.update!(enabled: false) }
+      let(:contract_period) { FactoryBot.create(:contract_period, :previous, enabled: false) }
 
       it "is invalid" do
         expect(service).to be_invalid
         expect(service.errors[:contract_period_year]).to eq(["You cannot create this partnership as the contract period is closed."])
+      end
+    end
+
+    context "when the contract period has not started" do
+      let(:contract_period) { FactoryBot.create(:contract_period, :next) }
+
+      it "is invalid" do
+        expect(service).to be_invalid
+        expect(service.errors[:contract_period_year]).to eq(["You cannot create a partnership for a future contract period."])
       end
     end
 
@@ -89,7 +98,7 @@ RSpec.describe API::SchoolPartnerships::Create, type: :model do
 
     context "when a school partnership already exists for the lead provider and a different contract period" do
       before do
-        contract_period = FactoryBot.create(:contract_period, year: contract_period_year + 1)
+        contract_period = FactoryBot.create(:contract_period, :previous)
         active_lead_provider = FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:)
         lead_provider_delivery_partnership = FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:, delivery_partner:)
 

--- a/spec/support/shared_contexts/api/api_doc_request_auth.rb
+++ b/spec/support/shared_contexts/api/api_doc_request_auth.rb
@@ -1,5 +1,6 @@
 RSpec.shared_context("with authorization for api doc request") do
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
   let(:lead_provider) { active_lead_provider.lead_provider }
   let(:token) { generate_api_token.token }
   let(:Authorization) { "Bearer #{token}" }


### PR DESCRIPTION
### Context

We are going to be adding the upcoming 2026 `ContractPeriod` ahead of it officially starting. Between adding it and it starting, we want to ensure lead providers can't creating new partnerships against the contract period.

### Changes proposed in this pull request

- Prevent LPs creating partnerships against future contract periods

Request specs changed to ensure they all operate with the current contract period rather than the sequential year which often overflows past 2025.

### Guidance to review

We are not concerned about lead providers viewing statements, delivery partners or schools for the 2026 contract period.