### PR TITLE
Make fee structures non-nullable

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -24,14 +24,16 @@ class Contract < ApplicationRecord
             presence: { message: "VAT rate is required" },
             numericality: { in: 0..1, message: "VAT rate must be between 0 and 1" }
 
-  validate :fee_structures_are_correct_for_contract_type
-
   with_options if: :ittecf_ectp_contract_type? do
+    validates :flat_rate_fee_structure, presence: { message: "Flat rate fee structure must be provided for ITTECF_ECTP contracts" }
+    validates :banded_fee_structure, presence: { message: "Banded fee structure must be provided for ITTECF_ECTP contracts" }
     validates :ecf_contract_version, presence: { message: "ECF contract version must be provided for ITTECF_ECTP contracts" }
     validates :ecf_mentor_contract_version, presence: { message: "ECF mentor contract version must be provided for ITTECF_ECTP contracts" }
   end
 
   with_options if: :ecf_contract_type? do
+    validates :flat_rate_fee_structure, absence: { message: "Flat rate fee structure must be blank for ECF contracts" }
+    validates :banded_fee_structure, presence: { message: "Banded fee structure must be provided for ECF contracts" }
     validates :ecf_contract_version, presence: { message: "ECF contract version must be provided for ECF contracts" }
   end
 
@@ -39,15 +41,5 @@ class Contract < ApplicationRecord
     return 0 unless lead_provider.vat_registered
 
     vat_rate
-  end
-
-  def fee_structures_are_correct_for_contract_type
-    if ittecf_ectp_contract_type?
-      errors.add(:flat_rate_fee_structure, "Flat rate fee structure must be provided for ITTECF_ECTP contracts") if flat_rate_fee_structure.blank?
-      errors.add(:banded_fee_structure, "Banded fee structure must be provided for ITTECF_ECTP contracts") if banded_fee_structure.blank?
-    elsif ecf_contract_type?
-      errors.add(:flat_rate_fee_structure, "Flat rate fee structure must be blank for ECF contracts") if flat_rate_fee_structure.present?
-      errors.add(:banded_fee_structure, "Banded fee structure must be provided for ECF contracts") if banded_fee_structure.blank?
-    end
   end
 end

--- a/app/models/contract/banded_fee_structure.rb
+++ b/app/models/contract/banded_fee_structure.rb
@@ -10,7 +10,7 @@ class Contract::BandedFeeStructure < ApplicationRecord
            dependent: :destroy
 
   # Validations
-  validates :contract_id, uniqueness: { message: "Contract with the same banded fee structure already exist" }, allow_nil: true
+  validates :contract_id, uniqueness: { message: "Contract with the same banded fee structure already exist" }
 
   validates :recruitment_target,
             presence: { message: "Recruitment target is required" },

--- a/app/models/contract/banded_fee_structure/band.rb
+++ b/app/models/contract/banded_fee_structure/band.rb
@@ -96,10 +96,11 @@ private
 
     attributes_to_ignore = %w[id banded_fee_structure_id created_at updated_at].freeze
     unique_bands_by_index = bands_for_active_lead_provider
-      .group_by { it.banded_fee_structure.reload.bands.index(it) || it.banded_fee_structure.bands.count }
+      .group_by { it.banded_fee_structure.bands.index(it) || it.banded_fee_structure.bands.count }
       .transform_values { |bands| bands.map { it.attributes.except(*attributes_to_ignore) }.uniq }
 
     inconsistent_bands = unique_bands_by_index.select { |_, bands| bands.size > 1 }
+
     inconsistent_bands.each_key do |index|
       errors.add(:base, "Band at index #{index} is inconsistent across statements for the same active lead provider")
     end

--- a/app/models/contract/flat_rate_fee_structure.rb
+++ b/app/models/contract/flat_rate_fee_structure.rb
@@ -5,7 +5,7 @@ class Contract::FlatRateFeeStructure < ApplicationRecord
   belongs_to :contract
 
   # Validations
-  validates :contract_id, uniqueness: { message: "Contract with the same flat rate fee structure already exists" }, allow_nil: true
+  validates :contract_id, uniqueness: { message: "Contract with the same flat rate fee structure already exists" }
 
   validates :recruitment_target,
             presence: { message: "Recruitment target is required" },

--- a/app/services/active_lead_providers/seed_from_previous.rb
+++ b/app/services/active_lead_providers/seed_from_previous.rb
@@ -77,39 +77,31 @@ private
     # would run those validations before the siblings exist.
     previous_contract = previous_latest_contract
 
-    # fee structures now belong_to a contract and can be added first
-    banded_fee_structure = create_banded_fee_structure(previous_contract.banded_fee_structure)
-    flat_rate_fee_structure = create_flat_rate_fee_structure(previous_contract.flat_rate_fee_structure)
-
     active_lead_provider.contracts.create!(
       contract_type: previous_contract.contract_type,
       ecf_contract_version: previous_contract.ecf_contract_version,
       ecf_mentor_contract_version: previous_contract.ecf_mentor_contract_version,
-      banded_fee_structure:,
-      flat_rate_fee_structure:,
+      banded_fee_structure: build_banded_fee_structure(previous_contract.banded_fee_structure),
+      flat_rate_fee_structure: build_flat_rate_fee_structure(previous_contract.flat_rate_fee_structure),
       statements: build_new_statements,
       vat_rate: previous_contract.vat_rate
     )
   end
 
-  def create_banded_fee_structure(previous_fee_structure)
+  def build_banded_fee_structure(previous_fee_structure)
     return unless previous_fee_structure
 
-    # Band's band_consistency_across_active_lead_provider calls .reload on its parent
-    # banded_fee_structure, so the parent must be inserted before any newly created band validates.
     previous_fee_structure.dup.tap do |new_fee_structure|
       new_fee_structure.contract_id = nil
-      new_fee_structure.save!
       previous_fee_structure.bands.each { |band| new_fee_structure.bands << band.dup }
     end
   end
 
-  def create_flat_rate_fee_structure(previous_fee_structure)
+  def build_flat_rate_fee_structure(previous_fee_structure)
     return unless previous_fee_structure
 
     previous_fee_structure.dup.tap do |new_fee_structure|
       new_fee_structure.contract_id = nil
-      new_fee_structure.save!
     end
   end
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -342,6 +342,8 @@
   - updated_at
   :contracts:
   - vat_rate
+  - flat_rate_fee_structure_id
+  - banded_fee_structure_id
   - ecf_contract_version
   - ecf_mentor_contract_version
   - created_at

--- a/db/migrate/20260522155215_remove_fee_structure_ids_from_contract.rb
+++ b/db/migrate/20260522155215_remove_fee_structure_ids_from_contract.rb
@@ -1,6 +1,0 @@
-class RemoveFeeStructureIdsFromContract < ActiveRecord::Migration[8.1]
-  def change
-    remove_reference :contracts, :flat_rate_fee_structure, foreign_key: { to_table: :contract_flat_rate_fee_structures }, index: { unique: true }
-    remove_reference :contracts, :banded_fee_structure, foreign_key: { to_table: :contract_banded_fee_structures }, index: { unique: true }
-  end
-end

--- a/db/migrate/20260528082643_require_contract_id_on_fee_structures.rb
+++ b/db/migrate/20260528082643_require_contract_id_on_fee_structures.rb
@@ -1,0 +1,6 @@
+class RequireContractIdOnFeeStructures < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :contract_banded_fee_structures, :contract_id, false
+    change_column_null :contract_flat_rate_fee_structures, :contract_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_22_155215) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_082643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -157,7 +157,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_155215) do
   end
 
   create_table "contract_banded_fee_structures", force: :cascade do |t|
-    t.bigint "contract_id"
+    t.bigint "contract_id", null: false
     t.datetime "created_at", null: false
     t.decimal "monthly_service_fee", precision: 12, scale: 2
     t.integer "recruitment_target", null: false
@@ -169,7 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_155215) do
   end
 
   create_table "contract_flat_rate_fee_structures", force: :cascade do |t|
-    t.bigint "contract_id"
+    t.bigint "contract_id", null: false
     t.datetime "created_at", null: false
     t.decimal "fee_per_declaration", precision: 12, scale: 2, null: false
     t.integer "recruitment_target", null: false
@@ -195,13 +195,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_155215) do
 
   create_table "contracts", force: :cascade do |t|
     t.bigint "active_lead_provider_id", null: false
+    t.bigint "banded_fee_structure_id"
     t.enum "contract_type", null: false, enum_type: "contract_types"
     t.datetime "created_at", null: false
     t.string "ecf_contract_version", default: "1.0.0", null: false
     t.string "ecf_mentor_contract_version"
+    t.bigint "flat_rate_fee_structure_id"
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
     t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"
+    t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true, where: "(banded_fee_structure_id IS NOT NULL)"
+    t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true, where: "(flat_rate_fee_structure_id IS NOT NULL)"
   end
 
   create_table "declarations", force: :cascade do |t|
@@ -947,6 +951,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_155215) do
   add_foreign_key "contract_banded_fee_structures", "contracts"
   add_foreign_key "contract_flat_rate_fee_structures", "contracts"
   add_foreign_key "contracts", "active_lead_providers"
+  add_foreign_key "contracts", "contract_banded_fee_structures", column: "banded_fee_structure_id"
+  add_foreign_key "contracts", "contract_flat_rate_fee_structures", column: "flat_rate_fee_structure_id"
   add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"

--- a/db/seeds/declarations.rb
+++ b/db/seeds/declarations.rb
@@ -91,8 +91,8 @@ ITTECF_BOUNDARIES = [
 
 print_seed_info("Creating Statements")
 
-ecf_fee_structure = FactoryBot.create(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ECF_BOUNDARIES)
-ittecf_fee_structure = FactoryBot.create(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ITTECF_BOUNDARIES)
+ecf_fee_structure = FactoryBot.build(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ECF_BOUNDARIES)
+ittecf_fee_structure = FactoryBot.build(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ITTECF_BOUNDARIES)
 
 ucl = LeadProvider.find_by!(name: "UCL Institute of Education")
 grain_teaching_school_hub = DeliveryPartner.find_by!(name: "Grain Teaching School Hub")

--- a/spec/components/admin/statements/output_payments_component_spec.rb
+++ b/spec/components/admin/statements/output_payments_component_spec.rb
@@ -3,16 +3,16 @@ RSpec.describe Admin::Statements::OutputPaymentsComponent, type: :component do
 
   let(:statement) { FactoryBot.create(:statement, contract:) }
 
-  let(:banded_fee_structure) do
-    fs = FactoryBot.create(:contract_banded_fee_structure)
+  let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, bands:) }
+
+  let(:bands) do
     [
       { min: 1, max: 10, fee: 100 },
       { min: 11, max: 20, fee: 75 },
       { min: 21, max: 30, fee: 50 },
-    ].each do |attrs|
-      FactoryBot.create(
+    ].map do |attrs|
+      FactoryBot.build(
         :contract_banded_fee_structure_band,
-        banded_fee_structure: fs,
         min_declarations: attrs[:min],
         max_declarations: attrs[:max],
         fee_per_declaration: attrs[:fee],
@@ -20,10 +20,7 @@ RSpec.describe Admin::Statements::OutputPaymentsComponent, type: :component do
         service_fee_ratio: 0.2
       )
     end
-    fs.reload
   end
-
-  let(:bands) { banded_fee_structure.bands }
 
   let(:banded_outputs) do
     fee_proportions = PaymentCalculator::Banded::DeclarationTypeOutput::FEE_PROPORTIONS

--- a/spec/components/admin/statements/payment_overview/ecf_component_spec.rb
+++ b/spec/components/admin/statements/payment_overview/ecf_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::Statements::PaymentOverview::ECFComponent, type: :componen
   let(:statement) { Admin::StatementPresenter.new(statement_rec) }
 
   let(:banded_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_banded_fee_structure,
       monthly_service_fee:,
       uplift_fee_per_declaration: 50,

--- a/spec/components/admin/statements/payment_overview/ittecf_ectp_component_spec.rb
+++ b/spec/components/admin/statements/payment_overview/ittecf_ectp_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::Statements::PaymentOverview::IttecfEctpComponent, type: :c
   let(:statement) { Admin::StatementPresenter.new(statement_rec) }
 
   let(:banded_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_banded_fee_structure,
       monthly_service_fee:,
       uplift_fee_per_declaration: 50,
@@ -32,7 +32,7 @@ RSpec.describe Admin::Statements::PaymentOverview::IttecfEctpComponent, type: :c
   end
 
   let(:flat_rate_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_flat_rate_fee_structure,
       fee_per_declaration: 100.00
     )

--- a/spec/components/admin/statements/provider_targets_component/flat_rate_fee_component_spec.rb
+++ b/spec/components/admin/statements/provider_targets_component/flat_rate_fee_component_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Admin::Statements::ProviderTargetsComponent::FlatRateFeeComponent
 
   let(:contract) { FactoryBot.build_stubbed(:contract, flat_rate_fee_structure:) }
   let(:flat_rate_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_flat_rate_fee_structure,
       recruitment_target: 3000,
       fee_per_declaration: 750

--- a/spec/factories/contract/banded_fee_structure_factory.rb
+++ b/spec/factories/contract/banded_fee_structure_factory.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
         declaration_boundaries do
           min = 1
 
-          Array.new(Faker::Number.between(from: 3, to: 4)) do
-            max = min + Faker::Number.between(from: 20, to: 200)
+          Array.new(3) do
+            max = min + 80
             { min:, max: }.tap { min = max + 1 }
           end
         end
@@ -23,7 +23,9 @@ FactoryBot.define do
             :contract_banded_fee_structure_band,
             banded_fee_structure: instance,
             min_declarations: boundary[:min],
-            max_declarations: boundary[:max]
+            max_declarations: boundary[:max],
+            fee_per_declaration: boundary[:max] + 100,
+            strategy: :build
           )
         end
       end

--- a/spec/factories/contract_factory.rb
+++ b/spec/factories/contract_factory.rb
@@ -2,18 +2,21 @@ FactoryBot.define do
   factory(:contract) do
     association :active_lead_provider
 
+    for_ittecf_ectp
+
     trait(:for_ecf) do
       contract_type { "ecf" }
       ecf_contract_version { "1" }
-      association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure
+      association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure, strategy: :build
+      flat_rate_fee_structure { nil }
     end
 
     trait(:for_ittecf_ectp) do
       contract_type { "ittecf_ectp" }
       ecf_contract_version { "1" }
       ecf_mentor_contract_version { "2" }
-      association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure
-      association :flat_rate_fee_structure, factory: :contract_flat_rate_fee_structure
+      association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure, strategy: :build
+      association :flat_rate_fee_structure, factory: :contract_flat_rate_fee_structure, strategy: :build
     end
   end
 end

--- a/spec/models/contract/banded_fee_structure/band_spec.rb
+++ b/spec/models/contract/banded_fee_structure/band_spec.rb
@@ -60,8 +60,10 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
         )
       end
 
+      let!(:contract) { FactoryBot.create(:contract, :for_ecf, banded_fee_structure:) }
+
       let(:banded_fee_structure) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure,
           :with_bands,
           declaration_boundaries: [
@@ -105,7 +107,7 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
       context "when the banded fee structure has no bands yet " \
               "and the band's min declarations is not 1" do
         let(:banded_fee_structure) do
-          FactoryBot.build_stubbed(:contract_banded_fee_structure)
+          FactoryBot.build(:contract_banded_fee_structure)
         end
         let(:min_declarations) { 2 }
         let(:max_declarations) { 400 }
@@ -119,7 +121,7 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
       context "when the banded fee structure has no bands yet " \
               "and the band's min declarations is 1" do
         let(:banded_fee_structure) do
-          FactoryBot.build_stubbed(:contract_banded_fee_structure)
+          FactoryBot.build(:contract_banded_fee_structure)
         end
         let(:min_declarations) { 1 }
         let(:max_declarations) { 400 }
@@ -128,7 +130,7 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
       end
 
       context "when updating an existing band" do
-        let(:banded_fee_structure) { FactoryBot.create(:contract_banded_fee_structure, :with_bands) }
+        let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, :with_bands) }
 
         it "is valid if the updated band still has sequential declaration boundaries" do
           band = banded_fee_structure.bands.last
@@ -151,33 +153,35 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
       let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
 
       it "is valid when creating the first band for the active lead provider" do
-        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
+        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
         band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure:)
+        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
         expect(band).to be_valid
       end
 
       it "is valid when creating bands for another contract for the same active lead provider when the bands are consistent" do
-        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
+        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
+        FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100)
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100)
 
-        new_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
-        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
+        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure)
         new_band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 100)
+        FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
 
         expect(new_band).to be_valid
       end
 
       it "is invalid when creating bands for another contract for the same active lead provider when the bands are not consistent" do
-        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
+        bands = [
+          FactoryBot.build(:contract_banded_fee_structure_band, fee_per_declaration: 100, min_declarations: 1, max_declarations: 2),
+          FactoryBot.build(:contract_banded_fee_structure_band, fee_per_declaration: 150, min_declarations: 3, max_declarations: 4)
+        ]
+        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, bands:)
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100, min_declarations: 1, max_declarations: 2)
-        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 150, min_declarations: 3, max_declarations: 4)
 
-        new_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
+        new_band = FactoryBot.build(:contract_banded_fee_structure_band, fee_per_declaration: 150, min_declarations: 1, max_declarations: 2)
+        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, bands: [new_band])
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
-        new_band = FactoryBot.build(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 150, min_declarations: 1, max_declarations: 2)
 
         expect(new_band).to be_invalid
         expect(new_band.errors[:base]).to include(/Band at index 0 is inconsistent across statements for the same active lead provider/)
@@ -195,13 +199,13 @@ RSpec.describe Contract::BandedFeeStructure::Band, type: :model do
       end
 
       it "is invalid when updating a band such that it becomes inconsistent with bands for the same active lead provider" do
-        banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
+        band = FactoryBot.build(:contract_banded_fee_structure_band, fee_per_declaration: 100)
+        banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, bands: [band])
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:)
-        FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, fee_per_declaration: 100)
 
-        new_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure)
+        new_band = FactoryBot.build(:contract_banded_fee_structure_band, fee_per_declaration: 100)
+        new_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, bands: [new_band])
         FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure: new_banded_fee_structure)
-        new_band = FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure: new_banded_fee_structure, fee_per_declaration: 100)
 
         new_band.fee_per_declaration = 150
 

--- a/spec/models/contract/banded_fee_structure_spec.rb
+++ b/spec/models/contract/banded_fee_structure_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe Contract::BandedFeeStructure, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:bands).order(min_declarations: :asc).class_name("Contract::BandedFeeStructure::Band").inverse_of(:banded_fee_structure).dependent(:destroy) }
-    it { is_expected.to belong_to(:contract).optional }
+    it { is_expected.to belong_to(:contract) }
   end
 
   describe "validations" do
+    subject { FactoryBot.create(:contract).banded_fee_structure }
+
     it { is_expected.to validate_presence_of(:recruitment_target).with_message("Recruitment target is required") }
     it { is_expected.to validate_numericality_of(:recruitment_target).is_greater_than_or_equal_to(0).only_integer.with_message("Recruitment target must be a number greater than zero") }
 
@@ -15,5 +17,7 @@ RSpec.describe Contract::BandedFeeStructure, type: :model do
 
     it { is_expected.to validate_presence_of(:setup_fee).with_message("Setup fee is required") }
     it { is_expected.to validate_numericality_of(:setup_fee).is_greater_than_or_equal_to(0).with_message("Setup fee must be greater than or equal to zero") }
+
+    it { is_expected.to validate_uniqueness_of(:contract_id).with_message("Contract with the same banded fee structure already exist") }
   end
 end

--- a/spec/models/contract/flat_rate_fee_structure_spec.rb
+++ b/spec/models/contract/flat_rate_fee_structure_spec.rb
@@ -1,29 +1,15 @@
 describe Contract::FlatRateFeeStructure do
   describe "associations" do
-    it { is_expected.to belong_to(:contract).optional }
+    it { is_expected.to belong_to(:contract) }
   end
 
   describe "validations" do
-    subject { FactoryBot.build(:contract_flat_rate_fee_structure) }
+    subject { FactoryBot.create(:contract).flat_rate_fee_structure }
 
     it { is_expected.to validate_presence_of(:recruitment_target).with_message("Recruitment target is required") }
     it { is_expected.to validate_presence_of(:fee_per_declaration).with_message("Fee per declaration is required") }
     it { is_expected.to validate_numericality_of(:recruitment_target).only_integer.is_greater_than(0).with_message("Value must be greater than 0") }
     it { is_expected.to validate_numericality_of(:fee_per_declaration).is_greater_than(0).with_message("Amount must be greater than 0") }
-
-    context "uniqueness" do
-      subject(:flat_rate_fee_structure) { FactoryBot.create(:contract_flat_rate_fee_structure) }
-
-      let!(:existing_contract_1) { FactoryBot.create(:contract, :for_ittecf_ectp, flat_rate_fee_structure:) }
-      let!(:existing_contract_2) { FactoryBot.create(:contract, :for_ittecf_ectp) }
-
-      it "validates that the flat_fee_structure is only used on 1 contract" do
-        new_flat_rate_fee_structure = flat_rate_fee_structure.dup
-        new_flat_rate_fee_structure.contract = existing_contract_2
-
-        expect(new_flat_rate_fee_structure).not_to be_valid
-        expect(new_flat_rate_fee_structure.errors[:contract_id]).to include("Contract with the same flat rate fee structure already exists")
-      end
-    end
+    it { is_expected.to validate_uniqueness_of(:contract_id).with_message("Contract with the same flat rate fee structure already exists") }
   end
 end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -20,7 +20,7 @@ describe Contract do
   end
 
   describe "validations" do
-    subject { FactoryBot.create(:contract, :for_ittecf_ectp) }
+    subject { FactoryBot.create(:contract) }
 
     it { is_expected.to validate_presence_of(:contract_type).with_message("Enter a contract type") }
     it { is_expected.to validate_inclusion_of(:contract_type).in_array(Contract.contract_types.keys).with_message("Choose a valid contract type") }
@@ -28,7 +28,7 @@ describe Contract do
     it { is_expected.to validate_numericality_of(:vat_rate).is_in(0..1).with_message("VAT rate must be between 0 and 1") }
 
     context "when active_lead_provider is nil" do
-      subject(:contract) { FactoryBot.build(:contract, :for_ittecf_ectp, active_lead_provider: nil) }
+      subject(:contract) { FactoryBot.build(:contract, active_lead_provider: nil) }
 
       it "is not valid" do
         expect(contract).not_to be_valid
@@ -37,7 +37,7 @@ describe Contract do
     end
 
     context "when contract type is `ITTECF_ECTP`" do
-      subject { FactoryBot.create(:contract, :for_ittecf_ectp) }
+      subject { FactoryBot.build(:contract, :for_ittecf_ectp) }
 
       it { is_expected.to validate_presence_of(:ecf_contract_version).with_message("ECF contract version must be provided for ITTECF_ECTP contracts") }
       it { is_expected.to validate_presence_of(:ecf_mentor_contract_version).with_message("ECF mentor contract version must be provided for ITTECF_ECTP contracts") }
@@ -46,16 +46,11 @@ describe Contract do
     end
 
     context "when contract type is `ECF`" do
-      subject { FactoryBot.create(:contract, :for_ecf) }
+      subject { FactoryBot.build(:contract, :for_ecf) }
 
       it { is_expected.to validate_presence_of(:ecf_contract_version).with_message("ECF contract version must be provided for ECF contracts") }
       it { is_expected.to validate_presence_of(:banded_fee_structure).with_message("Banded fee structure must be provided for ECF contracts") }
-
-      it "validates the flat_rate_fee_structure is not present" do
-        subject.flat_rate_fee_structure = FactoryBot.build(:contract_flat_rate_fee_structure)
-        expect(subject).not_to be_valid
-        expect(subject.errors[:flat_rate_fee_structure]).to include("Flat rate fee structure must be blank for ECF contracts")
-      end
+      it { is_expected.to validate_absence_of(:flat_rate_fee_structure).with_message("Flat rate fee structure must be blank for ECF contracts") }
 
       it "allows multiple ECF contracts to have a NULL flat_rate_fee_structure" do
         FactoryBot.create(:contract, :for_ecf, flat_rate_fee_structure: nil)
@@ -68,14 +63,7 @@ describe Contract do
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider) }
 
     context "when creating a new contract" do
-      let(:contract) do
-        FactoryBot.build(
-          :contract,
-          :for_ittecf_ectp,
-          active_lead_provider:,
-          banded_fee_structure: FactoryBot.create(:contract_banded_fee_structure)
-        )
-      end
+      let(:contract) { FactoryBot.build(:contract, active_lead_provider:) }
 
       it "assigns the active lead provider" do
         expect { contract.save! }.not_to raise_error
@@ -85,7 +73,7 @@ describe Contract do
 
     context "when updating an existing contract" do
       let(:other_active_lead_provider) { FactoryBot.create(:active_lead_provider) }
-      let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:) }
+      let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
 
       it "raises an error" do
         expect { contract.update!(active_lead_provider: other_active_lead_provider) }
@@ -100,7 +88,7 @@ describe Contract do
 
     let(:lead_provider) { FactoryBot.create(:lead_provider, vat_registered:) }
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-    let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:, vat_rate: 0.2) }
+    let(:contract) { FactoryBot.create(:contract, active_lead_provider:, vat_rate: 0.2) }
 
     context "when the lead provider is VAT registered" do
       let(:vat_registered) { true }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -27,7 +27,7 @@ describe Statement do
 
     describe "uniqueness of month and year for the same active lead provider" do
       let(:active_lead_provider) { contract.active_lead_provider }
-      let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp) }
+      let(:contract) { FactoryBot.create(:contract) }
 
       before { FactoryBot.create(:statement, active_lead_provider:, month: 5, year: 2024) }
 
@@ -39,7 +39,7 @@ describe Statement do
 
       it "is valid to create another statement with the same month and year for a different active lead provider" do
         other_active_lead_provider = FactoryBot.create(:active_lead_provider)
-        other_contract = FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider: other_active_lead_provider)
+        other_contract = FactoryBot.create(:contract, active_lead_provider: other_active_lead_provider)
         statement = described_class.new(contract: other_contract, month: 5, year: 2024, deadline_date: Date.new(2024, 5, 1).prev_day)
 
         expect(statement).to be_valid

--- a/spec/presenters/admin/statement_presenter_spec.rb
+++ b/spec/presenters/admin/statement_presenter_spec.rb
@@ -64,7 +64,7 @@ describe Admin::StatementPresenter do
   describe "#lead_provider_name" do
     let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
-    let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:) }
+    let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
     let(:statement) { FactoryBot.build(:statement, contract:) }
 
     it "returns the lead provider name" do
@@ -75,7 +75,7 @@ describe Admin::StatementPresenter do
   describe "#contract_period_year" do
     let(:contract_period) { FactoryBot.create(:contract_period, year: 2022) }
     let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
-    let(:contract) { FactoryBot.create(:contract, :for_ittecf_ectp, active_lead_provider:) }
+    let(:contract) { FactoryBot.create(:contract, active_lead_provider:) }
     let(:statement) { FactoryBot.build(:statement, contract:) }
 
     it "returns the lead provider name" do

--- a/spec/requests/admin/finance/statements/statements_spec.rb
+++ b/spec/requests/admin/finance/statements/statements_spec.rb
@@ -134,14 +134,12 @@ RSpec.describe "Admin finance statements index", type: :request do
       let(:lead_provider) { FactoryBot.create(:lead_provider) }
       let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
       let(:banded_fee_structure) do
-        FactoryBot.create(:contract_banded_fee_structure).tap do |structure|
-          FactoryBot.create(
-            :contract_banded_fee_structure_band,
-            banded_fee_structure: structure,
-            min_declarations: 1,
-            max_declarations: 100
-          )
-        end
+        band = FactoryBot.build(
+          :contract_banded_fee_structure_band,
+          min_declarations: 1,
+          max_declarations: 100
+        )
+        FactoryBot.build(:contract_banded_fee_structure, bands: [band])
       end
       let(:contract) { FactoryBot.create(:contract, :for_ecf, active_lead_provider:, banded_fee_structure:) }
       let!(:statement) do

--- a/spec/services/payment_calculator/banded/band_allocator_spec.rb
+++ b/spec/services/payment_calculator/banded/band_allocator_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe PaymentCalculator::Banded::BandAllocator do
     )
   end
 
-  let(:banded_fee_structure) { FactoryBot.create(:contract_banded_fee_structure) }
-  let!(:band_a) { FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, min_declarations: 1, max_declarations: 2) }
-  let!(:band_b) { FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, min_declarations: 3, max_declarations: 4) }
-  let!(:band_c) { FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, min_declarations: 5, max_declarations: 6) }
+  let!(:contract) { FactoryBot.create(:contract, banded_fee_structure:) }
+  let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, bands: [band_a, band_b, band_c]) }
+  let(:band_a) { FactoryBot.build(:contract_banded_fee_structure_band, min_declarations: 1, max_declarations: 2) }
+  let(:band_b) { FactoryBot.build(:contract_banded_fee_structure_band, min_declarations: 3, max_declarations: 4) }
+  let(:band_c) { FactoryBot.build(:contract_banded_fee_structure_band, min_declarations: 5, max_declarations: 6) }
   let(:bands) { banded_fee_structure.bands.order(:min_declarations) }
 
   let(:current_billable_ids) { [] }

--- a/spec/services/payment_calculator/banded/outputs_spec.rb
+++ b/spec/services/payment_calculator/banded/outputs_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe PaymentCalculator::Banded::Outputs do
   let(:previous_refundable_declarations) { Declaration.none }
   let(:billable_declarations) { Declaration.billable.where.not(id: previous_billable_declarations.pluck(:id)) }
   let(:refundable_declarations) { Declaration.refundable }
-  let(:banded_fee_structure) { FactoryBot.create(:contract_banded_fee_structure) }
-  let!(:band_a) { FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, min_declarations: 1, max_declarations: 2, fee_per_declaration: 100.0) }
-  let!(:band_b) { FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, min_declarations: 3, max_declarations: 4, fee_per_declaration: 100.0) }
-  let!(:band_c) { FactoryBot.create(:contract_banded_fee_structure_band, banded_fee_structure:, min_declarations: 5, max_declarations: 6, fee_per_declaration: 100.0) }
+  let!(:contract) { FactoryBot.create(:contract, :for_ecf, banded_fee_structure:) }
+  let(:banded_fee_structure) { FactoryBot.build(:contract_banded_fee_structure, bands: [band_a, band_b, band_c]) }
+  let(:band_a) { FactoryBot.build(:contract_banded_fee_structure_band, min_declarations: 1, max_declarations: 2, fee_per_declaration: 100.0) }
+  let(:band_b) { FactoryBot.build(:contract_banded_fee_structure_band, min_declarations: 3, max_declarations: 4, fee_per_declaration: 100.0) }
+  let(:band_c) { FactoryBot.build(:contract_banded_fee_structure_band, min_declarations: 5, max_declarations: 6, fee_per_declaration: 100.0) }
 
   before do
     FactoryBot.create_list(:declaration, 5, :eligible)

--- a/spec/services/payment_calculator/banded_spec.rb
+++ b/spec/services/payment_calculator/banded_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PaymentCalculator::Banded do
   end
 
   let(:banded_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_banded_fee_structure,
       :with_bands,
       monthly_service_fee: 1_000,
@@ -203,7 +203,7 @@ RSpec.describe PaymentCalculator::Banded do
 
     context "when banded_fee_structure monthly_service_fee is nil" do
       let(:banded_fee_structure) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure,
           monthly_service_fee: nil
         )

--- a/spec/services/payment_calculator/flat_rate_spec.rb
+++ b/spec/services/payment_calculator/flat_rate_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe PaymentCalculator::FlatRate do
   end
 
   let(:flat_rate_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_flat_rate_fee_structure,
       fee_per_declaration: 100.00
     )

--- a/spec/services/payment_calculator/service_fees_spec.rb
+++ b/spec/services/payment_calculator/service_fees_spec.rb
@@ -1,19 +1,19 @@
 RSpec.describe PaymentCalculator::ServiceFees do
-  subject(:service_fees) { described_class.new(banded_fee_structure: banded_fee_structure.reload) }
+  subject(:service_fees) { described_class.new(banded_fee_structure:) }
 
   describe "#monthly_amount" do
     context "with a single band" do
       let(:banded_fee_structure) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure,
           recruitment_target: 100,
-          setup_fee: 500
+          setup_fee: 500,
+          bands: [band]
         )
       end
       let!(:band) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure_band,
-          banded_fee_structure:,
           min_declarations: 1,
           max_declarations: 100,
           fee_per_declaration: 800,
@@ -33,16 +33,16 @@ RSpec.describe PaymentCalculator::ServiceFees do
 
     context "with multiple bands" do
       let(:banded_fee_structure) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure,
           recruitment_target: 150,
-          setup_fee: 500
+          setup_fee: 500,
+          bands: [band_a, band_b]
         )
       end
       let!(:band_a) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure_band,
-          banded_fee_structure:,
           min_declarations: 1,
           max_declarations: 100,
           fee_per_declaration: 800,
@@ -51,10 +51,8 @@ RSpec.describe PaymentCalculator::ServiceFees do
         )
       end
       let!(:band_b) do
-        banded_fee_structure.bands.reset
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure_band,
-          banded_fee_structure:,
           min_declarations: 101,
           max_declarations: 200,
           fee_per_declaration: 600,
@@ -74,16 +72,16 @@ RSpec.describe PaymentCalculator::ServiceFees do
 
     context "when recruitment target is less than first band capacity" do
       let(:banded_fee_structure) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure,
           recruitment_target: 50,
-          setup_fee: 500
+          setup_fee: 500,
+          bands: [band]
         )
       end
       let!(:band) do
-        FactoryBot.create(
+        FactoryBot.build(
           :contract_banded_fee_structure_band,
-          banded_fee_structure:,
           min_declarations: 1,
           max_declarations: 100,
           fee_per_declaration: 800,

--- a/spec/services/statements/declaration_selection_spec.rb
+++ b/spec/services/statements/declaration_selection_spec.rb
@@ -6,25 +6,26 @@ RSpec.describe Statements::DeclarationSelection do
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
 
   let(:band_max) { 10 }
+  let(:bands) do
+    FactoryBot.build_list(
+      :contract_banded_fee_structure_band,
+      1,
+      min_declarations: 1,
+      max_declarations: band_max,
+      fee_per_declaration: 100,
+      output_fee_ratio: 1.0,
+      service_fee_ratio: 0.0
+    )
+  end
   let(:banded_fee_structure) do
-    FactoryBot.create(
+    FactoryBot.build(
       :contract_banded_fee_structure,
       recruitment_target: 10,
       uplift_fee_per_declaration: 0,
       monthly_service_fee: 0,
-      setup_fee: 0
-    ).tap do |structure|
-      FactoryBot.create(
-        :contract_banded_fee_structure_band,
-        banded_fee_structure: structure,
-        min_declarations: 1,
-        max_declarations: band_max,
-        fee_per_declaration: 100,
-        output_fee_ratio: 1.0,
-        service_fee_ratio: 0.0
-      )
-      structure.bands.reload
-    end
+      setup_fee: 0,
+      bands:
+    )
   end
 
   let(:contract) do

--- a/spec/services/statements/declarations_csv_spec.rb
+++ b/spec/services/statements/declarations_csv_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Statements::DeclarationsCSV do
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Ambition Institute") }
   let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
   let(:banded_fee_structure) do
-    FactoryBot.create(:contract_banded_fee_structure).tap do |structure|
-      FactoryBot.create(
+    FactoryBot.build(:contract_banded_fee_structure).tap do |structure|
+      FactoryBot.build(
         :contract_banded_fee_structure_band,
         banded_fee_structure: structure,
         min_declarations: 1,

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
   end
 
   let(:banded_fee_structure) do
-    FactoryBot.create(:contract_banded_fee_structure, :with_bands)
+    FactoryBot.build(:contract_banded_fee_structure, :with_bands)
   end
 
   let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Some LP") }


### PR DESCRIPTION
Builds upon https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2975

### Context

We want fee structures to always be associated with a `Contract`, however the `Contract` must know about it's fee structures at the time of creation to satisfy the `contract_type`/fee structure validation. This means we need to persist contracts with their fee structures.

### Changes proposed in this pull request

Remove redundant `reload` from band consistency check.

Switch contract association strategy to `build` so we can save together and avoid validation issues.

Ensure bands are created consistently in factories.

Drop migration to remove old foreign keys (will re-add in follow up PR to avoid errors due to inconsistent app/DB state on deploy).

Switch validation rules back to `with_options`.