### PR TITLE
Remove unused contract foreign keys

### DIFF
--- a/db/migrate/20260529104725_remove_fee_structure_ids_from_contracts.rb
+++ b/db/migrate/20260529104725_remove_fee_structure_ids_from_contracts.rb
@@ -1,0 +1,6 @@
+class RemoveFeeStructureIdsFromContracts < ActiveRecord::Migration[8.1]
+  def change
+    remove_reference :contracts, :flat_rate_fee_structure, foreign_key: { to_table: :contract_flat_rate_fee_structures }, index: { unique: true }
+    remove_reference :contracts, :banded_fee_structure, foreign_key: { to_table: :contract_banded_fee_structures }, index: { unique: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_082643) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_104725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -195,17 +195,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_082643) do
 
   create_table "contracts", force: :cascade do |t|
     t.bigint "active_lead_provider_id", null: false
-    t.bigint "banded_fee_structure_id"
     t.enum "contract_type", null: false, enum_type: "contract_types"
     t.datetime "created_at", null: false
     t.string "ecf_contract_version", default: "1.0.0", null: false
     t.string "ecf_mentor_contract_version"
-    t.bigint "flat_rate_fee_structure_id"
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 3, scale: 2, default: "0.2", null: false
     t.index ["active_lead_provider_id"], name: "index_contracts_on_active_lead_provider_id"
-    t.index ["banded_fee_structure_id"], name: "index_contracts_on_banded_fee_structure_id", unique: true, where: "(banded_fee_structure_id IS NOT NULL)"
-    t.index ["flat_rate_fee_structure_id"], name: "index_contracts_on_flat_rate_fee_structure_id", unique: true, where: "(flat_rate_fee_structure_id IS NOT NULL)"
   end
 
   create_table "declarations", force: :cascade do |t|
@@ -951,8 +947,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_082643) do
   add_foreign_key "contract_banded_fee_structures", "contracts"
   add_foreign_key "contract_flat_rate_fee_structures", "contracts"
   add_foreign_key "contracts", "active_lead_providers"
-  add_foreign_key "contracts", "contract_banded_fee_structures", column: "banded_fee_structure_id"
-  add_foreign_key "contracts", "contract_flat_rate_fee_structures", column: "flat_rate_fee_structure_id"
   add_foreign_key "declarations", "delivery_partners", column: "delivery_partner_when_created_id"
   add_foreign_key "declarations", "statements", column: "clawback_statement_id"
   add_foreign_key "declarations", "statements", column: "payment_statement_id"


### PR DESCRIPTION
As of https://github.com/DFE-Digital/register-early-career-teachers-public/pull/2975 we have switched over the associations, so we can remove the old foreign keys.