### PR TITLE
[3397] button to authorise statement

### DIFF
--- a/app/controllers/admin/finance/authorisations_controller.rb
+++ b/app/controllers/admin/finance/authorisations_controller.rb
@@ -11,7 +11,7 @@ module Admin::Finance
     def create
       if @form.valid?
         authorise_payment!
-        flash[:alert] = "Statement authorisation processed successfully."
+        flash[:alert] = "Statement authorisation processed successfully"
         redirect_to admin_finance_statement_path(@statement)
       else
         render :new, status: :unprocessable_content

--- a/app/controllers/admin/finance/authorisations_controller.rb
+++ b/app/controllers/admin/finance/authorisations_controller.rb
@@ -11,7 +11,7 @@ module Admin::Finance
     def create
       if @form.valid?
         authorise_payment!
-        flash[:alert] = "Statement authorisation processing"
+        flash[:alert] = "Statement authorisation processed successfully."
         redirect_to admin_finance_statement_path(@statement)
       else
         render :new, status: :unprocessable_content
@@ -36,8 +36,7 @@ module Admin::Finance
     end
 
     def authorise_payment!
-      # TODO: run in a background job
-      Statements::AuthorisePayment.new(@statement.__getobj__, author: current_user).authorise!
+      Statements::AuthorisePayment.new(statement: @statement.__getobj__, author: current_user).authorise!
     end
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -74,7 +74,11 @@ class Statement < ApplicationRecord
   end
 
   def can_authorise_payment?
-    output_fee? && payable? && !marked_as_paid_at? && has_outstanding_declarations? && within_deadline?
+    output_fee? &&
+      payable? &&
+      !marked_as_paid_at? &&
+      has_outstanding_declarations? &&
+      deadline_date.before?(Date.current)
   end
 
   def referenced_by_declarations?
@@ -99,13 +103,9 @@ private
 
   def deadline_date_in_the_past
     return unless payable? || paid?
-    return if within_deadline?
+    return if deadline_date.before?(Date.current)
 
     errors.add(:deadline_date, "Deadline date must be in the past")
-  end
-
-  def within_deadline?
-    deadline_date < Date.current
   end
 
   def has_outstanding_declarations?

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -74,8 +74,7 @@ class Statement < ApplicationRecord
   end
 
   def can_authorise_payment?
-    # TODO: will also need to include: `participant_declarations.any?`
-    output_fee? && payable? && !marked_as_paid_at? && deadline_date < Date.current
+    output_fee? && payable? && !marked_as_paid_at? && has_outstanding_declarations? && within_deadline?
   end
 
   def referenced_by_declarations?
@@ -100,8 +99,16 @@ private
 
   def deadline_date_in_the_past
     return unless payable? || paid?
-    return if deadline_date < Date.current
+    return if within_deadline?
 
     errors.add(:deadline_date, "Deadline date must be in the past")
+  end
+
+  def within_deadline?
+    deadline_date < Date.current
+  end
+
+  def has_outstanding_declarations?
+    payment_declarations.payment_status_payable.exists? || clawback_declarations.clawback_status_awaiting_clawback.exists?
   end
 end

--- a/app/services/statements/authorise_payment.rb
+++ b/app/services/statements/authorise_payment.rb
@@ -4,30 +4,67 @@ module Statements
 
     attr_reader :statement, :author
 
-    def initialize(statement, author:)
+    def initialize(statement:, author:)
       @statement = statement
       @author = author
     end
 
     def authorise!
+      raise NotAuthorisable unless statement.can_authorise_payment?
+
       ActiveRecord::Base.transaction do
-        raise NotAuthorisable unless statement.can_authorise_payment?
-
-        if statement.marked_as_paid_at.blank?
-          paid_at = Time.zone.now
-
-          statement.update!(marked_as_paid_at: paid_at)
-          statement.mark_as_paid!
-
-          Events::Record.record_statement_authorised_for_payment_event!(
-            author:,
-            statement:,
-            happened_at: paid_at
-          )
-        end
-
-        true
+        settle_declarations!
+        refund_declarations!
+        settle_statement!
       end
+    end
+
+  private
+
+    def settle_statement!
+      statement.mark_as_paid!
+      statement.update!(marked_as_paid_at: Time.zone.now)
+      record_statement_authorised_for_payment_event!
+    end
+
+    def settle_declarations!
+      declarations_payable.find_each do |declaration|
+        declaration.mark_as_paid!
+        record_declaration_paid_event!(declaration)
+      end
+    end
+
+    def refund_declarations!
+      declarations_awaiting_clawback.find_each do |declaration|
+        declaration.mark_as_clawed_back!
+        record_declaration_clawed_back_event!(declaration)
+      end
+    end
+
+    def declarations_payable
+      statement.payment_declarations.payment_status_payable
+    end
+
+    def declarations_awaiting_clawback
+      statement.payment_declarations.clawback_status_awaiting_clawback
+    end
+
+    def record_declaration_paid_event!(declaration)
+      Events::Record.record_teacher_declaration_paid!(author:,
+                                                      teacher: declaration.teacher,
+                                                      training_period: declaration.training_period,
+                                                      declaration:)
+    end
+
+    def record_declaration_clawed_back_event!(declaration)
+      Events::Record.record_teacher_declaration_clawed_back!(author:,
+                                                             teacher: declaration.teacher,
+                                                             training_period: declaration.training_period,
+                                                             declaration:)
+    end
+
+    def record_statement_authorised_for_payment_event!
+      Events::Record.record_statement_authorised_for_payment_event!(author:, statement:)
     end
   end
 end

--- a/app/services/statements/authorise_payment.rb
+++ b/app/services/statements/authorise_payment.rb
@@ -46,7 +46,7 @@ module Statements
     end
 
     def declarations_awaiting_clawback
-      statement.payment_declarations.clawback_status_awaiting_clawback
+      statement.clawback_declarations.clawback_status_awaiting_clawback
     end
 
     def record_declaration_paid_event!(declaration)

--- a/app/services/statements/authorise_payment.rb
+++ b/app/services/statements/authorise_payment.rb
@@ -10,9 +10,9 @@ module Statements
     end
 
     def authorise!
-      raise NotAuthorisable unless statement.can_authorise_payment?
-
       ActiveRecord::Base.transaction do
+        raise NotAuthorisable unless statement.can_authorise_payment?
+
         settle_declarations!
         refund_declarations!
         settle_statement!

--- a/app/views/admin/finance/authorisations/new.html.erb
+++ b/app/views/admin/finance/authorisations/new.html.erb
@@ -7,37 +7,7 @@
 <span class="govuk-caption-l"><%= @statement.lead_provider_name %></span>
 <h2 class="govuk-heading-m"><%= @statement.period %></h2>
 
-<div class="finance-panel">
-  <div class="govuk-grid-row govuk-!-margin-bottom-6">
-    <div class="govuk-grid-column-one-third">
-      <strong class="govuk-body-s govuk-!-margin-bottom-0">Milestone cut off date</strong>
-      <p class="govuk-heading-m govuk-!-padding-top-0"><%= @statement.formatted_deadline_date %></p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <strong class="govuk-body-s govuk-!-margin-bottom-0">Payment date</strong>
-      <p class="govuk-heading-m govuk-!-padding-top-0"><%= @statement.formatted_payment_date %></p>
-    </div>
-  </div>
-
-  <%= govuk_table classes: %w[govuk-!-margin-bottom-2] do |table|
-    table.with_caption(text: "Total #{number_to_pounds(0)}", size: "l")
-    table.with_body do |body|
-      [
-        ["Output payment", 0],
-        ["Service fee", 0],
-        ["Uplift fees", 0],
-        ["Clawbacks", 0],
-        ["Additional adjustments", @statement.adjustments.sum(:amount)],
-        ["VAT", 0],
-      ].each do |label, amount|
-        body.with_row do |row|
-          row.with_cell(text: label)
-          row.with_cell(text: number_to_pounds(amount), numeric: true)
-        end
-      end
-    end
-  end %>
-</div>
+<%= render Admin::Statements::PaymentOverviewComponent.for(statement: @statement) %>
 
 <%= form_with(model: @form, url: admin_finance_statement_authorisations_path(@statement), method: :post, class: "govuk-!-margin-top-6") do |f| %>
   <%= content_for(:error_summary) { f.govuk_error_summary } %>

--- a/db/seeds/declarations.rb
+++ b/db/seeds/declarations.rb
@@ -75,20 +75,6 @@ def milestones
   %w[started retained-1 retained-2 retained-3 retained-4 extended-1 extended-2 extended-3 completed]
 end
 
-ECF_BOUNDARIES = [
-  { min: 1, max: 5 },
-  { min: 6, max: 10 },
-  { min: 11, max: 20 },
-  { min: 21, max: 40 },
-].freeze
-
-ITTECF_BOUNDARIES = [
-  { min: 1, max: 5 },
-  { min: 6, max: 10 },
-  { min: 11, max: 15 },
-  { min: 16, max: 20 },
-].freeze
-
 print_seed_info("Creating Statements")
 
 ucl = LeadProvider.find_by!(name: "UCL Institute of Education")
@@ -113,22 +99,16 @@ school_partnership_2025 = FactoryBot.create(:school_partnership,
   describe_school_partnership(partnership)
 end
 
-ecf_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ECF_BOUNDARIES)
 ucl_contract_2024 = FactoryBot.create(:contract,
                                       :for_ecf,
                                       active_lead_provider: school_partnership_2024.active_lead_provider,
-                                      banded_fee_structure: ecf_banded_fee_structure,
                                       flat_rate_fee_structure: nil).tap do |contract|
   describe_contract(contract)
 end
 
-ittecf_banded_fee_structure = FactoryBot.build(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ITTECF_BOUNDARIES)
-ittecf_flat_rate_fee_structure = FactoryBot.build(:contract_flat_rate_fee_structure)
 ucl_contract_2025 = FactoryBot.create(:contract,
                                       :for_ittecf_ectp,
-                                      active_lead_provider: school_partnership_2025.active_lead_provider,
-                                      banded_fee_structure: ittecf_banded_fee_structure,
-                                      flat_rate_fee_structure: ittecf_flat_rate_fee_structure).tap do |contract|
+                                      active_lead_provider: school_partnership_2025.active_lead_provider).tap do |contract|
   describe_contract(contract)
 end
 

--- a/db/seeds/declarations.rb
+++ b/db/seeds/declarations.rb
@@ -134,6 +134,7 @@ end
 
 august_statement_2024 = FactoryBot.create(:statement,
                                           :adjustable,
+                                          :payable,
                                           month: 8,
                                           year: 2024,
                                           deadline_date: Date.new(2024, 7, 31),
@@ -145,6 +146,7 @@ end
 
 october_statement_2024 = FactoryBot.create(:statement,
                                            :adjustable,
+                                           :payable,
                                            month: 10,
                                            year: 2024,
                                            deadline_date: Date.new(2024, 9, 30),
@@ -156,6 +158,7 @@ end
 
 august_statement_2025 = FactoryBot.create(:statement,
                                           :adjustable,
+                                          :payable,
                                           month: 8,
                                           year: 2025,
                                           deadline_date: Date.new(2025, 7, 31),
@@ -167,6 +170,7 @@ end
 
 october_statement_2025 = FactoryBot.create(:statement,
                                            :adjustable,
+                                           :payable,
                                            month: 10,
                                            year: 2025,
                                            deadline_date: Date.new(2025, 9, 30),
@@ -193,7 +197,8 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
     # Create billable declarations
     n = Random.rand(25)
     pupil_premium_uplift = assign_uplift(declaration_type, uplift_count)
-    FactoryBot.create_list(:declaration, n, :with_ect, :paid,
+    FactoryBot.create_list(:declaration, n, :with_ect,
+                           payment_status: "payable",
                            declaration_type:,
                            school_partnership:,
                            pupil_premium_uplift:,
@@ -214,7 +219,9 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
 
     # Create refunded declarations
     n = Random.rand(25)
-    FactoryBot.create_list(:declaration, n, :with_ect, :awaiting_clawback,
+    FactoryBot.create_list(:declaration, n, :with_ect,
+                           payment_status: "payable",
+                           clawback_status: "awaiting_clawback",
                            declaration_type:,
                            school_partnership:,
                            payment_statement: august_statement,
@@ -226,7 +233,8 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
     next unless %w[started completed].include?(declaration_type)
 
     # Create billable declarations for mentors
-    FactoryBot.create(:declaration, :with_mentor, :paid,
+    FactoryBot.create(:declaration, :with_mentor,
+                      payment_status: "payable",
                       declaration_type:,
                       school_partnership:,
                       payment_statement: october_statement)
@@ -234,7 +242,9 @@ data = { 2024 => { school_partnership: school_partnership_2024, october_statemen
     add_to_results(results, year, declaration_type, :mentors, 1)
 
     # Create refunded declarations for mentors
-    FactoryBot.create(:declaration, :with_mentor, :awaiting_clawback,
+    FactoryBot.create(:declaration, :with_mentor,
+                      payment_status: "payable",
+                      clawback_status: "awaiting_clawback",
                       declaration_type:,
                       school_partnership:,
                       payment_statement: august_statement,

--- a/spec/features/admin/finance/statements/payment_authorisation_spec.rb
+++ b/spec/features/admin/finance/statements/payment_authorisation_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe "Payment authorisation for statement" do
 
   scenario "Statement can be authorised for payment" do
     given_a_payable_finance_statement_exists
+    and_i_have_a_payable_declaration_for_the_statement
 
     when_i_visit_the_finance_statement_page
     and_i_click_authorise_for_payment_button
@@ -13,10 +14,16 @@ RSpec.describe "Payment authorisation for statement" do
     then_i_see_payment_authorised_notice
     and_i_see_payment_authorised_text
     and_statement_is_payment_authorised
+    and_the_declarations_are_marked_as_paid
   end
 
   def given_a_payable_finance_statement_exists
     @statement = FactoryBot.create(:statement, :payable, :output_fee, marked_as_paid_at: nil, deadline_date: 3.days.ago.to_date)
+  end
+
+  def and_i_have_a_payable_declaration_for_the_statement
+    school_partnership = FactoryBot.create(:school_partnership, :for_year, year: @statement.contract_period.year, active_lead_provider: @statement.active_lead_provider)
+    @declaration = FactoryBot.create(:declaration, :with_ect, declaration_type: "started", payment_status: "payable", school_partnership:, payment_statement: @statement)
   end
 
   def when_i_visit_the_finance_statement_page
@@ -37,7 +44,7 @@ RSpec.describe "Payment authorisation for statement" do
   end
 
   def then_i_see_payment_authorised_notice
-    expect(page.get_by_text("Statement authorisation processing")).to be_visible
+    expect(page.get_by_text("Statement authorisation processed")).to be_visible
   end
 
   def and_i_see_payment_authorised_text
@@ -48,5 +55,9 @@ RSpec.describe "Payment authorisation for statement" do
   def and_statement_is_payment_authorised
     expect(@statement.marked_as_paid_at).to be_present
     expect(@statement.status).to eq("paid")
+  end
+
+  def and_the_declarations_are_marked_as_paid
+    expect(@declaration.reload).to be_paid
   end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -251,48 +251,73 @@ describe Statement do
   end
 
   describe ".can_authorise_payment?" do
-    context "open statement" do
-      subject { FactoryBot.build(:statement, :open) }
+    subject { statement.can_authorise_payment? }
 
-      it { expect(subject.can_authorise_payment?).to be(false) }
+    let(:statement) do
+      FactoryBot.create(:statement,
+                        fee_type: "output",
+                        status: "payable",
+                        marked_as_paid_at: nil,
+                        deadline_date: Date.yesterday)
     end
 
-    context "paid statement" do
-      subject { FactoryBot.build(:statement, :paid) }
+    let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: statement.contract_period.year, active_lead_provider: statement.active_lead_provider) }
 
-      it { expect(subject.can_authorise_payment?).to be(false) }
+    let!(:declaration) { FactoryBot.create(:declaration, :with_ect, declaration_type: "started", payment_status: "payable", school_partnership:, payment_statement: statement) }
+    let!(:clawback_declaration) { FactoryBot.create(:declaration, :with_ect, declaration_type: "started", clawback_status: "awaiting_clawback", school_partnership:, clawback_statement: statement) }
+
+    it { is_expected.to be_truthy }
+
+    context "when statement is not an output fee" do
+      before { statement.fee_type = "service" }
+
+      it { is_expected.to be_falsey }
     end
 
-    context "payable statement" do
-      context "service_fee statement" do
-        subject { FactoryBot.build(:statement, :payable, :service_fee) }
+    context "when statement is not payable" do
+      before { statement.status = "open" }
 
-        it { expect(subject.can_authorise_payment?).to be(false) }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when statement is marked as paid" do
+      before { statement.marked_as_paid_at = Time.current }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when statement is past the deadline" do
+      before { statement.deadline_date = Date.tomorrow }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when there are clawback declarations awaiting clawback but no payment declarations" do
+      let!(:declaration) { nil }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there are payment declarations payable but no clawback declarations" do
+      let!(:clawback_declaration) { nil }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when there are no payment or clawback declarations" do
+      let!(:declaration) { nil }
+      let!(:clawback_declaration) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when statement has no declarations requiring settlement" do
+      before do
+        declaration.update!(payment_status: "paid")
+        clawback_declaration.update!(clawback_status: "clawed_back")
       end
 
-      context "output_fee statement" do
-        context "with deadline_date in future" do
-          subject { FactoryBot.build(:statement, :payable, :output_fee, deadline_date: 3.days.from_now.to_date) }
-
-          it { expect(subject.can_authorise_payment?).to be(false) }
-        end
-
-        context "with deadline_date in past" do
-          let(:deadline_date) { 3.days.ago.to_date }
-
-          context "marked as payable" do
-            subject { FactoryBot.build(:statement, :payable, :output_fee, deadline_date:, marked_as_paid_at: Time.zone.now) }
-
-            it { expect(subject.can_authorise_payment?).to be(false) }
-          end
-
-          context "is not marked as payable" do
-            subject { FactoryBot.build(:statement, :payable, :output_fee, deadline_date:, marked_as_paid_at: nil) }
-
-            it { expect(subject.can_authorise_payment?).to be(true) }
-          end
-        end
-      end
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/requests/admin/finance/statements/authorisations_spec.rb
+++ b/spec/requests/admin/finance/statements/authorisations_spec.rb
@@ -2,10 +2,6 @@ RSpec.describe "Admin finance statement authorisations", type: :request do
   let!(:statement) { FactoryBot.create(:statement) }
   let(:service) { double(authorise!: true) }
 
-  before do
-    allow(Statements::AuthorisePayment).to receive(:new).and_return(service)
-  end
-
   describe "GET /admin/finance/statements/:statement_id/authorisations/new" do
     subject do
       get "/admin/finance/statements/#{statement.id}/authorisations/new"
@@ -24,10 +20,6 @@ RSpec.describe "Admin finance statement authorisations", type: :request do
       it "renders the confirmation form" do
         expect(subject.body).to include("Check and authorise statement for payment")
       end
-
-      it "does not authorise the payment" do
-        expect(service).not_to have_received(:authorise!)
-      end
     end
   end
 
@@ -39,6 +31,10 @@ RSpec.describe "Admin finance statement authorisations", type: :request do
     end
 
     let(:confirmed) { "0" }
+
+    before do
+      allow(Statements::AuthorisePayment).to receive(:new).and_return(service)
+    end
 
     include_examples "requires finance access"
 
@@ -54,7 +50,7 @@ RSpec.describe "Admin finance statement authorisations", type: :request do
           expect(subject.body).to include("You must have completed all assurance checks")
         end
 
-        it "does not authorise the payment" do
+        it "does not call the service" do
           expect(service).not_to have_received(:authorise!)
         end
       end
@@ -62,14 +58,16 @@ RSpec.describe "Admin finance statement authorisations", type: :request do
       context "with confirmation" do
         let(:confirmed) { "1" }
 
-        it { is_expected.to redirect_to(admin_finance_statement_path(statement)) }
+        it "redirects to the statement page" do
+          expect(subject).to redirect_to(admin_finance_statement_path(statement))
+        end
 
-        it "authorises the payment" do
+        it "calls the service to authorise the payment" do
           expect(service).to have_received(:authorise!)
         end
 
         it "flashes a success message" do
-          expect(flash[:alert]).to eq "Statement authorisation processing"
+          expect(flash[:alert]).to eq "Statement authorisation processed successfully."
         end
       end
     end

--- a/spec/requests/admin/finance/statements/authorisations_spec.rb
+++ b/spec/requests/admin/finance/statements/authorisations_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Admin finance statement authorisations", type: :request do
         end
 
         it "flashes a success message" do
-          expect(flash[:alert]).to eq "Statement authorisation processed successfully."
+          expect(flash[:alert]).to eq "Statement authorisation processed successfully"
         end
       end
     end

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Statements::AuthorisePayment do
                                  declaration_type: "started",
                                  clawback_status: "awaiting_clawback",
                                  school_partnership:,
-                                 payment_statement: statement)
+                                 clawback_statement: statement)
         end
 
         it "marks declarations awaiting clawback as clawed back and records events" do

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Statements::AuthorisePayment do
     end
 
     context "when the statement is payable" do
-      before do
+      let!(:declarations) do
         FactoryBot.create_list(:declaration, 3, :with_ect,
                                declaration_type: "started",
                                payment_status: "payable",
@@ -32,15 +32,16 @@ RSpec.describe Statements::AuthorisePayment do
 
         subject.authorise!
 
-        expect(statement.payment_declarations).to all(be_paid)
+        expect(declarations.each(&:reload)).to all(be_paid)
       end
 
       it "marks the statement as paid" do
-        subject.authorise!
-        statement.reload
+        freeze_time do
+          subject.authorise!
 
-        expect(statement).to be_paid
-        expect(statement.marked_as_paid_at).to be_within(1.minute).of(Time.current)
+          expect(statement.reload).to be_paid
+          expect(statement.marked_as_paid_at).to eq(Time.zone.now)
+        end
       end
 
       it "records a statement authorised for payment event" do
@@ -52,8 +53,56 @@ RSpec.describe Statements::AuthorisePayment do
         subject.authorise!
       end
 
-      context "when there are declarations awaiting clawback" do
+      context "when the statement errors when transitioning to paid" do
         before do
+          allow(statement).to receive(:mark_as_paid!).and_raise(ActiveRecord::RecordInvalid)
+        end
+
+        it "raises, does not create events and does not update the statement or declarations" do
+          expect {
+            subject.authorise!
+          }.to raise_error(ActiveRecord::RecordInvalid)
+
+          expect(Event.count).to eq(0)
+
+          expect(statement.reload.marked_as_paid_at).to be_nil
+          expect(statement).not_to be_paid
+          expect(declarations.each(&:reload)).to all(be_payable)
+        end
+      end
+
+      context "when a payment declaration cannot transition to paid" do
+        before do
+          allow(subject).to receive(:declarations_payable)
+            .and_return(declarations)
+
+          allow(declarations.first).to receive(:mark_as_paid!).and_call_original
+          allow(declarations.second).to receive(:mark_as_paid!).and_raise(StandardError)
+
+          call_count = 0
+
+          allow_any_instance_of(Declaration)
+            .to receive(:mark_as_paid!) do
+              call_count += 1
+              raise StandardError if call_count == 2
+            end
+        end
+
+        it "raises, does not record events, and does not persist changes" do
+          expect {
+            subject.authorise!
+          }.to raise_error(StandardError)
+
+          expect(Event.count).to eq(0)
+
+          expect(statement.reload.marked_as_paid_at).to be_nil
+          expect(statement).not_to be_paid
+          expect(declarations.each(&:reload)).to all(be_payable)
+        end
+      end
+
+      context "when there are declarations awaiting clawback" do
+        let!(:declarations_awaiting_clawback) do
           FactoryBot.create_list(:declaration, 2, :with_ect,
                                  declaration_type: "started",
                                  clawback_status: "awaiting_clawback",
@@ -66,7 +115,31 @@ RSpec.describe Statements::AuthorisePayment do
 
           subject.authorise!
 
-          expect(statement.payment_declarations.clawback_status_awaiting_clawback).to all(be_clawed_back)
+          expect(declarations.each(&:reload)).to all(be_paid)
+          expect(declarations_awaiting_clawback.each(&:reload)).to all(be_clawed_back)
+        end
+
+        context "when a clawback declaration cannot transition to paid" do
+          before do
+            allow(subject).to receive(:declarations_awaiting_clawback)
+              .and_return(declarations_awaiting_clawback)
+
+            allow(declarations_awaiting_clawback.first).to receive(:mark_as_paid!).and_call_original
+            allow(declarations_awaiting_clawback.second).to receive(:mark_as_paid!).and_raise(StandardError)
+          end
+
+          it "raises, does not record an event, and does not persist changes" do
+            expect {
+              subject.authorise!
+            }.to raise_error(StandardError)
+
+            expect(Event.count).to eq(0)
+
+            expect(statement.reload.marked_as_paid_at).to be_nil
+            expect(statement).not_to be_paid
+            expect(declarations.each(&:reload)).to all(be_payable)
+            expect(declarations_awaiting_clawback.each(&:reload)).to all(be_awaiting_clawback)
+          end
         end
       end
     end

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -53,54 +53,6 @@ RSpec.describe Statements::AuthorisePayment do
         subject.authorise!
       end
 
-      context "when the statement errors when transitioning to paid" do
-        before do
-          allow(statement).to receive(:mark_as_paid!).and_raise(ActiveRecord::RecordInvalid)
-        end
-
-        it "raises, does not create events and does not update the statement or declarations" do
-          expect {
-            subject.authorise!
-          }.to raise_error(ActiveRecord::RecordInvalid)
-
-          expect(Event.count).to eq(0)
-
-          expect(statement.reload.marked_as_paid_at).to be_nil
-          expect(statement).not_to be_paid
-          expect(declarations.each(&:reload)).to all(be_payable)
-        end
-      end
-
-      context "when a payment declaration cannot transition to paid" do
-        before do
-          allow(subject).to receive(:declarations_payable)
-            .and_return(declarations)
-
-          allow(declarations.first).to receive(:mark_as_paid!).and_call_original
-          allow(declarations.second).to receive(:mark_as_paid!).and_raise(StandardError)
-
-          call_count = 0
-
-          allow_any_instance_of(Declaration)
-            .to receive(:mark_as_paid!) do
-              call_count += 1
-              raise StandardError if call_count == 2
-            end
-        end
-
-        it "raises, does not record events, and does not persist changes" do
-          expect {
-            subject.authorise!
-          }.to raise_error(StandardError)
-
-          expect(Event.count).to eq(0)
-
-          expect(statement.reload.marked_as_paid_at).to be_nil
-          expect(statement).not_to be_paid
-          expect(declarations.each(&:reload)).to all(be_payable)
-        end
-      end
-
       context "when there are declarations awaiting clawback" do
         let!(:declarations_awaiting_clawback) do
           FactoryBot.create_list(:declaration, 2, :with_ect,
@@ -117,29 +69,6 @@ RSpec.describe Statements::AuthorisePayment do
 
           expect(declarations.each(&:reload)).to all(be_paid)
           expect(declarations_awaiting_clawback.each(&:reload)).to all(be_clawed_back)
-        end
-
-        context "when a clawback declaration cannot transition to paid" do
-          before do
-            allow(subject).to receive(:declarations_awaiting_clawback)
-              .and_return(declarations_awaiting_clawback)
-
-            allow(declarations_awaiting_clawback.first).to receive(:mark_as_paid!).and_call_original
-            allow(declarations_awaiting_clawback.second).to receive(:mark_as_paid!).and_raise(StandardError)
-          end
-
-          it "raises, does not record an event, and does not persist changes" do
-            expect {
-              subject.authorise!
-            }.to raise_error(StandardError)
-
-            expect(Event.count).to eq(0)
-
-            expect(statement.reload.marked_as_paid_at).to be_nil
-            expect(statement).not_to be_paid
-            expect(declarations.each(&:reload)).to all(be_payable)
-            expect(declarations_awaiting_clawback.each(&:reload)).to all(be_awaiting_clawback)
-          end
         end
       end
     end

--- a/spec/services/statements/authorise_payment_spec.rb
+++ b/spec/services/statements/authorise_payment_spec.rb
@@ -1,89 +1,73 @@
 RSpec.describe Statements::AuthorisePayment do
-  subject { described_class.new(statement, author:) }
+  subject { described_class.new(statement:, author:) }
 
-  let(:statement) { FactoryBot.create(:statement, :payable, marked_as_paid_at: nil) }
   let(:user)      { FactoryBot.create(:user, email: "test@example.com", name: "Test User") }
   let(:author)    { Sessions::Users::DfEPersona.new(email: user.email) }
 
+  let!(:statement) { FactoryBot.create(:statement, :payable, deadline_date: Date.yesterday) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: statement.contract_period.year, active_lead_provider: statement.active_lead_provider) }
+
   describe "#authorise!" do
-    context "can authorise payment" do
-      before { allow(statement).to receive(:can_authorise_payment?).and_return(true) }
+    context "when the statement is not payable" do
+      let(:statement) { FactoryBot.create(:statement) }
 
-      it "sets marked_as_paid_at and status to paid and records the event with the same timestamp" do
-        freeze_time do
-          expect(Events::Record).to receive(:record_statement_authorised_for_payment_event!).with(
-            author:,
-            statement:,
-            happened_at: kind_of(ActiveSupport::TimeWithZone)
-          )
-
-          expect(subject.authorise!).to be(true)
-        end
-
-        statement.reload
-        expect(statement.marked_as_paid_at).to be_present
-        expect(statement).to be_paid
-      end
-
-      it "uses marked_as_paid_at as happened_at" do
-        freeze_time do
-          allow(Events::Record).to receive(:record_statement_authorised_for_payment_event!)
-
-          expect(subject.authorise!).to be(true)
-
-          expect(Events::Record).to have_received(:record_statement_authorised_for_payment_event!).with(
-            hash_including(happened_at: statement.reload.marked_as_paid_at)
-          )
-        end
-      end
-    end
-
-    context "cannot authorise payment" do
-      before { allow(statement).to receive(:can_authorise_payment?).and_return(false) }
-
-      it "raises NotAuthorisable and does not record an event" do
-        expect(Events::Record).not_to receive(:record_statement_authorised_for_payment_event!)
-
+      it "raises NotAuthorisable" do
         expect {
           subject.authorise!
         }.to raise_error(Statements::AuthorisePayment::NotAuthorisable)
       end
     end
 
-    context "when mark_as_paid! raises" do
+    context "when the statement is payable" do
       before do
-        allow(statement).to receive(:can_authorise_payment?).and_return(true)
-        allow(statement).to receive(:mark_as_paid!).and_raise(ActiveRecord::RecordInvalid)
+        FactoryBot.create_list(:declaration, 3, :with_ect,
+                               declaration_type: "started",
+                               payment_status: "payable",
+                               school_partnership:,
+                               payment_statement: statement)
       end
 
-      it "raises, does not record an event, and does not persist changes" do
-        expect(Events::Record).not_to receive(:record_statement_authorised_for_payment_event!)
+      it "marks all payable declarations as paid and records events" do
+        expect(Events::Record).to receive(:record_teacher_declaration_paid!).exactly(3).times
 
-        expect {
-          subject.authorise!
-        }.to raise_error(ActiveRecord::RecordInvalid)
+        subject.authorise!
 
+        expect(statement.payment_declarations).to all(be_paid)
+      end
+
+      it "marks the statement as paid" do
+        subject.authorise!
         statement.reload
-        expect(statement.marked_as_paid_at).to be_nil
-        expect(statement).not_to be_paid
-      end
-    end
 
-    context "when recording the event raises" do
-      before do
-        allow(statement).to receive(:can_authorise_payment?).and_return(true)
-        allow(Events::Record).to receive(:record_statement_authorised_for_payment_event!)
-          .and_raise(StandardError)
+        expect(statement).to be_paid
+        expect(statement.marked_as_paid_at).to be_within(1.minute).of(Time.current)
       end
 
-      it "raises and rolls back the payment change" do
-        expect {
+      it "records a statement authorised for payment event" do
+        expect(Events::Record).to receive(:record_statement_authorised_for_payment_event!).with(
+          statement:,
+          author:
+        )
+
+        subject.authorise!
+      end
+
+      context "when there are declarations awaiting clawback" do
+        before do
+          FactoryBot.create_list(:declaration, 2, :with_ect,
+                                 declaration_type: "started",
+                                 clawback_status: "awaiting_clawback",
+                                 school_partnership:,
+                                 payment_statement: statement)
+        end
+
+        it "marks declarations awaiting clawback as clawed back and records events" do
+          expect(Events::Record).to receive(:record_teacher_declaration_clawed_back!).twice
+
           subject.authorise!
-        }.to raise_error(StandardError)
 
-        statement.reload
-        expect(statement.marked_as_paid_at).to be_nil
-        expect(statement).not_to be_paid
+          expect(statement.payment_declarations.clawback_status_awaiting_clawback).to all(be_clawed_back)
+        end
       end
     end
   end

--- a/spec/views/admin/finance/authorisations/new.html.erb_spec.rb
+++ b/spec/views/admin/finance/authorisations/new.html.erb_spec.rb
@@ -1,8 +1,37 @@
 RSpec.describe "admin/finance/authorisations/new.html.erb" do
   subject { rendered }
 
-  let(:statement) { Admin::StatementPresenter.new(FactoryBot.create(:statement)) }
+  let(:contract_period) { FactoryBot.create(:contract_period, year:) }
+  let(:contract) do
+    FactoryBot.create(
+      :contract,
+      contract_trait,
+      active_lead_provider:
+    )
+  end
+  let(:contract_trait) { :for_ecf }
+
+  let(:payment_statement) { FactoryBot.create(:statement, :payable, deadline_date: Date.yesterday, contract:) }
+  let(:year) { 2024 }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, contract_period:) }
+  let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year:, active_lead_provider:) }
+  let(:statement) { Admin::StatementPresenter.new(payment_statement) }
   let(:form) { Admin::Finance::AuthorisePaymentForm.new }
+  let!(:declaration) do
+    FactoryBot.create(:declaration, :with_ect,
+                      declaration_type: "started",
+                      payment_status: "payable",
+                      school_partnership:,
+                      payment_statement:)
+  end
+
+  let!(:clawed_back_declaration) do
+    FactoryBot.create(:declaration, :with_ect,
+                      declaration_type: "started",
+                      clawback_status: "awaiting_clawback",
+                      school_partnership:,
+                      payment_statement:)
+  end
 
   before do
     assign(:statement, statement)
@@ -19,33 +48,45 @@ RSpec.describe "admin/finance/authorisations/new.html.erb" do
     expect(view.content_for(:backlink_or_breadcrumb)).to have_link("Back", href: admin_finance_statement_path(statement))
   end
 
-  it { is_expected.to have_text(statement.lead_provider_name) }
-  it { is_expected.to have_text(statement.period) }
-  it { is_expected.to have_text(statement.formatted_deadline_date) }
-  it { is_expected.to have_text(statement.formatted_payment_date) }
-  it { is_expected.to have_field("I confirm I've completed all assurance checks and I authorise payment", type: "checkbox") }
-  it { is_expected.to have_button("Authorise for payment") }
+  it "has summary information" do
+    expect(subject).to have_text(statement.lead_provider_name)
+    expect(subject).to have_text(statement.period)
+    expect(subject).to have_text(statement.formatted_deadline_date)
+    expect(subject).to have_text(statement.formatted_payment_date)
+    expect(subject).to have_text("Total")
+  end
 
-  it "shows the total amount for the statement" do
-    pending("calculators")
-    fail
+  it "has a button to authorise the payment, with a tickbox confirmation" do
+    expect(subject).to have_field("I confirm I've completed all assurance checks and I authorise payment", type: "checkbox")
+    expect(subject).to have_button("Authorise for payment")
   end
 
   describe "summary table" do
-    it "needs real figures" do
-      pending("calculators")
-      fail
+    context "when the statement is for an ECF contract" do
+      let(:contract_trait) { :for_ecf }
+
+      it "displays the ECF payment overview component" do
+        expect(subject).to have_css("table tr:nth-child(1) td:nth-child(1)", text: "Output payment")
+        expect(subject).to have_css("table tr:nth-child(2) td:nth-child(1)", text: "Service fee")
+        expect(subject).to have_css("table tr:nth-child(3) td:nth-child(1)", text: "Uplift fees")
+        expect(subject).to have_css("table tr:nth-child(4) td:nth-child(1)", text: "Clawbacks")
+        expect(subject).to have_css("table tr:nth-child(5) td:nth-child(1)", text: "Additional adjustments")
+        expect(subject).to have_css("table tr:nth-child(6) td:nth-child(1)", text: "VAT")
+      end
     end
 
-    it do
-      expect(subject).to have_table with_rows: [
-        ["Output payment", 0],
-        ["Service fee", 0],
-        ["Uplift fees", 0],
-        ["Clawbacks", 0],
-        ["Additional adjustments", 0],
-        ["VAT", 0],
-      ]
+    context "when the statement is for an ITTECF ECTP contract" do
+      let(:contract_trait) { :for_ittecf_ectp }
+
+      it "displays the ITTECF ECTP payment overview component" do
+        expect(subject).to have_css("table tr:nth-child(1) td:nth-child(1)", text: "ECTs output payment")
+        expect(subject).to have_css("table tr:nth-child(2) td:nth-child(1)", text: "Mentors output payment")
+        expect(subject).to have_css("table tr:nth-child(3) td:nth-child(1)", text: "Service fee")
+        expect(subject).to have_css("table tr:nth-child(4) td:nth-child(1)", text: "ECTs clawbacks")
+        expect(subject).to have_css("table tr:nth-child(5) td:nth-child(1)", text: "Mentors clawbacks")
+        expect(subject).to have_css("table tr:nth-child(6) td:nth-child(1)", text: "Additional adjustments")
+        expect(subject).to have_css("table tr:nth-child(7) td:nth-child(1)", text: "VAT")
+      end
     end
   end
 

--- a/spec/views/admin/finance/authorisations/new.html.erb_spec.rb
+++ b/spec/views/admin/finance/authorisations/new.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "admin/finance/authorisations/new.html.erb" do
                       declaration_type: "started",
                       clawback_status: "awaiting_clawback",
                       school_partnership:,
-                      payment_statement:)
+                      clawback_statement: payment_statement)
   end
 
   before do

--- a/spec/views/admin/finance/statements/show.html.erb_spec.rb
+++ b/spec/views/admin/finance/statements/show.html.erb_spec.rb
@@ -87,13 +87,13 @@ RSpec.describe "admin/finance/statements/show.html.erb" do
   def create_clawback(training_period, payment_statement:, clawback_statement:)
     FactoryBot.create(
       :declaration,
-      :paid,
+      :payable,
       payment_statement:,
       training_period:
     )
     FactoryBot.create(
       :declaration,
-      :clawed_back,
+      :awaiting_clawback,
       clawback_statement:,
       training_period:
     )


### PR DESCRIPTION
### Context

Now we are live finance users need to be able to authorise statements.  The layout etc is largely unchanged.

### Changes proposed in this pull request

Update the background service to transition associated declarations to paid/clawed_back.  Refactor so that the state machine will not raise unexpected errors.
The ticket notes that it is not worth using a background job at this stage and so that is the route I've followed.

### Guidance to review
This can be tested on Aug/Oct 24 and 25 statements.
