### PR TITLE
Comment out production from ptr restore workflow

### DIFF
--- a/.github/workflows/database-restore-ptr.yml
+++ b/.github/workflows/database-restore-ptr.yml
@@ -13,7 +13,7 @@ on:
           - migration
           - paritycheck
           - sandbox
-          - production
+          # - production
       confirm-production:
         description: Must be set to true if restoring production
         required: true


### PR DESCRIPTION
This is a really drastic thing to do, this puts another little hurdle in the way to prevent it from being run accidentally.
