### PR TITLE
Simplify start date validators

### DIFF
--- a/app/validators/ect_start_date_validator.rb
+++ b/app/validators/ect_start_date_validator.rb
@@ -1,9 +1,6 @@
 class ECTStartDateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    start_date = Schools::Validation::ECTStartDate.new(
-      date_as_hash: value,
-      current_date: options[:current_date]
-    )
+    start_date = Schools::Validation::ECTStartDate.new(date_as_hash: value)
 
     unless start_date.valid?
       record.errors.add(attribute, start_date.error_message)

--- a/app/validators/mentor_start_date_validator.rb
+++ b/app/validators/mentor_start_date_validator.rb
@@ -1,9 +1,6 @@
 class MentorStartDateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    start_date = Schools::Validation::MentorStartDate.new(
-      date_as_hash: value,
-      current_date: options[:current_date]
-    )
+    start_date = Schools::Validation::MentorStartDate.new(date_as_hash: value)
 
     unless start_date.valid?
       record.errors.add(attribute, start_date.error_message)

--- a/lib/schools/validation/ect_start_date.rb
+++ b/lib/schools/validation/ect_start_date.rb
@@ -4,9 +4,8 @@ module Schools
       DATE_MISSING_MESSAGE = "Enter the date the ECT started or will start teaching at your school"
       INVALID_FORMAT_MESSAGE = "Enter the start date using the correct format, for example, 17 09 1999"
 
-      def initialize(date_as_hash:, current_date: nil)
+      def initialize(date_as_hash:)
         super(date_as_hash)
-        @current_date = current_date || Time.zone.today
       end
 
       # String containing the full month name and year with century. Ex: 'January 2025'
@@ -16,8 +15,6 @@ module Schools
 
     private
 
-      attr_reader :current_date
-
       def date_missing?
         super || date_as_hash.values_at(1, 2, 3).all?(&:nil?)
       end
@@ -26,7 +23,7 @@ module Schools
         return unless earliest_permitted_date
         return unless value_as_date < earliest_permitted_date
 
-        "Start date cannot be this far in the past. Enter a date later than #{earliest_permitted_date.to_formatted_s(:govuk)}."
+        "Start date cannot be this far in the past. Enter a date later than #{earliest_permitted_date.to_fs(:govuk)}."
       end
 
       def earliest_permitted_date

--- a/lib/schools/validation/mentor_start_date.rb
+++ b/lib/schools/validation/mentor_start_date.rb
@@ -4,9 +4,8 @@ module Schools
       DATE_MISSING_MESSAGE = "Enter the date they started or will start ECT mentoring at your school"
       INVALID_FORMAT_MESSAGE = "Enter the date in the correct format, for example 12 03 1998"
 
-      def initialize(date_as_hash:, current_date: nil)
+      def initialize(date_as_hash:)
         super(date_as_hash)
-        @current_date = current_date || Time.zone.today
       end
 
       # String containing the full month name and year with century. Ex: 'January 2025'
@@ -15,8 +14,6 @@ module Schools
       end
 
     private
-
-      attr_reader :current_date
 
       def date_missing?
         super || date_as_hash.values_at(1, 2, 3).all?(&:nil?)

--- a/spec/validators/ect_start_date_validator_spec.rb
+++ b/spec/validators/ect_start_date_validator_spec.rb
@@ -1,102 +1,67 @@
 RSpec.describe ECTStartDateValidator, type: :model do
-  context "when date is in an invalid format" do
-    subject { test_class.new(start_date:) }
+  subject { test_class.new(start_date: start_date_hash) }
 
-    let(:start_date) { { 1 => "invalid year", 2 => "invalid month", 3 => "invalid day" } }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
+  let(:test_class) do
+    Class.new do
+      include ActiveModel::Model
 
-        validates :start_date, ect_start_date: { current_date: Time.zone.today }
-      end
-    end
+      attr_accessor :start_date
 
-    it "adds an error" do
-      subject.valid?
-      expect(subject.errors[:start_date]).to include("Enter the start date using the correct format, for example, 17 09 1999")
+      validates :start_date, ect_start_date: true
     end
   end
 
-  context "when the start date has invalid values" do
-    subject { test_class.new(start_date:) }
-
+  context "when date is in an invalid format" do
     let(:error_message) { "Enter the start date using the correct format, for example, 17 09 1999" }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
+    let(:start_date_hash) { { 1 => "invalid year", 2 => "invalid month", 3 => "invalid day" } }
 
-        validates :start_date, ect_start_date: true
-      end
-    end
+    it { is_expected.to have_error(:start_date, error_message) }
+  end
+
+  context "when the start date has invalid values" do
+    let(:error_message) { "Enter the start date using the correct format, for example, 17 09 1999" }
 
     context "when the month is outside the range 1-12" do
-      let(:start_date) { { 1 => "2024", 2 => "13", 3 => "1" } }
+      let(:start_date_hash) { { 1 => "2024", 2 => "13", 3 => "1" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
 
     context "when the year is non-integer" do
       # "abcd".to_i == 0 and and therefore a valid date year but it is not valid
-      let(:start_date) { { 1 => "abcd", 2 => "07", 3 => "1" } }
+      let(:start_date_hash) { { 1 => "abcd", 2 => "07", 3 => "1" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
 
     context "when the month is non-integer" do
-      let(:start_date) { { 1 => "2024", 2 => "abcd", 3 => "1" } }
+      let(:start_date_hash) { { 1 => "2024", 2 => "abcd", 3 => "1" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
 
     context "when the day is not an integer" do
-      let(:start_date) { { 1 => "2024", 2 => "07", 3 => "abcd" } }
+      let(:start_date_hash) { { 1 => "2024", 2 => "07", 3 => "abcd" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
   end
 
-  context "on the last day of the contract period" do
-    subject { test_class.new(start_date:) }
-
-    around do |example|
-      travel_to Date.new(2026, 5, 31) do
-        example.run
-      end
+  context "when the start date is earlier than the earliest permitted date" do
+    let!(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+    let!(:previous_contract_period) do
+      FactoryBot.create(:contract_period, :previous)
+    end
+    let!(:earliest_permitted_contract_period) do
+      FactoryBot.create(:contract_period, year: previous_contract_period.year - 1)
     end
 
-    before do
-      FactoryBot.create(:contract_period, year: 2025)
-      FactoryBot.create(:contract_period, year: 2024)
-      FactoryBot.create(:contract_period, year: 2023)
-      FactoryBot.create(:contract_period, year: 2022)
-    end
+    let(:error_message) { "Start date cannot be this far in the past. Enter a date later than #{earliest_permitted_contract_period.started_on.to_fs(:govuk)}." }
+    let(:start_date) { earliest_permitted_contract_period.started_on.prev_day }
+    let(:start_date_hash) { { 1 => start_date.year, 2 => start_date.month, 3 => start_date.day } }
 
-    let(:start_date) { { 1 => 2023, 2 => 5, 3 => 31 } }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
-
-        validates :start_date, ect_start_date: { current_date: Date.new(2026, 5, 31) }
-      end
-    end
-
-    it "is invalid for a date before the two previous contract periods" do
-      expect(subject).not_to be_valid
-    end
+    it { is_expected.to have_error(:start_date, error_message) }
   end
 end

--- a/spec/validators/mentor_start_date_validator_spec.rb
+++ b/spec/validators/mentor_start_date_validator_spec.rb
@@ -1,71 +1,48 @@
 RSpec.describe MentorStartDateValidator, type: :model do
-  context "when date is in an invalid format" do
-    subject { test_class.new(start_date:) }
+  subject { test_class.new(start_date: start_date_hash) }
 
-    let(:start_date) { { 1 => "invalid year", 2 => "invalid month", 3 => "invalid day" } }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
+  let(:test_class) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :start_date
 
-        validates :start_date, mentor_start_date: { current_date: Time.zone.today }
-      end
-    end
-
-    it "adds an error" do
-      subject.valid?
-      expect(subject.errors[:start_date]).to include("Enter the date in the correct format, for example 12 03 1998")
+      validates :start_date, mentor_start_date: true
     end
   end
 
-  context "when the start date has invalid values" do
-    subject { test_class.new(start_date:) }
-
+  context "when date is in an invalid format" do
     let(:error_message) { "Enter the date in the correct format, for example 12 03 1998" }
-    let(:test_class) do
-      Class.new do
-        include ActiveModel::Model
-        attr_accessor :start_date
+    let(:start_date_hash) { { 1 => "invalid year", 2 => "invalid month", 3 => "invalid day" } }
 
-        validates :start_date, mentor_start_date: true
-      end
-    end
+    it { is_expected.to have_error(:start_date, error_message) }
+  end
+
+  context "when the start date has invalid values" do
+    let(:error_message) { "Enter the date in the correct format, for example 12 03 1998" }
 
     context "when the month is outside the range 1-12" do
-      let(:start_date) { { 1 => "2024", 2 => "13", 3 => "1" } }
+      let(:start_date_hash) { { 1 => "2024", 2 => "13", 3 => "1" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
 
     context "when the year is non-integer" do
       # "abcd".to_i == 0 and and therefore a valid date year but it is not valid
-      let(:start_date) { { 1 => "abcd", 2 => "07", 3 => "1" } }
+      let(:start_date_hash) { { 1 => "abcd", 2 => "07", 3 => "1" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
 
     context "when the month is non-integer" do
-      let(:start_date) { { 1 => "2024", 2 => "abcd", 3 => "1" } }
+      let(:start_date_hash) { { 1 => "2024", 2 => "abcd", 3 => "1" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
 
     context "when the day is not an integer" do
-      let(:start_date) { { 1 => "2024", 2 => "07", 3 => "abcd" } }
+      let(:start_date_hash) { { 1 => "2024", 2 => "07", 3 => "abcd" } }
 
-      it "adds an error" do
-        subject.valid?
-        expect(subject.errors[:start_date]).to include(error_message)
-      end
+      it { is_expected.to have_error(:start_date, error_message) }
     end
   end
 end


### PR DESCRIPTION
On my quest to eliminate the magic date (31st May 2025) from the test suite, I took the opportunity to simplify these validators.

The `current_date` argument is never used outside the tests, so we may aswell remove it.

The tests have been simplified to use the `have_error` matcher, and context blocks reorganised to reduce unnecessary duplication.

The `ECTStartDateValidator` spec no longer relies on a magic date, and instead uses preceding contract periods to determine the earliest invalid date.