### PR TITLE
WIP contract period specs

### DIFF
--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     enabled { true }
     started_on { Date.new(year, *START_MONTH_AND_DAY) }
-    finished_on { Date.new(started_on.year + 1, *FINISH_MONTH_AND_DAY) }
+    finished_on { Date.new(started_on.year.next, *FINISH_MONTH_AND_DAY) }
     mentor_funding_enabled { true }
     detailed_evidence_types_enabled { true }
     uplift_fees_enabled { true }

--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     enabled { true }
     started_on { Date.new(year, *START_MONTH_AND_DAY) }
-    finished_on { Date.new(year.next, *FINISH_MONTH_AND_DAY) }
+    finished_on { Date.new(started_on.year + 1, *FINISH_MONTH_AND_DAY) }
     mentor_funding_enabled { true }
     detailed_evidence_types_enabled { true }
     uplift_fees_enabled { true }

--- a/spec/support/shared_examples/registration_window_redirect.rb
+++ b/spec/support/shared_examples/registration_window_redirect.rb
@@ -1,7 +1,6 @@
 RSpec.shared_examples "a route blocked when the registration window is closed" do
   around do |example|
-    travel_to(date)
-    example.run
+    travel_to(date) { example.run }
   end
 
   before do


### PR DESCRIPTION
### Context

Any spec that overrides `ContractPeriod#started_on` also needs to shift `finished_on`

### Changes proposed in this pull request

### Guidance to review
