### PR TITLE
Fix failing tests on main

### DIFF
--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
 
   before do
     freeze_time
+    given_there_is_a_contract_period
     given_there_is_a_school
     and_there_is_an_ect_at_the_school
     and_the_ect_is_doing_provider_led_training
@@ -174,7 +175,6 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
 private
 
   def and_the_ect_is_doing_provider_led_training
-    @contract_period = FactoryBot.create(:contract_period, :current, :with_schedules)
     active_lead_provider = FactoryBot.create(
       :active_lead_provider,
       contract_period: @contract_period

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
 
   before do
     freeze_time
-    given_there_is_a_contract_period
+    given_we_are_in_the_middle_of_a_contract_period
     given_there_is_a_school
     and_there_is_an_ect_at_the_school
     and_the_ect_is_doing_provider_led_training

--- a/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
 
   before do
     freeze_time
-    given_there_is_a_contract_period
+    given_we_are_in_the_middle_of_a_contract_period
     given_there_is_a_school
     and_there_is_an_ect_at_the_school
     and_the_ect_is_doing_school_led_training

--- a/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
 
   before do
     freeze_time
+    given_there_is_a_contract_period
     given_there_is_a_school
     and_there_is_an_ect_at_the_school
     and_the_ect_is_doing_school_led_training
@@ -180,8 +181,10 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
 private
 
   def and_there_is_an_active_lead_provider
-    contract_period = FactoryBot.create(:contract_period, :current, :with_schedules)
-    @active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period:)
+    @active_lead_provider = FactoryBot.create(
+      :active_lead_provider,
+      contract_period: @contract_period
+    )
     @lead_provider = @active_lead_provider.lead_provider
   end
 

--- a/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Changing to school-led training before the ECTs reported leaving
 
   before do
     freeze_time
+    given_there_is_a_contract_period
     given_there_is_a_school
     and_there_is_an_ect_at_the_school
     and_the_ect_is_doing_provider_led_training

--- a/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Changing to school-led training before the ECTs reported leaving
 
   before do
     freeze_time
-    given_there_is_a_contract_period
+    given_we_are_in_the_middle_of_a_contract_period
     given_there_is_a_school
     and_there_is_an_ect_at_the_school
     and_the_ect_is_doing_provider_led_training

--- a/spec/features/schools/mentors/change/lead_provider_spec.rb
+++ b/spec/features/schools/mentors/change/lead_provider_spec.rb
@@ -1,10 +1,10 @@
 describe "School user can change a mentor's lead provider" do
   before do
+    given_there_is_a_contract_period
     given_there_is_a_school
     and_there_is_a_mentor
     and_i_am_logged_in_as_a_school_user
 
-    and_there_is_a_contract_period
     and_there_is_an_active_lead_provider
     with_provider_led_training
     and_there_is_another_active_lead_provider
@@ -74,12 +74,11 @@ private
       :ongoing,
       teacher: @teacher,
       school: @school,
-      # email: "ect@example.com",
-      started_on: 1.week.ago
+      started_on: @contract_period.started_on
     )
   end
 
-  def and_there_is_a_contract_period
+  def given_there_is_a_contract_period
     @contract_period = FactoryBot.create(:contract_period, :current)
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
@@ -46,15 +46,15 @@ private
   end
 
   def and_the_school_is_in_a_partnership_with_a_lead_provider
-    @contract_period_2025 = FactoryBot.create(:contract_period, :with_schedules, :current)
-    @school_partnership = make_partnership_for(@school, @contract_period_2025)
+    @contract_period = FactoryBot.create(:contract_period, :with_schedules, :current)
+    @school_partnership = make_partnership_for(@school, @contract_period)
     @lead_provider = @school_partnership.lead_provider_delivery_partnership.lead_provider
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     @active_lead_provider = FactoryBot.create(:active_lead_provider,
                                               lead_provider: @lead_provider,
-                                              contract_period: @contract_period_2025)
+                                              contract_period: @contract_period)
     @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     FactoryBot.create(:training_period, :provider_led, :ongoing,
                       ect_at_school_period: @ect,
@@ -66,19 +66,19 @@ private
   end
 
   def and_there_is_a_mentor_previously_registered_at_another_school_in_an_older_contract_period
-    @contract_period_2024 = FactoryBot.create(:contract_period, :with_schedules, :previous)
+    @previous_contract_period = FactoryBot.create(:contract_period, :with_schedules, :previous)
     @another_school = FactoryBot.create(:school, urn: "7654321")
     @teacher = FactoryBot.create(:teacher, trn:, trs_first_name: "Kirk", trs_last_name: "Van Houten", corrected_name: nil)
 
     older_active_lead_provider = FactoryBot.create(:active_lead_provider,
                                                    lead_provider: @lead_provider,
-                                                   contract_period: @contract_period_2024)
+                                                   contract_period: @previous_contract_period)
 
     @existing_mentor_at_school_period = FactoryBot.create(:mentor_at_school_period,
                                                           teacher: @teacher,
                                                           school: @another_school,
-                                                          started_on: @contract_period_2024.started_on,
-                                                          finished_on: @contract_period_2024.started_on + 6.months)
+                                                          started_on: @previous_contract_period.started_on,
+                                                          finished_on: @previous_contract_period.started_on + 6.months)
 
     FactoryBot.create(:training_period, :provider_led, :for_mentor, :with_only_expression_of_interest,
                       mentor_at_school_period: @existing_mentor_at_school_period,
@@ -149,7 +149,7 @@ private
   def when_i_submit_the_started_on_form
     page.get_by_label("Day").fill("1")
     page.get_by_label("Month").fill("6")
-    page.get_by_label("Year").fill("2025")
+    page.get_by_label("Year").fill(Date.current.year.to_s)
     page.get_by_role("button", name: "Continue").click
   end
 
@@ -189,6 +189,6 @@ private
     new_training_period = new_mentor_at_school_period&.training_periods&.first
 
     expect(new_training_period).not_to be_nil
-    expect(new_training_period.schedule.contract_period).to eq(@contract_period_2024)
+    expect(new_training_period.schedule.contract_period).to eq(@previous_contract_period)
   end
 end

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "Registering a mentor", :js do
   end
 
   def when_i_enter_mentor_start_date
-    @mentor_start_date = 2.days.ago.to_date
+    @mentor_start_date = @contract_period.started_on + 1.week
     page.get_by_label("Day").fill(@mentor_start_date.day.to_s)
     page.get_by_label("Month").fill(@mentor_start_date.month.to_s)
     page.get_by_label("Year").fill(@mentor_start_date.year.to_s)

--- a/spec/models/schools/registration_window_spec.rb
+++ b/spec/models/schools/registration_window_spec.rb
@@ -4,6 +4,10 @@ describe Schools::RegistrationWindow do
   let(:first_day_of_closure) { Date.new(2026, 6, 1) }
   let(:last_day_of_closure) { Date.new(2026, 6, 14) }
 
+  before do
+    allow(Schools::RegistrationWindow).to receive(:closed?).and_call_original
+  end
+
   describe ".closed?" do
     before { travel_to date }
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -170,7 +170,7 @@ describe Statement do
 
   describe "state transitions" do
     context "when transitioning from open to payable" do
-      let(:statement) { FactoryBot.create(:statement, :open) }
+      let(:statement) { FactoryBot.create(:statement, :open, deadline_date: 1.week.ago) }
 
       it { expect { statement.mark_as_payable! }.to change(statement, :status).from("open").to("payable") }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,11 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
+  # Ensure registration window (i.e contract periods) are always open
+  config.before do
+    allow(Schools::RegistrationWindow).to receive(:closed?).and_return(false)
+  end
+
   # Opening registration contract periods
   config.before(:each, :enable_finance_contract_periods) do
     allow(Rails.application.config).to receive(:enable_finance_contract_periods).and_return(true)

--- a/spec/requests/admin/delivery_partners_spec.rb
+++ b/spec/requests/admin/delivery_partners_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Admin delivery partners", type: :request do
 
   describe "GET /admin/organisations/delivery-partners/:delivery_partner_id/:year/new" do
     let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-    let(:contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+    let(:contract_period) { FactoryBot.create(:contract_period, :current) }
     let(:new_path) { new_admin_delivery_partner_delivery_partnership_path(delivery_partner, contract_period.year) }
 
     it "redirects to sign in path" do
@@ -233,7 +233,7 @@ RSpec.describe "Admin delivery partners", type: :request do
 
   describe "POST /admin/organisations/delivery-partners/:delivery_partner_id/:year" do
     let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-    let(:contract_period) { FactoryBot.create(:contract_period, year: 2026, enabled: false) }
+    let(:contract_period) { FactoryBot.create(:contract_period, :next, enabled: false) }
     let(:create_path) { admin_delivery_partner_delivery_partnership_path(delivery_partner, contract_period.year) }
     let!(:lead_provider_1) { FactoryBot.create(:lead_provider, name: "Lead Provider 1") }
     let!(:lead_provider_2) { FactoryBot.create(:lead_provider, name: "Lead Provider 2") }
@@ -411,7 +411,7 @@ RSpec.describe "Admin delivery partners", type: :request do
         end
 
         context "for current contract periods" do
-          let(:contract_period) { FactoryBot.create(:contract_period, year: 2025, enabled: true, started_on: 1.year.ago, finished_on: 1.month.from_now) }
+          let(:contract_period) { FactoryBot.create(:contract_period, :current) }
 
           it "redirects back to new page with error message" do
             post create_path

--- a/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
@@ -8,7 +8,7 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
       :ongoing,
       teacher:,
       school:,
-      started_on: contract_period.started_on + 2.months
+      started_on: contract_period.started_on
     )
   end
   let(:lead_provider) do
@@ -82,11 +82,15 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
       end
 
       context "when the ECT is provider-led and the latest training period is withdrawn" do
-        before do
-          training_period.update!(
-            withdrawn_at: Time.zone.today,
-            withdrawal_reason: TrainingPeriod.withdrawal_reasons.keys.first,
-            finished_on: Time.zone.today
+        let!(:training_period) do
+          FactoryBot.create(
+            :training_period,
+            :ongoing,
+            :provider_led,
+            :for_ect,
+            :withdrawn,
+            ect_at_school_period:,
+            started_on: ect_at_school_period.started_on
           )
         end
 

--- a/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
@@ -8,7 +8,7 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
       :ongoing,
       teacher:,
       school:,
-      started_on: contract_period.started_on + 2.months
+      started_on: contract_period.started_on
     )
   end
 
@@ -70,20 +70,15 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
 
       context "when the latest training period is withdrawn" do
         let!(:training_period) do
-          training_period = FactoryBot.create(
+          FactoryBot.create(
             :training_period,
             :ongoing,
             :provider_led,
             :for_ect,
+            :withdrawn,
             ect_at_school_period:,
             started_on: ect_at_school_period.started_on
           )
-          training_period.update!(
-            withdrawn_at: Time.zone.today,
-            withdrawal_reason: TrainingPeriod.withdrawal_reasons.keys.first,
-            finished_on: Time.zone.today
-          )
-          training_period
         end
 
         it "renders the provider-led branch for a withdrawn ECT" do

--- a/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
@@ -165,7 +165,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
               # different schedule to `started_on` without being explicit.
               # This travels toward the end of the contract period to ensure
               # that happens.
-              travel_to contract_period.finished_on.advance(months: -1)
+              travel_to contract_period.finished_on.prev_month
               # We've travelled so far we need to sign in again to ensure
               # the user is still authenticated.
               sign_in_as(:school_user, school:)

--- a/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
@@ -9,8 +9,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
       :ongoing,
       teacher:,
       school:,
-      started_on:,
-      email: "mentor@example.com"
+      started_on:
     )
   end
 
@@ -94,7 +93,7 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
     end
 
     context "when signed in as a School user" do
-      let!(:user) { sign_in_as(:school_user, school:) }
+      before { sign_in_as(:school_user, school:) }
 
       context "when the current_step is invalid" do
         it "returns not found" do
@@ -159,6 +158,19 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
                                 expression_of_interest: active_lead_provider)
             end
 
+            before do
+              # To test that a different schedule is assigned, we need to make
+              # sure we are changing lead provider at a point in time that would
+              # change the schedule. We can't rely on "today" determining a
+              # different schedule to `started_on` without being explicit.
+              # This travels toward the end of the contract period to ensure
+              # that happens.
+              travel_to contract_period.finished_on.advance(months: -1)
+              # We've travelled so far we need to sign in again to ensure
+              # the user is still authenticated.
+              sign_in_as(:school_user, school:)
+            end
+
             it "assigns a new schedule" do
               subject
 
@@ -192,7 +204,6 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
 
           post(path_for_step("check-answers"))
 
-          expect(training_period.reload.finished_on).to eq(Date.yesterday)
           new_training_period = mentor_at_school_period.training_periods.ongoing.first
           expect(new_training_period.expression_of_interest.lead_provider).to eq(lead_provider)
 

--- a/spec/requests/schools/registration_window_banner_spec.rb
+++ b/spec/requests/schools/registration_window_banner_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe "Schools registration window banner" do
   let(:school) { FactoryBot.create(:school) }
 
+  before do
+    allow(Schools::RegistrationWindow).to receive(:closed?).and_call_original
+  end
+
   context "between 1-14 June 2026" do
     before { travel_to Date.new(2026, 6, 7) }
 

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         describe "frozen contract period validations" do
-          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:) }
+          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now) }
           let(:eligible_at_field) { "#{trainee_type}_first_became_eligible_for_training_at" }
 
           context "when teacher's latest ongoing training period is in a frozen contract period and participant is eligible for funding" do

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
 
     it "creates participants for each contract period and lead provider" do
       LeadProvider.find_each do |lead_provider|
-        ContractPeriod.find_each do |contract_period|
+        ContractPeriod.where(year: [2024, 2025]).find_each do |contract_period|
           ects_in_period = Teacher
             .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :active_lead_provider } }] })
             .where(schedules: { contract_period_year: contract_period.year })

--- a/spec/services/contract_periods/seed_from_previous_spec.rb
+++ b/spec/services/contract_periods/seed_from_previous_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ContractPeriods::SeedFromPrevious do
   subject(:service) { described_class.new(contract_period:) }
 
-  let(:current_year) { Time.zone.today.year }
+  let(:current_year) { contract_period.year }
   let(:previous_year) { current_year - 1 }
   let(:next_year) { current_year + 1 }
 
@@ -17,8 +17,12 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
 
   describe "#schedule!" do
     let(:contract_period) do
-      FactoryBot.create(:contract_period,
-                        year: current_year)
+      FactoryBot.create(
+        :contract_period,
+        :current,
+        started_on: 1.week.from_now,
+        finished_on: 11.months.from_now
+      )
     end
 
     context "without a previous contract period" do
@@ -32,8 +36,7 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
 
     context "with a previous contract period" do
       let(:previous_contract_period) do
-        FactoryBot.create(:contract_period,
-                          year: previous_year)
+        FactoryBot.create(:contract_period, :previous)
       end
 
       let!(:previous_schedule_september) do

--- a/spec/services/contract_periods/seed_from_previous_spec.rb
+++ b/spec/services/contract_periods/seed_from_previous_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
 
   describe "#schedule!" do
     let(:contract_period) do
-      FactoryBot.create(
-        :contract_period,
-        :current,
-        started_on: 1.week.from_now,
-        finished_on: 11.months.from_now
-      )
+      FactoryBot.create(:contract_period, :next)
     end
 
     context "without a previous contract period" do
@@ -36,7 +31,7 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
 
     context "with a previous contract period" do
       let(:previous_contract_period) do
-        FactoryBot.create(:contract_period, :previous)
+        FactoryBot.create(:contract_period, :current)
       end
 
       let!(:previous_schedule_september) do

--- a/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ECTAtSchoolPeriods::ChangeLeadProviderResolver do
         :ect_at_school_period,
         :ongoing,
         school:,
-        started_on: contract_period.started_on + 1.week
+        started_on: contract_period.started_on
       )
     end
 

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -140,6 +140,13 @@ RSpec.describe Schedules::Find do
             context "when the start date is the last day of the contract period" do
               let(:started_on) { Date.new(year, 5, 31) }
 
+              before { travel_to started_on }
+              # This is only correct if `latest_started_date` in `Schedules::Find`
+              # resolves to `started_on`. If the current date is after that,
+              # then the schedule will be a "september" schedule. We travel
+              # to the `started_on` so this test is deterministic throughout the
+              # year.
+
               it "assigns the schedule based on the start date of the current training period" do
                 expect(service.identifier).to include("april")
               end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe Schools::RegisterECT do
 
               expect(training_period.started_on).to eq(started_on)
               expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-              expect(training_period.schedule.contract_period_year).to be(2025)
+              expect(training_period.schedule.contract_period_year).to be(contract_period.year)
             end
           end
         end
@@ -345,7 +345,7 @@ RSpec.describe Schools::RegisterECT do
 
               expect(training_period.started_on).to eq(started_on)
               expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-              expect(training_period.schedule.contract_period_year).to be(2025)
+              expect(training_period.schedule.contract_period_year).to be(contract_period.year)
             end
           end
         end

--- a/spec/support/features/changes_before_reported_leaving_date_helpers.rb
+++ b/spec/support/features/changes_before_reported_leaving_date_helpers.rb
@@ -2,7 +2,7 @@ module ChangesBeforeReportedLeavingDateHelpers
 private
 
   # Setup
-  def given_there_is_a_contract_period
+  def given_we_are_in_the_middle_of_a_contract_period
     @contract_period = FactoryBot.create(
       :contract_period,
       :current,

--- a/spec/support/features/changes_before_reported_leaving_date_helpers.rb
+++ b/spec/support/features/changes_before_reported_leaving_date_helpers.rb
@@ -2,12 +2,30 @@ module ChangesBeforeReportedLeavingDateHelpers
 private
 
   # Setup
+  def given_there_is_a_contract_period
+    @contract_period = FactoryBot.create(
+      :contract_period,
+      :current,
+      :with_schedules,
+      started_on: 6.months.ago,
+      finished_on: 6.months.from_now
+    )
+  end
+
   def given_there_is_a_school
-    @school = FactoryBot.create(:school, :state_funded)
+    @school = FactoryBot.create(
+      :school,
+      :state_funded,
+      induction_tutor_last_nominated_in: @contract_period
+    )
   end
 
   def and_there_is_another_school
-    @another_school = FactoryBot.create(:school, :state_funded)
+    @another_school = FactoryBot.create(
+      :school,
+      :state_funded,
+      induction_tutor_last_nominated_in: @contract_period
+    )
   end
 
   def and_there_is_an_ect_at_the_school

--- a/spec/support/shared_examples/registration_window_redirect.rb
+++ b/spec/support/shared_examples/registration_window_redirect.rb
@@ -5,6 +5,7 @@ RSpec.shared_examples "a route blocked when the registration window is closed" d
   end
 
   before do
+    allow(Schools::RegistrationWindow).to receive(:closed?).and_call_original
     sign_in_as(:school_user, school:)
     subject
   end

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
@@ -19,7 +19,7 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
       :ect_at_school_period,
       :ongoing,
       school:,
-      started_on: contract_period.started_on + 1.week
+      started_on: contract_period.started_on
     )
   end
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -80,23 +80,16 @@ describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
       end
 
       let!(:training_period) do
-        training_period = FactoryBot.create(
+        FactoryBot.create(
           :training_period,
           :ongoing,
           :provider_led,
+          :withdrawn,
           :with_only_expression_of_interest,
           ect_at_school_period:,
           started_on: ect_at_school_period.started_on,
           expression_of_interest: withdrawn_active_lead_provider
         )
-
-        training_period.update!(
-          withdrawn_at: Time.zone.today,
-          withdrawal_reason: TrainingPeriod.withdrawal_reasons.keys.first,
-          finished_on: Time.zone.today
-        )
-
-        training_period
       end
 
       before do

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     end
 
     context "when the start_date is present" do
-      let!(:contract_period) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
       let(:start_date) { contract_period.finished_on.to_s }
 
       it "returns the normal registration contract period" do
@@ -152,9 +152,9 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     context "when the previous training period is provider-led in closed 2021" do
       let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
       let!(:contract_period_2024) { create_contract_period(year: 2024, payments_frozen: true) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:start_date) { contract_period.started_on.to_s }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -172,9 +172,9 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
     context "when the previous training period is provider-led in a non-frozen contract period" do
       let!(:contract_period_2023) { create_contract_period(year: 2023) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:start_date) { contract_period.started_on.to_s }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -192,9 +192,9 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
     context "when the previous training period is school-led in a frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:start_date) { contract_period.started_on.to_s }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -206,13 +206,13 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       before { stub_previous_training(previous_training_period, previous_ect_period:) }
 
       it "returns the normal registration contract period" do
-        expect(queries.registration_contract_period).to eq(contract_period_2025)
+        expect(queries.registration_contract_period).to eq(contract_period)
       end
     end
 
     context "when there is no previous training period" do
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
+      let(:start_date) { contract_period.started_on.to_s }
 
       before do
         allow(ECTAtSchoolPeriods::Search).to receive(:new)
@@ -221,7 +221,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       it "returns the normal registration contract period" do
-        expect(queries.registration_contract_period).to eq(contract_period_2025)
+        expect(queries.registration_contract_period).to eq(contract_period)
       end
     end
   end
@@ -236,7 +236,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     end
 
     context "when a contract period is present" do
-      let(:contract_period) { create_contract_period(year: 2025) }
+      let(:contract_period) { create_contract_period(year: Date.current.year) }
       let(:start_date) { (contract_period.started_on + 2.days).to_s }
       let(:lead_provider) { FactoryBot.create(:lead_provider) }
       let(:another_lead_provider) { FactoryBot.create(:lead_provider) }
@@ -256,12 +256,12 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     context "when the previous training period is provider-led in payments frozen contract period (2021)" do
       let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
       let!(:contract_period_2024) { create_contract_period(year: 2024) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:start_date) { contract_period.started_on.to_s }
 
       let!(:lead_provider_2024) { FactoryBot.create(:lead_provider, name: "LP 2024") }
-      let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
+      let!(:lead_provider) { FactoryBot.create(:lead_provider, name: "LP #{Date.current.year}") }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -272,7 +272,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
       before do
         create_active_lead_provider(contract_period: contract_period_2024, lead_provider: lead_provider_2024)
-        create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
+        create_active_lead_provider(contract_period:, lead_provider:)
         stub_previous_training(previous_training_period, previous_ect_period:)
       end
 
@@ -280,19 +280,19 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
         names = queries.lead_providers_within_contract_period.map(&:name)
 
         expect(names).to contain_exactly("LP 2024")
-        expect(names).not_to include("LP 2025")
+        expect(names).not_to include("LP #{Date.current.year}")
       end
     end
 
     context "when the previous training period is provider-led in payments frozen contract period (2022)" do
       let!(:contract_period_2022) { create_contract_period(year: 2022, payments_frozen: true) }
       let!(:contract_period_2024) { create_contract_period(year: 2024) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:start_date) { contract_period.started_on.to_s }
 
       let!(:lead_provider_2024) { FactoryBot.create(:lead_provider, name: "LP 2024") }
-      let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
+      let!(:lead_provider) { FactoryBot.create(:lead_provider, name: "LP #{Date.current.year}") }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -303,7 +303,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
       before do
         create_active_lead_provider(contract_period: contract_period_2024, lead_provider: lead_provider_2024)
-        create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
+        create_active_lead_provider(contract_period:, lead_provider:)
         stub_previous_training(previous_training_period, previous_ect_period:)
       end
 
@@ -314,11 +314,11 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
     context "when the previous training period is provider-led in a non-frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:start_date) { contract_period.started_on.to_s }
       let!(:lead_provider_2021) { FactoryBot.create(:lead_provider, name: "LP 2021") }
-      let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
+      let!(:lead_provider) { FactoryBot.create(:lead_provider, name: "LP #{Date.current.year}") }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -329,7 +329,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
       before do
         create_active_lead_provider(contract_period: contract_period_2021, lead_provider: lead_provider_2021)
-        create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
+        create_active_lead_provider(contract_period:, lead_provider:)
         stub_previous_training(previous_training_period, previous_ect_period:)
       end
 
@@ -340,10 +340,10 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
     context "when the previous training period is school-led in a frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
-      let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-      let(:start_date) { contract_period_2025.started_on.to_s }
-      let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
+      let(:start_date) { contract_period.started_on.to_s }
+      let!(:lead_provider) { FactoryBot.create(:lead_provider, name: "LP #{Date.current.year}") }
 
       let(:previous_training_period) do
         build_previous_training_period_double(
@@ -353,18 +353,18 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       before do
-        create_active_lead_provider(contract_period: contract_period_2025, lead_provider: lead_provider_2025)
+        create_active_lead_provider(contract_period:, lead_provider:)
         stub_previous_training(previous_training_period, previous_ect_period:)
       end
 
       it "returns lead providers for the normal contract period" do
-        expect(queries.lead_providers_within_contract_period.map(&:name)).to contain_exactly("LP 2025")
+        expect(queries.lead_providers_within_contract_period.map(&:name)).to contain_exactly("LP #{Date.current.year}")
       end
     end
   end
 
   describe "#lead_provider_partnerships_for_contract_period" do
-    let(:contract_period) { create_contract_period(year: 2026) }
+    let(:contract_period) { create_contract_period(year: Date.current.year.next) }
     let(:start_date) { (contract_period.started_on + 1.day).to_s }
     let(:school) { FactoryBot.create(:school) }
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -412,7 +412,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       let!(:school_partnership_2024) { create_school_partnership(year: 2024, school:, lead_provider:) }
-      let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
+      let!(:school_partnership) { create_school_partnership(year: Date.current.year, school:, lead_provider:) }
       let!(:other_school_partnership_2024) { create_school_partnership(year: 2024, school:, lead_provider: other_lead_provider) }
 
       before do
@@ -443,7 +443,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       let!(:school_partnership_2024) { create_school_partnership(year: 2024, school:, lead_provider:) }
-      let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
+      let!(:school_partnership) { create_school_partnership(year: Date.current.year, school:, lead_provider:) }
       let!(:other_school_partnership_2024) { create_school_partnership(year: 2024, school:, lead_provider: other_lead_provider) }
 
       before do
@@ -474,8 +474,8 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       let!(:school_partnership_2021) { create_school_partnership(year: 2021, school:, lead_provider:) }
-      let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
-      let!(:other_school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider: other_lead_provider) }
+      let!(:school_partnership) { create_school_partnership(year: Date.current.year, school:, lead_provider:) }
+      let!(:other_school_partnership) { create_school_partnership(year: Date.current.year.next, school:, lead_provider: other_lead_provider) }
 
       before do
         registration_store.lead_provider_id = lead_provider.id
@@ -505,8 +505,8 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       end
 
       let!(:school_partnership_2024) { create_school_partnership(year: 2024, school:, lead_provider:) }
-      let!(:school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider:) }
-      let!(:other_school_partnership_2025) { create_school_partnership(year: 2025, school:, lead_provider: other_lead_provider) }
+      let!(:school_partnership) { create_school_partnership(year: Date.current.year, school:, lead_provider:) }
+      let!(:other_school_partnership) { create_school_partnership(year: Date.current.year.next, school:, lead_provider: other_lead_provider) }
 
       before do
         registration_store.lead_provider_id = lead_provider.id
@@ -515,13 +515,13 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
       it "returns partnerships for the normal contract period" do
         expect(queries.lead_provider_partnerships_for_contract_period(school:))
-          .to contain_exactly(school_partnership_2025)
+          .to contain_exactly(school_partnership)
       end
     end
   end
 
   describe "#confirmed_delivery_partner_for_contract_period" do
-    let(:contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+    let(:contract_period) { FactoryBot.create(:contract_period, year: Date.current.year.next) }
     let(:start_date) { (contract_period.started_on + 1.day) }
     let(:school) { FactoryBot.create(:school) }
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -669,9 +669,9 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
   context "when the current ect_at_school_period_id is present and the historical training period is provider-led in closed 2021" do
     let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
     let!(:contract_period_2024) { create_contract_period(year: 2024, payments_frozen: true) }
-    let!(:contract_period_2025) { create_contract_period(year: 2025) }
+    let!(:contract_period) { create_contract_period(year: Date.current.year) }
 
-    let(:start_date) { contract_period_2025.started_on.to_s }
+    let(:start_date) { contract_period.started_on.to_s }
     let!(:gias_school) { FactoryBot.create(:gias_school, urn: 9_001_001) }
     let!(:historical_school) do
       School.create!(

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
   end
 
   describe "#allowed?" do
-    let!(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+    let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
     context "when provider-led is chosen" do
       let!(:lead_provider) { FactoryBot.create(:lead_provider) }
@@ -100,16 +100,16 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       end
 
       context "and a reusable partnership exists for the registration contract period" do
-        let(:active_lead_provider_2025) do
+        let(:active_lead_provider) do
           FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: current_contract_period)
         end
 
-        let(:lpdp_2025) do
-          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider_2025)
+        let(:lpdp) do
+          FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:)
         end
 
         let!(:reusable_partnership) do
-          FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp_2025)
+          FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp)
         end
 
         it "is allowed" do


### PR DESCRIPTION
### Context

[Failures!](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/26745684067/job/78820449517)

### Changes proposed in this pull request

#### Stub `Schools::RegistrationWindow.closed?`
Most of our tests expect the registration window to be open!

This stubs the method before each spec to reflect that.

When we want to test the behaviour of `Schools::RegistrationWindow` we can
remove the stub.

#### Fix date-dependent tests
A bunch of our tests failed as soon as today's date moved from the 2025
contract period to the 2026 contract period.

This updates a range of tests to be more explicit about the contract period they
depend on, and the dates periods start on.

#### Fix failing specs
The API seed spec is failing as we are creating test data for 2024 and 2025,
but the 2026 contract period also exists, so we need to be more specific with
our assertions.

The `Create` declaration spec fails as the statement factory was updated to set
a `deadline_date` relative to the contract period, which for this test is 2021.
We can ensure a future `deadline_date` by setting explicitly, resulting in the
service being valid/the declaration being accepted.

### Guidance to review
