### PR TITLE
Use safe schedules

### DIFF
--- a/spec/factories/statement_factory.rb
+++ b/spec/factories/statement_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
 
     trait :open do
       status { :open }
+      deadline_date { [Date.new(year, month, 1).prev_day, Date.yesterday].min }
     end
 
     trait :payable do

--- a/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_lead_provider_before_reported_leaving_date_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe "Changing lead provider before the ECTs reported leaving date" do
   include ChangesBeforeReportedLeavingDateHelpers
 
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   before do
     freeze_time

--- a/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_provider_led_training_before_reported_leaving_date_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe "Changing to provider-led training before the ECTs reported leavi
   include ChangesBeforeReportedLeavingDateHelpers
 
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   before do
     freeze_time

--- a/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_to_school_led_training_before_reported_leaving_date_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe "Changing to school-led training before the ECTs reported leaving
   include ChangesBeforeReportedLeavingDateHelpers
 
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   before do
     freeze_time

--- a/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
+++ b/spec/features/schools/ects/change/edge_cases/changing_training_programme_for_ects_in_closed_contract_periods_spec.rb
@@ -1,4 +1,6 @@
 describe "Changing training programme for ECTs who started provider-led training in a closed contract period" do
+  include_context "safe_schedules"
+
   before do
     given_there_is_a_school
     and_there_is_a_closed_contract_period

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_istip_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "Independent school selects ISTIP as appropriate body" do
     given_i_am_logged_in_as_an_independent_school_user

--- a/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/appropriate_body_selection/independent_school_selects_teaching_school_hub_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   before do
     FactoryBot.create(:appropriate_body_period, name: "Golden Leaf Teaching Hub")

--- a/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/cant_use_email_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   let(:trn) { "3002586" }
 

--- a/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "Finding a teacher using national insurance number" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/find_ect_step_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher that has passed their induction"
+  include_context "safe_schedules"
 
   scenario "User enters date of birth (find ECT step) but teacher has completed their induction" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_completed/national_insurance_number_step_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher and then a teacher that has passed their induction"
+  include_context "safe_schedules"
 
   scenario "User enters national insurance number but teacher has completed their induction" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/find_ect_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher that is exempt from induction"
+  include_context "safe_schedules"
 
   scenario "User enters date of birth (find ECT step) but teacher has completed their induction" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_exempt/national_insurance_number_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher and then a teacher that is exempt from induction"
+  include_context "safe_schedules"
 
   scenario "User enters national insurance number but teacher is exempt from induction" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/find_ect_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher that has failed their induction"
+  include_context "safe_schedules"
 
   scenario "User enters date of birth (find ECT step) but teacher has failed their induction" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/induction_failed/national_insurance_number_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher and then a teacher that has failed their induction"
+  include_context "safe_schedules"
 
   scenario "User enters national insurance number but teacher has failed their induction" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_at_school_already_registered_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "Teacher with trn has already registered as an ECT at a school" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_prohibited_from_teaching_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher prohibited from teaching"
+  include_context "safe_schedules"
 
   scenario "The ECT is prohibited from teaching" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_national_insurance_number_is_not_found_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher and then nothing"
+  include_context "safe_schedules"
 
   scenario "Teacher with national insurance number is not found" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/ects/register/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns nothing"
+  include_context "safe_schedules"
 
   scenario "Teacher with TRN is not found" do
     given_i_am_logged_in_as_a_school_user

--- a/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
+++ b/spec/features/schools/ects/register/previously_registered_but_inactive_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering an ECT" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "previously registered" do
     given_i_am_logged_in_as_a_state_funded_school_user_who_has_previously_registered_an_ect

--- a/spec/features/schools/mentors/change/lead_provider_spec.rb
+++ b/spec/features/schools/mentors/change/lead_provider_spec.rb
@@ -1,4 +1,6 @@
 describe "School user can change a mentor's lead provider" do
+  include_context "safe_schedules"
+
   before do
     given_there_is_a_school
     and_there_is_a_mentor

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_nino_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "mentor already active at the school from trn and nino" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/already_active_at_school_after_trn_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "mentor already active at the school from trn and dob" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cannot_mentor_themself_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "An ECT becoming mentor cannot mentor themself" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/cant_use_email_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   let(:trn) { "3002586" }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/find_teacher_using_national_insurance_number_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   scenario "Finding a teacher using national insurance number" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/fully_moving_schools_before_reported_leaving_date_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor that is mentoring at the new school only" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   before { freeze_time }

--- a/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/mentor_prohibited_from_teaching_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns a teacher prohibited from teaching"
+  include_context "safe_schedules"
 
   scenario "School attempts to register a prohibited teacher as a mentor" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/no_trn_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Registering a mentor" do
+  include_context "safe_schedules"
+
   scenario "Teacher without a TRN cannot be registered" do
     given_there_is_a_school_in_the_service
     and_there_is_an_ect_with_no_mentor_registered_at_the_school

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_found_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns a teacher and then nothing"
+  include_context "safe_schedules"
 
   scenario "Teacher with TRN is not found" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/not_mentoring_at_new_school_only_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   let(:trn) { "3002586" }

--- a/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
@@ -47,15 +47,15 @@ private
   end
 
   def and_the_school_is_in_a_partnership_with_a_lead_provider
-    @contract_period_2025 = FactoryBot.create(:contract_period, :with_schedules, :current)
-    @school_partnership = make_partnership_for(@school, @contract_period_2025)
+    @contract_period = FactoryBot.create(:contract_period, :with_schedules, :current)
+    @school_partnership = make_partnership_for(@school, @contract_period)
     @lead_provider = @school_partnership.lead_provider_delivery_partnership.lead_provider
   end
 
   def and_there_is_an_ect_with_no_mentor_registered_at_the_school
     @active_lead_provider = FactoryBot.create(:active_lead_provider,
                                               lead_provider: @lead_provider,
-                                              contract_period: @contract_period_2025)
+                                              contract_period: @contract_period)
     @ect = FactoryBot.create(:ect_at_school_period, :ongoing, school: @school)
     FactoryBot.create(:training_period, :provider_led, :ongoing,
                       ect_at_school_period: @ect,
@@ -150,7 +150,7 @@ private
   def when_i_submit_the_started_on_form
     page.get_by_label("Day").fill("1")
     page.get_by_label("Month").fill("6")
-    page.get_by_label("Year").fill("2025")
+    page.get_by_label("Year").fill(@contract_period.year.to_s)
     page.get_by_role("button", name: "Continue").click
   end
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/preserves_contract_period_on_re_registration_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   let(:trn) { "3002586" }

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_choose_lead_provider_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   let(:trn) { "3002586" }

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_eligible_for_funding_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   let(:trn) { "3002586" }

--- a/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/provider_led_ect_mentor_ineligible_for_funding_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
-
+  include_context "safe_schedules"
   let(:trn) { "3002586" }
 
   scenario "mentor has existing mentorship, mentoring at new school only and is ineligible for funding with provider-led ect" do

--- a/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/school_led_ect_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
 
   let(:trn) { "3002586" }
 

--- a/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/teacher_with_trn_not_found_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns nothing"
+  include_context "safe_schedules"
 
   scenario "Teacher with TRN is not found" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/edge_cases/trn_not_found_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Registering a mentor" do
   include_context "test TRS API returns nothing"
+  include_context "safe_schedules"
 
   scenario "Teacher with TRN is not found" do
     given_there_is_a_school_in_the_service

--- a/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/happy_path_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe "Registering a mentor", :js do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
+
   include SchoolPartnershipHelpers
 
   let(:trn) { "3002586" }

--- a/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentors/register_mentor/selecting_a_different_lead_provider_when_registering_a_new_mentor_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Selecting a different lead provider" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   scenario "Registering a new mentor" do

--- a/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
+++ b/spec/features/schools/mentorship/redirect_to_register_a_new_mentor_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Redirect to register a new mentor for an ECT" do
   include_context "test TRS API returns a teacher"
+  include_context "safe_schedules"
   include SchoolPartnershipHelpers
 
   let(:trn) { "9876543" }

--- a/spec/requests/admin/delivery_partners_spec.rb
+++ b/spec/requests/admin/delivery_partners_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "Admin delivery partners", type: :request do
 
   describe "POST /admin/organisations/delivery-partners/:delivery_partner_id/:year" do
     let(:delivery_partner) { FactoryBot.create(:delivery_partner) }
-    let(:contract_period) { FactoryBot.create(:contract_period, year: 2026, enabled: false) }
+    let(:contract_period) { FactoryBot.create(:contract_period, :next, enabled: false) }
     let(:create_path) { admin_delivery_partner_delivery_partnership_path(delivery_partner, contract_period.year) }
     let!(:lead_provider_1) { FactoryBot.create(:lead_provider, name: "Lead Provider 1") }
     let!(:lead_provider_2) { FactoryBot.create(:lead_provider, name: "Lead Provider 2") }

--- a/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_lead_provider_wizard_spec.rb
@@ -82,6 +82,8 @@ describe "Schools::ECTs::ChangeLeadProviderWizardController" do
       end
 
       context "when the ECT is provider-led and the latest training period is withdrawn" do
+        include_context "safe_schedules"
+
         before do
           training_period.update!(
             withdrawn_at: Time.zone.today,

--- a/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
@@ -1,4 +1,6 @@
 describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
+  include_context "safe_schedules"
+
   let(:contract_period) { FactoryBot.create(:contract_period, :with_schedules, :current) }
   let(:school) { FactoryBot.create(:school) }
   let(:teacher) { FactoryBot.create(:teacher) }

--- a/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
+++ b/spec/requests/schools/mentors/change_lead_provider_wizard_spec.rb
@@ -1,4 +1,5 @@
 describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
+  include_context "safe_schedules"
   let(:started_on) { contract_period.started_on + 2.months }
   let(:school) { FactoryBot.create(:school) }
   let(:teacher) { FactoryBot.create(:teacher) }
@@ -158,6 +159,9 @@ describe "Schools::Mentors::ChangeLeadProviderWizard Requests" do
                                 started_on:,
                                 expression_of_interest: active_lead_provider)
             end
+
+            # Ensure the change happens in a month with a different identifier in order to observe the effect
+            let(:overridden_current_date) { contract_period.started_on + 10.months }
 
             it "assigns a new schedule" do
               subject

--- a/spec/requests/schools/register_ect_wizard_spec.rb
+++ b/spec/requests/schools/register_ect_wizard_spec.rb
@@ -3,6 +3,8 @@ describe "Schools::RegisterECTWizardController" do
   let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:) }
   let(:ect_at_school_period_id) { ect_at_school_period.id }
 
+  include_context "safe_schedules"
+
   describe "GET #new" do
     subject { get path_for_step("what-you-will-need") }
 

--- a/spec/requests/schools/register_mentor_wizard_spec.rb
+++ b/spec/requests/schools/register_mentor_wizard_spec.rb
@@ -1,4 +1,5 @@
 describe "Schools::RegisterMentorWizardController" do
+  include_context "safe_schedules"
   let(:school) { FactoryBot.create(:school) }
   let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, school:) }
   let(:mentor_at_school_period_id) { mentor_at_school_period.id }

--- a/spec/services/api/declarations/create_spec.rb
+++ b/spec/services/api/declarations/create_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe API::Declarations::Create, type: :model do
         end
 
         describe "frozen contract period validations" do
-          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:) }
+          let!(:payment_statement) { FactoryBot.create(:statement, :open, active_lead_provider:, deadline_date: 1.month.from_now) }
           let(:eligible_at_field) { "#{trainee_type}_first_became_eligible_for_training_at" }
 
           context "when teacher's latest ongoing training period is in a frozen contract period and participant is eligible for funding" do

--- a/spec/services/api_seed_data/participant_scenarios_spec.rb
+++ b/spec/services/api_seed_data/participant_scenarios_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe APISeedData::ParticipantScenarios do
 
     it "creates participants for each contract period and lead provider" do
       LeadProvider.find_each do |lead_provider|
-        ContractPeriod.find_each do |contract_period|
+        ContractPeriod.where(year: [2024, 2025]).find_each do |contract_period|
           ects_in_period = Teacher
             .joins(ect_at_school_periods: { training_periods: [:schedule, { school_partnership: { lead_provider_delivery_partnership: :active_lead_provider } }] })
             .where(schedules: { contract_period_year: contract_period.year })

--- a/spec/services/contract_periods/seed_from_previous_spec.rb
+++ b/spec/services/contract_periods/seed_from_previous_spec.rb
@@ -1,10 +1,6 @@
 RSpec.describe ContractPeriods::SeedFromPrevious do
   subject(:service) { described_class.new(contract_period:) }
 
-  let(:current_year) { Time.zone.today.year }
-  let(:previous_year) { current_year - 1 }
-  let(:next_year) { current_year + 1 }
-
   describe "#initialize" do
     context "when :contract_period is nil" do
       let(:contract_period) { nil }
@@ -16,10 +12,7 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
   end
 
   describe "#schedule!" do
-    let(:contract_period) do
-      FactoryBot.create(:contract_period,
-                        year: current_year)
-    end
+    let(:contract_period) { FactoryBot.create(:contract_period, :next) }
 
     context "without a previous contract period" do
       it do
@@ -31,10 +24,7 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
     end
 
     context "with a previous contract period" do
-      let(:previous_contract_period) do
-        FactoryBot.create(:contract_period,
-                          year: previous_year)
-      end
+      let(:previous_contract_period) { FactoryBot.create(:contract_period, :current) }
 
       let!(:previous_schedule_september) do
         FactoryBot.create(:schedule,
@@ -54,27 +44,27 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
                           identifier: "ecf-standard-april")
       end
 
-      let(:new_schedules) { Schedule.where(contract_period_year: current_year) }
+      let(:new_schedules) { Schedule.where(contract_period_year: contract_period.year) }
 
       before do
         previous_schedule_september.milestones.create!(
           declaration_type: "started",
-          start_date: Date.new(previous_year, 6, 1),
-          milestone_date: Date.new(previous_year, 11, 30)
+          start_date: Date.new(previous_contract_period.year, 6, 1),
+          milestone_date: Date.new(previous_contract_period.year, 11, 30)
         )
         previous_schedule_september.milestones.create!(
           declaration_type: "retained-1",
-          start_date: Date.new(previous_year, 9, 1),
+          start_date: Date.new(previous_contract_period.year, 9, 1),
           milestone_date: nil
         )
         previous_schedule_january.milestones.create!(
           declaration_type: "started",
-          start_date: Date.new(current_year, 1, 1),
-          milestone_date: Date.new(current_year, 6, 30)
+          start_date: Date.new(contract_period.year, 1, 1),
+          milestone_date: Date.new(contract_period.year, 6, 30)
         )
         previous_schedule_january.milestones.create!(
           declaration_type: "completed",
-          start_date: Date.new(current_year, 3, 1),
+          start_date: Date.new(contract_period.year, 3, 1),
           milestone_date: nil
         )
       end
@@ -107,10 +97,10 @@ RSpec.describe ContractPeriods::SeedFromPrevious do
         it "advances dates by one year if set" do
           service.schedule!
 
-          expect(new_september_schedule.milestones.find_by(declaration_type: "started").start_date).to eq(Date.new(current_year, 6, 1))
+          expect(new_september_schedule.milestones.find_by(declaration_type: "started").start_date).to eq(Date.new(contract_period.year, 6, 1))
           expect(new_september_schedule.milestones.find_by(declaration_type: "retained-1").milestone_date).to be_nil
 
-          expect(new_january_schedule.milestones.find_by(declaration_type: "started").milestone_date).to eq(Date.new(next_year, 6, 30))
+          expect(new_january_schedule.milestones.find_by(declaration_type: "started").milestone_date).to eq(Date.new(contract_period.year + 1, 6, 30))
         end
 
         it "rolls back changes if an error occurs" do

--- a/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
+++ b/spec/services/ect_at_school_periods/change_lead_provider_resolver_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ECTAtSchoolPeriods::ChangeLeadProviderResolver do
+  include_context "safe_schedules"
+
   describe "#call" do
     subject(:resolver) { described_class.new(ect_at_school_period) }
 

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe Schedules::Find do
             context "when the start date is the last day of the contract period" do
               let(:started_on) { Date.new(year, 5, 31) }
 
+              around do |example|
+                travel_to(Date.new(year, 5, 15)) do
+                  example.run
+                end
+              end
+
               it "assigns the schedule based on the start date of the current training period" do
                 expect(service.identifier).to include("april")
               end

--- a/spec/services/schools/register_ect_spec.rb
+++ b/spec/services/schools/register_ect_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe Schools::RegisterECT do
 
               expect(training_period.started_on).to eq(started_on)
               expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-              expect(training_period.schedule.contract_period_year).to be(2025)
+              expect(training_period.schedule.contract_period_year).to be(contract_period.year)
             end
           end
         end
@@ -345,7 +345,7 @@ RSpec.describe Schools::RegisterECT do
 
               expect(training_period.started_on).to eq(started_on)
               expect(training_period.schedule.identifier).to eql("ecf-standard-april")
-              expect(training_period.schedule.contract_period_year).to be(2025)
+              expect(training_period.schedule.contract_period_year).to be(contract_period.year)
             end
           end
         end

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/check_answers_step_spec.rb
@@ -1,6 +1,8 @@
 describe Schools::ECTs::ChangeLeadProviderWizard::CheckAnswersStep do
   subject(:current_step) { wizard.current_step }
 
+  include_context "safe_schedules"
+
   let(:wizard) do
     Schools::ECTs::ChangeLeadProviderWizard::Wizard.new(
       current_step: :check_answers,

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -136,6 +136,8 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
   end
 
   describe "#registration_contract_period" do
+    let(:overridden_current_date) { Date.new(2026, 5, 1) }
+
     context "when the start_date is blank" do
       it "returns nil" do
         expect(queries.registration_contract_period).to be_nil
@@ -239,6 +241,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
     context "when a contract period is present" do
       let(:contract_period) { create_contract_period(year: 2025) }
+      let(:overridden_current_date) { start_date }
       let(:start_date) { (contract_period.started_on + 2.days).to_s }
       let(:lead_provider) { FactoryBot.create(:lead_provider) }
       let(:another_lead_provider) { FactoryBot.create(:lead_provider) }
@@ -317,6 +320,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
     context "when the previous training period is provider-led in a non-frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021) }
       let!(:contract_period_2025) { create_contract_period(year: 2025) }
+      let(:overridden_current_date) { start_date }
 
       let(:start_date) { contract_period_2025.started_on.to_s }
       let!(:lead_provider_2021) { FactoryBot.create(:lead_provider, name: "LP 2021") }
@@ -345,6 +349,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
       let!(:contract_period_2025) { create_contract_period(year: 2025) }
 
       let(:start_date) { contract_period_2025.started_on.to_s }
+      let(:overridden_current_date) { start_date }
       let!(:lead_provider_2025) { FactoryBot.create(:lead_provider, name: "LP 2025") }
 
       let(:previous_training_period) do
@@ -492,6 +497,7 @@ RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
 
     context "when the previous training period is school-led in a frozen contract period" do
       let!(:contract_period_2021) { create_contract_period(year: 2021, payments_frozen: true) }
+      let(:overridden_current_date) { start_date }
 
       let(:start_date) { Date.new(2025, 9, 1).to_s }
       let(:school) { FactoryBot.create(:school) }

--- a/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/registration_store/queries_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Schools::RegisterECTWizard::RegistrationStore::Queries do
   subject(:queries) { described_class.new(registration_store:) }
 
+  include_context "safe_schedules"
+
   let(:teacher) { FactoryBot.create(:teacher) }
   let(:trn) { teacher.trn }
   let(:previous_ect_period) { instance_double(ECTAtSchoolPeriod, id: 123) }

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
   end
 
   describe "#allowed?" do
-    let!(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+    let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
     context "when provider-led is chosen" do
       let!(:lead_provider) { FactoryBot.create(:lead_provider) }


### PR DESCRIPTION
### Context
Multiple failures on test suite when we entered new contract period: [link](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/26745684067/job/78820449517)

### Changes proposed in this pull request
Where possible fix the issues by using the shared context which travels to a safe date within the middle of a contract period which can help standardize the tests.

### Guidance to review
