### PR TITLE
Switch order of staging seeds so default runs first

### DIFF
--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -29,6 +29,13 @@ jobs:
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 
+    - name: Seed default data
+      shell: bash
+      run: |
+        echo "Running default seeds..."
+        make ci staging get-cluster-credentials
+        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed"
+
     - name: Seed API data
       run: |
         echo "Running API seeds..."
@@ -44,10 +51,3 @@ jobs:
             RAILS_ENV=staging \
             /usr/local/bin/bundle exec rake api_seed_data:generate
           '
-
-    - name: Seed default data
-      shell: bash
-      run: |
-        echo "Running default seeds..."
-        make ci staging get-cluster-credentials
-        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed"


### PR DESCRIPTION
The API seeds check for the existence of statements before trying to create them, so run those after the defaults (which assume an empty database).
