### PR TITLE
Add `changed_lead_provider` to `TrainingPeriod.withdrawal_reason`

### DIFF
--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -16,6 +16,7 @@ class TrainingPeriod < ApplicationRecord
     moved_school: "moved_school",
     mentor_no_longer_being_mentor: "mentor_no_longer_being_mentor",
     switched_to_school_led: "switched_to_school_led",
+    changed_lead_provider: "changed_lead_provider",
     other: "other"
   }, validate: { message: "Must be a valid withdrawal reason", allow_nil: true }, suffix: :withdrawal_reason
 

--- a/db/migrate/20260601121555_add_changed_lead_provider_to_withdrawal_reasons_enum.rb
+++ b/db/migrate/20260601121555_add_changed_lead_provider_to_withdrawal_reasons_enum.rb
@@ -1,0 +1,5 @@
+class AddChangedLeadProviderToWithdrawalReasonsEnum < ActiveRecord::Migration[8.1]
+  def change
+    add_enum_value :withdrawal_reasons, "changed_lead_provider"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_102349) do
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
-  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other"]
+  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other", "changed_lead_provider"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
   create_table "active_lead_providers", force: :cascade do |t|

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -2661,6 +2661,7 @@ components:
                   - moved-school
                   - mentor-no-longer-being-mentor
                   - switched-to-school-led
+                  - changed-lead-provider
                   - other
                   example: left-teaching-profession
                 course_identifier:
@@ -2953,6 +2954,7 @@ components:
               - moved-school
               - mentor-no-longer-being-mentor
               - switched-to-school-led
+              - changed-lead-provider
               - other
               example: moved-school
             date:

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -109,6 +109,7 @@ describe TrainingPeriod do
                              moved_school: "moved_school",
                              mentor_no_longer_being_mentor: "mentor_no_longer_being_mentor",
                              switched_to_school_led: "switched_to_school_led",
+                             changed_lead_provider: "changed_lead_provider",
                              other: "other"
                            })
                            .validating(allowing_nil: true)


### PR DESCRIPTION
### Context

Adds a new withdrawal reason to the `TrainingPeriod.withdrawal_reason` enum and the underlying database 

The enum does not appear to be surfaced anywhere other than via `.values` (so no mapping except for `dasherize`) or surfaced as a statement that training has been withdrawn by the provider without specifying the reason.

### Changes proposed in this pull request

- Adds `changed_lead_provider` to DB enum type `withdrawal_reasons` and in the `TrainingPeriod.withdrawal_reason` enum.
- Adds the new value to the spec.

### Guidance to review
