### PR TITLE
Fix contract seed data

### DIFF
--- a/db/seeds/declarations.rb
+++ b/db/seeds/declarations.rb
@@ -91,9 +91,6 @@ ITTECF_BOUNDARIES = [
 
 print_seed_info("Creating Statements")
 
-ecf_fee_structure = FactoryBot.create(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ECF_BOUNDARIES)
-ittecf_fee_structure = FactoryBot.create(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ITTECF_BOUNDARIES)
-
 ucl = LeadProvider.find_by!(name: "UCL Institute of Education")
 grain_teaching_school_hub = DeliveryPartner.find_by!(name: "Grain Teaching School Hub")
 school = FactoryBot.create(:school)
@@ -116,17 +113,22 @@ school_partnership_2025 = FactoryBot.create(:school_partnership,
   describe_school_partnership(partnership)
 end
 
+ecf_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ECF_BOUNDARIES)
 ucl_contract_2024 = FactoryBot.create(:contract,
                                       :for_ecf,
                                       active_lead_provider: school_partnership_2024.active_lead_provider,
-                                      banded_fee_structure: ecf_fee_structure).tap do |contract|
+                                      banded_fee_structure: ecf_banded_fee_structure,
+                                      flat_rate_fee_structure: nil).tap do |contract|
   describe_contract(contract)
 end
 
+ittecf_banded_fee_structure = FactoryBot.create(:contract_banded_fee_structure, :with_bands, declaration_boundaries: ITTECF_BOUNDARIES)
+ittecf_flat_rate_fee_structure = FactoryBot.create(:contract_flat_rate_fee_structure)
 ucl_contract_2025 = FactoryBot.create(:contract,
                                       :for_ittecf_ectp,
                                       active_lead_provider: school_partnership_2025.active_lead_provider,
-                                      banded_fee_structure: ittecf_fee_structure).tap do |contract|
+                                      banded_fee_structure: ittecf_banded_fee_structure,
+                                      flat_rate_fee_structure: ittecf_flat_rate_fee_structure).tap do |contract|
   describe_contract(contract)
 end
 

--- a/spec/factories/contract_factory.rb
+++ b/spec/factories/contract_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
       contract_type { "ecf" }
       ecf_contract_version { "1" }
       association :banded_fee_structure, :with_bands, factory: :contract_banded_fee_structure
-      flat_rate_fee_structure_id { nil }
+      flat_rate_fee_structure { nil }
     end
 
     trait(:for_ittecf_ectp) do


### PR DESCRIPTION
We were getting duplicate `FlatRateFeeStructure`s created due to setting the `id` to `nil` and not the association in the `Contract` factory.

We were also creating and sharing fee structures across the contracts in the declarations seeds.
