### PR TITLE
Replant the seeds on staging reseed

### DIFF
--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         echo "Running default seeds..."
         make ci staging get-cluster-credentials
-        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed"
+        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed:replant"
 
     - name: Seed API data
       run: |


### PR DESCRIPTION
At the moment it runs `db:seed` which will fail due to trying to create existing statements again. We should `replant` to wipe what's there as we run a full reseed anyway. This is consistent with how the review apps reseed.
