### PR TITLE
Fix induction tutor bug

### DIFF
--- a/app/controllers/schools/induction_tutor/confirm_existing_induction_tutor_wizard_controller.rb
+++ b/app/controllers/schools/induction_tutor/confirm_existing_induction_tutor_wizard_controller.rb
@@ -2,6 +2,17 @@ module Schools
   module InductionTutor
     class ConfirmExistingInductionTutorWizardController < SchoolsController
       include InductionTutorable
+
+      before_action :redirect_when_no_contract_period
+
+    private
+
+      def redirect_when_no_contract_period
+        return if ContractPeriod.current_or_upcoming.present?
+
+        redirect_to schools_induction_tutor_path,
+                    alert: "You cannot assign or confirm an induction tutor at this time"
+      end
     end
   end
 end

--- a/app/controllers/schools/induction_tutor/new_induction_tutor_wizard_controller.rb
+++ b/app/controllers/schools/induction_tutor/new_induction_tutor_wizard_controller.rb
@@ -2,6 +2,17 @@ module Schools
   module InductionTutor
     class NewInductionTutorWizardController < SchoolsController
       include InductionTutorable
+
+      before_action :redirect_when_no_contract_period
+
+    private
+
+      def redirect_when_no_contract_period
+        return if ContractPeriod.current_or_upcoming.present?
+
+        redirect_to schools_induction_tutor_path,
+                    alert: "You cannot assign or confirm an induction tutor at this time"
+      end
     end
   end
 end

--- a/app/wizards/schools/induction_tutor/check_answers_step.rb
+++ b/app/wizards/schools/induction_tutor/check_answers_step.rb
@@ -7,14 +7,10 @@ module Schools
 
       def save!
         ActiveRecord::Base.transaction do
-          record_event!
-
-          school.update!(
-            induction_tutor_name: store.induction_tutor_name,
-            induction_tutor_email: store.induction_tutor_email,
-            induction_tutor_last_nominated_in: closest_contract_period
-          )
-          true
+          old_induction_tutor_name = school.induction_tutor_name
+          assign_induction_tutor_attributes
+          school.save!
+          record_event!(old_induction_tutor_name)
         end
 
         send_confirmation_email!
@@ -23,19 +19,27 @@ module Schools
 
     private
 
+      def assign_induction_tutor_attributes
+        school.induction_tutor_name = store.induction_tutor_name
+        school.induction_tutor_email = store.induction_tutor_email
+        if closest_contract_period.present?
+          school.induction_tutor_last_nominated_in = closest_contract_period
+        end
+      end
+
       def send_confirmation_email!
         return unless wizard.send_confirmation_email?
 
         Schools::InductionTutorConfirmationMailer.with(school:).confirmation.deliver_later
       end
 
-      def record_event!
+      def record_event!(old_induction_tutor_name)
         Events::Record.record_school_induction_tutor_updated_event!(
           school:,
-          old_name: school.induction_tutor_name,
+          old_name: old_induction_tutor_name,
           new_name: store.induction_tutor_name,
           new_email: store.induction_tutor_email,
-          contract_period_year: closest_contract_period.year,
+          contract_period_year: closest_contract_period&.year,
           author:
         )
       end

--- a/app/wizards/schools/induction_tutor/wizard.rb
+++ b/app/wizards/schools/induction_tutor/wizard.rb
@@ -16,7 +16,9 @@ module Schools
         @school ||= School.find(school_id)
       end
 
-      def closest_contract_period = ContractPeriod.current_or_upcoming!
+      def closest_contract_period
+        @closest_contract_period ||= ContractPeriod.current_or_upcoming
+      end
 
       def send_confirmation_email?
         raise NotImplementedError, "#{self.class} must implement #send_confirmation_email?"

--- a/spec/requests/schools/induction_tutor/confirm_existing_induction_tutor_wizard_spec.rb
+++ b/spec/requests/schools/induction_tutor/confirm_existing_induction_tutor_wizard_spec.rb
@@ -3,6 +3,7 @@ describe "Schools::InductionTutor::ConfirmExistingInductionTutorWizardController
   let(:params) { {} }
   let(:induction_tutor_name) { "Old Induction Tutor Name" }
   let(:induction_tutor_email) { "old.name@gmail.com" }
+  let!(:contract_period) { FactoryBot.create(:contract_period, :current) }
 
   describe "GET #new" do
     context "when not signed in" do
@@ -41,12 +42,16 @@ describe "Schools::InductionTutor::ConfirmExistingInductionTutorWizardController
           expect(response).to have_http_status(:ok)
         end
       end
-    end
 
-    context "when visiting an invalid step" do
-      it "renders a 404 page" do
-        get path_for_step("fake-step")
-        expect(response).to have_http_status(:not_found)
+      context "when there is not a current or upcoming contract period" do
+        let!(:contract_period) { nil }
+
+        it "redirects to the schools page" do
+          get path_for_step("edit")
+
+          expect(response).to redirect_to(schools_induction_tutor_path)
+          expect(flash[:alert]).to eq("You cannot assign or confirm an induction tutor at this time")
+        end
       end
     end
   end
@@ -81,12 +86,21 @@ describe "Schools::InductionTutor::ConfirmExistingInductionTutorWizardController
         end
       end
 
+      context "when there is not a current or upcoming contract period" do
+        let!(:contract_period) { nil }
+
+        it "redirects to the schools page" do
+          post path_for_step("edit")
+
+          expect(response).to redirect_to(schools_induction_tutor_path)
+          expect(flash[:alert]).to eq("You cannot assign or confirm an induction tutor at this time")
+        end
+      end
+
       context "when the current details are confirmed" do
         let(:params) { { edit: { are_these_details_correct: "true" } } }
 
         it "sets induction_tutor_last_nominated_in but does not change the details" do
-          FactoryBot.create(:contract_period, :current)
-
           post(path_for_step("edit"), params:)
 
           expect { school.reload }.to change(school, :induction_tutor_last_nominated_in)
@@ -101,8 +115,6 @@ describe "Schools::InductionTutor::ConfirmExistingInductionTutorWizardController
         let(:params) { { edit: { are_these_details_correct: "false", induction_tutor_name: "New Name", induction_tutor_email: "new.name@gmail.com" } } }
 
         it "updates the details" do
-          FactoryBot.create(:contract_period, :current)
-
           expect { post(path_for_step("edit"), params:) }
             .not_to change(school, :induction_tutor_email)
 
@@ -130,13 +142,6 @@ describe "Schools::InductionTutor::ConfirmExistingInductionTutorWizardController
           expect(response).to have_http_status(:ok)
           expect(response.body).to include("You must change the induction tutor details or confirm they are correct")
         end
-      end
-    end
-
-    context "when visiting an invalid step" do
-      it "renders a 404 page" do
-        post path_for_step("fake-step")
-        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/schools/induction_tutor/new_induction_tutor_wizard_spec.rb
+++ b/spec/requests/schools/induction_tutor/new_induction_tutor_wizard_spec.rb
@@ -3,6 +3,7 @@ describe "Schools::InductionTutor::NewInductionTutorWizardController" do
   let(:params) { {} }
   let(:induction_tutor_name) { "Old Induction Tutor Name" }
   let(:induction_tutor_email) { "old.name@gmail.com" }
+  let!(:contract_period) { FactoryBot.create(:contract_period, :current) }
 
   describe "GET #new" do
     context "when not signed in" do
@@ -41,12 +42,16 @@ describe "Schools::InductionTutor::NewInductionTutorWizardController" do
           expect(response).to have_http_status(:ok)
         end
       end
-    end
 
-    context "when visiting an invalid step" do
-      it "renders a 404 page" do
-        get path_for_step("fake-step")
-        expect(response).to have_http_status(:not_found)
+      context "when there is not a current or upcoming contract period" do
+        let!(:contract_period) { nil }
+
+        it "redirects to the schools page" do
+          get path_for_step("edit")
+
+          expect(response).to redirect_to(schools_induction_tutor_path)
+          expect(flash[:alert]).to eq("You cannot assign or confirm an induction tutor at this time")
+        end
       end
     end
   end
@@ -85,8 +90,6 @@ describe "Schools::InductionTutor::NewInductionTutorWizardController" do
         let(:params) { { edit: { induction_tutor_name: "New Name", induction_tutor_email: "new.name@gmail.com" } } }
 
         it "updates the details" do
-          FactoryBot.create(:contract_period, :current)
-
           expect { post(path_for_step("edit"), params:) }
             .not_to change(school, :induction_tutor_email)
 
@@ -103,13 +106,17 @@ describe "Schools::InductionTutor::NewInductionTutorWizardController" do
 
           expect(response).to redirect_to(path_for_step("confirmation"))
         end
-      end
-    end
 
-    context "when visiting an invalid step" do
-      it "renders a 404 page" do
-        post path_for_step("fake-step")
-        expect(response).to have_http_status(:not_found)
+        context "when there is not a current or upcoming contract period" do
+          let!(:contract_period) { nil }
+
+          it "redirects to the schools page" do
+            post path_for_step("edit")
+
+            expect(response).to redirect_to(schools_induction_tutor_path)
+            expect(flash[:alert]).to eq("You cannot assign or confirm an induction tutor at this time")
+          end
+        end
       end
     end
   end

--- a/spec/requests/schools/induction_tutor/update_induction_tutor_wizard_spec.rb
+++ b/spec/requests/schools/induction_tutor/update_induction_tutor_wizard_spec.rb
@@ -59,13 +59,6 @@ describe "Schools::InductionTutor::UpdateInductionTutorWizardController" do
         expect(response.body).to include("second.school.tutor@example.com")
       end
     end
-
-    context "when visiting an invalid step" do
-      it "renders a 404 page" do
-        get path_for_step("fake-step")
-        expect(response).to have_http_status(:not_found)
-      end
-    end
   end
 
   describe "POST #create" do
@@ -120,13 +113,26 @@ describe "Schools::InductionTutor::UpdateInductionTutorWizardController" do
 
           expect(response).to redirect_to(path_for_step("confirmation"))
         end
-      end
-    end
 
-    context "when visiting an invalid step" do
-      it "renders a 404 page" do
-        post path_for_step("fake-step")
-        expect(response).to have_http_status(:not_found)
+        context "when there is not a current or upcoming contract period" do
+          it "updates the details" do
+            expect { post(path_for_step("edit"), params:) }
+              .not_to change(school, :induction_tutor_email)
+
+            expect(response).to redirect_to(path_for_step("check-answers"))
+
+            follow_redirect!
+
+            expect { post path_for_step("check-answers") }
+              .to change { school.reload.induction_tutor_email }
+              .to("new.name@gmail.com")
+              .and change { school.reload.induction_tutor_name }
+              .to("New Name")
+              .and(not_change { school.reload.induction_tutor_last_nominated_in })
+
+            expect(response).to redirect_to(path_for_step("confirmation"))
+          end
+        end
       end
     end
   end

--- a/spec/wizards/schools/induction_tutor/confirm_existing_induction_tutor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/induction_tutor/confirm_existing_induction_tutor_wizard/check_answers_step_spec.rb
@@ -13,8 +13,21 @@ describe Schools::InductionTutor::ConfirmExistingInductionTutorWizard::CheckAnsw
 
   let(:store)  { FactoryBot.build(:session_repository, induction_tutor_email:, induction_tutor_name:) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
-  let(:school) { FactoryBot.create(:school, :with_induction_tutor) }
-  let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:school) do
+    FactoryBot.create(
+      :school,
+      :with_induction_tutor,
+      induction_tutor_last_nominated_in: previous_contract_period
+    )
+  end
+  let!(:previous_contract_period) do
+    FactoryBot.create(
+      :contract_period,
+      :previous,
+      started_on: 1.year.ago,
+      finished_on: 2.months.ago
+    )
+  end
 
   let(:induction_tutor_email) { Faker::Internet.email }
   let(:induction_tutor_name) { Faker::Name.name }
@@ -34,25 +47,38 @@ describe Schools::InductionTutor::ConfirmExistingInductionTutorWizard::CheckAnsw
   end
 
   describe "#save!" do
-    context "when the induction tutor details are confirmed as correct" do
-      before { store.are_these_details_correct = true }
-
-      it "updates the school's induction tutor details and sets induction_tutor_last_nominated_in" do
-        current_step.save!
-
-        school.reload
-        expect(school.induction_tutor_email).to eq(induction_tutor_email)
-        expect(school.induction_tutor_name).to eq(induction_tutor_name)
-        expect(school.induction_tutor_last_nominated_in).to eq(current_contract_period)
+    context "when the current contract period is ongoing today" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 1.month.ago,
+          finished_on: 1.month.from_now
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: 2.months.from_now,
+          finished_on: 6.months.from_now
+        )
       end
 
-      it "is truthy" do
-        expect(current_step.save!).to be_truthy
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
+      it "assigns the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_last_nominated_in }
+          .from(previous_contract_period)
+          .to(current_contract_period)
       end
 
       it "records an event" do
-        freeze_time
-
         expect(Events::Record)
           .to receive(:record_school_induction_tutor_updated_event!)
           .with(
@@ -67,18 +93,145 @@ describe Schools::InductionTutor::ConfirmExistingInductionTutorWizard::CheckAnsw
         current_step.save!
       end
 
-      it "does not send a confirmation email" do
-        expect { current_step.save! }
-          .not_to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      context "when the induction tutor details are confirmed as correct" do
+        before { store.are_these_details_correct = true }
+
+        it "does not send a confirmation email" do
+          expect { current_step.save! }
+            .not_to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        end
+      end
+
+      context "when the induction tutor details are not confirmed as correct" do
+        before { store.are_these_details_correct = false }
+
+        it "sends a confirmation email" do
+          expect { current_step.save! }
+            .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        end
       end
     end
 
-    context "when the induction tutor details are not confirmed as correct" do
-      before { store.are_these_details_correct = false }
+    context "when the current contract period has finished" do
+      let!(:current_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :current,
+          started_on: 1.month.ago,
+          finished_on: 1.day.ago
+        )
+      end
+      let!(:upcoming_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :next,
+          started_on: 2.months.from_now,
+          finished_on: 6.months.from_now
+        )
+      end
 
-      it "sends a confirmation email" do
+      it "updates the induction tutor details" do
         expect { current_step.save! }
-          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
+      it "assigns the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_last_nominated_in }
+          .from(previous_contract_period)
+          .to(upcoming_contract_period)
+      end
+
+      it "records an event" do
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: upcoming_contract_period.year
+          )
+
+        current_step.save!
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      context "when the induction tutor details are confirmed as correct" do
+        before { store.are_these_details_correct = true }
+
+        it "does not send a confirmation email" do
+          expect { current_step.save! }
+            .not_to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        end
+      end
+
+      context "when the induction tutor details are not confirmed as correct" do
+        before { store.are_these_details_correct = false }
+
+        it "sends a confirmation email" do
+          expect { current_step.save! }
+            .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        end
+      end
+    end
+
+    context "when there is no current or upcoming contract period" do
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
+      it "does not assign the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .not_to(change { school.reload.induction_tutor_last_nominated_in })
+      end
+
+      it "records an event" do
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: nil
+          )
+
+        current_step.save!
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      context "when the induction tutor details are confirmed as correct" do
+        before { store.are_these_details_correct = true }
+
+        it "does not send a confirmation email" do
+          expect { current_step.save! }
+            .not_to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        end
+      end
+
+      context "when the induction tutor details are not confirmed as correct" do
+        before { store.are_these_details_correct = false }
+
+        it "sends a confirmation email" do
+          expect { current_step.save! }
+            .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        end
       end
     end
   end

--- a/spec/wizards/schools/induction_tutor/new_induction_tutor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/induction_tutor/new_induction_tutor_wizard/check_answers_step_spec.rb
@@ -14,7 +14,6 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
   let(:store)  { FactoryBot.build(:session_repository, induction_tutor_email:, induction_tutor_name:) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school, :without_induction_tutor) }
-  let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
   let(:induction_tutor_email) { Faker::Internet.email }
   let(:induction_tutor_name) { Faker::Name.name }
@@ -52,6 +51,12 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
         )
       end
 
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
       it "assigns the induction_tutor_last_nominated_in" do
         expect { current_step.save! }
           .to change { school.reload.induction_tutor_last_nominated_in }
@@ -60,8 +65,6 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
       end
 
       it "records an event" do
-        freeze_time
-
         expect(Events::Record)
           .to receive(:record_school_induction_tutor_updated_event!)
           .with(
@@ -74,6 +77,15 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
           )
 
         current_step.save!
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      it "sends a confirmation email" do
+        expect { current_step.save! }
+          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
       end
     end
 
@@ -95,6 +107,12 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
         )
       end
 
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
       it "assigns the induction_tutor_last_nominated_in" do
         expect { current_step.save! }
           .to change { school.reload.induction_tutor_last_nominated_in }
@@ -103,8 +121,6 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
       end
 
       it "records an event" do
-        freeze_time
-
         expect(Events::Record)
           .to receive(:record_school_induction_tutor_updated_event!)
           .with(
@@ -118,23 +134,52 @@ describe Schools::InductionTutor::NewInductionTutorWizard::CheckAnswersStep do
 
         current_step.save!
       end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      it "sends a confirmation email" do
+        expect { current_step.save! }
+          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+      end
     end
 
-    it "updates the school's induction tutor details" do
-      current_step.save!
+    context "when there is no current or upcoming contract period" do
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
 
-      school.reload
-      expect(school.induction_tutor_email).to eq(induction_tutor_email)
-      expect(school.induction_tutor_name).to eq(induction_tutor_name)
-    end
+      it "does not assign the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .not_to(change { school.reload.induction_tutor_last_nominated_in })
+      end
 
-    it "is truthy" do
-      expect(current_step.save!).to be_truthy
-    end
+      it "records an event" do
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: nil
+          )
 
-    it "sends a confirmation email" do
-      expect { current_step.save! }
-        .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        current_step.save!
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      it "sends a confirmation email" do
+        expect { current_step.save! }
+          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+      end
     end
   end
 end

--- a/spec/wizards/schools/induction_tutor/update_induction_tutor_wizard/check_answers_step_spec.rb
+++ b/spec/wizards/schools/induction_tutor/update_induction_tutor_wizard/check_answers_step_spec.rb
@@ -14,7 +14,6 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
   let(:store)  { FactoryBot.build(:session_repository, induction_tutor_email:, induction_tutor_name:) }
   let(:author) { FactoryBot.build(:school_user, school_urn: school.urn) }
   let(:school) { FactoryBot.create(:school, :with_unconfirmed_induction_tutor) }
-  let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
   let(:induction_tutor_email) { Faker::Internet.email }
   let(:induction_tutor_name) { Faker::Name.name }
@@ -52,6 +51,12 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
         )
       end
 
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
       it "assigns the induction_tutor_last_nominated_in" do
         expect { current_step.save! }
           .to change { school.reload.induction_tutor_last_nominated_in }
@@ -60,8 +65,6 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
       end
 
       it "records an event" do
-        freeze_time
-
         expect(Events::Record)
           .to receive(:record_school_induction_tutor_updated_event!)
           .with(
@@ -74,6 +77,15 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
           )
 
         current_step.save!
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      it "sends a confirmation email" do
+        expect { current_step.save! }
+          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
       end
     end
 
@@ -95,6 +107,12 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
         )
       end
 
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
+
       it "assigns the induction_tutor_last_nominated_in" do
         expect { current_step.save! }
           .to change { school.reload.induction_tutor_last_nominated_in }
@@ -103,8 +121,6 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
       end
 
       it "records an event" do
-        freeze_time
-
         expect(Events::Record)
           .to receive(:record_school_induction_tutor_updated_event!)
           .with(
@@ -118,23 +134,52 @@ describe Schools::InductionTutor::UpdateInductionTutorWizard::CheckAnswersStep d
 
         current_step.save!
       end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      it "sends a confirmation email" do
+        expect { current_step.save! }
+          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+      end
     end
 
-    it "updates the school's induction tutor details" do
-      current_step.save!
+    context "when there is no current or upcoming contract period" do
+      it "updates the induction tutor details" do
+        expect { current_step.save! }
+          .to change { school.reload.induction_tutor_name }.to(induction_tutor_name)
+          .and change { school.reload.induction_tutor_email }.to(induction_tutor_email)
+      end
 
-      school.reload
-      expect(school.induction_tutor_email).to eq(induction_tutor_email)
-      expect(school.induction_tutor_name).to eq(induction_tutor_name)
-    end
+      it "does not assign the induction_tutor_last_nominated_in" do
+        expect { current_step.save! }
+          .not_to(change { school.reload.induction_tutor_last_nominated_in })
+      end
 
-    it "is truthy" do
-      expect(current_step.save!).to be_truthy
-    end
+      it "records an event" do
+        expect(Events::Record)
+          .to receive(:record_school_induction_tutor_updated_event!)
+          .with(
+            author:,
+            school:,
+            old_name: school.induction_tutor_name,
+            new_name: induction_tutor_name,
+            new_email: induction_tutor_email,
+            contract_period_year: nil
+          )
 
-    it "sends a confirmation email" do
-      expect { current_step.save! }
-        .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+        current_step.save!
+      end
+
+      it "is truthy" do
+        expect(current_step.save!).to be_truthy
+      end
+
+      it "sends a confirmation email" do
+        expect { current_step.save! }
+          .to have_enqueued_mail(Schools::InductionTutorConfirmationMailer, :confirmation)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4040

### Changes proposed in this pull request

#### Handle no contract period in induction tutor wizard
Before, if there was no contract period users would run into errors if they
attempted to update induction tutor details.

We don't need to know the contract period to update a school's induction tutor
name or email address.

This reworks the `Schools::InductionTutor::CheckAnswersStep` to handle this
scenario.

Now, users can update their school's induction tutor name or email address
without running into any errors.

[Sentry]

[Sentry]: https://dfe-teacher-services.sentry.io/issues/7511558483

#### Prevent assigning induction tutor without contract period
If there is neither a current or upcoming contract period, we have no way of
knowing which contract period to assign as the school's
`induction_tutor_last_nominated_in`.

In https://github.com/DFE-Digital/register-early-career-teachers-public/commit/f6bea6b052f943dcd131a1e39f71f852a7cb9fe2, we made changes to the
`Schools::InductionTutorDetails` service so it would not redirect users to
add or confirm details if there was no relevant contract period.

This adds some redundancy in the form of explicit redirects on the respective
wizard controllers if that is the case.

Typically we wouldn't expect any users to reach these pages, but this adds a
guard-rail which will prevent errors if they did reach these pages and attempt
to complete the wizards.

### Guidance to review
