### PR TITLE
Fix flaky contract period tests

### DIFF
--- a/spec/factories/contract_period_factory.rb
+++ b/spec/factories/contract_period_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     enabled { true }
     started_on { Date.new(year, *START_MONTH_AND_DAY) }
-    finished_on { Date.new(year.next, *FINISH_MONTH_AND_DAY) }
+    finished_on { Date.new(started_on.year.next, *FINISH_MONTH_AND_DAY) }
     mentor_funding_enabled { true }
     detailed_evidence_types_enabled { true }
     uplift_fees_enabled { true }


### PR DESCRIPTION
Before, the tests for `ContractPeriod#editable?` were flaky (with seed `14606` at least).

If we're overriding the `started_on`, the `finished_on` should be defined relative to that, otherwise we could run into date validation errors.

This updates the factory to ensure that happens by default.

[Failure](https://github.com/DFE-Digital/register-early-career-teachers-public/actions/runs/26815576230/job/79056371091?pr=3002)