### PR TITLE
Investigate how to expose a better "date a transfer was created" in the API

### DIFF
--- a/app/serializers/api/teachers/school_transfer_serializer.rb
+++ b/app/serializers/api/teachers/school_transfer_serializer.rb
@@ -27,7 +27,7 @@ class API::Teachers::SchoolTransferSerializer < Blueprinter::Base
       transfer.status
     end
     field(:created_at) do |(transfer, _teacher, _options)|
-      transfer.leaving_training_period.created_at
+      transfer.leaving_training_period.transfer_initiated_at.presence || transfer.leaving_training_period.created_at
     end
     association :leaving, blueprint: TrainingPeriodSerializer do |(transfer, _teacher, _options)|
       training_period = transfer.leaving_training_period

--- a/app/services/ect_at_school_periods/finish.rb
+++ b/app/services/ect_at_school_periods/finish.rb
@@ -79,7 +79,7 @@ module ECTAtSchoolPeriods
 
       return if training_period.finished_on.present? && training_period.finished_on <= finished_on
 
-      TrainingPeriods::Finish.ect_training(author:, training_period:, ect_at_school_period:, finished_on:, record_event: record_event?).finish!
+      TrainingPeriods::Finish.ect_training(author:, training_period:, ect_at_school_period:, finished_on:, record_event: record_event?, leaving_school: true).finish!
     end
 
     def destroy_unstarted_training_periods!

--- a/app/services/mentor_at_school_periods/finish.rb
+++ b/app/services/mentor_at_school_periods/finish.rb
@@ -76,7 +76,7 @@ private
     destroy_unstarted_training_periods!(period)
 
     period.training_periods.ongoing_on(finished_on).each do |training_period|
-      TrainingPeriods::Finish.mentor_training(training_period:, mentor_at_school_period: period, finished_on:, author:).finish!
+      TrainingPeriods::Finish.mentor_training(training_period:, mentor_at_school_period: period, finished_on:, author:, leaving_school: true).finish!
     end
   end
 

--- a/app/services/training_periods/finish.rb
+++ b/app/services/training_periods/finish.rb
@@ -6,11 +6,12 @@ module TrainingPeriods
                 :ect_at_school_period,
                 :mentor_at_school_period,
                 :teacher,
-                :school
+                :school,
+                :leaving_school
 
     private_class_method :new
 
-    def initialize(training_period:, finished_on:, author:, ect_at_school_period:, mentor_at_school_period:, teacher:, school:, record_event:)
+    def initialize(training_period:, finished_on:, author:, ect_at_school_period:, mentor_at_school_period:, teacher:, school:, record_event:, leaving_school:)
       @training_period = training_period
       @finished_on = finished_on
       @author = author
@@ -21,25 +22,28 @@ module TrainingPeriods
       @teacher = teacher
       @school = school
       @record_event = record_event
+      @leaving_school = leaving_school
     end
 
-    def self.ect_training(training_period:, ect_at_school_period:, finished_on:, author:, record_event: true)
+    def self.ect_training(training_period:, ect_at_school_period:, finished_on:, author:, record_event: true, leaving_school: false)
       school = ect_at_school_period.school
       teacher = ect_at_school_period.teacher
 
-      new(mentor_at_school_period: nil, training_period:, ect_at_school_period:, teacher:, school:, finished_on:, author:, record_event:)
+      new(mentor_at_school_period: nil, training_period:, ect_at_school_period:, teacher:, school:, finished_on:, author:, record_event:, leaving_school:)
     end
 
-    def self.mentor_training(training_period:, mentor_at_school_period:, finished_on:, author:)
+    def self.mentor_training(training_period:, mentor_at_school_period:, finished_on:, author:, leaving_school: false)
       school = mentor_at_school_period.school
       teacher = mentor_at_school_period.teacher
 
-      new(ect_at_school_period: nil, training_period:, mentor_at_school_period:, teacher:, school:, finished_on:, author:, record_event: true)
+      new(ect_at_school_period: nil, training_period:, mentor_at_school_period:, teacher:, school:, finished_on:, author:, record_event: true, leaving_school:)
     end
 
     def finish!
+      transfer_initiated_at = Time.zone.now if leaving_school
+
       ActiveRecord::Base.transaction do
-        training_period.update!(finished_on:)
+        training_period.update!(finished_on:, transfer_initiated_at:)
 
         record_teacher_finishes_training_period_event!
       end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -128,6 +128,7 @@ shared:
     - withdrawal_reason
     - schedule_id
     - api_transfer_updated_at
+    - transfer_initiated_at
   :schools:
     - last_chosen_appropriate_body_id
     - last_chosen_lead_provider_id

--- a/db/migrate/20260602141805_add_transfer_initiated_at_to_training_periods.rb
+++ b/db/migrate/20260602141805_add_transfer_initiated_at_to_training_periods.rb
@@ -1,0 +1,5 @@
+class AddTransferInitiatedAtToTrainingPeriods < ActiveRecord::Migration[8.1]
+  def change
+    add_column :training_periods, :transfer_initiated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_21_133546) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_141805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_133546) do
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
-  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other"]
+  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other", "changed_lead_provider"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
   create_table "active_lead_providers", force: :cascade do |t|
@@ -911,6 +911,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_133546) do
     t.bigint "school_partnership_id"
     t.date "started_on", null: false
     t.enum "training_programme", null: false, enum_type: "training_programme"
+    t.datetime "transfer_initiated_at"
     t.datetime "updated_at", null: false
     t.enum "withdrawal_reason", enum_type: "withdrawal_reasons"
     t.datetime "withdrawn_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_02_141805) do
   create_enum "schedule_identifiers", ["ecf-extended-april", "ecf-extended-january", "ecf-extended-september", "ecf-reduced-april", "ecf-reduced-january", "ecf-reduced-september", "ecf-replacement-april", "ecf-replacement-january", "ecf-replacement-september", "ecf-standard-april", "ecf-standard-january", "ecf-standard-september"]
   create_enum "statement_statuses", ["open", "payable", "paid"]
   create_enum "training_programme", ["provider_led", "school_led"]
-  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other", "changed_lead_provider"]
+  create_enum "withdrawal_reasons", ["left_teaching_profession", "moved_school", "mentor_no_longer_being_mentor", "switched_to_school_led", "other"]
   create_enum "working_pattern", ["part_time", "full_time"]
 
   create_table "active_lead_providers", force: :cascade do |t|


### PR DESCRIPTION
### Context

Currently the `TrainingPeriod.created_at` is used in the transfers API as the date a transfer was `created_at`.
Obviously this is when the training period was added so it does not feel correct.

Looking at options to improve this so if we added a new attribute `transfer_initiated_at` to `TrainingPeriod` and recorded the date a school/admin told us that a teacher was leaving their school it would provide a more accurate value for the API.

This spike assumes that we'll only record when a ongoing `training_period` is closed by the parent `school_period`  closing.  It would be even simpler if we wanted to record this whenever a `training_period` closes (i.e. provider changes).

I've stopped short of writing specs at this stage, just to make sure this is going in the correct direction, so comments welcome please.

### Changes proposed in this pull request

- Adds a new `datetime` column to `training_periods` named `transfer_initiated_at`
- Adds extra param to the `TrainingPeriod::Finish` methods named `leaving_school` which defaults to `false`.  This is used to decide whether to set the `transfer_initiated_at` or not
- Use the `transfer_initiated_at` in the transfers serializer (defaulting to `created_at` if not present) for the `created_at` attribute


### Guidance to review
