### PR TITLE
Change status for deferred or withdrawn participants

### DIFF
--- a/app/services/api/training_periods/teacher_status.rb
+++ b/app/services/api/training_periods/teacher_status.rb
@@ -2,7 +2,7 @@ module API::TrainingPeriods
   class TeacherStatus
     attr_reader :training_period, :teacher
 
-    delegate :started_on, :finished_on, :for_ect?, :for_mentor?, to: :training_period, allow_nil: true
+    delegate :started_on, :finished_on, :for_ect?, :for_mentor?, :withdrawn_at, :deferred_at, to: :training_period, allow_nil: true
     delegate :mentor_became_ineligible_for_funding_on, to: :teacher, allow_nil: true
 
     def initialize(latest_training_period:, teacher:)
@@ -11,7 +11,9 @@ module API::TrainingPeriods
     end
 
     def status
-      if teacher_is_ect_and_completed_induction? || teacher_is_mentor_and_completed_training?
+      if withdrawn_at.present? || deferred_at.present?
+        finished_on.future? ? :leaving : :left
+      elsif teacher_is_ect_and_completed_induction? || teacher_is_mentor_and_completed_training?
         :active # longer term we would prefer something like :complete
       elsif finished_on.present?
         finished_on.future? ? :leaving : :left

--- a/db/scripts/affected_api_updated_at_teachers_with_deferred_or_withdrawn.rb
+++ b/db/scripts/affected_api_updated_at_teachers_with_deferred_or_withdrawn.rb
@@ -30,10 +30,31 @@ end
 latest_ect_ids    = Metadata::TeacherLeadProvider.where.not(latest_ect_training_period_id: nil).select(:latest_ect_training_period_id)
 latest_mentor_ids = Metadata::TeacherLeadProvider.where.not(latest_mentor_training_period_id: nil).select(:latest_mentor_training_period_id)
 
-withdrawn_ect_periods    = TrainingPeriod.where(id: latest_ect_ids).where.not(withdrawn_at: nil).includes(ect_at_school_period: :teacher)
-deferred_ect_periods     = TrainingPeriod.where(id: latest_ect_ids).where.not(deferred_at: nil).includes(ect_at_school_period: :teacher)
-withdrawn_mentor_periods = TrainingPeriod.where(id: latest_mentor_ids).where.not(withdrawn_at: nil).includes(mentor_at_school_period: :teacher)
-deferred_mentor_periods  = TrainingPeriod.where(id: latest_mentor_ids).where.not(deferred_at: nil).includes(mentor_at_school_period: :teacher)
+# Mirrors teacher_is_ect_and_completed_induction? — only ECTs who completed induction
+# on or before the training period ended were previously returning :active and are affected.
+completed_ect_induction = <<~SQL
+  (
+    teachers.trs_induction_completed_date IS NOT NULL
+    AND (training_periods.finished_on IS NULL OR teachers.trs_induction_completed_date <= training_periods.finished_on)
+  ) OR EXISTS (
+    SELECT 1 FROM induction_periods
+    WHERE induction_periods.teacher_id = teachers.id
+      AND induction_periods.finished_on IS NOT NULL
+      AND induction_periods.outcome IS NOT NULL
+      AND (training_periods.finished_on IS NULL OR induction_periods.finished_on <= training_periods.finished_on)
+  )
+SQL
+
+# Mirrors teacher_is_mentor_and_completed_training?
+completed_mentor_training = <<~SQL
+  teachers.mentor_became_ineligible_for_funding_on IS NOT NULL
+  AND (training_periods.finished_on IS NULL OR teachers.mentor_became_ineligible_for_funding_on <= training_periods.finished_on)
+SQL
+
+withdrawn_ect_periods    = TrainingPeriod.where(id: latest_ect_ids).where.not(withdrawn_at: nil).joins(ect_at_school_period: :teacher).where(completed_ect_induction).includes(ect_at_school_period: :teacher)
+deferred_ect_periods     = TrainingPeriod.where(id: latest_ect_ids).where.not(deferred_at: nil).joins(ect_at_school_period: :teacher).where(completed_ect_induction).includes(ect_at_school_period: :teacher)
+withdrawn_mentor_periods = TrainingPeriod.where(id: latest_mentor_ids).where.not(withdrawn_at: nil).joins(mentor_at_school_period: :teacher).where(completed_mentor_training).includes(mentor_at_school_period: :teacher)
+deferred_mentor_periods  = TrainingPeriod.where(id: latest_mentor_ids).where.not(deferred_at: nil).joins(mentor_at_school_period: :teacher).where(completed_mentor_training).includes(mentor_at_school_period: :teacher)
 
 $stdout.puts "Teachers affected by participant status changes:"
 $stdout.puts "Withdrawn ECT:    from a total of #{withdrawn_ect_periods.count} training_periods"

--- a/db/scripts/affected_api_updated_at_teachers_with_deferred_or_withdrawn.rb
+++ b/db/scripts/affected_api_updated_at_teachers_with_deferred_or_withdrawn.rb
@@ -1,0 +1,59 @@
+# Identifies teachers whose participant_status changes from :active to :left/:leaving
+# due to the fix that ensures withdrawal/deferral takes precedence.
+#
+# Run after deploying the teacher_status fix. Touching api_updated_at notifies
+# lead providers that the participant_status field has changed.
+
+def find_affected(periods)
+  left_ids    = []
+  leaving_ids = []
+
+  periods.find_each(batch_size: 1000) do |training_period|
+    teacher = training_period.teacher
+    status = API::TrainingPeriods::TeacherStatus.new(latest_training_period: training_period, teacher:).status
+
+    if status == :left
+      $stdout.print "."
+      left_ids << training_period.teacher_id
+    end
+    if status == :leaving
+      $stdout.print "."
+      leaving_ids << training_period.teacher_id
+    end
+  end
+
+  [left_ids, leaving_ids]
+end
+
+# Only consider the latest training period per teacher per lead provider,
+# as that's what TeacherStatus is evaluated against in the API.
+latest_ect_ids    = Metadata::TeacherLeadProvider.where.not(latest_ect_training_period_id: nil).select(:latest_ect_training_period_id)
+latest_mentor_ids = Metadata::TeacherLeadProvider.where.not(latest_mentor_training_period_id: nil).select(:latest_mentor_training_period_id)
+
+withdrawn_ect_periods    = TrainingPeriod.where(id: latest_ect_ids).where.not(withdrawn_at: nil).includes(ect_at_school_period: :teacher)
+deferred_ect_periods     = TrainingPeriod.where(id: latest_ect_ids).where.not(deferred_at: nil).includes(ect_at_school_period: :teacher)
+withdrawn_mentor_periods = TrainingPeriod.where(id: latest_mentor_ids).where.not(withdrawn_at: nil).includes(mentor_at_school_period: :teacher)
+deferred_mentor_periods  = TrainingPeriod.where(id: latest_mentor_ids).where.not(deferred_at: nil).includes(mentor_at_school_period: :teacher)
+
+$stdout.puts "Teachers affected by participant status changes:"
+$stdout.puts "Withdrawn ECT:    from a total of #{withdrawn_ect_periods.count} training_periods"
+$stdout.puts "Deferred ECT:     from a total of #{deferred_ect_periods.count} training_periods"
+$stdout.puts "Withdrawn mentor: from a total of #{withdrawn_mentor_periods.count} training_periods"
+$stdout.puts "Deferred mentor:  from a total of #{deferred_mentor_periods.count} training_periods"
+
+withdrawn_ect_left,    withdrawn_ect_leaving    = find_affected(withdrawn_ect_periods)
+deferred_ect_left,     deferred_ect_leaving     = find_affected(deferred_ect_periods)
+withdrawn_mentor_left, withdrawn_mentor_leaving = find_affected(withdrawn_mentor_periods)
+deferred_mentor_left,  deferred_mentor_leaving  = find_affected(deferred_mentor_periods)
+
+$stdout.puts "- ECT withdrawn    — left: #{withdrawn_ect_left.count}, leaving: #{withdrawn_ect_leaving.count}"
+$stdout.puts "- ECT deferred     — left: #{deferred_ect_left.count}, leaving: #{deferred_ect_leaving.count}"
+$stdout.puts "- Mentor withdrawn — left: #{withdrawn_mentor_left.count}, leaving: #{withdrawn_mentor_leaving.count}"
+$stdout.puts "- Mentor deferred  — left: #{deferred_mentor_left.count}, leaving: #{deferred_mentor_leaving.count}"
+
+teacher_ids = (withdrawn_ect_left + withdrawn_ect_leaving + deferred_ect_left + deferred_ect_leaving +
+               withdrawn_mentor_left + withdrawn_mentor_leaving + deferred_mentor_left + deferred_mentor_leaving).uniq
+
+Teacher.where(id: teacher_ids).update_all(api_updated_at: Time.current, updated_at: Time.current)
+$stdout.puts ""
+$stdout.puts "Done — a total of #{teacher_ids.count} teachers have been effected"

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -1283,23 +1283,23 @@ describe_training_period(
 # Deferred + leaving (finished_on future) — picked up by affected_api_updated_at script
 sal_deferred = Teacher.find_by!(trn: "0000042")
 sal_deferred_at_school = FactoryBot.create(:ect_at_school_period, teacher: sal_deferred, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: nil)
-FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: sal_deferred_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2026, 12, 31), deferred_at: Date.new(2023, 3, 15), deferral_reason: "career_break")
+FactoryBot.create(:training_period, :for_ect, ect_at_school_period: sal_deferred_at_school, school_partnership: ambition_artisan_abbey_grove_2022, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2026, 12, 31), deferred_at: Date.new(2023, 3, 15), deferral_reason: "career_break")
 FactoryBot.create(:induction_period, :pass, teacher: sal_deferred, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
 
 # Deferred + left (finished_on past) — picked up by affected_api_updated_at script
 pat_deferred = Teacher.find_by!(trn: "0000043")
 pat_deferred_at_school = FactoryBot.create(:ect_at_school_period, teacher: pat_deferred, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31))
-FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: pat_deferred_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31), deferred_at: Date.new(2023, 3, 15), deferral_reason: "career_break")
+FactoryBot.create(:training_period, :for_ect, ect_at_school_period: pat_deferred_at_school, school_partnership: ambition_artisan_abbey_grove_2022, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31), deferred_at: Date.new(2023, 3, 15), deferral_reason: "career_break")
 FactoryBot.create(:induction_period, :pass, teacher: pat_deferred, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
 
 # Withdrawn + leaving (finished_on future) — picked up by affected_api_updated_at script
 sal_withdrawn = Teacher.find_by!(trn: "0000044")
 sal_withdrawn_at_school = FactoryBot.create(:ect_at_school_period, teacher: sal_withdrawn, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: 3.days.from_now.to_date)
-FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: sal_withdrawn_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: 3.days.from_now.to_date, withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
+FactoryBot.create(:training_period, :for_ect, ect_at_school_period: sal_withdrawn_at_school, school_partnership: ambition_artisan_abbey_grove_2022, started_on: Date.new(2022, 9, 1), finished_on: 3.days.from_now.to_date, withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
 FactoryBot.create(:induction_period, :pass, teacher: sal_withdrawn, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
 
 # Withdrawn + left (finished_on past) — picked up by affected_api_updated_at script
 pat_withdrawn = Teacher.find_by!(trn: "0000045")
 pat_withdrawn_at_school = FactoryBot.create(:ect_at_school_period, teacher: pat_withdrawn, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31))
-FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: pat_withdrawn_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31), withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
+FactoryBot.create(:training_period, :for_ect, ect_at_school_period: pat_withdrawn_at_school, school_partnership: ambition_artisan_abbey_grove_2022, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31), withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
 FactoryBot.create(:induction_period, :pass, teacher: pat_withdrawn, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -1279,3 +1279,27 @@ describe_training_period(
     finished_on: nil
   )
 )
+
+# Deferred + leaving (finished_on future) — picked up by affected_api_updated_at script
+sal_deferred = Teacher.find_by!(trn: "0000042")
+sal_deferred_at_school = FactoryBot.create(:ect_at_school_period, teacher: sal_deferred, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: nil)
+FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: sal_deferred_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2026, 12, 31), deferred_at: Date.new(2023, 3, 15), deferral_reason: "career_break")
+FactoryBot.create(:induction_period, :pass, teacher: sal_deferred, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
+
+# Deferred + left (finished_on past) — picked up by affected_api_updated_at script
+pat_deferred = Teacher.find_by!(trn: "0000043")
+pat_deferred_at_school = FactoryBot.create(:ect_at_school_period, teacher: pat_deferred, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31))
+FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: pat_deferred_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31), deferred_at: Date.new(2023, 3, 15), deferral_reason: "career_break")
+FactoryBot.create(:induction_period, :pass, teacher: pat_deferred, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
+
+# Withdrawn + leaving (finished_on future) — picked up by affected_api_updated_at script
+sal_withdrawn = Teacher.find_by!(trn: "0000044")
+sal_withdrawn_at_school = FactoryBot.create(:ect_at_school_period, teacher: sal_withdrawn, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: nil)
+FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: sal_withdrawn_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2026, 12, 31), withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
+FactoryBot.create(:induction_period, :pass, teacher: sal_withdrawn, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
+
+# Withdrawn + left (finished_on past) — picked up by affected_api_updated_at script
+pat_withdrawn = Teacher.find_by!(trn: "0000045")
+pat_withdrawn_at_school = FactoryBot.create(:ect_at_school_period, teacher: pat_withdrawn, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31))
+FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: pat_withdrawn_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 7, 31), withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
+FactoryBot.create(:induction_period, :pass, teacher: pat_withdrawn, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)

--- a/db/seeds/teacher_histories.rb
+++ b/db/seeds/teacher_histories.rb
@@ -1294,8 +1294,8 @@ FactoryBot.create(:induction_period, :pass, teacher: pat_deferred, appropriate_b
 
 # Withdrawn + leaving (finished_on future) — picked up by affected_api_updated_at script
 sal_withdrawn = Teacher.find_by!(trn: "0000044")
-sal_withdrawn_at_school = FactoryBot.create(:ect_at_school_period, teacher: sal_withdrawn, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: nil)
-FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: sal_withdrawn_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2026, 12, 31), withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
+sal_withdrawn_at_school = FactoryBot.create(:ect_at_school_period, teacher: sal_withdrawn, school: abbey_grove_school, started_on: Date.new(2022, 9, 1), finished_on: 3.days.from_now.to_date)
+FactoryBot.create(:training_period, :for_ect, :school_led, ect_at_school_period: sal_withdrawn_at_school, school_partnership: nil, expression_of_interest: nil, started_on: Date.new(2022, 9, 1), finished_on: 3.days.from_now.to_date, withdrawn_at: Date.new(2023, 3, 15), withdrawal_reason: "left_teaching_profession")
 FactoryBot.create(:induction_period, :pass, teacher: sal_withdrawn, appropriate_body_period: south_yorkshire_studio_hub, started_on: Date.new(2022, 9, 1), finished_on: Date.new(2024, 1, 31), number_of_terms: 6)
 
 # Withdrawn + left (finished_on past) — picked up by affected_api_updated_at script

--- a/db/seeds/teachers.rb
+++ b/db/seeds/teachers.rb
@@ -79,6 +79,10 @@ teachers = [
   { trn: "0000039", trs_first_name: "Barbara", trs_last_name: "Winsor", trs_induction_status: "Passed", trs_induction_completed_date: Date.new(2023, 6, 30) },
   { trn: "0000040", trs_first_name: "Kenneth", trs_last_name: "Williams", trs_induction_status: "Passed", trs_induction_completed_date: Date.new(2024, 6, 30) },
   { trn: "0000041", trs_first_name: "Dave", trs_last_name: "Seville", trs_induction_status: "InProgress" },
+  { trn: "0000042", trs_first_name: "Sal", trs_last_name: "Deferred", trs_induction_status: "Passed", trs_induction_completed_date: Date.new(2024, 1, 31) },
+  { trn: "0000043", trs_first_name: "Pat", trs_last_name: "Deferred", trs_induction_status: "Passed", trs_induction_completed_date: Date.new(2024, 1, 31) },
+  { trn: "0000044", trs_first_name: "Sal", trs_last_name: "Withdrawn", trs_induction_status: "Passed", trs_induction_completed_date: Date.new(2024, 1, 31) },
+  { trn: "0000045", trs_first_name: "Pat", trs_last_name: "Withdrawn", trs_induction_status: "Passed", trs_induction_completed_date: Date.new(2024, 1, 31) },
 ]
 
 teachers.each do |attrs|

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -44,14 +44,11 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
 
         it { is_expected.to eq(:left) }
 
-        context "when completed induction" do
-          before do
-            FactoryBot.create(:induction_period, :pass, teacher:,
-                                                        started_on: training_period.started_on,
-                                                        finished_on: training_period.finished_on)
-          end
+        context "when finished in the future" do
+          let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, finished_on: 1.month.from_now) }
+          let(:training_period) { FactoryBot.create(:training_period, :for_ect, :withdrawn, ect_at_school_period:, finished_on: 1.month.from_now) }
 
-          it { is_expected.to eq(:left) }
+          it { is_expected.to eq(:leaving) }
         end
       end
 
@@ -60,15 +57,11 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
 
         it { is_expected.to eq(:left) }
 
-        context "when teacher becomes ineligible before period has finished" do
-          before do
-            teacher.update!(
-              mentor_became_ineligible_for_funding_on: training_period.finished_on - 1.week,
-              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
-            )
-          end
+        context "when finished in the future" do
+          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, finished_on: 1.month.from_now) }
+          let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :withdrawn, mentor_at_school_period:, finished_on: 1.month.from_now) }
 
-          it { is_expected.to eq(:left) }
+          it { is_expected.to eq(:leaving) }
         end
       end
     end
@@ -79,14 +72,11 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
 
         it { is_expected.to eq(:left) }
 
-        context "when completed induction" do
-          before do
-            FactoryBot.create(:induction_period, :pass, teacher:,
-                                                        started_on: training_period.started_on,
-                                                        finished_on: training_period.finished_on)
-          end
+        context "when finished in the future" do
+          let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, finished_on: 1.month.from_now) }
+          let(:training_period) { FactoryBot.create(:training_period, :for_ect, :deferred, ect_at_school_period:, finished_on: 1.month.from_now) }
 
-          it { is_expected.to eq(:left) }
+          it { is_expected.to eq(:leaving) }
         end
       end
 
@@ -95,15 +85,11 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
 
         it { is_expected.to eq(:left) }
 
-        context "when teacher becomes ineligible before period has finished" do
-          before do
-            teacher.update!(
-              mentor_became_ineligible_for_funding_on: training_period.finished_on - 1.week,
-              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
-            )
-          end
+        context "when finished in the future" do
+          let(:mentor_at_school_period) { FactoryBot.create(:mentor_at_school_period, finished_on: 1.month.from_now) }
+          let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :deferred, mentor_at_school_period:, finished_on: 1.month.from_now) }
 
-          it { is_expected.to eq(:left) }
+          it { is_expected.to eq(:leaving) }
         end
       end
     end

--- a/spec/services/api/training_periods/teacher_status_spec.rb
+++ b/spec/services/api/training_periods/teacher_status_spec.rb
@@ -38,6 +38,76 @@ RSpec.describe API::TrainingPeriods::TeacherStatus do
       end
     end
 
+    context "when training period is withdrawn" do
+      context "when the teacher is acting as an ECT for this training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :withdrawn) }
+
+        it { is_expected.to eq(:left) }
+
+        context "when completed induction" do
+          before do
+            FactoryBot.create(:induction_period, :pass, teacher:,
+                                                        started_on: training_period.started_on,
+                                                        finished_on: training_period.finished_on)
+          end
+
+          it { is_expected.to eq(:left) }
+        end
+      end
+
+      context "when the teacher is acting as a mentor for this training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :withdrawn) }
+
+        it { is_expected.to eq(:left) }
+
+        context "when teacher becomes ineligible before period has finished" do
+          before do
+            teacher.update!(
+              mentor_became_ineligible_for_funding_on: training_period.finished_on - 1.week,
+              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
+            )
+          end
+
+          it { is_expected.to eq(:left) }
+        end
+      end
+    end
+
+    context "when training period is deferred" do
+      context "when the teacher is acting as an ECT for this training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_ect, :deferred) }
+
+        it { is_expected.to eq(:left) }
+
+        context "when completed induction" do
+          before do
+            FactoryBot.create(:induction_period, :pass, teacher:,
+                                                        started_on: training_period.started_on,
+                                                        finished_on: training_period.finished_on)
+          end
+
+          it { is_expected.to eq(:left) }
+        end
+      end
+
+      context "when the teacher is acting as a mentor for this training period" do
+        let(:training_period) { FactoryBot.create(:training_period, :for_mentor, :deferred) }
+
+        it { is_expected.to eq(:left) }
+
+        context "when teacher becomes ineligible before period has finished" do
+          before do
+            teacher.update!(
+              mentor_became_ineligible_for_funding_on: training_period.finished_on - 1.week,
+              mentor_became_ineligible_for_funding_reason: "completed_declaration_received"
+            )
+          end
+
+          it { is_expected.to eq(:left) }
+        end
+      end
+    end
+
     context "when training period has already finished" do
       context "when the teacher is acting as an ECT for this training period" do
         let(:training_period) { FactoryBot.create(:training_period, :for_ect, :finished) }


### PR DESCRIPTION
### Context

Resolves https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/4010

Changes status of participants who are deferred or withdrawn to left or leaving.

### Changes proposed in this pull request

Change participant status when a teacher has withdrawn or has been deferred in line with the requirement.

Script to identify and update the `api_updated_at` for these Teachers.

### Guidance to review

Moderately simple change, the script is the most complex bit here. There is a lot of data so we process in batches, try to limit N+1s, and do the final update_at rather than updating each.

#### Results of the script run on snapshot as at 8 June 2026:
```
Teachers affected by participant status changes:
Withdrawn ECT:    from a total of 2095 training_periods
Deferred ECT:     from a total of 178 training_periods
Withdrawn mentor: from a total of 4286 training_periods
Deferred mentor:  from a total of 871 training_periods
....
- ECT withdrawn    — left: 2095, leaving: 0
- ECT deferred     — left: 178, leaving: 0
- Mentor withdrawn — left: 4286, leaving: 0
- Mentor deferred  — left: 871, leaving: 0

Done — a total of 7424 teachers have been effected
```