### PR TITLE
Remove metadata from DP query and serializer

### DIFF
--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -4,6 +4,7 @@ class DeliveryPartner < ApplicationRecord
 
   # Associations
   has_many :lead_provider_delivery_partnerships, inverse_of: :delivery_partner
+  has_many :active_lead_providers, through: :lead_provider_delivery_partnerships
   has_many :school_partnerships, through: :lead_provider_delivery_partnerships
   has_many :events
   has_many :lead_provider_metadata, class_name: "Metadata::DeliveryPartnerLeadProvider"

--- a/app/serializers/api/delivery_partner_serializer.rb
+++ b/app/serializers/api/delivery_partner_serializer.rb
@@ -6,13 +6,10 @@ class API::DeliveryPartnerSerializer < Blueprinter::Base
     field :created_at
     field(:api_updated_at, name: :updated_at)
     field(:cohort) do |delivery_partner, options|
-      lead_provider_metadata(delivery_partner:, options:).contract_period_years.map(&:to_s)
-    end
-
-    class << self
-      def lead_provider_metadata(delivery_partner:, options:)
-        delivery_partner.lead_provider_metadata.select { it.lead_provider_id == options[:lead_provider_id] }.sole
-      end
+      delivery_partner
+        .active_lead_providers
+        .select { it.lead_provider_id == options[:lead_provider_id] }
+        .map { it.contract_period_year.to_s }
     end
   end
 

--- a/app/services/api/delivery_partners/query.rb
+++ b/app/services/api/delivery_partners/query.rb
@@ -32,25 +32,17 @@ module API::DeliveryPartners
   private
 
     def preload_associations(results)
-      preloaded_results = results
+      results
         .strict_loading
-        .includes(:lead_provider_metadata)
-
-      unless ignore?(filter: lead_provider_id)
-        preloaded_results = preloaded_results
-          .references(:metadata_delivery_partners_lead_providers)
-          .where(metadata_delivery_partners_lead_providers: { lead_provider_id: })
-      end
-
-      preloaded_results
+        .includes(:active_lead_providers)
     end
 
     def where_lead_provider_is(lead_provider_id)
       return if ignore?(filter: lead_provider_id)
 
       delivery_partners_with_lead_provider = DeliveryPartner
-        .joins(lead_provider_delivery_partnerships: :active_lead_provider)
-        .where(active_lead_provider: { lead_provider_id: })
+        .joins(:active_lead_providers)
+        .where(active_lead_providers: { lead_provider_id: })
 
       scope.merge!(delivery_partners_with_lead_provider)
     end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -9,6 +9,7 @@ describe DeliveryPartner do
   describe "associations" do
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:lead_provider_delivery_partnerships).inverse_of(:delivery_partner) }
+    it { is_expected.to have_many(:active_lead_providers).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:school_partnerships).through(:lead_provider_delivery_partnerships) }
     it { is_expected.to have_many(:lead_provider_metadata).class_name("Metadata::DeliveryPartnerLeadProvider") }
   end

--- a/spec/serializers/api/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/delivery_partner_serializer_spec.rb
@@ -1,11 +1,13 @@
-describe API::DeliveryPartnerSerializer, :with_metadata, type: :serializer do
+describe API::DeliveryPartnerSerializer, type: :serializer do
   subject(:response) do
     options = { lead_provider_id: lead_provider.id }
     JSON.parse(described_class.render(delivery_partner, **options))
   end
 
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
-  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:) }
+  let(:contract_period) { FactoryBot.create(:contract_period, :current) }
+  let(:previous_contract_period) { FactoryBot.create(:contract_period, :previous) }
+  let(:active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period:) }
   let(:lead_provider_delivery_partnership) { FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider:) }
   let(:delivery_partner) do
     lead_provider_delivery_partnership.delivery_partner.tap do |dp|
@@ -17,8 +19,10 @@ describe API::DeliveryPartnerSerializer, :with_metadata, type: :serializer do
   let(:api_updated_at) { Time.utc(2023, 7, 2, 12, 0, 0) }
 
   before do
-    # Ensure other metadata exists for another lead provider.
-    FactoryBot.create(:lead_provider)
+    # Ensure a delivery partnership exists with a different lead provider
+    # and contract period, to ensure it is not included in the `cohort` attribute.
+    other_active_lead_provider = FactoryBot.create(:active_lead_provider, contract_period: previous_contract_period)
+    FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: other_active_lead_provider, delivery_partner:)
   end
 
   describe "core attributes" do
@@ -33,9 +37,21 @@ describe API::DeliveryPartnerSerializer, :with_metadata, type: :serializer do
 
     it "serializes correctly" do
       expect(attributes["name"]).to eq(delivery_partner.name)
-      expect(attributes["cohort"]).to contain_exactly(active_lead_provider.contract_period_year.to_s)
+      expect(attributes["cohort"]).to contain_exactly(contract_period.year.to_s)
       expect(attributes["created_at"]).to eq(delivery_partner.created_at.utc.rfc3339)
       expect(attributes["updated_at"]).to eq(delivery_partner.api_updated_at.utc.rfc3339)
+    end
+
+    context "when there are multiple delivery partnerships for the same lead provider" do
+      let(:other_active_lead_provider) { FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period) }
+
+      before do
+        FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: other_active_lead_provider, delivery_partner:)
+      end
+
+      it "includes the contract period year only once in the cohort attribute" do
+        expect(attributes["cohort"]).to contain_exactly(contract_period.year.to_s, previous_contract_period.year.to_s)
+      end
     end
   end
 end

--- a/spec/services/api/delivery_partners/query_spec.rb
+++ b/spec/services/api/delivery_partners/query_spec.rb
@@ -5,31 +5,12 @@ RSpec.describe API::DeliveryPartners::Query do
 
   describe "preloading relationships" do
     shared_examples "preloaded associations" do
-      it { expect(result.association(:lead_provider_metadata)).to be_loaded }
-
-      context "when a lead_provider_id is specified" do
-        let(:lead_provider_id) { lead_provider.id }
-
-        before { FactoryBot.create(:lead_provider_delivery_partnership, lead_provider:, delivery_partner:) }
-
-        it "only contains relevant metadata" do
-          expect(result.lead_provider_metadata).to contain_exactly(lead_provider_metadata)
-        end
-      end
+      it { expect(result.association(:active_lead_providers)).to be_loaded }
     end
 
-    let(:lead_provider_id) { :ignore }
-    let(:instance) { described_class.new(lead_provider_id:) }
-
+    let(:instance) { described_class.new }
     let!(:delivery_partner) { FactoryBot.create(:delivery_partner) }
     let(:lead_provider) { FactoryBot.create(:lead_provider) }
-    let!(:lead_provider_metadata) { FactoryBot.create(:delivery_partner_lead_provider_metadata, delivery_partner:, lead_provider:) }
-
-    before do
-      # Ensure other metadata exists.
-      other_lead_provider = FactoryBot.create(:lead_provider)
-      FactoryBot.create(:delivery_partner_lead_provider_metadata, delivery_partner:, lead_provider: other_lead_provider)
-    end
 
     describe "#delivery_partners" do
       subject(:result) { instance.delivery_partners.first }


### PR DESCRIPTION
### Context

The metadata isn't really saving us much for delivery partners; if anything it adds complexity and is marginally more performant.

### Changes proposed in this pull request

Remove references to metadata in the query and serializer, instead pulling in the `active_lead_providers` in the query and extracting the contract periods from there in the serializer to populate `cohort`.

### Guidance to review

There will be a follow on PR to remove the metadata model and handler (#3022).

Some back of the napkin testing against snapshot:

| Lead Provider | Query Match | Serialize Match | Old (ms) | New (ms) |
|---------------|-------------|-----------------|----------|----------|
| UCL Institute of Education | true | true | 67.532 | 90.282 |
| Capita | true | true | 27.728 | 84.618 |
| National Institute of Teaching | true | true | 29.518 | 80.358 |
| Teach First | true | true | 76.501 | 81.149 |
| Education Development Trust | true | true | 75.516 | 80.172 |
| Ambition Institute | true | true | 76.630 | 32.025 |
| Best Practice Network | true | true | 74.676 | 33.696 |