### PR TITLE
Care less about 31st May in tests

### DIFF
--- a/spec/models/contract_period_spec.rb
+++ b/spec/models/contract_period_spec.rb
@@ -63,34 +63,34 @@ describe ContractPeriod do
   end
 
   describe ".current" do
-    context "when there is a current contract period" do
-      let!(:period) do
-        FactoryBot.create(:contract_period, started_on: Date.new(2024, 6, 1), finished_on: Date.new(2025, 5, 31))
-      end
+    subject(:current) { described_class.current }
 
-      it "returns the current contract period" do
-        FactoryBot.create(:contract_period, started_on: Date.new(2023, 6, 1), finished_on: Date.new(2024, 5, 31))
-
-        travel_to Date.new(2024, 6, 1) do
-          expect(ContractPeriod.current).to eq(period)
-        end
-      end
-
-      context "when we are on the last day of the contract period" do
-        it "returns the current contract period" do
-          travel_to period.finished_on do
-            expect(ContractPeriod.current).to eq(period)
-          end
-        end
-      end
+    let(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
     end
 
-    context "when there is no current contract period" do
-      it "returns nil" do
-        travel_to Date.new(2025, 6, 1) do
-          expect(ContractPeriod.current).to be_nil
-        end
-      end
+    context "when we are in the current contract period" do
+      before { travel_to current_contract_period.started_on }
+
+      it { is_expected.to eq(current_contract_period) }
+    end
+
+    context "when we are on the last day of the current contract period" do
+      before { travel_to current_contract_period.finished_on }
+
+      it { is_expected.to eq(current_contract_period) }
+    end
+
+    context "when we are before the current contract period" do
+      before { travel_to current_contract_period.started_on.prev_day }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when we are past the current contract period" do
+      before { travel_to current_contract_period.finished_on.next_day }
+
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/requests/schools/registration_window_banner_spec.rb
+++ b/spec/requests/schools/registration_window_banner_spec.rb
@@ -1,12 +1,10 @@
 RSpec.describe "Schools registration window banner" do
   let(:school) { FactoryBot.create(:school) }
 
-  before do
-    allow(Schools::RegistrationWindow).to receive(:closed?).and_call_original
-  end
-
-  context "between 1-14 June 2026" do
-    before { travel_to Date.new(2026, 6, 7) }
+  context "when the registration window is closed" do
+    before do
+      allow(Schools::RegistrationWindow).to receive(:closed?).and_return(true)
+    end
 
     it "displays for school users" do
       sign_in_as(:school_user, school:)
@@ -22,25 +20,13 @@ RSpec.describe "Schools registration window banner" do
     end
   end
 
-  context "before 1 June 2026" do
+  context "when the registration window is open" do
     before do
-      travel_to Date.new(2026, 5, 31)
-      sign_in_as(:school_user, school:)
+      allow(Schools::RegistrationWindow).to receive(:closed?).and_return(false)
     end
 
     it "does not display on schools pages" do
-      get "/school/home/ects"
-      expect(response.body).not_to include("Registration not currently open")
-    end
-  end
-
-  context "from 15 June 2026" do
-    before do
-      travel_to Date.new(2026, 6, 15)
       sign_in_as(:school_user, school:)
-    end
-
-    it "does not display on schools pages" do
       get "/school/home/ects"
       expect(response.body).not_to include("Registration not currently open")
     end

--- a/spec/services/ect_at_school_periods/switch_training_spec.rb
+++ b/spec/services/ect_at_school_periods/switch_training_spec.rb
@@ -279,12 +279,8 @@ module ECTAtSchoolPeriods
             expect(new_training_period.expression_of_interest).to be_nil
           end
 
-          context "when the switch happens on the last day of the current contract period" do
-            around do |example|
-              travel_to(Date.new(2025, 5, 31)) do
-                example.run
-              end
-            end
+          context "when the switch happens on the last day of the contract period" do
+            before { travel_to contract_period.finished_on }
 
             it "finds the existing partnership and assigns it" do
               SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
@@ -314,12 +310,8 @@ module ECTAtSchoolPeriods
             expect(new_training_period.expression_of_interest).to eq(active_lead_provider)
           end
 
-          context "when the switch happens on the last day of the current contract period" do
-            around do |example|
-              travel_to(Date.new(2025, 5, 31)) do
-                example.run
-              end
-            end
+          context "when the switch happens on the last day of the contract period" do
+            before { travel_to contract_period.finished_on }
 
             it "finds the active_lead_provider with the correct contract period" do
               SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
@@ -361,8 +353,10 @@ module ECTAtSchoolPeriods
         end
 
         context "when the switch happens before the ECT has started" do
-          let(:ect_at_school_period) do
-            FactoryBot.create(:ect_at_school_period, :not_started_yet)
+          before { travel_to current_contract_period.started_on }
+
+          let!(:current_contract_period) do
+            FactoryBot.create(:contract_period, :current, :with_schedules)
           end
 
           let!(:training_period) do
@@ -377,10 +371,12 @@ module ECTAtSchoolPeriods
           end
 
           context "when the ECT starts in the current contract period" do
-            around do |example|
-              travel_to(Date.new(2025, 11, 15)) do
-                example.run
-              end
+            let(:ect_at_school_period) do
+              FactoryBot.create(
+                :ect_at_school_period,
+                :not_started_yet,
+                started_on: current_contract_period.started_on.next_month
+              )
             end
 
             it "removes the existing training period" do
@@ -400,23 +396,23 @@ module ECTAtSchoolPeriods
           end
 
           context "when the ect starts in the next contract period" do
-            around do |example|
-              travel_to(Date.new(2026, 5, 31)) do
-                example.run
-              end
+            let(:upcoming_contract_period) do
+              FactoryBot.create(:contract_period, :next, :with_schedules)
             end
 
             let(:ect_at_school_period) do
-              FactoryBot.create(:ect_at_school_period, :ongoing, started_on: 2.weeks.from_now)
+              FactoryBot.create(
+                :ect_at_school_period,
+                :ongoing,
+                started_on: upcoming_contract_period.started_on
+              )
             end
-
-            let(:future_contract_period) { FactoryBot.create(:contract_period, :with_schedules, year: 2026) }
 
             let!(:future_active_lead_provider) do
               FactoryBot.create(
                 :active_lead_provider,
                 lead_provider:,
-                contract_period: future_contract_period
+                contract_period: upcoming_contract_period
               )
             end
 
@@ -881,12 +877,20 @@ module ECTAtSchoolPeriods
                 )
             end
 
-            context "when the switch happens on the last day of the current contract period" do
-              around do |example|
-                travel_to(Date.new(2025, 5, 31)) do
-                  example.run
-                end
+            context "when the switch happens on the last day of the contract period" do
+              let(:mentorship_period) do
+                FactoryBot.create(
+                  :mentorship_period,
+                  # We need there to be a `current_or_next_mentorship_period`
+                  # otherwise a new provider-led mentor training period
+                  # won't be created
+                  finished_on: contract_period.finished_on.next_week,
+                  mentee: ect_at_school_period,
+                  mentor: mentor_at_school_period
+                )
               end
+
+              before { travel_to contract_period.finished_on }
 
               it "finds the active lead provider with the correct contract period" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)
@@ -924,12 +928,20 @@ module ECTAtSchoolPeriods
               expect(new_training_period.schedule.contract_period.year).to eq(contract_period.year)
             end
 
-            context "when the switch happens on the last day of the current contract period" do
-              around do |example|
-                travel_to(Date.new(2025, 5, 31)) do
-                  example.run
-                end
+            context "when the switch happens on the last day of the contract period" do
+              let(:mentorship_period) do
+                FactoryBot.create(
+                  :mentorship_period,
+                  # We need there to be a `current_or_next_mentorship_period`
+                  # otherwise a new provider-led mentor training period
+                  # won't be created
+                  finished_on: contract_period.finished_on.next_week,
+                  mentee: ect_at_school_period,
+                  mentor: mentor_at_school_period
+                )
               end
+
+              before { travel_to contract_period.finished_on }
 
               it "finds the existing lead provider" do
                 SwitchTraining.to_provider_led(ect_at_school_period, lead_provider:, author:)

--- a/spec/services/schedules/find_spec.rb
+++ b/spec/services/schedules/find_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Schedules::Find do
             end
 
             context "when the start date is the last day of the contract period" do
-              let(:started_on) { Date.new(year, 5, 31) }
+              let(:started_on) { contract_period.finished_on }
 
               before { travel_to started_on }
               # This is only correct if `latest_started_date` in `Schedules::Find`

--- a/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/ects/change_lead_provider_wizard/edit_step_spec.rb
@@ -96,58 +96,84 @@ describe Schools::ECTs::ChangeLeadProviderWizard::EditStep do
   end
 
   describe "#lead_providers_for_select" do
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, school:, started_on:) }
-    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
+    subject(:lead_providers_for_select) { current_step.lead_providers_for_select }
+
+    let(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+    let(:upcoming_contract_period) do
+      FactoryBot.create(:contract_period, :next)
+    end
+    let!(:active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:other_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:future_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
+    end
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:)
+    end
+    let!(:training_period) do
+      FactoryBot.create(
+        :training_period,
+        :for_ect,
+        :ongoing,
+        :provider_led,
+        ect_at_school_period:,
+        started_on: ect_at_school_period.started_on
+      )
+    end
 
     context "when there are no active lead providers in contract period containing the ect's start date" do
-      let(:started_on) { Date.new(2024, 6, 1) }
-      let!(:training_period) do
-        FactoryBot.create(:training_period, :for_ect,
-                          :with_only_expression_of_interest,
-                          ect_at_school_period:,
-                          started_on:,
-                          expression_of_interest: active_lead_provider)
-      end
+      let(:started_on) { current_contract_period.started_on.prev_day }
 
-      it "returns an empty array" do
-        expect(current_step.lead_providers_for_select).to be_empty
-      end
+      it { is_expected.to be_empty }
     end
 
     context "when there are active lead providers in contract period containing the ect's start date" do
-      let(:started_on) { Date.new(2025, 6, 1) }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on:) }
-      let!(:other_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
-      let!(:future_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2026) }
+      let(:started_on) { current_contract_period.started_on.next_month }
 
-      it "returns the active lead providers in the contract period" do
-        expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-      end
+      it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
 
       context "when the ect starts on the last day of the contract period" do
-        let(:started_on) { Date.new(2026, 5, 31) }
+        let(:started_on) { current_contract_period.finished_on }
 
-        it "returns the active lead providers in the contract period" do
-          expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-        end
+        it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
       end
     end
 
-    context "when the ECT's current confirmed training period is in a closed contract period" do
-      let(:started_on) { Date.new(2021, 9, 1) }
+    context "when the ECT started provider-led training in a frozen contract period" do
+      let(:started_on) { frozen_contract_period.started_on.next_week }
 
-      let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2024) }
-      let!(:other_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2024) }
-
-      let!(:contract_period_2024) { FactoryBot.create(:contract_period, :with_schedules, year: 2024) }
-      let!(:contract_period_2021) { FactoryBot.create(:contract_period, :with_schedules, :with_payments_frozen, year: 2021) }
-
-      let(:school_partnership) { FactoryBot.create(:school_partnership, :for_year, year: 2021, school:) }
-      let!(:training_period) { FactoryBot.create(:training_period, :for_ect, ect_at_school_period:, started_on:, school_partnership:) }
-
-      it "only returns the active lead providers in the replacement contract period and no other year" do
-        expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
+      let(:frozen_contract_period) do
+        FactoryBot.create(
+          :contract_period,
+          :with_payments_frozen,
+          year: 2021
+        )
       end
+      let(:school_partnership) do
+        FactoryBot.create(:school_partnership, :for_year, year: 2021, school:)
+      end
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          :provider_led,
+          ect_at_school_period:,
+          started_on: ect_at_school_period.started_on,
+          school_partnership:
+        )
+      end
+
+      let!(:replacement_active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, :for_year, year: 2024)
+      end
+
+      it { is_expected.to contain_exactly(replacement_active_lead_provider.lead_provider) }
     end
   end
 end

--- a/spec/wizards/schools/ects/change_mentor_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/ects/change_mentor_wizard/lead_provider_step_spec.rb
@@ -118,39 +118,42 @@ describe Schools::ECTs::ChangeMentorWizard::LeadProviderStep do
   end
 
   describe "#lead_providers_for_select" do
-    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
-    let!(:other_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
-    let!(:future_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2026) }
+    subject(:lead_providers_for_select) { current_step.lead_providers_for_select }
+
+    let(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+    let(:upcoming_contract_period) do
+      FactoryBot.create(:contract_period, :next)
+    end
+    let!(:active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:other_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:future_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
+    end
     let(:mentor_at_school_period) do
-      FactoryBot.create(
-        :mentor_at_school_period,
-        :ongoing,
-        school:,
-        started_on:
-      )
+      FactoryBot.create(:mentor_at_school_period, school:, started_on:)
     end
 
     context "when there are no active lead providers in contract period containing the mentor's start date" do
-      let(:started_on) { Date.new(2024, 6, 1) }
+      let(:started_on) { current_contract_period.started_on.prev_day }
 
-      it "returns an empty array" do
-        expect(current_step.lead_providers_for_select).to be_empty
-      end
+      it { is_expected.to be_empty }
     end
 
     context "when there are active lead providers in contract period containing the mentor's start date" do
-      let(:started_on) { Date.new(2025, 6, 1) }
+      let(:started_on) { current_contract_period.started_on.next_month }
 
-      it "returns the active lead providers in the contract period" do
-        expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-      end
+      it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
 
       context "when the mentor started on the last day of the contract period" do
-        let(:started_on) { Date.new(2026, 5, 31) }
+        let(:started_on) { current_contract_period.finished_on }
 
-        it "returns the active lead providers in the contract period" do
-          expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-        end
+        it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
       end
     end
   end

--- a/spec/wizards/schools/ects/change_training_programme_wizard/lead_provider_step_spec.rb
+++ b/spec/wizards/schools/ects/change_training_programme_wizard/lead_provider_step_spec.rb
@@ -98,58 +98,74 @@ describe Schools::ECTs::ChangeTrainingProgrammeWizard::LeadProviderStep do
   end
 
   describe "#lead_providers_for_select" do
-    let(:ect_at_school_period) { FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:) }
-    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year:) }
-    let!(:other_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year:) }
-    let!(:future_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: year + 1) }
-    let(:year) { 2025 }
+    subject(:lead_providers_for_select) { current_step.lead_providers_for_select }
+
+    let(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+    let(:upcoming_contract_period) do
+      FactoryBot.create(:contract_period, :next)
+    end
+    let!(:active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:other_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:future_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
+    end
+    let(:ect_at_school_period) do
+      FactoryBot.create(:ect_at_school_period, :ongoing, school:, started_on:)
+    end
 
     context "when there are no active lead providers in contract period containing the ect's start date" do
-      let(:started_on) { Date.new(2024, 6, 1) }
+      let(:started_on) { current_contract_period.started_on.prev_day }
 
-      it "returns an empty array" do
-        expect(current_step.lead_providers_for_select).to be_empty
-      end
+      it { is_expected.to be_empty }
     end
 
     context "when there are active lead providers in contract period containing the ect's start date" do
-      let(:started_on) { Date.new(2025, 6, 1) }
+      let(:started_on) { current_contract_period.started_on.next_month }
 
-      it "returns the active lead providers in the contract period" do
-        expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-      end
+      it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
 
       context "when the ect starts on the last day of the contract period" do
-        let(:started_on) { Date.new(2026, 5, 31) }
+        let(:started_on) { current_contract_period.finished_on }
 
-        it "returns the active lead providers in the contract period" do
-          expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-        end
+        it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
       end
     end
 
-    context "when the ect started provider-led training in a closed contract period" do
-      let(:started_on) { Date.new(2021, 9, 1) }
-      let(:year) { 2024 }
+    context "when the ECT started provider-led training in a frozen contract period" do
+      let(:started_on) { frozen_contract_period.started_on.next_week }
 
-      let(:school_partnership) do
+      let(:frozen_contract_period) do
         FactoryBot.create(
-          :school_partnership,
-          :for_year,
-          year: 2021,
-          school: ect_at_school_period.school
+          :contract_period,
+          :with_payments_frozen,
+          year: 2021
+        )
+      end
+      let(:school_partnership) do
+        FactoryBot.create(:school_partnership, :for_year, year: 2021, school:)
+      end
+      let!(:training_period) do
+        FactoryBot.create(
+          :training_period,
+          :for_ect,
+          :provider_led,
+          ect_at_school_period:,
+          started_on: ect_at_school_period.started_on,
+          school_partnership:
         )
       end
 
-      before do
-        FactoryBot.create(:contract_period, :with_schedules, :with_payments_frozen, year: 2021)
-        old_training_period = FactoryBot.create(:training_period, :for_ect, :finished, :provider_led, ect_at_school_period:, school_partnership:, started_on:)
-        FactoryBot.create(:training_period, :for_ect, :ongoing, :school_led, ect_at_school_period:, started_on: old_training_period.finished_on + 1.day)
+      let!(:replacement_active_lead_provider) do
+        FactoryBot.create(:active_lead_provider, :for_year, year: 2024)
       end
 
-      it "returns the active lead providers in the successor contract period" do
-        expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-      end
+      it { is_expected.to contain_exactly(replacement_active_lead_provider.lead_provider) }
     end
   end
 end

--- a/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
+++ b/spec/wizards/schools/mentors/change_lead_provider_wizard/edit_step_spec.rb
@@ -94,39 +94,42 @@ describe Schools::Mentors::ChangeLeadProviderWizard::EditStep, type: :model do
   end
 
   describe "#lead_providers_for_select" do
-    let!(:active_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
-    let!(:other_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2025) }
-    let!(:future_lead_provider) { FactoryBot.create(:active_lead_provider, :for_year, year: 2026) }
+    subject(:lead_providers_for_select) { current_step.lead_providers_for_select }
+
+    let(:current_contract_period) do
+      FactoryBot.create(:contract_period, :current)
+    end
+    let(:upcoming_contract_period) do
+      FactoryBot.create(:contract_period, :next)
+    end
+    let!(:active_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:other_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: current_contract_period)
+    end
+    let!(:future_lead_provider) do
+      FactoryBot.create(:active_lead_provider, contract_period: upcoming_contract_period)
+    end
     let(:mentor_at_school_period) do
-      FactoryBot.create(
-        :mentor_at_school_period,
-        :ongoing,
-        school:,
-        started_on:
-      )
+      FactoryBot.create(:mentor_at_school_period, :ongoing, school:, started_on:)
     end
 
     context "when there are no active lead providers in contract period containing the mentor's start date" do
-      let(:started_on) { Date.new(2024, 6, 1) }
+      let(:started_on) { current_contract_period.started_on.prev_day }
 
-      it "returns an empty array" do
-        expect(current_step.lead_providers_for_select).to be_empty
-      end
+      it { is_expected.to be_empty }
     end
 
     context "when there are active lead providers in contract period containing the mentor's start date" do
-      let(:started_on) { Date.new(2025, 6, 1) }
+      let(:started_on) { current_contract_period.started_on.next_month }
 
-      it "returns the active lead providers in the contract period" do
-        expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-      end
+      it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
 
       context "when the mentor started on the last day of the contract period" do
-        let(:started_on) { Date.new(2026, 5, 31) }
+        let(:started_on) { current_contract_period.finished_on }
 
-        it "returns the active lead providers in the contract period" do
-          expect(current_step.lead_providers_for_select).to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider)
-        end
+        it { is_expected.to contain_exactly(active_lead_provider.lead_provider, other_lead_provider.lead_provider) }
       end
     end
   end

--- a/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/use_previous_ect_choices_step_spec.rb
@@ -117,31 +117,29 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
         end
 
         context "with a start date on the last day of the next contract period, when today is the end of the current period" do
-          around do |example|
-            travel_to Date.new(2026, 5, 31) { example.run }
+          let(:upcoming_contract_period) { FactoryBot.create(:contract_period, :next) }
+
+          let(:upcoming_active_lead_provider) do
+            FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: upcoming_contract_period)
           end
 
-          let(:next_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
-
-          let(:active_lead_provider_2026) do
-            FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
-          end
-
-          let(:lpdp_2026) do
-            FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: active_lead_provider_2026)
+          let(:upcoming_lpdp) do
+            FactoryBot.create(:lead_provider_delivery_partnership, active_lead_provider: upcoming_active_lead_provider)
           end
 
           let!(:reusable_partnership) do
-            FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: lpdp_2026)
+            FactoryBot.create(:school_partnership, school:, lead_provider_delivery_partnership: upcoming_lpdp)
           end
 
           let(:store) do
             FactoryBot.build(
               :session_repository,
               use_previous_ect_choices:,
-              start_date: "31 May 2027"
+              start_date: upcoming_contract_period.finished_on
             )
           end
+
+          before { travel_to current_contract_period.finished_on }
 
           it "finds a partnership in the next contract period, and the step is allowed" do
             expect(SchoolPartnerships::FindReusablePartnership)
@@ -149,7 +147,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
               .with(
                 school:,
                 lead_provider: school.last_chosen_lead_provider,
-                contract_period: next_contract_period
+                contract_period: upcoming_contract_period
               )
               .and_call_original
 
@@ -456,13 +454,13 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       end
 
       context "and no partnership is reusable but a previous EOI exists and the LP is available in the registration contract period" do
-        let!(:previous_contract_period) { FactoryBot.create(:contract_period, year: 2024) }
+        let!(:previous_contract_period) { FactoryBot.create(:contract_period, :previous) }
 
         let!(:previous_year_active_lead_provider) do
           FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: previous_contract_period)
         end
 
-        let!(:active_lead_provider_2025) do
+        let!(:active_lead_provider) do
           FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: current_contract_period)
         end
 
@@ -470,7 +468,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
           FactoryBot.create(
             :ect_at_school_period,
             school:,
-            started_on: Date.new(2024, 9, 1),
+            started_on: previous_contract_period.started_on.next_month,
             finished_on: nil
           )
         end
@@ -482,7 +480,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
             training_programme: "provider_led",
             expression_of_interest: previous_year_active_lead_provider,
             school_partnership: nil,
-            started_on: Date.new(2024, 9, 1),
+            started_on: ect_at_school_period.started_on,
             finished_on: nil
           )
         end
@@ -500,30 +498,28 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
         end
 
         context "with a start date on the last day of the next contract period, when today is the end of the current period" do
-          around do |example|
-            travel_to Date.new(2026, 5, 31) { example.run }
-          end
-
-          let(:next_contract_period) { FactoryBot.create(:contract_period, year: 2026) }
+          let(:upcoming_contract_period) { FactoryBot.create(:contract_period, :next) }
 
           let(:store) do
             FactoryBot.build(
               :session_repository,
               use_previous_ect_choices:,
-              start_date: "31 May 2027"
+              start_date: upcoming_contract_period.finished_on
             )
           end
 
-          let!(:active_lead_provider_2026) do
-            FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: next_contract_period)
+          let!(:upcoming_active_lead_provider) do
+            FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: upcoming_contract_period)
           end
+
+          before { travel_to current_contract_period.finished_on }
 
           it "is allowed" do
             expect(ActiveLeadProvider)
               .to receive(:exists?)
               .with(
-                contract_period_year: 2026,
-                lead_provider_id: active_lead_provider_2026.lead_provider_id
+                contract_period_year: previous_contract_period.year,
+                lead_provider_id: previous_year_active_lead_provider.lead_provider_id
               )
               .and_call_original
 
@@ -678,7 +674,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
   end
 
   describe "#save!" do
-    let!(:current_contract_period) { FactoryBot.create(:contract_period, year: 2025) }
+    let!(:current_contract_period) { FactoryBot.create(:contract_period, :current) }
 
     let(:step_params) do
       ActionController::Parameters.new(
@@ -749,14 +745,14 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
       let!(:lead_provider) { FactoryBot.create(:lead_provider) }
       let!(:delivery_partner) { FactoryBot.create(:delivery_partner) }
 
-      let!(:active_lead_provider_2025) do
+      let!(:active_lead_provider) do
         FactoryBot.create(:active_lead_provider, lead_provider:, contract_period: current_contract_period)
       end
 
-      let!(:lpdp_2025) do
+      let!(:lpdp) do
         FactoryBot.create(
           :lead_provider_delivery_partnership,
-          active_lead_provider: active_lead_provider_2025,
+          active_lead_provider:,
           delivery_partner:
         )
       end
@@ -765,7 +761,7 @@ RSpec.describe Schools::RegisterECTWizard::UsePreviousECTChoicesStep, type: :mod
         FactoryBot.create(
           :school_partnership,
           school:,
-          lead_provider_delivery_partnership: lpdp_2025
+          lead_provider_delivery_partnership: lpdp
         )
       end
 

--- a/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
+++ b/spec/wizards/schools/register_ect_wizard/wizard_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Schools::RegisterECTWizard::Wizard do
-  let(:school) { FactoryBot.create(:school, :state_funded) }
+  let(:school) { FactoryBot.create(:school, :state_funded, create_contract_period: false) }
   let(:user) { FactoryBot.create(:user) }
   let(:store) { SessionRepository.new(session: {}, form_key: :register_ect_wizard) }
   let(:wizard) { described_class.new(current_step: :find_ect, author: user, step_params: {}, store:, school:) }
@@ -276,28 +276,12 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
     end
 
     context "when the school has previous programme choices" do
-      around do |example|
-        travel_to(Date.new(2024, 9, 15)) { example.run } # inside CP 2024
-      end
-
       let!(:previous_contract_period) do
-        FactoryBot.create(
-          :contract_period,
-          year: 2023,
-          started_on: Date.new(2023, 6, 1),
-          finished_on: Date.new(2024, 5, 31),
-          enabled: true
-        )
+        FactoryBot.create(:contract_period, :previous)
       end
 
       let!(:current_contract_period) do
-        FactoryBot.create(
-          :contract_period,
-          year: 2024,
-          started_on: Date.new(2024, 6, 1),
-          finished_on: Date.new(2025, 5, 31),
-          enabled: true
-        )
+        FactoryBot.create(:contract_period, :current)
       end
 
       let(:lead_provider) { FactoryBot.create(:lead_provider, name: "Spec Lead Provider") }
@@ -601,13 +585,11 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
   end
 
   describe "contract period validation" do
-    around do |example|
-      travel_to(Date.new(2024, 9, 15)) { example.run }
-    end
-
-    let(:future_start_date) { Date.new(2025, 7, 1) } # future relative to 2024-09-15
+    let(:start_date_value) { start_date.strftime("%Y-%m-%d") }
 
     before do
+      travel_to date_to_travel_to
+
       wizard.ect.update!(
         trn: "1234567",
         date_of_birth: "1990-01-01",
@@ -628,16 +610,14 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
     end
 
     context "when start date is in future and contract period is not enabled" do
-      let(:start_date_value) { future_start_date.strftime("%Y-%m-%d") }
-
-      let!(:contract_period_2025) do
-        FactoryBot.create(
-          :contract_period,
-          year: 2025,
-          started_on: Date.new(2025, 6, 1),
-          finished_on: Date.new(2026, 5, 31),
-          enabled: false
-        )
+      # We want to ensure the start date is in the future and within the
+      # current contract period.
+      # This travels to some point in the contract period so that always holds
+      # no matter when "today" actually is
+      let(:date_to_travel_to) { current_contract_period.started_on.next_month }
+      let(:start_date) { date_to_travel_to + 1.week }
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current, enabled: false)
       end
 
       it "includes cannot_register_ect_yet step" do
@@ -649,17 +629,11 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
       end
     end
 
-    context "when start date is in past" do
-      let(:start_date_value) { Date.new(2024, 1, 1).strftime("%Y-%m-%d") }
-
-      let!(:contract_period_2024) do
-        FactoryBot.create(
-          :contract_period,
-          year: 2024,
-          started_on: Date.new(2024, 6, 1),
-          finished_on: Date.new(2025, 5, 31),
-          enabled: false
-        )
+    context "when start date is in past and contract period is not enabled" do
+      let(:date_to_travel_to) { Date.current }
+      let(:start_date) { previous_contract_period.finished_on.prev_month }
+      let!(:previous_contract_period) do
+        FactoryBot.create(:contract_period, :previous, enabled: false)
       end
 
       it "includes working_pattern step" do
@@ -671,17 +645,15 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
       end
     end
 
-    context "when start date is in future but contract period is enabled" do
-      let(:start_date_value) { future_start_date.strftime("%Y-%m-%d") }
-
-      let!(:contract_period_2025) do
-        FactoryBot.create(
-          :contract_period,
-          year: 2025,
-          started_on: Date.new(2025, 6, 1),
-          finished_on: Date.new(2026, 5, 31),
-          enabled: true
-        )
+    context "when start date is in future and contract period is enabled" do
+      # We want to ensure the start date is in the future and within the
+      # current contract period.
+      # This travels to some point in the contract period so that always holds
+      # no matter when "today" actually is
+      let(:date_to_travel_to) { current_contract_period.started_on.next_month }
+      let(:start_date) { date_to_travel_to + 1.week }
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current, enabled: true)
       end
 
       it "includes working_pattern step" do
@@ -694,8 +666,11 @@ RSpec.describe Schools::RegisterECTWizard::Wizard do
     end
 
     context "when start date is last day of contract period" do
-      let(:start_date_value) { Date.new(2026, 5, 31).strftime("%Y-%m-%d") }
-      let!(:contract_period_2025) { FactoryBot.create(:contract_period, year: 2025, enabled: true) }
+      let(:date_to_travel_to) { Date.current }
+      let(:start_date) { current_contract_period.finished_on }
+      let!(:current_contract_period) do
+        FactoryBot.create(:contract_period, :current, enabled: true)
+      end
 
       it "includes working_pattern step" do
         expect(wizard.allowed_steps).to include(:working_pattern)


### PR DESCRIPTION
Before, lots of our tests were focused on 31st May (and 2025 in particular).

In #2995 we fixed a bunch of tests that failed on `main` once we moved from the 2025 to the 2026 contract period.

This reworks a handful of tests that didn't break, but had a similar focus on the 2025 contract period and/or the 31st May.

Both of those are arbitrary, so this removes some of that focus.

Where tests are intended to focus on the end of a contract period, then they do that explicitly. They don't assume that 31st May is always the end of the contract period.

Also, tests focus less on the 2025 contract period and more on the "current" contract period.

This should make our test suite more robust and ensure they stay relevant over time.