### PR TITLE
Add some time travel logging

### DIFF
--- a/app/controllers/concerns/time_travellable.rb
+++ b/app/controllers/concerns/time_travellable.rb
@@ -13,13 +13,18 @@ private
 
   def travel_in_time
     if session["date_after_time_travel"].present?
+      Rails.logger.info("[Time travel] Preparing travel to #{session['date_after_time_travel']}")
       Current.date_before_time_travel = Date.current
       Current.date_after_time_travel = Date.parse(session["date_after_time_travel"])
+      Rails.logger.info("[Time travel] Travelling to #{Current.date_after_time_travel}")
       travel_to Current.date_after_time_travel
+      Rails.logger.info("[Time travel] Travelled to #{Date.current}")
     end
 
     yield
   ensure
     travel_back
+    Current.date_before_time_travel = nil
+    Current.date_after_time_travel = nil
   end
 end


### PR DESCRIPTION
We ran into some issues testing in the migration environment.

We think these might have been time-travel related.

There was an [error][error1] related to stubbing time, and an [error][error2] related to an unrecognised user type.

This adds some extra logging, and ensures the `Current` time travel attributes are reset between requests. The intention of this is to help us debug the issues, and eliminate the possibility of a mismatch between the `session["date_after_time_travel"]` and the `Current.date_after_time_travel`.

[error1]: https://dfe-teacher-services.sentry.io/issues/7526461321
[error2]: https://dfe-teacher-services.sentry.io/issues/7518993490