### PR TITLE
Block changing or assigning mentors when registration is closed

### DIFF
--- a/app/controllers/schools/assign_existing_mentor_wizard_controller.rb
+++ b/app/controllers/schools/assign_existing_mentor_wizard_controller.rb
@@ -1,4 +1,5 @@
 class Schools::AssignExistingMentorWizardController < SchoolsController
+  include Schools::RegistrationWindowRedirectable
   include Schools::InductionRedirectable
 
   before_action :initialize_wizard, only: %i[new create]

--- a/app/controllers/schools/ects/change_mentor_wizard_controller.rb
+++ b/app/controllers/schools/ects/change_mentor_wizard_controller.rb
@@ -1,6 +1,7 @@
 module Schools
   module ECTs
     class ChangeMentorWizardController < SchoolsController
+      include Schools::RegistrationWindowRedirectable
       include Schools::InductionRedirectable
 
       include Wizardable

--- a/app/controllers/schools/mentorships_controller.rb
+++ b/app/controllers/schools/mentorships_controller.rb
@@ -1,5 +1,6 @@
 module Schools
   class MentorshipsController < SchoolsController
+    include Schools::RegistrationWindowRedirectable
     include Schools::InductionRedirectable
 
     before_action :set_ect

--- a/app/views/schools/registration_window_closed/show.html.erb
+++ b/app/views/schools/registration_window_closed/show.html.erb
@@ -6,7 +6,9 @@
 <%= govuk_list(
   [
     "register new early career teachers (ECTs) and mentors",
-    "change ECT training programmes"
+    "change ECT training programmes",
+    "change an ECT’s mentor",
+    "assign a mentor to an ECT"
   ],
   type: :bullet
 ) %>

--- a/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
+++ b/spec/requests/schools/assign_existing_mentor_wizard_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Assign existing mentor wizard" do
     subject { get schools_assign_existing_mentor_wizard_review_mentor_eligibility_path }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when signed in as a school user" do
       before { sign_in_as(:school_user, school:) }
@@ -74,6 +75,7 @@ RSpec.describe "Assign existing mentor wizard" do
     before { sign_in_as(:school_user, school:) }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when the wizard is not started" do
       it "redirects to the root path" do

--- a/spec/requests/schools/ects/change_mentor_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_mentor_wizard_spec.rb
@@ -37,6 +37,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
     subject { get path_for_step("edit") }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when not signed in" do
       it "redirects to the root page" do
@@ -125,6 +126,7 @@ describe "Schools::ECTs::ChangeMentorWizardController" do
     let(:other_mentor_teacher) { FactoryBot.create(:teacher) }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when not signed in" do
       it "redirects to the root path" do

--- a/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
+++ b/spec/requests/schools/ects/change_training_programme_wizard_spec.rb
@@ -98,6 +98,7 @@ describe "Schools::ECTs::ChangeTrainingProgrammeWizardController" do
     let(:new_training_programme) { "provider_led" }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when not signed in" do
       it "redirects to the root path" do

--- a/spec/requests/schools/mentorships_spec.rb
+++ b/spec/requests/schools/mentorships_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Create mentorship of an ECT to a mentor" do
     subject { get("/school/ects/#{ect_at_school_period.id}/mentorship/new") }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when not signed in" do
       it "redirects to the root page" do
@@ -39,6 +40,7 @@ RSpec.describe "Create mentorship of an ECT to a mentor" do
     let(:params) { {} }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
 
     context "when not signed in" do
       it "redirects to the root page" do

--- a/spec/requests/schools/register_mentor_wizard_spec.rb
+++ b/spec/requests/schools/register_mentor_wizard_spec.rb
@@ -16,6 +16,7 @@ describe "Schools::RegisterMentorWizardController" do
     let(:params) { { edit: { mentor_at_school_period_id: } } }
 
     it_behaves_like "an induction redirectable route"
+    it_behaves_like "a route blocked when the registration window is closed"
   end
 
 private


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4052

### Changes proposed in this pull request

Before, we allowed users to access these journeys.

However since 1st June, we have seen a bunch of [errors] and received some support queries from users with problems.

We need to investigate further why some of these errors are happening (in some cases the mentors shouldn't be eligible for funding and we shouldn't be creating training periods), but this restricts the journeys until we have a better understanding of the situation.

Now, users cannot change or assign a mentor while the registration window is closed.

Our intention is to allow these journeys again, but this buys us some time while we investigate further.

[errors]: https://kibana-uk1.logit.io/s/e9b9162d-0b5e-4362-bed0-8e577f88d06e/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!t,sort:!()),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2026-05-31T23:00:00.000Z',to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.deployment.name,negate:!f,params:(query:cpd-ec2-production-web),type:phrase),query:(match_phrase:(kubernetes.deployment.name:cpd-ec2-production-web))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:app.exception.name,negate:!f,params:(query:'ActiveRecord::RecordNotFound'),type:phrase),query:(match_phrase:(app.exception.name:'ActiveRecord::RecordNotFound')))),query:(language:lucene,query:''))

### Guidance to review
