### PR TITLE
Don't truncate tables before generating API seeds in staging

### DIFF
--- a/.github/workflows/reseed-staging-db.yml
+++ b/.github/workflows/reseed-staging-db.yml
@@ -34,7 +34,14 @@ jobs:
       run: |
         echo "Running default seeds..."
         make ci staging get-cluster-credentials
-        kubectl exec -n cpd-development deployment/cpd-ec2-staging-web -- /bin/sh -c "cd /app && DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bin/bundle exec rails db:seed:replant"
+        kubectl exec -n cpd-development \
+          deployment/cpd-ec2-staging-web \
+          -- sh -c '
+            cd /app &&
+            DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
+            RAILS_ENV=staging \
+            /usr/local/bin/bundle exec rails db:seed:replant
+          '
 
     - name: Seed API data
       run: |
@@ -44,9 +51,6 @@ jobs:
           deployment/cpd-ec2-staging-web \
           -- sh -c '
             cd /app &&
-            DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
-            RAILS_ENV=staging \
-            /usr/local/bin/bundle exec rails db:truncate_all &&
             DISABLE_DATABASE_ENVIRONMENT_CHECK=1 \
             RAILS_ENV=staging \
             /usr/local/bin/bundle exec rake api_seed_data:generate


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/4054

### Changes proposed in this pull request

We run `rails db:seed:replant` which deletes all data from tables in the step beforehand, so there is no need to truncate tables.

We also don't want to truncate tables **after** we've run the default seeds.

This was causing issues in staging, where we couldn't use personas to login (we were missing the relevant `AppropriateBodyPeriod` records).

This became an issue when we changed the order of the steps in #3001.

As part of this change I tweaked the formatting slightly so it's easier to compare both steps of the action.

### Guidance to review
