### PR TITLE
Fix metadata nightly alert false positives

### DIFF
--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -28,6 +28,10 @@ module Metadata::Handlers
 
   protected
 
+    def alert_exclusions = []
+
+  private
+
     def lead_provider_ids
       @lead_provider_ids ||= LeadProvider.pluck(:id)
     end
@@ -43,7 +47,9 @@ module Metadata::Handlers
     # Allows individual handlers to exclude attributes that we can't
     # reliably update at the moment they change. Prevents them from
     # being included in the alerts.
-    def alertable_changes(saved_changes) = saved_changes
+    def alertable_changes(saved_changes)
+      saved_changes.excluding(alert_exclusions)
+    end
 
     def alert_on_changes(metadata)
       return unless @alert_on_changes

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -32,39 +32,21 @@ module Metadata::Handlers
       @lead_provider_ids ||= LeadProvider.pluck(:id)
     end
 
-    def changes?(metadata, changes)
-      changes.stringify_keys!
-      metadata.attributes.slice(*changes.keys) != changes
-    end
-
-    def commit_changes!(metadata, changes)
-      return unless metadata.new_record? || changes?(metadata, changes)
-
+    def update_metadata!(metadata, latest_attributes)
       # As we touch other models when metadata is updated via ActiveRecord callbacks,
       # we need to ensure this remains a method that will trigger those callbacks
       # (rather than using something like upsert_all which would otherwise be quicker).
-      metadata.update!(changes)
-      alert_on_changes(metadata, changes)
+      metadata.update!(latest_attributes)
+      alert_on_changes(metadata)
     end
 
-    def alert_on_changes(metadata, changes)
-      return unless @alert_on_changes
-
-      changed_attributes_with_history = changes.each_with_object({}) do |(key, new_value), hash|
-        old_value = metadata.attributes[key]
-
-        next if old_value == new_value
-
-        hash[key] = {
-          old: old_value,
-          new: new_value
-        }
-      end
+    def alert_on_changes(metadata)
+      return unless @alert_on_changes && metadata.saved_changes.any?
 
       attrs = {
         class: metadata.class.name,
         id: metadata.id,
-        changed_attributes: changed_attributes_with_history,
+        saved_changes: metadata.saved_changes
       }
 
       Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -40,13 +40,22 @@ module Metadata::Handlers
       alert_on_changes(metadata)
     end
 
+    # Allows individual handlers to exclude attributes that we can't
+    # reliably update at the moment they change. Prevents them from
+    # being included in the alerts.
+    def alertable_changes(saved_changes) = saved_changes
+
     def alert_on_changes(metadata)
-      return unless @alert_on_changes && metadata.saved_changes.any?
+      return unless @alert_on_changes
+
+      alertable_changes = alertable_changes(metadata.saved_changes)
+
+      return unless alertable_changes.any?
 
       attrs = {
         class: metadata.class.name,
         id: metadata.id,
-        saved_changes: metadata.saved_changes
+        alertable_changes:
       }
 
       Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")

--- a/app/services/metadata/handlers/base.rb
+++ b/app/services/metadata/handlers/base.rb
@@ -48,14 +48,14 @@ module Metadata::Handlers
     def alert_on_changes(metadata)
       return unless @alert_on_changes
 
-      alertable_changes = alertable_changes(metadata.saved_changes)
+      relevant_changes = alertable_changes(metadata.saved_changes)
 
-      return unless alertable_changes.any?
+      return unless relevant_changes.any?
 
       attrs = {
         class: metadata.class.name,
         id: metadata.id,
-        alertable_changes:
+        relevant_changes:
       }
 
       Rails.logger.warn("[Metadata] #{metadata.class.name} change: #{attrs.inspect}")

--- a/app/services/metadata/handlers/school.rb
+++ b/app/services/metadata/handlers/school.rb
@@ -24,14 +24,14 @@ module Metadata::Handlers
         metadata = existing_contract_period_metadata[contract_period_year] ||
           Metadata::SchoolContractPeriod.new(school:, contract_period_year:)
 
-        changes = {
+        latest_attributes = {
           school_id: school.id,
           contract_period_year:,
           in_partnership: contract_period_year.in?(school_partnership_contract_period_years),
           induction_programme_choice: school.training_programme_for(contract_period_year)
         }
 
-        commit_changes!(metadata, changes)
+        update_metadata!(metadata, latest_attributes)
       end
     end
 
@@ -42,14 +42,14 @@ module Metadata::Handlers
 
         expression_of_interest_or_school_partnership = expression_of_interest_or_school_partnership_pairings.include?([lead_provider_id, contract_period_year])
 
-        changes = {
+        latest_attributes = {
           school_id: school.id,
           lead_provider_id:,
           contract_period_year:,
           expression_of_interest_or_school_partnership:
         }
 
-        commit_changes!(metadata, changes)
+        update_metadata!(metadata, latest_attributes)
       end
     end
 

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -32,7 +32,7 @@ module Metadata::Handlers
         involved_in_school_transfer = school_transfers_exist_for(teacher.ect_at_school_periods, lead_provider_id) ||
           school_transfers_exist_for(teacher.mentor_at_school_periods, lead_provider_id)
 
-        changes = {
+        latest_attributes = {
           teacher_id: teacher.id,
           lead_provider_id:,
           latest_ect_training_period_id: latest_ect_training_period&.id,
@@ -43,7 +43,7 @@ module Metadata::Handlers
           involved_in_school_transfer:
         }
 
-        commit_changes!(metadata, changes)
+        update_metadata!(metadata, latest_attributes)
       end
     end
 

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -16,6 +16,15 @@ module Metadata::Handlers
       end
     end
 
+  protected
+
+    def alertable_changes(saved_changes)
+      # Depends on mentorship periods that are ongoing/future dated, which
+      # is a moving target, so the nightly refresh will often update this.
+      # We don't want to alert on this change when that happens.
+      saved_changes.excluding("ect_assigned_mentor_latest_school_period_id")
+    end
+
   private
 
     def upsert_lead_provider_metadata!

--- a/app/services/metadata/handlers/teacher.rb
+++ b/app/services/metadata/handlers/teacher.rb
@@ -18,11 +18,11 @@ module Metadata::Handlers
 
   protected
 
-    def alertable_changes(saved_changes)
+    def alert_exclusions
       # Depends on mentorship periods that are ongoing/future dated, which
       # is a moving target, so the nightly refresh will often update this.
       # We don't want to alert on this change when that happens.
-      saved_changes.excluding("ect_assigned_mentor_latest_school_period_id")
+      %w[ect_assigned_mentor_latest_school_period_id]
     end
 
   private

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 
+RSpec::Matchers.define_negated_matcher :a_hash_excluding, :a_hash_including
+
 RSpec.configure do |config|
   config.fixture_paths = [
     Rails.root.join("spec/fixtures")

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Metadata::Handlers::Teacher do
             expect(scope).to have_received(:set_context).with(
               "metadata_changes",
               a_hash_including(
-                alertable_changes: a_hash_excluding("ect_assigned_mentor_latest_school_period_id")
+                relevant_changes: a_hash_excluding("ect_assigned_mentor_latest_school_period_id")
               )
             )
           end

--- a/spec/services/metadata/handlers/teacher_spec.rb
+++ b/spec/services/metadata/handlers/teacher_spec.rb
@@ -327,6 +327,22 @@ RSpec.describe Metadata::Handlers::Teacher do
             expect(metadata.ect_assigned_mentor_latest_school_period).to eq(future_mentorship_period.mentor)
           end
 
+          it "does not alert on changes to ect_assigned_mentor_latest_school_period_id" do
+            handler.track_changes!
+
+            scope = instance_double(Sentry::Scope, set_context: nil)
+            allow(Sentry).to receive(:with_scope).and_yield(scope)
+
+            refresh_metadata
+
+            expect(scope).to have_received(:set_context).with(
+              "metadata_changes",
+              a_hash_including(
+                alertable_changes: a_hash_excluding("ect_assigned_mentor_latest_school_period_id")
+              )
+            )
+          end
+
           context "when there is also an ongoing mentorship period" do
             let!(:ongoing_mentorship_period) do
               FactoryBot.create(

--- a/spec/support/shared_examples/metadata_support.rb
+++ b/spec/support/shared_examples/metadata_support.rb
@@ -111,7 +111,7 @@ RSpec.shared_examples "supports tracking metadata upsert changes" do |metadata_m
           a_hash_including(
             class: metadata_model.name,
             id: kind_of(Integer),
-            alertable_changes: a_hash_including("id" => kind_of(Array))
+            relevant_changes: a_hash_including("id" => kind_of(Array))
           )
         )
 

--- a/spec/support/shared_examples/metadata_support.rb
+++ b/spec/support/shared_examples/metadata_support.rb
@@ -97,12 +97,24 @@ RSpec.shared_examples "supports tracking metadata upsert changes" do |metadata_m
       before { handler.track_changes! }
 
       it "tracks changes" do
+        scope = instance_double(Sentry::Scope, set_context: nil)
+        allow(Sentry).to receive(:with_scope).and_yield(scope)
         allow(Sentry).to receive(:capture_message)
+
         allow(Rails.logger).to receive(:warn)
 
         perform_refresh_metadata
 
         expect(Sentry).to have_received(:capture_message).with("[Metadata] #{metadata_model.name} change")
+        expect(scope).to have_received(:set_context).with(
+          "metadata_changes",
+          a_hash_including(
+            class: metadata_model.name,
+            id: kind_of(Integer),
+            alertable_changes: a_hash_including("id" => kind_of(Array))
+          )
+        )
+
         expect(Rails.logger).to have_received(:warn).with(a_string_starting_with("[Metadata] #{metadata_model.name} change:"))
       end
     end


### PR DESCRIPTION
### Context

We run a nightly metadata refresh; in an ideal world this would serve as an integrity check and not flag any changes, as our metadata is updated via callbacks when relevant objects are changed.

We've found this isn't the case for all metadata attributes, however. The `ect_assigned_mentor_latest_school_period_id` of the `Metadata::TeacherLeadProvider` is a moving target and depends on `MentorshipPeriod`s that are ongoing/future dated at any given point in time.

### Changes proposed in this pull request

- Clean up handler updates/change tracking

We had rolled our own change/dirty tracking originally as we were using `upsert_all` for performance reasons. We since changed to call `update!` on individual objects as we need callbacks for the declarative touch operations.

Simplify change tracking and update; `update!` will only update changed attributes and we can use `ActiveRecord`'s built in dirty tracking for logging the changes to Sentry.

- Support excluding metadata changes from alerting

Our nightly refresh (which runs daily at 1am) is currently updating this field for mentorship periods that satisfy the criteria in the coming day. Instead of running another nightly job _before_ the current one to update these we are opting to silence the alert for this attribute and allow it to be updated with the existing job.

- Improve track_changes tests

Ensure we are sending the correct context to Sentry when tracking changes.

### Guidance to review

In v4 we will be moving away from metadata, so we don't want to spend a lot of time trying to fix this and the risk of not alerting on this reasonably low.