### PR TITLE
Increase Band B for EDT in 2025

### DIFF
--- a/db/scripts/increase_band_b_for_edt.rb
+++ b/db/scripts/increase_band_b_for_edt.rb
@@ -3,20 +3,18 @@
 #
 # $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/increase_band_b_for_edt.rb
 
-begin
-  name = "Education Development Trust"
-  contract_period_year = 2025
+name = "Education Development Trust"
+contract_period_year = 2025
 
-  lead_provider = LeadProvider.find_by!(name:)
-  active_lead_provider = ActiveLeadProvider.find_by!(lead_provider:, contract_period_year:)
+lead_provider = LeadProvider.find_by!(name:)
+active_lead_provider = ActiveLeadProvider.find_by!(lead_provider:, contract_period_year:)
 
-  contract = Contract.find_by!(active_lead_provider:)
+contract = Contract.find_by!(active_lead_provider:)
 
-  band = contract.banded_fee_structure.bands.order(min_declarations: :desc).second
+band = contract.banded_fee_structure.bands.order(min_declarations: :desc).second
 
-  raise "Max declarations #{band.max_declarations} is not 3102!" if band.max_declarations != 3102
+raise "Max declarations #{band.max_declarations} is not 3102!" if band.max_declarations != 3102
 
-  band.update!(max_declarations: 4000)
+band.update!(max_declarations: 4000)
 
-  puts "Band B updated: #{band.min_declarations} - #{band.max_declarations}"
-end
+Rails.logger.info "EDT 2025 contract band B updated: #{band.min_declarations} - #{band.max_declarations}"

--- a/db/scripts/increase_band_b_for_edt.rb
+++ b/db/scripts/increase_band_b_for_edt.rb
@@ -9,9 +9,9 @@ contract_period_year = 2025
 lead_provider = LeadProvider.find_by!(name:)
 active_lead_provider = ActiveLeadProvider.find_by!(lead_provider:, contract_period_year:)
 
-contract = Contract.find_by!(active_lead_provider:)
+contract = Contract.where(active_lead_provider:).sole
 
-band = contract.banded_fee_structure.bands.order(min_declarations: :desc).second
+band = contract.banded_fee_structure.bands.last
 
 raise "Max declarations #{band.max_declarations} is not 3102!" if band.max_declarations != 3102
 

--- a/db/scripts/increase_band_b_for_edt.rb
+++ b/db/scripts/increase_band_b_for_edt.rb
@@ -1,0 +1,22 @@
+# Increase the max Band B upper limit for EDT for 2025
+# This script will change the max_declarations from 3102 to 4000
+#
+# $ kubectl exec -it <pod-name> -- bin/rails runner db/scripts/increase_band_b_for_edt.rb
+
+begin
+  name = "Education Development Trust"
+  contract_period_year = 2025
+
+  lead_provider = LeadProvider.find_by!(name:)
+  active_lead_provider = ActiveLeadProvider.find_by!(lead_provider:, contract_period_year:)
+
+  contract = Contract.find_by!(active_lead_provider:)
+
+  band = contract.banded_fee_structure.bands.order(min_declarations: :desc).second
+
+  raise "Max declarations #{band.max_declarations} is not 3102!" if band.max_declarations != 3102
+
+  band.update!(max_declarations: 4000)
+
+  puts "Band B updated: #{band.min_declarations} - #{band.max_declarations}"
+end


### PR DESCRIPTION
### Context

We need to increase the `max_declarations` level from `3102` to `4000` for Band B in 2025 for EDT to ensure they can submit the correct data.

### Changes proposed in this pull request

Add a script to update the level

### Guidance to review

This will need to be run in migration and checked by an analyst before applying to production.