### PR TITLE
Remove previous Induction Tutor column in Check and Release Check Data Page

### DIFF
--- a/app/components/tasks_index/leavers/table_row_component.html.erb
+++ b/app/components/tasks_index/leavers/table_row_component.html.erb
@@ -1,7 +1,6 @@
 <% row.with_cell(text: teacher_name) %>
 <% row.with_cell(text: teacher_trn) %>
 <% row.with_cell(text: recorded_by_school_name) %>
-<% row.with_cell(text: induction_tutor_name) %>
 <% row.with_cell do
   govuk_link_to "Release", new_ab_teacher_release_ect_path(teacher), no_visited_state: true
 end %>

--- a/app/components/tasks_index/leavers/table_row_component.rb
+++ b/app/components/tasks_index/leavers/table_row_component.rb
@@ -4,10 +4,9 @@ module TasksIndex
       include Rails.application.routes.url_helpers
 
       def self.headings
-        ["Name", "TRN", "Recorded by", "Induction tutor name", ""]
+        ["Name", "TRN", "Recorded by", ""]
       end
 
-      delegate :induction_tutor_name, to: :school
       delegate :ect_at_school_periods, to: :teacher
       delegate :ongoing, to: :ect_at_school_periods, prefix: true
 

--- a/spec/components/tasks_index/table_section_component_spec.rb
+++ b/spec/components/tasks_index/table_section_component_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe TasksIndex::TableSectionComponent, type: :component do
 
     it "renders the correct headings" do
       headers = rendered.css("th").map(&:text)
-      expect(headers).to contain_exactly("Name", "TRN", "Recorded by", "Induction tutor name", "")
+      expect(headers).to contain_exactly("Name", "TRN", "Recorded by", "")
     end
 
     it "renders a release link" do


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/DFE-Digital/register-ects-project-board/issues/3962

### Changes proposed in this pull request

DRAFT

### Guidance to review

DRAFT