### PR TITLE
[4027] Update cookies page to reflect current cookie usage

### DIFF
--- a/app/services/sessions/manager.rb
+++ b/app/services/sessions/manager.rb
@@ -25,7 +25,7 @@ module Sessions
       if id_token.present?
         cookies["id_token"] = { value: encrypt_token(id_token), httponly: true, secure: true, same_site: :strict }
       else
-        cookies.delete("id_token")
+        cookies.delete("id_token") unless cookies["id_token"].nil?
       end
     end
 

--- a/app/services/sessions/manager.rb
+++ b/app/services/sessions/manager.rb
@@ -18,11 +18,15 @@ module Sessions
     end
 
     # @see Sessions::Users::Builder#session_user
-    def begin_session!(session_user, id_token: "")
+    def begin_session!(session_user, id_token: nil)
       check_authorisation!(session_user)
       @current_user = nil
       session["user_session"] = session_user.to_h
-      cookies["id_token"] = { value: encrypt_token(id_token), httponly: true, secure: true, same_site: :strict }
+      if id_token.present?
+        cookies["id_token"] = { value: encrypt_token(id_token), httponly: true, secure: true, same_site: :strict }
+      else
+        cookies.delete("id_token")
+      end
     end
 
     # @see Sessions::User

--- a/app/views/pages/cookies.md.erb
+++ b/app/views/pages/cookies.md.erb
@@ -11,3 +11,11 @@ We use the **<%= Rails.application.config.session_options[:key] %>** cookie to k
 It is an essential cookie and we do not need to ask for permission to use it.
 
 It will be cleared at the end of your browser session.
+
+## DfE Sign-in cookie
+
+If you sign in with DfE Sign-in, we also use the **id_token** cookie to support secure sign-out.
+
+It is an essential cookie and we do not need to ask for permission to use it.
+
+It will be cleared when your session ends.

--- a/app/views/pages/cookies.md.erb
+++ b/app/views/pages/cookies.md.erb
@@ -6,7 +6,7 @@ Cookies are small files saved on your phone, tablet or computer when you visit a
 
 ## Session cookie
 
-We use the **_register_early_career_teachers_session** cookie to keep you signed in and your data secure.
+We use the **<%= Rails.application.config.session_options[:key] %>** cookie to keep you signed in and your data secure.
 
 It is an essential cookie and we do not need to ask for permission to use it.
 

--- a/app/views/pages/cookies.md.erb
+++ b/app/views/pages/cookies.md.erb
@@ -4,11 +4,11 @@ title: Cookies
 
 Cookies are small files saved on your phone, tablet or computer when you visit a website.
 
-We use cookies to make this service work.
+We use some essential cookies to make this service work.
 
 ## Essential cookies
 
-Essential cookies keep your information secure while you use this service. We do not need to ask for permission to use them.
+We do not need to ask for permission to use essential cookies.
 
 <%=
   govuk_table(
@@ -17,12 +17,12 @@ Essential cookies keep your information secure while you use this service. We do
       [
         tag.code(Rails.application.config.session_options[:key]),
         "Keeps you signed in and your data secure.",
-        "At the end of your browser session"
+        "When you sign out, when your browser session ends, or after 2 hours of inactivity."
       ],
       [
         tag.code("id_token"),
         "Used only for DfE Sign-in journeys to support secure sign-out.",
-        "At the end of your browser session"
+        "When you sign out or when your browser session ends."
       ]
     ]
   )

--- a/app/views/pages/cookies.md.erb
+++ b/app/views/pages/cookies.md.erb
@@ -4,18 +4,28 @@ title: Cookies
 
 Cookies are small files saved on your phone, tablet or computer when you visit a website.
 
-## Session cookie
+We use cookies to make this service work.
 
-We use the **<%= Rails.application.config.session_options[:key] %>** cookie to keep you signed in and your data secure.
+## Essential cookies
 
-It is an essential cookie and we do not need to ask for permission to use it.
+Essential cookies keep your information secure while you use this service. We do not need to ask for permission to use them.
 
-It will be cleared at the end of your browser session.
+<%=
+  govuk_table(
+    head: ["Name", "Purpose", "Expires"],
+    rows: [
+      [
+        tag.code(Rails.application.config.session_options[:key]),
+        "Keeps you signed in and your data secure.",
+        "At the end of your browser session"
+      ],
+      [
+        tag.code("id_token"),
+        "Used only for DfE Sign-in journeys to support secure sign-out.",
+        "At the end of your browser session"
+      ]
+    ]
+  )
+%>
 
-## DfE Sign-in cookie
-
-If you sign in with DfE Sign-in, we also use the **id_token** cookie to support secure sign-out.
-
-It is an essential cookie and we do not need to ask for permission to use it.
-
-It will be cleared when your session ends.
+Read more about how we process personal data in our [privacy policy](/privacy).

--- a/spec/requests/otp_sessions_spec.rb
+++ b/spec/requests/otp_sessions_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe "OTP sessions", type: :request do
         expect(response).to redirect_to(admin_path)
         expect(session.dig("user_session", "type")).to eq("Sessions::Users::DfEUser")
       end
+
+      it "does not set an id_token cookie" do
+        sign_in_with_otp
+
+        expect(response.headers["Set-Cookie"].to_s).not_to include("id_token")
+      end
     end
 
     context "when the user has a school urn that exists in GIAS" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe "Pages", type: :request do
       expect(response).to be_successful
       expect(response.body).to include("Cookies")
       expect(response.body).to include(Rails.application.config.session_options[:key])
+      expect(response.body).to include("id_token")
+      expect(response.body).to include("If you sign in with DfE Sign-in")
     end
   end
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -47,9 +47,10 @@ RSpec.describe "Pages", type: :request do
       get "/cookies"
       expect(response).to be_successful
       expect(response.body).to include("Cookies")
+      expect(response.body).to include("Essential cookies")
       expect(response.body).to include(Rails.application.config.session_options[:key])
       expect(response.body).to include("id_token")
-      expect(response.body).to include("If you sign in with DfE Sign-in")
+      expect(response.body).to include("Used only for DfE Sign-in journeys")
     end
   end
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe "Pages", type: :request do
       get "/cookies"
       expect(response).to be_successful
       expect(response.body).to include("Cookies")
+      expect(response.body).to include(Rails.application.config.session_options[:key])
     end
   end
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -47,10 +47,13 @@ RSpec.describe "Pages", type: :request do
       get "/cookies"
       expect(response).to be_successful
       expect(response.body).to include("Cookies")
+      expect(response.body).to include("We use some essential cookies to make this service work.")
       expect(response.body).to include("Essential cookies")
       expect(response.body).to include(Rails.application.config.session_options[:key])
       expect(response.body).to include("id_token")
       expect(response.body).to include("Used only for DfE Sign-in journeys")
+      expect(response.body).to include("When you sign out, when your browser session ends")
+      expect(response.body).to include("after 2 hours of inactivity")
     end
   end
 

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Sessions::Manager do
         end
       end
 
-      context "when a stale id_token cookie exists and the current login does not provide a new id_token" do
+      context "when signing in without an id_token and a stale cookie exists" do
         let(:cookies) { HashWithIndifferentAccess.new("id_token" => "stale_token") }
 
         before do
@@ -80,6 +80,25 @@ RSpec.describe Sessions::Manager do
 
         it "does not persist the id_token cookie" do
           expect(cookies["id_token"]).to be_nil
+        end
+
+        it "does not encrypt a token" do
+          expect(ActiveSupport::MessageEncryptor).not_to have_received(:new)
+        end
+      end
+
+      context "when signing in without an id_token and no stale cookie exists" do
+        let(:cookies) { double("ActionDispatch::Cookies::CookieJar") }
+
+        before do
+          allow(cookies).to receive(:[]).with("id_token").and_return(nil)
+          allow(cookies).to receive(:delete)
+          allow(ActiveSupport::MessageEncryptor).to receive(:new).and_call_original
+          service.begin_session!(user)
+        end
+
+        it "does not delete the id_token cookie" do
+          expect(cookies).not_to have_received(:delete)
         end
 
         it "does not encrypt a token" do

--- a/spec/services/sessions/session_manager_spec.rb
+++ b/spec/services/sessions/session_manager_spec.rb
@@ -43,29 +43,48 @@ RSpec.describe Sessions::Manager do
     describe "storing the 'id_token' cookie" do
       let(:secret_key) { Rails.application.secret_key_base.byteslice(0, 32) }
 
-      before do
-        allow(ActiveSupport::MessageEncryptor).to receive(:new).and_call_original
-        service.begin_session!(user, id_token: "dfe_token")
+      context "when id_token is present" do
+        before do
+          allow(ActiveSupport::MessageEncryptor).to receive(:new).and_call_original
+          service.begin_session!(user, id_token: "dfe_token")
+        end
+
+        it "is set" do
+          expect(cookies["id_token"]).to be_present
+        end
+
+        it "id_token is encrypted" do
+          expect(ActiveSupport::MessageEncryptor).to have_received(:new).once.with(secret_key)
+        end
+
+        it "has 'httponly: true' set" do
+          expect(cookies.dig("id_token", "httponly")).to be(true)
+        end
+
+        it "has 'secure: true' set" do
+          expect(cookies.dig("id_token", "secure")).to be(true)
+        end
+
+        it "has 'same_site: :strict' set" do
+          expect(cookies.dig("id_token", "same_site")).to be(:strict)
+        end
       end
 
-      it "is set" do
-        expect(cookies["id_token"]).to be_present
-      end
+      context "when a stale id_token cookie exists and the current login does not provide a new id_token" do
+        let(:cookies) { HashWithIndifferentAccess.new("id_token" => "stale_token") }
 
-      it "id_token is encrypted" do
-        expect(ActiveSupport::MessageEncryptor).to have_received(:new).once.with(secret_key)
-      end
+        before do
+          allow(ActiveSupport::MessageEncryptor).to receive(:new).and_call_original
+          service.begin_session!(user)
+        end
 
-      it "has 'httponly: true' set" do
-        expect(cookies.dig("id_token", "httponly")).to be(true)
-      end
+        it "does not persist the id_token cookie" do
+          expect(cookies["id_token"]).to be_nil
+        end
 
-      it "has 'secure: true' set" do
-        expect(cookies.dig("id_token", "secure")).to be(true)
-      end
-
-      it "has 'same_site: :strict' set" do
-        expect(cookies.dig("id_token", "same_site")).to be(:strict)
+        it "does not encrypt a token" do
+          expect(ActiveSupport::MessageEncryptor).not_to have_received(:new)
+        end
       end
     end
 


### PR DESCRIPTION
### Summary

Updates the cookies page so it reflects the cookies the service currently uses, including the configured session cookie name, `id_token` for DfE Sign-in journeys, and clearer expiry wording.

Also fixes session handling so `id_token` is only stored when provided by DSI, while stale `id_token` cookies are still cleared for OTP sign-ins.


| Before | After |
|--------|-------|
|<img width="865" height="511" alt="image" src="https://github.com/user-attachments/assets/f3e900ee-1d08-4d39-acb6-71b12ef8b90d" />|<img width="936" height="762" alt="image" src="https://github.com/user-attachments/assets/6112781f-fc76-418e-b170-d2b21eb5bac0" />|