### PR TITLE
[3173] Fix for duplicate scheme in comms out-opt host

### DIFF
--- a/db/seeds/blazer_queries/school_comms.rb
+++ b/db/seeds/blazer_queries/school_comms.rb
@@ -205,11 +205,17 @@ module BlazerQueries
         host = options[:host].presence
         raise "action_mailer default_url_options host is not configured" if host.blank?
 
-        scheme = host == "localhost" ? "http" : "https"
-        authority = [host, options[:port]].compact.join(":")
+        # In production the configured host can already include the scheme
+        # (e.g. "https://example.com"); only add one when it's missing.
+        unless host.include?("://")
+          scheme = host == "localhost" ? "http" : "https"
+          host = "#{scheme}://#{host}"
+        end
+
+        origin = [host, options[:port]].compact.join(":")
         path = Rails.application.routes.url_helpers.new_schools_reminder_email_opt_out_path
 
-        "#{scheme}://#{authority}#{path}"
+        "#{origin}#{path}"
       end
     end
   end

--- a/db/seeds/blazer_queries/school_comms.rb
+++ b/db/seeds/blazer_queries/school_comms.rb
@@ -208,7 +208,7 @@ module BlazerQueries
         # In production the configured host can already include the scheme
         # (e.g. "https://example.com"); only add one when it's missing.
         unless host.include?("://")
-          scheme = host == "localhost" ? "http" : "https"
+          scheme = (host == "localhost") ? "http" : "https"
           host = "#{scheme}://#{host}"
         end
 

--- a/spec/seeds/blazer_queries/school_comms_spec.rb
+++ b/spec/seeds/blazer_queries/school_comms_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe BlazerQueries::SchoolComms do
       )
     end
 
+    it "does not duplicate the scheme when the configured host already includes one" do
+      allow(Rails.application.config.action_mailer)
+        .to receive(:default_url_options)
+        .and_return(host: "https://example.com")
+
+      statements = definitions.pluck(:statement)
+
+      expect(statements)
+        .to all(include("https://example.com/school/opt-out-of-reminder-emails/new?school_id="))
+      expect(statements).to all(satisfy { |statement| statement.exclude?("https://https://") })
+    end
+
     it "excludes children's centres and their linked sites everywhere (#2501)" do
       definitions.each do |definition|
         expect(definition[:statement]).to include(


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-ects-project-board/issues/3173 but after deployment it turns out that production has "https" baked into the action mailer host configuration.

### Changes proposed in this pull request

Rather than always prepend the scheme to the URL, only add it if it's not already present