### PR TITLE
Touch `SchoolPartnership#api_updated_at` on `participants_currently_training` change

### DIFF
--- a/app/jobs/touch_school_partnership_for_participants_currently_training_job.rb
+++ b/app/jobs/touch_school_partnership_for_participants_currently_training_job.rb
@@ -1,0 +1,14 @@
+# Ensure changes to `participants_currently_training` in the
+# API::SchoolPartnershipSerializer are reflected in the `updated_at`.
+#
+# Job is scheduled to run daily at 12:01am.
+class TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob < ApplicationJob
+  def perform
+    training_periods_starting_today = TrainingPeriod.where(started_on: Time.zone.today)
+    training_periods_finished_yesterday = TrainingPeriod.where(finished_on: Time.zone.yesterday)
+
+    SchoolPartnership
+      .where(id: training_periods_starting_today.or(training_periods_finished_yesterday).select(:school_partnership_id))
+      .update_all(api_updated_at: Time.current)
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -23,6 +23,11 @@ production:
     queue: metadata
     schedule: every day at 1am
 
+  touch_school_partnership_for_participants_currently_training_job:
+    class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
+    queue: default
+    schedule: every day at 00:01
+
   mark_statements_as_payable:
     class: Statements::MarkAsPayableJob
     queue: default
@@ -51,6 +56,11 @@ sandbox:
     queue: metadata
     schedule: every day at 1am
 
+  touch_school_partnership_for_participants_currently_training_job:
+    class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
+    queue: default
+    schedule: every day at 00:01
+
 staging:
   purge_pending_induction_submissions:
     class: PurgePendingInductionSubmissionsJob
@@ -60,6 +70,11 @@ staging:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  
+  touch_school_partnership_for_participants_currently_training_job:
+    class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
+    queue: default
+    schedule: every day at 00:01
 
 review:
   purge_pending_induction_submissions:
@@ -67,3 +82,7 @@ review:
     queue: default
     schedule: Every hour
 
+  touch_school_partnership_for_participants_currently_training_job:
+    class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
+    queue: default
+    schedule: every day at 00:01

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -70,6 +70,11 @@ staging:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+    
+  refresh_all_metadata_job:
+    class: RefreshAllMetadataJob
+    queue: metadata
+    schedule: every day at 1am
   
   touch_school_partnership_for_participants_currently_training_job:
     class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob
@@ -81,6 +86,11 @@ review:
     class: PurgePendingInductionSubmissionsJob
     queue: default
     schedule: Every hour
+
+  refresh_all_metadata_job:
+    class: RefreshAllMetadataJob
+    queue: metadata
+    schedule: every day at 1am
 
   touch_school_partnership_for_participants_currently_training_job:
     class: TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob

--- a/spec/jobs/touch_school_partnership_for_participants_currently_training_job_spec.rb
+++ b/spec/jobs/touch_school_partnership_for_participants_currently_training_job_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe TouchSchoolPartnershipForParticipantsCurrentlyTrainingJob, type: :job do
+  let(:instance) { described_class.new }
+
+  around { |example| freeze_time { example.run } }
+
+  describe "#perform" do
+    subject(:perform) { instance.perform }
+
+    let(:school_partnership) { FactoryBot.create(:school_partnership, api_updated_at: 1.week.ago) }
+
+    before do
+      ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on:, finished_on:)
+      FactoryBot.create(:training_period, started_on:, finished_on:, school_partnership:, ect_at_school_period:)
+    end
+
+    context "when a training period starts today" do
+      let(:started_on) { Time.zone.today }
+      let(:finished_on) { nil }
+
+      it { expect { perform }.to change { school_partnership.reload.api_updated_at }.to eq(Time.current) }
+    end
+
+    context "when a training period finished yesterday" do
+      let(:started_on) { 1.week.ago }
+      let(:finished_on) { Time.zone.yesterday }
+
+      it { expect { perform }.to change { school_partnership.reload.api_updated_at }.to eq(Time.current) }
+    end
+
+    context "when a training period starts after today" do
+      let(:started_on) { Time.zone.tomorrow }
+      let(:finished_on) { 1.week.from_now }
+
+      it { expect { perform }.not_to(change { school_partnership.reload.api_updated_at }) }
+    end
+
+    context "when a training period finished before yesterday" do
+      let(:started_on) { 2.weeks.ago }
+      let(:finished_on) { 2.days.ago }
+
+      it { expect { perform }.not_to(change { school_partnership.reload.api_updated_at }) }
+    end
+
+    context "when a training period starts before today and finishes after yesterday" do
+      let(:started_on) { Time.zone.yesterday }
+      let(:finished_on) { Time.zone.tomorrow }
+
+      it { expect { perform }.not_to(change { school_partnership.reload.api_updated_at }) }
+    end
+
+    context "when there are multiple school partnerships with training periods starting today" do
+      let(:started_on) { Time.zone.today }
+      let(:finished_on) { nil }
+
+      let(:another_school_partnership) { FactoryBot.create(:school_partnership, api_updated_at: 2.weeks.ago) }
+
+      before do
+        ect_at_school_period = FactoryBot.create(:ect_at_school_period, started_on:, finished_on:)
+        FactoryBot.create(:training_period, started_on:, finished_on:, school_partnership: another_school_partnership, ect_at_school_period:)
+      end
+
+      it "updates all relevant school partnerships" do
+        expect { perform }.to change { school_partnership.reload.api_updated_at }.and(change { another_school_partnership.reload.api_updated_at })
+
+        timestamps = [school_partnership.api_updated_at, another_school_partnership.api_updated_at]
+        expect(timestamps).to all(eq(Time.current))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We surface the `participants_currently_training` in the `API::SchoolPartnershipSerializer`, however when a participant starts/finishes their training we don't touch the `api_updated_at` of the `SchoolPartnership`.

This has confused lead providers; when something changes in the serialized response the `updated_at` should reflect the change.

### Changes proposed in this pull request

- Add job to touch SchoolPartnership#api_updated_at

As the `participants_currently_training` is a moving target, we have opted to add a nightly job that will touch relevant partnerships for participants that start training on that day, or finished training the previous day.

I opted to keep the `participant` terminology for consistency with the serializedfield name and used `updated_all` for efficiency as callbacks can safely be skipped.

- Add RefreshAllMetadataJob to review/staging

We only ran this in production/sandbox previously as it was only intended to be an integrity check. That changed recently as we now rely on the nightly refresh to update the `ect_assigned_mentor_latest_school_period_id` on
`Metadata::TeacherLeadProvider`, so we should run it on review/staging environments in order to avoid consistency issues in the metadata.

### Guidance to review

Create a participant due to start training tomorrow or finish training today, wait a day and check the `updated_at` in the partnerships response correctly reflects the change.